### PR TITLE
[frontend] fix(catalog): fix stale injector content flash when navigating between connectors (#4835)

### DIFF
--- a/openaev-front/src/admin/components/integrations/common/ConnectorLayout.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorLayout.tsx
@@ -62,15 +62,14 @@ const ConnectorLayout = () => {
   useEffect(() => {
     isXtmComposerIsReachable().then(({ data }) => setIsXtmComposerUp(data));
 
+    setIsRelatedIdsLoaded(false);
     setLoading(true);
     setRelatedIds(undefined);
-    setIsRelatedIdsLoaded(false);
 
     if (!connectorId) {
       setLoading(false);
       return;
     }
-    setIsRelatedIdsLoaded(false);
     apiRequest.getRelatedIds(connectorId).then(({ data }: { data: ConnectorIds }) => {
       setRelatedIds(data);
       setIsRelatedIdsLoaded(true);


### PR DESCRIPTION
### Proposed changes

* Clear previous values before fetching new ones.

### Testing Instructions

1. Open a detail page of one connector in the catalog (connector A)
2. Go back on the catalog page
3. Navigate to another detail page (connector B)
4. Verify there is no brief flash of Item A content while Item B loads

### Related issues

* Closes #4835
