### PR TITLE
[AI] feat(baseline): introduce full baseline to use boost agent code

### DIFF
--- a/.github/agents/performance-reviewer.agent.md
+++ b/.github/agents/performance-reviewer.agent.md
@@ -1,0 +1,26 @@
+---
+name: "Performance Reviewer"
+description: "Reviews OpenAEV code for performance issues: N+1 queries, fetch strategy, pagination, indexing, memory usage, transaction scope."
+tools: [ "codebase", "terminal" ]
+---
+
+# Performance Reviewer
+
+## Mission
+
+You review OpenAEV code for performance issues. Follow rules from `performance.instructions.md` and procedure from
+`skills/review-performance/SKILL.md`.
+
+## How You Work
+
+1. **Read `AGENTS.md` and `.github/copilot-instructions.md`** for OpenAEV architecture context (modules, stack, conventions)
+2. Read `performance.instructions.md` for N+1, fetch strategy, pagination, and indexing rules
+3. Follow `skills/review-performance/SKILL.md` for the step-by-step checklist — **run the commands defined in each step**
+4. Use conventional comments for findings (`issue (blocking):`, `suggestion:`, etc.)
+
+## Boundaries
+
+- Never modify production code directly — only suggest changes
+- Focus on performance — leave security to the Security Reviewer and style to linters
+- Escalate to a human reviewer if a fix requires significant architectural changes
+- Prefer DB-level fixes (indexes, queries) over application-level workarounds

--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -1,0 +1,26 @@
+---
+name: "Security Reviewer"
+description: "Reviews OpenAEV code for security vulnerabilities: RBAC, tenant isolation, data exposure, auth bypasses."
+tools: [ "codebase", "terminal" ]
+---
+
+# Security Reviewer
+
+## Mission
+
+You review OpenAEV code for security issues. Follow rules from `security.instructions.md` and procedure from
+`skills/review-security/SKILL.md`.
+
+## How You Work
+
+1. **Read `AGENTS.md` and `.github/copilot-instructions.md`** for OpenAEV architecture context (modules, stack, multi-tenancy model)
+2. Read `security.instructions.md` for RBAC, tenant isolation, and data exposure rules
+3. Follow `skills/review-security/SKILL.md` for the step-by-step checklist — run the commands defined in each step
+4. Use conventional comments for findings (`issue (blocking):`, `suggestion:`, etc.)
+
+## Boundaries
+
+- Never modify production code directly — only suggest changes
+- Never commit `.env` files or anything containing secrets
+- Escalate to a human reviewer if you find a high-severity issue
+- Focus on security — leave style/formatting to other reviewers

--- a/.github/agents/test-specialist.agent.md
+++ b/.github/agents/test-specialist.agent.md
@@ -1,0 +1,25 @@
+---
+name: "Test Specialist"
+description: "Creates and maintains tests for OpenAEV following project patterns: integration tests, unit tests, fixtures, composers."
+tools: [ "codebase", "terminal" ]
+---
+
+# Test Specialist
+
+## Mission
+
+You write tests for OpenAEV. Follow conventions from `testing.instructions.md` and procedure from
+`skills/add-test/SKILL.md`.
+
+## How You Work
+
+1. **Read `AGENTS.md` and `.github/copilot-instructions.md`** for OpenAEV architecture context (modules, stack, conventions)
+2. Read `testing.instructions.md` for rules (`given_X_should_Y` naming, AAA pattern, custom `@WithMockUser`, etc.)
+3. Follow `skills/add-test/SKILL.md` for the step-by-step procedure
+4. Search for existing tests of similar entities for reference patterns
+
+## Boundaries
+
+- Only create or modify test files, fixtures, and composers
+- Never change production code to make tests pass — flag the issue instead
+- Always verify: `mvn test -Dtest="{TestClass}"` after creating tests

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,23 +2,30 @@
 
 ## Repository Overview
 
-**OpenAEV** is an open source platform for planning, scheduling, and conducting cyber adversary simulation campaigns and tests. It helps organizations identify security gaps through simulations, training, and exercises from technical to strategic levels.
+**OpenAEV** is an open source platform for planning, scheduling, and conducting cyber adversary simulation campaigns and
+tests. It helps organizations identify security gaps through simulations, training, and exercises from technical to
+strategic levels.
 
 ### Architecture
-- **Backend**: Spring Boot 3.3.7 (Java 21), PostgreSQL, Elasticsearch/OpenSearch, MinIO, RabbitMQ
-- **Frontend**: React 19, TypeScript, Vite, Material-UI, Yarn 4.12.0
+
+- **Backend**: Spring Boot (Java), PostgreSQL, Elasticsearch/OpenSearch, MinIO, RabbitMQ
+- **Frontend**: React, TypeScript, Vite, Material-UI
 - **Multi-module Maven project** with 3 modules: `openaev-model`, `openaev-framework`, `openaev-api`
-- **Size**: ~1,882 Java files, ~809 TypeScript/React files
+- ⚠️ **`openaev-framework` is deprecated** — it will be removed. **Never add new code to `openaev-framework`**. Place
+  new utilities in `openaev-api` or `openaev-model` instead.
+
+> For exact framework/library versions, read `pom.xml` (backend) and `openaev-front/package.json` (frontend).
 
 ## Critical Build Requirements
 
 ### Java Version Requirement
-**ALWAYS use Java 21**. The project WILL FAIL to build with Java 17 or lower due to:
-- Maven compiler plugin configured for Java 21 (`<source>21</source>`, `<target>21</target>`)
-- Error message: `release version 21 not supported`
+
+The project requires the Java version configured in `pom.xml` (`maven-compiler-plugin` source/target).
+Building with an older version will fail with: `release version XX not supported`.
 
 ### Node.js Version Requirement
-**Use Node.js >= 22.11.0** as specified in `openaev-front/package.json` engines field.
+
+The minimum Node.js version is specified in `openaev-front/package.json` (`engines` field).
 
 ## Build & Development Workflow
 
@@ -26,7 +33,8 @@
 
 **ALWAYS follow this sequence:**
 
-1. **Start services**: `cd openaev-dev && docker-compose up -d openaev-dev-pgsql openaev-dev-minio openaev-dev-elasticsearch openaev-dev-rabbitmq`
+1. **Start services**:
+   `cd openaev-dev && docker-compose up -d openaev-dev-pgsql openaev-dev-minio openaev-dev-elasticsearch openaev-dev-rabbitmq`
 2. **Build frontend**: `cd openaev-front && yarn install && yarn build` (~4min)
 3. **Build backend**: `cd .. && mvn clean install -DskipTests -Pdev`
 
@@ -34,7 +42,8 @@
 
 **Backend**: `mvn spotless:check` / `mvn spotless:apply` (Google Java Format)
 **Frontend**: `yarn lint` (~60s), `yarn check-ts`, `yarn i18n-checker`
-**Known Issue**: Pre-existing Spotless errors in `DetectionRemediationApiTest.java` and `InjectExpectationUtils.java` - ignore unless your changes touch these.
+**Known Issue**: Pre-existing Spotless errors in `DetectionRemediationApiTest.java` and `InjectExpectationUtils.java` -
+ignore unless your changes touch these.
 
 ### Testing
 
@@ -45,15 +54,18 @@
 ## Continuous Integration
 
 ### Drone CI Pipeline
+
 Primary CI runs on every push:
+
 1. **API Tests**: `mvn spotless:check`, `mvn clean install -DskipTests`, tests, `mvn jacoco:check`
 2. **Frontend Tests**: `yarn install/build/check-ts/lint/i18n-checker/test`
 3. **E2E Tests**: Full app test with Playwright
 4. **Type Check**: `yarn generate-types-from-api` verification
 
-**Services**: PostgreSQL 17, MinIO RELEASE.2025-06-13T11-33-47Z, Elasticsearch 8.18.3, RabbitMQ 4.1
+**Services**: PostgreSQL, MinIO, Elasticsearch, RabbitMQ (see `.drone.yml` for exact versions)
 
 ### GitHub Actions
+
 - **test-feature-branch.yml**: Docker image build (Alpine Linux)
 - **codeql.yml**: Security scanning (weekly + master push)
 - **pr-title-check-worker.yml**: Conventional Commits validation
@@ -61,15 +73,17 @@ Primary CI runs on every push:
 ## Project Structure
 
 ### Root Files
