### PR TITLE
[frontend] Taxonomies is available with access right

### DIFF
--- a/openbas-front/src/admin/components/nav/LeftBar.tsx
+++ b/openbas-front/src/admin/components/nav/LeftBar.tsx
@@ -208,14 +208,14 @@ const LeftBar = () => {
       ],
     },
     {
-      userRight: true,
+      userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS),
       items: [
         {
           path: `/admin/settings`,
           icon: () => (<SettingsOutlined />),
           label: 'Settings',
           href: 'settings',
-          userRight: true,
+          userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS),
           subItems: [
             {
               link: '/admin/settings/parameters',
@@ -235,7 +235,7 @@ const LeftBar = () => {
             {
               link: '/admin/settings/taxonomies',
               label: 'Taxonomies',
-              userRight: true,
+              userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS),
             },
             {
               link: '/admin/settings/data_ingestion',

--- a/openbas-front/src/admin/components/settings/Index.tsx
+++ b/openbas-front/src/admin/components/settings/Index.tsx
@@ -1,10 +1,7 @@
-import { useContext } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 
 import { errorWrapper } from '../../../components/Error';
 import NotFound from '../../../components/NotFound';
-import { AbilityContext } from '../../../utils/permissions/PermissionsProvider';
-import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
 import { isFeatureEnabled } from '../../../utils/utils';
 import AttackPatterns from './attack_patterns/AttackPatterns';
 import Cves from './cves/Cves';
@@ -21,11 +18,10 @@ import Users from './users/Users';
 
 const Index = () => {
   const isHubRegistrationEnabled = isFeatureEnabled('OPENAEV_REGISTRATION');
-  const ability = useContext(AbilityContext);
 
   return (
     <Routes>
-      <Route path="" element={<Navigate to={ability.can(ACTIONS.ACCESS, SUBJECTS.PLATFORM_SETTINGS) ? 'parameters' : 'taxonomies'} replace={true} />} />
+      <Route path="" element={<Navigate to="parameters" replace={true} />} />
       <Route path="parameters" element={errorWrapper(Parameters)()} />
       <Route path="security" element={<Navigate to="roles" replace={true} />} />
       <Route path="security/groups" element={errorWrapper(Groups)()} />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

All parameter menus should only be available to users with the access capability on Platform Settings. Without this capability, the user should not see any parameters menus, not even Taxonomies.

### Testing Instructions

1. Login to user without access right on platform settings
2. You should not have parameters on the left bar


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
