### PR TITLE
[frontend] List styles - Header titles should be in bold, not the content of the lists

### DIFF
--- a/openbas-front/src/components/common/pagination/SortHeadersComponent.tsx
+++ b/openbas-front/src/components/common/pagination/SortHeadersComponent.tsx
@@ -20,6 +20,7 @@ const useStyles = makeStyles()(() => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    fontWeight: '700',
   },
 }));
 

--- a/openbas-front/src/components/common/queryable/sort/SortHeadersComponentV2.tsx
+++ b/openbas-front/src/components/common/queryable/sort/SortHeadersComponentV2.tsx
@@ -13,11 +13,13 @@ const useStyles = makeStyles()(() => ({
     display: 'flex',
     cursor: 'pointer',
     alignItems: 'center',
+    fontWeight: '700',
   },
   headerItemText: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    fontWeight: '700',
   },
 }));
 

--- a/openbas-front/src/components/common/queryable/style/style.ts
+++ b/openbas-front/src/components/common/queryable/style/style.ts
@@ -12,7 +12,6 @@ const useBodyItemsStyles: () => {
       display: 'flex',
       flexWrap: 'nowrap',
       maxWidth: '100%',
-      fontWeight: '700',
     },
     bodyItem: {
       height: 20,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update list styles so that only the headers are bold, while the list content remains with normal font weight.

### Testing Instructions

1. Navigate to a list.
2. Verify that header titles (both sorted and unsorted) are displayed in bold.
3. Verify that list items are displayed in regular (non-bold) text.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
