### PR TITLE
[frontend] chore(deps): bump @redux-devtools/extension from 3.3.0 to 4.0.0

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -48,7 +48,7 @@
     "@mui/material": "7.3.9",
     "@mui/system": "7.3.9",
     "@mui/x-date-pickers": "8.27.2",
-    "@redux-devtools/extension": "3.3.0",
+    "@redux-devtools/extension": "4.0.0",
     "@uiw/react-md-editor": "4.1.0",
     "@xyflow/react": "12.10.2",
     "apexcharts": "5.3.6",

--- a/openaev-front/src/components/CKEditor.tsx
+++ b/openaev-front/src/components/CKEditor.tsx
@@ -64,9 +64,9 @@ const LazyCKEditorComponent = lazy(async () => {
       TodoList,
       Underline,
     },
-    { defautl: en },
-    { defautl: fr },
-    { defautl: zh },
+    { default: en },
+    { default: fr },
+    { default: zh },
   ] = await Promise.all([
     import('@ckeditor/ckeditor5-react'),
     import('ckeditor5'),

--- a/openaev-front/tsconfig.json
+++ b/openaev-front/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -155,7 +155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
@@ -2669,15 +2669,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redux-devtools/extension@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@redux-devtools/extension@npm:3.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.2"
-    immutable: "npm:^4.3.4"
+"@redux-devtools/extension@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@redux-devtools/extension@npm:4.0.0"
   peerDependencies:
     redux: ^3.1.0 || ^4.0.0 || ^5.0.0
-  checksum: 10c0/a582d26687fdcbb9fc98181a6a28c7e286a6a74f35f5bba181b9b8b766029d34754bd8f8e60acaa757a34aca385056783d2efb95f943282f2ee66039931c942f
+  checksum: 10c0/bb3b5b48245f4eb40ffc4384df31f7fe1a14cff2749f8a4058ae5d266436f33e1e97f633daf724e131fc69edfa5c2bcd0f9562bdf9493058fec813641961ccb6
   languageName: node
   linkType: hard
 
@@ -7579,13 +7576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^4.3.4":
-  version: 4.3.7
-  resolution: "immutable@npm:4.3.7"
-  checksum: 10c0/9b099197081b22f6433003e34929da8ecddbbdc1474cdc8aa3b7669dee4adda349c06143de22def36016d1b6de5322b043eccd7a11db1dad2ca85dad4fff5435
-  languageName: node
-  linkType: hard
-
 "import-fresh@npm:^3.2.1":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -9845,7 +9835,7 @@ __metadata:
     "@mui/system": "npm:7.3.9"
     "@mui/x-date-pickers": "npm:8.27.2"
     "@playwright/test": "npm:1.58.2"
-    "@redux-devtools/extension": "npm:3.3.0"
+    "@redux-devtools/extension": "npm:4.0.0"
     "@stylistic/eslint-plugin": "npm:5.10.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Bump direct dependency eliminating vulenrable transitive dependency
