### PR TITLE
fix(ci): add `corepack enable` after install in Drone CI steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,7 @@ steps:
     image: node:22.22.2-alpine
     commands:
       - npm install -g corepack
+      - corepack enable
       - cd openaev-front
       - yarn install
       - yarn build
@@ -63,6 +64,7 @@ steps:
       - curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
       - apt update && apt install -y nodejs
       - npm install -g corepack
+      - corepack enable
       - cd openaev-front
       - yarn install
       - yarn build
@@ -80,6 +82,7 @@ steps:
       - apt -y install netcat-traditional
       - while ! nc -z app-e2e 8080 ; do sleep 1 ; done
       - npm install -g corepack
+      - corepack enable
       - cd openaev-front
       - yarn install
       - yarn playwright install --with-deps chromium
@@ -97,6 +100,7 @@ steps:
       - apt -y install netcat-traditional
       - while ! nc -z app-e2e 8080 ; do sleep 1 ; done
       - npm install -g corepack
+      - corepack enable
       - cd openaev-front
       - yarn install
       - API_URL=http://app-e2e:8080 yarn generate-types-from-api


### PR DESCRIPTION
## Problem

On Node 22, `npm install -g corepack` installs the Corepack binary but does **not** automatically activate it. When a `package.json` contains a `packageManager` field (e.g. `yarn@4.13.0`), Node 22 now **errors out** instead of silently falling back to Yarn 1.x.

This causes CI failures on Renovate PRs (and potentially any PR) where the `packageManager` hash is stripped or slightly different from master.

**Error:**
```
error This project's package.json defines "packageManager": "yarn@4.13.0".
However the current global version of Yarn is 1.22.22.
```

## Fix

Added `corepack enable` after `npm install -g corepack` in all 4 Drone CI steps that run `yarn install`:

| Step | Image | Fix |
|---|---|---|
| `frontend-tests` | `node:22.22.2-alpine` | ✅ `corepack enable` added |
| `app-e2e` | `maven:3.9.9-eclipse-temurin-22` | ✅ `corepack enable` added |
| `frontend-e2e-tests` | `node:22.22.2` | ✅ `corepack enable` added |
| `frontend-api-types` | `node:22.22.2` | ✅ `corepack enable` added |

## ⚠️ Manual action needed

The same fix is needed in `.github/workflows/test-feature-branch.yml` but the CI bot doesn't have permission to modify `.github/workflows/`. Please add manually:

```yaml
      - name: Setup Node.js
        run: |
          npm install -g corepack
          corepack enable              # ← ADD THIS LINE
        shell: alpine.sh --root {0}
```

## Context

Unblocks PR #5259 (`@vitejs/plugin-react` v5 → v6) and any future Renovate PR that touches `package.json`.