-- `pom.xml` - Parent Maven POM (Spring Boot 3.3.7, Java 21)
+
+- `pom.xml` - Parent Maven POM
 - `.drone.yml` - Primary CI/CD pipeline
 - `docker-compose.yml` - Dev services (in `openaev-dev/`)
 - `Dockerfile` / `Dockerfile_ga` - Production / GitHub Actions images
 
 ### Backend
+
 ```
 openaev-model/       # Domain models, entities, DTOs
-openaev-framework/   # Core framework, utilities, base services
+openaev-framework/   # ⚠️ DEPRECATED — will be removed (see Architecture section above)
 openaev-api/         # REST API, main application
   src/main/java/io/openaev/
     api/             # REST controllers
@@ -82,6 +96,7 @@ openaev-api/         # REST API, main application
 ```
 
 ### Frontend
+
 ```
 openaev-front/
   src/
@@ -90,10 +105,11 @@ openaev-front/
     components/      # Reusable components
     utils/           # Utilities, API types
   builder/prod/      # Production build (esbuild)
-  package.json       # 2.0.10, Node >= 22.11.0
+  package.json
 ```
 
 ### Config Files
+
 - **Backend**: `pom.xml` (spotless-maven-plugin, Google Java Format)
 - **Frontend**: `eslint.config.js`, `tsconfig.json`, `vite.config.ts`
 
@@ -108,11 +124,13 @@ openaev-front/
 ## Commit Message Format
 
 **ALL commit messages MUST follow Conventional Commits format:**
+
 ```
 [<context>] <type>(<scope>?): <short description> (#<issue-number>?)
 ```
 
 **Examples:**
+
 - `[backend] feat(auth): add JWT authentication (#123)`
 - `[frontend] fix(ui): resolve button alignment issue`
 - `[docs] chore: update README with setup instructions`
@@ -123,6 +141,7 @@ openaev-front/
 ## Key Commands Reference
 
 ### Backend
+
 ```bash
 mvn spotless:check              # Check formatting
 mvn spotless:apply              # Fix formatting
@@ -132,6 +151,7 @@ mvn jacoco:check                # Verify coverage
 ```
 
 ### Frontend
+
 ```bash
 yarn install                    # Install dependencies
 yarn build                      # Production build
@@ -145,18 +165,50 @@ yarn generate-types-from-api    # Generate TypeScript types from API
 ```
 
 **Checklist:**
+
 - Formatting: `mvn spotless:check` (backend), `yarn lint` (frontend)
 - Type safety: `yarn check-ts` (frontend only)
 - Tests: Ensure existing tests pass, add tests for new functionality
 - Coverage: Maintain 50% line, 30% branch coverage (backend)
 
+## Code Conventions
+
+Conventions are defined in dedicated instruction files that activate automatically when you work on matching files:
+
+| Domain                               | File                                                                            |
+|--------------------------------------|---------------------------------------------------------------------------------|
+| Backend (Java/Spring/Hibernate)      | [backend.instructions.md](.github/instructions/backend.instructions.md)         |
+| Frontend (React/TypeScript/MUI)      | [frontend.instructions.md](.github/instructions/frontend.instructions.md)       |
+| Database (schema/migrations/tenancy) | [database.instructions.md](.github/instructions/database.instructions.md)       |
+| Tests (integration/unit/fixtures)    | [testing.instructions.md](.github/instructions/testing.instructions.md)         |
+| Security (RBAC/@AccessControl)       | [security.instructions.md](.github/instructions/security.instructions.md)       |
+| Performance (N+1/pagination/fetch)   | [performance.instructions.md](.github/instructions/performance.instructions.md) |
+| Code Review                          | [code-review.instructions.md](.github/instructions/code-review.instructions.md) |
+
+## PR & Review Conventions
+
+### Conventional Comments (for code reviews)
+
+Format: `<label>[decorations]: <subject>`
+
+Labels: `praise:`, `nitpick:`, `suggestion:`, `issue:`, `todo:`, `question:`, `thought:`, `chore:`, `note:`, `typo:`
+
+Decorations: `(non-blocking)`, `(blocking)`, `(if-minor)`
+
+Examples:
+
+- `suggestion (non-blocking): prefer functional approach for immutability`
+- `todo (blocking): remove debug comments before merging`
+- `praise: nice improvement 🤩`
+
 ## Important Notes
 
-1. **Trust these instructions**: Only search for information if instructions are incomplete or incorrect.
-2. **Pre-existing issues**: Don't fix unrelated linting/build issues unless they block your task.
-3. **Frontend must build first**: The backend copies frontend build artifacts.
-4. **Services required**: PostgreSQL, MinIO, Elasticsearch/OpenSearch, and RabbitMQ must be running for tests.
-5. **Java 21 is mandatory**: The project will not compile with earlier versions.
-6. **Node >= 22.11.0**: Required for frontend development.
-7. **API types**: After API changes, run `yarn generate-types-from-api` in frontend to update TypeScript types.
-8. **Coverage enforcement**: Backend tests must maintain 50% line coverage, 30% branch coverage.
+1. **Follow existing patterns** — before creating anything, search for a similar file and replicate its structure.
+2. **Trust these instructions**: Only search for information if instructions are incomplete or incorrect.
+3. **Pre-existing issues**: Don't fix unrelated linting/build issues unless they block your task.
+4. **Frontend must build first**: The backend copies frontend build artifacts.
+5. **Services required**: PostgreSQL, MinIO, Elasticsearch/OpenSearch, and RabbitMQ must be running for tests.
+6. **Java 21 is mandatory**: The project will not compile with earlier versions.
+7. **Node.js version**: Check `openaev-front/package.json` engines field for the minimum required version.
+8. **API types**: After API changes, run `yarn generate-types-from-api` in frontend to update TypeScript types.
+9. **Coverage enforcement**: Backend tests must maintain 50% line coverage, 30% branch coverage.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,96 @@
+---
+applyTo: "openaev-api/src/main/java/**/*.java,openaev-model/src/main/java/**/*.java,openaev-framework/src/main/java/**/*.java"
+description: "Backend Java/Spring conventions: entities, services, controllers, Hibernate, transactions"
+---
+
+# Backend Conventions
+
+## ⚠️ Module Rule
+
+> `openaev-framework` is deprecated — see [copilot-instructions.md](../copilot-instructions.md) for details. Never add new code there.
+
+## Layering
+
+- **Controller (API)** → depends only on **Service** — never inject a Repository in a controller
+- Service → can call other Services and its own Repositories
+- Repository → data access only, never called from controllers or utils
+- Utils → static methods only, no state
+
+## New Controllers (package `io.openaev.api.*`)
+
+- `@RestController @RequestMapping("/api/{entities}") @RequiredArgsConstructor`
+- Every endpoint: `@AccessControl` + `@LogExecutionTime` + `@Operation`
+- URI: lowercase, hyphens, nouns — HTTP method defines the action
+- Search: `@PostMapping("/search")`, Create: `201`, Delete: `204`
+- Organize endpoints with section comments: `// -- CREATE --`, `// -- READ --`, `// -- UPDATE --`, `// -- DELETE --`
+- **Never return JPA entities directly** from API endpoints — always use DTOs
+
+## API DTOs, Mappers & Sub-resources
+
+For each entity exposed via REST, create three files in the same `io.openaev.api.*` package:
+
+- **`{Entity}Input.java`** — Java `record` for request body (`@JsonProperty`, `@NotBlank`, etc.)
+- **`{Entity}Output.java`** — Java `record` for response body (all fields the client needs)
+- **`{Entity}Mapper.java`** — Utility class with `private` constructor, static methods `toOutput(Entity)` and optionally `fromInput(String id, Input)`
+
+```java
+// DTOs — immutable Java record
+public record {Entity}Input(
+    @JsonProperty("entity_name") @NotBlank String name,
+    @JsonProperty("entity_description") String description) {}
+
+public record {Entity}Output(
+    @JsonProperty("entity_id") @NotBlank String id,
+    @JsonProperty("entity_name") @NotBlank String name,
+    @JsonProperty("entity_description") String description) {}
+
+// Mapper
+public class {Entity}Mapper {
+  private {Entity}Mapper() {}
+  public static {Entity}Output toOutput({Entity} entity) { ... }
+}
+
+// Usage in controller (static import):
+import static io.openaev.api.feature.{Entity}Mapper.toOutput;
+public {Entity}Output findById(...) { return toOutput(service.findById(id)); }
+public Page<{Entity}Output> search(...) { return service.search(input).map({Entity}Mapper::toOutput); }
+```
+
+## Entities
+
+- Tenant-scoped: `TenantBase` + `@Filter("tenantFilter")` + `TenantBaseListener`
+- Platform-level: `Base` only + `ModelBaseListener`
+- Audit timestamps: implement `Auditable` + add `AuditableListener` (do **not** use Hibernate `@CreationTimestamp`/`@UpdateTimestamp`)
+- Column: `{entity_singular}_{field}` → `@JsonProperty("same")`
+- Tenant relation: always `@JsonIgnore`
+- Collections: mutable (`new ArrayList<>()`) + `@Fetch(FetchMode.SUBSELECT)`
+
+## Hibernate
+
+- Collections must be mutable — never `List.of()` directly on entity fields
+- Prefer unidirectional relationships
+- `@Transactional` does NOT work on self-calls (Spring proxy bypass)
+- Background tasks: explicit `@Transactional` (no OSIV outside controllers)
+- `deleteById()` does a SELECT first — use native `@Query @Modifying` for perf-critical deletes
+
+## Services
+
+- `@Service @RequiredArgsConstructor @Transactional(rollbackFor = Exception.class)`
+- Read methods: `@Transactional(readOnly = true)`
+- Always use `org.springframework.transaction.annotation.Transactional` — **never** `jakarta.transaction.Transactional` (which lacks `rollbackFor`, `readOnly`, etc.)
+- Organize methods with section comments in this order: `// -- CREATE --`, `// -- READ --`, `// -- UPDATE --`, `// -- DELETE --`
+- JavaDoc on all public methods (what + why)
+- Fail fast: `Objects.requireNonNull()`, custom exceptions for business rules
+- **Resolving associations from IDs**: use `ReferenceResolver.resolve(ids, Entity.class, repo::countByIdIn)` — never loop `findById()` (see `performance.instructions.md`)
+
+## Repositories
+
+- Use `JpaRepository` instead of `CrudRepository`
+- Extend `JpaSpecificationExecutor` for entities that need search/filtering
+
+## Lombok
+
+- Services: `@RequiredArgsConstructor` + `private final` fields
+- Entities: `@Getter @Setter` (not `@Data`)
+- DTOs: `@Builder` OK, prefer records for new code
+- Never `@Autowired` on fields in new code

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -2,45 +2,42 @@
 applyTo: "**/*"
 ---
 
