### PR TITLE
[frontend] - Detection Remediation: fix rules display when two requests are sent for two different collectors simultaneously — Atomic testing

### DIFF
--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
@@ -160,23 +160,18 @@ const AtomicTestingRemediations = () => {
   }, []);
 
   function addOrUpdateRemediation(newRemediation: DetectionRemediationOutput) {
-    if (detectionRemediations.length === 0) {
-      setDetectionRemediations([newRemediation]);
-    } else {
-      setDetectionRemediations((prev) => {
-        const index = prev.findIndex(item => item.detection_remediation_collector === newRemediation.detection_remediation_collector);
+    setDetectionRemediations((prev) => {
+      const index = prev.findIndex(item => item.detection_remediation_collector === newRemediation.detection_remediation_collector);
+      if (index === -1) {
+        return [...prev, newRemediation];
+      } else {
+        const update = [...prev];
+        update[index] = newRemediation;
+        return update;
+      }
+    },
+    );
 
-        if (index === -1) {
-          return [...prev, newRemediation];
-        } else {
-          const update = [...prev];
-          update[index].detection_remediation_values = newRemediation.detection_remediation_values;
-          update[index].detection_remediation_author_rule = newRemediation.detection_remediation_author_rule;
-          return update;
-        }
-      },
-      );
-    }
     let i = 0;
     const text = newRemediation.detection_remediation_values;
     const interval = setInterval(() => {
@@ -266,7 +261,9 @@ const AtomicTestingRemediations = () => {
                       </>
                     ) : (
                       activeCollectorRemediations.map((rem) => {
-                        const content = rem.detection_remediation_values?.trim();
+                        const content = (snapshot?.get(tabs[activeTab].collector_type)?.AIRules) != null
+                          ? (snapshot?.get(tabs[activeTab].collector_type)?.AIRules)
+                          : rem.detection_remediation_values?.trim();
 
                         return (
                           <div key={'paper.' + rem.detection_remediation_id}>
@@ -286,11 +283,11 @@ const AtomicTestingRemediations = () => {
                                       const collector = rem?.detection_remediation_collector;
                                       const entry = collector ? snapshot?.get?.(collector) : undefined;
                                       const aiRules = entry?.AIRules;
-                                      const isLoading = entry?.isLoading;
                                       let raw: string;
+
                                       if (typing) {
                                         raw = displayedText ?? '';
-                                      } else if (isLoading && aiRules != null) {
+                                      } else if (aiRules != null) {
                                         raw = String(aiRules);
                                       } else {
                                         raw = rem?.detection_remediation_values ?? '';


### PR DESCRIPTION
### Proposed changes

* fix display content if 2 collectors are call at the same time on the atomic testing remediation tab

### Testing Instructions

1. Launch the CrowdStrike and Splunk remediations at the same time.
2. After generation, only one collector’s rules are displayed.
3. You should see content for each collector without reloading the page.

### Related issues

* Closes #3668 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
