### PR TITLE
[backend] fix: add transaction for all XTM Hub API calls

### DIFF
--- a/openbas-api/src/main/java/io/openbas/api/xtmhub/XtmHubApi.java
+++ b/openbas-api/src/main/java/io/openbas/api/xtmhub/XtmHubApi.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -33,6 +34,7 @@ public class XtmHubApi extends RestBehavior {
       description = "Save registration data into settings from XTM Hub registration")
   @ApiResponses({@ApiResponse(responseCode = "200", description = "Successful registration")})
   @RBAC(actionPerformed = Action.WRITE, resourceType = ResourceType.PLATFORM_SETTING)
+  @Transactional(rollbackFor = Exception.class)
   public PlatformSettings register(@Valid @RequestBody XtmHubRegisterInput input) {
     return this.xtmHubService.register(input.getToken());
   }
@@ -46,6 +48,7 @@ public class XtmHubApi extends RestBehavior {
       description = "Delete XTM Hub registration data from Settings.")
   @ApiResponses({@ApiResponse(responseCode = "200", description = "Successful unregistration")})
   @RBAC(actionPerformed = Action.WRITE, resourceType = ResourceType.PLATFORM_SETTING)
+  @Transactional(rollbackFor = Exception.class)
   public PlatformSettings unregister() {
     return this.xtmHubService.unregister();
   }
@@ -59,6 +62,7 @@ public class XtmHubApi extends RestBehavior {
       description = "Refresh status in settings and version in XTM Hub")
   @ApiResponses({@ApiResponse(responseCode = "200", description = "Successful refresh")})
   @RBAC(actionPerformed = Action.WRITE, resourceType = ResourceType.PLATFORM_SETTING)
+  @Transactional(rollbackFor = Exception.class)
   public PlatformSettings refreshConnectivity() {
     return this.xtmHubService.refreshConnectivity();
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add Transaction for all XTM Hub API calls to prevent concurrency error when updating settings

### Testing Instructions

Testing is only possible on prerelease because it works on other environments

1. Try to register and unregister from XTM Hub
2. Unregistration should not timeout

### Related issues


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
