### PR TITLE
[backend] fix: do not get exercise.getId on atomic testing (#4727)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -721,8 +721,6 @@ public class InjectExpectationService {
 
     List<InjectExpectation> injectExpectations = new ArrayList<>();
     if (!teams.isEmpty()) {
-      final String exerciseId = executableInject.getInjection().getExercise().getId();
-
       List<InjectExpectation> injectExpectationsByUserAndTeam;
       // If atomicTesting, We create expectation for every player and every team
       if (isAtomicTesting) {
@@ -758,6 +756,7 @@ public class InjectExpectationService {
                                                     expectationPropertiesConfig))))
                 .toList();
       } else {
+        final String exerciseId = executableInject.getInjection().getExercise().getId();
         // Create expectations for every enabled player in every team
         injectExpectationsByUserAndTeam =
             teams.stream()


### PR DESCRIPTION
### Proposed changes

* Fix injectExpectation build function by retrieving Exercise ID only for non-atomic testing.

### Testing Instructions

1. Create a new **Send Email** atomic testing
2. Add a manual expectation to the atomic testing
3. Run the atomic testing
4. Verify the expectation is processed correctly without errors

### Related issues

* Closes #4727 