### PR TITLE
[backend] fix: optimistic lock error - use native delete query

### DIFF
--- a/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
+++ b/openbas-api/src/main/java/io/openbas/service/PlatformSettingsService.java
@@ -602,18 +602,19 @@ public class PlatformSettingsService {
             XTM_HUB_REGISTRATION_DATE.key(),
             XTM_HUB_REGISTRATION_STATUS.key(),
             XTM_HUB_REGISTRATION_USER_ID.key(),
+            XTM_HUB_REGISTRATION_USER_NAME.key(),
             XTM_HUB_LAST_CONNECTIVITY_CHECK.key(),
             XTM_HUB_SHOULD_SEND_CONNECTIVITY_EMAIL.key());
 
-    List<Setting> toDelete = new ArrayList<>();
+    List<String> toDelete = new ArrayList<>();
     keys.forEach(
         settingsKey -> {
           if (dbSettings.containsKey(settingsKey)) {
-            toDelete.add(dbSettings.get(settingsKey));
+            toDelete.add(dbSettings.get(settingsKey).getId());
           }
         });
 
-    this.settingRepository.deleteAll(toDelete);
+    this.settingRepository.deleteByIdsNative(toDelete);
     return findSettings();
   }
 

--- a/openbas-model/src/main/java/io/openbas/database/repository/SettingRepository.java
+++ b/openbas-model/src/main/java/io/openbas/database/repository/SettingRepository.java
@@ -2,11 +2,14 @@ package io.openbas.database.repository;
 
 import io.openbas.database.model.Setting;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +24,11 @@ public interface SettingRepository
 
   @Query(value = "SHOW server_version", nativeQuery = true)
   String getServerVersion();
+
+  @Modifying
+  @Query(value = "delete from parameters where parameter_id in :ids", nativeQuery = true)
+  @Transactional
+  void deleteByIdsNative(@Param("ids") List<String> ids);
 
   @Transactional
   void deleteByKeyIn(@NotNull final Collection<String> keys);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Use a native query to delete xtmhub  registration settings.

### Testing Instructions

We were not able to reproduce the issue on local/feature env, but we can check it still works.

1.Register on xtmhub, check there is no error
2.Reload filgran experience page to make a connectivity check and ensure there is no error
3.Unregister xtmhub, check there is no error

### Related issues

* Closes #3958 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
