### PR TITLE
[frontend] fix(multi-tenancy): multiple tabs tenant switcher issue (#4864)

### DIFF
--- a/openaev-front/src/__tests__/utils/hooks/UseTenant.test.tsx
+++ b/openaev-front/src/__tests__/utils/hooks/UseTenant.test.tsx
@@ -20,12 +20,15 @@ const mockBuildTenantUrl = vi.fn(
     `/fake-base/${tenantId}${pathname}${search}${hash}`,
 );
 
+const mockExtractTenantFromUrl = vi.fn<() => string | null>(() => null);
+
 vi.mock('../../../utils/tenant-url-helper', async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const original = await importOriginal<typeof import('../../../utils/tenant-url-helper')>();
   return {
     ...original,
     buildTenantUrl: (...args: [string, string, string, string]) => mockBuildTenantUrl(...args),
+    extractTenantFromUrl: () => mockExtractTenantFromUrl(),
   };
 });
 
@@ -258,6 +261,56 @@ describe('useTenant', () => {
   });
 
   // -- DISPATCH TENANT_SWITCH_SUCCESS --
+
+  describe('URL-based tenant resolution (cross-tab)', () => {
+    it('given_urlTenantDiffersFromStorage_should_selectUrlTenant', async () => {
+      // Arrange — simulate: Tab 2 switched to BETA (localStorage), but Tab 1 URL has ALPHA
+      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_BETA));
+      mockExtractTenantFromUrl.mockReturnValue(TENANT_ALPHA.tenant_id);
+      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA, TENANT_GAMMA]);
+      const useTenant = await importUseTenant();
+
+      // Act
+      const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
+
+      // Assert — URL tenant (ALPHA) must win over localStorage (BETA)
+      await waitFor(() => {
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
+      });
+    });
+
+    it('given_noTenantInUrl_should_fallbackToStorage', async () => {
+      // Arrange — no tenant UUID in URL, valid tenant in localStorage
+      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_BETA));
+      mockExtractTenantFromUrl.mockReturnValue(null);
+      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
+      const useTenant = await importUseTenant();
+
+      // Act
+      const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
+
+      // Assert — should fall back to localStorage (BETA)
+      await waitFor(() => {
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_BETA.tenant_id);
+      });
+    });
+
+    it('given_urlTenantNotInList_should_fallbackToStorage', async () => {
+      // Arrange — URL has a tenant UUID that is not in the user's tenant list
+      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_ALPHA));
+      mockExtractTenantFromUrl.mockReturnValue('unknown-tenant-id');
+      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
+      const useTenant = await importUseTenant();
+
+      // Act
+      const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
+
+      // Assert — should fall back to localStorage (ALPHA)
+      await waitFor(() => {
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
+      });
+    });
+  });
 
   describe('Dispatch TENANT_SWITCH_SUCCESS', () => {
     it('given_tenantLoad_should_dispatchTenantSwitchSuccess', async () => {

--- a/openaev-front/src/utils/hooks/useTenant.ts
+++ b/openaev-front/src/utils/hooks/useTenant.ts
@@ -6,7 +6,7 @@ import { fetchUserTenants } from '../../actions/user/user-tenant-actions';
 import { TENANT_SWITCH_SUCCESS } from '../../constants/ActionTypes';
 import { type TenantOutput, type User } from '../api-types';
 import { useAppDispatch } from '../hooks';
-import { buildTenantUrl, TENANT_STORAGE_KEY } from '../tenant-url-helper';
+import { buildTenantUrl, extractTenantFromUrl, TENANT_STORAGE_KEY } from '../tenant-url-helper';
 
 /**
  * Internal hook that encapsulates the current-tenant state and
@@ -81,7 +81,13 @@ const useTenant = (me: User | undefined, logged: unknown) => {
 
   useEffect(() => {
     if (me && logged) {
-      loadUserTenants();
+      // On page load / hard refresh the URL is the source of truth for
+      // which tenant the user is working in.  localStorage is shared
+      // across tabs, so another tab's tenant switch can leave a stale
+      // value there.  By reading the tenant UUID from the URL we make
+      // sure TenantSwitcher displays the tenant that matches the URL.
+      const urlTenantId = extractTenantFromUrl() ?? undefined;
+      loadUserTenants(urlTenantId);
     }
   }, [me, logged, loadUserTenants]);
 


### PR DESCRIPTION

### Proposed changes
Bug: When two browser tabs are open on different tenants and you hard-refresh one tab, the TenantSwitcher displays the wrong tenant (the one from the other tab) while the URL still shows the correct tenant.

### Testing Instructions

Prerequisites:
* create tenant A
* create tenant B

Steps to reproduce bug:
Tab 1 opens Tenant A → localStorage is set to Tenant A
Tab 2 switches to Tenant B → localStorage is overwritten to Tenant B
Tab 1 hard refreshes → URL still has Tenant A, but loadUserTenants() reads currentTenantStorage from localStorage (now Tenant B) and selects Tenant B
Root cause: On initial load/hard refresh, useTenant prioritizes localStorage over the URL. Since localStorage is shared across tabs, another tab's tenant switch corrupts the first tab's state.


### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
