### PR TITLE
[backend/frontend] fix(tabletop): add results to inject expectation as player (#5190)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -823,9 +823,7 @@ public class InjectExpectationService {
       TargetType targetTypeEnum = TargetType.valueOf(targetType);
       return switch (targetTypeEnum) {
         case TEAMS -> injectExpectationRepository.findAllByInjectAndTeam(injectId, targetId);
-        case PLAYERS ->
-            injectExpectationRepository.findAllByInjectAndTeamAndPlayer(
-                injectId, parentTargetId, targetId);
+        case PLAYERS -> injectExpectationRepository.findAllByInjectAndPlayer(injectId, targetId);
         case AGENT -> injectExpectationRepository.findAllByInjectAndAgent(injectId, targetId);
         case ASSETS -> injectExpectationRepository.findAllByInjectAndAsset(injectId, targetId);
         case ASSETS_GROUPS ->
@@ -973,10 +971,11 @@ public class InjectExpectationService {
           electedExpectations
               .get(expectation.getType())
               .setScore(
-                  Collections.max(
-                      electedExpectations.get(expectation.getType()).getResults().stream()
-                          .map(InjectExpectationResult::getScore)
-                          .toList()));
+                  electedExpectations.get(expectation.getType()).getResults().stream()
+                      .map(InjectExpectationResult::getScore)
+                      .filter(Objects::nonNull)
+                      .max(Double::compareTo)
+                      .orElse(null));
         }
       }
     }

--- a/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
@@ -488,6 +488,7 @@ public class ExpectationUtils {
         .filter(ExpectationUtils::isTeamExpectation)
         .filter(e -> e.getTeam().getId().equals(injectExpectation.getTeam().getId()))
         .filter(e -> e.getType().equals(injectExpectation.getType()))
+        .filter(e -> Objects.equals(e.getName(), injectExpectation.getName()))
         .toList();
   }
 

