### PR TITLE
[backend] fix(stix): normalise platform affinity in tags (#4737)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/tag/TagService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/tag/TagService.java
@@ -41,7 +41,7 @@ public class TagService {
   }
 
   public Tag upsertTag(TagCreateInput input) {
-    Optional<Tag> tag = tagRepository.findByName(input.getName());
+    Optional<Tag> tag = tagRepository.findByName(input.getName().toLowerCase());
     if (tag.isPresent()) {
       return tag.get();
     } else {

--- a/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/stix_process/StixApiTest.java
@@ -8,6 +8,7 @@ import static io.openaev.utils.constants.StixConstants.STIX_PLATFORMS_AFFINITY;
 import static io.openaev.utils.fixtures.VulnerabilityFixture.CVE_2023_48788;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -776,6 +777,27 @@ class StixApiTest extends IntegrationTest {
       injects = injectRepository.findByScenarioId(scenario.getId());
       assertThat(injects).hasSize(1);
       assertThat(injects.stream().findFirst().get().getAssets()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Should normalise tag names from platform affinity")
+    void shouldNormaliseTagNamesFromPlatformAffinity() throws Exception {
+      String platformName = "Platform Name";
+      // create a tag for the security coverage
+      tagComposer
+          .forTag(TagFixture.getTagWithText("security coverage: %s".formatted(platformName)))
+          .persist();
+
+      JsonNode updated =
+          updateStixObjectField(
+              stixSecurityCoverageOnlyVulns,
+              STIX_PLATFORMS_AFFINITY,
+              null,
+              List.of(platformName),
+              0);
+
+      assertThatNoException()
+          .isThrownBy(() -> getScenarioIdResponse(mapper.writeValueAsString(updated)));
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Normalise platform affinity while collecting tags for scenario

### Testing Instructions

1. On OCTI, choose platform affinity with capital letters in the name
2. Make changes to created scenario so that it gets updated -> should be updated correctly
3. Tags should be current with OCTI scenario

### Related issues

* Closes #4737

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
