### PR TITLE
[frontend] Fix document argument name (#3949)

### DIFF
--- a/openaev-front/src/admin/components/payloads/PayloadComponent.tsx
+++ b/openaev-front/src/admin/components/payloads/PayloadComponent.tsx
@@ -96,6 +96,13 @@ const PayloadComponent: FunctionComponent<Props> = ({ selectedPayload, documents
     }
   };
 
+  const getArgumentContent = (argument: PayloadArgument): string => {
+    if (argument?.type === 'document' && documentsMap && documentsMap[argument.default_value]) {
+      return documentsMap[argument.default_value].document_name;
+    }
+    return argument.default_value;
+  };
+
   return (
     <div className={classes.payloadContainer}>
       <Typography variant="h2" gutterBottom>{selectedPayload?.payload_name}</Typography>
@@ -315,7 +322,7 @@ const PayloadComponent: FunctionComponent<Props> = ({ selectedPayload, documents
                               </TableCell>
                               <TableCell>
                                 <pre>
-                                  <ItemCopy content={argument.default_value} />
+                                  <ItemCopy content={getArgumentContent(argument)} />
                                 </pre>
                               </TableCell>
                             </TableRow>


### PR DESCRIPTION
### Proposed changes

* Display document name instead of his id on payloads arguments
<img width="931" height="560" alt="image" src="https://github.com/user-attachments/assets/0fba8427-5f99-4930-8613-15d985ffa9f1" />

### Testing Instructions

1. Create a payload with a document argument and save
2. Check for your payload details, document argument should display document name.
3. Check for payload details tab on inject details on scenario, should display document name

### Related issues

* Closes #3949 
