### PR TITLE
[backend/frontend] feature(xtmhub registration): add airgapped platforms check

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
+++ b/openbas-api/src/main/java/io/openbas/rest/settings/response/PlatformSettings.java
@@ -265,6 +265,10 @@ public class PlatformSettings {
   @Schema(description = "Url of XTM Hub")
   private String xtmHubUrl;
 
+  @JsonProperty("xtm_hub_reachable")
+  @Schema(description = "True if xtmhub backend is reachable")
+  private Boolean xtmHubReachable;
+
   @JsonProperty("xtm_hub_token")
   @Schema(description = "XTM Hub token")
   private String xtmHubToken;

--- a/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
+++ b/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
@@ -29,6 +29,7 @@ import io.openbas.rest.settings.form.*;
 import io.openbas.rest.settings.response.OAuthProvider;
 import io.openbas.rest.settings.response.PlatformSettings;
 import io.openbas.rest.stream.ai.AiConfig;
+import io.openbas.xtmhub.XtmHubConnectivityService;
 import io.openbas.xtmhub.XtmHubRegistrationStatus;
 import io.openbas.xtmhub.config.XTMHubConfig;
 import jakarta.annotation.Resource;
@@ -67,6 +68,7 @@ public class PlatformSettingsService {
   private final CalderaExecutorConfig calderaExecutorConfig;
   private final Ee eeService;
   private final EngineService engineService;
+  private final XtmHubConnectivityService xtmHubConnectivityService;
 
   @Value("${openbas.mail.imap.enabled}")
   private boolean imapEnabled;
@@ -310,6 +312,7 @@ public class PlatformSettingsService {
     // XTM Hub
     platformSettings.setXtmHubEnable(xtmHubConfig.getEnable());
     platformSettings.setXtmHubUrl(xtmHubConfig.getUrl());
+    platformSettings.setXtmHubReachable(xtmHubConnectivityService.isReachable());
     platformSettings.setXtmHubToken(getValueFromMapOfSettings(dbSettings, XTM_HUB_TOKEN.key()));
     platformSettings.setXtmHubRegistrationStatus(
         getValueFromMapOfSettings(dbSettings, XTM_HUB_REGISTRATION_STATUS.key()));

--- a/openbas-api/src/main/java/io/openbas/xtmhub/XtmHubConnectivityService.java
+++ b/openbas-api/src/main/java/io/openbas/xtmhub/XtmHubConnectivityService.java
@@ -1,0 +1,40 @@
+package io.openbas.xtmhub;
+
+import io.openbas.xtmhub.config.XTMHubConfig;
+import jakarta.annotation.PostConstruct;
+import java.net.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class XtmHubConnectivityService {
+  private final XTMHubConfig xtmHubConfig;
+
+  @Getter private boolean isReachable;
+
+  @PostConstruct
+  void init() {
+    this.isReachable = xtmHubConfig.getEnable() && checkIsReachable();
+  }
+
+  boolean checkIsReachable() {
+    HttpURLConnection connection = null;
+    try {
+      URI uri = new URI(xtmHubConfig.getApiUrl());
+      connection = (HttpURLConnection) uri.toURL().openConnection();
+      connection.setRequestMethod("HEAD");
+      connection.setConnectTimeout(5000);
+      connection.setReadTimeout(5000);
+      return HttpStatus.valueOf(connection.getResponseCode()).is2xxSuccessful();
+    } catch (Exception e) {
+      return false;
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+}

--- a/openbas-api/src/test/java/io/openbas/xtmhub/XtmHubConnectivityServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/xtmhub/XtmHubConnectivityServiceTest.java
@@ -1,0 +1,58 @@
+package io.openbas.xtmhub;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import io.openbas.xtmhub.config.XTMHubConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class XtmHubConnectivityServiceTest {
+  @Mock private XTMHubConfig xtmHubConfig;
+
+  private XtmHubConnectivityService createServiceWithMockedHttp() {
+    return mock(
+        XtmHubConnectivityService.class,
+        withSettings().useConstructor(xtmHubConfig).defaultAnswer(CALLS_REAL_METHODS));
+  }
+
+  @Test
+  void testInitWhenEnabledAndReachable() {
+    // Given
+    when(xtmHubConfig.getEnable()).thenReturn(true);
+    XtmHubConnectivityService service = createServiceWithMockedHttp();
+    doReturn(true).when(service).checkIsReachable();
+
+    service.init();
+
+    assertTrue(service.isReachable());
+  }
+
+  @Test
+  void testInitWhenEnabledButNotReachable() {
+    // Given
+    when(xtmHubConfig.getEnable()).thenReturn(true);
+    XtmHubConnectivityService service = createServiceWithMockedHttp();
+    doReturn(false).when(service).checkIsReachable();
+
+    service.init();
+
+    assertFalse(service.isReachable());
+  }
+
+  @Test
+  void testInitWhenDisabled() {
+    // Given
+    when(xtmHubConfig.getEnable()).thenReturn(false);
+    XtmHubConnectivityService service = createServiceWithMockedHttp();
+
+    service.init();
+
+    assertFalse(service.isReachable());
+    verify(service, never()).checkIsReachable();
+  }
+}

--- a/openbas-front/src/admin/components/scenarios/Scenarios.tsx
+++ b/openbas-front/src/admin/components/scenarios/Scenarios.tsx
@@ -23,6 +23,7 @@ import ItemTags from '../../../components/ItemTags';
 import PaginatedListLoader from '../../../components/PaginatedListLoader';
 import PlatformIcon from '../../../components/PlatformIcon';
 import { type FilterGroup, type Scenario, type SearchPaginationInput } from '../../../utils/api-types';
+import useAuth from '../../../utils/hooks/useAuth';
 import { Can } from '../../../utils/permissions/PermissionsProvider';
 import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
 import ImportFromHubButton from '../common/ImportFromHubButton';
@@ -52,6 +53,7 @@ const Scenarios = () => {
   const bodyItemsStyles = useBodyItemsStyles();
   const { t, nsdt } = useFormatter();
   const theme = useTheme();
+  const { isXTMHubAccessible } = useAuth();
 
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -192,9 +194,13 @@ const Scenarios = () => {
         queryableHelpers={queryableHelpers}
         topBarButtons={(
           <Box display="flex" gap={1}>
-            <Can I={ACTIONS.MANAGE} a={SUBJECTS.ASSESSMENT}>
-              <ImportFromHubButton serviceIdentifier="openaev_scenarios" />
-            </Can>
+            {
+              isXTMHubAccessible && (
+                <Can I={ACTIONS.MANAGE} a={SUBJECTS.ASSESSMENT}>
+                  <ImportFromHubButton serviceIdentifier="openaev_scenarios" />
+                </Can>
+              )
+            }
             <ToggleButtonGroup value="fake" exclusive>
               <ExportButton totalElements={queryableHelpers.paginationHelpers.getTotalElements()} exportProps={exportProps} />
               <Can I={ACTIONS.MANAGE} a={SUBJECTS.ASSESSMENT}>

--- a/openbas-front/src/admin/components/settings/experience/xtm_hub/XtmHubSettings.tsx
+++ b/openbas-front/src/admin/components/settings/experience/xtm_hub/XtmHubSettings.tsx
@@ -41,7 +41,7 @@ const XtmHubSettings: React.FC = () => {
           {t('XTM Hub')}
         </Typography>
         {
-          isXTMHubAccessible && (
+          isXTMHubAccessible && settings.xtm_hub_reachable && (
             <Can I={ACTIONS.MANAGE} a={SUBJECTS.PLATFORM_SETTINGS}>
               <XtmHubTab />
             </Can>

--- a/openbas-front/src/admin/components/settings/experience/xtm_hub/XtmHubSettings.tsx
+++ b/openbas-front/src/admin/components/settings/experience/xtm_hub/XtmHubSettings.tsx
@@ -6,6 +6,7 @@ import type { LoggedHelper } from '../../../../../actions/helper';
 import { useFormatter } from '../../../../../components/i18n';
 import { useHelper } from '../../../../../store';
 import type { PlatformSettings } from '../../../../../utils/api-types';
+import useAuth from '../../../../../utils/hooks/useAuth';
 import { Can } from '../../../../../utils/permissions/PermissionsProvider';
 import { ACTIONS, SUBJECTS } from '../../../../../utils/permissions/types';
 import XtmHubRegisteredSection from './XtmHubRegisteredSection';
@@ -14,6 +15,7 @@ import XtmHubUnregisteredSection from './XtmHubUnregisteredSection';
 const XtmHubSettings: React.FC = () => {
   const { t } = useFormatter();
   const theme = useTheme();
+  const { isXTMHubAccessible } = useAuth();
   const { settings }: { settings: PlatformSettings } = useHelper((helper: LoggedHelper) => ({ settings: helper.getPlatformSettings() }));
 
   const isXTMHubRegistered = settings?.xtm_hub_registration_status === 'registered' || settings?.xtm_hub_registration_status === 'lost_connectivity';
@@ -38,9 +40,13 @@ const XtmHubSettings: React.FC = () => {
         >
           {t('XTM Hub')}
         </Typography>
-        <Can I={ACTIONS.MANAGE} a={SUBJECTS.PLATFORM_SETTINGS}>
-          <XtmHubTab />
-        </Can>
+        {
+          isXTMHubAccessible && (
+            <Can I={ACTIONS.MANAGE} a={SUBJECTS.PLATFORM_SETTINGS}>
+              <XtmHubTab />
+            </Can>
+          )
+        }
       </div>
       <Paper
         style={{

--- a/openbas-front/src/root.tsx
+++ b/openbas-front/src/root.tsx
@@ -19,6 +19,7 @@ import { useHelper } from './store';
 import ErrorHandler from './utils/error/ErrorHandler';
 import { useAppDispatch } from './utils/hooks';
 import { UserContext } from './utils/hooks/useAuth';
+import useNetworkCheck from './utils/hooks/useCheckNetwork';
 import { PermissionsProvider } from './utils/permissions/PermissionsProvider';
 
 const RootPublic = lazy(() => import('./public/Root'));
@@ -47,11 +48,12 @@ const Root = () => {
     dispatch(fetchPlatformParameters());
   }, []);
 
+  const { isReachable } = useNetworkCheck(settings?.xtm_hub_url);
   if (R.isEmpty(logged)) {
     return <div />;
   }
 
-  if (!logged || !me || !settings) {
+  if (!logged || !me || !settings || isReachable === undefined) {
     return (
       <Suspense fallback={<Loader />}>
         <RootPublic />
@@ -64,6 +66,7 @@ const Root = () => {
         value={{
           me,
           settings,
+          isXTMHubAccessible: isReachable,
         }}
       >
         <StyledEngineProvider injectFirst>

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -4714,6 +4714,8 @@ export interface PlatformSettings {
   telemetry_manager_enable?: boolean;
   /** True if connection with XTM Hub is enabled */
   xtm_hub_enable?: boolean;
+  /** True if xtmhub backend is reachable */
+  xtm_hub_reachable?: boolean;
   /** XTM Hub registration date */
   xtm_hub_registration_date?: string;
   /** XTM Hub registration status */

--- a/openbas-front/src/utils/hooks/useAuth.ts
+++ b/openbas-front/src/utils/hooks/useAuth.ts
@@ -5,22 +5,25 @@ import { type PlatformSettings, type User } from '../api-types';
 export interface UserContextType {
   me: User | undefined;
   settings: PlatformSettings | undefined;
+  isXTMHubAccessible: boolean | undefined;
 }
 
 const defaultContext = {
   me: undefined,
   settings: undefined,
+  isXTMHubAccessible: undefined,
 };
 export const UserContext = createContext<UserContextType>(defaultContext);
 
 const useAuth = () => {
-  const { me, settings } = useContext(UserContext);
+  const { me, settings, isXTMHubAccessible } = useContext(UserContext);
   if (!me || !settings) {
     throw new Error('Invalid user context !');
   }
   return {
     me,
     settings,
+    isXTMHubAccessible,
   };
 };
 

--- a/openbas-front/src/utils/hooks/useCheckNetwork.tsx
+++ b/openbas-front/src/utils/hooks/useCheckNetwork.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+interface UseNetworkCheckResult { isReachable: boolean | undefined }
+
+const useNetworkCheck = (url?: string | null): UseNetworkCheckResult => {
+  const [isReachable, setIsReachable] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    if (!url) {
+      setIsReachable(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    fetch(url, {
+      method: 'HEAD',
+      mode: 'no-cors',
+      signal: controller.signal,
+    })
+      .then(() => setIsReachable(true))
+      .catch(() => setIsReachable(false))
+      .finally(() => clearTimeout(timeoutId));
+  }, [url]);
+
+  return { isReachable };
+};
+
+export default useNetworkCheck;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
We don't want to display 'Register in XTM Hub' or 'import from hub' buttons in case of air-gapped environment (same behavior as for opencti). 
* In the front end, add a hook to check the connectivity with xtmhub: if there is no connectivity, hide 'import from hub' and 'Register in XTM Hub' buttons. 
* In the backend, add a connectivity check to xtmhub backend, and return this value to the frontend in the platform settings. If there is no backend connectivity, hide the button to register the platform on the hub.

### Testing Instructions

- set `openbas.xtm.hub.url` to an invalid url (for example http://localhost:3008)
- activate feature flag `OPENAEV_REGISTRATION`
- on filigran experience page, check you don't see the 'Register in XTM Hub' button
- on scenario page, check you don't see the 'import from hub' button


### Related issues

* Closes #4036
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

For the backend connectivity check, I first wanted to use the `HttpClientFactory`, but with the `@PostConstruct`, I had some errors of  AsyncContext. So I used the java http client, as is done in [OpenTelemetryConfig](https://github.com/OpenAEV-Platform/openaev/blob/8ee7c601642e6f427e9e6c50ba9e527b432b01f3/openbas-api/src/main/java/io/openbas/telemetry/OpenTelemetryConfig.java#L123)