--- a/openaev-api/src/main/java/io/openaev/utils/InjectExpectationResultUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/InjectExpectationResultUtils.java
@@ -161,8 +161,7 @@ public class InjectExpectationResultUtils {
         .filter(e -> types.contains(e.getType()))
         .map(
             injectExpectation -> {
-              if (injectExpectation.getScore() == null
-                  || injectExpectation.getExpectedScore() == null) {
+              if (injectExpectation.getScore() == null) {
                 return null;
               }
               if (injectExpectation.getTeam() != null) {
@@ -175,7 +174,7 @@ public class InjectExpectationResultUtils {
                 if (injectExpectation.getScore() >= injectExpectation.getExpectedScore()) {
                   return 1.0;
                 }
-                if (Double.compare(injectExpectation.getScore(), 0.0) == 0) {
+                if (injectExpectation.getScore() == 0) {
                   return 0.0;
                 }
                 return 0.5;

--- a/openaev-api/src/main/java/io/openaev/utils/InjectExpectationResultUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/InjectExpectationResultUtils.java
@@ -161,7 +161,8 @@ public class InjectExpectationResultUtils {
         .filter(e -> types.contains(e.getType()))
         .map(
             injectExpectation -> {
-              if (injectExpectation.getScore() == null) {
+              if (injectExpectation.getScore() == null
+                  || injectExpectation.getExpectedScore() == null) {
                 return null;
               }
               if (injectExpectation.getTeam() != null) {
@@ -174,7 +175,7 @@ public class InjectExpectationResultUtils {
                 if (injectExpectation.getScore() >= injectExpectation.getExpectedScore()) {
                   return 1.0;
                 }
-                if (injectExpectation.getScore() == 0) {
+                if (Double.compare(injectExpectation.getScore(), 0.0) == 0) {
                   return 0.0;
                 }
                 return 0.5;

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/InjectExpectationMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/InjectExpectationMapper.java
@@ -122,6 +122,12 @@ public class InjectExpectationMapper {
             injects.stream()
                 .map(
                     inject -> {
+                      // Use primary expectations, fall back to all expectations when primary is
+                      // empty (e.g. only agent-level expectations exist) to compute real scores
+                      List<InjectExpectation> primary = injectUtils.getPrimaryExpectations(inject);
+                      List<InjectExpectation> expectations =
+                          primary.isEmpty() ? new ArrayList<>(inject.getExpectations()) : primary;
+
                       InjectExpectationResultsByAttackPattern.InjectExpectationResultsByType
                           result =
                               new InjectExpectationResultsByAttackPattern
@@ -131,7 +137,7 @@ public class InjectExpectationMapper {
                       result.setResults(
                           extractExpectationResults(
                               inject.getContent(),
-                              injectUtils.getPrimaryExpectations(inject),
+                              expectations,
                               InjectExpectationResultUtils::getScores));
                       return result;
                     })

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/InjectMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/InjectMapper.java
@@ -56,6 +56,15 @@ public class InjectMapper {
             .map(Document::getId)
             .toList();
 
+    // Use primary (top-level) expectations for score computation.
+    // When no primary expectations match (e.g. only agent-level expectations exist),
+    // fall back to all expectations to avoid losing scores in buildFallbackResults.
+    List<InjectExpectation> primaryExpectations = injectUtils.getPrimaryExpectations(inject);
+    List<InjectExpectation> expectationsForScoring =
+        primaryExpectations.isEmpty()
+            ? new ArrayList<>(inject.getExpectations())
+            : primaryExpectations;
+
     return InjectResultOverviewOutput.builder()
         .id(inject.getId())
         .title(inject.getTitle())
@@ -72,7 +81,7 @@ public class InjectMapper {
         .expectationResultByTypes(
             injectExpectationMapper.extractExpectationResults(
                 inject.getContent(),
-                injectUtils.getPrimaryExpectations(inject),
+                expectationsForScoring,
                 InjectExpectationResultUtils::getScores))
         .isReady(healthCheckUtils.runContentChecks(inject).isEmpty())
         .updatedAt(inject.getUpdatedAt())

--- a/openaev-front/src/admin/components/simulations/simulation/injects/InjectIndexHeader.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/injects/InjectIndexHeader.tsx
@@ -62,9 +62,18 @@ const InjectIndexHeader = ({ injectResultOverview, exercise }: Props) => {
         <Box display="flex" flexDirection="column" justifyContent="left" alignItems="flex-start">
           <Breadcrumbs variant="object" elements={breadcrumbs} />
           <AtomicTestingTitle injectResultOverview={injectResultOverview} />
-          <InjectIndexTabs injectResultOverview={injectResultOverview} exercise={exercise} backlabel={backlabel} backuri={backuri} />
+          <InjectIndexTabs
+            injectResultOverview={injectResultOverview}
+            exercise={exercise}
+            backlabel={backlabel}
+            backuri={backuri}
+          />
         </Box>
-        <ResponsePie hasTitles={false} forceSize={112} expectationResultsByTypes={injectResultOverview.inject_expectation_results} />
+        <ResponsePie
+          hasTitles={false}
+          forceSize={112}
+          expectationResultsByTypes={injectResultOverview.inject_expectation_results}
+        />
       </div>
     </Box>
   );

--- a/openaev-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/validation/expectations/ManualExpectationsValidationForm.tsx
@@ -53,7 +53,12 @@ interface FormProps {
   isDisabled?: boolean;
 }
 
-const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expectation, onUpdate, withSummary = true, isDisabled }) => {
+const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({
+  expectation,
+  onUpdate,
+  withSummary = true,
+  isDisabled,
+}) => {
   const { classes } = useStyles();
   const { t } = useFormatter();
   const theme = useTheme();
@@ -92,7 +97,7 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
     formState: { errors, isSubmitting },
   } = useForm<{ expectation_score: number }>({
     mode: 'onTouched',
-    resolver: zodResolver(zodImplement<{ expectation_score: number }>().with({ expectation_score: z.number({ error: t('Score must be a valid number') }).min(1, t('Score must be greater than 0')).max(100, t('Score must be less than or equal to 100')).int(t('Score must be a whole number')) })),
+    resolver: zodResolver(zodImplement<{ expectation_score: number }>().with({ expectation_score: z.number({ error: t('Score must be a valid number') }).min(0, t('Score must be greater than 0')).max(100, t('Score must be less than or equal to 100')).int(t('Score must be a whole number')) })),
     defaultValues: { expectation_score: expectation.inject_expectation_score ?? expectation.inject_expectation_expected_score ?? 0 },
   });
   useEffect(() => {
@@ -101,7 +106,7 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
 
   const targetLabel = (expectationToProcess: InjectExpectationsStore) => {
     if (expectationToProcess.inject_expectation_user && usersMap[expectationToProcess.inject_expectation_user]) {
-      return truncate(resolveUserName(usersMap[expectationToProcess.inject_expectation_user]), 22);
+      return truncate(resolveUserName(usersMap[expectationToProcess.inject_expectation_user]), 40);
     }
     if (expectationToProcess.inject_expectation_team) {
       return teamsMap[expectationToProcess.inject_expectation_team]?.team_name;
@@ -119,7 +124,13 @@ const ManualExpectationsValidationForm: FunctionComponent<FormProps> = ({ expect
             label={t(computeLabel(expectation.inject_expectation_status))}
           />
         )}
-        {withSummary && (<Typography variant="h3">{expectation.inject_expectation_user ? t('Player') : t('Team')}</Typography>)}
+        {withSummary && (
+          <Typography
+            variant="h3"
+          >
+            {expectation.inject_expectation_user ? t('Player') : t('Team')}
+          </Typography>
+        )}
         {withSummary && targetLabel(expectation)}
         <Grid container spacing={3} className={withSummary ? classes.marginTop_2 : classes.scoreAcc}>
           <Grid size={{ xs: 6 }}>


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Tab "manual" is displayed for both : teams and players 
* Synchronize the teams and players validations

### Testing Instructions

1. Create a scenario with a tabletop inject (Manual or Challenge type)
2. Add expectations to the inject
3. Start the simulation
4. Try to add/edit a result at the Player level
5. You should be able to edit the expectation validation at team AND player level 
6. Expectation "All players must validate the expectation" : if all the players individually succeed, the team should also be marked as successful
7. Expectation : "At least one player (per team) must validate the expectation": If at least one player succeeds, the team should be marked as successful

### Related issues

* Closes #5190
