### PR TITLE
[backend] fix(mail): missing inject id on footers (#4957)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/email/model/EmailContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/model/EmailContent.java
@@ -46,7 +46,6 @@ public class EmailContent {
       data.append(HEADER_DIV).append(header).append(END_DIV);
     }
     data.append(START_DIV).append(body).append(END_DIV);
-    // If imap is enable we need to inject the id marker
     if (injection.isRuntime()) {
       data.append(START_DIV)
           .append("<br/><br/><br/><br/>")


### PR DESCRIPTION
### Proposed changes

* Fix missing inject id on footers mail

### Testing Instructions

1. Create a simulation or a scenario with a mail sender inject
2. Run the simulation or scenario
3. Received mail should include a footer with inject_id

### Related issues

* Closes #4957
