### PR TITLE
[backend] allow updating contracts via API with passing external vuln IDs (#3334)

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/InjectorContractService.java
@@ -211,15 +211,8 @@ public class InjectorContractService {
     }
     injectorContract.setAttackPatterns(aps);
 
-    Set<Cve> vulns = new HashSet<>();
-    if (!input.getVulnerabilityExternalIds().isEmpty()) {
-      vulns =
-          cveService.findAllByExternalIdsOrThrowIfMissing(
-              new HashSet<>(input.getVulnerabilityExternalIds()));
-    } else if (!input.getVulnerabilityIds().isEmpty()) {
-      vulns = cveService.findAllByIdsOrThrowIfMissing(new HashSet<>(input.getVulnerabilityIds()));
-    }
-    injectorContract.setVulnerabilities(vulns);
+    setVulnerabilitiesFromExternalOrInternalIds(
+        input.getVulnerabilityExternalIds(), input.getVulnerabilityIds(), injectorContract);
 
     injectorContract.setInjector(
         updateRelation(input.getInjectorId(), injectorContract.getInjector(), injectorRepository));
@@ -236,10 +229,21 @@ public class InjectorContractService {
     injectorContract.setAttackPatterns(
         attackPatternService.findAllByInternalIdsThrowIfMissing(
             new HashSet<>(input.getAttackPatternsIds())));
-    injectorContract.setVulnerabilities(
-        cveService.findAllByIdsOrThrowIfMissing(new HashSet<>(input.getVulnerabilityIds())));
+    setVulnerabilitiesFromExternalOrInternalIds(
+        input.getVulnerabilityExternalIds(), input.getVulnerabilityIds(), injectorContract);
     injectorContract.setUpdatedAt(Instant.now());
     return injectorContractRepository.save(injectorContract);
+  }
+
+  private void setVulnerabilitiesFromExternalOrInternalIds(
+      List<String> externalIds, List<String> internalIds, InjectorContract injectorContract) {
+    Set<Cve> vulns = new HashSet<>();
+    if (!externalIds.isEmpty()) {
+      vulns = cveService.findAllByExternalIdsOrThrowIfMissing(new HashSet<>(externalIds));
+    } else if (!internalIds.isEmpty()) {
+      vulns = cveService.findAllByIdsOrThrowIfMissing(new HashSet<>(internalIds));
+    }
+    injectorContract.setVulnerabilities(vulns);
   }
 
   public InjectorContract updateAttackPatternMappings(

--- a/openbas-api/src/main/java/io/openbas/rest/injector_contract/form/InjectorContractUpdateInput.java
+++ b/openbas-api/src/main/java/io/openbas/rest/injector_contract/form/InjectorContractUpdateInput.java
@@ -25,6 +25,9 @@ public class InjectorContractUpdateInput {
   @JsonProperty("contract_vulnerability_ids")
   private List<String> vulnerabilityIds = new ArrayList<>();
 
+  @JsonProperty("contract_vulnerability_external_ids")
+  private List<String> vulnerabilityExternalIds = new ArrayList<>();
+
   @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("contract_content")
   private String content;

--- a/openbas-api/src/test/java/io/openbas/rest/injector_contract/InjectorContractApiTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/injector_contract/InjectorContractApiTest.java
@@ -352,7 +352,7 @@ public class InjectorContractApiTest extends IntegrationTest {
         assertThatJson(response)
             .node("injector_contract_attack_patterns")
             .isEqualTo(mapper.writeValueAsString(List.of(attackPatternWrapper.get().getId())));
-        // external iDs should override internal IDs as per consistency
+        // external iDs should override internal IDs for consistency
         assertThatJson(response)
             .node("injector_contract_vulnerabilities")
             .isEqualTo(mapper.writeValueAsString(List.of(otherVulnWrapper.get().getId())));

--- a/openbas-front/src/utils/api-types.d.ts
+++ b/openbas-front/src/utils/api-types.d.ts
@@ -3306,6 +3306,7 @@ export interface InjectorContractUpdateInput {
   contract_labels?: Record<string, string>;
   contract_manual?: boolean;
   contract_platforms?: string[];
+  contract_vulnerability_external_ids?: string[];
   contract_vulnerability_ids?: string[];
   is_atomic_testing?: boolean;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Allow passing external vuln IDs in the contract update input

### Testing Instructions

1. Use API to update injector contract and include `contract_vulnerability_external_ids` fileds with external vuln IDs set
2. related vulns are linked to contract

### Related issues

* Contributes to #3334

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
