### PR TITLE
[backend] fix(rabbitmq): fixed a hardcoded string set to HTTP (#4468)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/helper/RabbitMQHelper.java
+++ b/openaev-api/src/main/java/io/openaev/helper/RabbitMQHelper.java
@@ -46,8 +46,9 @@ public class RabbitMQHelper {
     // If we already have the version, we don't need to get it again
     if (rabbitMQVersion == null && rabbitmqConfig.getHostname() != null) {
       // Init the rabbit MQ management api overview url
+      String protocol = rabbitmqConfig.isSsl() ? "https://" : "http://";
       String uri =
-          "http://"
+          protocol
               + rabbitmqConfig.getHostname()
               + ":"
               + rabbitmqConfig.getManagementPort()


### PR DESCRIPTION
### Proposed changes

* Use openaev.rabbitmq.ssl as basis to choose between http and https for rabbitmq's URL to fetch its version

### Testing Instructions

1. Setup your env with a non-SSL rabbitmq and set openaev.rabbitmq.ssl to false
2. Access the configuration page in the GUI, no error should happen.
3. Set openaev.rabbitmq.ssl to true, restart your backend
4. Access the configuration page in the GUI, an error should popup.
5. Do the same with an SSL rabbitms env

### Related issues

* Closes #4468 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug