### PR TITLE
[frontend] fix(frontend): fix timeline display when all teams is selected (#4021)

### DIFF
--- a/openaev-front/src/components/Timeline.tsx
+++ b/openaev-front/src/components/Timeline.tsx
@@ -99,7 +99,7 @@ const Timeline: FunctionComponent<Props> = ({ injects, onSelectInject, teams }) 
 
   // Retrieve data
   const getInjectsPerTeam = (teamId: string) => {
-    return injects.filter(i => i.inject_teams?.includes(teamId));
+    return injects.filter(i => i.inject_teams?.includes(teamId) || i.inject_all_teams);
   };
 
   const injectsPerTeam = R.mergeAll(


### PR DESCRIPTION
### Proposed changes

* Fix Timeline display for "All teams" injects

<img width="1502" height="565" alt="image" src="https://github.com/user-attachments/assets/84c53341-836e-4d38-b396-1b3c709ea662" />

### Testing Instructions

1. Create a injects with teams field, and select all teams toggle on it.
2. On "Animation" tab, you should see all teams with your inject, instead of a "No teams" line.

### Related issues

* Closes #4021 
