### PR TITLE
[backend] fix: flush and clear entity manager during settings save

### DIFF
--- a/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
+++ b/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
@@ -31,6 +31,8 @@ import io.openbas.xtmhub.XtmHubRegistererRecord;
 import io.openbas.xtmhub.XtmHubRegistrationStatus;
 import io.openbas.xtmhub.config.XtmHubConfig;
 import jakarta.annotation.Resource;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -55,6 +57,7 @@ public class PlatformSettingsService {
   public static final String THEME_TYPE_LIGHT = "light";
   public static final String THEME_TYPE_DARK = "dark";
 
+  @PersistenceContext private EntityManager entityManager;
   private final ApplicationContext context;
   private final Environment env;
   private final SettingRepository settingRepository;
@@ -575,7 +578,12 @@ public class PlatformSettingsService {
         });
 
     settingRepository.deleteAllById(delete);
+    entityManager.flush();
+
     settingRepository.saveAll(update);
+    entityManager.flush();
+
+    entityManager.clear();
 
     return findSettings();
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* flush and clear entity manager during XTM Hub data update

### Testing Instructions

1. Register and unregister XTM Hub

### Related issues

* Refers to #3905 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
