### PR TITLE
[backend] chore(telemetry): log user event

### DIFF
--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,10 @@
+Follow Conventional Commits format:
+- Pattern: [backend/frontend] type(scope): short description
+- Types: feat, fix, refactor, test, docs, chore, build
+- Examples:
+  [backend] feat(inject): add parallel execution support
+  [frontend] fix(scenario): correct date display timezone
+  [backend/frontend] refactor(auth): extract JWT helper
+
+Keep messages concise and descriptive.
+Never include secrets or sensitive data.

--- a/openaev-api/pom.xml
+++ b/openaev-api/pom.xml
@@ -227,6 +227,16 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
+        </dependency>
+        <!-- OpenTelemetry test-->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/openaev-api/src/main/java/io/openaev/service/user_events/UserEventService.java
+++ b/openaev-api/src/main/java/io/openaev/service/user_events/UserEventService.java
@@ -2,6 +2,7 @@ package io.openaev.service.user_events;
 
 import static io.openaev.database.model.UserEventType.LOGIN_SUCCESS;
 import static io.openaev.database.model.UserEventType.USER_CREATED;
+import static io.openaev.telemetry.TelemetryAttributes.CREATED_AT;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,6 +10,9 @@ import io.openaev.database.model.User;
 import io.openaev.database.model.UserEvent;
 import io.openaev.database.model.UserEventType;
 import io.openaev.database.repository.UserEventRepository;
+import io.openaev.telemetry.registry.LogRegistry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
 import jakarta.annotation.Resource;
 import java.time.Duration;
 import java.time.Instant;
