### PR TITLE
[backend] fix(stix): set dates on security coverage for response (#5142)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -456,6 +456,13 @@ public class SecurityCoverageService {
     Optional<Timestamp> sroStopTime =
         exerciseService.getLatestValidityDate(simulation).map(Timestamp::new);
 
+    sroStartTime.ifPresent(
+        instant -> coverage.setProperty(ExtendedProperties.VALID_FROM.toString(), instant));
+    sroStartTime.ifPresent(
+        instant -> coverage.setProperty(ExtendedProperties.LAST_RESULT.toString(), instant));
+    sroStopTime.ifPresent(
+        instant -> coverage.setProperty(ExtendedProperties.VALID_TO.toString(), instant));
+
     // Process coverage refs by stix object: attack patterns
     processCoverageRefs(
         simulation.getSecurityCoverage().getAttackPatternRefs(),

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -24,6 +24,7 @@ import io.openaev.utils.fixtures.composers.*;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -494,6 +495,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
       "When all attack patterns are covered and half of expectations are successful, bundle is correct")
   public void whenAllAttackPatternsAreCoveredAndHalfOfAllExpectationsAreSuccessful_bundleIsCorrect()
       throws ParsingException, JsonProcessingException {
+    Instant simulationStartTime = Instant.parse("2024-09-23T14:09:43Z");
+    Instant nextSimulationStartTime = Instant.parse("2024-09-24T14:09:43Z");
     AttackPatternComposer.Composer ap1 =
         attackPatternComposer.forAttackPattern(
             AttackPatternFixture.createAttackPatternsWithExternalId("T1234"));
@@ -515,6 +518,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
     // create exercise cover all TTPs
     ExerciseComposer.Composer exerciseWrapper =
         createExerciseWrapperWithInjectsForDomainObjects(Map.of(ap1, true, ap2, true), Map.of());
+    exerciseWrapper.get().setStart(simulationStartTime);
     exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
     // expectation results
@@ -564,10 +568,12 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
               exp.setScore(0.0);
             });
 
-    scenarioComposer
-        .forScenario(ScenarioFixture.createDefaultCrisisScenario())
-        .withSimulation(exerciseWrapper)
-        .persist();
+    ScenarioComposer.Composer scenarioWrapper =
+        scenarioComposer.forScenario(ScenarioFixture.createDefaultCrisisScenario());
+    scenarioWrapper.get().setRecurrence("P1D");
+    scenarioWrapper.get().setRecurrenceStart(simulationStartTime);
+    scenarioWrapper.get().setRecurrenceEnd(simulationStartTime.plus(30, ChronoUnit.DAYS));
+    scenarioWrapper.withSimulation(exerciseWrapper).persist();
 
     entityManager.flush();
     entityManager.refresh(exerciseWrapper.get());
@@ -588,7 +594,12 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
     List<SecurityPlatform> generatedSecurityPlatforms = securityPlatformComposer.generatedItems;
 
     DomainObject expectedAssessmentWithCoverage =
-        getExpectedMainSecurityCoverage(generatedCoverage, generatedInjects);
+        addPropertiesToDomainObject(
+            getExpectedMainSecurityCoverage(generatedCoverage, generatedInjects),
+            Map.of(
+                ExtendedProperties.VALID_FROM.toString(), new Timestamp(simulationStartTime),
+                ExtendedProperties.LAST_RESULT.toString(), new Timestamp(simulationStartTime),
+                ExtendedProperties.VALID_TO.toString(), new Timestamp(nextSimulationStartTime)));
     List<DomainObject> expectedPlatformIdentities =
         generatedSecurityPlatforms.stream().map(SecurityPlatform::toStixDomainObject).toList();
 
@@ -625,6 +636,10 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                   expectedAssessmentWithCoverage.getId(),
                   RelationshipObject.Properties.TARGET_REF.toString(),
                   platformSdo.getId(),
+                  RelationshipObject.Properties.START_TIME.toString(),
+                  new Timestamp(simulationStartTime),
+                  RelationshipObject.Properties.STOP_TIME.toString(),
+                  new Timestamp(nextSimulationStartTime),
                   ExtendedProperties.COVERED.toString(),
                   new io.openaev.stix.types.Boolean(true),
                   ExtendedProperties.COVERAGE.toString(),
@@ -673,6 +688,10 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                   expectedAssessmentWithCoverage.getId(),
                   RelationshipObject.Properties.TARGET_REF.toString(),
                   new Identifier(stixRef.getStixRef()),
+                  RelationshipObject.Properties.START_TIME.toString(),
+                  new Timestamp(simulationStartTime),
+                  RelationshipObject.Properties.STOP_TIME.toString(),
+                  new Timestamp(nextSimulationStartTime),
                   ExtendedProperties.COVERED.toString(),
                   new io.openaev.stix.types.Boolean(true),
                   ExtendedProperties.COVERAGE.toString(),

--- a/openaev-model/src/main/java/io/openaev/stix/objects/constants/ExtendedProperties.java
+++ b/openaev-model/src/main/java/io/openaev/stix/objects/constants/ExtendedProperties.java
@@ -5,6 +5,9 @@ import jakarta.validation.constraints.NotBlank;
 public enum ExtendedProperties {
   COVERED("covered"),
   COVERAGE("coverage"),
+  LAST_RESULT("last_result"),
+  VALID_FROM("valid_from"),
+  VALID_TO("valid_to"),
   MITRE_EXTENSION_DEFINITION("extension-definition--322b8f77-262a-4cb8-a915-1e441e00329b"),
   OPENCTI_EXTENSION_DEFINITION("extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba");
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* When applicable, set relevant validity dates on Security Coverage in STIX bundle response

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #5142 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
