### PR TITLE
[backend] fix(enable-player): enable player facing 'element already exists' error (#4415)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/exercise/ExerciseApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/ExerciseApi.java
@@ -258,21 +258,8 @@ public class ExerciseApi extends RestBehavior {
       @PathVariable String exerciseId,
       @PathVariable String teamId,
       @Valid @RequestBody ExerciseTeamPlayersEnableInput input) {
-    Exercise exercise =
-        exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     Team team = teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
-    input
-        .getPlayersIds()
-        .forEach(
-            playerId -> {
-              ExerciseTeamUser exerciseTeamUser = new ExerciseTeamUser();
-              exerciseTeamUser.setExercise(exercise);
-              exerciseTeamUser.setTeam(team);
-              exerciseTeamUser.setUser(
-                  userRepository.findById(playerId).orElseThrow(ElementNotFoundException::new));
-              exerciseTeamUserRepository.save(exerciseTeamUser);
-            });
-    return exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
+    return exerciseService.enablePlayers(exerciseId, team, input.getPlayersIds());
   }
 
   @Transactional(rollbackFor = Exception.class)
@@ -308,24 +295,11 @@ public class ExerciseApi extends RestBehavior {
       @PathVariable String exerciseId,
       @PathVariable String teamId,
       @Valid @RequestBody ExerciseTeamPlayersEnableInput input) {
-    Exercise exercise =
-        exerciseRepository.findById(exerciseId).orElseThrow(ElementNotFoundException::new);
     Team team = teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
     Iterable<User> teamUsers = userRepository.findAllById(input.getPlayersIds());
     team.getUsers().addAll(fromIterable(teamUsers));
     teamRepository.save(team);
-    input
-        .getPlayersIds()
-        .forEach(
-            playerId -> {
-              ExerciseTeamUser exerciseTeamUser = new ExerciseTeamUser();
-              exerciseTeamUser.setExercise(exercise);
-              exerciseTeamUser.setTeam(team);
-              exerciseTeamUser.setUser(
-                  userRepository.findById(playerId).orElseThrow(ElementNotFoundException::new));
-              exerciseTeamUserRepository.save(exerciseTeamUser);
-            });
-    return exercise;
+    return exerciseService.enablePlayers(exerciseId, team, input.getPlayersIds());
   }
 
   @PutMapping(EXERCISE_URI + "/{exerciseId}/teams/{teamId}/players/remove")


### PR DESCRIPTION
### Proposed changes

* add defensif code to not throw error

### Testing Instructions

1. go to a simulation
2. add a team
3. enable a player with latency: player should be enabled by default but because of store latencies, he is not
4. try to enable it
5. 'element already exists' error

### Related issues

* Related to https://github.com/OpenAEV-Platform/openaev/issues/4415

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
