### PR TITLE
[frontend]: change xtmhub dot color and link depending on registration

### DIFF
--- a/openbas-front/src/admin/components/nav/TopBar.tsx
+++ b/openbas-front/src/admin/components/nav/TopBar.tsx
@@ -172,6 +172,21 @@ const TopBar: FunctionComponent = () => {
   const [searchParams] = useSearchParams();
   const [search] = searchParams.getAll('search');
 
+  const xtmhubBadgeImg = (
+    <img
+      style={{
+        width: '100%',
+        paddingRight: theme.spacing(2),
+        paddingLeft: theme.spacing(2),
+      }}
+      src={theme.palette.mode === 'dark' ? xtmhubDark : xtmhubLight}
+      alt="XTM Hub"
+    />
+  );
+  const shouldXtmHubRedirectToSite = !isHubRegistrationEnabled
+    || settings.xtm_hub_registration_status === 'registered'
+    || !ability.can(ACTIONS.MANAGE, SUBJECTS.PLATFORM_SETTINGS);
+
   return (
     <AppBar
       position="fixed"
@@ -249,43 +264,25 @@ const TopBar: FunctionComponent = () => {
                 <Grid container spacing={3}>
                   <Grid size={12}>
                     <Tooltip title="XTM Hub">
-                      { !isHubRegistrationEnabled
-                        || settings.xtm_hub_registration_status === 'registered'
-                        || !ability.can(ACTIONS.MANAGE, SUBJECTS.PLATFORM_SETTINGS) ? (
-                            <a
-                              className={classes.xtmItem}
-                              href={settings.xtm_hub_enable && settings.xtm_hub_url ? settings.xtm_hub_url : 'https://hub.filigran.io'}
-                              target="_blank"
-                              rel="noreferrer"
-                              onClick={handleCloseXtm}
-                            >
-                              <Badge variant="dot" color={!isHubRegistrationEnabled || settings.xtm_hub_registration_status === 'registered' ? 'success' : 'warning'}>
-                                <img
-                                  style={{
-                                    width: '100%',
-                                    paddingRight: theme.spacing(2),
-                                    paddingLeft: theme.spacing(2),
-                                  }}
-                                  src={theme.palette.mode === 'dark' ? xtmhubDark : xtmhubLight}
-                                  alt="XTM Hub"
-                                />
-                              </Badge>
-                            </a>
-                          ) : (
-                            <Link className={classes.xtmItem} to="/admin/settings/experience" onClick={handleCloseXtm}>
-                              <Badge variant="dot" color="warning">
-                                <img
-                                  style={{
-                                    width: '100%',
-                                    paddingRight: theme.spacing(2),
-                                    paddingLeft: theme.spacing(2),
-                                  }}
-                                  src={theme.palette.mode === 'dark' ? xtmhubDark : xtmhubLight}
-                                  alt="XTM Hub"
-                                />
-                              </Badge>
-                            </Link>
-                          )}
+                      { shouldXtmHubRedirectToSite ? (
+                        <a
+                          className={classes.xtmItem}
+                          href={settings.xtm_hub_enable && settings.xtm_hub_url ? settings.xtm_hub_url : 'https://hub.filigran.io'}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={handleCloseXtm}
+                        >
+                          <Badge variant="dot" color={!isHubRegistrationEnabled || settings.xtm_hub_registration_status === 'registered' ? 'success' : 'warning'}>
+                            {xtmhubBadgeImg}
+                          </Badge>
+                        </a>
+                      ) : (
+                        <Link className={classes.xtmItem} to="/admin/settings/experience" onClick={handleCloseXtm}>
+                          <Badge variant="dot" color="warning">
+                            {xtmhubBadgeImg}
+                          </Badge>
+                        </Link>
+                      )}
                     </Tooltip>
                   </Grid>
                   <Grid size={6}>


### PR DESCRIPTION

### Proposed changes

* Implement the same logic for the xtmhub link and dot color as in [opencti](https://github.com/OpenCTI-Platform/opencti/blob/43e87c32488891c17a57642d2d6017a25a773f9a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx#L407-L419):
> If the platform is registered on XTM Hub or the user does not have the rights to register a platform:
> - The link points to XTM Hub
> - The dot is green if the platform is registered, orange otherwise
>
> Otherwise:
> - The link redirects to the Filigran Experience page
> - The dot is orange
* if feature flag is not activated, keep the current behavior

### Testing Instructions

- Without feature flag `OPENAEV_REGISTRATION`
Clicking on xtmhub (in the top right menu with the 9 dots) must redirect to xtm hub, dot must be green

- With feature flag `OPENAEV_REGISTRATION`
  - with a user without `PLATFORM_SETTINGS` permission: 
    Clicking on xtmhub (in the top right menu with the 9 dots) must redirect to xtm hub, dot must be orange
  - with a user with `PLATFORM_SETTINGS` permission:
    - Click on xtmhub (in the top right menu with the 9 dots): 
      - dot must be orange
      - Filigran experience page must be opened
    - Register the platform in xtmhub
    - Click on xtmhub in the top right menu with the 9 dots:
      - dot must be green
      - xtmhub page must open  


### Related issues

* Closes #4017


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug


### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
