### PR TITLE
[backend] Allowing to update a status to ERROR with action COMPLETE Issue/4096

### DIFF
--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectStatusService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectStatusService.java
@@ -160,8 +160,7 @@ public class InjectStatusService {
   protected void computeExecutionTraceStatusIfNeeded(
       InjectStatus injectStatus, ExecutionTrace executionTrace, Agent agent) {
 
-    // if the execution trace is COMPLETED with a status different than INFO we need don't to
-    // compute
+    // if the execution trace is COMPLETED with a status different than INFO -> no compute
     if (agent != null
         && executionTrace.getAction().equals(ExecutionTraceAction.COMPLETE)
         && ExecutionTraceStatus.INFO.equals(executionTrace.getStatus())) {

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectStatusService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectStatusService.java
@@ -164,7 +164,6 @@ public class InjectStatusService {
     // compute
     if (agent != null
         && executionTrace.getAction().equals(ExecutionTraceAction.COMPLETE)
-        && executionTrace.getStatus() != null
         && ExecutionTraceStatus.INFO.equals(executionTrace.getStatus())) {
       ExecutionTraceStatus traceStatus =
           convertExecutionStatus(

--- a/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectStatusService.java
+++ b/openbas-api/src/main/java/io/openbas/rest/inject/service/InjectStatusService.java
@@ -4,6 +4,7 @@ import static io.openbas.utils.ExecutionTraceUtils.convertExecutionAction;
 import static io.openbas.utils.ExecutionTraceUtils.convertExecutionStatus;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import io.openbas.aop.lock.Lock;
 import io.openbas.aop.lock.LockResourceType;
 import io.openbas.database.model.*;
@@ -155,9 +156,16 @@ public class InjectStatusService {
     return ExecutionTrace.from(base, structuredOutput);
   }
 
-  private void computeExecutionTraceStatusIfNeeded(
+  @VisibleForTesting
+  protected void computeExecutionTraceStatusIfNeeded(
       InjectStatus injectStatus, ExecutionTrace executionTrace, Agent agent) {
-    if (agent != null && executionTrace.getAction().equals(ExecutionTraceAction.COMPLETE)) {
+
+    // if the execution trace is COMPLETED with a status different than INFO we need don't to
+    // compute
+    if (agent != null
+        && executionTrace.getAction().equals(ExecutionTraceAction.COMPLETE)
+        && executionTrace.getStatus() != null
+        && ExecutionTraceStatus.INFO.equals(executionTrace.getStatus())) {
       ExecutionTraceStatus traceStatus =
           convertExecutionStatus(
               computeStatus(

--- a/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectStatusServiceTest.java
+++ b/openbas-api/src/test/java/io/openbas/rest/inject/service/InjectStatusServiceTest.java
@@ -1,0 +1,104 @@
+package io.openbas.rest.inject.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.openbas.database.model.*;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class InjectStatusServiceTest {
+
+  @InjectMocks private InjectStatusService injectStatusService;
+
+  @Test
+  public void givenExecutionTraceIsCompleteError_whenComputing_thenTrace_isCompleteError() {
+    // given
+    Agent agent = new Agent();
+    ExecutionTrace executionTrace = new ExecutionTrace();
+    executionTrace.setStatus(ExecutionTraceStatus.ERROR);
+    executionTrace.setAction(ExecutionTraceAction.COMPLETE);
+    executionTrace.setAgent(agent);
+
+    // traces:
+    ExecutionTrace executionTrace1 = new ExecutionTrace();
+    executionTrace1.setStatus(ExecutionTraceStatus.INFO);
+    executionTrace1.setAction(ExecutionTraceAction.START);
+    executionTrace1.setAgent(agent);
+    ExecutionTrace executionTrace2 = new ExecutionTrace();
+    executionTrace2.setStatus(ExecutionTraceStatus.SUCCESS);
+    executionTrace2.setAction(ExecutionTraceAction.EXECUTION);
+    executionTrace2.setAgent(agent);
+    InjectStatus injectStatus = new InjectStatus();
+    injectStatus.setTraces(List.of(executionTrace1, executionTrace2));
+
+    // when
+    injectStatusService.computeExecutionTraceStatusIfNeeded(injectStatus, executionTrace, agent);
+
+    // then
+    assertEquals(ExecutionTraceStatus.ERROR, executionTrace.getStatus());
+    assertEquals(ExecutionTraceAction.COMPLETE, executionTrace.getAction());
+  }
+
+  @Test
+  public void
+      givenExecutionTraceIsCompleteInfoAndNoError_whenComputing_thenTrace_isCompleteSuccess() {
+    // given
+    Agent agent = new Agent();
+    ExecutionTrace executionTrace = new ExecutionTrace();
+    executionTrace.setStatus(ExecutionTraceStatus.INFO);
+    executionTrace.setAction(ExecutionTraceAction.COMPLETE);
+    executionTrace.setAgent(agent);
+
+    // traces:
+    ExecutionTrace executionTrace1 = new ExecutionTrace();
+    executionTrace1.setStatus(ExecutionTraceStatus.INFO);
+    executionTrace1.setAction(ExecutionTraceAction.START);
+    executionTrace1.setAgent(agent);
+    ExecutionTrace executionTrace2 = new ExecutionTrace();
+    executionTrace2.setStatus(ExecutionTraceStatus.SUCCESS);
+    executionTrace2.setAction(ExecutionTraceAction.EXECUTION);
+    executionTrace2.setAgent(agent);
+    InjectStatus injectStatus = new InjectStatus();
+    injectStatus.setTraces(List.of(executionTrace1, executionTrace2));
+
+    // when
+    injectStatusService.computeExecutionTraceStatusIfNeeded(injectStatus, executionTrace, agent);
+
+    // then
+    assertEquals(ExecutionTraceStatus.SUCCESS, executionTrace.getStatus());
+    assertEquals(ExecutionTraceAction.COMPLETE, executionTrace.getAction());
+  }
+
+  @Test
+  public void givenExecutionTraceIsCompleteInfoWithError_whenComputing_thenTrace_isCompleteError() {
+    // given
+    Agent agent = new Agent();
+    ExecutionTrace executionTrace = new ExecutionTrace();
+    executionTrace.setStatus(ExecutionTraceStatus.INFO);
+    executionTrace.setAction(ExecutionTraceAction.COMPLETE);
+    executionTrace.setAgent(agent);
+
+    // traces:
+    ExecutionTrace executionTrace1 = new ExecutionTrace();
+    executionTrace1.setStatus(ExecutionTraceStatus.INFO);
+    executionTrace1.setAction(ExecutionTraceAction.START);
+    executionTrace1.setAgent(agent);
+    ExecutionTrace executionTrace2 = new ExecutionTrace();
+    executionTrace2.setStatus(ExecutionTraceStatus.ERROR);
+    executionTrace2.setAction(ExecutionTraceAction.EXECUTION);
+    executionTrace2.setAgent(agent);
+    InjectStatus injectStatus = new InjectStatus();
+    injectStatus.setTraces(List.of(executionTrace1, executionTrace2));
+
+    // when
+    injectStatusService.computeExecutionTraceStatusIfNeeded(injectStatus, executionTrace, agent);
+
+    // then
+    assertEquals(ExecutionTraceStatus.ERROR, executionTrace.getStatus());
+    assertEquals(ExecutionTraceAction.COMPLETE, executionTrace.getAction());
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Allowing to update a status to ERROR with action COMPLETE: this will be used by the implant to mark the inject as complete and error when it crashes


### Testing Instructions

* Easier to test with the implant code associated -> put a "panic" in the implant code that should trigger this api call and update the status to error
* You could try to update an implant to Complete/Error with the API 

### Related issues

* Closes #4096
* Implant PR: https://github.com/OpenAEV-Platform/implant/pull/79

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [NA] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [X] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->


