### PR TITLE
[frontend] less aggressive tab reload (#3274)

### DIFF
--- a/openbas-front/src/admin/components/atomic_testings/atomic_testing/PaginatedTargetTab.tsx
+++ b/openbas-front/src/admin/components/atomic_testings/atomic_testing/PaginatedTargetTab.tsx
@@ -45,7 +45,7 @@ const PaginatedTargetTab: React.FC<Props> = (props) => {
   };
 
   useEffect(() => {
-    if (targets && targets.length > 0) {
+    if (targets && targets.length > 0 && !targets.find(t => t.target_id == selectedTarget?.target_id)) {
       handleSelectTarget(targets[0]);
     }
   }, [targets]);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Reload tabs less agressively

### Testing Instructions

Multiple interaction patterns:
1. Add/Remove entire classes of targets (e.g. asset groups)
2. Create/Delete a manual expectation result
3. Remove currently selected target from target list (eg edit inject to remove the selected endpoint)
4. Remove a different target than currently selected (should keep the current one selected and displayed but still reload the tab content)

### Related issues

* Closes #3274

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

