### PR TITLE
[frontend] fix(bulk-injects): remove select all checkbox and add pagination (#4285)

### DIFF
--- a/openaev-front/src/admin/components/common/injects/CreateInject.tsx
+++ b/openaev-front/src/admin/components/common/injects/CreateInject.tsx
@@ -223,7 +223,6 @@ const CreateInject: FunctionComponent<Props> = ({
     deSelectedElements,
     selectAll,
     handleClearSelectedElements,
-    handleToggleSelectAll,
     onToggleEntity,
     numberOfSelectedElements,
   } = useEntityToggle<InjectorContractFullOutput>('injector_contract', contracts, queryableHelpers.paginationHelpers.getTotalElements());
@@ -266,18 +265,6 @@ const CreateInject: FunctionComponent<Props> = ({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     return onToggleEntity(currentEntity, event);
-  };
-
-  const injectIdsToProcess = (selectAll: boolean) => {
-    return selectAll
-      ? []
-      : Object.keys(selectedElements).filter(k => !Object.keys(deSelectedElements).includes(k));
-  };
-
-  const injectIdsToIgnore = (selectAll: boolean) => {
-    return selectAll
-      ? Object.keys(deSelectedElements)
-      : Object.keys(deSelectedElements).filter(k => !Object.keys(selectedElements).includes(k));
   };
 
   const onCreateAll = (result: {
@@ -374,11 +361,15 @@ const CreateInject: FunctionComponent<Props> = ({
         gridTemplateColumns: selectedContract ? `60% calc(40% - ${theme.spacing(2)})` : '1fr',
         gap: theme.spacing(2),
         overflow: 'hidden',
-        padding: `${theme.spacing(2.5)} 0 ${theme.spacing(2.5)} ${theme.spacing(2.5)}`,
+        padding: `${theme.spacing(2)} 0 ${theme.spacing(2.5)} ${theme.spacing(2.5)}`,
       }}
     >
       <>
-        <div style={{ overflowY: 'auto' }}>
+        <div style={{
+          overflowY: 'auto',
+          paddingTop: theme.spacing(0.5),
+        }}
+        >
           <PaginationComponentV2
             fetch={searchInjectorContracts}
             searchPaginationInput={searchPaginationInput}
@@ -386,7 +377,6 @@ const CreateInject: FunctionComponent<Props> = ({
             entityPrefix="injector_contract"
             availableFilterNames={availableFilterNames}
             queryableHelpers={queryableHelpers}
-            disablePagination
             attackPatterns={attackPatterns}
           />
           <List>
@@ -396,18 +386,7 @@ const CreateInject: FunctionComponent<Props> = ({
               style={{ paddingTop: 0 }}
               secondaryAction={<>&nbsp;</>}
             >
-              {!isAtomic && (
-                <ListItemIcon style={{ minWidth: 40 }}>
-                  <Checkbox
-                    edge="start"
-                    disableRipple
-                    checked={selectAll}
-                    onChange={handleToggleSelectAll}
-                    disabled={typeof handleToggleSelectAll !== 'function'}
-                  />
-                </ListItemIcon>
-              )}
-              <ListItemIcon style={{ minWidth: 56 }} />
+              <ListItemIcon style={{ minWidth: 90 }} />
               <ListItemText
                 primary={(
                   <SortHeadersComponentV2


### PR DESCRIPTION
### Proposed changes

* Today the selection process work as an include process only, or all the selection process in the platform work as an include process if the select all checkbox is unselected, and as an exclusion process if the select all check box is selected.
This process have to be implemented, but as a workaround, it have been decided to remove the possibility to select all items, and add the pagination to allow the user to select the injects he wants to create in bulk.
All the process have to be reviewed to implement the same process has the others, but this include to review the frontend and implement the backend route and method.

### Testing Instructions

1. Open the injects creation drawer, it should be possible to navigate in the pagination pages, and select the injects you want to create all them at once.

### Related issues

* Closes #4285 
