### PR TITLE
[backend] null check on SecurityCoverageConnector.getUrl() (#3705)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnector.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnector.java
@@ -30,6 +30,10 @@ public class SecurityCoverageConnector extends ConnectorBase {
 
   @Override
   public String getUrl() {
+    if (io.openaev.utils.StringUtils.isBlank(super.getUrl())) {
+      return null;
+    }
+
     String configuredStripped = StringUtils.stripEnd(super.getUrl(), "/");
     if (configuredStripped.endsWith("/%s".formatted(GRAPHQL_ENDPOINT_URI))) {
       return configuredStripped;

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -278,6 +278,11 @@ openaev.xtm.hub.collector.enable=false
 openaev.xtm.hub.collector.id=b402f1f5-29ba-4ee3-b366-f0467754cf4e
 #openaev.xtm.hub.collector.connectivity-check-interval=3600000
 
+# security coverage connector
+#openaev.xtm.opencti.connector.security-coverage.url=
+#openaev.xtm.opencti.connector.security-coverage.id=
+#openaev.xtm.opencti.connector.security-coverage.auth-token=
+
 # XLS Import
 openaev.xls.import.mail.enable=true
 openaev.xls.import.sms.enable=true

--- a/openaev-api/src/test/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnectorTest.java
@@ -13,8 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 public class SecurityCoverageConnectorTest extends IntegrationTest {
-  private static final Object NULL = null;
-
   @Nested
   @DisplayName("Remote URL override")
   public class RemoteUrlOverride {

--- a/openaev-api/src/test/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnectorTest.java
@@ -65,7 +65,7 @@ public class SecurityCoverageConnectorTest extends IntegrationTest {
       @Autowired private SecurityCoverageConnector connector;
 
       @Test
-      @DisplayName("it appends the graphql endpoint to the url")
+      @DisplayName("it is null")
       public void itAppendsTheGraphQLEndpointToTheURL() {
         assertThat(connector.getUrl()).isNull();
       }

--- a/openaev-api/src/test/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/opencti/connectors/impl/SecurityCoverageConnectorTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 public class SecurityCoverageConnectorTest extends IntegrationTest {
+  private static final Object NULL = null;
 
   @Nested
   @DisplayName("Remote URL override")
@@ -56,6 +57,19 @@ public class SecurityCoverageConnectorTest extends IntegrationTest {
       @DisplayName("it appends the graphql endpoint to the url")
       public void itAppendsTheGraphQLEndpointToTheURL() {
         assertThat(connector.getUrl()).isEqualTo("https://opencti/graphql");
+      }
+    }
+
+    @Nested
+    @SpringBootTest
+    @DisplayName("With OpenCTI URL not defined")
+    public class WithNullUrl {
+      @Autowired private SecurityCoverageConnector connector;
+
+      @Test
+      @DisplayName("it appends the graphql endpoint to the url")
+      public void itAppendsTheGraphQLEndpointToTheURL() {
+        assertThat(connector.getUrl()).isNull();
       }
     }
   }

--- a/openaev-api/src/test/java/io/openaev/opencti/connectors/service/OpenCTIConnectorServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/opencti/connectors/service/OpenCTIConnectorServiceTest.java
@@ -12,6 +12,7 @@ import io.openaev.opencti.client.mutations.RegisterConnector;
 import io.openaev.opencti.connectors.ConnectorBase;
 import io.openaev.utils.fixtures.opencti.ResponseFixture;
 import io.openaev.utils.fixtures.opencti.TestBeanConnector;
+import io.openaev.utils.mockConfig.WithMockSecurityCoverageConnectorConfig;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.*;
@@ -19,7 +20,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 
-// @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@WithMockSecurityCoverageConnectorConfig(
+    url = "some-url",
+    authToken = "68949a7b-c1c2-4649-b3de-7db804ba02bb",
+    id = "a0f2d50c-3712-47bd-8305-e2412769eb86")
 public class OpenCTIConnectorServiceTest extends IntegrationTest {
   @MockBean private OpenCTIClient mockOpenCTIClient;
   @Autowired OpenCTIConnectorService openCTIConnectorService;

--- a/openaev-api/src/test/resources/application.properties
+++ b/openaev-api/src/test/resources/application.properties
@@ -115,12 +115,6 @@ openaev.xtm.opencti.enable=false
 openaev.xtm.opencti.url=<opencti-url>
 openaev.xtm.opencti.token=<opencti-token>
 
-
-# security coverage connector
-openaev.xtm.opencti.connector.security-coverage.url=some-url
-openaev.xtm.opencti.connector.security-coverage.id=68949a7b-c1c2-4649-b3de-7db804ba02bb
-openaev.xtm.opencti.connector.security-coverage.auth-token=a0f2d50c-3712-47bd-8305-e2412769eb86
-
 # XTM Hub configuration
 openaev.xtm.hub.enable=false
 openaev.xtm.hub.url=<xtm-hub-url>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* missing null check on getUrl for when a connector is not configured

### Testing Instructions

1. Unconfigured connectors should not trigger NPE in background job

### Related issues

* Contributes to #3705

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
