### PR TITLE
Fix exercise duplication saving original instead of duplicate

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -186,7 +186,7 @@ public class ExerciseService {
     getListOfVariables(exerciseDuplicate, exerciseOrigin);
     getObjectives(exerciseDuplicate, exerciseOrigin);
     getLessonsCategories(exerciseDuplicate, exerciseOrigin);
-    return exerciseRepository.save(exercise);
+    return exerciseRepository.save(exerciseDuplicate);
   }
 
   private Exercise copyExercice(Exercise exerciseOrigin) {


### PR DESCRIPTION
The duplicate exercise endpoint was saving the original exercise object instead of the duplicate. This one-line fix passes the correct variable to the repository save method. Fixes #5011