@@ -31,6 +35,7 @@ public class UserEventService {
 
   @Resource private ObjectMapper mapper;
   private final UserEventRepository userEventRepository;
+  private final LogRegistry logRegistry;
 
   // -- CRUD --
 
@@ -73,6 +78,11 @@ public class UserEventService {
     event.setPayload(payload);
 
     userEventRepository.save(event);
+
+    AttributesBuilder attrsBuilder =
+        Attributes.builder().put(CREATED_AT, event.getCreatedAt().toString());
+
+    logRegistry.emit(type.name(), attrsBuilder.build());
     return CompletableFuture.completedFuture(null);
   }
 

--- a/openaev-api/src/main/java/io/openaev/telemetry/CustomMetricReader.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/CustomMetricReader.java
@@ -1,10 +1,13 @@
 package io.openaev.telemetry;
 
-import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.*;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.GaugeData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
@@ -18,7 +21,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Slf4j
 public class CustomMetricReader implements MetricReader {
-  private final OtlpHttpMetricExporter otlpExporter;
+  private final MetricExporter otlpExporter;
   private final ThreadPoolTaskScheduler taskScheduler;
   private final Duration collectInterval;
   private final Duration exportInterval;
@@ -29,11 +32,11 @@ public class CustomMetricReader implements MetricReader {
   private final AtomicLong collectMetricCount = new AtomicLong(0);
 
   public CustomMetricReader(
-      @NotNull OtlpHttpMetricExporter otlpExporter,
+      @NotNull MetricExporter metricExporter,
       @NotNull ThreadPoolTaskScheduler taskScheduler,
       @NotNull Duration collectIntervalInput,
       @NotNull Duration exportIntervalInput) {
-    this.otlpExporter = otlpExporter;
+    this.otlpExporter = metricExporter;
     this.taskScheduler = taskScheduler;
     this.collectInterval = collectIntervalInput;
     this.exportInterval = exportIntervalInput;

--- a/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
@@ -9,9 +9,14 @@ import io.openaev.database.model.Setting;
 import io.openaev.database.repository.SettingRepository;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingLogRecordExporter;
+import io.opentelemetry.exporter.logging.otlp.OtlpJsonLoggingMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
@@ -53,14 +58,22 @@ public class OpenTelemetryConfig {
   private final SettingRepository settingRepository;
   private final ThreadPoolTaskScheduler taskScheduler;
 
-  @Getter private final Duration collectInterval = Duration.ofMinutes(60);
-  @Getter private final Duration exportInterval = Duration.ofMinutes(6 * 60);
-
   private static final DateTimeFormatter CREATION_DATE_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.n]");
 
   @Value("${openbas.telemetry.enabled:${openaev.telemetry.enabled:true}}")
   private boolean telemetryEnabled;
+
+  @Getter
+  @Value("${openaev.telemetry.collect-interval:PT60M}")
+  private Duration collectInterval;
+
+  @Getter
+  @Value("${openaev.telemetry.export-interval:PT360M}")
+  private Duration exportInterval;
+
+  @Value("${openaev.telemetry.exporter:otlp}")
+  private String telemetryExporter;
 
   @Bean
   public OpenTelemetry openTelemetry() {
@@ -69,10 +82,43 @@ public class OpenTelemetryConfig {
       return OpenTelemetry.noop();
     }
 
+    log.info("Telemetry - Using collect interval: {}", collectInterval);
+    log.info("Telemetry - Using export interval: {}", exportInterval);
+
+    if ("file".equalsIgnoreCase(telemetryExporter)) {
+      return buildFileOpenTelemetry();
+    } else {
+      return buildOtlpOpenTelemetry();
+    }
+  }
+
+  private OpenTelemetry buildFileOpenTelemetry() {
+    log.info("Telemetry exporter: FILE (OTLP JSON via JUL -> Logback)");
+    Resource resource = buildResource();
+
+    MetricReader metricReader =
+        new CustomMetricReader(
+            OtlpJsonLoggingMetricExporter.create(), taskScheduler, collectInterval, exportInterval);
+
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().setResource(resource).registerMetricReader(metricReader).build();
+
+    SdkLoggerProvider loggerProvider =
+        SdkLoggerProvider.builder()
+            .setResource(resource)
+            .addLogRecordProcessor(
+                SimpleLogRecordProcessor.create(OtlpJsonLoggingLogRecordExporter.create()))
+            .build();
+
+    return OpenTelemetrySdk.builder()
+        .setMeterProvider(meterProvider)
+        .setLoggerProvider(loggerProvider)
+        .build();
+  }
+
+  private OpenTelemetry buildOtlpOpenTelemetry() {
     String endpoint = getOTELEndpoint();
-    log.info("Telemetry enabled - using endpoint: " + endpoint);
-    log.info("Telemetry - Using collect interval: " + collectInterval);
-    log.info("Telemetry - Using export interval: " + exportInterval);
+    log.info("Telemetry exporter: OTLP - endpoint: {}", endpoint);
 
     if (!isEndpointReachable(endpoint)) {
       log.warn("OTLP endpoint not reachable. Falling back to noop OpenTelemetry.");
@@ -81,23 +127,17 @@ public class OpenTelemetryConfig {
 
     Resource resource = buildResource();
 
-    // Set OTLP Exporter
     OtlpHttpMetricExporter otlpExporter =
         OtlpHttpMetricExporter.builder()
-            .setEndpoint(getOTELEndpoint())
+            .setEndpoint(endpoint)
             .setAggregationTemporalitySelector(instrumentType -> AggregationTemporality.DELTA)
             .build();
 
-    // Set Metric Reader
-    MetricReader customMetricReader =
+    MetricReader metricReader =
         new CustomMetricReader(otlpExporter, taskScheduler, collectInterval, exportInterval);
 
-    // Create MeterProvider
     SdkMeterProvider meterProvider =
-        SdkMeterProvider.builder()
-            .setResource(resource)
-            .registerMetricReader(customMetricReader)
-            .build();
+        SdkMeterProvider.builder().setResource(resource).registerMetricReader(metricReader).build();
 
     return OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
   }
@@ -105,6 +145,11 @@ public class OpenTelemetryConfig {
   @Bean
   public Meter meter(@NotNull final OpenTelemetry openTelemetry) {
     return openTelemetry.getMeter("openaev-api-meter");
+  }
+
+  @Bean
+  public Logger logger(@NotNull final OpenTelemetry openTelemetry) {
+    return openTelemetry.getLogsBridge().loggerBuilder("openaev-api-events").build();
   }
 
   // -- PRIVATE --

--- a/openaev-api/src/main/java/io/openaev/telemetry/TelemetryAttributes.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/TelemetryAttributes.java
@@ -1,0 +1,15 @@
+package io.openaev.telemetry;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/**
+ * Centralizes OpenTelemetry attribute keys used for telemetry events. Keys follow the <a
+ * href="https://opentelemetry.io/docs/specs/semconv/">OTel Semantic Conventions</a> naming style.
+ */
+public final class TelemetryAttributes {
+
+  private TelemetryAttributes() {}
+
+  public static final AttributeKey<String> EVENT_TYPE = AttributeKey.stringKey("event.type");
+  public static final AttributeKey<String> CREATED_AT = AttributeKey.stringKey("event.created_at");
+}

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/ActionMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/ActionMetricCollector.java
@@ -1,6 +1,7 @@
 package io.openaev.telemetry.metric_collectors;
 
 import io.openaev.injectors.openaev.OpenAEVImplantContract;
+import io.openaev.telemetry.registry.MetricRegistry;
 import jakarta.annotation.PostConstruct;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/AgentMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/AgentMetricCollector.java
@@ -4,6 +4,7 @@ import io.openaev.database.model.Executor;
 import io.openaev.executors.ExecutorService;
 import io.openaev.service.AgentService;
 import io.openaev.telemetry.OpenTelemetryConfig;
+import io.openaev.telemetry.registry.MetricRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.Tuple;
 import java.time.Duration;

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/GlobalMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/GlobalMetricCollector.java
@@ -2,6 +2,7 @@ package io.openaev.telemetry.metric_collectors;
 
 import io.openaev.ee.Ee;
 import io.openaev.service.UserService;
+import io.openaev.telemetry.registry.MetricRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/UserMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/UserMetricCollector.java
@@ -1,6 +1,7 @@
 package io.openaev.telemetry.metric_collectors;
 
 import io.openaev.service.user_events.UserEventService;
+import io.openaev.telemetry.registry.MetricRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/openaev-api/src/main/java/io/openaev/telemetry/registry/LogRegistry.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/registry/LogRegistry.java
@@ -1,0 +1,24 @@
+package io.openaev.telemetry.registry;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogRegistry {
+
+  @Lazy private final Logger logger;
+
+  public void emit(String eventName, Attributes attributes) {
+    logger
+        .logRecordBuilder()
+        .setSeverity(Severity.INFO)
+        .setBody(eventName)
+        .setAllAttributes(attributes)
+        .emit();
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/telemetry/registry/MetricRegistry.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/registry/MetricRegistry.java
@@ -1,4 +1,4 @@
-package io.openaev.telemetry.metric_collectors;
+package io.openaev.telemetry.registry;
 
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableDoubleGauge;

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -395,3 +395,13 @@ management.endpoints.web.exposure.include=
 #management.endpoints.web.exposure.include=metrics,prometheus
 management.endpoint.health.show-details=always
 management.server.port=8080
+
+#############################
+# FEATURE UNDER DEVELOPMENT #
+#############################
+openaev.enabled-dev-features=
+
+#############
+# TELEMETRY #
+#############
+openaev.telemetry.exporter=otlp

--- a/openaev-api/src/main/resources/logback-spring.xml
+++ b/openaev-api/src/main/resources/logback-spring.xml
@@ -7,6 +7,22 @@
             </encoder>
         </appender>
 
+        <appender name="TELEMETRY_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>./logs/openaev-telemetry.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./logs/openaev-telemetry.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>%msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="io.opentelemetry.exporter.logging.otlp" level="INFO" additivity="false">
+            <appender-ref ref="TELEMETRY_FILE"/>
+        </logger>
+
         <root>
             <appender-ref ref="STDOUT" />
         </root>

--- a/openaev-api/src/test/java/io/openaev/config/NoOpOpenTelemetryConfig.java
+++ b/openaev-api/src/test/java/io/openaev/config/NoOpOpenTelemetryConfig.java
@@ -6,8 +6,9 @@ import io.openaev.service.AgentService;
 import io.openaev.telemetry.OpenTelemetryConfig;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.telemetry.metric_collectors.AgentMetricCollector;
-import io.openaev.telemetry.metric_collectors.MetricRegistry;
+import io.openaev.telemetry.registry.MetricRegistry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import org.mockito.Mockito;
@@ -29,6 +30,11 @@ public class NoOpOpenTelemetryConfig {
   @Bean
   public Meter meter() {
     return MeterProvider.noop().get("noop-meter");
+  }
+
+  @Bean
+  public Logger otelLogger() {
+    return OpenTelemetry.noop().getLogsBridge().loggerBuilder("noop-logger").build();
   }
 
   @Bean

--- a/openaev-api/src/test/java/io/openaev/telemetry/LogRegistryTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/LogRegistryTest.java
@@ -1,0 +1,59 @@
+package io.openaev.telemetry;
+
+import static io.openaev.database.model.UserEventType.USER_CREATED;
+import static io.openaev.telemetry.TelemetryAttributes.CREATED_AT;
+import static io.openaev.telemetry.TelemetryAttributes.EVENT_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.telemetry.registry.LogRegistry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LogRegistry tests")
+class LogRegistryTest {
+
+  private InMemoryLogRecordExporter logExporter;
+  private SdkLoggerProvider loggerProvider;
+  private LogRegistry logRegistry;
+
+  @BeforeEach
+  void setUp() {
+    logExporter = InMemoryLogRecordExporter.create();
+    loggerProvider =
+        SdkLoggerProvider.builder()
+            .addLogRecordProcessor(SimpleLogRecordProcessor.create(logExporter))
+            .build();
+    Logger logger = loggerProvider.loggerBuilder("test-logger").build();
+    logRegistry = new LogRegistry(logger);
+  }
+
+  @AfterEach
+  void tearDown() {
+    loggerProvider.shutdown();
+  }
+
+  @Test
+  @DisplayName("emit should produce a log record with body and structured attributes")
+  void should_produce_log_record_with_body_and_attributes() {
+    // -- ACT --
+    logRegistry.emit(
+        "user-registered",
+        Attributes.of(EVENT_TYPE, USER_CREATED.name(), CREATED_AT, "2026-02-09T10:30:00Z"));
+
+    // -- ASSERT --
+    LogRecordData logRecord = logExporter.getFinishedLogRecordItems().getFirst();
+    assertThat(logRecord.getSeverity()).isEqualTo(Severity.INFO);
+    assertThat(logRecord.getBodyValue().asString()).isEqualTo("user-registered");
+    assertThat(logRecord.getAttributes().get(EVENT_TYPE)).isEqualTo(USER_CREATED.name());
+    assertThat(logRecord.getAttributes().get(CREATED_AT)).isEqualTo("2026-02-09T10:30:00Z");
+  }
+}


### PR DESCRIPTION
### Proposed changes

* Add a file telemetry exporter mode (openaev.telemetry.exporter=file) that writes OTLP JSON (metrics + log records) to a rolling file via Logback
* Emit structured OTel log records on user events (LOGIN_SUCCESS, LOGIN_FAILED, USER_CREATED) via a new LogRegistry
* Make collect-interval and export-interval configurable via Spring properties

### Testing Instructions

1. Set openaev.telemetry.exporter=file in application-dev.properties
2. Check logs/openaev-telemetry.log for scopeLogs (user events) and scopeMetrics entries

### Related issues

* https://github.com/OpenAEV-Platform/openaev/issues/4834

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug