### PR TITLE
refactor(openaev-api): expiration calculation truncates seconds to minutes, causing incorrect expiry decisions

### DIFF
--- a/openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/utils/ExpectationUtils.java
@@ -5,7 +5,6 @@ import io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE;
 import io.openaev.expectation.ExpectationType;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 public class ExpectationUtils {
 
@@ -18,9 +17,8 @@ public class ExpectationUtils {
    * @return true if the expectation has exceeded its expiration time
    */
   public static boolean isExpired(@NotNull final InjectExpectation expectation) {
-    // expirationTime is stored in seconds, convert to minutes for comparison
-    long expirationTimeInMinutes = expectation.getExpirationTime() / 60;
-    Instant expirationThreshold = Instant.now().minus(expirationTimeInMinutes, ChronoUnit.MINUTES);
+    long expirationTimeInSeconds = expectation.getExpirationTime();
+    Instant expirationThreshold = Instant.now().minusSeconds(expirationTimeInSeconds);
     return expectation.getCreatedAt().isBefore(expirationThreshold);
   }
 


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`isExpired()` converts seconds to minutes using integer division (`/ 60`) and then subtracts minutes. This truncates sub-minute values to 0 and loses precision for non-multiples of 60. Impact: expectations with `<60s` expiration are treated as expired almost immediately, and others can expire late, producing silent logic/data corruption in expectation lifecycle handling.


**Severity**: `medium`
**File**: `openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/utils/ExpectationUtils.java`

### Solution
Compare using seconds directly to preserve precision:

public static boolean isExpired(@NotNull final InjectExpectation expectation) {
  long expirationTimeInSeconds = expectation.getExpirationTime();
  Instant expirationThreshold = Instant.now().minusSeconds(expirationTimeInSeconds);
  return expectation.getCreatedAt().isBefore(expirationThreshold);
}

### Changes
- `openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/utils/ExpectationUtils.java` (modified)



### Proposed changes

*
*

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist



- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug




### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


Closes #5319