### PR TITLE
[backend] fix(securitycoverage): convert coverage score in fractions to percentage points (#4390)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -463,7 +463,9 @@ public class SecurityCoverageService {
       List<InjectExpectationResultUtils.ExpectationResultsByType> coverageResults) {
     List<Complex<?>> coverageValues = new ArrayList<>();
     for (InjectExpectationResultUtils.ExpectationResultsByType result : coverageResults) {
-      CoverageResult cov = new CoverageResult(result.type().name(), result.getSuccessRate());
+      CoverageResult cov =
+          new CoverageResult(
+              result.type().name(), result.getSuccessRate() * 100); // force percentage points
       coverageValues.add(new Complex<>(cov));
     }
     return new io.openaev.stix.types.List<>(coverageValues);

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -170,7 +170,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
             injects.stream().map(Inject::getId).collect(Collectors.toSet()));
     return toList(
         results.stream()
-            .map(r -> new Complex<>(new CoverageResult(r.type().name(), r.getSuccessRate())))
+            .map(r -> new Complex<>(new CoverageResult(r.type().name(), r.getSuccessRate() * 100)))
             .toList());
   }
 
@@ -315,7 +315,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                             .getId()
                                             .getValue()
                                             .contains(securityPlatformWrapper.get().getId())
-                                        ? 1.0
+                                        ? 100.0
                                         : 0.0)),
                             new Complex<>(
                                 new CoverageResult(
@@ -324,7 +324,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                             .getId()
                                             .getValue()
                                             .contains(securityPlatformWrapper.get().getId())
-                                        ? 1.0
+                                        ? 100.0
                                         : 0.0))))));
         assertThatJson(actualSro.toStix(mapper))
             .whenIgnoringPaths(CommonProperties.ID.toString())
@@ -357,8 +357,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                     ExtendedProperties.COVERAGE.toString(),
                     toList(
                         List.of(
-                            new Complex<>(new CoverageResult("PREVENTION", 1.0)),
-                            new Complex<>(new CoverageResult("DETECTION", 1.0))))));
+                            new Complex<>(new CoverageResult("PREVENTION", 100.0)),
+                            new Complex<>(new CoverageResult("DETECTION", 100.0))))));
         assertThatJson(actualSro.toStix(mapper))
             .whenIgnoringPaths(CommonProperties.ID.toString())
             .isEqualTo(expectedSro.toStix(mapper));
@@ -429,7 +429,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                       ExtendedProperties.COVERED.toString(),
                       new io.openaev.stix.types.Boolean(true),
                       ExtendedProperties.COVERAGE.toString(),
-                      toList(List.of(new Complex<>(new CoverageResult("VULNERABILITY", 1.0))))));
+                      toList(List.of(new Complex<>(new CoverageResult("VULNERABILITY", 100.0))))));
           assertThatJson(actualSro.toStix(mapper))
               .whenIgnoringPaths(CommonProperties.ID.toString())
               .isEqualTo(expectedSro.toStix(mapper));
@@ -624,7 +624,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                           .getId()
                                           .getValue()
                                           .contains(securityPlatformWrapper.get().getId())
-                                      ? 0.5
+                                      ? 50.0
                                       : 0.0)),
                           new Complex<>(
                               new CoverageResult(
@@ -633,7 +633,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                           .getId()
                                           .getValue()
                                           .contains(securityPlatformWrapper.get().getId())
-                                      ? 0.5
+                                      ? 50.0
                                       : 0.0))))));
       assertThatJson(actualSro.toStix(mapper))
           .whenIgnoringPaths(CommonProperties.ID.toString())
@@ -668,11 +668,11 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                           new Complex<>(
                               new CoverageResult(
                                   "PREVENTION",
-                                  stixRef.getExternalRef().equals("T1234") ? 1.0 : 0.0)),
+                                  stixRef.getExternalRef().equals("T1234") ? 100.0 : 0.0)),
                           new Complex<>(
                               new CoverageResult(
                                   "DETECTION",
-                                  stixRef.getExternalRef().equals("T1234") ? 1.0 : 0.0))))));
+                                  stixRef.getExternalRef().equals("T1234") ? 100.0 : 0.0))))));
       assertThatJson(actualSro.toStix(mapper))
           .whenIgnoringPaths(CommonProperties.ID.toString())
           .isEqualTo(expectedSro.toStix(mapper));


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change reported coverage scores from fractions (0.0 - 1.0) to percentage points (0.0 - 100.0)

### Testing Instructions

1. Bring up two stacks: OCTI (+worker), OAEV
2. Create report in OCTI, add Attack Pattern to report
3. Configure OpenAEV Coverage connector in OpenAEV, link to OCTI server
4. Create taxonomy entry for the chosen Attack Pattern in 2/
5. Create payload linked to that taxonomy
6. Setup the `opencti` tag rule with an asset group containing endpoints compatible with payload from 5/
7. In OCTI report: Add Security Coverage
8. In OpenAEV: scenario is created, inject with payload created in 5/ is ready
9. Run Simulation; wait for inject to complete
10. Create manual security platform (easier than waiting for collectors)
11. Force results with manual security in inject expectations (both prevention and detection)
12. Wait for job to kick in and feed to OCTI (visible activity in OCTI worker)
13. Check results in OCTI security coverage
<img width="776" height="247" alt="image" src="https://github.com/user-attachments/assets/70f90e04-567f-4a80-bc8d-b4ab8642e1e9" />


### Related issues

* Closes #4390 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
