### PR TITLE
[backend] feat(implant): prevent traces being too large (#4779)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegration.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegration.java
@@ -105,6 +105,7 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
     Map<String, String> commands = new HashMap<>();
     String tokenVar = "token=\"" + cfg.getAdminToken() + "\"";
     String serverVar = "server=\"" + cfg.getBaseUrlForAgent() + "\"";
+    String maxSizeVar = "max_size=\"" + cfg.getLogsMaxSize() + "\"";
     String unsecuredCertificateVar =
         "unsecured_certificate=\"" + cfg.isUnsecuredCertificate() + "\"";
     String withProxyVar = "with_proxy=\"" + cfg.isWithProxy() + "\"";
@@ -118,6 +119,8 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
             + unsecuredCertificateVar
             + ";$"
             + withProxyVar
+            + ";$"
+            + maxSizeVar
             + ";"
             + dlVar(cfg, "windows", "x86_64")
             + ";$wc=New-Object System.Net.WebClient;$data=$wc.DownloadData($url);[io.file]::WriteAllBytes($filename,$data) | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -Direction Inbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Start-Process -FilePath \"$location\\$filename\" -ArgumentList \"--uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject}\" -WindowStyle hidden;");
@@ -131,6 +134,8 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
             + unsecuredCertificateVar
             + ";$"
             + withProxyVar
+            + ";$"
+            + maxSizeVar
             + ";"
             + dlVar(cfg, "windows", "arm64")
             + ";$wc=New-Object System.Net.WebClient;$data=$wc.DownloadData($url);[io.file]::WriteAllBytes($filename,$data) | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -Direction Inbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Start-Process -FilePath \"$location\\$filename\" -ArgumentList \"--uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject}\" -WindowStyle hidden;");
@@ -144,6 +149,8 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
             + unsecuredCertificateVar
             + ";"
             + withProxyVar
+            + ";"
+            + maxSizeVar
             + ";curl -s -X GET "
             + dlUri(cfg, "linux", "x86_64")
             + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} &");
@@ -157,6 +164,8 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
             + unsecuredCertificateVar
             + ";"
             + withProxyVar
+            + ";"
+            + maxSizeVar
             + ";curl -s -X GET "
             + dlUri(cfg, "linux", "arm64")
             + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} &");
@@ -170,6 +179,8 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
             + unsecuredCertificateVar
             + ";"
             + withProxyVar
+            + ";"
+            + maxSizeVar
             + ";curl -s -X GET "
             + dlUri(cfg, "macos", "x86_64")
             + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} &");
@@ -183,6 +194,8 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
             + unsecuredCertificateVar
             + ";"
             + withProxyVar
+            + ";$"
+            + maxSizeVar
             + ";curl -s -X GET "
             + dlUri(cfg, "macos", "arm64")
             + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} &");

--- a/openaev-framework/src/main/java/io/openaev/config/OpenAEVConfig.java
+++ b/openaev-framework/src/main/java/io/openaev/config/OpenAEVConfig.java
@@ -120,6 +120,10 @@ public class OpenAEVConfig {
   @Value("${openbas.with-proxy:${openaev.with-proxy:false}}")
   private boolean withProxy;
 
+  @JsonProperty("max_size")
+  @Value("${openaev.implant-logs-max-size:1000000}")
+  private int logsMaxSize;
+
   @JsonProperty("extra_trusted_certs_dir")
   @Value("${openbas.extra-trusted-certs-dir:${openaev.extra-trusted-certs-dir:#{null}}}")
   private String extraTrustedCertsDir;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a safeguard for when execution logs are too big. 
* You can set up the max length in your application.properties

### Testing Instructions

1. Use a custom payload that generates a lot of logs like gci -Recurse
2. Check that it ends up in ERROR with the correct error message
3. Try again with a smaller payload and make sure it still works as usual


### Related issues

* Closes #4779 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
