### PR TITLE
[backend] fix(catalog): don't collate log lines from xtm composer (#1)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/xtm_composer/XtmComposerApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/xtm_composer/XtmComposerApi.java
@@ -6,7 +6,6 @@ import io.openaev.api.xtm_composer.dto.XtmComposerOutput;
 import io.openaev.api.xtm_composer.dto.XtmComposerRegisterInput;
 import io.openaev.api.xtm_composer.dto.XtmComposerUpdateStatusInput;
 import io.openaev.database.model.Action;
-import io.openaev.database.model.ConnectorInstanceLog;
 import io.openaev.database.model.ResourceType;
 import io.openaev.rest.connector_instance.dto.ConnectorInstanceHealthInput;
 import io.openaev.rest.connector_instance.dto.ConnectorInstanceLogsInput;
@@ -103,11 +102,11 @@ public class XtmComposerApi extends RestBehavior {
       description = "Receive logs from connector instances")
   @RBAC(actionPerformed = Action.WRITE, resourceType = ResourceType.CATALOG)
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Successful reception")})
-  public ConnectorInstanceLog receiveConnectorInstanceLogs(
+  public void receiveConnectorInstanceLogs(
       @PathVariable @NotBlank final String xtmComposerId,
       @PathVariable @NotBlank final String connectorInstanceId,
       @Valid @RequestBody ConnectorInstanceLogsInput input) {
-    return orchestrationService.pushLogsByConnectorInstance(
+    orchestrationService.pushLogsByConnectorInstance(
         xtmComposerId, connectorInstanceId, input.getLogs());
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceLogService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceLogService.java
@@ -36,37 +36,36 @@ public class ConnectorInstanceLogService {
    * @param rawLogLines the set of raw log lines to transform
    * @return the formatted log string with lines separated by newlines
    */
-  public String transformRawLogsLineToLog(Set<String> rawLogLines) {
+  public Set<String> transformRawLogsLineToLog(Set<String> rawLogLines) {
     return rawLogLines.stream()
         .map(line -> line.replaceAll("^,", ""))
         .map(String::trim)
         .filter(line -> !line.isEmpty())
-        .collect(Collectors.joining("\n"));
+        .collect(Collectors.toSet());
   }
 
   /**
    * Creates a new log entry for a connector instance and maintains log limit.
    *
    * @param connectorInstance the connector instance to log for
-   * @param rawLog the log content to store
-   * @return the saved log entry
+   * @param rawLogs the log content to store
    * @throws IllegalArgumentException if rawLog is empty
    */
   @Transactional
-  public ConnectorInstanceLog pushLogByConnectorInstance(
-      ConnectorInstancePersisted connectorInstance, String rawLog) throws IllegalArgumentException {
-    if (rawLog.isEmpty()) {
-      return null;
+  public void pushLogByConnectorInstance(
+      ConnectorInstancePersisted connectorInstance, Set<String> rawLogs)
+      throws IllegalArgumentException {
+    if (rawLogs.isEmpty()) {
+      return;
+    }
+    for (String log : rawLogs) {
+      ConnectorInstanceLog logEntry = new ConnectorInstanceLog();
+      logEntry.setConnectorInstance(connectorInstance);
+      logEntry.setLog(log);
+      connectorInstanceLogRepository.save(logEntry);
     }
 
-    ConnectorInstanceLog logEntry = new ConnectorInstanceLog();
-    logEntry.setConnectorInstance(connectorInstance);
-    logEntry.setLog(rawLog);
-    ConnectorInstanceLog saved = connectorInstanceLogRepository.save(logEntry);
-
     cleanupExcessLogs(connectorInstance.getId());
-
-    return saved;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
@@ -244,17 +244,16 @@ public class ConnectorOrchestrationService {
    * @param xtmComposerId the unique identifier of the XTM composer to validate
    * @param connectorInstanceId the unique identifier of the connector instance to receive the logs
    * @param logs a set of log messages to be pushed to the connector instance
-   * @return the updated ConnectorInstanceLog
    */
-  public ConnectorInstanceLog pushLogsByConnectorInstance(
+  public void pushLogsByConnectorInstance(
       String xtmComposerId, String connectorInstanceId, Set<String> logs) {
     this.xtmComposerService.throwIfInvalidXtmComposerId(xtmComposerId);
     if (logs.isEmpty()) {
-      return null;
+      return;
     }
     ConnectorInstancePersisted instance =
         connectorInstanceService.connectorInstanceById(connectorInstanceId);
-    return connectorInstanceLogService.pushLogByConnectorInstance(
+    connectorInstanceLogService.pushLogByConnectorInstance(
         instance, connectorInstanceLogService.transformRawLogsLineToLog(logs));
   }
 

--- a/openaev-api/src/test/java/io/openaev/api/xtm_composer/XtmComposerApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/xtm_composer/XtmComposerApiTest.java
@@ -479,7 +479,7 @@ public class XtmComposerApiTest extends IntegrationTest {
 
         List<ConnectorInstanceLog> instanceLogsDbAfter =
             connectorInstanceLogRepository.findByConnectorInstanceId(instance.getId());
-        assertEquals(1, instanceLogsDbAfter.size());
+        assertEquals(2, instanceLogsDbAfter.size());
       }
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not collate log lines from xtm composer

Potential known issue: logs appear potentially out of order

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
