### PR TITLE
[frontend] allow hover and click on technical expectation result when successful (#4186)

### DIFF
--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationCard.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationCard.tsx
@@ -224,7 +224,6 @@ const InjectExpectationCard = ({ inject, injectExpectation, onUpdateInjectExpect
             <InjectExpectationResultList
               injectExpectationId={injectExpectation.inject_expectation_id}
               injectExpectationResults={injectExpectation.inject_expectation_results ?? []}
-              injectExpectationStatus={injectExpectation.inject_expectation_status}
               injectExpectationAgent={injectExpectation.inject_expectation_agent}
               injectorContractPayload={inject.inject_injector_contract?.injector_contract_payload}
               injectType={inject.inject_type}

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -28,7 +28,6 @@ import TargetResultAlertNumber from './TargetResultAlertNumber';
 interface Props {
   injectExpectationId: InjectExpectation['inject_expectation_id'];
   injectExpectationResults: InjectExpectationResult[];
-  injectExpectationStatus: InjectExpectation['inject_expectation_status'];
   injectExpectationAgent: InjectExpectation['inject_expectation_agent'];
   injectorContractPayload?: PayloadSimple;
   injectType: Inject['inject_type'];
@@ -40,7 +39,6 @@ interface Props {
 const InjectExpectationResultList = ({
   injectExpectationId,
   injectExpectationResults,
-  injectExpectationStatus,
   injectExpectationAgent,
   injectorContractPayload,
   injectType,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Can hover and click on technical expectation specific result anytime it is successful

### Testing Instructions

1. Setup at least two EDR collectors
2. Run an inject
3. One collector must pick up a successful result, the other _not_ 
4. Alert is reported in openaev for the first collector, and the other is still pending a result
5. Can click the alert

### Related issues

* Closes #4186

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