-When reviewing code, focus on:
+When reviewing code, check for issues in these categories.
+Rules are defined in dedicated instruction files — refer to them for the full checklist.
 
-## Security Critical Issues
-- Check for hardcoded secrets, API keys, or credentials
-- Look for SQL injection and XSS vulnerabilities
-- Verify proper input validation and sanitization
-- Review authentication and authorization logic
+## Security
 
-## Performance Red Flags
-- Identify N+1 database query problems
-- Spot inefficient loops and algorithmic issues
-- Check for memory leaks and resource cleanup
-- Review caching opportunities for expensive operations
+> Full rules: [security.instructions.md](security.instructions.md)
 
-## Code Quality Essentials
-- Functions should be focused and appropriately sized
-- Use clear, descriptive naming conventions
-- Ensure proper error handling throughout
+Key checks: `@AccessControl` on every endpoint, native `@Query` with `WHERE tenant_id`, no `tenant_id` in responses, no hardcoded secrets, no raw error messages to clients.
+
+## Performance
+
+> Full rules: [performance.instructions.md](performance.instructions.md)
+
+Key checks: N+1 queries, `@Fetch(FetchMode.SUBSELECT)` on collections, `FetchType.LAZY` default, `Page<T>` not unbounded `List<T>`, `ReferenceResolver` instead of `findById()` loops, `@Transactional(readOnly = true)` on reads.
+
+## Architecture
+
+> Full rules: [backend.instructions.md](backend.instructions.md)
+
+Key checks: layering (Controller → Service → Repository, never skip), JPA entities never returned from controllers (use DTOs), `@Transactional` self-call (Spring proxy bypass), no new code in `openaev-framework` (deprecated).
+
+## Test Quality
+
+> Full rules: [testing.instructions.md](testing.instructions.md)
+
+Key checks: `@Nested` + `@DisplayName` grouping, `given_X_should_Y` naming, AAA comments, OpenAEV's `@WithMockUser` (not Spring's), Fixture + Composer (no inline data).
+
+## Frontend
+
+> Full rules: [frontend.instructions.md](frontend.instructions.md)
+
+Key checks: no MUI for layout (native HTML), `sx` prop only (no `makeStyles`), `t()` called early, auto-generated `api-types.d.ts` (no manual types).
 
 ## Review Style
-- Be specific and actionable in feedback
-- Explain the "why" behind recommendations
-- Acknowledge good patterns when you see them
-- Ask clarifying questions when code intent is unclear
 
-Always prioritize security vulnerabilities and performance issues that could impact users.
-
-Always suggest changes to improve readability. For example, this suggestion seeks to make the code more readable and also makes the validation logic reusable and testable.
-
-// Instead of:
-if (user.email && user.email.includes('@') && user.email.length > 5) {
-  submitButton.enabled = true;
-} else {
-  submitButton.enabled = false;
-}
-
-// Consider:
-function isValidEmail(email) {
-  return email && email.includes('@') && email.length > 5;
-}
-
-submitButton.enabled = isValidEmail(user.email);
+- Use **conventional comments**: `suggestion:`, `issue:`, `todo:`, `nitpick:`, `praise:`
+- Add `(blocking)` or `(non-blocking)` decoration
+- Be specific, actionable, explain the "why"
+- When flagging a rule violation, mention which instruction file defines the rule

--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -1,0 +1,52 @@
+---
+applyTo: "openaev-model/src/main/java/**/model/**,openaev-model/src/main/java/**/repository/**,**/migration/**,**/application.sql"
+description: "Database conventions: schema naming, Flyway migrations, PostgreSQL, tenant isolation"
+---
+
+# Database Conventions
+
+## Schema Naming
+
+- Table: `snake_case_plural` (e.g. `platform_groups`)
+- Column: `{entity_singular}_{field}` (e.g. `group_name`)
+- ID column: `{entity_singular}_id`
+- FK to tenant: `tenant_id VARCHAR(255) NOT NULL` + `ON DELETE CASCADE`
+- Always add index on `tenant_id` for tenant-scoped tables
+- Join tables: `{table1}_{table2}` with composite PK + FKs `ON DELETE CASCADE`
+
+## Business Keys & Unique Constraints
+
+- Use `@BusinessId` annotation on fields that serve as natural/business keys (e.g. `tag_name`, `domain_external_id`, `attack_pattern_external_id`)
+- **Single-tenant context**: `@Column(unique = true)` or `@Table(uniqueConstraints = ...)` is sufficient
+- **Multi-tenant context**: unique constraints MUST be **tenant-scoped** — use composite unique constraints:
+  ```sql
+  ALTER TABLE tags ADD CONSTRAINT uk_tags_name_tenant UNIQUE (tag_name, tenant_id);
+  ```
+- Never use a global `unique = true` on a business key in a tenant-scoped entity — two tenants must be able to have the same tag name, domain, etc.
+- When migrating existing `unique = true` to multi-tenancy: drop the old constraint, create a composite one with `tenant_id`
+
+## Flyway Migrations
+
+- Java-based: `V4_{next}__Description.java` in `io.openaev.migration`
+- Find next number: `ls openaev-api/src/main/java/io/openaev/migration/ | sort | tail -5`
+- Extends `BaseJavaMigration`, annotated `@Component`
+- Use `context.getConnection().createStatement()` for raw SQL
+- Batch: `statement.addBatch(...)` then `statement.executeBatch()`
+- Default tenant UUID: `2cffad3a-0001-4078-b0e2-ef74274022c3`
+- For ES reindex: add a migration that deletes from `indexing_status`
+
+## Multi-tenancy
+
+- `TenantContext.getCurrentTenant()` — ThreadLocal
+- `@Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")` on all `TenantBase` entities
+- Activated automatically by `HibernateFilterTransactionAspect` on every `@Transactional`
+- `TenantBaseListener`: auto-sets tenant on `@PrePersist`, asserts immutability on `@PreUpdate`
+- Native `@Query` bypasses the filter — always add `WHERE tenant_id = :tenantId`
+- User is platform-level (no tenant filter), Group/Role are tenant-scoped
+
+## Audit Timestamps
+
+- Entities with `created_at` / `updated_at` must implement `Auditable` and register `AuditableListener`
+- Do **not** use Hibernate-specific `@CreationTimestamp` / `@UpdateTimestamp`
+- `AuditableListener` auto-sets `createdAt` on `@PrePersist` and refreshes `updatedAt` on `@PreUpdate`
+- Mark `created_at` column with `updatable = false`

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,50 @@
+---
+applyTo: "openaev-front/**/*.ts,openaev-front/**/*.tsx,openaev-front/**/*.js,openaev-front/**/*.jsx"
+description: "Frontend React/TypeScript conventions: components, MUI, forms, permissions, i18n, Redux"
+---
+
+# Frontend Conventions
+
+## File Structure
+
+- Use `snake_case` for folder names, one folder per feature, one file per behavior
+- Split by behavior: `{feature}-action.ts`, `{feature}-helper.d.ts`, `{feature}-schema.ts`
+- Pages in `src/admin/components/{section}/{feature}/`
+
+## TypeScript
+
+- Use auto-generated `api-types.d.ts` — prefer over manual types
+- Migrate `.js`/`.jsx` → `.ts`/`.tsx` when touching files
+- TypeScript strict mode, annotate API responses with generated types
+
+## MUI & Layout
+
+- **No MUI for layout** — use native HTML (`div`, `section`, `header`)
+- MUI only for interactive components (`Button`, `TextField`, `Dialog`)
+- Styling: `sx` prop only — never `makeStyles` / `withStyles`
+- Buttons: Create/Update → `secondary`, Cancel → `primary`, Delete → `secondary`/`error`
+
+## Forms
+
+- Zod for validation, React Hook Form for management
+- Atomic form fields: `TextFieldController`, `SelectFieldController`, etc.
+- Field `name` = JSON property name from API
+
+## Permissions (CASL)
+
+- Capability: `ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT)`
+- Grant: `ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, resourceId)`
+- Create/Edit: wrap with `<Can I={ACTIONS.MANAGE} a={SUBJECTS.X}>`
+- Delete: `ability.can()` in popover entries `userRight`
+- New subject → add in `src/utils/permissions/types.ts`
+
+## i18n
+
+- Call `t()` as early as possible — pass translated strings, not raw keys
+- Null-check backend strings before `t()` (crashes on null/undefined)
+- Keys = English text: `t('Tenant name')`
+
+## Data Loading
+
+- Small/medium datasets: Redux store (normalized via normalizr)
+- Large datasets: fetch directly, bypass store

