### PR TITLE
[frontend] choose simulation and filter series to go on step 3

### DIFF
--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/WidgetCreationSecurityCoverageSeries.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/widgets/WidgetCreationSecurityCoverageSeries.tsx
@@ -84,7 +84,7 @@ const WidgetCreationSecurityCoverageSeries: FunctionComponent<Props> = ({ value,
   const onSimulationChange = (simulationId: string | undefined) => {
     setSimulationId(simulationId);
     setShowSimulationError(!simulationId);
-    if (simulationId && value?.length > 0) {
+    if (simulationId && value?.length > 0 && value[0].filter !== undefined) {
       addSimulationFilterOnSeries(value, simulationId);
       onChange(value);
       onSubmit();


### PR DESCRIPTION
### Proposed changes

* fix : Choosing a simulation leads me to step 3 even if I didn’t choose a dimension

