### PR TITLE
[frontend]Align widgets margin with top items

### DIFF
--- a/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardReactLayout.tsx
+++ b/openbas-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardReactLayout.tsx
@@ -91,7 +91,7 @@ const CustomDashboardReactLayout: FunctionComponent<{
     <ReactGridLayout
       style={style}
       className="layout"
-      margin={[20, 20]}
+      margin={[0, 20]}
       rowHeight={50}
       cols={12}
       draggableCancel=".noDrag,.MuiAutocomplete-paper,.MuiModal-backdrop,.MuiPopover-paper,.MuiDialog-paper"


### PR DESCRIPTION
Current layout
<img width="768" height="325" alt="image" src="https://github.com/user-attachments/assets/56515d6c-5995-4879-9bd0-4d3821fc6980" />


New layout
<img width="764" height="315" alt="image" src="https://github.com/user-attachments/assets/f429fb0b-e3ee-4211-8522-4476c26463cc" />
