### PR TITLE
[backend] fix(stix): fallback to name when external ID does not exist for TTP (#4428)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/SecurityCoverageUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/SecurityCoverageUtils.java
@@ -57,11 +57,13 @@ public class SecurityCoverageUtils {
             refId = (String) extensionObj.get(CommonProperties.ID.toString()).getValue();
           }
         }
-      } else if (obj.hasProperty(STIX_NAME)) {
+      }
+
+      if (obj.hasProperty(STIX_NAME) && StringUtils.isBlank(refId)) {
         refId = (String) obj.getProperty(STIX_NAME).getValue();
       }
 
-      if (refId != null) {
+      if (!StringUtils.isBlank(refId)) {
         String stixId = (String) obj.getProperty(CommonProperties.ID).getValue();
         if (stixId != null) {
           stixToRef.add(new StixRefToExternalRef(stixId, refId));

--- a/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
@@ -396,12 +396,15 @@ class StixApiTest extends IntegrationTest {
           .contains(OPENCTI_TAG_NAME);
 
       // -- ASSERT Security Coverage --
-      assertThat(createdScenario.getSecurityCoverage().getAttackPatternRefs()).hasSize(2);
+      assertThat(createdScenario.getSecurityCoverage().getAttackPatternRefs()).hasSize(3);
 
       StixRefToExternalRef stixRef1 =
           new StixRefToExternalRef("attack-pattern--a24d97e6-401c-51fc-be24-8f797a35d1f1", T_1531);
       StixRefToExternalRef stixRef2 =
           new StixRefToExternalRef("attack-pattern--033921be-85df-5f05-8bc0-d3d9fc945db9", T_1003);
+      StixRefToExternalRef stixRef3 =
+          new StixRefToExternalRef(
+              "attack-pattern--c1fad538-bb66-4e3f-97f5-9a9a15fd34b1", "Attack!");
 
       // -- Vulnerabilities --
       assertThat(createdScenario.getSecurityCoverage().getVulnerabilitiesRefs()).hasSize(1);
@@ -414,14 +417,14 @@ class StixApiTest extends IntegrationTest {
           createdScenario
               .getSecurityCoverage()
               .getAttackPatternRefs()
-              .containsAll(List.of(stixRef1, stixRef2)));
+              .containsAll(List.of(stixRef1, stixRef2, stixRef3)));
       assertThat(createdScenario.getSecurityCoverage().getVulnerabilitiesRefs())
           .containsAll(List.of(stixRefVuln));
       assertThat(createdScenario.getSecurityCoverage().getContent()).isNotBlank();
 
       // -- ASSERT Injects --
       Set<Inject> injects = injectRepository.findByScenarioId(scenarioId);
-      assertThat(injects).hasSize(3);
+      assertThat(injects).hasSize(4);
     }
 
     @Test
@@ -445,7 +448,7 @@ class StixApiTest extends IntegrationTest {
           .isEqualTo("Security Coverage Q3 2025 - Threat Report XYZ");
 
       Set<Inject> injects = injectRepository.findByScenarioId(createdScenario.getId());
-      assertThat(injects).hasSize(3);
+      assertThat(injects).hasSize(4);
 
       entityManager.flush();
       entityManager.clear();
@@ -467,7 +470,7 @@ class StixApiTest extends IntegrationTest {
           .isEqualTo("Security Coverage Q3 2025 - Threat Report XYZ");
       // ASSERT injects for updated stix
       injects = injectRepository.findByScenarioId(updatedScenario.getId());
-      assertThat(injects).hasSize(3);
+      assertThat(injects).hasSize(4);
     }
 
     @Test
@@ -490,7 +493,7 @@ class StixApiTest extends IntegrationTest {
           .isEqualTo("Security Coverage Q3 2025 - Threat Report XYZ");
 
       Set<Inject> injects = injectRepository.findByScenarioId(createdScenario.getId());
-      assertThat(injects).hasSize(3);
+      assertThat(injects).hasSize(4);
 
       // Push stix without object type attack-pattern
       String updatedResponse =
@@ -541,7 +544,7 @@ class StixApiTest extends IntegrationTest {
           .isEqualTo("Security Coverage Q3 2025 - Threat Report XYZ");
 
       Set<Inject> injects = injectRepository.findByScenarioId(createdScenario.getId());
-      assertThat(injects).hasSize(3);
+      assertThat(injects).hasSize(4);
 
       entityManager.flush();
       entityManager.clear();
@@ -595,7 +598,7 @@ class StixApiTest extends IntegrationTest {
           .isEqualTo("Security Coverage Q3 2025 - Threat Report XYZ");
 
       Set<Inject> injects = injectRepository.findByScenarioId(createdScenario.getId());
-      assertThat(injects).hasSize(3);
+      assertThat(injects).hasSize(4);
 
       // Push stix without object type attack-pattern
       String updatedResponse =


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fallback to the `name` property when external ID does not exist, for attack patterns

### Testing Instructions

1. In OCTI, create a report and include attack pattern specifcially without External ID (null)
2. Create the security coverage for it
3. In OpenAEV: there should be at least a placeholder inject in the created scenario, or
4. if the name matches an attack pattern taxonomy in OpenAEV AND there is an injector contract related to that taxonomy then there should be an actual inject in place.

### Related issues

* Closes #4428
* Closes #4403

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
