### PR TITLE
[frontend] fix(dashboard): should scroll in widget list and mitre section (#4883)

### DIFF
--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/SecurityCoverageContent.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/SecurityCoverageContent.tsx
@@ -92,6 +92,7 @@ const SecurityCoverageContent: FunctionComponent<Props> = ({ widgetId, data }) =
       display="flex"
       flexDirection="column"
       minHeight={0}
+      height="100%"
     >
       <div style={headerStyle}>
         <Box className="noDrag">

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/list/ListWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/list/ListWidget.tsx
@@ -156,7 +156,11 @@ const ListWidget = ({ widgetConfig, elements }: Props) => {
   }
 
   return (
-    <Box style={{ overflow: 'auto' }}>
+    <Box style={{
+      height: '100%',
+      overflow: 'auto',
+    }}
+    >
       <MuiList>
         <MuiListItem
           classes={{ root: classes.itemHead }}


### PR DESCRIPTION
### Proposed changes

* Add an height for the list widget and mitre section to be able to scroll 

### Testing Instructions

1. Open the Widget List or MITRE in dashboard
2. Try to scroll through the items
3. A scrollbar should appear when content exceeds the visible area

### Related issues

* Closes #4883 