### PR TITLE
[backend] refactor(contract-types): extract ContractOutputType business logic into handler classes (#4302)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -1308,7 +1308,7 @@ public class V1_DataImporter implements Importer {
 
   public static ContractOutputType formatStringToContractOutputType(String value) {
     for (ContractOutputType type : ContractOutputType.values()) {
-      if (type.label.equalsIgnoreCase(value)) {
+      if (type.getLabel().equalsIgnoreCase(value)) {
         return type;
       }
     }

--- a/openaev-api/src/main/java/io/openaev/output_processor/AbstractOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/AbstractOutputProcessor.java
@@ -1,0 +1,122 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputField;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+/** Abstract base class providing common functionality for structured output processor handlers. */
+@Slf4j
+public abstract class AbstractOutputProcessor implements OutputProcessor {
+
+  protected final ContractOutputType type;
+  protected final ContractOutputTechnicalType technicalType;
+  protected final List<ContractOutputField> fields;
+  protected final boolean isFindingCompatible;
+
+  protected AbstractOutputProcessor(
+      ContractOutputType type,
+      ContractOutputTechnicalType technicalType,
+      List<ContractOutputField> fields,
+      boolean isFindingCompatible) {
+    this.type = type;
+    this.technicalType = technicalType;
+    this.fields = fields;
+    this.isFindingCompatible = isFindingCompatible;
+  }
+
+  @Override
+  public ContractOutputType getType() {
+    return type;
+  }
+
+  @Override
+  public ContractOutputTechnicalType getTechnicalType() {
+    return technicalType;
+  }
+
+  @Override
+  public List<ContractOutputField> getFields() {
+    return fields;
+  }
+
+  @Override
+  public boolean isFindingCompatible() {
+    return isFindingCompatible;
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return jsonNode != null;
+  }
+
+  // FINDING METHODS
+  // Override these in handlers that support findings
+
+  /**
+   * Convert JSON node to finding value string. Override this method if handler supports findings.
+   * Default returns empty string with warning log.
+   */
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    log.warn("Handler {} does not implement toFindingValue, returning empty string", type);
+    return "";
+  }
+
+  /**
+   * Extract asset IDs from JSON node for finding linking. Override to provide custom logic, default
+   * returns empty list.
+   */
+  public List<String> toFindingAssets(JsonNode jsonNode) {
+    log.warn("Handler {} does not implement toFindingAssets, returning an empty list", type);
+    return Collections.emptyList();
+  }
+
+  /**
+   * Extract user IDs from JSON node for finding linking. Override to provide custom logic, default
+   * returns empty list.
+   */
+  public List<String> toFindingUsers(JsonNode jsonNode) {
+    log.warn("Handler {} does not implement toFindingUsers, returning an empty list", type);
+    return Collections.emptyList();
+  }
+
+  /**
+   * Extract team IDs from JSON node for finding linking. Override to provide custom logic, default
+   * returns empty list.
+   */
+  public List<String> toFindingTeams(JsonNode jsonNode) {
+    log.warn("Handler {} does not implement toFindingTeams, returning an empty list", type);
+    return Collections.emptyList();
+  }
+
+  // Utility methods
+  protected String buildString(@NotNull final JsonNode jsonNode) {
+    if (jsonNode.isArray()) {
+      List<String> values = new ArrayList<>();
+      for (JsonNode element : jsonNode) {
+        values.add(trimQuotes(element.asText()));
+      }
+      return String.join(" ", values);
+    }
+    return trimQuotes(jsonNode.asText());
+  }
+
+  protected String buildString(@NotNull final JsonNode jsonNode, @NotBlank final String key) {
+    JsonNode valueNode = jsonNode.get(key);
+    if (valueNode == null || valueNode.isNull()) {
+      return "";
+    }
+    return buildString(valueNode);
+  }
+
+  protected String trimQuotes(@NotBlank final String value) {
+    return value.replaceAll("^\"|\"$", "");
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/AssetOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/AssetOutputProcessor.java
@@ -1,0 +1,14 @@
+package io.openaev.output_processor;
+
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AssetOutputProcessor extends AbstractOutputProcessor {
+
+  public AssetOutputProcessor() {
+    super(ContractOutputType.Asset, ContractOutputTechnicalType.Object, List.of(), false);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/CVEOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/CVEOutputProcessor.java
@@ -1,0 +1,58 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputField;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CVEOutputProcessor extends AbstractOutputProcessor {
+
+  private static final String ASSET_ID = "asset_id";
+  private static final String ID = "id";
+  private static final String HOST = "host";
+  private static final String SEVERITY = "severity";
+
+  public CVEOutputProcessor() {
+    super(
+        ContractOutputType.CVE,
+        ContractOutputTechnicalType.Object,
+        List.of(
+            new ContractOutputField(ASSET_ID, ContractOutputTechnicalType.Text, false),
+            new ContractOutputField(ID, ContractOutputTechnicalType.Text, true),
+            new ContractOutputField(HOST, ContractOutputTechnicalType.Text, true),
+            new ContractOutputField(SEVERITY, ContractOutputTechnicalType.Text, true)),
+        true);
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return jsonNode.hasNonNull(ID) && jsonNode.hasNonNull(HOST) && jsonNode.hasNonNull(SEVERITY);
+  }
+
+  // Findings
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    return buildString(jsonNode, ID);
+  }
+
+  @Override
+  public List<String> toFindingAssets(JsonNode jsonNode) {
+    JsonNode assetIdNode = jsonNode.get(ASSET_ID);
+    if (assetIdNode == null) {
+      return Collections.emptyList();
+    }
+    if (assetIdNode.isArray()) {
+      List<String> result = new ArrayList<>();
+      for (JsonNode idNode : assetIdNode) {
+        result.add(idNode.asText());
+      }
+      return result;
+    }
+    return List.of(assetIdNode.asText());
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/CredentialsOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/CredentialsOutputProcessor.java
@@ -1,0 +1,37 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputField;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CredentialsOutputProcessor extends AbstractOutputProcessor {
+
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+
+  public CredentialsOutputProcessor() {
+    super(
+        ContractOutputType.Credentials,
+        ContractOutputTechnicalType.Object,
+        List.of(
+            new ContractOutputField(USERNAME, ContractOutputTechnicalType.Text, true),
+            new ContractOutputField(PASSWORD, ContractOutputTechnicalType.Text, true)),
+        true);
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return jsonNode.hasNonNull(USERNAME) && jsonNode.hasNonNull(PASSWORD);
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    String username = buildString(jsonNode, USERNAME);
+    String password = buildString(jsonNode, PASSWORD);
+    return username + ":" + password;
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/IPv4OutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/IPv4OutputProcessor.java
@@ -1,0 +1,28 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IPv4OutputProcessor extends AbstractOutputProcessor {
+
+  private static final InetAddressValidator VALIDATOR = InetAddressValidator.getInstance();
+
+  public IPv4OutputProcessor() {
+    super(ContractOutputType.IPv4, ContractOutputTechnicalType.Text, List.of(), true);
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return VALIDATOR.isValidInet4Address(jsonNode.asText());
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    return buildString(jsonNode);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/IPv6OutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/IPv6OutputProcessor.java
@@ -1,0 +1,28 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IPv6OutputProcessor extends AbstractOutputProcessor {
+
+  private static final InetAddressValidator VALIDATOR = InetAddressValidator.getInstance();
+
+  public IPv6OutputProcessor() {
+    super(ContractOutputType.IPv6, ContractOutputTechnicalType.Text, List.of(), true);
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return VALIDATOR.isValidInet6Address(jsonNode.asText());
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    return buildString(jsonNode);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/NumberOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/NumberOutputProcessor.java
@@ -1,0 +1,20 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NumberOutputProcessor extends AbstractOutputProcessor {
+
+  public NumberOutputProcessor() {
+    super(ContractOutputType.Number, ContractOutputTechnicalType.Number, List.of(), true);
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    return buildString(jsonNode);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/OutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/OutputProcessor.java
@@ -1,0 +1,39 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputField;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+
+/**
+ * Handler interface for processing structured outputs in different contexts. Implementations of
+ * this interface will define how to validate and process structured outputs based on their type and
+ * technical type, as well as the contexts they support.
+ */
+public interface OutputProcessor {
+
+  /** Get the type (matches ContractOutputType enum) */
+  ContractOutputType getType();
+
+  /** Get the technical type (matches ContractOutputTechnicalType enum) */
+  ContractOutputTechnicalType getTechnicalType();
+
+  /** Get fields */
+  List<ContractOutputField> getFields();
+
+  /** Is finding compatible */
+  boolean isFindingCompatible();
+
+  /** Validate that the JSON node is correctly formatted for this type */
+  boolean validate(JsonNode jsonNode);
+
+  // FINDING methods
+  String toFindingValue(JsonNode jsonNode);
+
+  List<String> toFindingAssets(JsonNode jsonNode);
+
+  List<String> toFindingUsers(JsonNode jsonNode);
+
+  List<String> toFindingTeams(JsonNode jsonNode);
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/OutputProcessorFactory.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/OutputProcessorFactory.java
@@ -1,0 +1,31 @@
+package io.openaev.output_processor;
+
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OutputProcessorFactory {
+
+  private final Map<ContractOutputType, OutputProcessor> outputProcessorHandlerMap;
+
+  public OutputProcessorFactory(List<OutputProcessor> handlers) {
+    this.outputProcessorHandlerMap =
+        handlers.stream().collect(Collectors.toMap(OutputProcessor::getType, Function.identity()));
+  }
+
+  public OutputProcessor getHandler(ContractOutputType type) {
+    return Optional.ofNullable(outputProcessorHandlerMap.get(type))
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "No handler found for type: "
+                        + type
+                        + ". Available types: "
+                        + outputProcessorHandlerMap.keySet()));
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/PortOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/PortOutputProcessor.java
@@ -1,0 +1,20 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortOutputProcessor extends AbstractOutputProcessor {
+
+  public PortOutputProcessor() {
+    super(ContractOutputType.Port, ContractOutputTechnicalType.Number, List.of(), true);
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    return buildString(jsonNode);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/PortScanOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/PortScanOutputProcessor.java
@@ -1,0 +1,53 @@
+package io.openaev.output_processor;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputField;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortScanOutputProcessor extends AbstractOutputProcessor {
+
+  private static final String ASSET_ID = "asset_id";
+  private static final String HOST = "host";
+  private static final String PORT = "port";
+  private static final String SERVICE = "service";
+
+  public PortScanOutputProcessor() {
+    super(
+        ContractOutputType.PortsScan,
+        ContractOutputTechnicalType.Object,
+        List.of(
+            new ContractOutputField(ASSET_ID, ContractOutputTechnicalType.Text, false),
+            new ContractOutputField(HOST, ContractOutputTechnicalType.Text, true),
+            new ContractOutputField(PORT, ContractOutputTechnicalType.Number, true),
+            new ContractOutputField(SERVICE, ContractOutputTechnicalType.Text, true)),
+        true);
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return jsonNode.hasNonNull(HOST) && jsonNode.hasNonNull(PORT) && jsonNode.hasNonNull(SERVICE);
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    String host = buildString(jsonNode, HOST);
+    String port = buildString(jsonNode, PORT);
+    String service = buildString(jsonNode, SERVICE);
+    return host + ":" + port + (hasText(service) ? " (" + service + ")" : "");
+  }
+
+  @Override
+  public List<String> toFindingAssets(JsonNode jsonNode) {
+    JsonNode assetIdNode = jsonNode.get(ASSET_ID);
+    if (assetIdNode != null) {
+      return List.of(assetIdNode.asText());
+    }
+    return List.of();
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/output_processor/TextOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/TextOutputProcessor.java
@@ -1,0 +1,20 @@
+package io.openaev.output_processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.ContractOutputTechnicalType;
+import io.openaev.database.model.ContractOutputType;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TextOutputProcessor extends AbstractOutputProcessor {
+
+  public TextOutputProcessor() {
+    super(ContractOutputType.Text, ContractOutputTechnicalType.Text, List.of(), true);
+  }
+
+  @Override
+  public String toFindingValue(JsonNode jsonNode) {
+    return buildString(jsonNode);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/output_processor/AbstractOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/AbstractOutputProcessorTest.java
@@ -1,0 +1,72 @@
+package io.openaev.output_processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AbstractOutputProcessorTest {
+
+  private static class TestOutputProcessor extends AbstractOutputProcessor {
+
+    TestOutputProcessor() {
+      super(null, null, Collections.emptyList(), false);
+    }
+  }
+
+  private TestOutputProcessor processor;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    processor = new TestOutputProcessor();
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  @DisplayName(
+      "should join array elements and trim quotes when buildString is called with an array node")
+  void shouldJoinArrayElementsAndTrimQuotesWhenBuildStringCalledWithArrayNode() throws Exception {
+    JsonNode node = objectMapper.readTree("[\"foo\", \"bar\"]");
+    String result = processor.buildString(node);
+    assertEquals("foo bar", result);
+  }
+
+  @Test
+  @DisplayName("should trim quotes when buildString is called with a string node")
+  void shouldTrimQuotesWhenBuildStringCalledWithStringNode() throws Exception {
+    JsonNode node = objectMapper.readTree("\"baz\"");
+    String result = processor.buildString(node);
+    assertEquals("baz", result);
+  }
+
+  @Test
+  @DisplayName("should extract and process value when buildString is called with a key")
+  void shouldExtractAndProcessValueWhenBuildStringCalledWithKey() throws Exception {
+    JsonNode node = objectMapper.readTree("{\"key\": [\"a\", \"b\"]}");
+    String result = processor.buildString(node, "key");
+    assertEquals("a b", result);
+  }
+
+  @Test
+  @DisplayName("should return empty string when buildString is called with a missing or null key")
+  void shouldReturnEmptyStringWhenBuildStringCalledWithMissingOrNullKey() throws Exception {
+    JsonNode node = objectMapper.readTree("{}");
+    assertEquals("", processor.buildString(node, "missing"));
+    JsonNode node2 = objectMapper.readTree("{\"key\": null}");
+    assertEquals("", processor.buildString(node2, "key"));
+  }
+
+  @Test
+  @DisplayName("should remove leading and trailing quotes when trimQuotes is called")
+  void shouldRemoveLeadingAndTrailingQuotesWhenTrimQuotesCalled() {
+    assertEquals("foo", processor.trimQuotes("\"foo\""));
+    assertEquals("bar", processor.trimQuotes("bar"));
+    assertEquals("foo\"bar", processor.trimQuotes("\"foo\"bar"));
+    assertEquals("foo\"bar", processor.trimQuotes("foo\"bar"));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/output_processor/CVEOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/CVEOutputProcessorTest.java
@@ -1,0 +1,45 @@
+package io.openaev.output_processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CVEOutputProcessorTest {
+
+  private final CVEOutputProcessor processor = new CVEOutputProcessor();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("should return empty list when asset_id is missing")
+  void shouldReturnEmptyListWhenAssetIdMissing() throws Exception {
+    JsonNode node =
+        objectMapper.readTree("{\"id\": \"CVE-123\", \"host\": \"host1\", \"severity\": \"high\"}");
+    List<String> result = processor.toFindingAssets(node);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  @DisplayName("should return single asset id when asset_id is present as string")
+  void shouldReturnSingleAssetIdWhenAssetIdPresentAsString() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{\"asset_id\": \"asset42\", \"id\": \"CVE-123\", \"host\": \"host1\", \"severity\": \"high\"}");
+    List<String> result = processor.toFindingAssets(node);
+    assertEquals(List.of("asset42"), result);
+  }
+
+  @Test
+  @DisplayName("should return multiple asset ids when asset_id is array")
+  void shouldReturnMultipleAssetIdsWhenAssetIdIsArray() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{\"asset_id\": [\"asset1\", \"asset2\"], \"id\": \"CVE-123\", \"host\": \"host1\", \"severity\": \"high\"}");
+    List<String> result = processor.toFindingAssets(node);
+    assertEquals(List.of("asset1", "asset2"), result);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/output_processor/CredentialsOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/CredentialsOutputProcessorTest.java
@@ -1,0 +1,43 @@
+package io.openaev.output_processor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CredentialsOutputProcessorTest {
+
+  private final CredentialsOutputProcessor processor = new CredentialsOutputProcessor();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("should return true when both username and password are present")
+  void shouldReturnTrueWhenBothUsernameAndPasswordPresent() throws Exception {
+    JsonNode node = objectMapper.readTree("{\"username\": \"alice\", \"password\": \"pass1\"}");
+    assertTrue(processor.validate(node));
+  }
+
+  @Test
+  @DisplayName("should return false when username is missing")
+  void shouldReturnFalseWhenUsernameMissing() throws Exception {
+    JsonNode node = objectMapper.readTree("{\"password\": \"pass1\"}");
+    assertFalse(processor.validate(node));
+  }
+
+  @Test
+  @DisplayName("should return false when password is missing")
+  void shouldReturnFalseWhenPasswordMissing() throws Exception {
+    JsonNode node = objectMapper.readTree("{\"username\": \"bob\"}");
+    assertFalse(processor.validate(node));
+  }
+
+  @Test
+  @DisplayName("should return finding value as username:password")
+  void shouldReturnFindingValueAsUsernamePassword() throws Exception {
+    JsonNode node = objectMapper.readTree("{\"username\": \"charles\", \"password\": \"pass1\"}");
+    String result = processor.toFindingValue(node);
+    assertEquals("charles:pass1", result);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/output_processor/OutputProcessorIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/OutputProcessorIntegrationTest.java
@@ -1,0 +1,46 @@
+package io.openaev.output_processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.ContractOutputType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@TestInstance(PER_CLASS)
+@DisplayName("Integration tests for OutputProcessor loading and context support")
+class OutputProcessorIntegrationTest extends IntegrationTest {
+
+  @Autowired private OutputProcessorFactory registry;
+
+  @Test
+  void shouldLoadAllHandlersFromSpring() {
+    for (ContractOutputType type : ContractOutputType.values()) {
+      OutputProcessor handler = registry.getHandler(type);
+
+      assertThat(handler).withFailMessage("Handler not found for type: " + type).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldReturnCorrectHandlerForEachType() {
+    assertThat(registry.getHandler(ContractOutputType.Text))
+        .isInstanceOf(TextOutputProcessor.class);
+
+    assertThat(registry.getHandler(ContractOutputType.PortsScan))
+        .isInstanceOf(PortScanOutputProcessor.class);
+
+    assertThat(registry.getHandler(ContractOutputType.CVE)).isInstanceOf(CVEOutputProcessor.class);
+  }
+
+  @Test
+  void shouldReturnSameInstanceOnMultipleCalls() {
+    OutputProcessor handler1 = registry.getHandler(ContractOutputType.Text);
+    OutputProcessor handler2 = registry.getHandler(ContractOutputType.Text);
+
+    assertThat(handler1).isSameAs(handler2);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/output_processor/PortScanOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/PortScanOutputProcessorTest.java
@@ -1,0 +1,60 @@
+package io.openaev.output_processor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PortScanOutputProcessorTest {
+
+  private final PortScanOutputProcessor processor = new PortScanOutputProcessor();
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("should return correct finding value for valid port scan output")
+  void shouldReturnCorrectFindingValueForValidPortScanOutput() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{" + "\"host\": \"192.168.1.1\"," + "\"port\": \"22\"," + "\"service\": \"ssh\"}");
+    String result = processor.toFindingValue(node);
+    assertEquals("192.168.1.1:22 (ssh)", result);
+  }
+
+  @Test
+  @DisplayName("should return finding value without service if service is empty")
+  void shouldReturnFindingValueWithoutServiceIfServiceIsEmpty() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{" + "\"host\": \"192.168.1.1\"," + "\"port\": \"80\"," + "\"service\": \"\"}");
+    String result = processor.toFindingValue(node);
+    assertEquals("192.168.1.1:80", result);
+  }
+
+  @Test
+  @DisplayName("should return single asset id when asset_id is present")
+  void shouldReturnSingleAssetIdWhenAssetIdPresent() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{"
+                + "\"asset_id\": \"asset123\","
+                + "\"host\": \"192.168.1.1\","
+                + "\"port\": \"22\","
+                + "\"service\": \"ssh\"}");
+    List<String> result = processor.toFindingAssets(node);
+    assertEquals(List.of("asset123"), result);
+  }
+
+  @Test
+  @DisplayName("should return empty list when asset_id is missing")
+  void shouldReturnEmptyListWhenAssetIdMissing() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{" + "\"host\": \"192.168.1.1\"," + "\"port\": \"22\"," + "\"service\": \"ssh\"}");
+    List<String> result = processor.toFindingAssets(node);
+    assertTrue(result.isEmpty());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/finding/FindingApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/finding/FindingApiTest.java
@@ -728,7 +728,8 @@ class FindingApiTest extends IntegrationTest {
       entityManager.clear();
 
       performCallbackRequest(FINDING_URI + "/search", input)
-          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(
+              jsonPath("$.content.[0].finding_type").value(savedFinding.getType().getLabel()))
           .andExpect(jsonPath("$.content.[0].finding_value").value("text_value"))
           .andExpect(
               jsonPath("$.content.[0].finding_assets.[0].asset_id").value(savedEndpoint.getId()))
@@ -759,7 +760,8 @@ class FindingApiTest extends IntegrationTest {
 
       performCallbackRequest(
               FINDING_URI + "/exercises/" + savedSimulation.getId() + "/search", input)
-          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(
+              jsonPath("$.content.[0].finding_type").value(savedFinding.getType().getLabel()))
           .andExpect(
               jsonPath("$.content.[0].finding_value")
                   .value("2001:0000:130F:0000:0000:09C0:876A:130B"));
@@ -792,7 +794,8 @@ class FindingApiTest extends IntegrationTest {
       performCallbackRequest(FINDING_URI + "/scenarios/" + savedScenario.getId() + "/search", input)
           .andExpect(
               jsonPath("$.content.[0].finding_scenario.scenario_id").value(savedScenario.getId()))
-          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(
+              jsonPath("$.content.[0].finding_type").value(savedFinding.getType().getLabel()))
           .andExpect(jsonPath("$.content.[0].finding_value").value("admin:admin"));
     }
 
@@ -814,7 +817,8 @@ class FindingApiTest extends IntegrationTest {
       performCallbackRequest(FINDING_URI + "/endpoints/" + savedEndpoint.getId() + "/search", input)
           .andExpect(
               jsonPath("$.content.[0].finding_assets.[0].asset_id").value(savedEndpoint.getId()))
-          .andExpect(jsonPath("$.content.[0].finding_type").value(savedFinding.getType().label))
+          .andExpect(
+              jsonPath("$.content.[0].finding_type").value(savedFinding.getType().getLabel()))
           .andExpect(jsonPath("$.content.[0].finding_value").value("text_value"));
     }
 
@@ -858,12 +862,13 @@ class FindingApiTest extends IntegrationTest {
 
       Set<String> distinctPairs =
           results.stream()
-              .map(f -> f.getType().label + "::" + f.getValue())
+              .map(f -> f.getType().getLabel() + "::" + f.getValue())
               .collect(Collectors.toSet());
 
       assertThat(distinctPairs)
           .containsExactlyInAnyOrder(
-              f1.getType().label + "::" + f1.getValue(), f3.getType().label + "::" + f3.getValue());
+              f1.getType().getLabel() + "::" + f1.getValue(),
+              f3.getType().getLabel() + "::" + f3.getValue());
     }
   }
 
@@ -882,7 +887,8 @@ class FindingApiTest extends IntegrationTest {
 
     List<Filters.Filter> filters = new ArrayList<>();
 
-    filters.add(buildFilter("finding_type", Filters.FilterOperator.contains, List.of(type.label)));
+    filters.add(
+        buildFilter("finding_type", Filters.FilterOperator.contains, List.of(type.getLabel())));
     filters.add(
         buildFilter("finding_created_at", Filters.FilterOperator.gt, List.of(now.toString())));
     filters.add(

--- a/openaev-api/src/test/java/io/openaev/rest/inject/StructuredOutputUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/StructuredOutputUtilsTest.java
@@ -2,6 +2,7 @@ package io.openaev.rest.inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -12,10 +13,12 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
-@ExtendWith(MockitoExtension.class)
+@Transactional
+@TestInstance(PER_CLASS)
+@DisplayName("Process OutputParsers to extract structured data")
 class StructuredOutputUtilsTest extends IntegrationTest {
 
   public static final String SIMPLE_RAW_OUTPUT_TASKLIST =
@@ -32,14 +35,7 @@ class StructuredOutputUtilsTest extends IntegrationTest {
           + "  TCP    176.125.125.10:445            0.0.0.0:0              LISTENING\n"
           + "  TCP    192.168.12.12:902            0.0.0.0:0              LISTENING\n";
 
-  private final ObjectMapper mapper = new ObjectMapper();
-
-  private StructuredOutputUtils structuredOutputUtils;
-
-  @BeforeEach
-  void setup() {
-    structuredOutputUtils = new StructuredOutputUtils(mapper);
-  }
+  @Autowired private StructuredOutputUtils structuredOutputUtils;
 
   @Test
   @DisplayName("Should return null string for a raw output empty")

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/OutputParserFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/OutputParserFixture.java
@@ -35,8 +35,8 @@ public class OutputParserFixture {
     contractOutputElement.setType(type);
     contractOutputElement.setRule(rule);
     contractOutputElement.setRegexGroups(regexGroup);
-    contractOutputElement.setKey(type.label + "-key");
-    contractOutputElement.setName(type.label + " Name");
+    contractOutputElement.setKey(type.getLabel() + "-key");
+    contractOutputElement.setName(type.getLabel() + " Name");
     contractOutputElement.setFinding(isFinding);
     return contractOutputElement;
   }

--- a/openaev-model/src/main/java/io/openaev/database/model/ContractOutputField.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ContractOutputField.java
@@ -10,7 +10,7 @@ public class ContractOutputField {
   private ContractOutputTechnicalType type;
   private boolean required;
 
-  ContractOutputField(String key, ContractOutputTechnicalType type, boolean required) {
+  public ContractOutputField(String key, ContractOutputTechnicalType type, boolean required) {
     this.key = key;
     this.type = type;
     this.required = required;

--- a/openaev-model/src/main/java/io/openaev/database/model/ContractOutputType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ContractOutputType.java
@@ -1,221 +1,44 @@
 package io.openaev.database.model;
 
-import static org.springframework.util.StringUtils.hasText;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.oas.annotations.Hidden;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Function;
-import org.apache.commons.validator.routines.InetAddressValidator;
 
 public enum ContractOutputType {
   @JsonProperty("text")
-  Text(
-      "text",
-      ContractOutputTechnicalType.Text,
-      null,
-      true,
-      Objects::nonNull,
-      ContractOutputType::buildString,
-      null,
-      null,
-      null),
+  Text("text"),
+
   @JsonProperty("number")
-  Number(
-      "number",
-      ContractOutputTechnicalType.Number,
-      null,
-      true,
-      Objects::nonNull,
-      ContractOutputType::buildString,
-      null,
-      null,
-      null),
+  Number("number"),
+
   @JsonProperty("port")
-  Port(
-      "port",
-      ContractOutputTechnicalType.Number,
-      null,
-      true,
-      Objects::nonNull,
-      ContractOutputType::buildString,
-      null,
-      null,
-      null),
+  Port("port"),
+
   @JsonProperty("portscan")
-  PortsScan(
-      "portscan",
-      ContractOutputTechnicalType.Object,
-      new ArrayList<>(
-          List.of(
-              new ContractOutputField("asset_id", ContractOutputTechnicalType.Text, false),
-              new ContractOutputField("host", ContractOutputTechnicalType.Text, true),
-              new ContractOutputField("port", ContractOutputTechnicalType.Number, true),
-              new ContractOutputField("service", ContractOutputTechnicalType.Text, true))),
-      true,
-      (JsonNode jsonNode) ->
-          jsonNode.hasNonNull("host")
-              && jsonNode.hasNonNull("port")
-              && jsonNode.hasNonNull("service"),
-      (JsonNode jsonNode) -> {
-        String host = buildString(jsonNode, "host");
-        String port = buildString(jsonNode, "port");
-        String service = buildString(jsonNode, "service");
-        return host + ":" + port + (hasText(service) ? " (" + service + ")" : "");
-      },
-      (JsonNode jsonNode) -> {
-        if (jsonNode.get("asset_id") != null) {
-          return List.of(jsonNode.get("asset_id").asText());
-        }
-        return new ArrayList<>();
-      },
-      null,
-      null),
+  PortsScan("portscan"),
+
   @JsonProperty("ipv4")
-  IPv4(
-      "ipv4",
-      ContractOutputTechnicalType.Text,
-      null,
-      true,
-      (JsonNode jsonNode) ->
-          InetAddressValidator.getInstance().isValidInet4Address(jsonNode.asText()),
-      ContractOutputType::buildString,
-      null,
-      null,
-      null),
+  IPv4("ipv4"),
+
   @JsonProperty("ipv6")
-  IPv6(
-      "ipv6",
-      ContractOutputTechnicalType.Text,
-      null,
-      true,
-      (JsonNode jsonNode) ->
-          InetAddressValidator.getInstance().isValidInet6Address(jsonNode.asText()),
-      ContractOutputType::buildString,
-      null,
-      null,
-      null),
+  IPv6("ipv6"),
+
   @JsonProperty("credentials")
-  Credentials(
-      "credentials",
-      ContractOutputTechnicalType.Object,
-      new ArrayList<>(
-          List.of(
-              new ContractOutputField("username", ContractOutputTechnicalType.Text, true),
-              new ContractOutputField("password", ContractOutputTechnicalType.Text, true))),
-      true,
-      (JsonNode jsonNode) -> jsonNode.hasNonNull("username") && jsonNode.hasNonNull("password"),
-      (JsonNode jsonNode) -> {
-        String username = buildString(jsonNode, "username");
-        String password = buildString(jsonNode, "password");
-        return username + ":" + password;
-      },
-      null,
-      null,
-      null),
+  Credentials("credentials"),
+
   @JsonProperty("cve")
-  CVE(
-      "cve",
-      ContractOutputTechnicalType.Object,
-      new ArrayList<>(
-          List.of(
-              new ContractOutputField("asset_id", ContractOutputTechnicalType.Text, false),
-              new ContractOutputField("id", ContractOutputTechnicalType.Text, true),
-              new ContractOutputField("host", ContractOutputTechnicalType.Text, true),
-              new ContractOutputField("severity", ContractOutputTechnicalType.Text, true))),
-      true,
-      (JsonNode jsonNode) ->
-          jsonNode.hasNonNull("id")
-              && jsonNode.hasNonNull("host")
-              && jsonNode.hasNonNull("severity"),
-      (JsonNode jsonNode) -> buildString(jsonNode, "id"),
-      (JsonNode jsonNode) -> {
-        JsonNode assetIdNode = jsonNode.get("asset_id");
-        if (assetIdNode == null) {
-          return Collections.emptyList();
-        }
-        if (assetIdNode.isArray()) {
-          List<String> result = new ArrayList<>();
-          for (JsonNode idNode : assetIdNode) {
-            result.add(idNode.asText());
-          }
-          return result;
-        } else {
-          return List.of(assetIdNode.asText());
-        }
-      },
-      null,
-      null),
+  CVE("cve"),
+
   @Hidden
   @JsonProperty("asset")
-  Asset(
-      "asset",
-      ContractOutputTechnicalType.Object,
-      null,
-      false,
-      Objects::nonNull,
-      ContractOutputType::buildString,
-      null,
-      null,
-      null);
+  Asset("asset");
 
-  public final String label;
-  public final ContractOutputTechnicalType technicalType;
-  public final List<ContractOutputField> fields;
-  public final Boolean isFindingCompatible;
-  public final Function<JsonNode, Boolean> validate;
-  public final Function<JsonNode, String> toFindingValue;
-  public final Function<JsonNode, List<String>> toFindingAssets;
-  public final Function<JsonNode, List<String>> toFindingUsers;
-  public final Function<JsonNode, List<String>> toFindingTeams;
+  private final String label;
 
-  ContractOutputType(
-      String label,
-      ContractOutputTechnicalType technicalType,
-      List<ContractOutputField> fields,
-      Boolean isFindingCompatible,
-      Function<JsonNode, Boolean> validate,
-      Function<JsonNode, String> toFindingValue,
-      Function<JsonNode, List<String>> toFindingAssets,
-      Function<JsonNode, List<String>> toFindingUsers,
-      Function<JsonNode, List<String>> toFindingTeams) {
+  ContractOutputType(String label) {
     this.label = label;
-    this.technicalType = technicalType;
-    this.fields = fields; // used only for object, to declare the composition of the object
-    this.isFindingCompatible = isFindingCompatible;
-    this.validate = validate;
-    this.toFindingValue = toFindingValue;
-    this.toFindingAssets = toFindingAssets;
-    this.toFindingUsers = toFindingUsers;
-    this.toFindingTeams = toFindingTeams;
   }
 
-  private static String buildString(@NotNull final JsonNode jsonNode) {
-    if (jsonNode.isArray()) {
-      List<String> values = new ArrayList<>();
-      for (JsonNode element : jsonNode) {
-        values.add(trimQuotes(element.asText()));
-      }
-      return String.join(" ", values);
-    }
-    return trimQuotes(jsonNode.asText());
-  }
-
-  private static String buildString(@NotNull final JsonNode jsonNode, @NotBlank final String key) {
-    JsonNode valueNode = jsonNode.get(key);
-    if (valueNode == null || valueNode.isNull()) {
-      return "";
-    }
-    return buildString(valueNode);
-  }
-
-  private static String trimQuotes(@NotBlank final String value) {
-    return value.replaceAll("^\"|\"$", "");
+  public String getLabel() {
+    return label;
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Chunk 1: Part 1 

* Cleaned up the ContractOutputType enum by moving all business logic into separate handler classes. 
* Created handler classes for each output type (Text, Number, Port, PortScan, IPv4, IPv6, Credentials, CVE, Asset)
* Services now fetch handlers from a factory instead of calling enum functions

### Testing Instructions
[Test refact_2026-02-18T08_40_12.089231500Z_(with_teams & with_players & with_variable_values).zip](https://github.com/user-attachments/files/25387446/Test.refact_2026-02-18T08_40_12.089231500Z_.with_teams.with_players.with_variable_values.zip)

1. Atomic Testing with Payload and Output Parsers
You should be able to execute an atomic test using a payload with output parsers configured.
The test should work as expected, with normal execution behavior.

2. Inject Execution with Nuclei
You should be able to execute an inject operation Nuclei.
The execution should complete successfully and produce:
* Findings (including CVEs, if applicable)
* Execution traces
* No unexpected errors

3. Atomic Testing with Vulnerability Expectation (CVE Validation)
You should be able to execute an atomic test with a defined vulnerability expectation.
If the payload uses an output parser of type cve, the system should correctly validate the vulnerability expectation against the detected CVE.

### Related issues

* Related #4302 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
