### PR TITLE
[frontend] fix(catalog): fix stale injector content flash when navigating between connectors (#4835)

### DIFF
--- a/openaev-front/src/admin/components/integrations/common/ConnectorLayout.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorLayout.tsx
@@ -1,5 +1,5 @@
 import { capitalize } from '@mui/material';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { Outlet, useParams } from 'react-router';
 
 import { fetchConnector, isXtmComposerIsReachable } from '../../../../actions/catalog/catalog-actions';
@@ -68,7 +68,7 @@ const ConnectorLayout = () => {
     }
     setLoading(true);
     apiRequest.getRelatedIds(connectorId).then(({ data }: { data: ConnectorIds }) => {
-      if(!data) {
+      if (!data) {
         setLoading(false);
       } else {
         setRelatedIds(data);
@@ -83,7 +83,7 @@ const ConnectorLayout = () => {
         }
         Promise.all(promises).finally(() => setLoading(false));
       }
-    }).catch(() => setLoading(false))
+    }).catch(() => setLoading(false));
   }, [connectorId, apiRequest, dispatch]);
 
   const breadcrumbElements = connectorId


### PR DESCRIPTION
### Proposed changes

* Clear previous values before fetching new ones.

### Testing Instructions

1. Open a detail page of one connector in the catalog (connector A)
2. Go back on the catalog page
3. Navigate to another detail page (connector B)
4. Verify there is no brief flash of Item A content while Item B loads

### Related issues

* Closes #4835
