### PR TITLE
[frontend] RBAC: fix apply button permission

### DIFF
--- a/openbas-front/src/admin/components/lessons/scenarios/Lessons.tsx
+++ b/openbas-front/src/admin/components/lessons/scenarios/Lessons.tsx
@@ -7,7 +7,7 @@ import Transition from '../../../../components/common/Transition';
 import { useFormatter } from '../../../../components/i18n';
 import { type LessonsAnswer, type LessonsCategory, type LessonsQuestion, type LessonsTemplate, type Objective, type Team } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
-import { Can } from '../../../../utils/permissions/PermissionsProvider';
+import { AbilityContext, Can } from '../../../../utils/permissions/PermissionsProvider';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
 import { LessonContext, PermissionsContext } from '../../common/Context';
 import CreateLessonsTemplate from '../../components/lessons/CreateLessonsTemplate';
@@ -57,6 +57,8 @@ const Lessons: FunctionComponent<Props> = ({
   const [openEmptyLessons, setOpenEmptyLessons] = useState<boolean>(false);
   const [openAnonymize, setOpenAnonymize] = useState<boolean>(false);
   const [templateValue, setTemplateValue] = useState<string | null>(null);
+  const ability = useContext(AbilityContext);
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setTemplateValue(event.target.value);
   };
@@ -131,7 +133,7 @@ const Lessons: FunctionComponent<Props> = ({
               </Grid>
             )}
 
-            <Can I={ACTIONS.ACCESS} a={SUBJECTS.LESSONS_LEARNED}>
+            {(permissions.canManage && ability.can(ACTIONS.ACCESS, SUBJECTS.LESSONS_LEARNED)) && (
               <Grid size={{ xs: 6 }}>
                 <Typography variant="h3">{t('Template')}</Typography>
                 <Button
@@ -143,7 +145,7 @@ const Lessons: FunctionComponent<Props> = ({
                   {t('Apply')}
                 </Button>
               </Grid>
-            </Can>
+            )}
             <Grid size={{ xs: 6 }}>
               <Typography variant="h3">{t('Check')}</Typography>
               <Button

--- a/openbas-front/src/admin/components/lessons/simulations/Lessons.tsx
+++ b/openbas-front/src/admin/components/lessons/simulations/Lessons.tsx
@@ -27,7 +27,7 @@ import Transition from '../../../../components/common/Transition';
 import { useFormatter } from '../../../../components/i18n';
 import { type Inject, type LessonsAnswer, type LessonsCategory, type LessonsQuestion, type LessonsSendInput, type LessonsTemplate, type Objective, type Team, type User } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
-import { Can } from '../../../../utils/permissions/PermissionsProvider';
+import { AbilityContext, Can } from '../../../../utils/permissions/PermissionsProvider';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
 import { LessonContext, PermissionsContext } from '../../common/Context';
 import CreateLessonsTemplate from '../../components/lessons/CreateLessonsTemplate';
@@ -121,6 +121,8 @@ const Lessons: FunctionComponent<Props> = ({
   const [openAnonymize, setOpenAnonymize] = useState<boolean>(false);
   const [selectedQuestion, setSelectedQuestion] = useState<LessonsQuestion | null>(null);
   const [templateValue, setTemplateValue] = useState<string | null>(null);
+  const ability = useContext(AbilityContext);
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setTemplateValue(event.target.value);
   };
@@ -283,7 +285,7 @@ const Lessons: FunctionComponent<Props> = ({
                 />
               </Grid>
             )}
-            <Can I={ACTIONS.ACCESS} a={SUBJECTS.LESSONS_LEARNED}>
+            {(permissions.canManage && ability.can(ACTIONS.ACCESS, SUBJECTS.LESSONS_LEARNED)) && (
               <Grid size={{ xs: 6 }}>
                 <Typography variant="h3">{t('Template')}</Typography>
                 <Button
@@ -295,7 +297,7 @@ const Lessons: FunctionComponent<Props> = ({
                   {t('Apply')}
                 </Button>
               </Grid>
-            </Can>
+            )}
             <Grid size={{ xs: 6 }}>
               <Typography variant="h3">{t('Check')}</Typography>
               <Button


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Lesson learned "apply" button should only be displayed if the user has the write on the scenario/simulation, this PR is adding this check


### Testing Instructions

1. Create a user with access assesment + access lesson learned
2. Go to a "Lesson learned" tab in a scenario and simulation and verify that the "apply" button is not visible
3. Add the capa "Manage assessment" to the user
4. Verify that the appy button is now visible

### Related issues

* #375
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

