### PR TITLE
[backend] fix(pagination): take into account the search filter in pagination (#3431)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/pagination/PaginationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/pagination/PaginationUtils.java
@@ -59,7 +59,9 @@ public class PaginationUtils {
         PageRequest.of(input.getPage(), input.getSize(), toSortJpa(input.getSorts(), clazz));
 
     return findAll.apply(
-        filterSpecifications.and(searchSpecifications), filterSpecificationsForCount, pageable);
+        filterSpecifications.and(searchSpecifications),
+        filterSpecificationsForCount.and(searchSpecifications),
+        pageable);
   }
 
   public static <T, U> Page<U> buildPaginationCriteriaBuilder(


### PR DESCRIPTION
### Proposed changes
* apply the search specification to the count query as well, so that totalElements correctly reflects the number of results matching both the filters and the text search.

### Testing Instructions

1. Go on scenario page
2. Do a research with the search bar
3. The number of elements should be updated

### Related issues

* Closes #3431 