--- a/.github/instructions/performance.instructions.md
+++ b/.github/instructions/performance.instructions.md
@@ -1,0 +1,79 @@
+---
+applyTo: "openaev-api/src/main/java/**/*.java,openaev-model/src/main/java/**/*.java"
+description: "Performance conventions: N+1 queries, lazy/eager loading, pagination, caching, indexing"
+---
+
+# Performance Conventions
+
+## JPA & Hibernate
+
+### N+1 Queries
+
+- **Never** iterate a collection to call the DB in a loop — batch or join fetch instead
+- Use `@Fetch(FetchMode.SUBSELECT)` on `@ManyToMany` / `@OneToMany` collections to avoid N+1
+- Prefer `@Transactional(readOnly = true)` on read methods — disables dirty checking
+
+### Fetch Strategy
+
+- Default to `FetchType.LAZY` for all associations — only load what's needed
+- `FetchType.EAGER` is acceptable only for small, always-needed collections (e.g. capabilities on a role)
+- Never use `FetchType.EAGER` on collections that can grow unbounded
+- For APIs returning IDs only (serialized via `MultiIdListSerializer`): LAZY + `@Fetch(FetchMode.SUBSELECT)` is enough
+
+### Resolving Entity Associations from IDs
+
+When a service receives a list of entity IDs to set as associations (e.g. role IDs on a group):
+- **Never** loop with `findById()` — that's N SELECT queries
+- **Use `ReferenceResolver`** (`io.openaev.utils.ReferenceResolver`):
+  - 1 `COUNT` query to validate all IDs exist
+  - 0 `SELECT` queries to build proxies via `EntityManager.getReference()`
+  - Throws `EntityNotFoundException` with a clear message if any ID is invalid
+
+```java
+// ✅ Good — 2 queries total (1 count roles + 1 count users)
+group.setPlatformRoles(
+    referenceResolver.resolve(roleIds, PlatformRole.class, roleRepo::countByIdIn));
+group.setUsers(
+    referenceResolver.resolve(userIds, User.class, userRepo::countByIdIn));
+
+// ❌ Bad — N queries (1 SELECT per ID)
+roleIds.stream().map(roleService::findById).toList();
+```
+
+Repositories that are used with `ReferenceResolver` must expose a `countByIdIn(Set<String>)` method.
+
+### Pagination
+
+- All list/search endpoints MUST use pagination (`Page<T>`)
+- Never return unbounded `List<T>` from an API endpoint (except for small reference data)
+- Use `PaginationUtils.buildPaginationJPA()` for standard search endpoints
+- Set reasonable default page size (10-20), max page size (100)
+
+### Queries
+
+- Prefer repository methods or `@Query` JPQL over `CrudRepository.findAll()` when filtering
+- Use `existsById()` instead of `findById().isPresent()` for existence checks
+- Use `@Modifying @Query` for bulk updates/deletes — avoid loading entities just to delete them
+- Use projections (DTO queries) for read-heavy endpoints that don't need the full entity
+- Add database indexes on columns used in WHERE, ORDER BY, and JOIN conditions
+
+## Collections & Streams
+
+- Never materialize large collections in memory — stream and filter at the DB level
+- Use `Set` instead of `List` when order doesn't matter and uniqueness is required
+
+## REST API
+
+- Large responses: always paginate
+- Search endpoints: support filtering at DB level, not in Java
+- Avoid returning deep object graphs — use DTOs with IDs, let the client fetch related entities
+- File downloads: use streaming (`StreamingResponseBody`), not `byte[]` in memory
+
+## Anti-Patterns to Avoid
+
+- ❌ Loading all entities to count them — use `repository.count()` or `COUNT()` query
+- ❌ `findAll()` without pagination on tables that can grow
+- ❌ Iterating a list to call `repository.findById()` in a loop — use `ReferenceResolver` or `findAllById()` instead
+- ❌ Opening a transaction for read-only operations without `readOnly = true`
+- ❌ Returning JPA entities with LAZY collections from `@RestController` (triggers proxy outside session)
+

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,0 +1,58 @@
+---
+applyTo: "openaev-api/src/main/java/**/*.java,openaev-model/src/main/java/**/*.java,openaev-front/src/**/*.ts,openaev-front/src/**/*.tsx"
+description: "Security conventions: RBAC, @AccessControl, permission chain, security rules, tenant isolation"
+---
+
+# Security Conventions
+
+## @AccessControl (AOP aspect)
+
+Every REST endpoint must have `@AccessControl`. See the annotation in `io.openaev.aop.AccessControl` for the full definition.
+
+## Adding a new resource type
+
+### Backend
+
+1. `ResourceType.java` — add enum value
+2. `Capability.java` — add ACCESS/MANAGE/DELETE with parent hierarchy
+3. `@AccessControl` on all endpoints
+4. Configure access model in `PermissionService.java`:
+   - Grant-managed (like Scenario): add to `RESOURCES_MANAGED_BY_GRANTS`
+   - Open for READ (like Player): add to `RESOURCES_OPEN`
+   - Sub-resource (like Inject): add to `RESOURCES_USING_PARENT_PERMISSION`
+   - Standard capability-based: no change (handled by `Capability.of()` lookup)
+
+### Frontend
+
+5. `types.ts` — add SUBJECT if new category:
+   ```typescript
+   export const SUBJECTS = { ...existing, MY_FEATURE: 'MY_FEATURE' } as const;
+   ```
+   Parser auto-maps `ACCESS_MY_FEATURE` → `[ACCESS, MY_FEATURE]`.
+
+6. Use in components:
+   ```typescript
+   const canAccess = ability.can(ACTIONS.ACCESS, SUBJECTS.MY_FEATURE);
+   ```
+
+7. For grant-based resources, create a permission hook (follow `useScenarioPermissions.ts`):
+   ```typescript
+   const canAccess = ability.can(ACTIONS.ACCESS, SUBJECTS.RESOURCE, resourceId)
+       || ability.can(ACTIONS.ACCESS, SUBJECTS.MY_FEATURE);
+   ```
+
+## Tenant Isolation
+
+- Every `TenantBase` entity must have `@Filter(name = "tenantFilter")`
+- Native `@Query` bypasses the Hibernate filter — always add `WHERE tenant_id = :tenantId`
+- Never return `tenant_id` in API responses — use `@JsonIgnore` on the tenant relation
+- Never assign platform-only capabilities to tenant roles or vice versa
+
+## Never Do
+
+- Never hardcode secrets, API keys, or credentials
+- Never send raw error messages/stack traces to clients
+- Never bypass `@AccessControl` without explicit `skipRBAC = true` and a comment explaining why
+- Never return `tenant_id` in API responses
+- Never use native `@Query` without `WHERE tenant_id = ...`
+- Never assign platform-only capabilities to tenant roles or vice versa

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "**/*Test.java,**/*Test*.java,**/test/**,**/*.test.*,**/*.spec.*,**/tests_e2e/**"
+description: "Testing conventions: integration tests, unit tests, fixtures, composers, assertions"
+---
+
+# Testing Conventions
+
+## Integration Tests (API)
+
+- Extend `IntegrationTest`
+- `@TestInstance(PER_CLASS) @Transactional` on the class
+- `@WithMockUser` → `io.openaev.utils.mockUser.WithMockUser` (NOT `org.springframework`)
+- Group with `@Nested` + `@DisplayName`
+- **Method naming**: `given_X_should_Y` → e.g. `given_validInput_should_createGroup()`, `given_crowdstrike_should_not_LaunchAtomicTesting()`
+- **AAA pattern**: `// Arrange` / `// Act` / `// Assert`
+- JSON: `assertThatJson(response).node("field").isEqualTo(...)` (json-unit library)
+- URI constant at class level: `public static final String FEATURE_URI = "/api/..."`
+
+## Unit Tests (Service)
+
+- `@ExtendWith(MockitoExtension.class)`
+- `@Mock` for dependencies, `@InjectMocks` for the service under test
+- Same `given_X_should_Y` naming and AAA pattern
+
+## Fixtures
+
+- Dedicated class per entity: `{Entity}Fixture`
+- `createDefault{Entity}()` for unique names
+- No inline data, no test duplication
+
+## Composers
+
+- `@Component`, extends `ComposerBase<{Entity}>`
+- Call `.reset()` in `@BeforeEach`
+
+## Frontend Tests
+
+- Vitest for unit tests: `yarn test`
+- Playwright for E2E: `yarn test:e2e`
+- E2E config: `tests_e2e/`, fixtures in `tests_e2e/fixtures/`

