### PR TITLE
[tools] fix(ci): capture closed bugs from 'Bugs backlog' milestone

### DIFF
--- a/.github/workflows/move-issue-to-release-milestone.yml
+++ b/.github/workflows/move-issue-to-release-milestone.yml
@@ -18,7 +18,8 @@ jobs:
   move_to_release_milestone:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.issue.milestone && github.event.issue.milestone.title == 'Next Minor')
+      (github.event.issue.milestone &&
+        (github.event.issue.milestone.title == 'Next Minor' || github.event.issue.milestone.title == 'Bugs backlog'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Capture bugs closed from both **"Next Minor"** and **"Bugs backlog"** milestones into the next patch release milestone.

## Why

Previously, only issues with the `Next Minor` milestone were automatically moved to the next release milestone when closed.

## Changes

- Added `Bugs backlog` as a second accepted milestone in the workflow trigger condition.