### PR TITLE
[backend] feat(simulations): fix never ending simulations when error on injects (#4353)

### DIFF
--- a/openaev-model/src/main/java/io/openaev/database/repository/ExerciseRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ExerciseRepository.java
@@ -45,10 +45,10 @@ public interface ExerciseRepository
       value =
           "select e.*, se.scenario_id from exercises e "
               + "left join injects as inject on e.exercise_id = inject.inject_exercise and inject.inject_enabled = 'true' "
-              + "left join injects_statuses as status on inject.inject_id = status.status_inject and status.status_name not in ('PENDING', 'QUEUING', 'EXECUTING')"
+              + "left join injects_statuses as status on inject.inject_id = status.status_inject and status.status_name not in ('DRAFT', 'PENDING', 'QUEUING', 'EXECUTING')"
               + "left join scenarios_exercises as se on e.exercise_id = se.exercise_id "
               + "where e.exercise_status = 'RUNNING' group by e.exercise_id, se.scenario_id having count(status) = count(inject) "
-              + "and count(inject) filter (where inject.inject_collect_status = 'COMPLETED' or status.status_name <> 'ERROR') = count(inject) filter (where status.status_name <> 'ERROR');",
+              + "and count(inject) filter (where inject.inject_collect_status = 'COMPLETED' and status.status_name <> 'ERROR') = count(inject) filter (where status.status_name <> 'ERROR');",
       nativeQuery = true)
   List<Exercise> thatMustBeFinished();
 


### PR DESCRIPTION
### Proposed changes

* Fix never ending simulations when one or more injects are in error

### Testing Instructions

1. Run a simulation with at least on inject in error, simulation should end

### Related issues

* Closes #4353
