### PR TITLE
[backend] Trigger stix coverage at end of simulation (#3707)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
+++ b/openbas-api/src/main/java/io/openbas/injectors/email/EmailExecutor.java
@@ -16,6 +16,7 @@ import io.openbas.model.expectation.ManualExpectation;
 import io.openbas.service.InjectExpectationService;
 import jakarta.annotation.Resource;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -103,7 +104,9 @@ public class EmailExecutor extends Injector {
     Exercise exercise = injection.getInjection().getExercise();
     String from = exercise != null ? exercise.getFrom() : this.openBASConfig.getDefaultMailer();
     List<String> replyTos =
-        exercise != null ? exercise.getReplyTos() : List.of(this.openBASConfig.getDefaultReplyTo());
+        exercise != null
+            ? exercise.getReplyTos()
+            : new ArrayList<>(List.of(this.openBASConfig.getDefaultReplyTo()));
     //noinspection SwitchStatementWithTooFewBranches
     switch (inject
         .getInjectorContract()

--- a/openbas-api/src/main/java/io/openbas/rest/exercise/service/ExerciseService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/exercise/service/ExerciseService.java
@@ -136,7 +136,7 @@ public class ExerciseService {
         exercise.setReplyTos(List.of(imapUsername));
       } else {
         exercise.setFrom(openBASConfig.getDefaultMailer());
-        exercise.setReplyTos(List.of(openBASConfig.getDefaultReplyTo()));
+        exercise.setReplyTos(new ArrayList<>(List.of(openBASConfig.getDefaultReplyTo())));
       }
     }
 
@@ -201,10 +201,6 @@ public class ExerciseService {
     List<Article> articles = exercise.getArticles();
     List<Inject> injects = exercise.getInjects();
     return documentService.getPlayerDocuments(articles, injects);
-  }
-
-  public boolean hasPendingResults(Exercise exercise) {
-    return exercise.getInjects().stream().anyMatch(injectService::hasPendingResults);
   }
 
   public Optional<Exercise> getFollowingSimulation(Exercise exercise) {
@@ -805,6 +801,10 @@ public class ExerciseService {
         .stream()
         .findFirst()
         .orElse(null);
+  }
+
+  public boolean isFinished(Exercise exercise) {
+    return ExerciseStatus.FINISHED.equals(exercise.getStatus());
   }
 
   public boolean isThereAScoreDegradation(

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectService.java
@@ -242,11 +242,6 @@ public class InjectService {
   }
 
   // -- ASSETS --
-
-  public boolean hasPendingResults(Inject inject) {
-    return inject.getExpectations().stream().anyMatch(ex -> ex.getResults().isEmpty());
-  }
-
   public List<AssetToExecute> resolveAllAssetsToExecute(@NotNull final Inject inject) {
     List<AssetToExecute> assetToExecutes = new ArrayList<>();
 

--- a/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
+++ b/openbas-api/src/main/java/io/openbas/scheduler/jobs/InjectsExecutionJob.java
@@ -20,6 +20,7 @@ import io.openbas.rest.inject.service.InjectService;
 import io.openbas.rest.inject.service.InjectStatusService;
 import io.openbas.scheduler.jobs.exception.ErrorMessagesPreExecutionException;
 import io.openbas.service.NotificationEventService;
+import io.openbas.service.SecurityCoverageSendJobService;
 import io.openbas.telemetry.metric_collectors.ActionMetricCollector;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
@@ -65,6 +66,7 @@ public class InjectsExecutionJob implements Job {
   private final io.openbas.executors.Executor executor;
   private final ActionMetricCollector actionMetricCollector;
   private final NotificationEventService notificationEventService;
+  private final SecurityCoverageSendJobService securityCoverageSendJobService;
 
   private final List<ExecutionStatus> executionStatusesNotReady =
       List.of(
@@ -116,6 +118,10 @@ public class InjectsExecutionJob implements Job {
                       exercise.setUpdatedAt(now());
                     })
                 .toList());
+
+    // maybe trigger stix coverage background job
+    securityCoverageSendJobService.createOrUpdateCoverageSendJobForSimulationsIfReady(
+        exercisesFinished);
 
     // send notification
     exercisesFinished.stream()

--- a/openbas-api/src/main/java/io/openbas/service/SecurityCoverageSendJobService.java
+++ b/openbas-api/src/main/java/io/openbas/service/SecurityCoverageSendJobService.java
@@ -84,7 +84,7 @@ public class SecurityCoverageSendJobService {
   private boolean shouldCreateCoverageSendJob(Exercise exercise) {
     return exercise != null
         && exercise.getSecurityCoverage() != null
-        && !exerciseService.hasPendingResults(exercise)
+        && exerciseService.isFinished(exercise)
         && exerciseService.getFollowingSimulation(exercise).isEmpty();
   }
 }

--- a/openbas-api/src/test/java/io/openbas/scheduler/jobs/InjectsExecutionJobTest.java
+++ b/openbas-api/src/test/java/io/openbas/scheduler/jobs/InjectsExecutionJobTest.java
@@ -1,52 +1,46 @@
 package io.openbas.scheduler.jobs;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.openbas.IntegrationTest;
 import io.openbas.database.model.*;
-import io.openbas.database.repository.ExerciseRepository;
 import io.openbas.database.repository.InjectRepository;
+import io.openbas.database.repository.SecurityCoverageSendJobRepository;
 import io.openbas.rest.exercise.service.ExerciseService;
 import io.openbas.utils.fixtures.*;
-import io.openbas.utils.fixtures.composers.AgentComposer;
-import io.openbas.utils.fixtures.composers.EndpointComposer;
-import io.openbas.utils.fixtures.composers.InjectComposer;
-import io.openbas.utils.fixtures.composers.InjectStatusComposer;
+import io.openbas.utils.fixtures.composers.*;
+import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.*;
 import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InjectsExecutionJobTest extends IntegrationTest {
 
   @Autowired private InjectsExecutionJob job;
 
   @Autowired private ExerciseService exerciseService;
-  @Autowired private ExerciseRepository exerciseRepository;
   @Autowired private InjectRepository injectRepository;
 
+  @Autowired private ExerciseComposer exerciseComposer;
   @Autowired private InjectComposer injectComposer;
   @Autowired private EndpointComposer endpointComposer;
   @Autowired private AgentComposer agentComposer;
   @Autowired private InjectStatusComposer injectStatusComposer;
-
-  static String EXERCISE_ID;
-
-  @AfterAll
-  public void teardown() {
-    this.exerciseRepository.deleteById(EXERCISE_ID);
-  }
+  @Autowired private EntityManager entityManager;
+  @Autowired private SecurityCoverageSendJobRepository securityCoverageSendJobRepository;
+  @Autowired private SecurityCoverageComposer securityCoverageComposer;
 
   @DisplayName("Not start children injects at the same time as parent injects")
   @Test
-  @Order(1)
   void given_cron_in_one_minute_should_not_start_children_injects() throws JobExecutionException {
     // -- PREPARE --
     Exercise exercise = ExerciseFixture.getExercise();
@@ -79,20 +73,24 @@ class InjectsExecutionJobTest extends IntegrationTest {
             .withDependsOn(injectParent)
             .persist()
             .get();
+    entityManager.flush();
+
     injectParent.setExercise(exerciseSaved);
     injectChildren.setExercise(exerciseSaved);
     injectParent.setStatus(null);
     injectChildren.setStatus(null);
-    exerciseSaved.setInjects(List.of(injectParent, injectChildren));
-    EXERCISE_ID = exerciseSaved.getId();
+    exerciseSaved.setInjects(new ArrayList<>(List.of(injectParent, injectChildren)));
+    String exerciseId = exerciseSaved.getId();
 
-    injectRepository.saveAll(List.of(injectParent, injectChildren));
-
+    injectRepository.saveAll(new ArrayList<>(List.of(injectParent, injectChildren)));
+    entityManager.flush();
     // -- EXECUTE --
     this.job.execute(null);
+    entityManager.flush();
+    entityManager.clear();
 
     // -- ASSERT --
-    List<Inject> injectsSaved = injectRepository.findByExerciseId(EXERCISE_ID);
+    List<Inject> injectsSaved = injectRepository.findByExerciseId(exerciseId);
     Optional<Inject> savedInjectParent =
         injectsSaved.stream()
             .filter(inject -> inject.getId().equals(injectParent.getId()))
@@ -101,7 +99,6 @@ class InjectsExecutionJobTest extends IntegrationTest {
         injectsSaved.stream()
             .filter(inject -> inject.getId().equals(injectChildren.getId()))
             .findFirst();
-
     // Checking that only the parent inject has a status
     assertTrue(savedInjectParent.isPresent());
     assertTrue(savedInjectChildren.isPresent());
@@ -110,5 +107,81 @@ class InjectsExecutionJobTest extends IntegrationTest {
     assertTrue(savedInjectChildren.get().getStatus().isEmpty());
 
     assertNotNull(savedInjectParent.get().getStatus().get().getName());
+  }
+
+  @Test
+  @DisplayName("When auto closing of stix-created simulation, trigger stix coverage job")
+  public void whenAutoClosingStixCreatedSimulation_TriggerStixCoverageJob()
+      throws JobExecutionException {
+    ExerciseComposer.Composer exerciseWrapper =
+        exerciseComposer
+            .forExercise(ExerciseFixture.createDefaultExercise())
+            .withSecurityCoverage(
+                securityCoverageComposer.forSecurityCoverage(
+                    SecurityCoverageFixture.createDefaultSecurityCoverage()))
+            .withInject(
+                injectComposer
+                    .forInject(InjectFixture.getDefaultInject())
+                    .withInjectStatus(
+                        injectStatusComposer.forInjectStatus(
+                            InjectStatusFixture.createSuccessStatus())))
+            .withInject(
+                injectComposer
+                    .forInject(InjectFixture.getDefaultInject())
+                    .withInjectStatus(
+                        injectStatusComposer.forInjectStatus(
+                            InjectStatusFixture.createSuccessStatus())));
+
+    injectComposer.generatedItems.forEach(
+        i -> i.setCollectExecutionStatus(CollectExecutionStatus.COMPLETED));
+    exerciseWrapper.get().setStatus(ExerciseStatus.RUNNING);
+    exerciseWrapper.persist();
+    entityManager.flush();
+
+    this.job.execute(null);
+    entityManager.flush();
+    entityManager.clear();
+
+    // assert
+    Optional<SecurityCoverageSendJob> job =
+        securityCoverageSendJobRepository.findBySimulation(exerciseWrapper.get());
+    assertThat(job).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "When auto closing of NON stix-created simulation, DOES NOT trigger stix coverage job")
+  public void whenAutoClosingNONStixCreatedSimulation_DoesNotTriggerStixCoverageJob()
+      throws JobExecutionException {
+    ExerciseComposer.Composer exerciseWrapper =
+        exerciseComposer
+            .forExercise(ExerciseFixture.createDefaultExercise())
+            .withInject(
+                injectComposer
+                    .forInject(InjectFixture.getDefaultInject())
+                    .withInjectStatus(
+                        injectStatusComposer.forInjectStatus(
+                            InjectStatusFixture.createSuccessStatus())))
+            .withInject(
+                injectComposer
+                    .forInject(InjectFixture.getDefaultInject())
+                    .withInjectStatus(
+                        injectStatusComposer.forInjectStatus(
+                            InjectStatusFixture.createSuccessStatus())));
+
+    injectComposer.generatedItems.forEach(
+        i -> i.setCollectExecutionStatus(CollectExecutionStatus.COMPLETED));
+    exerciseWrapper.get().setStatus(ExerciseStatus.RUNNING);
+    exerciseWrapper.persist();
+    entityManager.flush();
+
+    this.job.execute(null);
+    entityManager.flush();
+    entityManager.clear();
+
+    // assert
+    Optional<SecurityCoverageSendJob> job =
+        securityCoverageSendJobRepository.findBySimulation(exerciseWrapper.get());
+    assertThat(job).isEmpty();
   }
 }

--- a/openbas-api/src/test/java/io/openbas/service/SecurityCoverageSendJobServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/SecurityCoverageSendJobServiceTest.java
@@ -3,10 +3,7 @@ package io.openbas.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.openbas.IntegrationTest;
-import io.openbas.database.model.Exercise;
-import io.openbas.database.model.InjectExpectation;
-import io.openbas.database.model.InjectExpectationResult;
-import io.openbas.database.model.SecurityCoverageSendJob;
+import io.openbas.database.model.*;
 import io.openbas.database.repository.SecurityCoverageSendJobRepository;
 import io.openbas.utils.fixtures.*;
 import io.openbas.utils.fixtures.composers.*;
@@ -114,9 +111,10 @@ public class SecurityCoverageSendJobServiceTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("Adding final result to expectation triggers coverage job")
-  public void addingFinalResultDoesTriggerCoverageJob() {
+  @DisplayName("Adding result to expectation of finished simulation triggers coverage job again")
+  public void addingResultToFinishedSimulationDoesTriggerCoverageJobAgain() {
     ExerciseComposer.Composer exerciseWrapper = createExerciseWrapper();
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     injectExpectationComposer.generatedItems.forEach(
         exp ->

--- a/openbas-api/src/test/java/io/openbas/service/SecurityCoverageServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/service/SecurityCoverageServiceTest.java
@@ -87,6 +87,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                         attackPatternWrappers.keySet().stream()
                             .map(AttackPatternComposer.Composer::get)
                             .toList())));
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     for (Map.Entry<AttackPatternComposer.Composer, java.lang.Boolean> apw :
         attackPatternWrappers.entrySet()) {
@@ -180,6 +181,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
     // create exercise cover all TTPs
     ExerciseComposer.Composer exerciseWrapper =
         createExerciseWrapperWithInjectsForAttackPatterns(Map.of(ap1, true, ap2, true));
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     // set SUCCESS results for all inject expectations
     injectExpectationComposer.generatedItems.forEach(
@@ -333,6 +335,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
     // create exercise cover all TTPs
     ExerciseComposer.Composer exerciseWrapper =
         createExerciseWrapperWithInjectsForAttackPatterns(Map.of(ap1, true, ap2, true));
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     // expectation results
     Inject successfulInject =
@@ -514,6 +517,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
     // create exercise cover all TTPs
     ExerciseComposer.Composer exerciseWrapper =
         createExerciseWrapperWithInjectsForAttackPatterns(Map.of(ap1, true));
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     // set SUCCESS results for all inject expectations
     Inject successfulInject =
@@ -684,6 +688,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
     Instant sroStartTime = Instant.parse("2003-02-15T19:45:02Z");
     Instant sroStopTime = Instant.parse("2003-02-16T16:00:00Z");
     exerciseWrapper.get().setStart(sroStartTime);
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     // persist
     exerciseWrapper.persist();

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectStatusFixture.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/InjectStatusFixture.java
@@ -47,4 +47,8 @@ public class InjectStatusFixture {
   public static InjectStatus createQueuingInjectStatus() {
     return createInjectStatus(ExecutionStatus.QUEUING);
   }
+
+  public static InjectStatus createSuccessStatus() {
+    return createInjectStatus(ExecutionStatus.SUCCESS);
+  }
 }

--- a/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/InjectComposer.java
+++ b/openbas-api/src/test/java/io/openbas/utils/fixtures/composers/InjectComposer.java
@@ -116,7 +116,7 @@ public class InjectComposer extends ComposerBase<Inject> {
       injectDependencyId.setInjectParent(injectParent);
       injectDependencyId.setInjectChildren(this.inject);
       injectDependency.setCompositeId(injectDependencyId);
-      this.inject.setDependsOn(List.of(injectDependency));
+      this.inject.setDependsOn(new ArrayList<>(List.of(injectDependency)));
       return this;
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add trigger for creating stix coverage bundle at end of simulation

### Testing Instructions

1. Import stix bundle; it creates a scenario
2. Run simulation from scenario
3. When simulation attains the "FINISHED" status, a stix coverage job is create
4. Shortly after that, a coverage is produced 

### Related issues

* Contributes to #3707

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
