### PR TITLE
[frontend] fix(permissions): manage expectations (#3721)

### DIFF
--- a/openaev-front/src/admin/components/common/injects/expectations/InjectExpectations.tsx
+++ b/openaev-front/src/admin/components/common/injects/expectations/InjectExpectations.tsx
@@ -40,7 +40,8 @@ const InjectExpectations: FunctionComponent<InjectExpectationsProps> = ({
   const { t } = useFormatter();
   const { permissions, inherited_context } = useContext(PermissionsContext);
   const ability = useContext(AbilityContext);
-  const userCanAddExpectations = permissions.canManage || (inherited_context == INHERITED_CONTEXT.NONE && ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId));
+  const userCanAddExpectations = permissions.canManage || ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT)
+    || (inherited_context == INHERITED_CONTEXT.NONE && ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId));
 
   const [sortedExpectations, setSortedExpectations] = useState<ExpectationInput[]>([]);
   const [sortBy] = useState('expectation_name');
@@ -102,6 +103,7 @@ const InjectExpectations: FunctionComponent<InjectExpectationsProps> = ({
               <ExpectationPopover
                 index={idx}
                 expectation={expectation}
+                injectId={injectId}
                 handleUpdate={handleUpdateExpectation}
                 handleDelete={handleRemoveExpectation}
               />


### PR DESCRIPTION
### Proposed changes

* fix permissions to manage expectations 

### Testing Instructions

1. Create a new Atomic testing, 
2. Select an inject with at least 2 expectations
3. Remove 1 expectation and Save
4. Go to Configure of your new Atomic testing
5. You should see the same number of expectation 
6. Do it again with different User Access (Manage Assessment || Admin || Specific Ressource(Inject))

### Related issues

* Closes #3721 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
