### PR TITLE
[backend] fix: fix optimistic lock error during xtmhub settings update

### DIFF
--- a/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
+++ b/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
@@ -534,56 +534,28 @@ public class PlatformSettingsService {
       Boolean shouldSendConnectivityEmail) {
     Map<String, Setting> dbSettings = mapOfSettings(fromIterable(this.settingRepository.findAll()));
 
+    Map<SettingKeys, String> xtmhubSettingsMap = new HashMap<>();
+    xtmhubSettingsMap.put(XTM_HUB_TOKEN, token);
+    xtmhubSettingsMap.put(XTM_HUB_REGISTRATION_DATE, registrationDate != null ? registrationDate.toString() : null);
+    xtmhubSettingsMap.put(XTM_HUB_REGISTRATION_STATUS, registrationStatus.label);
+    xtmhubSettingsMap.put(XTM_HUB_REGISTRATION_USER_ID, registerer != null ? registerer.id() : null);
+    xtmhubSettingsMap.put(XTM_HUB_REGISTRATION_USER_NAME, registerer != null ? registerer.name() : null);
+    xtmhubSettingsMap.put(XTM_HUB_LAST_CONNECTIVITY_CHECK, lastConnectivityCheck != null ? lastConnectivityCheck.toString() : null);
+    xtmhubSettingsMap.put(XTM_HUB_SHOULD_SEND_CONNECTIVITY_EMAIL, shouldSendConnectivityEmail != null ? shouldSendConnectivityEmail.toString() : null);
+
     List<Setting> settingsToSave = new ArrayList<>();
+    List<String> settingsIdsToDelete = new ArrayList<>();
 
-    settingsToSave.add(resolveFromMap(dbSettings, XTM_HUB_TOKEN.key(), token));
-    settingsToSave.add(
-        resolveFromMap(
-            dbSettings,
-            XTM_HUB_REGISTRATION_DATE.key(),
-            registrationDate != null ? registrationDate.toString() : null));
-    settingsToSave.add(
-        resolveFromMap(dbSettings, XTM_HUB_REGISTRATION_STATUS.key(), registrationStatus.label));
-    settingsToSave.add(
-        resolveFromMap(
-            dbSettings,
-            XTM_HUB_REGISTRATION_USER_ID.key(),
-            registerer != null ? registerer.id() : null));
-    settingsToSave.add(
-        resolveFromMap(
-            dbSettings,
-            XTM_HUB_REGISTRATION_USER_NAME.key(),
-            registerer != null ? registerer.name() : null));
-    settingsToSave.add(
-        resolveFromMap(
-            dbSettings,
-            XTM_HUB_LAST_CONNECTIVITY_CHECK.key(),
-            lastConnectivityCheck != null ? lastConnectivityCheck.toString() : null));
-    settingsToSave.add(
-        resolveFromMap(
-            dbSettings,
-            XTM_HUB_SHOULD_SEND_CONNECTIVITY_EMAIL.key(),
-            shouldSendConnectivityEmail != null ? shouldSendConnectivityEmail.toString() : null));
+    xtmhubSettingsMap.forEach((settingKey, value) -> {
+      if (value != null) {
+        settingsToSave.add(resolveFromMap(dbSettings, settingKey.key(), value));
+      } else if (dbSettings.get(settingKey.key()) != null) {
+        settingsIdsToDelete.add(dbSettings.get(settingKey.key()).getId());
+      }
+    });
 
-    List<Setting> update = new ArrayList<>();
-    List<String> delete = new ArrayList<>();
-
-    settingsToSave.forEach(
-        setting -> {
-          if (StringUtils.hasText(setting.getValue())) {
-            update.add(setting);
-          } else if (StringUtils.hasText(setting.getId())) {
-            delete.add(setting.getId());
-          }
-        });
-
-    settingRepository.deleteAllById(delete);
-    entityManager.flush();
-
-    settingRepository.saveAll(update);
-    entityManager.flush();
-
-    entityManager.clear();
+    settingRepository.deleteAllById(settingsIdsToDelete);
+    settingRepository.saveAll(settingsToSave);
 
     return findSettings();
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Don't update the entities before deleting them for xtmhub settings. This should allow to avoid the 'optimistic lock' exception when deleting the settings from DB when unregistering xtmhub


### Testing Instructions
We were not able to reproduce the issue on local/feature env, but we can check it still works. 
1. Register on xtmhub, check there is no error
2. Reload filgran experience page to make a connectivity check and ensure there is no error
3. Unregister xtmhub, check there is no error

### Related issues

* Closes #3958
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
