### PR TITLE
[backend]RBAC remove user filter dashboard Issue/375 

### DIFF
--- a/openbas-model/src/main/java/io/openbas/service/ElasticService.java
+++ b/openbas-model/src/main/java/io/openbas/service/ElasticService.java
@@ -261,10 +261,12 @@ public class ElasticService implements EngineService {
       Map<String, CustomDashboardParameters> definitionParameters) {
     BoolQuery.Builder mainQuery = new BoolQuery.Builder();
     List<Query> mainMust = new ArrayList<>();
-    Query restrictionQuery = buildQueryRestrictions(user);
+    // TODO removing user specific restrictions -> issue/3768 will refactor this logic to have
+    // restriction based on markings
+    /*Query restrictionQuery = buildQueryRestrictions(user);
     if (restrictionQuery != null) {
       mainMust.add(restrictionQuery);
-    }
+    }*/
     BoolQuery.Builder dataQueryBuilder = new BoolQuery.Builder();
     List<Query> shouldList = new ArrayList<>();
     if (search != null) {

--- a/openbas-model/src/main/java/io/openbas/service/OpenSearchService.java
+++ b/openbas-model/src/main/java/io/openbas/service/OpenSearchService.java
@@ -321,10 +321,12 @@ public class OpenSearchService implements EngineService {
       Map<String, CustomDashboardParameters> definitionParameters) {
     BoolQuery.Builder mainQuery = new BoolQuery.Builder();
     List<Query> mainMust = new ArrayList<>();
-    Query restrictionQuery = buildQueryRestrictions(user);
+    // TODO removing user specific restrictions -> issue/3768 will refactor this logic to have
+    // restriction based on markings
+    /*Query restrictionQuery = buildQueryRestrictions(user);
     if (restrictionQuery != null) {
       mainMust.add(restrictionQuery);
-    }
+    }*/
     BoolQuery.Builder dataQueryBuilder = new BoolQuery.Builder();
     List<Query> shouldList = new ArrayList<>();
     if (search != null) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removing filtering on user grants in the dashboard
* The current implementation doesn't take into account capa, with the RBAC we decided that any user with the dashboard permission will see the same dashboard
* The filtering will be reimplemented with the markings (issue/3768)

### Testing Instructions

1. Create a dashboard with a count on injects executed 
2. Create a user with only bypass capa
3. Admin and user should see the same numbers 

### Related issues

* #375
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug


