### PR TITLE
[backend] Disable scheduling on tests

### DIFF
--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -248,7 +248,6 @@ spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=<username@mail.com>
 spring.mail.password=<password>
-openaev.listener.smtp.enabled=false
 # Extra mail configuration
 spring.mail.properties.mail.smtp.ssl.trust=*
 spring.mail.properties.mail.smtp.auth=true

--- a/openaev-api/src/test/java/io/openaev/service/SmtpServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/SmtpServiceTest.java
@@ -40,6 +40,7 @@ public class SmtpServiceTest {
 
     this.mailSender = Mockito.mock(JavaMailSenderImpl.class, Mockito.CALLS_REAL_METHODS);
     ReflectionTestUtils.setField(smtpService, "mailSender", mailSender);
+    ReflectionTestUtils.setField(smtpService, "enabled", true);
   }
 
   @Test

--- a/openaev-api/src/test/resources/application.properties
+++ b/openaev-api/src/test/resources/application.properties
@@ -81,6 +81,7 @@ spring.mail.properties.mail.smtp.ssl.trust=*
 spring.mail.properties.mail.smtp.ssl.enable=true
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+openaev.listener.smtp.enabled=false
 # IMAP Configuration
 openaev.mail.imap.enabled=false
 openaev.mail.imap.host=imap.mail.com


### PR DESCRIPTION
### Proposed changes

* Disable scheduling process on tests to avoid duplicate keys

### Testing Instructions

1. Try to launch the tests, they should not fail for duplicate key
