### PR TITLE
[frontend] fix(rbac): access teams and player capability does not exists (#4890)

### DIFF
--- a/openaev-front/src/admin/components/common/injects/form/teams/InjectTeamsList.tsx
+++ b/openaev-front/src/admin/components/common/injects/form/teams/InjectTeamsList.tsx
@@ -119,7 +119,7 @@ const InjectTeamsList: FunctionComponent<Props> = ({ readOnly = false, hideEnabl
       </List>
       {!allTeams
         && (
-          <Can I={ACTIONS.ACCESS} a={SUBJECTS.TEAMS_AND_PLAYERS}>
+          <Can I={ACTIONS.MANAGE} a={SUBJECTS.TEAMS_AND_PLAYERS}>
             <InjectAddTeams disabled={readOnly} handleModifyTeams={onTeamsChange} injectTeamsIds={injectTeamIds} error={error} />
           </Can>
         )}


### PR DESCRIPTION
### Proposed changes

* Change capa access to manage for the teams and players because access teams and player does not exists. 

### Testing Instructions

1. Create a new user.
2. Assign the user to a group with the default Manager role (all capabilities except "Platform Settings" and "Bypass").
3/ Have the user create a simulation.
4. Add Teams on the "Definition" tab
5. Create an email inject.
6. The user should be able to select a targeted team in the inject settings.

### Related issues

* Closes #4890 