### PR TITLE
[frontend] force https protocol by default if no one is set on links (#4262)

### DIFF
--- a/openaev-front/src/components/CKEditor.tsx
+++ b/openaev-front/src/components/CKEditor.tsx
@@ -193,6 +193,7 @@ const CKEditor = (props: CKEditorProps<ClassicEditor> & { toolbarDropdownSize?: 
   const config: EditorConfig = {
     ...CKEDITOR_DEFAULT_CONFIG,
     language: locale.slice(0, 2),
+    link: { defaultProtocol: 'https://' },
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Proposed changes

* On text areas, set by default the https protocol, if no one is provided on links, to avoid links failure when text is used for mail

### Testing Instructions

1. On mail inject, write a body with a link, without providing a protocol.
2. Added link should have https protocol by default.
3. Add a link and provide http protocol.
4. Added link should have http protocol.
5. Add a link with a mailto protocol.
6. Added link should have the mailto protocol.
7. Launch your Scenario/Simulation/Atomic Test to receive the mail.
8. Received mail should be well displayed on outlook mailbox.

### Related issues

* Closes #4262 