--- a/.github/skills/add-migration/SKILL.md
+++ b/.github/skills/add-migration/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: add-migration
+description: >-
+  Creates a Flyway Java-based migration for schema changes. Handles table creation,
+  column additions, tenant isolation, and ES reindex. Use when asked to modify the database schema.
+---
+
+# Add Migration
+
+## Prerequisites
+
+- What schema change is needed (new table, new column, FK, index, etc.)
+- Whether the table is tenant-scoped or platform-level
+- The next migration version number
+
+## Procedure
+
+### Step 1 — Find the next version number
+
+```bash
+ls openaev-api/src/main/java/io/openaev/migration/ | sort | tail -5
+```
+
+Pattern: `V4_{XX}__Description.java` — increment `XX`.
+
+### Step 2 — Create the migration class
+
+Location: `openaev-api/src/main/java/io/openaev/migration/`
+
+```java
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V4_XX__Description extends BaseJavaMigration {
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // SQL here
+    }
+  }
+}
+```
+
+### Step 3 — Apply tenant isolation (if applicable)
+
+For tenant-scoped tables:
+```sql
+CREATE TABLE my_entities (
+  my_entity_id VARCHAR(255) NOT NULL,
+  my_entity_name VARCHAR(255) NOT NULL,
+  tenant_id VARCHAR(255) NOT NULL,
+  -- ... other columns ...
+  CONSTRAINT pk_my_entities PRIMARY KEY (my_entity_id),
+  CONSTRAINT fk_my_entities_tenant FOREIGN KEY (tenant_id)
+    REFERENCES tenants(tenant_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_my_entities_tenant ON my_entities(tenant_id);
+```
+
+Default tenant: `2cffad3a-0001-4078-b0e2-ef74274022c3`
+
+### Step 4 — Handle ES reindex (if needed)
+
+If modifying an entity indexed in Elasticsearch, add a reindex trigger:
+```sql
+DELETE FROM indexing_status;
+```
+
+### Step 5 — Verify
+
+```bash
+mvn clean install -DskipTests -Pdev    # Migration runs on startup
+mvn test                                # Ensure tests pass with new schema
+```
+

--- a/.github/skills/add-test/SKILL.md
+++ b/.github/skills/add-test/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: add-test
+description: >-
+  Creates tests for an existing feature following OpenAEV patterns: fixture class,
+  composer, integration test with @Nested groups, and optionally unit tests.
+  Use when asked to add tests or improve test coverage.
+---
+
+# Add Tests
+
+## Prerequisites
+
+- Entity/feature to test
+- Existing service and controller to test against
+
+## Procedure
+
+### Step 1 — Create or update the Fixture
+
+Location: `openaev-api/src/test/java/io/openaev/utils/fixtures/files/`
+
+```java
+public class {Entity}Fixture {
+  public static {Entity} createDefault{Entity}() {
+    {Entity} entity = new {Entity}();
+    entity.setName("{Entity}-" + RandomStringUtils.random(25, true, true));
+    // set required fields
+    return entity;
+  }
+}
+```
+
+### Step 2 — Create or update the Composer
+
+Location: `openaev-api/src/test/java/io/openaev/utils/fixtures/composers/`
+
+- Extend `ComposerBase<{Entity}>`
+- Inner `Composer` with `persist()`, `delete()`, `get()`, `withId()`
+
+### Step 3 — Create the Integration Test
+
+Location: `openaev-api/src/test/java/io/openaev/rest/` or `api/`
+
+Structure:
+```java
+@TestInstance(PER_CLASS)
+@Transactional
+@DisplayName("{Feature} API tests")
+public class {Feature}ApiTest extends IntegrationTest {
+  public static final String URI = "/api/{features}";
+  @Autowired private MockMvc mvc;
+  @Autowired private {Feature}Composer composer;
+
+  @BeforeEach void setup() { composer.reset(); }
+
+  @Nested @WithMockUser(isAdmin = true) @DisplayName("CRUD operations")
+  class CrudOperations {
+    @Test @DisplayName("Can create") void given_validInput_should_createEntity() { /* Arrange / Act / Assert */ }
+    @Test @DisplayName("Can read") void given_existingId_should_returnEntity() { ... }
+    @Test @DisplayName("Can update") void given_existingEntity_should_updateSuccessfully() { ... }
+    @Test @DisplayName("Can delete") void given_existingEntity_should_deleteSuccessfully() { ... }
+    @Test @DisplayName("Can search") void given_searchInput_should_returnPage() { ... }
+  }
+
+  @Nested @WithMockUser(withCapabilities = {...}) @DisplayName("Permission checks")
+  class PermissionChecks { ... }
+}
+```
+
+### Step 4 — (Optional) Create Unit Test
+
+For complex service logic:
+```java
+@ExtendWith(MockitoExtension.class)
+class {Feature}ServiceUnitTest {
+  @Mock private {Entity}Repository repository;
+  @InjectMocks private {Feature}Service service;
+  // given_X_should_Y naming + AAA (Arrange/Act/Assert) pattern
+}
+```
+
+### Step 5 — Verify
+
+```bash
+mvn test -pl openaev-api -Dtest="{Feature}ApiTest"
+mvn jacoco:check
+```
+
+
+

