### PR TITLE
[backend] fix(inject): inject expectations with existing results are overwritten when expiration_time is set (#4532)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/expectation/ExpectationApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/expectation/ExpectationApi.java
@@ -54,6 +54,15 @@ public class ExpectationApi extends RestBehavior {
   @RBAC(actionPerformed = Action.READ, resourceType = ResourceType.SIMULATION)
   public List<InjectExpectation> getInjectExpectationsNotFilledAndNotExpired(
       @RequestParam(required = false, name = "expiration_time") final Integer expirationTime) {
+    if (expirationTime == null) {
+      return Stream.of(
+              injectExpectationService.manualExpectationsNotFill(),
+              injectExpectationService.preventionExpectationsNotFill(),
+              injectExpectationService.detectionExpectationsNotFill())
+          .flatMap(List::stream)
+          .toList();
+    }
+
     return Stream.of(
             injectExpectationService.manualExpectationsNotFillAndNotExpired(expirationTime),
             injectExpectationService.preventionExpectationsNotFillAndNotExpired(expirationTime),
@@ -87,6 +96,12 @@ public class ExpectationApi extends RestBehavior {
   public List<InjectExpectation> getInjectExpectationsAssetsNotFilledAndNotExpiredForSource(
       @PathVariable String sourceId,
       @RequestParam(required = false, name = "expiration_time") final Integer expirationTime) {
+    if (expirationTime == null) {
+      return Stream.concat(
+              injectExpectationService.preventionExpectationsNotFill(sourceId).stream(),
+              injectExpectationService.detectionExpectationsNotFill(sourceId).stream())
+          .toList();
+    }
     return Stream.concat(
             injectExpectationService
                 .preventionExpectationsNotFilledAndNotExpired(expirationTime, sourceId)

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -512,6 +512,14 @@ public class InjectExpectationService {
         .toList();
   }
 
+  public List<InjectExpectation> manualExpectationsNotFill() {
+    return this.injectExpectationRepository
+        .findAll(Specification.where(InjectExpectationSpecification.type(MANUAL)))
+        .stream()
+        .filter(e -> hasNoResults(e.getResults()))
+        .toList();
+  }
+
   public List<InjectExpectation> manualExpectationsNotFillAndNotExpired(
       @NotNull Integer expirationTime) {
     return expectationsNotFilledAndNotExpired(MANUAL, expirationTime);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Prevent inject expectations with existing results from being reprocessed when expiration_time is set.
* Centralize logic to apply both not expired and no result checks

### Testing Instructions

1. Create a simulation with 2 injects: one inject is correctly marked as prevented/detected, while the other is not (because Defender never actually caught it — which is expected).
2. Verify expectations with existing results are not updated

### Related issues

* Closes #4532 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
