### PR TITLE
[frontend] fix(security-coverage): manage unique and reusable uuid for relationship (#4514)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -499,7 +499,8 @@ public class SecurityCoverageService {
               new HashMap<>(
                   Map.of(
                       CommonProperties.ID.toString(),
-                      generateRelationship(coverage.getId().getValue(), platformIdentity.getId().getValue()),
+                      generateRelationship(
+                          coverage.getId().getValue(), platformIdentity.getId().getValue()),
                       CommonProperties.TYPE.toString(),
                       new StixString(ObjectTypes.RELATIONSHIP.toString()),
                       RelationshipObject.Properties.RELATIONSHIP_TYPE.toString(),

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -487,65 +487,69 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
         }
       }
 
-        @Test
-        @DisplayName(
-                "Multiple bundles are created should have the same SRO ID")
-        public void whenMultipleBundlesAreCreatedShouldHaveTheSameSROID()
-                throws ParsingException, JsonProcessingException {
-            AttackPatternComposer.Composer ap1 =
-                    attackPatternComposer.forAttackPattern(
-                            AttackPatternFixture.createAttackPatternsWithExternalId("T1234"));
-            AttackPatternComposer.Composer ap2 =
-                    attackPatternComposer.forAttackPattern(
-                            AttackPatternFixture.createAttackPatternsWithExternalId("T5678"));
-            // some security platforms
-            SecurityPlatformComposer.Composer securityPlatformWrapper =
-                    securityPlatformComposer
-                            .forSecurityPlatform(
-                                    SecurityPlatformFixture.createDefault(
-                                            "Bad EDR", SecurityPlatform.SECURITY_PLATFORM_TYPE.EDR.name()))
-                            .persist();
-            // another nameless platform not involved in simulation
+      @Test
+      @DisplayName("Multiple bundles are created should have the same SRO ID")
+      public void whenMultipleBundlesAreCreatedShouldHaveTheSameSROID()
+          throws ParsingException, JsonProcessingException {
+        AttackPatternComposer.Composer ap1 =
+            attackPatternComposer.forAttackPattern(
+                AttackPatternFixture.createAttackPatternsWithExternalId("T1234"));
+        AttackPatternComposer.Composer ap2 =
+            attackPatternComposer.forAttackPattern(
+                AttackPatternFixture.createAttackPatternsWithExternalId("T5678"));
+        // some security platforms
+        SecurityPlatformComposer.Composer securityPlatformWrapper =
             securityPlatformComposer
-                    .forSecurityPlatform(
-                            SecurityPlatformFixture.createDefault(
-                                    "New SIEM", SecurityPlatform.SECURITY_PLATFORM_TYPE.SIEM.name()))
-                    .persist();
-            // create exercise cover all TTPs
-            ExerciseComposer.Composer exerciseWrapper =
-                    createExerciseWrapperWithInjectsForDomainObjects(Map.of(ap1, true, ap2, true), Map.of());
-            exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
+                .forSecurityPlatform(
+                    SecurityPlatformFixture.createDefault(
+                        "Bad EDR", SecurityPlatform.SECURITY_PLATFORM_TYPE.EDR.name()))
+                .persist();
+        // another nameless platform not involved in simulation
+        securityPlatformComposer
+            .forSecurityPlatform(
+                SecurityPlatformFixture.createDefault(
+                    "New SIEM", SecurityPlatform.SECURITY_PLATFORM_TYPE.SIEM.name()))
+            .persist();
+        // create exercise cover all TTPs
+        ExerciseComposer.Composer exerciseWrapper =
+            createExerciseWrapperWithInjectsForDomainObjects(
+                Map.of(ap1, true, ap2, true), Map.of());
+        exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
 
-            // set SUCCESS results for all inject expectations
-            setupSuccessfulExpectations(securityPlatformWrapper);
-            persistScenario(exerciseWrapper);
+        // set SUCCESS results for all inject expectations
+        setupSuccessfulExpectations(securityPlatformWrapper);
+        persistScenario(exerciseWrapper);
 
-            Optional<SecurityCoverageSendJob> job =
-                    securityCoverageSendJobService.createOrUpdateCoverageSendJobForSimulationIfReady(
-                            exerciseWrapper.get());
+        Optional<SecurityCoverageSendJob> job =
+            securityCoverageSendJobService.createOrUpdateCoverageSendJobForSimulationIfReady(
+                exerciseWrapper.get());
 
-            // intermediate assert
-            assertThat(job).isNotEmpty();
+        // intermediate assert
+        assertThat(job).isNotEmpty();
 
-            // act
-            Bundle bundle1 = securityCoverageService.createBundleFromSendJobs(List.of(job.orElseThrow()));
-            Bundle bundle2 = securityCoverageService.createBundleFromSendJobs(List.of(job.orElseThrow()));
+        // act
+        Bundle bundle1 =
+            securityCoverageService.createBundleFromSendJobs(List.of(job.orElseThrow()));
+        Bundle bundle2 =
+            securityCoverageService.createBundleFromSendJobs(List.of(job.orElseThrow()));
 
-            // assert
-            assertThat(bundle1).isNotNull();
-            assertThat(bundle2).isNotNull();
+        // assert
+        assertThat(bundle1).isNotNull();
+        assertThat(bundle2).isNotNull();
 
-            List<String> sroIds1 = bundle1.getRelationshipObjects().stream()
-                    .filter(sro -> sro.hasProperty("id"))
-                    .map(sro -> sro.getProperty("id").getValue().toString())
-                    .toList();
-            List<String> sroIds2 = bundle2.getRelationshipObjects().stream()
-                    .filter(sro -> sro.hasProperty("id"))
-                    .map(sro -> sro.getProperty("id").getValue().toString())
-                    .toList();
+        List<String> sroIds1 =
+            bundle1.getRelationshipObjects().stream()
+                .filter(sro -> sro.hasProperty("id"))
+                .map(sro -> sro.getProperty("id").getValue().toString())
+                .toList();
+        List<String> sroIds2 =
+            bundle2.getRelationshipObjects().stream()
+                .filter(sro -> sro.hasProperty("id"))
+                .map(sro -> sro.getProperty("id").getValue().toString())
+                .toList();
 
-            assertThat(sroIds1).containsExactlyInAnyOrderElementsOf(sroIds2);
-        }
+        assertThat(sroIds1).containsExactlyInAnyOrderElementsOf(sroIds2);
+      }
     }
   }
 


### PR DESCRIPTION
### Proposed changes

* Use a unique and reusable uuid for SRO on Security Coverage, instead a new different one each time.
This allow us to modify an existing SRO, and avoid duplication of data on OCTI side.

### Testing Instructions

1. Run an environment linked with an OCTI instance
2. Create and execute the Security Coverage process (create report, create Security Coverage from it, and check for OAEV response)
3. Run multiple time the scenario on OAEV, with different coverage results, to push multiple bundles on OCTI
4. Only the existing SRO lines should be modified on OCTI, instead of creating a new one


### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] For bug fix -> I implemented a test that covers the bug
