### PR TITLE
[backend] feat(multi-tenancy): manage custom_dashboards table (#3505)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/CustomDashboardService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/CustomDashboardService.java
@@ -5,6 +5,7 @@ import static io.openaev.database.specification.CustomDashboardSpecification.byN
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.CustomDashboard;
 import io.openaev.database.model.Setting;
 import io.openaev.database.model.SettingKeys;
@@ -95,7 +96,8 @@ public class CustomDashboardService {
    */
   @Transactional(readOnly = true)
   public List<CustomDashboardOutput> customDashboards() {
-    List<RawCustomDashboard> customDashboards = customDashboardRepository.rawAll();
+    List<RawCustomDashboard> customDashboards =
+        customDashboardRepository.rawAll(TenantContext.getCurrentTenant());
     return customDashboardMapper.getCustomDashboardOutputs(customDashboards);
   }
 

--- a/openaev-api/src/test/java/io/openaev/datapack/packs/StarterPackTest.java
+++ b/openaev-api/src/test/java/io/openaev/datapack/packs/StarterPackTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.model.Tag;
 import io.openaev.database.repository.*;
@@ -508,13 +509,16 @@ public class StarterPackTest extends IntegrationTest {
     long dashboardCount = customDashboardRepository.count();
     assertEquals(3, dashboardCount);
 
-    Optional<CustomDashboard> dashboardTest = customDashboardRepository.findByName("Test 1");
+    Optional<CustomDashboard> dashboardTest =
+        customDashboardRepository.findByNameAndTenantId("Test 1", TenantContext.getCurrentTenant());
     assertTrue(dashboardTest.isPresent());
 
-    Optional<CustomDashboard> dashboardTest2 = customDashboardRepository.findByName("Test 2");
+    Optional<CustomDashboard> dashboardTest2 =
+        customDashboardRepository.findByNameAndTenantId("Test 2", TenantContext.getCurrentTenant());
     assertTrue(dashboardTest2.isPresent());
 
-    Optional<CustomDashboard> dashboardTest3 = customDashboardRepository.findByName("Test 3");
+    Optional<CustomDashboard> dashboardTest3 =
+        customDashboardRepository.findByNameAndTenantId("Test 3", TenantContext.getCurrentTenant());
     assertTrue(dashboardTest3.isPresent());
   }
 
@@ -524,7 +528,8 @@ public class StarterPackTest extends IntegrationTest {
   }
 
   private void verifyDefaultHomeDashboardParameterExist() {
-    Optional<CustomDashboard> dashboardTest = customDashboardRepository.findByName("Test 1");
+    Optional<CustomDashboard> dashboardTest =
+        customDashboardRepository.findByNameAndTenantId("Test 1", TenantContext.getCurrentTenant());
     assertTrue(dashboardTest.isPresent());
 
     Optional<Setting> staticsParameters = settingRepository.findByKey("platform_home_dashboard");
@@ -533,7 +538,8 @@ public class StarterPackTest extends IntegrationTest {
   }
 
   private void verifyDefaultScenarioDashboardParameterExist() {
-    Optional<CustomDashboard> dashboardTest = customDashboardRepository.findByName("Test 2");
+    Optional<CustomDashboard> dashboardTest =
+        customDashboardRepository.findByNameAndTenantId("Test 2", TenantContext.getCurrentTenant());
     assertTrue(dashboardTest.isPresent());
 
     Optional<Setting> staticsParameters =
@@ -543,7 +549,8 @@ public class StarterPackTest extends IntegrationTest {
   }
 
   private void verifyDefaultSimulationDashboardParameterExist() {
-    Optional<CustomDashboard> dashboardTest = customDashboardRepository.findByName("Test 3");
+    Optional<CustomDashboard> dashboardTest =
+        customDashboardRepository.findByNameAndTenantId("Test 3", TenantContext.getCurrentTenant());
     assertTrue(dashboardTest.isPresent());
 
     Optional<Setting> staticsParameters =

--- a/openaev-api/src/test/java/io/openaev/rest/custom_dashboard/CustomDashboardApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/custom_dashboard/CustomDashboardApiTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.CustomDashboard;
 import io.openaev.database.model.Setting;
 import io.openaev.database.repository.CustomDashboardRepository;
@@ -60,7 +61,8 @@ class CustomDashboardApiTest extends IntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.custom_dashboard_name").value(name));
 
-    assertThat(repository.findByName(name)).isPresent();
+    assertThat(repository.findByNameAndTenantId(name, TenantContext.getCurrentTenant()))
+        .isPresent();
   }
 
   @Test

--- a/openaev-model/src/main/java/io/openaev/database/repository/CustomDashboardRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/CustomDashboardRepository.java
@@ -16,7 +16,8 @@ import org.springframework.stereotype.Repository;
 public interface CustomDashboardRepository
     extends CrudRepository<CustomDashboard, String>, JpaSpecificationExecutor<CustomDashboard> {
 
-  Optional<CustomDashboard> findByName(@NotBlank final String name);
+  Optional<CustomDashboard> findByNameAndTenantId(
+      @NotBlank final String name, @NotBlank final String tenantId);
 
   /**
    * Get the raw version of the custom dashboards
@@ -27,9 +28,10 @@ public interface CustomDashboardRepository
       value =
           " SELECT cd.custom_dashboard_id, "
               + "cd.custom_dashboard_name "
-              + "FROM custom_dashboards cd;",
+              + "FROM custom_dashboards cd "
+              + "WHERE cd.tenant_id = :tenantId;",
       nativeQuery = true)
-  List<RawCustomDashboard> rawAll();
+  List<RawCustomDashboard> rawAll(String tenantId);
 
   @Query(
       value =
@@ -45,6 +47,7 @@ public interface CustomDashboardRepository
       nativeQuery = true)
   Optional<CustomDashboard> findByResourceId(String resourceId);
 
+  // TODO multi-tenancy: add tenant_id on parameters?
   @Query(
       """
   SELECT d FROM CustomDashboard d


### PR DESCRIPTION
### Proposed changes

* Add tenant_id on native requests that can't be automatically managed on custom_dashboards table

### Testing Instructions

1. OpenAEV must work as before

### Related issues

* 3505

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