--- a/.github/skills/create-feature-module/SKILL.md
+++ b/.github/skills/create-feature-module/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: create-feature-module
+description: >-
+  Scaffolds a complete feature end-to-end: JPA entity, repository, service,
+  DTOs, mapper, controller, migration, tests (fixture + composer + integration test),
+  and frontend actions/page. Use when asked to create a new feature or module.
+---
+
+# Create Feature Module
+
+## Prerequisites
+
+- Entity name (singular, e.g. `PlatformGroup`)
+- Table name (plural snake_case, e.g. `platform_groups`)
+- Whether tenant-scoped or platform-level
+- Fields with types and constraints
+
+## Procedure
+
+### Step 1 — Create the JPA Entity
+
+Location: `openaev-model/src/main/java/io/openaev/database/model/`
+
+Follow `Group.java` (tenant-scoped) or `Tenant.java` (platform-level):
+- `@ControlledUuidGeneration` for ID
+- `@Queryable` on filterable fields
+- `@Transient @JsonIgnore ResourceType` field
+- Collections initialized as mutable (`new ArrayList<>()`)
+- Follow conventions from `database.instructions.md`
+
+### Step 2 — Create the Repository
+
+Location: `openaev-model/src/main/java/io/openaev/database/repository/`
+
+```java
+public interface {Entity}Repository extends JpaRepository<{Entity}, String>,
+    JpaSpecificationExecutor<{Entity}> {}
+```
+
+### Step 3 — Add ResourceType + Capabilities
+
+- Add value in `ResourceType.java`
+- Add `ACCESS_`, `MANAGE_`, `DELETE_` in `Capability.java` with parent hierarchy
+
+### Step 4 — Create the Service
+
+Location: `openaev-api/src/main/java/io/openaev/service/`
+
+- `@Service @RequiredArgsConstructor @Transactional(rollbackFor = Exception.class)`
+- CRUD + search with pagination
+- JavaDoc on all public methods
+
+### Step 5 — Create DTOs + Mapper
+
+Location: `openaev-api/src/main/java/io/openaev/api/{feature}/`
+
+- `{Entity}Input` and `{Entity}Output` as Java `record`
+- `{Entity}Mapper` with static `fromInput()` + `toOutput()`
+
+### Step 6 — Create the Controller
+
+Location: `openaev-api/src/main/java/io/openaev/api/{feature}/`
+
+- `@AccessControl` + `@LogExecutionTime` + `@Operation` on every endpoint
+- CRUD + search endpoints
+
+### Step 7 — Create the Migration
+
+Location: `openaev-api/src/main/java/io/openaev/migration/`
+
+- Find next version number in existing migrations
+- `CREATE TABLE`, FK constraints, indexes
+
+### Step 8 — Create Test Fixtures + Composer
+
+Location: `openaev-api/src/test/java/io/openaev/utils/fixtures/`
+
+- Fixture: `createDefault{Entity}()` with random names
+- Composer: extends `ComposerBase`, inner `Composer` class
+
+### Step 9 — Create Integration Test
+
+Location: `openaev-api/src/test/java/io/openaev/rest/` or `api/`
+
+- `@Nested @DisplayName` groups, `@WithMockUser`, `assertThatJson`
+
+### Step 10 — Create Frontend Actions + Page
+
+> Follow templates and conventions from [frontend.instructions.md](../../instructions/frontend.instructions.md).
+
+Location: `openaev-front/src/actions/{feature}/` and `src/admin/components/`
+
+- `{feature}-action.ts` — API calls (CRUD + search)
+- `{feature}-helper.d.ts` — TypeScript types (or use auto-generated `api-types.d.ts`)
+- `{feature}-schema.ts` — Zod validation schema
+- List page with `Queryable` + `DataTable`
+- Create/Edit form with React Hook Form + Zod
+- Permission guards with CASL (`ability.can(ACTIONS.MANAGE, SUBJECTS.X)`)
+
+### Step 11 — Verify
+
+```bash
+mvn spotless:apply
+mvn test
+cd openaev-front && yarn lint && yarn check-ts && yarn test
+```

--- a/.github/skills/review-performance/SKILL.md
+++ b/.github/skills/review-performance/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: review-performance
+description: >-
+  Performance review checklist for OpenAEV code: N+1 queries, fetch strategy,
+  pagination, indexing, memory usage. Use when reviewing PRs or auditing performance of a feature.
+---
+
+# Performance Review
+
+## Procedure
+
+### Step 1 — Check for N+1 queries
+
+- Search for loops that call the database:
+  ```bash
+  grep -rn "\.findById\|\.findAll\|\.existsById" openaev-api/src/main/java/ --include="*.java"
+  ```
+- Verify that no `findById()` or `findAll()` is called inside a `for` / `forEach` / `stream().map()`
+- If a loop needs related entities, prefer `findAllById()` or a single `@Query` with `IN` clause
+- Check `@ManyToMany` / `@OneToMany` collections have `@Fetch(FetchMode.SUBSELECT)` to avoid N+1
+
+### Step 2 — Check fetch strategy
+
+- All associations should default to `FetchType.LAZY`
+- `FetchType.EAGER` is only acceptable for small, always-needed collections (e.g. capabilities)
+- Search for EAGER on potentially large collections:
+  ```bash
+  grep -rn "FetchType.EAGER" openaev-model/src/main/java/ --include="*.java"
+  ```
+- Verify that LAZY collections are never accessed outside a transaction (causes `LazyInitializationException`)
+- For API endpoints returning IDs only: LAZY + subselect is preferred
+
+### Step 3 — Check pagination
+
+- All list/search REST endpoints MUST return `Page<T>`, not unbounded `List<T>`
+- Search for endpoints returning lists:
+  ```bash
+  grep -rn "List<.*>" openaev-api/src/main/java/io/openaev/api/ --include="*.java" | grep -i "public\|return"
+  ```
+- Verify reasonable default page size (10-20) and max page size (100)
+- `findAll()` without pagination is only acceptable for small reference data tables
+
+### Step 4 — Check query efficiency
+
+- Search for `findAll()` that could be filtered at DB level:
+  ```bash
+  grep -rn "\.findAll()" openaev-api/src/main/java/ --include="*.java"
+  ```
+- Verify existence checks use `existsById()` instead of `findById().isPresent()`
+- Verify bulk deletes use `@Modifying @Query` instead of loading + deleting one by one
+- Check that `@Transactional(readOnly = true)` is used on all read methods
+
+### Step 5 — Check database indexing
+
+- New columns used in WHERE / ORDER BY / JOIN should have indexes
+- FK columns in join tables should be indexed (composite PK covers one direction, check the other)
+- For new migrations, verify:
+  ```bash
+  grep -rn "CREATE TABLE\|CREATE INDEX\|ADD COLUMN" openaev-api/src/main/java/io/openaev/migration/ --include="*.java"
+  ```
+
+### Step 6 — Check memory usage
+
+- No large `byte[]` or full file content loaded in memory — use streaming
+- No unbounded in-memory collections (e.g. `findAll()` result stored in a `List`)
+- Search for potential memory issues:
+  ```bash
+  grep -rn "byte\[\]\|ByteArrayOutputStream\|toByteArray" openaev-api/src/main/java/ --include="*.java"
+  ```
+
+### Step 7 — Check transaction scope
+
+- Read-only operations use `@Transactional(readOnly = true)`
+- No long-running computation inside `@Transactional` (keep transactions short)
+- Verify no `@Transactional` self-calls (Spring proxy bypass):
+  ```bash
+  grep -rn "this\." openaev-api/src/main/java/io/openaev/service/ --include="*.java" | grep -i "find\|get\|search\|create\|update\|delete"
+  ```
+
+### Step 8 — Report
+
+Document findings using conventional comments format:
+- `issue (blocking):` for performance bugs (N+1, missing pagination, unbounded queries)
+- `suggestion (non-blocking):` for optimizations (index, fetch strategy, caching)
+- `note:` for informational items (acceptable tradeoffs, future improvements)
+

