### PR TITLE
[backend] deal with case when MITRE ID is missing (#4348)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -130,13 +130,12 @@ public class SecurityCoverageService {
     securityCoverage.setScheduling(scheduling);
 
     // Period Start
-    String createdAt =
-        (String)
-            ((Dictionary)
-                    stixCoverageObj.getExtension(ExtendedProperties.OPENCTI_EXTENSION_DEFINITION))
-                .get(STIX_CREATED_AT)
-                .getValue();
-    securityCoverage.setPeriodStart(Instant.parse(createdAt));
+    Dictionary extensionObj =
+        (Dictionary) stixCoverageObj.getExtension(ExtendedProperties.OPENCTI_EXTENSION_DEFINITION);
+    if (extensionObj.has(STIX_CREATED_AT)) {
+      String createdAt = (String) extensionObj.get(STIX_CREATED_AT).getValue();
+      securityCoverage.setPeriodStart(Instant.parse(createdAt));
+    }
 
     securityCoverage.setContent(stixCoverageObj.toStix(objectMapper).toString());
     return save(securityCoverage);

--- a/openaev-api/src/main/java/io/openaev/utils/SecurityCoverageUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/SecurityCoverageUtils.java
@@ -51,11 +51,11 @@ public class SecurityCoverageUtils {
 
       if (ObjectTypes.ATTACK_PATTERN.toString().equals(stixType)) {
         if (obj.hasExtension(ExtendedProperties.MITRE_EXTENSION_DEFINITION)) {
-          refId =
-              (String)
-                  ((Dictionary) obj.getExtension(ExtendedProperties.MITRE_EXTENSION_DEFINITION))
-                      .get(CommonProperties.ID.toString())
-                      .getValue();
+          Dictionary extensionObj =
+              (Dictionary) obj.getExtension(ExtendedProperties.MITRE_EXTENSION_DEFINITION);
+          if (extensionObj.has(CommonProperties.ID.toString())) {
+            refId = (String) extensionObj.get(CommonProperties.ID.toString()).getValue();
+          }
         }
       } else if (obj.hasProperty(STIX_NAME)) {
         refId = (String) obj.getProperty(STIX_NAME).getValue();

--- a/openaev-api/src/test/resources/stix-bundles/security-coverage.json
+++ b/openaev-api/src/test/resources/stix-bundles/security-coverage.json
@@ -125,6 +125,31 @@
           "x_opencti_id": "50e82364-5bce-453e-9e79-b9743774d310",
           "x_opencti_type": "Vulnerability",
           "type": "vulnerability"
+        },
+        {
+          "aliases": [
+            "T1531"
+          ],
+          "confidence": 100,
+          "created": "2019-10-09T18:48:31.906Z",
+          "created_by_ref": "identity--be52eaf9-be82-46db-92b2-9e808fad3f86",
+          "description": "Non-MITRE attack pattern",
+          "id": "attack-pattern--c1fad538-bb66-4e3f-97f5-9a9a15fd34b1",
+          "modified": "2025-01-31T14:04:33.112Z",
+          "name": "Attack!",
+          "object_marking_refs": [
+            "marking-definition--5ec5c3bd-99b6-45c1-b47d-4a74661af0f1",
+            "marking-definition--d79c734e-0d18-405c-92f1-8b4ebb1a6e4f"
+          ],
+          "revoked": false,
+          "spec_version": "2.1",
+          "type": "attack-pattern",
+          "x_opencti_id": "1cd1b639-8b8a-4620-bc73-cfd6fdf0e588",
+          "x_opencti_type": "Attack-Pattern",
+          "extensions": {
+            "extension-definition--322b8f77-262a-4cb8-a915-1e441e00329b": {
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* `id` field may be absent from the extension object, leading to potential crash on stix ingestion
* added more has-checks where relevant

### Testing Instructions

1. Trigger coverage run similar to https://testing.octi.staging.filigran.io/dashboard/analyses/security_coverages/91ab680b-6d06-4c76-b806-d1734e087d0e


### Related issues

* Closes #4348

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
