### PR TITLE
[frontend] fix(ui-improvement): animation drawer (#4267)

### DIFF
--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsSecurityPlatform.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/TargetResultsSecurityPlatform.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles()(() => ({ flexContainer: { display: 'flex' } }));
 interface Props {
   injectExpectation: InjectExpectationsStore;
   sourceId: string;
-  expectationResult: InjectExpectationResult;
+  expectationResult: InjectExpectationResult | null;
   open: boolean;
   handleClose: () => void;
 }
@@ -40,7 +40,7 @@ const TargetResultsSecurityPlatform: FunctionComponent<Props> = ({
     <Drawer
       open={open}
       handleClose={handleClose}
-      title={t(expectationResult.sourceName || '-')}
+      title={expectationResult ? t(expectationResult.sourceName || '-') : '-'}
     >
       <>
         <Typography variant="body1">

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationCard.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationCard.tsx
@@ -247,16 +247,14 @@ const InjectExpectationCard = ({ inject, injectExpectation, onUpdateInjectExpect
         text={t('Do you want to delete this expectation result?')}
         handleSubmit={onDelete}
       />
-      {selectedResult
-        && (
-          <TargetResultsSecurityPlatform
-            injectExpectation={injectExpectation}
-            sourceId={selectedResult?.sourceId ?? ''}
-            expectationResult={selectedResult}
-            open={openSecurityPlatform}
-            handleClose={onCloseSecurityPlatformResult}
-          />
-        )}
+      <TargetResultsSecurityPlatform
+        injectExpectation={injectExpectation}
+        sourceId={selectedResult?.sourceId ?? ''}
+        expectationResult={selectedResult}
+        open={openSecurityPlatform}
+        handleClose={onCloseSecurityPlatformResult}
+      />
+
     </>
   );
 };


### PR DESCRIPTION
### Proposed changes

* Generate drawer even if no data, the animation renderer isn't apply if the component are not generate. 
* NB: Can be open only if data (result expectation)

### Testing Instructions

1. Click on result with data 
2. Animation left to right should be display

### Related issues

* Closes #4267 
*

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

