### PR TITLE
[backend] fix: fix import for output parsers (#5179)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/api/payload/PayloadApiImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/payload/PayloadApiImporterTest.java
@@ -215,7 +215,7 @@ class PayloadApiImporterTest extends IntegrationTest {
     elementAttrs.put("contract_output_element_rule", "\\d+");
     elementAttrs.put("contract_output_element_key", "IPv6-key");
     elementAttrs.put("contract_output_element_name", "IPv6 Name");
-    elementAttrs.put("contract_output_element_type", "IPv6");
+    elementAttrs.put("contract_output_element_type", "ipv6");
     elementAttrs.put("contract_output_element_is_finding", false);
     ResourceObject contractOutputElementResource =
         new ResourceObject(
@@ -358,7 +358,7 @@ class PayloadApiImporterTest extends IntegrationTest {
     element1Attrs.put("contract_output_element_rule", "(\\d{1,3}(?:\\.\\d{1,3}){3}):(\\d+)");
     element1Attrs.put("contract_output_element_key", "portscan-key");
     element1Attrs.put("contract_output_element_name", "PortsScan Name");
-    element1Attrs.put("contract_output_element_type", "PortsScan");
+    element1Attrs.put("contract_output_element_type", "portscan");
     element1Attrs.put("contract_output_element_is_finding", true);
     ResourceObject contractOutputElement1 =
         new ResourceObject(
@@ -377,7 +377,7 @@ class PayloadApiImporterTest extends IntegrationTest {
     element2Attrs.put("contract_output_element_rule", "(\\w+)");
     element2Attrs.put("contract_output_element_key", "username-key");
     element2Attrs.put("contract_output_element_name", "Username Name");
-    element2Attrs.put("contract_output_element_type", "Username");
+    element2Attrs.put("contract_output_element_type", "text");
     element2Attrs.put("contract_output_element_is_finding", true);
     ResourceObject contractOutputElement2 =
         new ResourceObject(

--- a/openaev-model/src/main/java/io/openaev/database/model/ContractOutputElement.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ContractOutputElement.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openaev.helper.MultiIdSetSerializer;
+import io.openaev.jsonapi.InnerRelationship;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
@@ -23,6 +24,7 @@ import org.hibernate.annotations.UuidGenerator;
 @Data
 @Entity
 @Table(name = "contract_output_elements")
+@InnerRelationship
 public class ContractOutputElement implements Base {
 
   @Id

--- a/openaev-model/src/main/java/io/openaev/database/model/OutputParser.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/OutputParser.java
@@ -4,6 +4,7 @@ import static java.time.Instant.now;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.jsonapi.InnerRelationship;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,6 +20,7 @@ import org.hibernate.annotations.UuidGenerator;
 @Data
 @Entity
 @Table(name = "output_parsers")
+@InnerRelationship
 public class OutputParser implements Base {
 
   @Id

--- a/openaev-model/src/main/java/io/openaev/database/model/RegexGroup.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/RegexGroup.java
@@ -4,6 +4,7 @@ import static java.time.Instant.now;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.jsonapi.InnerRelationship;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import org.hibernate.annotations.UuidGenerator;
 @Data
 @Entity
 @Table(name = "regex_groups")
+@InnerRelationship
 public class RegexGroup implements Base {
 
   @Id

--- a/openaev-model/src/main/java/io/openaev/jsonapi/GenericJsonApiImporter.java
+++ b/openaev-model/src/main/java/io/openaev/jsonapi/GenericJsonApiImporter.java
@@ -65,16 +65,7 @@ public class GenericJsonApiImporter<T extends Base> {
             doc.data(), includedMap, entityCache, entitiesNeedingRemapping, includeOptions, true);
     T toPersist = Optional.ofNullable(sanityCheck).map(check -> check.apply(entity)).orElse(entity);
 
-    // Persist the root entity first so its cascade chain (e.g. Payload → OutputParser →
-    // ContractOutputElement → RegexGroup) makes all inner entities managed before the loop below.
-    // Without this, the HashMap-based cache loop iterates in non-deterministic order and may try to
-    // persist a child (e.g. RegexGroup) before its parent (e.g. ContractOutputElement) is
-    // persisted, causing TransientPropertyValueException on the non-null FK column.
-    entityManager.persist(toPersist);
-
-    // Persist included entities that are not part of the root cascade chain
-    // (e.g. shared entities like Tags, AttackPatterns).
-    // Inner entities already managed via cascade above are skipped by the contains() check.
+    // Persist included entities that not inner relationship
     for (Pair<T, Boolean> value : entityCache.values()) {
       if (!entityManager.contains(value.getLeft()) && !value.getRight()) {
         T e = value.getLeft();
@@ -88,6 +79,10 @@ public class GenericJsonApiImporter<T extends Base> {
 
     // Validate constraint
     entityManager.flush();
+
+    // persists a first time to obtain generated IDs for all db-bound entities
+    // to enable establishing a map from exported ID to new ID
+    entityManager.persist(toPersist);
 
     Map<String, String> swappedIds =
         entityCache.entrySet().stream()


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
 
Added @InnerRelationship to OutputParser, ContractOutputElement, and RegexGroup. This tells the importer to skip these entities in the cache loop and let JPA cascade handle their persistence from the root entity, which always processes the object graph in the correct parent-first order.

### Testing Instructions

1. Create a payload with output parsers
2. Export it
3. Import it

### Related issues

* Closes #5179 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
