### PR TITLE
refactor(openaev-api): `openaevoauth2user.isadmin()` always returns `false`

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/OpenAEVOAuth2User.java
+++ b/openaev-api/src/main/java/io/openaev/config/OpenAEVOAuth2User.java
@@ -49,7 +49,7 @@ public class OpenAEVOAuth2User implements OpenAEVPrincipal, OAuth2User, Serializ
 
   @Override
   public boolean isAdmin() {
-    return false;
+    return this.user.isAdmin();
   }
 
   @Override


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`isAdmin()` is hardcoded to `false`, which contradicts `getAuthorities()` where admin users receive `ROLE_ADMIN`. Any authorization path relying on `principal.isAdmin()` will incorrectly deny admin access in production, causing broken admin functionality and inconsistent security behavior depending on which check is used.


**Severity**: `high`
**File**: `openaev-api/src/main/java/io/openaev/config/OpenAEVOAuth2User.java`

### Solution
Replace the hardcoded return value with the underlying user flag:

@Override
public boolean isAdmin() {
  return this.user.isAdmin();
}


### Changes
- `openaev-api/src/main/java/io/openaev/config/OpenAEVOAuth2User.java` (modified)



### Proposed changes

*
*

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist



- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug




### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


Closes #5317