### PR TITLE
[frontend] Fix documentation link

### DIFF
--- a/openaev-front/src/admin/components/common/healthchecks/Healthchecks.tsx
+++ b/openaev-front/src/admin/components/common/healthchecks/Healthchecks.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const Healthchecks = ({ healthchecks, scenarioId }: Props) => {
-  const documentationRootUrl = 'https://docs.openbas.io';
+  const documentationRootUrl = 'https://docs.openaev.io';
   const theme = useTheme();
   const navigate = useNavigate();
   const { t } = useFormatter();


### PR DESCRIPTION
### Proposed changes

* Use openaev link for documentation, instead of openbas

### Testing Instructions

1. Clic on an healthcheck with link redirection (SMTP,IMAP, missing collector, NMAP or Nuclei), and it should redirect to openaev documentation url