### PR TITLE
[backend] fix: update stix test api (#4521)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
-import org.h2.schema.Domain;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -54,7 +53,6 @@ class StixApiTest extends IntegrationTest {
 
   public static final String T_1531 = "T1531";
   public static final String T_1003 = "T1003";
-  String stixModifiedDateForTesting = Instant.now().toString();
 
   @Resource protected ObjectMapper mapper;
   @Autowired private MockMvc mvc;
@@ -458,7 +456,7 @@ class StixApiTest extends IntegrationTest {
       entityManager.clear();
 
       String modifiedSecurityCoverage =
-          stixSecurityCoverage.replace("2025-08-04T14:00:00Z", stixModifiedDateForTesting);
+          stixSecurityCoverage.replace("2025-12-31T14:00:00Z", Instant.now().toString());
 
       // Push same stix in order to check the number of created injects
       String updatedResponse =
@@ -512,14 +510,11 @@ class StixApiTest extends IntegrationTest {
       entityManager.flush();
       entityManager.clear();
 
-      String modifiedSecurityCoverage =
-          stixSecurityCoverage.replace("2025-08-04T14:00:00Z", stixModifiedDateForTesting);
-
       // Push an old Stix
       mvc.perform(
               post(STIX_URI + "/process-bundle")
                   .contentType(MediaType.APPLICATION_JSON)
-                  .content(modifiedSecurityCoverage))
+                  .content(stixSecurityCoverage))
           .andExpect(status().isBadRequest());
     }
 
@@ -545,12 +540,14 @@ class StixApiTest extends IntegrationTest {
       Set<Inject> injects = injectRepository.findByScenarioId(createdScenario.getId());
       assertThat(injects).hasSize(4);
 
+      String modifiedSecurityCoverageWithoutTtps =
+          stixSecurityCoverageWithoutTtps.replace("2025-12-31T14:00:00Z", Instant.now().toString());
       // Push stix without object type attack-pattern
       String updatedResponse =
           mvc.perform(
                   post(STIX_URI + "/process-bundle")
                       .contentType(MediaType.APPLICATION_JSON)
-                      .content(stixSecurityCoverageWithoutTtps))
+                      .content(modifiedSecurityCoverageWithoutTtps))
               .andExpect(status().isOk())
               .andReturn()
               .getResponse()
@@ -599,12 +596,16 @@ class StixApiTest extends IntegrationTest {
       entityManager.flush();
       entityManager.clear();
 
+      String modifiedSecurityCoverageWithoutVulns =
+          stixSecurityCoverageWithoutVulns.replace(
+              "2025-12-31T14:00:00Z", Instant.now().toString());
+
       // Push stix without object type attack-pattern
       String updatedResponse =
           mvc.perform(
                   post(STIX_URI + "/process-bundle")
                       .contentType(MediaType.APPLICATION_JSON)
-                      .content(stixSecurityCoverageWithoutVulns))
+                      .content(modifiedSecurityCoverageWithoutVulns))
               .andExpect(status().isOk())
               .andReturn()
               .getResponse()
@@ -650,12 +651,15 @@ class StixApiTest extends IntegrationTest {
       Set<Inject> injects = injectRepository.findByScenarioId(createdScenario.getId());
       assertThat(injects).hasSize(4);
 
+      String modifiedSecurityCoverageWithoutObjects =
+          stixSecurityCoverageWithoutObjects.replace(
+              "2025-12-31T14:00:00Z", Instant.now().toString());
       // Push stix without object type attack-pattern
       String updatedResponse =
           mvc.perform(
                   post(STIX_URI + "/process-bundle")
                       .contentType(MediaType.APPLICATION_JSON)
-                      .content(stixSecurityCoverageWithoutObjects))
+                      .content(modifiedSecurityCoverageWithoutObjects))
               .andExpect(status().isOk())
               .andReturn()
               .getResponse()
@@ -812,7 +816,9 @@ class StixApiTest extends IntegrationTest {
       assertThat(injects.stream().findFirst().get().getAssets()).hasSize(3);
 
       stixSecurityCoverageOnlyVulnsWithUpdatedLabel =
-          stixSecurityCoverageOnlyVulns.replace("opencti", "empty-asset-groups");
+          stixSecurityCoverageOnlyVulns
+              .replace("opencti", "empty-asset-groups")
+              .replace("2025-12-31T14:00:00Z", Instant.now().toString());
 
       mvc.perform(
               post(STIX_URI + "/process-bundle")
@@ -854,7 +860,9 @@ class StixApiTest extends IntegrationTest {
       assertThat(inject.getAssets()).isEmpty();
 
       stixSecurityCoverageOnlyVulnsWithUpdatedLabel =
-          stixSecurityCoverageOnlyVulns.replace("opencti", "coverage");
+          stixSecurityCoverageOnlyVulns
+              .replace("opencti", "coverage")
+              .replace("2025-12-31T14:00:00Z", Instant.now().toString());
 
       mvc.perform(
               post(STIX_URI + "/process-bundle")
@@ -879,12 +887,13 @@ class StixApiTest extends IntegrationTest {
     @Test
     @DisplayName("Should not remove security coverage even if scenario is deleted")
     void shouldExistSecurityCoverage() throws Exception {
-
+      String modifiedSecurityCoverage =
+          stixSecurityCoverage.replace("2025-12-31T14:00:00Z", Instant.now().toString());
       String response =
           mvc.perform(
                   post(STIX_URI + "/process-bundle")
                       .contentType(MediaType.APPLICATION_JSON)
-                      .content(stixSecurityCoverage))
+                      .content(modifiedSecurityCoverage))
               .andExpect(status().isOk())
               .andReturn()
               .getResponse()

--- a/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
@@ -34,11 +34,13 @@ import jakarta.transaction.Transactional;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
+import org.h2.schema.Domain;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -52,6 +54,7 @@ class StixApiTest extends IntegrationTest {
 
   public static final String T_1531 = "T1531";
   public static final String T_1003 = "T1003";
+  String stixModifiedDateForTesting = Instant.now().toString();
 
   @Resource protected ObjectMapper mapper;
   @Autowired private MockMvc mvc;
@@ -455,7 +458,7 @@ class StixApiTest extends IntegrationTest {
       entityManager.clear();
 
       String modifiedSecurityCoverage =
-          stixSecurityCoverage.replace("2025-08-04T14:00:00Z", "2025-12-20T14:00:00Z");
+          stixSecurityCoverage.replace("2025-08-04T14:00:00Z", stixModifiedDateForTesting);
 
       // Push same stix in order to check the number of created injects
       String updatedResponse =
@@ -510,7 +513,7 @@ class StixApiTest extends IntegrationTest {
       entityManager.clear();
 
       String modifiedSecurityCoverage =
-          stixSecurityCoverage.replace("2025-12-31T14:00:00Z", "2025-12-10T13:00:00Z");
+          stixSecurityCoverage.replace("2025-08-04T14:00:00Z", stixModifiedDateForTesting);
 
       // Push an old Stix
       mvc.perform(


### PR DESCRIPTION
We use the field modified from Stix in order to know if this object has changed.
We will refact these test in other pr.