### PR TITLE
[frontend] The label of payload command should not be an asterix

### DIFF
--- a/openaev-front/src/admin/components/payloads/form/CommandsFormTab.tsx
+++ b/openaev-front/src/admin/components/payloads/form/CommandsFormTab.tsx
@@ -119,7 +119,7 @@ const CommandsFormTab = ({ disabledPayloadType = false }: Props) => {
         <>
           <Typography variant="h5" marginTop={theme.spacing(3)}>{t('Attack command')}</Typography>
           <SelectFieldController name="command_executor" label={t('Executor')} items={executorsItems} required />
-          <TextFieldController variant="outlined" multiline rows={3} name="command_content" required />
+          <TextFieldController variant="outlined" multiline rows={3} name="command_content" />
         </>
       )}
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove the visual required in the command text field 

### Testing Instructions

1. Create new payload, navigate to command tab
2. The Command text field no longer displays an asterisk (*)
3. Try to create a payload with the command field left empty
4. The field is still "should not be empty"

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