--- a/.github/skills/review-security/SKILL.md
+++ b/.github/skills/review-security/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: review-security
+description: >-
+  Security review checklist for OpenAEV code: RBAC, tenant isolation, data exposure,
+  authentication. Use when reviewing PRs or auditing security of a feature.
+---
+
+# Security Review
+
+## Procedure
+
+### Step 1 — Check @AccessControl coverage
+
+- Every REST endpoint MUST have `@AccessControl`
+- Verify `resourceType` matches the entity being accessed
+- Verify `actionPerformed` matches the HTTP method semantics
+- If `skipRBAC = true` is used, verify there's a comment explaining why
+
+### Step 2 — Check tenant isolation
+
+- All `TenantBase` entities must have `@Filter(name = "tenantFilter")`
+- Search for any native `@Query` — they bypass the filter:
+  ```bash
+  grep -rn "nativeQuery = true" openaev-model/ openaev-api/
+  ```
+- Each native query MUST include `WHERE tenant_id = :tenantId` or join via tenant
+- Tenant relation must be `@JsonIgnore` — never in API output
+
+### Step 3 — Check data exposure
+
+- New controllers must use Output DTOs — never return JPA entities directly
+- Swagger annotations must be explicit for LAZY relations:
+  `@ArraySchema(schema = @Schema(type = "string"))` when returning IDs
+- No `tenant_id` in any JSON response
+- No stack traces or internal error details exposed to clients
+
+### Step 4 — Check authentication & authorization
+
+- Protected endpoints require valid session (Spring Security)
+- Admin-only operations: `ResourceType.UNKNOWN` or explicit admin check
+- Grant-managed resources: verify they're in `RESOURCES_MANAGED_BY_GRANTS`
+- `isUserHasAccess()` returns meaningful logic, not just `return true`
+
+### Step 5 — Check secrets & credentials
+
+```bash
+grep -rn "password\|secret\|api_key\|apiKey\|token" --include="*.java" --include="*.ts" src/
+```
+
+- No hardcoded credentials
+- Secrets in `application.properties` use environment variables
+- No `.env` files committed
+
+### Step 6 — Report
+
+Document findings using conventional comments format:
+- `issue (blocking):` for security vulnerabilities
+- `suggestion (non-blocking):` for improvements
+- `note:` for informational items
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+> **Quick reference index.** For full conventions, read [.github/copilot-instructions.md](.github/copilot-instructions.md).
+
+## What is OpenAEV?
+
+OpenAEV — Breach & Attack Simulation platform. Multi-tenant SaaS (**multi-tenancy is actively being developed** — not all entities are tenant-scoped yet).
+Java / Spring Boot / React / TypeScript / PostgreSQL. See `pom.xml` and `package.json` for exact versions.
+
+## Modules
+
+| Module | Role | Status |
+|---|---|---|
+| `openaev-model/` | JPA entities, repositories | Active |
+| `openaev-framework/` | Shared abstractions | ⚠️ Deprecated ([details](/.github/copilot-instructions.md#architecture)) |
+| `openaev-api/` | REST API, services, migrations | Active |
+| `openaev-front/` | React SPA (Redux, CASL, MUI, Zod) | Active |
+
+## Key Commands
+
+```bash
+mvn clean install -DskipTests -Pdev   # Build backend
+mvn spotless:apply                     # Format Java
+mvn test                               # Tests (needs Docker services)
+cd openaev-front && yarn build         # Build frontend
+yarn lint && yarn check-ts             # Lint + type-check
+yarn generate-types-from-api           # Sync API types
+```
+
+## Where to find conventions
+
+Do NOT look for conventions here — they live in dedicated instruction files, activated automatically based on the files you touch.
+
+| Domain | File | Applies to |
+|---|---|---|
+| **Backend** (entities, services, DTOs, API) | [backend.instructions.md](.github/instructions/backend.instructions.md) | `openaev-api/**`, `openaev-model/**` |
+| **Frontend** (components, hooks, folders) | [frontend.instructions.md](.github/instructions/frontend.instructions.md) | `openaev-front/**` |
+| **Database** (migrations, schema, indexes) | [database.instructions.md](.github/instructions/database.instructions.md) | `**/db/migration/**`, `**/model/**` |
+| **Security** (auth, RBAC, tenant isolation) | [security.instructions.md](.github/instructions/security.instructions.md) | All Java & TypeScript files |
+| **Performance** (queries, caching, patterns) | [performance.instructions.md](.github/instructions/performance.instructions.md) | All Java files |
+| **Testing** (unit, integration, coverage) | [testing.instructions.md](.github/instructions/testing.instructions.md) | `**/*Test.java`, `**/*.test.tsx` |
+| **Code Review** (review checklist) | [code-review.instructions.md](.github/instructions/code-review.instructions.md) | All files |
+
+
+## Skills (step-by-step procedures)
+
+| Skill | Use when... |
+|---|---|
+| [add-migration](.github/skills/add-migration/SKILL.md) | Adding a Flyway migration with validation |
+| [add-test](.github/skills/add-test/SKILL.md) | Writing tests with coverage verification |
+| [create-feature-module](.github/skills/create-feature-module/SKILL.md) | Full feature: entity → API → frontend |
+| [review-performance](.github/skills/review-performance/SKILL.md) | Auditing performance of a PR or module |
+| [review-security](.github/skills/review-security/SKILL.md) | Auditing security of a PR or module |
+
+## Specialized Agents
+
+| Agent | Role | Reads | Follows |
+|---|---|---|---|
+| [Performance Reviewer](.github/agents/performance-reviewer.agent.md) | Audit N+1, lazy loading, query efficiency | `AGENTS.md` → `copilot-instructions.md` → `performance.instructions.md` | `review-performance` skill |
+| [Security Reviewer](.github/agents/security-reviewer.agent.md) | Audit auth, RBAC, tenant isolation, injection | `AGENTS.md` → `copilot-instructions.md` → `security.instructions.md` | `review-security` skill |
+| [Test Specialist](.github/agents/test-specialist.agent.md) | Write/improve tests, check coverage | `AGENTS.md` → `copilot-instructions.md` → `testing.instructions.md` | `add-test` skill |


### PR DESCRIPTION
## Purpose

Introduce a structured AI framework to boost coding agent productivity (GitHub Copilot, Claude, Codex) when working on the OpenAEV codebase. This PR adds **instructions**, **prompts**, **skills**, **agents**, and a root `AGENTS.md` — each serving a distinct role in guiding AI agents.

---

## Architecture Overview

```
AGENTS.md                          ← Quick reference entry point (read first)
.github/copilot-instructions.md    ← Existing global context (setup, build, CI, routing)
│
├── .github/instructions/          ← RULES — always-on, scoped by file pattern
│   ├── backend.instructions.md        → Java/Spring Boot conventions
│   ├── code-review.instructions.md    → Review checklist (delegates to domain instructions)
│   ├── database.instructions.md       → Schema naming, Flyway, multi-tenancy, audit
│   ├── frontend.instructions.md       → React/TS, MUI, forms, CASL, i18n
│   ├── performance.instructions.md    → N+1, fetch strategy, pagination, ReferenceResolver
│   ├── security.instructions.md       → @AccessControl, tenant isolation, data exposure
│   └── testing.instructions.md        → Naming, AAA, fixtures, composers, E2E
│
├── .github/skills/                ← PROCEDURES — step-by-step workflows with verification
│   ├── add-migration/SKILL.md         → Find version → create class → tenant isolation → verify
│   ├── add-test/SKILL.md              → Fixture → Composer → Integration test → verify
│   ├── create-feature-module/SKILL.md → Full feature scaffold (11 steps, entity to frontend)
│   ├── review-performance/SKILL.md    → 8-step performance audit checklist with grep commands
│   └── review-security/SKILL.md       → 6-step security audit checklist with grep commands
│
└── .github/agents/                ← ROLES — specialized reviewer personas
    ├── performance-reviewer.agent.md  → Uses performance.instructions + review-performance skill
    ├── security-reviewer.agent.md     → Uses security.instructions + review-security skill
    └── test-specialist.agent.md       → Uses testing.instructions + add-test skill
```

---

## How the pieces fit together

### Activation model — When does each type kick in?

This is the most important concept to understand. Each file type has a **fundamentally different activation mechanism**:

```
┌─────────────────────────────────────────────────────────────────────┐
│  copilot-instructions.md         ← ALWAYS active (global context)  │
├─────────────────────────────────────────────────────────────────────┤
│  instructions/*.md               ← AUTO — activated when the file  │
│                                     you're editing matches applyTo │
├─────────────────────────────────────────────────────────────────────┤
│  agents/*.md                     ← MANUAL — you @mention the agent │
│                                     in the chat panel              │
├─────────────────────────────────────────────────────────────────────┤
│  skills/*/SKILL.md               ← INDIRECT — called by an agent   │
│                                     or prompt, never by the user   │
└─────────────────────────────────────────────────────────────────────┘
```

**Key implications:**
- **Instructions** consume tokens on every interaction matching their `applyTo` scope — they must stay lean
- **Prompts** only consume tokens when explicitly invoked — they can afford to be heavier (templates, steps)
- **Skills** are never loaded unless an agent or prompt references them — they can be the most detailed
- **Agents** are only loaded when @mentioned — they combine instructions + skills into a persona

### 1. `AGENTS.md` — Entry Point (Index Only)
The root file every agent reads first. Contains the project quick reference: modules table, key commands, and **routing tables** pointing to all instructions, prompts, skills, and agents. It contains **no detailed conventions** — those live in the instruction files. Points to `.github/copilot-instructions.md` for full context.

### 2. Instructions — Permanent Rules (always active based on `applyTo`)

Each instruction file has an `applyTo` YAML frontmatter header that scopes it to specific file glob patterns. **When an agent works on a file matching the pattern, the corresponding instructions are automatically injected into context** — the developer does not need to do anything.

**Concrete example — editing a Java file in `openaev-api/`:**

| Instruction file | `applyTo` pattern | Loaded? |
|---|---|---|
| `copilot-instructions.md` | *(always)* | ✅ Always |
| `code-review.instructions.md` | `**/*` | ✅ Yes — matches everything |
| `backend.instructions.md` | `openaev-api/**/*.java, openaev-model/**/*.java` | ✅ Yes |
| `security.instructions.md` | `openaev-api/**/*.java, openaev-model/**/*.java, openaev-front/**/*.ts, **/*.tsx` | ✅ Yes |
| `performance.instructions.md` | `openaev-api/**/*.java, openaev-model/**/*.java` | ✅ Yes |
| `database.instructions.md` | `**/model/**, **/repository/**, **/migration/**` | ❌ No (unless in model/repo/migration path) |
| `frontend.instructions.md` | `openaev-front/**/*.ts, **/*.tsx` | ❌ No |
| `testing.instructions.md` | `**/*Test.java, **/test/**, **/tests_e2e/**` | ❌ No (unless it's a test file) |

**Why `security` has a broad scope:** Security (`@AccessControl`, tenant isolation, data exposure) is a cross-cutting concern. A missing `@AccessControl` on any controller or a missing `WHERE tenant_id` in any `@Query` is a vulnerability — so the agent must think about security on every Java/TS file. The file is only ~1.4KB, so the token cost is negligible.

| Instruction | Scope (`applyTo`) | Key rules |
|---|---|---|
| `backend` | `openaev-api/**/*.java`, `openaev-model/**/*.java` | `@AccessControl` + `@LogExecutionTime` + `@Operation`, service annotations, JPA pitfalls |
| `code-review` | `**/*` | **Delegates** to backend/frontend/performance/testing/security instructions with key checks per domain |
| `database` | `**/model/**`, `**/repository/**`, `**/migration/**` | Schema naming, business keys, Flyway, multi-tenancy, audit |
| `frontend` | `openaev-front/**/*.ts{x}` | File structure, MUI rules, forms, CASL permissions, i18n |
| `performance` | `openaev-api/**/*.java`, `openaev-model/**/*.java` | N+1, fetch strategy, `ReferenceResolver`, pagination, anti-patterns |
| `security` | All backend Java + all frontend TS/TSX | `@AccessControl`, tenant isolation, data exposure, secrets |
| `testing` | `**/*Test*.java`, `**/test/**`, `**/tests_e2e/**` | `given_X_should_Y` naming, AAA, fixtures, composers, frontend E2E |

### 3. Prompts — Quick-Start Blueprints (on-demand, manually invoked)

Prompts are **never activated automatically**. The developer must explicitly invoke them:
- In VS Code chat: type `/new-migration`, `/new-entity`, etc.
- Via command palette: `Ctrl+Shift+P` → "GitHub Copilot: Run Prompt" → select from list

They serve as **quick-start checklists** that delegate to the corresponding skill for detailed steps. Two patterns:

- **Delegating prompts** (`new-entity`, `new-migration`): provide a quick reference checklist then point to their skill (`create-feature-module/SKILL.md`, `add-migration/SKILL.md`) for the full procedure
- **Standalone prompts** (`new-api-endpoint`, `new-frontend-feature`, `new-rbac-resource`): provide copy-paste-ready templates with placeholders

| Prompt | Invoked via | What it does |
|---|---|---|
| `new-api-endpoint` | `/new-api-endpoint` | Controller + Service + DTOs + Mapper with full annotations |
| `new-entity` | `/new-entity` | Quick checklist → **delegates to** `create-feature-module/SKILL.md` for full 11-step procedure |
| `new-frontend-feature` | `/new-frontend-feature` | Actions, helpers, schemas, queryables, pages (standalone) |
| `new-migration` | `/new-migration` | Quick reference → **delegates to** `add-migration/SKILL.md` for full procedure |
| `new-rbac-resource` | `/new-rbac-resource` | `ResourceType` + `Capability` hierarchy + `PermissionService` config + frontend CASL. Follows conventions from `security.instructions.md` |

### 4. Skills — Step-by-Step Procedures (never invoked directly)

Skills are **never loaded by themselves** — they are called by agents or prompts. They contain the most detailed, step-by-step procedures with **verification commands** (`mvn test`, `mvn jacoco:check`) and **discovery steps** (find next migration version, search for existing patterns). This is why they can be the heaviest files without impacting token usage on regular interactions.

| Skill | Called by | Steps | Ends with |
|---|---|---|---|
| `add-migration` | `new-migration` prompt | Find version → create class → tenant isolation → ES reindex | `mvn clean install` + `mvn test` |
| `add-test` | `test-specialist` agent | Fixture → Composer → Integration test → Unit test (optional) | `mvn test -Dtest={Class}` + `mvn jacoco:check` |
| `create-feature-module` | `new-entity` prompt | 11 steps: entity → repo → RBAC → service → DTOs → controller → migration → fixtures → tests → frontend → verify. Step 10 delegates to `new-frontend-feature.prompt.md` | `mvn test` + `yarn lint` + `yarn check-ts` |
| `review-performance` | `performance-reviewer` agent | 8-step audit: N+1 → fetch → pagination → queries → indexing → memory → transactions → report | Conventional comments |
| `review-security` | `security-reviewer` agent | 6-step audit: `@AccessControl` → tenant isolation → data exposure → auth → secrets → report | Conventional comments |

### 5. Agents — Specialized Roles (manually @mentioned)

Agents are **only activated when explicitly @mentioned** in the chat panel (e.g., `@performance-reviewer please review this PR`). They are never loaded automatically.

Each agent combines instructions + skills into a persona with clear boundaries:
1. Reads `AGENTS.md` + `copilot-instructions.md` for global context
2. Reads its domain-specific instruction file for rules
3. Follows its skill file for the step-by-step procedure (runs the commands defined in each step — no duplicated grep commands)
4. Reports using conventional comments (`issue (blocking):`, `suggestion:`, etc.)

| Agent | @mention | Reads | Follows | Boundaries |
|---|---|---|---|---|
| **Performance Reviewer** | `@performance-reviewer` | `performance.instructions.md` | `review-performance/SKILL.md` | Never modifies code — only suggests. Prefers DB-level fixes. |
| **Security Reviewer** | `@security-reviewer` | `security.instructions.md` | `review-security/SKILL.md` | Never modifies code — only suggests. Escalates high-severity. |
| **Test Specialist** | `@test-specialist` | `testing.instructions.md` | `add-test/SKILL.md` | Only creates/modifies test files. Never changes production code. |

---

## Design principle: Single Source of Truth

Every piece of information lives in **exactly one file**. All other files reference it instead of copying it:

| Information | Source of truth | Referenced by |
|---|---|---|
| Backend conventions | `backend.instructions.md` | `code-review`, `new-entity`, agents |
| Frontend conventions | `frontend.instructions.md` | `code-review`, `new-frontend-feature`, `create-feature-module` Step 10 |
| Testing conventions | `testing.instructions.md` | `code-review`, `add-test/SKILL.md`, `test-specialist.agent.md` |
| Security conventions | `security.instructions.md` | `code-review`, `new-rbac-resource`, `security-reviewer.agent.md` |
| Performance conventions | `performance.instructions.md` | `code-review`, `review-performance/SKILL.md`, `performance-reviewer.agent.md` |
| Migration template | `add-migration/SKILL.md` | `new-migration.prompt.md` |
| Entity creation steps | `create-feature-module/SKILL.md` | `new-entity.prompt.md` |
| `openaev-framework` deprecated | `copilot-instructions.md` | `AGENTS.md`, `backend.instructions.md` |
| Grep/audit commands | Skills (`review-performance`, `review-security`) | Agents (run commands from skill steps) |