### PR TITLE
[frontend/backend] feat(multi-tenancy): manage tenant API for components (#4864)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/payload/PayloadApiExporter.java
+++ b/openaev-api/src/main/java/io/openaev/api/payload/PayloadApiExporter.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(PayloadApi.PAYLOAD_URI)
+@RequestMapping({PayloadApi.PAYLOAD_URI, PayloadApi.TENANT_PAYLOAD_URI})
 @RequiredArgsConstructor
 public class PayloadApiExporter extends RestBehavior {
 

--- a/openaev-api/src/main/java/io/openaev/api/payload/PayloadApiImporter.java
+++ b/openaev-api/src/main/java/io/openaev/api/payload/PayloadApiImporter.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping(PayloadApi.PAYLOAD_URI)
+@RequestMapping({PayloadApi.PAYLOAD_URI, PayloadApi.TENANT_PAYLOAD_URI})
 @RequiredArgsConstructor
 public class PayloadApiImporter extends RestBehavior {
 

--- a/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
@@ -76,16 +76,19 @@ public class AppSecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/comcheck/**")
                     .permitAll()
+                    // TODO to delete after the multi tenancy upgrade
                     .requestMatchers("/api/player/**")
                     .permitAll()
                     .requestMatchers(TENANT_PLAYER_URI)
                     .permitAll()
                     .requestMatchers("/api/settings")
                     .permitAll()
+                    // TODO to delete after the multi tenancy upgrade
                     .requestMatchers("/api/agent/**")
                     .permitAll()
                     .requestMatchers(TENANT_AGENT_URI)
                     .permitAll()
+                    // TODO to delete after the multi tenancy upgrade
                     .requestMatchers("/api/implant/**")
                     .permitAll()
                     .requestMatchers(TENANT_IMPLANT_URI)

--- a/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
@@ -52,6 +52,7 @@ public class AppSecurityConfig {
 
   private static final String TENANT_AGENT_URI = "/api/tenants/*/agent/**";
   private static final String TENANT_IMPLANT_URI = "/api/tenants/*/implant/**";
+  private static final String TENANT_PLAYER_URI = "/api/tenants/*/player/**";
 
   private final OpenAEVConfig openAEVConfig;
   private final OpenSamlConfig openSamlConfig;
@@ -76,6 +77,8 @@ public class AppSecurityConfig {
                     .requestMatchers("/api/comcheck/**")
                     .permitAll()
                     .requestMatchers("/api/player/**")
+                    .permitAll()
+                    .requestMatchers(TENANT_PLAYER_URI)
                     .permitAll()
                     .requestMatchers("/api/settings")
                     .permitAll()

--- a/openaev-api/src/main/java/io/openaev/execution/ExecutionContextService.java
+++ b/openaev-api/src/main/java/io/openaev/execution/ExecutionContextService.java
@@ -34,7 +34,8 @@ public class ExecutionContextService {
     if (injection.getExercise() != null) {
       String exerciseId = injection.getExercise().getId();
       String queryParams = "?user=" + user.getId() + "&inject=" + injection.getId();
-      String baseUrl = this.openAEVCOnfig.getBaseUrl() + "/" + injection.getExercise().getTenant().getId();
+      String baseUrl =
+          this.openAEVCOnfig.getBaseUrl() + "/" + injection.getExercise().getTenant().getId();
       executionContext.put(PLAYER_URI, baseUrl + "/private/" + exerciseId + queryParams);
       executionContext.put(CHALLENGES_URI, baseUrl + "/challenges/" + exerciseId + queryParams);
       executionContext.put(SCOREBOARD_URI, baseUrl + "/scoreboard/" + exerciseId + queryParams);

--- a/openaev-api/src/main/java/io/openaev/execution/ExecutionContextService.java
+++ b/openaev-api/src/main/java/io/openaev/execution/ExecutionContextService.java
@@ -34,7 +34,7 @@ public class ExecutionContextService {
     if (injection.getExercise() != null) {
       String exerciseId = injection.getExercise().getId();
       String queryParams = "?user=" + user.getId() + "&inject=" + injection.getId();
-      String baseUrl = this.openAEVCOnfig.getBaseUrl();
+      String baseUrl = this.openAEVCOnfig.getBaseUrl() + "/" + injection.getExercise().getTenant().getId();
       executionContext.put(PLAYER_URI, baseUrl + "/private/" + exerciseId + queryParams);
       executionContext.put(CHALLENGES_URI, baseUrl + "/challenges/" + exerciseId + queryParams);
       executionContext.put(SCOREBOARD_URI, baseUrl + "/scoreboard/" + exerciseId + queryParams);

--- a/openaev-api/src/main/java/io/openaev/injectors/challenge/ChallengeExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/challenge/ChallengeExecutor.java
@@ -48,6 +48,8 @@ public class ChallengeExecutor extends Injector {
     String challengeId = challenge.getId();
     String exerciseId = exercise.getId();
     return this.context.getOpenAEVConfig().getBaseUrl()
+        + "/"
+        + exercise.getTenant().getId()
         + "/challenges/"
         + exerciseId
         + "?user="

--- a/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
@@ -46,12 +46,14 @@ public class ChannelExecutor extends Injector {
     this.injectExpectationService = injectExpectationService;
   }
 
-  private String buildArticleUri(ExecutionContext executionContext, Article article) {
+  private String buildArticleUri(ExecutionContext executionContext, Article article, String tenantId) {
     String userId = executionContext.getUser().getId();
     String channelId = article.getChannel().getId();
     String exerciseId = article.getExercise().getId();
     String queryOptions = "article=" + article.getId() + "&user=" + userId;
     return this.context.getOpenAEVConfig().getBaseUrl()
+        +"/"
+        + tenantId
         + "/channels/"
         + exerciseId
         + "/"
@@ -111,7 +113,7 @@ public class ChannelExecutor extends Injector {
                                   new ArticleVariable(
                                       article.getId(),
                                       article.getName(),
-                                      buildArticleUri(userInjectContext, article)))
+                                      buildArticleUri(userInjectContext, article, exercise.getTenant().getId())))
                           .toList();
                   userInjectContext.put(VARIABLE_ARTICLES, articleVariables);
                   // Send the email.

--- a/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
@@ -46,13 +46,14 @@ public class ChannelExecutor extends Injector {
     this.injectExpectationService = injectExpectationService;
   }
 
-  private String buildArticleUri(ExecutionContext executionContext, Article article, String tenantId) {
+  private String buildArticleUri(
+      ExecutionContext executionContext, Article article, String tenantId) {
     String userId = executionContext.getUser().getId();
     String channelId = article.getChannel().getId();
     String exerciseId = article.getExercise().getId();
     String queryOptions = "article=" + article.getId() + "&user=" + userId;
     return this.context.getOpenAEVConfig().getBaseUrl()
-        +"/"
+        + "/"
         + tenantId
         + "/channels/"
         + exerciseId
@@ -113,7 +114,10 @@ public class ChannelExecutor extends Injector {
                                   new ArticleVariable(
                                       article.getId(),
                                       article.getName(),
-                                      buildArticleUri(userInjectContext, article, exercise.getTenant().getId())))
+                                      buildArticleUri(
+                                          userInjectContext,
+                                          article,
+                                          exercise.getTenant().getId())))
                           .toList();
                   userInjectContext.put(VARIABLE_ARTICLES, articleVariables);
                   // Send the email.

--- a/openaev-api/src/main/java/io/openaev/rest/challenge/ChallengeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/challenge/ChallengeApi.java
@@ -1,5 +1,6 @@
 package io.openaev.rest.challenge;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.database.specification.ChallengeSpecification.fromIds;
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.helper.StreamHelper.iterableToSet;
@@ -33,6 +34,9 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ChallengeApi extends RestBehavior {
 
+  public static final String CHALLENGE_URI = "/api/challenges";
+  private static final String TENANT_CHALLENGE_URI = TENANT_PREFIX + "/challenges";
+
   private final ChallengeRepository challengeRepository;
   private final ChallengeFlagRepository challengeFlagRepository;
   private final TagRepository tagRepository;
@@ -40,7 +44,7 @@ public class ChallengeApi extends RestBehavior {
   private final ChallengeService challengeService;
   private final DocumentService documentService;
 
-  @GetMapping("/api/challenges")
+  @GetMapping({CHALLENGE_URI, TENANT_CHALLENGE_URI})
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.CHALLENGE)
   public Iterable<Challenge> challenges() {
     return fromIterable(challengeRepository.findAll()).stream()
@@ -49,7 +53,7 @@ public class ChallengeApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @PostMapping("/api/challenges/find")
+  @PostMapping({CHALLENGE_URI + "/find", TENANT_CHALLENGE_URI + "/find"})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.CHALLENGE)
   @org.springframework.transaction.annotation.Transactional(readOnly = true)
   public List<Challenge> findEndpoints(
@@ -57,7 +61,7 @@ public class ChallengeApi extends RestBehavior {
     return this.challengeRepository.findAll(fromIds(challengeIds));
   }
 
-  @PutMapping("/api/challenges/{challengeId}")
+  @PutMapping({CHALLENGE_URI + "/{challengeId}", TENANT_CHALLENGE_URI + "/{challengeId}"})
   @AccessControl(
       resourceId = "#challengeId",
       actionPerformed = Action.WRITE,
@@ -90,7 +94,7 @@ public class ChallengeApi extends RestBehavior {
     return challengeService.enrichChallengeWithExercisesOrScenarios(saveChallenge);
   }
 
-  @PostMapping("/api/challenges")
+  @PostMapping({CHALLENGE_URI, TENANT_CHALLENGE_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.CHALLENGE)
   @Transactional(rollbackOn = Exception.class)
   public Challenge createChallenge(@Valid @RequestBody ChallengeInput input) {
@@ -113,7 +117,7 @@ public class ChallengeApi extends RestBehavior {
     return challengeRepository.save(challenge);
   }
 
-  @DeleteMapping("/api/challenges/{challengeId}")
+  @DeleteMapping({CHALLENGE_URI + "/{challengeId}", TENANT_CHALLENGE_URI + "/{challengeId}"})
   @AccessControl(
       resourceId = "#challengeId",
       actionPerformed = Action.DELETE,
@@ -123,7 +127,10 @@ public class ChallengeApi extends RestBehavior {
     challengeRepository.deleteById(challengeId);
   }
 
-  @PostMapping("/api/challenges/{challengeId}/try")
+  @PostMapping({
+      CHALLENGE_URI + "/{challengeId}/try",
+      TENANT_CHALLENGE_URI + "/{challengeId}/try"
+  })
   @AccessControl(
       resourceId = "#challengeId",
       actionPerformed = Action.WRITE,
@@ -135,7 +142,10 @@ public class ChallengeApi extends RestBehavior {
     return challengeService.tryChallenge(challengeId, input);
   }
 
-  @GetMapping("/api/challenges/{challengeId}/documents")
+  @GetMapping({
+      CHALLENGE_URI + "/{challengeId}/documents",
+      TENANT_CHALLENGE_URI + "/{challengeId}/documents"
+  })
   @AccessControl(
       resourceId = "#challengeId",
       actionPerformed = Action.READ,

--- a/openaev-api/src/main/java/io/openaev/rest/challenge/ChallengeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/challenge/ChallengeApi.java
@@ -127,10 +127,7 @@ public class ChallengeApi extends RestBehavior {
     challengeRepository.deleteById(challengeId);
   }
 
-  @PostMapping({
-      CHALLENGE_URI + "/{challengeId}/try",
-      TENANT_CHALLENGE_URI + "/{challengeId}/try"
-  })
+  @PostMapping({CHALLENGE_URI + "/{challengeId}/try", TENANT_CHALLENGE_URI + "/{challengeId}/try"})
   @AccessControl(
       resourceId = "#challengeId",
       actionPerformed = Action.WRITE,
@@ -143,8 +140,8 @@ public class ChallengeApi extends RestBehavior {
   }
 
   @GetMapping({
-      CHALLENGE_URI + "/{challengeId}/documents",
-      TENANT_CHALLENGE_URI + "/{challengeId}/documents"
+    CHALLENGE_URI + "/{challengeId}/documents",
+    TENANT_CHALLENGE_URI + "/{challengeId}/documents"
   })
   @AccessControl(
       resourceId = "#challengeId",

--- a/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
@@ -1,6 +1,7 @@
 package io.openaev.rest.channel;
 
 import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.rest.channel.ChannelHelper.enrichArticleWithVirtualPublication;
 import static io.openaev.rest.exercise.ExerciseApi.TENANT_EXERCISE_URI;
 import static io.openaev.rest.scenario.ScenarioApi.SCENARIO_URI;
@@ -34,6 +35,13 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ChannelApi extends RestBehavior {
 
+  public static final String CHANNEL_URI = "/api/channels";
+  private static final String TENANT_CHANNEL_URI = TENANT_PREFIX + "/channels";
+  private static final String OBSERVER_CHANNEL_URI = "/api/observer/channels";
+  private static final String TENANT_OBSERVER_CHANNEL_URI = TENANT_PREFIX + "/observer/channels";
+  private static final String PLAYER_CHANNEL_URI = "/api/player/channels";
+  private static final String TENANT_PLAYER_CHANNEL_URI = TENANT_PREFIX + "/player/channels";
+
   private final ExerciseRepository exerciseRepository;
   private final ScenarioService scenarioService;
   private final ArticleRepository articleRepository;
@@ -45,13 +53,13 @@ public class ChannelApi extends RestBehavior {
 
   // -- CHANNELS --
 
-  @GetMapping("/api/channels")
+  @GetMapping({CHANNEL_URI, TENANT_CHANNEL_URI})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.CHANNEL)
   public Iterable<Channel> channels() {
     return channelRepository.findAll();
   }
 
-  @GetMapping("/api/channels/{channelId}")
+  @GetMapping({CHANNEL_URI + "/{channelId}", TENANT_CHANNEL_URI + "/{channelId}"})
   @AccessControl(
       resourceId = "#channelId",
       actionPerformed = Action.READ,
@@ -60,7 +68,7 @@ public class ChannelApi extends RestBehavior {
     return channelRepository.findById(channelId).orElseThrow(ElementNotFoundException::new);
   }
 
-  @PutMapping("/api/channels/{channelId}")
+  @PutMapping({CHANNEL_URI + "/{channelId}", TENANT_CHANNEL_URI + "/{channelId}"})
   @AccessControl(
       resourceId = "#channelId",
       actionPerformed = Action.WRITE,
@@ -74,7 +82,7 @@ public class ChannelApi extends RestBehavior {
     return channelRepository.save(channel);
   }
 
-  @PutMapping("/api/channels/{channelId}/logos")
+  @PutMapping({CHANNEL_URI + "/{channelId}/logos", TENANT_CHANNEL_URI + "/{channelId}/logos"})
   @AccessControl(
       resourceId = "#channelId",
       actionPerformed = Action.WRITE,
@@ -96,7 +104,7 @@ public class ChannelApi extends RestBehavior {
     return channelRepository.save(channel);
   }
 
-  @PostMapping("/api/channels")
+  @PostMapping({CHANNEL_URI, TENANT_CHANNEL_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.CHANNEL)
   @Transactional(rollbackOn = Exception.class)
   public Channel createChannel(@Valid @RequestBody ChannelCreateInput input) {
@@ -105,7 +113,7 @@ public class ChannelApi extends RestBehavior {
     return channelRepository.save(channel);
   }
 
-  @DeleteMapping("/api/channels/{channelId}")
+  @DeleteMapping({CHANNEL_URI + "/{channelId}", TENANT_CHANNEL_URI + "/{channelId}"})
   @AccessControl(
       resourceId = "#channelId",
       actionPerformed = Action.DELETE,
@@ -114,7 +122,10 @@ public class ChannelApi extends RestBehavior {
     channelRepository.deleteById(channelId);
   }
 
-  @GetMapping("/api/observer/channels/{exerciseId}/{channelId}")
+  @GetMapping({
+      OBSERVER_CHANNEL_URI + "/{exerciseId}/{channelId}",
+      TENANT_OBSERVER_CHANNEL_URI + "/{exerciseId}/{channelId}"
+  })
   @AccessControl(
       resourceId = "#exerciseId",
       actionPerformed = Action.READ,
@@ -146,7 +157,10 @@ public class ChannelApi extends RestBehavior {
     return channelReader;
   }
 
-  @GetMapping("/api/player/channels/{exerciseId}/{channelId}")
+  @GetMapping({
+      PLAYER_CHANNEL_URI + "/{exerciseId}/{channelId}",
+      TENANT_PLAYER_CHANNEL_URI + "/{exerciseId}/{channelId}"
+  })
   @AccessControl(skipRBAC = true)
   public ChannelReader playerArticles(
       @PathVariable String exerciseId,
@@ -375,7 +389,10 @@ public class ChannelApi extends RestBehavior {
     articleRepository.deleteById(articleId);
   }
 
-  @GetMapping("/api/channels/{channelId}/documents")
+  @GetMapping({
+      CHANNEL_URI + "/{channelId}/documents",
+      TENANT_CHANNEL_URI + "/{channelId}/documents"
+  })
   @AccessControl(
       resourceId = "#channelId",
       actionPerformed = Action.READ,

--- a/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
@@ -123,8 +123,8 @@ public class ChannelApi extends RestBehavior {
   }
 
   @GetMapping({
-      OBSERVER_CHANNEL_URI + "/{exerciseId}/{channelId}",
-      TENANT_OBSERVER_CHANNEL_URI + "/{exerciseId}/{channelId}"
+    OBSERVER_CHANNEL_URI + "/{exerciseId}/{channelId}",
+    TENANT_OBSERVER_CHANNEL_URI + "/{exerciseId}/{channelId}"
   })
   @AccessControl(
       resourceId = "#exerciseId",
@@ -158,8 +158,8 @@ public class ChannelApi extends RestBehavior {
   }
 
   @GetMapping({
-      PLAYER_CHANNEL_URI + "/{exerciseId}/{channelId}",
-      TENANT_PLAYER_CHANNEL_URI + "/{exerciseId}/{channelId}"
+    PLAYER_CHANNEL_URI + "/{exerciseId}/{channelId}",
+    TENANT_PLAYER_CHANNEL_URI + "/{exerciseId}/{channelId}"
   })
   @AccessControl(skipRBAC = true)
   public ChannelReader playerArticles(
@@ -390,8 +390,8 @@ public class ChannelApi extends RestBehavior {
   }
 
   @GetMapping({
-      CHANNEL_URI + "/{channelId}/documents",
-      TENANT_CHANNEL_URI + "/{channelId}/documents"
+    CHANNEL_URI + "/{channelId}/documents",
+    TENANT_CHANNEL_URI + "/{channelId}/documents"
   })
   @AccessControl(
       resourceId = "#channelId",

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -2,6 +2,7 @@ package io.openaev.rest.document;
 
 import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
 import static io.openaev.config.SessionHelper.currentUser;
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.helper.StreamHelper.iterableToSet;
 import static io.openaev.utils.mapper.DocumentMapper.toDocumentRelationsOutput;
@@ -56,6 +57,24 @@ import org.springframework.web.multipart.MultipartFile;
 public class DocumentApi extends RestBehavior {
 
   public static final String DOCUMENT_API = "/api/documents";
+  private static final String TENANT_DOCUMENT_API = TENANT_PREFIX + "/documents";
+  private static final String IMAGES_API = "/api/images";
+  private static final String TENANT_IMAGES_API = TENANT_PREFIX + "/images";
+  private static final String INJECTOR_IMAGES_API = IMAGES_API + "/injectors";
+  private static final String TENANT_INJECTOR_IMAGES_API = TENANT_IMAGES_API + "/injectors";
+  private static final String COLLECTOR_IMAGES_API = IMAGES_API + "/collectors";
+  private static final String TENANT_COLLECTOR_IMAGES_API = TENANT_IMAGES_API + "/collectors";
+  private static final String SECURITY_PLATFORM_IMAGES_API = IMAGES_API + "/security_platforms";
+  private static final String TENANT_SECURITY_PLATFORM_IMAGES_API =
+      TENANT_IMAGES_API + "/security_platforms";
+  private static final String CHANNEL_IMAGES_API = IMAGES_API + "/channels";
+  private static final String TENANT_CHANNEL_IMAGES_API = TENANT_IMAGES_API + "/channels";
+  private static final String EXECUTOR_IMAGES_API = IMAGES_API + "/executors";
+  private static final String TENANT_EXECUTOR_IMAGES_API = TENANT_IMAGES_API + "/executors";
+  private static final String PLAYER_DOCUMENTS_API = "/api/player/{exerciseOrScenarioId}/documents";
+  private static final String TENANT_PLAYER_DOCUMENTS_API =
+      TENANT_PREFIX + "/player/{exerciseOrScenarioId}/documents";
+
   private final TagRepository tagRepository;
   private final DocumentRepository documentRepository;
   private final ExerciseRepository exerciseRepository;
@@ -70,7 +89,7 @@ public class DocumentApi extends RestBehavior {
   private final InjectService injectService;
   private final ChannelService channelService;
 
-  @PostMapping(DOCUMENT_API)
+  @PostMapping({DOCUMENT_API, TENANT_DOCUMENT_API})
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.DOCUMENT)
   @Transactional(rollbackOn = Exception.class)
   public Document uploadDocument(
@@ -124,7 +143,7 @@ public class DocumentApi extends RestBehavior {
     }
   }
 
-  @PostMapping(DOCUMENT_API + "/upsert")
+  @PostMapping({DOCUMENT_API + "/upsert", TENANT_DOCUMENT_API + "/upsert"})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.DOCUMENT)
   @Transactional(rollbackOn = Exception.class)
   public Document upsertDocument(
@@ -139,13 +158,13 @@ public class DocumentApi extends RestBehavior {
         input);
   }
 
-  @GetMapping("/api/documents")
+  @GetMapping({DOCUMENT_API, TENANT_DOCUMENT_API})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.DOCUMENT)
   public List<RawDocument> documents() {
     return documentRepository.rawAllDocuments();
   }
 
-  @PostMapping(DOCUMENT_API + "/search")
+  @PostMapping({DOCUMENT_API + "/search", TENANT_DOCUMENT_API + "/search"})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.DOCUMENT)
   public Page<RawPaginationDocument> searchDocuments(
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
@@ -164,7 +183,7 @@ public class DocumentApi extends RestBehavior {
             });
   }
 
-  @GetMapping(DOCUMENT_API + "/{documentId}")
+  @GetMapping({DOCUMENT_API + "/{documentId}", TENANT_DOCUMENT_API + "/{documentId}"})
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.READ,
@@ -175,7 +194,10 @@ public class DocumentApi extends RestBehavior {
         .orElseThrow(() -> new ElementNotFoundException("Document not found"));
   }
 
-  @GetMapping(DOCUMENT_API + "/{documentId}/tags")
+  @GetMapping({
+      DOCUMENT_API + "/{documentId}/tags",
+      TENANT_DOCUMENT_API + "/{documentId}/tags"
+  })
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.READ,
@@ -188,7 +210,10 @@ public class DocumentApi extends RestBehavior {
     return document.getTags();
   }
 
-  @PutMapping(DOCUMENT_API + "/{documentId}/tags")
+  @PutMapping({
+      DOCUMENT_API + "/{documentId}/tags",
+      TENANT_DOCUMENT_API + "/{documentId}/tags"
+  })
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.WRITE,
@@ -204,7 +229,7 @@ public class DocumentApi extends RestBehavior {
   }
 
   @Transactional(rollbackOn = Exception.class)
-  @PutMapping(DOCUMENT_API + "/{documentId}")
+  @PutMapping({DOCUMENT_API + "/{documentId}", TENANT_DOCUMENT_API + "/{documentId}"})
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.WRITE,
@@ -266,7 +291,7 @@ public class DocumentApi extends RestBehavior {
     return documentService.save(document);
   }
 
-  @GetMapping(DOCUMENT_API + "/{documentId}/file")
+  @GetMapping({DOCUMENT_API + "/{documentId}/file", TENANT_DOCUMENT_API + "/{documentId}/file"})
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.READ,
@@ -288,7 +313,12 @@ public class DocumentApi extends RestBehavior {
     }
   }
 
-  @GetMapping(value = "/api/images/injectors/{injectorType}", produces = MediaType.IMAGE_PNG_VALUE)
+  @GetMapping(
+      value = {
+        INJECTOR_IMAGES_API + "/{injectorType}",
+        TENANT_INJECTOR_IMAGES_API + "/{injectorType}"
+      },
+      produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getInjectorImage(@PathVariable String injectorType)
       throws IOException {
@@ -301,7 +331,12 @@ public class DocumentApi extends RestBehavior {
     return null;
   }
 
-  @GetMapping(value = "/api/images/injectors/id/{injectorId}", produces = MediaType.IMAGE_PNG_VALUE)
+  @GetMapping(
+      value = {
+        INJECTOR_IMAGES_API + "/id/{injectorId}",
+        TENANT_INJECTOR_IMAGES_API + "/id/{injectorId}"
+      },
+      produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getInjectorImageFromId(
       @PathVariable String injectorId) throws IOException {
@@ -319,7 +354,10 @@ public class DocumentApi extends RestBehavior {
   }
 
   @GetMapping(
-      value = "/api/images/collectors/{collectorType}",
+      value = {
+        COLLECTOR_IMAGES_API + "/{collectorType}",
+        TENANT_COLLECTOR_IMAGES_API + "/{collectorType}"
+      },
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getCollectorImage(@PathVariable String collectorType)
@@ -348,7 +386,10 @@ public class DocumentApi extends RestBehavior {
   }
 
   @GetMapping(
-      value = "/api/images/collectors/id/{collectorId}",
+      value = {
+        COLLECTOR_IMAGES_API + "/id/{collectorId}",
+        TENANT_COLLECTOR_IMAGES_API + "/id/{collectorId}"
+      },
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getCollectorImageFromId(
@@ -366,7 +407,11 @@ public class DocumentApi extends RestBehavior {
     return null;
   }
 
-  @GetMapping(value = "/api/images/security_platforms/id/{assetId}/{theme}")
+  @GetMapping(
+      value = {
+        SECURITY_PLATFORM_IMAGES_API + "/id/{assetId}/{theme}",
+        TENANT_SECURITY_PLATFORM_IMAGES_API + "/id/{assetId}/{theme}"
+      })
   @AccessControl(skipRBAC = true)
   public void getSecurityPlatformImageFromId(
       @PathVariable String assetId, @PathVariable String theme, HttpServletResponse response)
@@ -384,7 +429,11 @@ public class DocumentApi extends RestBehavior {
     }
   }
 
-  @GetMapping(value = "/api/images/channels/id/{channelId}/{theme}")
+  @GetMapping(
+      value = {
+        CHANNEL_IMAGES_API + "/id/{channelId}/{theme}",
+        TENANT_CHANNEL_IMAGES_API + "/id/{channelId}/{theme}"
+      })
   @AccessControl(
       resourceId = "#channelId",
       actionPerformed = Action.READ,
@@ -410,7 +459,10 @@ public class DocumentApi extends RestBehavior {
   }
 
   @GetMapping(
-      value = "/api/images/executors/icons/{executorId}",
+      value = {
+        EXECUTOR_IMAGES_API + "/icons/{executorId}",
+        TENANT_EXECUTOR_IMAGES_API + "/icons/{executorId}"
+      },
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getExecutorIconImage(@PathVariable String executorId)
@@ -425,7 +477,10 @@ public class DocumentApi extends RestBehavior {
   }
 
   @GetMapping(
-      value = "/api/images/executors/banners/{executorId}",
+      value = {
+        EXECUTOR_IMAGES_API + "/banners/{executorId}",
+        TENANT_EXECUTOR_IMAGES_API + "/banners/{executorId}"
+      },
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getExecutorBannerImage(
@@ -453,7 +508,10 @@ public class DocumentApi extends RestBehavior {
 
   @LogExecutionTime
   @Operation(summary = "Fetch the entities related to this document id")
-  @GetMapping(DOCUMENT_API + "/{documentId}/relations")
+  @GetMapping({
+      DOCUMENT_API + "/{documentId}/relations",
+      TENANT_DOCUMENT_API + "/{documentId}/relations"
+  })
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.READ,
@@ -463,7 +521,7 @@ public class DocumentApi extends RestBehavior {
   }
 
   @Transactional(rollbackOn = Exception.class)
-  @DeleteMapping(DOCUMENT_API + "/{documentId}")
+  @DeleteMapping({DOCUMENT_API + "/{documentId}", TENANT_DOCUMENT_API + "/{documentId}"})
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.DELETE,
@@ -473,7 +531,7 @@ public class DocumentApi extends RestBehavior {
   }
 
   // -- EXERCISE & SENARIO--
-  @GetMapping("/api/player/{exerciseOrScenarioId}/documents")
+  @GetMapping({PLAYER_DOCUMENTS_API, TENANT_PLAYER_DOCUMENTS_API})
   @AccessControl(skipRBAC = true)
   public List<Document> playerDocuments(
       @PathVariable String exerciseOrScenarioId, @RequestParam Optional<String> userId) {
@@ -502,7 +560,10 @@ public class DocumentApi extends RestBehavior {
     }
   }
 
-  @GetMapping("/api/player/{exerciseOrScenarioId}/documents/{documentId}/file")
+  @GetMapping({
+      PLAYER_DOCUMENTS_API + "/{documentId}/file",
+      TENANT_PLAYER_DOCUMENTS_API + "/{documentId}/file"
+  })
   @AccessControl(skipRBAC = true)
   public void downloadPlayerDocument(
       @PathVariable String exerciseOrScenarioId,

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -194,10 +194,7 @@ public class DocumentApi extends RestBehavior {
         .orElseThrow(() -> new ElementNotFoundException("Document not found"));
   }
 
-  @GetMapping({
-      DOCUMENT_API + "/{documentId}/tags",
-      TENANT_DOCUMENT_API + "/{documentId}/tags"
-  })
+  @GetMapping({DOCUMENT_API + "/{documentId}/tags", TENANT_DOCUMENT_API + "/{documentId}/tags"})
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.READ,
@@ -210,10 +207,7 @@ public class DocumentApi extends RestBehavior {
     return document.getTags();
   }
 
-  @PutMapping({
-      DOCUMENT_API + "/{documentId}/tags",
-      TENANT_DOCUMENT_API + "/{documentId}/tags"
-  })
+  @PutMapping({DOCUMENT_API + "/{documentId}/tags", TENANT_DOCUMENT_API + "/{documentId}/tags"})
   @AccessControl(
       resourceId = "#documentId",
       actionPerformed = Action.WRITE,
@@ -509,8 +503,8 @@ public class DocumentApi extends RestBehavior {
   @LogExecutionTime
   @Operation(summary = "Fetch the entities related to this document id")
   @GetMapping({
-      DOCUMENT_API + "/{documentId}/relations",
-      TENANT_DOCUMENT_API + "/{documentId}/relations"
+    DOCUMENT_API + "/{documentId}/relations",
+    TENANT_DOCUMENT_API + "/{documentId}/relations"
   })
   @AccessControl(
       resourceId = "#documentId",
@@ -561,8 +555,8 @@ public class DocumentApi extends RestBehavior {
   }
 
   @GetMapping({
-      PLAYER_DOCUMENTS_API + "/{documentId}/file",
-      TENANT_PLAYER_DOCUMENTS_API + "/{documentId}/file"
+    PLAYER_DOCUMENTS_API + "/{documentId}/file",
+    TENANT_PLAYER_DOCUMENTS_API + "/{documentId}/file"
   })
   @AccessControl(skipRBAC = true)
   public void downloadPlayerDocument(

--- a/openaev-api/src/main/java/io/openaev/rest/inject/InjectExecutionResultApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/InjectExecutionResultApi.java
@@ -1,5 +1,7 @@
 package io.openaev.rest.inject;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
+
 import io.openaev.aop.AccessControl;
 import io.openaev.api.inject_result.dto.InjectResultPayloadExecutionOutput;
 import io.openaev.database.model.Action;
@@ -21,10 +23,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class InjectExecutionResultApi extends RestBehavior {
 
   public static final String INJECT_EXECUTION_URI = "/api/injects/{injectId}";
+  private static final String TENANT_INJECT_EXECUTION_URI = TENANT_PREFIX + "/injects/{injectId}";
 
   private final InjectExecutionResultService injectExecutionService;
 
-  @GetMapping(INJECT_EXECUTION_URI + "/execution-result")
+  @GetMapping({
+    INJECT_EXECUTION_URI + "/execution-result",
+    TENANT_INJECT_EXECUTION_URI + "/execution-result"
+  })
   @AccessControl(
       resourceId = "#injectId",
       actionPerformed = Action.READ,

--- a/openaev-api/src/main/java/io/openaev/rest/payload/PayloadApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/PayloadApi.java
@@ -91,8 +91,8 @@ public class PayloadApi extends RestBehavior {
   }
 
   @PostMapping({
-      PAYLOAD_URI + "/{payloadId}/duplicate",
-      TENANT_PAYLOAD_URI + "/{payloadId}/duplicate"
+    PAYLOAD_URI + "/{payloadId}/duplicate",
+    TENANT_PAYLOAD_URI + "/{payloadId}/duplicate"
   })
   @AccessControl(
       resourceId = "#payloadId",
@@ -193,7 +193,10 @@ public class PayloadApi extends RestBehavior {
         input.collectorId(), input.processedPayloadExternalIds());
   }
 
-  @GetMapping({PAYLOAD_URI + "/{payloadId}/documents", TENANT_PAYLOAD_URI + "/{payloadId}/documents"})
+  @GetMapping({
+    PAYLOAD_URI + "/{payloadId}/documents",
+    TENANT_PAYLOAD_URI + "/{payloadId}/documents"
+  })
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.READ,
@@ -207,7 +210,10 @@ public class PayloadApi extends RestBehavior {
     return documentService.documentsForPayload(payloadId);
   }
 
-  @GetMapping({PAYLOAD_URI + "/{payloadId}/collectors", TENANT_PAYLOAD_URI + "/{payloadId}/collectors"})
+  @GetMapping({
+    PAYLOAD_URI + "/{payloadId}/collectors",
+    TENANT_PAYLOAD_URI + "/{payloadId}/collectors"
+  })
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.READ,

--- a/openaev-api/src/main/java/io/openaev/rest/payload/PayloadApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/PayloadApi.java
@@ -1,5 +1,7 @@
 package io.openaev.rest.payload;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
+
 import io.openaev.aop.AccessControl;
 import io.openaev.database.model.*;
 import io.openaev.database.raw.RawDocument;
@@ -40,6 +42,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PayloadApi extends RestBehavior {
 
   public static final String PAYLOAD_URI = "/api/payloads";
+  public static final String TENANT_PAYLOAD_URI = TENANT_PREFIX + "/payloads";
 
   private final ImportService importService;
   private final PayloadRepository payloadRepository;
@@ -52,14 +55,14 @@ public class PayloadApi extends RestBehavior {
   private final CollectorService collectorsService;
   private final UserService userService;
 
-  @PostMapping(PAYLOAD_URI + "/search")
+  @PostMapping({PAYLOAD_URI + "/search", TENANT_PAYLOAD_URI + "/search"})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.PAYLOAD)
   public Page<Payload> payloads(
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
     return this.payloadService.searchPayloads(searchPaginationInput);
   }
 
-  @GetMapping(PAYLOAD_URI + "/{payloadId}")
+  @GetMapping({PAYLOAD_URI + "/{payloadId}", TENANT_PAYLOAD_URI + "/{payloadId}"})
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.READ,
@@ -68,14 +71,14 @@ public class PayloadApi extends RestBehavior {
     return payloadRepository.findById(payloadId).orElseThrow(ElementNotFoundException::new);
   }
 
-  @PostMapping(PAYLOAD_URI)
+  @PostMapping({PAYLOAD_URI, TENANT_PAYLOAD_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.PAYLOAD)
   @Transactional(rollbackOn = Exception.class)
   public Payload createPayload(@Valid @RequestBody PayloadCreateInput input) {
     return this.payloadCreationService.createPayload(input);
   }
 
-  @PutMapping(PAYLOAD_URI + "/{payloadId}")
+  @PutMapping({PAYLOAD_URI + "/{payloadId}", TENANT_PAYLOAD_URI + "/{payloadId}"})
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.WRITE,
@@ -87,7 +90,10 @@ public class PayloadApi extends RestBehavior {
     return this.payloadUpdateService.updatePayload(payloadId, input);
   }
 
-  @PostMapping(PAYLOAD_URI + "/{payloadId}/duplicate")
+  @PostMapping({
+      PAYLOAD_URI + "/{payloadId}/duplicate",
+      TENANT_PAYLOAD_URI + "/{payloadId}/duplicate"
+  })
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.DUPLICATE,
@@ -97,14 +103,16 @@ public class PayloadApi extends RestBehavior {
     return this.payloadService.duplicate(payloadId);
   }
 
-  @PostMapping(PAYLOAD_URI + "/upsert")
+  @PostMapping({PAYLOAD_URI + "/upsert", TENANT_PAYLOAD_URI + "/upsert"})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.PAYLOAD)
   @org.springframework.transaction.annotation.Transactional(rollbackFor = Exception.class)
   public Payload upsertPayload(@Valid @RequestBody PayloadUpsertInput input) {
     return this.payloadUpsertService.upsertPayload(input);
   }
 
-  @PostMapping(path = PAYLOAD_URI + "/{payloadId}/export", produces = "application/zip")
+  @PostMapping(
+      path = {PAYLOAD_URI + "/{payloadId}/export", TENANT_PAYLOAD_URI + "/{payloadId}/export"},
+      produces = "application/zip")
   @AccessControl(
       actionPerformed = Action.READ,
       resourceType = ResourceType.PAYLOAD,
@@ -124,7 +132,7 @@ public class PayloadApi extends RestBehavior {
     return new ResponseEntity<>(zippedExport, headers, HttpStatus.OK);
   }
 
-  @PostMapping(PAYLOAD_URI + "/export")
+  @PostMapping({PAYLOAD_URI + "/export", TENANT_PAYLOAD_URI + "/export"})
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.PAYLOAD)
   public void payloadsExport(
       @RequestBody @Valid final PayloadExportRequestInput payloadExportRequestInput,
@@ -146,7 +154,7 @@ public class PayloadApi extends RestBehavior {
     runPayloadExport(payloads, response);
   }
 
-  @PostMapping(PAYLOAD_URI + "/import")
+  @PostMapping({PAYLOAD_URI + "/import", TENANT_PAYLOAD_URI + "/import"})
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.PAYLOAD)
   public void importPayloads(@RequestPart("file") @NotNull MultipartFile file) throws Exception {
     this.importService.handleFileImport(file, null, null);
@@ -167,7 +175,7 @@ public class PayloadApi extends RestBehavior {
     outputStream.close();
   }
 
-  @DeleteMapping(PAYLOAD_URI + "/{payloadId}")
+  @DeleteMapping({PAYLOAD_URI + "/{payloadId}", TENANT_PAYLOAD_URI + "/{payloadId}"})
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.DELETE,
@@ -176,7 +184,7 @@ public class PayloadApi extends RestBehavior {
     payloadRepository.deleteById(payloadId);
   }
 
-  @PostMapping(PAYLOAD_URI + "/deprecate")
+  @PostMapping({PAYLOAD_URI + "/deprecate", TENANT_PAYLOAD_URI + "/deprecate"})
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.PAYLOAD)
   @Transactional(rollbackOn = Exception.class)
   public void deprecateNonProcessedPayloadsByCollector(
@@ -185,7 +193,7 @@ public class PayloadApi extends RestBehavior {
         input.collectorId(), input.processedPayloadExternalIds());
   }
 
-  @GetMapping(PAYLOAD_URI + "/{payloadId}/documents")
+  @GetMapping({PAYLOAD_URI + "/{payloadId}/documents", TENANT_PAYLOAD_URI + "/{payloadId}/documents"})
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.READ,
@@ -199,7 +207,7 @@ public class PayloadApi extends RestBehavior {
     return documentService.documentsForPayload(payloadId);
   }
 
-  @GetMapping(PAYLOAD_URI + "/{payloadId}/collectors")
+  @GetMapping({PAYLOAD_URI + "/{payloadId}/collectors", TENANT_PAYLOAD_URI + "/{payloadId}/collectors"})
   @AccessControl(
       resourceId = "#payloadId",
       actionPerformed = Action.READ,

--- a/openaev-front/src/admin/components/agents/ExecutorBanner.tsx
+++ b/openaev-front/src/admin/components/agents/ExecutorBanner.tsx
@@ -1,6 +1,8 @@
 import { type FunctionComponent } from 'react';
 
 import { type ExecutorOutput } from '../../../utils/api-types';
+import useAuth from '../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper';
 
 interface ExecutorBannerProps {
   executor: ExecutorOutput;
@@ -8,6 +10,7 @@ interface ExecutorBannerProps {
 }
 
 const ExecutorBanner: FunctionComponent<ExecutorBannerProps> = ({ executor, height }) => {
+  const { currentUserTenant } = useAuth();
   return (
     <div
       style={{
@@ -22,7 +25,7 @@ const ExecutorBanner: FunctionComponent<ExecutorBannerProps> = ({ executor, heig
       }}
     >
       <img
-        src={`/api/images/executors/banners/${executor.executor_type}`}
+        src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/banners/${executor.executor_type}`}
         alt={executor.executor_name}
         style={{ objectFit: 'cover' }}
       />

--- a/openaev-front/src/admin/components/agents/ExecutorBanner.tsx
+++ b/openaev-front/src/admin/components/agents/ExecutorBanner.tsx
@@ -1,8 +1,7 @@
 import { type FunctionComponent } from 'react';
 
 import { type ExecutorOutput } from '../../../utils/api-types';
-import useAuth from '../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../utils/tenant-url-helper';
 
 interface ExecutorBannerProps {
   executor: ExecutorOutput;
@@ -10,7 +9,6 @@ interface ExecutorBannerProps {
 }
 
 const ExecutorBanner: FunctionComponent<ExecutorBannerProps> = ({ executor, height }) => {
-  const { currentUserTenant } = useAuth();
   return (
     <div
       style={{
@@ -25,7 +23,7 @@ const ExecutorBanner: FunctionComponent<ExecutorBannerProps> = ({ executor, heig
       }}
     >
       <img
-        src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/banners/${executor.executor_type}`}
+        src={buildTenantApiPath(`/api/images/executors/banners/${executor.executor_type}`)}
         alt={executor.executor_name}
         style={{ objectFit: 'cover' }}
       />

--- a/openaev-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
+++ b/openaev-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
@@ -23,11 +23,10 @@ import { useHelper } from '../../../../store';
 import { type Endpoint, type EndpointOutput, type FilterGroup } from '../../../../utils/api-types';
 import { getActiveMsgTooltip, getExecutorsCount } from '../../../../utils/endpoints/utils';
 import { useAppDispatch } from '../../../../utils/hooks';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import AssetStatus from '../AssetStatus';
 
 interface Props {
@@ -55,8 +54,6 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
-  const { currentUserTenant } = useAuth();
-
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [endpointValues, setEndpointValues] = useState<(Endpoint | EndpointOutput)[]>([]);
   const { executorsMap } = useHelper((helper: ExecutorHelper) => ({ executorsMap: helper.getExecutorsMap() }));
@@ -162,7 +159,7 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
                           }}
                           >
                             <img
-                              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${executorType}`}
+                              src={buildTenantApiPath(`/api/images/executors/icons/${executorType}`)}
                               alt={executorType}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
+++ b/openaev-front/src/admin/components/assets/endpoints/EndpointsDialogAdding.tsx
@@ -23,9 +23,11 @@ import { useHelper } from '../../../../store';
 import { type Endpoint, type EndpointOutput, type FilterGroup } from '../../../../utils/api-types';
 import { getActiveMsgTooltip, getExecutorsCount } from '../../../../utils/endpoints/utils';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import AssetStatus from '../AssetStatus';
 
 interface Props {
@@ -53,6 +55,7 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
+  const { currentUserTenant } = useAuth();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [endpointValues, setEndpointValues] = useState<(Endpoint | EndpointOutput)[]>([]);
@@ -159,7 +162,7 @@ const EndpointsDialogAdding: FunctionComponent<Props> = ({
                           }}
                           >
                             <img
-                              src={`/api/images/executors/icons/${executorType}`}
+                              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${executorType}`}
                               alt={executorType}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/assets/endpoints/endpoint/AgentList.tsx
+++ b/openaev-front/src/admin/components/assets/endpoints/endpoint/AgentList.tsx
@@ -12,7 +12,9 @@ import { useFormatter } from '../../../../../components/i18n';
 import { useHelper } from '../../../../../store';
 import { type AgentOutput } from '../../../../../utils/api-types';
 import { useAppDispatch } from '../../../../../utils/hooks';
+import useAuth from '../../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../../utils/hooks/useDataLoader';
+import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper';
 import EEChip from '../../../common/entreprise_edition/EEChip';
 import AssetStatus from '../../AssetStatus';
 import AgentDeploymentMode from '../AgentDeploymentMode';
@@ -50,6 +52,7 @@ const AgentList: FunctionComponent<Props> = ({ agents }) => {
   const bodyItemsStyles = useBodyItemsStyles();
   const dispatch = useAppDispatch();
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
   // Fetching data
   const { settings, executorsMap } = useHelper((helper: ExecutorHelper & LoggedHelper) => ({
     settings: helper.getPlatformSettings(),
@@ -85,7 +88,7 @@ const AgentList: FunctionComponent<Props> = ({ agents }) => {
         return (
           <>
             <img
-              src={`/api/images/executors/icons/${executor_type}`}
+              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${executor_type}`}
               alt={executor_type}
               style={{
                 width: 20,

--- a/openaev-front/src/admin/components/assets/endpoints/endpoint/AgentList.tsx
+++ b/openaev-front/src/admin/components/assets/endpoints/endpoint/AgentList.tsx
@@ -12,9 +12,8 @@ import { useFormatter } from '../../../../../components/i18n';
 import { useHelper } from '../../../../../store';
 import { type AgentOutput } from '../../../../../utils/api-types';
 import { useAppDispatch } from '../../../../../utils/hooks';
-import useAuth from '../../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../../utils/hooks/useDataLoader';
-import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../../utils/tenant-url-helper';
 import EEChip from '../../../common/entreprise_edition/EEChip';
 import AssetStatus from '../../AssetStatus';
 import AgentDeploymentMode from '../AgentDeploymentMode';
@@ -52,7 +51,6 @@ const AgentList: FunctionComponent<Props> = ({ agents }) => {
   const bodyItemsStyles = useBodyItemsStyles();
   const dispatch = useAppDispatch();
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
   // Fetching data
   const { settings, executorsMap } = useHelper((helper: ExecutorHelper & LoggedHelper) => ({
     settings: helper.getPlatformSettings(),
@@ -88,7 +86,7 @@ const AgentList: FunctionComponent<Props> = ({ agents }) => {
         return (
           <>
             <img
-              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${executor_type}`}
+              src={buildTenantApiPath(`/api/images/executors/icons/${executor_type}`)}
               alt={executor_type}
               style={{
                 width: 20,

--- a/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatforms.tsx
+++ b/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatforms.tsx
@@ -16,8 +16,10 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import PaginatedListLoader from '../../../../components/PaginatedListLoader';
 import { type SearchPaginationInput, type SecurityPlatform } from '../../../../utils/api-types';
+import useAuth from '../../../../utils/hooks/useAuth';
 import { Can } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import { isNotEmptyField } from '../../../../utils/utils';
 import SecurityPlatformCreation from './SecurityPlatformCreation';
 import SecurityPlatformPopover from './SecurityPlatformPopover';
@@ -50,6 +52,7 @@ const SecurityPlatforms = () => {
   const bodyItemsStyles = useBodyItemsStyles();
   const theme = useTheme();
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
 
   // Query param
   const [searchParams] = useSearchParams();
@@ -160,7 +163,7 @@ const SecurityPlatforms = () => {
                 >
                   <ListItemIcon>
                     <img
-                      src={`/api/images/security_platforms/id/${securityPlatform.asset_id}/${theme.palette.mode}?${Date.now()}`}
+                      src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/security_platforms/id/${securityPlatform.asset_id}/${theme.palette.mode}?${Date.now()}`}
                       alt={securityPlatform.asset_name}
                       style={{
                         width: 25,

--- a/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatforms.tsx
+++ b/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatforms.tsx
@@ -16,10 +16,9 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import PaginatedListLoader from '../../../../components/PaginatedListLoader';
 import { type SearchPaginationInput, type SecurityPlatform } from '../../../../utils/api-types';
-import useAuth from '../../../../utils/hooks/useAuth';
 import { Can } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import { isNotEmptyField } from '../../../../utils/utils';
 import SecurityPlatformCreation from './SecurityPlatformCreation';
 import SecurityPlatformPopover from './SecurityPlatformPopover';
@@ -52,7 +51,6 @@ const SecurityPlatforms = () => {
   const bodyItemsStyles = useBodyItemsStyles();
   const theme = useTheme();
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
 
   // Query param
   const [searchParams] = useSearchParams();
@@ -163,7 +161,7 @@ const SecurityPlatforms = () => {
                 >
                   <ListItemIcon>
                     <img
-                      src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/security_platforms/id/${securityPlatform.asset_id}/${theme.palette.mode}?${Date.now()}`}
+                      src={buildTenantApiPath(`/api/images/security_platforms/id/${securityPlatform.asset_id}/${theme.palette.mode}?${Date.now()}`)}
                       alt={securityPlatform.asset_name}
                       style={{
                         width: 25,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
@@ -21,12 +21,11 @@ import {
   type InjectResultOverviewOutput,
 } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import { isNotEmptyField } from '../../../../utils/utils';
 import DetectionRemediationInfo from '../../payloads/form/DetectionRemediationInfo';
 import DetectionRemediationUseAriane from '../../payloads/form/DetectionRemediationUseAriane';
@@ -61,7 +60,6 @@ const AtomicTestingRemediations = () => {
   const [detectionRemediations, setDetectionRemediations] = useState<DetectionRemediationOutput[]>([]);
   const [hasFetchedRemediations, setHasFetchedRemediations] = useState(false);
   const ability = useContext(AbilityContext);
-  const { currentUserTenant } = useAuth();
 
   const isRemediationTab = location.pathname.includes('/remediations');
 
@@ -221,7 +219,7 @@ const AtomicTestingRemediations = () => {
                         label={(
                           <Box display="flex" alignItems="center">
                             <img
-                              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${tab.collector_type}`}
+                              src={buildTenantApiPath(`/api/images/collectors/${tab.collector_type}`)}
                               alt={tab.collector_type}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
@@ -21,10 +21,12 @@ import {
   type InjectResultOverviewOutput,
 } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import { isNotEmptyField } from '../../../../utils/utils';
 import DetectionRemediationInfo from '../../payloads/form/DetectionRemediationInfo';
 import DetectionRemediationUseAriane from '../../payloads/form/DetectionRemediationUseAriane';
@@ -59,6 +61,7 @@ const AtomicTestingRemediations = () => {
   const [detectionRemediations, setDetectionRemediations] = useState<DetectionRemediationOutput[]>([]);
   const [hasFetchedRemediations, setHasFetchedRemediations] = useState(false);
   const ability = useContext(AbilityContext);
+  const { currentUserTenant } = useAuth();
 
   const isRemediationTab = location.pathname.includes('/remediations');
 
@@ -218,7 +221,7 @@ const AtomicTestingRemediations = () => {
                         label={(
                           <Box display="flex" alignItems="center">
                             <img
-                              src={`/api/images/collectors/${tab.collector_type}`}
+                              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${tab.collector_type}`}
                               alt={tab.collector_type}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/NewTargetListItem.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/NewTargetListItem.tsx
@@ -5,6 +5,8 @@ import { SelectGroup } from 'mdi-material-ui';
 
 import PlatformIcon from '../../../../components/PlatformIcon';
 import type { InjectTarget } from '../../../../utils/api-types';
+import useAuth from '../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import NewAtomicTestingResult from './NewAtomicTestingResult';
 
 interface Props {
@@ -15,6 +17,7 @@ interface Props {
 
 const NewTargetListItem: React.FC<Props> = ({ onClick, target, selected }) => {
   const theme = useTheme();
+  const { currentUserTenant } = useAuth();
   const handleItemClick = () => {
     onClick(target);
   };
@@ -27,7 +30,7 @@ const NewTargetListItem: React.FC<Props> = ({ onClick, target, selected }) => {
       PLAYERS: <PersonOutlined fontSize="small" />,
       AGENT: (
         <img
-          src={`/api/images/executors/icons/${target.target_subtype}`}
+          src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${target.target_subtype}`}
           alt={target.target_subtype}
           style={{
             width: 20,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/NewTargetListItem.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/NewTargetListItem.tsx
@@ -5,8 +5,7 @@ import { SelectGroup } from 'mdi-material-ui';
 
 import PlatformIcon from '../../../../components/PlatformIcon';
 import type { InjectTarget } from '../../../../utils/api-types';
-import useAuth from '../../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import NewAtomicTestingResult from './NewAtomicTestingResult';
 
 interface Props {
@@ -17,7 +16,6 @@ interface Props {
 
 const NewTargetListItem: React.FC<Props> = ({ onClick, target, selected }) => {
   const theme = useTheme();
-  const { currentUserTenant } = useAuth();
   const handleItemClick = () => {
     onClick(target);
   };
@@ -30,7 +28,7 @@ const NewTargetListItem: React.FC<Props> = ({ onClick, target, selected }) => {
       PLAYERS: <PersonOutlined fontSize="small" />,
       AGENT: (
         <img
-          src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${target.target_subtype}`}
+          src={buildTenantApiPath(`/api/images/executors/icons/${target.target_subtype}`)}
           alt={target.target_subtype}
           style={{
             width: 20,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -18,8 +18,7 @@ import {
   type InjectExpectationResult,
   type PayloadSimple,
 } from '../../../../../utils/api-types';
-import useAuth from '../../../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../../utils/tenant-url-helper';
 import { isNotEmptyField } from '../../../../../utils/utils';
 import { type InjectExpectationsStore } from '../../../common/injects/expectations/Expectation';
 import InjectIcon from '../../../common/injects/InjectIcon';
@@ -44,7 +43,6 @@ const InjectExpectationResultList = ({
 }: Props) => {
   const { nsdt, t } = useFormatter();
   const theme = useTheme();
-  const { currentUserTenant } = useAuth();
 
   const { onOpenDeleteInjectExpectationResult, onOpenEditInjectExpectationResultResult, onOpenSecurityPlatform } = useContext(InjectExpectationContext);
 
@@ -53,8 +51,8 @@ const InjectExpectationResultList = ({
       return (
         <img
           src={expectationResult.sourceType === 'collector'
-            ? `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/id/${expectationResult.sourceId}`
-            : `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/security_platforms/id/${expectationResult.sourceId}/${theme.palette.mode}`}
+            ? buildTenantApiPath(`/api/images/collectors/id/${expectationResult.sourceId}`)
+            : buildTenantApiPath(`/api/images/security_platforms/id/${expectationResult.sourceId}/${theme.palette.mode}`)}
           alt={expectationResult.sourceId}
           style={{
             width: 25,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -18,6 +18,8 @@ import {
   type InjectExpectationResult,
   type PayloadSimple,
 } from '../../../../../utils/api-types';
+import useAuth from '../../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper';
 import { isNotEmptyField } from '../../../../../utils/utils';
 import { type InjectExpectationsStore } from '../../../common/injects/expectations/Expectation';
 import InjectIcon from '../../../common/injects/InjectIcon';
@@ -42,6 +44,7 @@ const InjectExpectationResultList = ({
 }: Props) => {
   const { nsdt, t } = useFormatter();
   const theme = useTheme();
+  const { currentUserTenant } = useAuth();
 
   const { onOpenDeleteInjectExpectationResult, onOpenEditInjectExpectationResultResult, onOpenSecurityPlatform } = useContext(InjectExpectationContext);
 
@@ -50,8 +53,8 @@ const InjectExpectationResultList = ({
       return (
         <img
           src={expectationResult.sourceType === 'collector'
-            ? `/api/images/collectors/id/${expectationResult.sourceId}`
-            : `/api/images/security_platforms/id/${expectationResult.sourceId}/${theme.palette.mode}`}
+            ? `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/id/${expectationResult.sourceId}`
+            : `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/security_platforms/id/${expectationResult.sourceId}/${theme.palette.mode}`}
           alt={expectationResult.sourceId}
           style={{
             width: 25,

--- a/openaev-front/src/admin/components/common/articles/ArticleForm.jsx
+++ b/openaev-front/src/admin/components/common/articles/ArticleForm.jsx
@@ -14,12 +14,11 @@ import OldTextField from '../../../../components/fields/OldTextField';
 import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import { useHelper } from '../../../../store';
-import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext, Can } from '../../../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 import ChannelIcon from '../../components/channels/ChannelIcon';
 import DocumentPopover from '../../components/documents/DocumentPopover';
 import DocumentType from '../../components/documents/DocumentType';
@@ -113,7 +112,6 @@ const ArticleForm = ({
 }) => {
   const { t } = useFormatter();
   const { classes } = useStyles();
-  const { currentUserTenant } = useAuth();
   const dispatch = useDispatch();
   const ability = useContext(AbilityContext);
 
@@ -343,7 +341,7 @@ const ArticleForm = ({
                     <ListItemButton
                       key={document.document_id}
                       component="a"
-                      href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+                      href={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
                     >
                       <ListItemIcon>
                         <AttachmentOutlined />

--- a/openaev-front/src/admin/components/common/articles/ArticleForm.jsx
+++ b/openaev-front/src/admin/components/common/articles/ArticleForm.jsx
@@ -14,10 +14,12 @@ import OldTextField from '../../../../components/fields/OldTextField';
 import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import { useHelper } from '../../../../store';
+import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext, Can } from '../../../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 import ChannelIcon from '../../components/channels/ChannelIcon';
 import DocumentPopover from '../../components/documents/DocumentPopover';
 import DocumentType from '../../components/documents/DocumentType';
@@ -111,6 +113,7 @@ const ArticleForm = ({
 }) => {
   const { t } = useFormatter();
   const { classes } = useStyles();
+  const { currentUserTenant } = useAuth();
   const dispatch = useDispatch();
   const ability = useContext(AbilityContext);
 
@@ -340,7 +343,7 @@ const ArticleForm = ({
                     <ListItemButton
                       key={document.document_id}
                       component="a"
-                      href={`/api/documents/${document.document_id}/file`}
+                      href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
                     >
                       <ListItemIcon>
                         <AttachmentOutlined />

--- a/openaev-front/src/admin/components/common/articles/Articles.tsx
+++ b/openaev-front/src/admin/components/common/articles/Articles.tsx
@@ -16,10 +16,9 @@ import ChannelColor from '../../../../public/components/channels/ChannelColor';
 import { useHelper } from '../../../../store';
 import { type Article } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import useSearchAndFilter from '../../../../utils/SortingFiltering';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import ChannelIcon from '../../components/channels/ChannelIcon';
 import { type ChannelOption } from '../../components/channels/ChannelOption';
 import ChannelsFilter from '../../components/channels/ChannelsFilter';
@@ -57,7 +56,6 @@ const Articles: FunctionComponent<Props> = ({ articles }) => {
   const { classes } = useStyles();
   const dispatch = useAppDispatch();
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
 
   // Fetching data
   const { channelsMap, documentsMap } = useHelper((helper: ChannelsHelper & DocumentHelper) => ({
@@ -226,14 +224,14 @@ const Articles: FunctionComponent<Props> = ({ articles }) => {
                         <CardMedia
                           component="img"
                           height="150"
-                          src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${doc.document_id}/file`}
+                          src={buildTenantApiPath(`/api/documents/${doc.document_id}/file`)}
                         />
                       )}
                       {doc.document_type.includes('video/') && (
                         <CardMedia
                           component="video"
                           height="150"
-                          src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${doc.document_id}/file`}
+                          src={buildTenantApiPath(`/api/documents/${doc.document_id}/file`)}
                           controls
                         />
                       )}

--- a/openaev-front/src/admin/components/common/articles/Articles.tsx
+++ b/openaev-front/src/admin/components/common/articles/Articles.tsx
@@ -16,8 +16,10 @@ import ChannelColor from '../../../../public/components/channels/ChannelColor';
 import { useHelper } from '../../../../store';
 import { type Article } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import useSearchAndFilter from '../../../../utils/SortingFiltering';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import ChannelIcon from '../../components/channels/ChannelIcon';
 import { type ChannelOption } from '../../components/channels/ChannelOption';
 import ChannelsFilter from '../../components/channels/ChannelsFilter';
@@ -55,6 +57,7 @@ const Articles: FunctionComponent<Props> = ({ articles }) => {
   const { classes } = useStyles();
   const dispatch = useAppDispatch();
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
 
   // Fetching data
   const { channelsMap, documentsMap } = useHelper((helper: ChannelsHelper & DocumentHelper) => ({
@@ -223,14 +226,14 @@ const Articles: FunctionComponent<Props> = ({ articles }) => {
                         <CardMedia
                           component="img"
                           height="150"
-                          src={`/api/documents/${doc.document_id}/file`}
+                          src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${doc.document_id}/file`}
                         />
                       )}
                       {doc.document_type.includes('video/') && (
                         <CardMedia
                           component="video"
                           height="150"
-                          src={`/api/documents/${doc.document_id}/file`}
+                          src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${doc.document_id}/file`}
                           controls
                         />
                       )}

--- a/openaev-front/src/admin/components/common/challenges/ChallengesPreviewDocumentsList.tsx
+++ b/openaev-front/src/admin/components/common/challenges/ChallengesPreviewDocumentsList.tsx
@@ -13,6 +13,8 @@ import { useQueryableWithLocalStorage } from '../../../../components/common/quer
 import ItemTags from '../../../../components/ItemTags';
 import { useHelper } from '../../../../store';
 import type { Challenge, Document } from '../../../../utils/api-types';
+import useAuth from '../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import DocumentType from '../../components/documents/DocumentType';
 
 const useStyles = makeStyles()(theme => ({
@@ -68,6 +70,7 @@ interface Props { currentChallenge: Challenge | null }
 const ChallengesPreviewDocumentsList: FunctionComponent<Props> = ({ currentChallenge }) => {
   const { classes } = useStyles();
   const bodyItemsStyles = useBodyItemsStyles();
+  const { currentUserTenant } = useAuth();
 
   const headers = [
     {
@@ -141,7 +144,7 @@ const ChallengesPreviewDocumentsList: FunctionComponent<Props> = ({ currentChall
               classes={{ root: classes.item }}
               component={Link}
               divider
-              to={`/api/documents/${document.document_id}/file`}
+              to={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
             >
               <ListItemIcon>
                 <AttachmentOutlined />

--- a/openaev-front/src/admin/components/common/challenges/ChallengesPreviewDocumentsList.tsx
+++ b/openaev-front/src/admin/components/common/challenges/ChallengesPreviewDocumentsList.tsx
@@ -13,8 +13,7 @@ import { useQueryableWithLocalStorage } from '../../../../components/common/quer
 import ItemTags from '../../../../components/ItemTags';
 import { useHelper } from '../../../../store';
 import type { Challenge, Document } from '../../../../utils/api-types';
-import useAuth from '../../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import DocumentType from '../../components/documents/DocumentType';
 
 const useStyles = makeStyles()(theme => ({
@@ -70,7 +69,6 @@ interface Props { currentChallenge: Challenge | null }
 const ChallengesPreviewDocumentsList: FunctionComponent<Props> = ({ currentChallenge }) => {
   const { classes } = useStyles();
   const bodyItemsStyles = useBodyItemsStyles();
-  const { currentUserTenant } = useAuth();
 
   const headers = [
     {
@@ -144,7 +142,7 @@ const ChallengesPreviewDocumentsList: FunctionComponent<Props> = ({ currentChall
               classes={{ root: classes.item }}
               component={Link}
               divider
-              to={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+              to={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
             >
               <ListItemIcon>
                 <AttachmentOutlined />

--- a/openaev-front/src/admin/components/common/endpoints/fragments/EndpointAgentsExecutorsFragment.tsx
+++ b/openaev-front/src/admin/components/common/endpoints/fragments/EndpointAgentsExecutorsFragment.tsx
@@ -7,15 +7,13 @@ import { useHelper } from '../../../../../store';
 import { type EndpointOutput } from '../../../../../utils/api-types';
 import { getExecutorsCount } from '../../../../../utils/endpoints/utils';
 import { useAppDispatch } from '../../../../../utils/hooks';
-import useAuth from '../../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../../utils/hooks/useDataLoader';
-import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../../utils/tenant-url-helper';
 
 type Props = { endpoint: EndpointOutput };
 
 const EndpointActiveFragment = (props: Props) => {
   const dispatch = useAppDispatch();
-  const { currentUserTenant } = useAuth();
   // Fetching data
   const { executorsMap } = useHelper((helper: ExecutorHelper) => ({ executorsMap: helper.getExecutorsMap() }));
   useDataLoader(() => {
@@ -48,7 +46,7 @@ const EndpointActiveFragment = (props: Props) => {
                 }}
                 >
                   <img
-                    src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${executorType}`}
+                    src={buildTenantApiPath(`/api/images/executors/icons/${executorType}`)}
                     alt={executorType}
                     style={{
                       width: 20,

--- a/openaev-front/src/admin/components/common/endpoints/fragments/EndpointAgentsExecutorsFragment.tsx
+++ b/openaev-front/src/admin/components/common/endpoints/fragments/EndpointAgentsExecutorsFragment.tsx
@@ -7,12 +7,15 @@ import { useHelper } from '../../../../../store';
 import { type EndpointOutput } from '../../../../../utils/api-types';
 import { getExecutorsCount } from '../../../../../utils/endpoints/utils';
 import { useAppDispatch } from '../../../../../utils/hooks';
+import useAuth from '../../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../../utils/hooks/useDataLoader';
+import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper';
 
 type Props = { endpoint: EndpointOutput };
 
 const EndpointActiveFragment = (props: Props) => {
   const dispatch = useAppDispatch();
+  const { currentUserTenant } = useAuth();
   // Fetching data
   const { executorsMap } = useHelper((helper: ExecutorHelper) => ({ executorsMap: helper.getExecutorsMap() }));
   useDataLoader(() => {
@@ -45,7 +48,7 @@ const EndpointActiveFragment = (props: Props) => {
                 }}
                 >
                   <img
-                    src={`/api/images/executors/icons/${executorType}`}
+                    src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${executorType}`}
                     alt={executorType}
                     style={{
                       width: 20,

--- a/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
+++ b/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
@@ -5,8 +5,7 @@ import { type FunctionComponent } from 'react';
 
 import CustomTooltip from '../../../../components/CustomTooltip';
 import { useFormatter } from '../../../../components/i18n';
-import useAuth from '../../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 
 interface Props {
   type: string | undefined;
@@ -33,7 +32,6 @@ const InjectIcon: FunctionComponent<Props> = ({
   const { t } = useFormatter();
   const theme = useTheme();
   const fontSize = size || 'medium';
-  const { currentUserTenant } = useAuth();
 
   const iconSelector = (type: string, isPayload: boolean, variant: string, fontSize: string, done: boolean, disabled: boolean) => {
     const style = {
@@ -53,7 +51,7 @@ const InjectIcon: FunctionComponent<Props> = ({
     if (isPayload) {
       if (type.startsWith('openaev_')) {
         return (
-          <img onClick={onClick} src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${type}`} alt={type} style={style} />
+          <img onClick={onClick} src={buildTenantApiPath(`/api/images/collectors/${type}`)} alt={type} style={style} />
         );
       }
       switch (type) {
@@ -73,7 +71,7 @@ const InjectIcon: FunctionComponent<Props> = ({
     }
     return (
       <img
-        src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/injectors/${type}`}
+        src={buildTenantApiPath(`/api/images/injectors/${type}`)}
         onClick={onClick}
         alt={type}
         style={style}

--- a/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
+++ b/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
@@ -5,6 +5,8 @@ import { type FunctionComponent } from 'react';
 
 import CustomTooltip from '../../../../components/CustomTooltip';
 import { useFormatter } from '../../../../components/i18n';
+import useAuth from '../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 
 interface Props {
   type: string | undefined;
@@ -31,6 +33,7 @@ const InjectIcon: FunctionComponent<Props> = ({
   const { t } = useFormatter();
   const theme = useTheme();
   const fontSize = size || 'medium';
+  const { currentUserTenant } = useAuth();
 
   const iconSelector = (type: string, isPayload: boolean, variant: string, fontSize: string, done: boolean, disabled: boolean) => {
     const style = {
@@ -50,7 +53,7 @@ const InjectIcon: FunctionComponent<Props> = ({
     if (isPayload) {
       if (type.startsWith('openaev_')) {
         return (
-          <img onClick={onClick} src={`/api/images/collectors/${type}`} alt={type} style={style} />
+          <img onClick={onClick} src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${type}`} alt={type} style={style} />
         );
       }
       switch (type) {
@@ -70,7 +73,7 @@ const InjectIcon: FunctionComponent<Props> = ({
     }
     return (
       <img
-        src={`/api/images/injectors/${type}`}
+        src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/injectors/${type}`}
         onClick={onClick}
         alt={type}
         style={style}

--- a/openaev-front/src/admin/components/common/injects/form/documents/InjectDocumentsList.tsx
+++ b/openaev-front/src/admin/components/common/injects/form/documents/InjectDocumentsList.tsx
@@ -11,8 +11,10 @@ import ItemBoolean from '../../../../../../components/ItemBoolean';
 import ItemTags from '../../../../../../components/ItemTags';
 import { useHelper } from '../../../../../../store';
 import { type Document } from '../../../../../../utils/api-types';
+import useAuth from '../../../../../../utils/hooks/useAuth';
 import { Can } from '../../../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../../../utils/tenant-url-helper';
 import DocumentPopover from '../../../../components/documents/DocumentPopover';
 import DocumentType from '../../../../components/documents/DocumentType';
 
@@ -39,6 +41,7 @@ const InjectDocumentsList = ({ readOnly, hasAttachments }: Props) => {
   const { t } = useFormatter();
   const { control } = useFormContext();
   const { classes } = useStyles();
+  const { currentUserTenant } = useAuth();
 
   const [sortedDocuments, setSortedDocuments] = useState<(Document & { document_attached: boolean })[]>([]);
   const { documentsMap } = useHelper((helper: DocumentHelper) => ({ documentsMap: helper.getDocumentsMap() }));
@@ -139,7 +142,7 @@ const InjectDocumentsList = ({ readOnly, hasAttachments }: Props) => {
             )}
           >
             <ListItemButton
-              href={`/api/documents/${document.document_id}/file`}
+              href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
             >
               <ListItemIcon>
                 <AttachmentOutlined />

--- a/openaev-front/src/admin/components/common/injects/form/documents/InjectDocumentsList.tsx
+++ b/openaev-front/src/admin/components/common/injects/form/documents/InjectDocumentsList.tsx
@@ -11,10 +11,9 @@ import ItemBoolean from '../../../../../../components/ItemBoolean';
 import ItemTags from '../../../../../../components/ItemTags';
 import { useHelper } from '../../../../../../store';
 import { type Document } from '../../../../../../utils/api-types';
-import useAuth from '../../../../../../utils/hooks/useAuth';
 import { Can } from '../../../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../../../utils/tenant-url-helper';
 import DocumentPopover from '../../../../components/documents/DocumentPopover';
 import DocumentType from '../../../../components/documents/DocumentType';
 
@@ -41,7 +40,6 @@ const InjectDocumentsList = ({ readOnly, hasAttachments }: Props) => {
   const { t } = useFormatter();
   const { control } = useFormContext();
   const { classes } = useStyles();
-  const { currentUserTenant } = useAuth();
 
   const [sortedDocuments, setSortedDocuments] = useState<(Document & { document_attached: boolean })[]>([]);
   const { documentsMap } = useHelper((helper: DocumentHelper) => ({ documentsMap: helper.getDocumentsMap() }));
@@ -142,7 +140,7 @@ const InjectDocumentsList = ({ readOnly, hasAttachments }: Props) => {
             )}
           >
             <ListItemButton
-              href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+              href={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
             >
               <ListItemIcon>
                 <AttachmentOutlined />

--- a/openaev-front/src/admin/components/common/injects/status/traces/AgentTraces.tsx
+++ b/openaev-front/src/admin/components/common/injects/status/traces/AgentTraces.tsx
@@ -6,8 +6,7 @@ import ExpandableSection from '../../../../../../components/common/ExpandableSec
 import { useFormatter } from '../../../../../../components/i18n';
 import ItemStatus from '../../../../../../components/ItemStatus';
 import { type ExecutionTraceOutput } from '../../../../../../utils/api-types';
-import useAuth from '../../../../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../../../utils/tenant-url-helper';
 import ExecutionTime from './ExecutionTime';
 import TraceMessage from './TraceMessage';
 
@@ -19,7 +18,6 @@ interface Props {
 const AgentTraces = ({ traces, isInitialExpanded = false }: Props) => {
   const { t } = useFormatter();
   const theme = useTheme();
-  const { currentUserTenant } = useAuth();
 
   const agentStatus = useMemo(() => {
     const sorted = [...traces].sort(
@@ -94,7 +92,7 @@ const AgentTraces = ({ traces, isInitialExpanded = false }: Props) => {
           <Typography variant="h3">{t('Executor')}</Typography>
           {agentStatus.executorType && (
             <img
-              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${agentStatus.executorType}`}
+              src={buildTenantApiPath(`/api/images/executors/icons/${agentStatus.executorType}`)}
               alt={agentStatus.executorType}
               style={{
                 width: 20,

--- a/openaev-front/src/admin/components/common/injects/status/traces/AgentTraces.tsx
+++ b/openaev-front/src/admin/components/common/injects/status/traces/AgentTraces.tsx
@@ -6,6 +6,8 @@ import ExpandableSection from '../../../../../../components/common/ExpandableSec
 import { useFormatter } from '../../../../../../components/i18n';
 import ItemStatus from '../../../../../../components/ItemStatus';
 import { type ExecutionTraceOutput } from '../../../../../../utils/api-types';
+import useAuth from '../../../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../../../utils/tenant-url-helper';
 import ExecutionTime from './ExecutionTime';
 import TraceMessage from './TraceMessage';
 
@@ -17,6 +19,7 @@ interface Props {
 const AgentTraces = ({ traces, isInitialExpanded = false }: Props) => {
   const { t } = useFormatter();
   const theme = useTheme();
+  const { currentUserTenant } = useAuth();
 
   const agentStatus = useMemo(() => {
     const sorted = [...traces].sort(
@@ -91,7 +94,7 @@ const AgentTraces = ({ traces, isInitialExpanded = false }: Props) => {
           <Typography variant="h3">{t('Executor')}</Typography>
           {agentStatus.executorType && (
             <img
-              src={`/api/images/executors/icons/${agentStatus.executorType}`}
+              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${agentStatus.executorType}`}
               alt={agentStatus.executorType}
               style={{
                 width: 20,

--- a/openaev-front/src/admin/components/components/challenges/ChallengeForm.jsx
+++ b/openaev-front/src/admin/components/components/challenges/ChallengeForm.jsx
@@ -18,9 +18,11 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import TagField from '../../../../components/TagField';
 import { useHelper } from '../../../../store';
+import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 import DocumentPopover from '../documents/DocumentPopover';
 import DocumentType from '../documents/DocumentType';
 
@@ -103,6 +105,7 @@ const ChallengeForm = (props) => {
   const { t } = useFormatter();
   const dispatch = useDispatch();
   const ability = useContext(AbilityContext);
+  const { currentUserTenant } = useAuth();
 
   const { onSubmit, handleClose, initialValues, editing, documentsIds } = props;
   const [documentsSortBy, setDocumentsSortBy] = useState('document_name');
@@ -282,7 +285,7 @@ const ChallengeForm = (props) => {
                     classes={{ root: classes.item }}
                     divider
                     component="a"
-                    href={`/api/documents/${document.document_id}/file`}
+                    href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
                   >
                     <ListItemIcon>
                       <AttachmentOutlined />

--- a/openaev-front/src/admin/components/components/challenges/ChallengeForm.jsx
+++ b/openaev-front/src/admin/components/components/challenges/ChallengeForm.jsx
@@ -18,11 +18,10 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import TagField from '../../../../components/TagField';
 import { useHelper } from '../../../../store';
-import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 import DocumentPopover from '../documents/DocumentPopover';
 import DocumentType from '../documents/DocumentType';
 
@@ -105,7 +104,6 @@ const ChallengeForm = (props) => {
   const { t } = useFormatter();
   const dispatch = useDispatch();
   const ability = useContext(AbilityContext);
-  const { currentUserTenant } = useAuth();
 
   const { onSubmit, handleClose, initialValues, editing, documentsIds } = props;
   const [documentsSortBy, setDocumentsSortBy] = useState('document_name');
@@ -285,7 +283,7 @@ const ChallengeForm = (props) => {
                     classes={{ root: classes.item }}
                     divider
                     component="a"
-                    href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+                    href={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
                   >
                     <ListItemIcon>
                       <AttachmentOutlined />

--- a/openaev-front/src/admin/components/components/channels/Channel.jsx
+++ b/openaev-front/src/admin/components/components/channels/Channel.jsx
@@ -8,9 +8,11 @@ import { makeStyles } from 'tss-react/mui';
 import { fetchDocumentsChannels, updateChannel, updateChannelLogos } from '../../../../actions/channels/channel-action';
 import { useFormatter } from '../../../../components/i18n';
 import { useHelper } from '../../../../store';
+import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext, Can } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 import ChannelAddLogo from './ChannelAddLogo';
 import ChannelOverviewMicroblogging from './ChannelOverviewMicroblogging';
 import ChannelOverviewNewspaper from './ChannelOverviewNewspaper';
@@ -34,6 +36,7 @@ const Channel = () => {
   const dispatch = useDispatch();
   const { t } = useFormatter();
   const ability = useContext(AbilityContext);
+  const { currentUserTenant } = useAuth();
 
   const { channel, documentsMap } = useHelper(helper => ({
     channel: helper.getChannel(channelId),
@@ -96,7 +99,7 @@ const Channel = () => {
                 </Typography>
                 {logoDark ? (
                   <img
-                    src={`/api/images/channels/id/${channelId}/dark`}
+                    src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/channels/id/${channelId}/dark`}
                     style={{
                       maxHeight: 200,
                       maxWidth: 200,
@@ -123,7 +126,7 @@ const Channel = () => {
                 </Typography>
                 {logoLight ? (
                   <img
-                    src={`/api/images/channels/id/${channelId}/light`}
+                    src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/channels/id/${channelId}/light`}
                     style={{
                       maxHeight: 200,
                       maxWidth: 200,

--- a/openaev-front/src/admin/components/components/channels/Channel.jsx
+++ b/openaev-front/src/admin/components/components/channels/Channel.jsx
@@ -8,11 +8,10 @@ import { makeStyles } from 'tss-react/mui';
 import { fetchDocumentsChannels, updateChannel, updateChannelLogos } from '../../../../actions/channels/channel-action';
 import { useFormatter } from '../../../../components/i18n';
 import { useHelper } from '../../../../store';
-import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext, Can } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 import ChannelAddLogo from './ChannelAddLogo';
 import ChannelOverviewMicroblogging from './ChannelOverviewMicroblogging';
 import ChannelOverviewNewspaper from './ChannelOverviewNewspaper';
@@ -36,7 +35,6 @@ const Channel = () => {
   const dispatch = useDispatch();
   const { t } = useFormatter();
   const ability = useContext(AbilityContext);
-  const { currentUserTenant } = useAuth();
 
   const { channel, documentsMap } = useHelper(helper => ({
     channel: helper.getChannel(channelId),
@@ -99,7 +97,7 @@ const Channel = () => {
                 </Typography>
                 {logoDark ? (
                   <img
-                    src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/channels/id/${channelId}/dark`}
+                    src={buildTenantApiPath(`/api/images/channels/id/${channelId}/dark`)}
                     style={{
                       maxHeight: 200,
                       maxWidth: 200,
@@ -126,7 +124,7 @@ const Channel = () => {
                 </Typography>
                 {logoLight ? (
                   <img
-                    src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/channels/id/${channelId}/light`}
+                    src={buildTenantApiPath(`/api/images/channels/id/${channelId}/light`)}
                     style={{
                       maxHeight: 200,
                       maxWidth: 200,

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewMicroblogging.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewMicroblogging.jsx
@@ -3,6 +3,9 @@ import { useTheme } from '@mui/material/styles';
 import { Fragment } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
+import useAuth from '../../../../utils/hooks/useAuth.ts';
+import {DEFAULT_TENANT_UUID} from "../../../../utils/tenant-url-helper.ts";
+
 const useStyles = makeStyles()(() => ({
   root: {
     flexGrow: 1,
@@ -17,6 +20,7 @@ const useStyles = makeStyles()(() => ({
 const ChannelOverviewMicroblogging = ({ channel }) => {
   const { classes } = useStyles();
   const theme = useTheme();
+  const { currentUserTenant } = useAuth();
   const isDark = theme.palette.mode === 'dark';
   const logo = isDark ? channel.logoDark : channel.logoLight;
   return (
@@ -30,7 +34,7 @@ const ChannelOverviewMicroblogging = ({ channel }) => {
           }}
         >
           <img
-            src={`/api/documents/${logo.document_id}/file`}
+            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${logo.document_id}/file`}
             className={classes.logo}
           />
         </div>

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewMicroblogging.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewMicroblogging.jsx
@@ -4,7 +4,7 @@ import { Fragment } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import useAuth from '../../../../utils/hooks/useAuth.ts';
-import {DEFAULT_TENANT_UUID} from "../../../../utils/tenant-url-helper.ts";
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewMicroblogging.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewMicroblogging.jsx
@@ -3,8 +3,7 @@ import { useTheme } from '@mui/material/styles';
 import { Fragment } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
-import useAuth from '../../../../utils/hooks/useAuth.ts';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {
@@ -20,7 +19,6 @@ const useStyles = makeStyles()(() => ({
 const ChannelOverviewMicroblogging = ({ channel }) => {
   const { classes } = useStyles();
   const theme = useTheme();
-  const { currentUserTenant } = useAuth();
   const isDark = theme.palette.mode === 'dark';
   const logo = isDark ? channel.logoDark : channel.logoLight;
   return (
@@ -34,7 +32,7 @@ const ChannelOverviewMicroblogging = ({ channel }) => {
           }}
         >
           <img
-            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${logo.document_id}/file`}
+            src={buildTenantApiPath(`/api/documents/${logo.document_id}/file`)}
             className={classes.logo}
           />
         </div>

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewNewspaper.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewNewspaper.jsx
@@ -3,6 +3,9 @@ import { useTheme } from '@mui/material/styles';
 import { Fragment } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
+import useAuth from '../../../../utils/hooks/useAuth.ts';
+import {DEFAULT_TENANT_UUID} from "../../../../utils/tenant-url-helper.ts";
+
 const useStyles = makeStyles()(() => ({
   root: {
     flexGrow: 1,
@@ -18,6 +21,7 @@ const ChannelOverviewNewspaper = ({ channel }) => {
   const { classes } = useStyles();
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
+  const { currentUserTenant } = useAuth();
   const logo = isDark ? channel.logoDark : channel.logoLight;
   return (
     <div className={classes.root}>
@@ -30,7 +34,7 @@ const ChannelOverviewNewspaper = ({ channel }) => {
           }}
         >
           <img
-            src={`/api/documents/${logo.document_id}/file`}
+            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${logo.document_id}/file`}
             className={classes.logo}
           />
         </div>

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewNewspaper.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewNewspaper.jsx
@@ -3,8 +3,7 @@ import { useTheme } from '@mui/material/styles';
 import { Fragment } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
-import useAuth from '../../../../utils/hooks/useAuth.ts';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {
@@ -21,7 +20,6 @@ const ChannelOverviewNewspaper = ({ channel }) => {
   const { classes } = useStyles();
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
-  const { currentUserTenant } = useAuth();
   const logo = isDark ? channel.logoDark : channel.logoLight;
   return (
     <div className={classes.root}>
@@ -34,7 +32,7 @@ const ChannelOverviewNewspaper = ({ channel }) => {
           }}
         >
           <img
-            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${logo.document_id}/file`}
+            src={buildTenantApiPath(`/api/documents/${logo.document_id}/file`)}
             className={classes.logo}
           />
         </div>

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewNewspaper.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewNewspaper.jsx
@@ -4,7 +4,7 @@ import { Fragment } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import useAuth from '../../../../utils/hooks/useAuth.ts';
-import {DEFAULT_TENANT_UUID} from "../../../../utils/tenant-url-helper.ts";
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewTvChannel.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewTvChannel.jsx
@@ -2,8 +2,7 @@ import { Card, CardHeader, GridLegacy, Skeleton, Typography } from '@mui/materia
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
-import useAuth from '../../../../utils/hooks/useAuth.ts';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {
@@ -21,7 +20,6 @@ const ChannelOverviewTvChannel = ({ channel }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const logo = isDark ? channel.logoDark : channel.logoLight;
-  const { currentUserTenant } = useAuth();
   return (
     <div className={classes.root}>
       {logo && channel.channel_mode !== 'title' && (
@@ -33,7 +31,7 @@ const ChannelOverviewTvChannel = ({ channel }) => {
           }}
         >
           <img
-            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${logo.document_id}/file`}
+            src={buildTenantApiPath(`/api/documents/${logo.document_id}/file`)}
             className={classes.logo}
           />
         </div>

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewTvChannel.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewTvChannel.jsx
@@ -3,7 +3,7 @@ import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
 import useAuth from '../../../../utils/hooks/useAuth.ts';
-import {DEFAULT_TENANT_UUID} from "../../../../utils/tenant-url-helper.ts";
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {

--- a/openaev-front/src/admin/components/components/channels/ChannelOverviewTvChannel.jsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelOverviewTvChannel.jsx
@@ -2,6 +2,9 @@ import { Card, CardHeader, GridLegacy, Skeleton, Typography } from '@mui/materia
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
+import useAuth from '../../../../utils/hooks/useAuth.ts';
+import {DEFAULT_TENANT_UUID} from "../../../../utils/tenant-url-helper.ts";
+
 const useStyles = makeStyles()(() => ({
   root: {
     flexGrow: 1,
@@ -18,6 +21,7 @@ const ChannelOverviewTvChannel = ({ channel }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const logo = isDark ? channel.logoDark : channel.logoLight;
+  const { currentUserTenant } = useAuth();
   return (
     <div className={classes.root}>
       {logo && channel.channel_mode !== 'title' && (
@@ -29,7 +33,7 @@ const ChannelOverviewTvChannel = ({ channel }) => {
           }}
         >
           <img
-            src={`/api/documents/${logo.document_id}/file`}
+            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${logo.document_id}/file`}
             className={classes.logo}
           />
         </div>

--- a/openaev-front/src/admin/components/components/documents/DocumentPopover.jsx
+++ b/openaev-front/src/admin/components/components/documents/DocumentPopover.jsx
@@ -18,10 +18,12 @@ import { useFormatter } from '../../../../components/i18n';
 import { ATOMIC_BASE_URL, CHALLENGE_BASE_URL, CHANNEL_BASE_URL, PAYLOAD_BASE_URL, SCENARIO_BASE_URL, SECURITY_PLATFORM_BASE_URL, SIMULATION_BASE_URL } from '../../../../constants/BaseUrls';
 import { useHelper } from '../../../../store';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { exerciseOptions, scenarioOptions, tagOptions } from '../../../../utils/Option';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 import DocumentForm from './DocumentForm';
 
 const entityPaths = {
@@ -46,6 +48,7 @@ const DocumentPopover = (props) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
+  const { currentUserTenant } = useAuth();
 
   const { document, disabled, onRemoveDocument, attached, onToggleAttach, inline, onUpdate, onDelete } = props;
 
@@ -92,7 +95,7 @@ const DocumentPopover = (props) => {
   const handleOpenDelete = () => {
     setOpenDelete(true);
     setLoadingRelations(true);
-    fetch(`/api/documents/${document.document_id}/relations`)
+    fetch(`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/relations`)
       .then(res => res.json())
       .then((data) => {
         setRelations(data);

--- a/openaev-front/src/admin/components/components/documents/DocumentPopover.jsx
+++ b/openaev-front/src/admin/components/components/documents/DocumentPopover.jsx
@@ -18,12 +18,11 @@ import { useFormatter } from '../../../../components/i18n';
 import { ATOMIC_BASE_URL, CHALLENGE_BASE_URL, CHANNEL_BASE_URL, PAYLOAD_BASE_URL, SCENARIO_BASE_URL, SECURITY_PLATFORM_BASE_URL, SIMULATION_BASE_URL } from '../../../../constants/BaseUrls';
 import { useHelper } from '../../../../store';
 import { useAppDispatch } from '../../../../utils/hooks';
-import useAuth from '../../../../utils/hooks/useAuth.ts';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { exerciseOptions, scenarioOptions, tagOptions } from '../../../../utils/Option';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 import DocumentForm from './DocumentForm';
 
 const entityPaths = {
@@ -48,7 +47,6 @@ const DocumentPopover = (props) => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
-  const { currentUserTenant } = useAuth();
 
   const { document, disabled, onRemoveDocument, attached, onToggleAttach, inline, onUpdate, onDelete } = props;
 
@@ -95,7 +93,7 @@ const DocumentPopover = (props) => {
   const handleOpenDelete = () => {
     setOpenDelete(true);
     setLoadingRelations(true);
-    fetch(`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/relations`)
+    fetch(buildTenantApiPath(`/api/documents/${document.document_id}/relations`))
       .then(res => res.json())
       .then((data) => {
         setRelations(data);

--- a/openaev-front/src/admin/components/components/documents/Documents.jsx
+++ b/openaev-front/src/admin/components/components/documents/Documents.jsx
@@ -17,10 +17,9 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import PaginatedListLoader from '../../../../components/PaginatedListLoader';
 import { useHelper } from '../../../../store';
-import useAuth from '../../../../utils/hooks/useAuth.ts';
 import { Can } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper.ts';
 import CreateDocument from './CreateDocument';
 import DocumentPopover from './DocumentPopover';
 import DocumentType from './DocumentType';
@@ -72,7 +71,6 @@ const Documents = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
   const { exercisesMap, scenariosMap } = useHelper(helper => ({
     exercisesMap: helper.getExercisesMap(),
     scenariosMap: helper.getScenariosMap(),
@@ -244,7 +242,7 @@ const Documents = () => {
                   <ListItemButton
                     classes={{ root: classes.item }}
                     component="a"
-                    href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+                    href={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
                   >
                     <ListItemIcon>
                       <DescriptionOutlined color="primary" />

--- a/openaev-front/src/admin/components/components/documents/Documents.jsx
+++ b/openaev-front/src/admin/components/components/documents/Documents.jsx
@@ -17,8 +17,10 @@ import { useFormatter } from '../../../../components/i18n';
 import ItemTags from '../../../../components/ItemTags';
 import PaginatedListLoader from '../../../../components/PaginatedListLoader';
 import { useHelper } from '../../../../store';
+import useAuth from '../../../../utils/hooks/useAuth.ts';
 import { Can } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper.ts';
 import CreateDocument from './CreateDocument';
 import DocumentPopover from './DocumentPopover';
 import DocumentType from './DocumentType';
@@ -70,6 +72,7 @@ const Documents = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
   const { exercisesMap, scenariosMap } = useHelper(helper => ({
     exercisesMap: helper.getExercisesMap(),
     scenariosMap: helper.getScenariosMap(),
@@ -241,7 +244,7 @@ const Documents = () => {
                   <ListItemButton
                     classes={{ root: classes.item }}
                     component="a"
-                    href={`/api/documents/${document.document_id}/file`}
+                    href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
                   >
                     <ListItemIcon>
                       <DescriptionOutlined color="primary" />

--- a/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
+++ b/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
@@ -5,6 +5,8 @@ import { useOutletContext } from 'react-router';
 
 import { useFormatter } from '../../../../components/i18n';
 import { type CatalogConnectorOutput } from '../../../../utils/api-types';
+import useAuth from '../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import ConnectorCard from '../common/ConnectorCard';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import CatalogFilters from './CatalogFilters';
@@ -14,6 +16,7 @@ const Catalog = () => {
   // Standard hooks
   const theme = useTheme();
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
   const { catalogConnectors, isXtmComposerUp } = useOutletContext<CatalogContextType>();
   const [filteredConnectors, setFilteredConnectors] = useState<CatalogConnectorOutput[]>(catalogConnectors);
 
@@ -48,7 +51,7 @@ const Catalog = () => {
                   connectorName: connector.catalog_connector_title,
                   connectorType: connector.catalog_connector_type,
                   connectorLogoName: `connector-logo-${connector.catalog_connector_id}`,
-                  connectorLogoUrl: `/api/images/catalog/connectors/logos/${connector.catalog_connector_logo_url}`,
+                  connectorLogoUrl: `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${connector.catalog_connector_logo_url}`,
                   connectorDescription: connector.catalog_connector_short_description,
                   isExternal: connector.catalog_connector_manager_supported,
                   isVerified: true,

--- a/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
+++ b/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
@@ -5,8 +5,7 @@ import { useOutletContext } from 'react-router';
 
 import { useFormatter } from '../../../../components/i18n';
 import { type CatalogConnectorOutput } from '../../../../utils/api-types';
-import useAuth from '../../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import ConnectorCard from '../common/ConnectorCard';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import CatalogFilters from './CatalogFilters';
@@ -16,7 +15,6 @@ const Catalog = () => {
   // Standard hooks
   const theme = useTheme();
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
   const { catalogConnectors, isXtmComposerUp } = useOutletContext<CatalogContextType>();
   const [filteredConnectors, setFilteredConnectors] = useState<CatalogConnectorOutput[]>(catalogConnectors);
 
@@ -51,7 +49,7 @@ const Catalog = () => {
                   connectorName: connector.catalog_connector_title,
                   connectorType: connector.catalog_connector_type,
                   connectorLogoName: `connector-logo-${connector.catalog_connector_id}`,
-                  connectorLogoUrl: `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${connector.catalog_connector_logo_url}`,
+                  connectorLogoUrl: buildTenantApiPath(`/api/images/catalog/connectors/logos/${connector.catalog_connector_logo_url}`),
                   connectorDescription: connector.catalog_connector_short_description,
                   isExternal: connector.catalog_connector_manager_supported,
                   isVerified: true,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
@@ -13,6 +13,10 @@ import type {
   ExecutorOutput,
   InjectorOutput,
 } from '../../../../utils/api-types';
+import useAuth from '../../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+
+const { currentUserTenant } = useAuth();
 
 export interface ConnectorOutput {
   id: string;
@@ -55,7 +59,7 @@ export const injectorConfig: ConnectorContextType<InjectorOutput> = {
     list: '/admin/integrations/injectors',
     detail: (id: string) => `/admin/integrations/injectors/${id}`,
   },
-  logoUrl: (type: string) => `/api/images/injectors/${type}`,
+  logoUrl: (type: string) => `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/injectors/${type}`,
   normalizeSingle: data => ({
     id: data?.injector_id,
     name: data?.injector_name,
@@ -76,7 +80,7 @@ export const collectorConfig: ConnectorContextType<CollectorOutput & Collector> 
     fetchSingle: (id: string) => fetchCollector(id),
     getRelatedIds: (id: string) => fetchCollectorRelatedIds(id),
   },
-  logoUrl: (type: string) => `/api/images/collectors/${type}`,
+  logoUrl: (type: string) => `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${type}`,
   normalizeSingle: data => ({
     id: data?.collector_id,
     name: data?.collector_name,
@@ -105,7 +109,7 @@ export const executorConfig: ConnectorContextType<ExecutorOutput> = {
     list: '/admin/integrations/executors',
     detail: (id: string) => `/admin/integrations/executors/${id}`,
   },
-  logoUrl: (type: string) => `/api/images/executors/icons/${type}`,
+  logoUrl: (type: string) => `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${type}`,
   normalizeSingle: data => ({
     id: data?.executor_id,
     name: data?.executor_name,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
@@ -13,7 +13,7 @@ import type {
   ExecutorOutput,
   InjectorOutput,
 } from '../../../../utils/api-types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 
 export interface ConnectorOutput {
   id: string;
@@ -45,9 +45,7 @@ export interface ConnectorContextType<T> {
   normalizeSingle: (data: T) => ConnectorOutput;
 }
 
-const resolveTenantId = (tenantId?: string | null): string => tenantId ?? DEFAULT_TENANT_UUID;
-
-export const createInjectorConfig = (tenantId?: string | null): ConnectorContextType<InjectorOutput> => ({
+export const injectorConfig: ConnectorContextType<InjectorOutput> = {
   connectorType: 'injector',
   apiRequest: {
     fetchAll: () => fetchInjectors(true),
@@ -58,7 +56,7 @@ export const createInjectorConfig = (tenantId?: string | null): ConnectorContext
     list: '/admin/integrations/injectors',
     detail: (id: string) => `/admin/integrations/injectors/${id}`,
   },
-  logoUrl: (type: string) => `/api/tenants/${resolveTenantId(tenantId)}/images/injectors/${type}`,
+  logoUrl: (type: string) => buildTenantApiPath(`/api/images/injectors/${type}`),
   normalizeSingle: data => ({
     id: data?.injector_id,
     name: data?.injector_name,
@@ -70,16 +68,16 @@ export const createInjectorConfig = (tenantId?: string | null): ConnectorContext
     isExternal: data?.injector_external,
     isExisting: data?.existing_injector,
   }),
-});
+};
 
-export const createCollectorConfig = (tenantId?: string | null): ConnectorContextType<CollectorOutput & Collector> => ({
+export const collectorConfig: ConnectorContextType<CollectorOutput & Collector> = {
   connectorType: 'collector',
   apiRequest: {
     fetchAll: () => fetchCollectors(true),
     fetchSingle: (id: string) => fetchCollector(id),
     getRelatedIds: (id: string) => fetchCollectorRelatedIds(id),
   },
-  logoUrl: (type: string) => `/api/tenants/${resolveTenantId(tenantId)}/images/collectors/${type}`,
+  logoUrl: (type: string) => buildTenantApiPath(`/api/images/collectors/${type}`),
   normalizeSingle: data => ({
     id: data?.collector_id,
     name: data?.collector_name,
@@ -95,9 +93,9 @@ export const createCollectorConfig = (tenantId?: string | null): ConnectorContex
     list: '/admin/integrations/collectors',
     detail: (id: string) => `/admin/integrations/collectors/${id}`,
   },
-});
+};
 
-export const createExecutorConfig = (tenantId?: string | null): ConnectorContextType<ExecutorOutput> => ({
+export const executorConfig: ConnectorContextType<ExecutorOutput> = {
   connectorType: 'executor',
   apiRequest: {
     fetchAll: () => fetchExecutors(true),
@@ -108,7 +106,7 @@ export const createExecutorConfig = (tenantId?: string | null): ConnectorContext
     list: '/admin/integrations/executors',
     detail: (id: string) => `/admin/integrations/executors/${id}`,
   },
-  logoUrl: (type: string) => `/api/tenants/${resolveTenantId(tenantId)}/images/executors/icons/${type}`,
+  logoUrl: (type: string) => buildTenantApiPath(`/api/images/executors/icons/${type}`),
   normalizeSingle: data => ({
     id: data?.executor_id,
     name: data?.executor_name,
@@ -119,7 +117,7 @@ export const createExecutorConfig = (tenantId?: string | null): ConnectorContext
     connectorInstance: data?.connector_instance,
     isExisting: data?.existing_executor,
   }),
-});
+};
 
 export const ConnectorContext = createContext<ConnectorContextType<InjectorOutput | CollectorOutput | ExecutorOutput>>({
   connectorType: 'collector',

--- a/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
@@ -13,10 +13,7 @@ import type {
   ExecutorOutput,
   InjectorOutput,
 } from '../../../../utils/api-types';
-import useAuth from '../../../../utils/hooks/useAuth';
 import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
-
-const { currentUserTenant } = useAuth();
 
 export interface ConnectorOutput {
   id: string;
@@ -48,7 +45,9 @@ export interface ConnectorContextType<T> {
   normalizeSingle: (data: T) => ConnectorOutput;
 }
 
-export const injectorConfig: ConnectorContextType<InjectorOutput> = {
+const resolveTenantId = (tenantId?: string | null): string => tenantId ?? DEFAULT_TENANT_UUID;
+
+export const createInjectorConfig = (tenantId?: string | null): ConnectorContextType<InjectorOutput> => ({
   connectorType: 'injector',
   apiRequest: {
     fetchAll: () => fetchInjectors(true),
@@ -59,7 +58,7 @@ export const injectorConfig: ConnectorContextType<InjectorOutput> = {
     list: '/admin/integrations/injectors',
     detail: (id: string) => `/admin/integrations/injectors/${id}`,
   },
-  logoUrl: (type: string) => `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/injectors/${type}`,
+  logoUrl: (type: string) => `/api/tenants/${resolveTenantId(tenantId)}/images/injectors/${type}`,
   normalizeSingle: data => ({
     id: data?.injector_id,
     name: data?.injector_name,
@@ -71,16 +70,16 @@ export const injectorConfig: ConnectorContextType<InjectorOutput> = {
     isExternal: data?.injector_external,
     isExisting: data?.existing_injector,
   }),
-};
+});
 
-export const collectorConfig: ConnectorContextType<CollectorOutput & Collector> = {
+export const createCollectorConfig = (tenantId?: string | null): ConnectorContextType<CollectorOutput & Collector> => ({
   connectorType: 'collector',
   apiRequest: {
     fetchAll: () => fetchCollectors(true),
     fetchSingle: (id: string) => fetchCollector(id),
     getRelatedIds: (id: string) => fetchCollectorRelatedIds(id),
   },
-  logoUrl: (type: string) => `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${type}`,
+  logoUrl: (type: string) => `/api/tenants/${resolveTenantId(tenantId)}/images/collectors/${type}`,
   normalizeSingle: data => ({
     id: data?.collector_id,
     name: data?.collector_name,
@@ -96,9 +95,9 @@ export const collectorConfig: ConnectorContextType<CollectorOutput & Collector> 
     list: '/admin/integrations/collectors',
     detail: (id: string) => `/admin/integrations/collectors/${id}`,
   },
-};
+});
 
-export const executorConfig: ConnectorContextType<ExecutorOutput> = {
+export const createExecutorConfig = (tenantId?: string | null): ConnectorContextType<ExecutorOutput> => ({
   connectorType: 'executor',
   apiRequest: {
     fetchAll: () => fetchExecutors(true),
@@ -109,7 +108,7 @@ export const executorConfig: ConnectorContextType<ExecutorOutput> = {
     list: '/admin/integrations/executors',
     detail: (id: string) => `/admin/integrations/executors/${id}`,
   },
-  logoUrl: (type: string) => `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/executors/icons/${type}`,
+  logoUrl: (type: string) => `/api/tenants/${resolveTenantId(tenantId)}/images/executors/icons/${type}`,
   normalizeSingle: data => ({
     id: data?.executor_id,
     name: data?.executor_name,
@@ -120,7 +119,7 @@ export const executorConfig: ConnectorContextType<ExecutorOutput> = {
     connectorInstance: data?.connector_instance,
     isExisting: data?.existing_executor,
   }),
-};
+});
 
 export const ConnectorContext = createContext<ConnectorContextType<InjectorOutput | CollectorOutput | ExecutorOutput>>({
   connectorType: 'collector',

--- a/openaev-front/src/admin/components/integrations/common/ConnectorDetails.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorDetails.tsx
@@ -3,8 +3,10 @@ import { useOutletContext } from 'react-router';
 
 import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
+import useAuth from '../../../../utils/hooks/useAuth';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import { type CatalogContextType } from '../catalog_connectors/CatalogLayout';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import ConnectorCatalogInfo from './ConnectorCatalogInfo';
@@ -14,6 +16,7 @@ const ConnectorDetails = () => {
   // Standard hooks
   const ability = useContext(AbilityContext);
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
 
   const { catalogConnector, isXtmComposerUp } = useOutletContext<CatalogContextType>();
 
@@ -33,7 +36,7 @@ const ConnectorDetails = () => {
           connectorName: catalogConnector.catalog_connector_title,
           connectorType: catalogConnector.catalog_connector_type,
           connectorLogoName: `connector-logo-${catalogConnector.catalog_connector_id}`,
-          connectorLogoUrl: `/api/images/catalog/connectors/logos/${catalogConnector.catalog_connector_logo_url}`,
+          connectorLogoUrl: `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${catalogConnector.catalog_connector_logo_url}`,
           connectorDescription: catalogConnector.catalog_connector_short_description,
           isExternal: catalogConnector.catalog_connector_manager_supported,
           isVerified: true,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorDetails.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorDetails.tsx
@@ -3,10 +3,9 @@ import { useOutletContext } from 'react-router';
 
 import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
-import useAuth from '../../../../utils/hooks/useAuth';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import { type CatalogContextType } from '../catalog_connectors/CatalogLayout';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import ConnectorCatalogInfo from './ConnectorCatalogInfo';
@@ -16,7 +15,6 @@ const ConnectorDetails = () => {
   // Standard hooks
   const ability = useContext(AbilityContext);
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
 
   const { catalogConnector, isXtmComposerUp } = useOutletContext<CatalogContextType>();
 
@@ -36,7 +34,7 @@ const ConnectorDetails = () => {
           connectorName: catalogConnector.catalog_connector_title,
           connectorType: catalogConnector.catalog_connector_type,
           connectorLogoName: `connector-logo-${catalogConnector.catalog_connector_id}`,
-          connectorLogoUrl: `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${catalogConnector.catalog_connector_logo_url}`,
+          connectorLogoUrl: buildTenantApiPath(`/api/images/catalog/connectors/logos/${catalogConnector.catalog_connector_logo_url}`),
           connectorDescription: catalogConnector.catalog_connector_short_description,
           isExternal: catalogConnector.catalog_connector_manager_supported,
           isVerified: true,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorList.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorList.tsx
@@ -20,8 +20,10 @@ import type {
   InjectorOutput,
 } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import useSearchAndFilter from '../../../../utils/SortingFiltering';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import ConnectorCard from '../common/ConnectorCard';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import { ConnectorContext, type ConnectorOutput } from './ConnectorContext';
@@ -33,6 +35,7 @@ const ConnectorList = () => {
   const dispatch = useAppDispatch();
   const { isXtmComposerUp } = useOutletContext<ConnectorContextLayoutType>();
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
   const { connectorType, apiRequest, routes, normalizeSingle, logoUrl } = useContext(ConnectorContext);
 
   // Filter and sort hook
@@ -110,7 +113,7 @@ const ConnectorList = () => {
                 connectorName: connector.name,
                 connectorType: connectorType.toUpperCase() as CatalogConnector['catalog_connector_type'],
                 connectorLogoName: connector.type,
-                connectorLogoUrl: connector?.isExisting ? logoUrl(connector.type) : (connector.catalog?.catalog_connector_logo_url && `/api/images/catalog/connectors/logos/${connector.catalog?.catalog_connector_logo_url}`),
+                connectorLogoUrl: connector?.isExisting ? logoUrl(connector.type) : (connector.catalog?.catalog_connector_logo_url && `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${connector.catalog?.catalog_connector_logo_url}`),
                 connectorDescription: connector.catalog?.catalog_connector_short_description,
                 lastUpdatedAt: connector.updatedAt,
                 isVerified: connector.isVerified,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorList.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorList.tsx
@@ -20,10 +20,9 @@ import type {
   InjectorOutput,
 } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import useSearchAndFilter from '../../../../utils/SortingFiltering';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import ConnectorCard from '../common/ConnectorCard';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import { ConnectorContext, type ConnectorOutput } from './ConnectorContext';
@@ -35,7 +34,6 @@ const ConnectorList = () => {
   const dispatch = useAppDispatch();
   const { isXtmComposerUp } = useOutletContext<ConnectorContextLayoutType>();
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
   const { connectorType, apiRequest, routes, normalizeSingle, logoUrl } = useContext(ConnectorContext);
 
   // Filter and sort hook
@@ -113,7 +111,7 @@ const ConnectorList = () => {
                 connectorName: connector.name,
                 connectorType: connectorType.toUpperCase() as CatalogConnector['catalog_connector_type'],
                 connectorLogoName: connector.type,
-                connectorLogoUrl: connector?.isExisting ? logoUrl(connector.type) : (connector.catalog?.catalog_connector_logo_url && `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${connector.catalog?.catalog_connector_logo_url}`),
+                connectorLogoUrl: connector?.isExisting ? logoUrl(connector.type) : (connector.catalog?.catalog_connector_logo_url && buildTenantApiPath(`/api/images/catalog/connectors/logos/${connector.catalog?.catalog_connector_logo_url}`)),
                 connectorDescription: connector.catalog?.catalog_connector_short_description,
                 lastUpdatedAt: connector.updatedAt,
                 isVerified: connector.isVerified,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -5,11 +5,10 @@ import useDialog from '../../../../components/common/dialog/useDialog';
 import Tabs, { type TabsEntry } from '../../../../components/common/tabs/Tabs';
 import useTabs from '../../../../components/common/tabs/useTabs';
 import { useFormatter } from '../../../../components/i18n';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import ConnectorAlerts from './ConnectorAlerts';
 import ConnectorCatalogInfo from './ConnectorCatalogInfo';
@@ -20,7 +19,6 @@ import ConnectorTitle from './ConnectorTitle';
 
 const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode }) => {
   const { t } = useFormatter();
-  const { currentUserTenant } = useAuth();
 
   const { connector, instance, catalogConnector, isXtmComposerUp, refreshConnector } = useOutletContext<ConnectorContextLayoutType>();
   const { isValidated: isEnterpriseEdition } = useEnterpriseEdition();
@@ -64,7 +62,7 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
           connectorName: connector?.name || catalogConnector?.catalog_connector_title,
           connectorType: catalogConnector?.catalog_connector_type,
           connectorLogoName: connector?.type || catalogConnector?.catalog_connector_slug,
-          connectorLogoUrl: instance ? `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}` : logoUrl(connector?.type),
+          connectorLogoUrl: instance ? buildTenantApiPath(`/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}`) : logoUrl(connector?.type),
           connectorDescription: catalogConnector?.catalog_connector_description,
           isExternal: catalogConnector?.catalog_connector_manager_supported,
           isVerified: instance != null,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -5,9 +5,11 @@ import useDialog from '../../../../components/common/dialog/useDialog';
 import Tabs, { type TabsEntry } from '../../../../components/common/tabs/Tabs';
 import useTabs from '../../../../components/common/tabs/useTabs';
 import { useFormatter } from '../../../../components/i18n';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import ConnectorAlerts from './ConnectorAlerts';
 import ConnectorCatalogInfo from './ConnectorCatalogInfo';
@@ -18,6 +20,7 @@ import ConnectorTitle from './ConnectorTitle';
 
 const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode }) => {
   const { t } = useFormatter();
+  const { currentUserTenant } = useAuth();
 
   const { connector, instance, catalogConnector, isXtmComposerUp, refreshConnector } = useOutletContext<ConnectorContextLayoutType>();
   const { isValidated: isEnterpriseEdition } = useEnterpriseEdition();
@@ -61,7 +64,7 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
           connectorName: connector?.name || catalogConnector?.catalog_connector_title,
           connectorType: catalogConnector?.catalog_connector_type,
           connectorLogoName: connector?.type || catalogConnector?.catalog_connector_slug,
-          connectorLogoUrl: instance ? `/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}` : logoUrl(connector?.type),
+          connectorLogoUrl: instance ? `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}` : logoUrl(connector?.type),
           connectorDescription: catalogConnector?.catalog_connector_description,
           isExternal: catalogConnector?.catalog_connector_manager_supported,
           isVerified: instance != null,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorProvider.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode } from 'react';
 
 import type {
   CatalogConnectorOutput,
@@ -6,13 +6,10 @@ import type {
   ExecutorOutput,
   InjectorOutput,
 } from '../../../../utils/api-types';
-import useAuth from '../../../../utils/hooks/useAuth';
 import {
+  collectorConfig,
   ConnectorContext,
-  type ConnectorContextType,
-  createCollectorConfig,
-  createExecutorConfig,
-  createInjectorConfig,
+  type ConnectorContextType, executorConfig, injectorConfig,
 } from './ConnectorContext';
 
 interface Props {
@@ -21,21 +18,14 @@ interface Props {
 }
 
 const ConnectorProvider = ({ children, type }: Props) => {
-  const { currentUserTenant } = useAuth();
-  const tenantId = currentUserTenant?.tenant_id;
-  const value = useMemo(() => {
-    const config = {
-      INJECTOR: createInjectorConfig(tenantId),
-      COLLECTOR: createCollectorConfig(tenantId),
-      EXECUTOR: createExecutorConfig(tenantId),
-    };
-    return config[type] as ConnectorContextType<
-      InjectorOutput | CollectorOutput | ExecutorOutput
-    >;
-  }, [tenantId, type]);
+  const config = {
+    INJECTOR: injectorConfig,
+    COLLECTOR: collectorConfig,
+    EXECUTOR: executorConfig,
+  };
 
   return (
-    <ConnectorContext.Provider value={value}>
+    <ConnectorContext.Provider value={config[type] as ConnectorContextType<InjectorOutput | CollectorOutput | ExecutorOutput>}>
       {children}
     </ConnectorContext.Provider>
   );

--- a/openaev-front/src/admin/components/integrations/common/ConnectorProvider.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorProvider.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 import type {
   CatalogConnectorOutput,
@@ -6,11 +6,13 @@ import type {
   ExecutorOutput,
   InjectorOutput,
 } from '../../../../utils/api-types';
+import useAuth from '../../../../utils/hooks/useAuth';
 import {
-  collectorConfig,
-  ConnectorContext, type ConnectorContextType,
-  executorConfig,
-  injectorConfig,
+  ConnectorContext,
+  type ConnectorContextType,
+  createCollectorConfig,
+  createExecutorConfig,
+  createInjectorConfig,
 } from './ConnectorContext';
 
 interface Props {
@@ -19,14 +21,21 @@ interface Props {
 }
 
 const ConnectorProvider = ({ children, type }: Props) => {
-  const config = {
-    INJECTOR: injectorConfig,
-    COLLECTOR: collectorConfig,
-    EXECUTOR: executorConfig,
-  };
+  const { currentUserTenant } = useAuth();
+  const tenantId = currentUserTenant?.tenant_id;
+  const value = useMemo(() => {
+    const config = {
+      INJECTOR: createInjectorConfig(tenantId),
+      COLLECTOR: createCollectorConfig(tenantId),
+      EXECUTOR: createExecutorConfig(tenantId),
+    };
+    return config[type] as ConnectorContextType<
+      InjectorOutput | CollectorOutput | ExecutorOutput
+    >;
+  }, [tenantId, type]);
 
   return (
-    <ConnectorContext.Provider value={config[type] as ConnectorContextType<InjectorOutput | CollectorOutput | ExecutorOutput>}>
+    <ConnectorContext.Provider value={value}>
       {children}
     </ConnectorContext.Provider>
   );

--- a/openaev-front/src/admin/components/payloads/Payloads.tsx
+++ b/openaev-front/src/admin/components/payloads/Payloads.tsx
@@ -23,8 +23,10 @@ import PaginatedListLoader from '../../../components/PaginatedListLoader';
 import PayloadIcon from '../../../components/PayloadIcon';
 import PlatformIcon from '../../../components/PlatformIcon';
 import { type Document, type Domain, type Payload, type SearchPaginationInput } from '../../../utils/api-types';
+import useAuth from '../../../utils/hooks/useAuth';
 import { Can } from '../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper';
 import { arrayToRecord } from '../../../utils/utils';
 import CreatePayload from './CreatePayload';
 import PayloadComponent from './PayloadComponent';
@@ -95,6 +97,7 @@ const Payloads = () => {
   const bodyItemsStyles = useBodyItemsStyles();
   const { t, nsdt } = useFormatter();
   const theme = useTheme();
+  const { currentUserTenant } = useAuth();
 
   const [selectedPayload, setSelectedPayload] = useState<Payload | null>(null);
 
@@ -314,7 +317,7 @@ const Payloads = () => {
                       <ListItemIcon>
                         {payload.payload_collector_type ? (
                           <img
-                            src={`/api/images/collectors/${payload.payload_collector_type}`}
+                            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${payload.payload_collector_type}`}
                             alt={payload.payload_collector_type}
                             style={{
                               padding: 0,

--- a/openaev-front/src/admin/components/payloads/Payloads.tsx
+++ b/openaev-front/src/admin/components/payloads/Payloads.tsx
@@ -23,10 +23,9 @@ import PaginatedListLoader from '../../../components/PaginatedListLoader';
 import PayloadIcon from '../../../components/PayloadIcon';
 import PlatformIcon from '../../../components/PlatformIcon';
 import { type Document, type Domain, type Payload, type SearchPaginationInput } from '../../../utils/api-types';
-import useAuth from '../../../utils/hooks/useAuth';
 import { Can } from '../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../utils/tenant-url-helper';
 import { arrayToRecord } from '../../../utils/utils';
 import CreatePayload from './CreatePayload';
 import PayloadComponent from './PayloadComponent';
@@ -97,7 +96,6 @@ const Payloads = () => {
   const bodyItemsStyles = useBodyItemsStyles();
   const { t, nsdt } = useFormatter();
   const theme = useTheme();
-  const { currentUserTenant } = useAuth();
 
   const [selectedPayload, setSelectedPayload] = useState<Payload | null>(null);
 
@@ -317,7 +315,7 @@ const Payloads = () => {
                       <ListItemIcon>
                         {payload.payload_collector_type ? (
                           <img
-                            src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${payload.payload_collector_type}`}
+                            src={buildTenantApiPath(`/api/images/collectors/${payload.payload_collector_type}`)}
                             alt={payload.payload_collector_type}
                             style={{
                               padding: 0,

--- a/openaev-front/src/admin/components/payloads/form/RemediationFormTabs.tsx
+++ b/openaev-front/src/admin/components/payloads/form/RemediationFormTabs.tsx
@@ -11,12 +11,11 @@ import { COLLECTOR_LIST } from '../../../../constants/Entities';
 import { useHelper } from '../../../../store';
 import { type Collector } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../../../utils/tenant-url-helper';
 import RemediationFormTab from './RemediationFormTab';
 
 interface RemediationFormTabsProps { payloadId?: string }
@@ -29,7 +28,6 @@ const RemediationFormTabs = ({ payloadId }: RemediationFormTabsProps) => {
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
   const [loading, setLoading] = useState(false);
-  const { currentUserTenant } = useAuth();
 
   const handleActiveTabChange = (_: SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);
@@ -89,7 +87,7 @@ const RemediationFormTabs = ({ payloadId }: RemediationFormTabsProps) => {
                         label={(
                           <Box display="flex" alignItems="center">
                             <img
-                              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${tab.collector_type}`}
+                              src={buildTenantApiPath(`/api/images/collectors/${tab.collector_type}`)}
                               alt={tab.collector_type}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/payloads/form/RemediationFormTabs.tsx
+++ b/openaev-front/src/admin/components/payloads/form/RemediationFormTabs.tsx
@@ -11,10 +11,12 @@ import { COLLECTOR_LIST } from '../../../../constants/Entities';
 import { useHelper } from '../../../../store';
 import { type Collector } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../../../utils/tenant-url-helper';
 import RemediationFormTab from './RemediationFormTab';
 
 interface RemediationFormTabsProps { payloadId?: string }
@@ -27,6 +29,7 @@ const RemediationFormTabs = ({ payloadId }: RemediationFormTabsProps) => {
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
   const [loading, setLoading] = useState(false);
+  const { currentUserTenant } = useAuth();
 
   const handleActiveTabChange = (_: SyntheticEvent, newValue: number) => {
     setActiveTab(newValue);
@@ -86,7 +89,7 @@ const RemediationFormTabs = ({ payloadId }: RemediationFormTabsProps) => {
                         label={(
                           <Box display="flex" alignItems="center">
                             <img
-                              src={`/api/images/collectors/${tab.collector_type}`}
+                              src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/collectors/${tab.collector_type}`}
                               alt={tab.collector_type}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/simulations/simulation/injects/CreateQuickInject.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/injects/CreateQuickInject.tsx
@@ -9,6 +9,7 @@ import { fetchInjectorContract } from '../../../../../actions/InjectorContracts'
 import { useHelper } from '../../../../../store';
 import { type Exercise, type InjectorContract } from '../../../../../utils/api-types';
 import { useAppDispatch } from '../../../../../utils/hooks';
+import useAuth from '../../../../../utils/hooks/useAuth';
 import { PermissionsContext } from '../../../common/Context';
 import QuickInject, { EMAIL_CONTRACT } from './QuickInject';
 
@@ -32,6 +33,7 @@ const CreateQuickInject: FunctionComponent<Props> = ({ exercise }) => {
   const { classes } = useStyles();
   const theme = useTheme();
   const { permissions } = useContext(PermissionsContext);
+  const { currentUserTenant } = useAuth();
 
   const [open, setOpen] = useState(false);
   const { injectorContract }: { injectorContract: InjectorContract }
@@ -69,6 +71,7 @@ const CreateQuickInject: FunctionComponent<Props> = ({ exercise }) => {
               handleClose={() => setOpen(false)}
               theme={theme}
               isDisabled={permissions.readOnly}
+              currentUserTenant={currentUserTenant}
             />
           </Drawer>
         )}

--- a/openaev-front/src/admin/components/simulations/simulation/injects/CreateQuickInject.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/injects/CreateQuickInject.tsx
@@ -9,7 +9,6 @@ import { fetchInjectorContract } from '../../../../../actions/InjectorContracts'
 import { useHelper } from '../../../../../store';
 import { type Exercise, type InjectorContract } from '../../../../../utils/api-types';
 import { useAppDispatch } from '../../../../../utils/hooks';
-import useAuth from '../../../../../utils/hooks/useAuth';
 import { PermissionsContext } from '../../../common/Context';
 import QuickInject, { EMAIL_CONTRACT } from './QuickInject';
 
@@ -33,7 +32,6 @@ const CreateQuickInject: FunctionComponent<Props> = ({ exercise }) => {
   const { classes } = useStyles();
   const theme = useTheme();
   const { permissions } = useContext(PermissionsContext);
-  const { currentUserTenant } = useAuth();
 
   const [open, setOpen] = useState(false);
   const { injectorContract }: { injectorContract: InjectorContract }
@@ -71,7 +69,6 @@ const CreateQuickInject: FunctionComponent<Props> = ({ exercise }) => {
               handleClose={() => setOpen(false)}
               theme={theme}
               isDisabled={permissions.readOnly}
-              currentUserTenant={currentUserTenant}
             />
           </Drawer>
         )}

--- a/openaev-front/src/admin/components/simulations/simulation/injects/QuickInject.jsx
+++ b/openaev-front/src/admin/components/simulations/simulation/injects/QuickInject.jsx
@@ -45,6 +45,7 @@ import OldTextField from '../../../../../components/fields/OldTextField';
 import inject18n from '../../../../../components/i18n';
 import ItemBoolean from '../../../../../components/ItemBoolean';
 import ItemTags from '../../../../../components/ItemTags';
+import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper.ts';
 import { secondsFromToNow } from '../../../../../utils/Time';
 import InjectExpectations from '../../../common/injects/expectations/InjectExpectations';
 import InjectAddTeams from '../../../common/injects/form/teams/InjectAddTeams';
@@ -800,6 +801,7 @@ class QuickInjectComponent extends Component {
       teamsMap,
       documentsMap,
       isDisabled,
+      currentUserTenant,
     } = this.props;
     const {
       allTeams,
@@ -1311,7 +1313,7 @@ class QuickInjectComponent extends Component {
                         classes={{ root: classes.item }}
                         divider={true}
                         component="a"
-                        href={`/api/documents/${document.document_id}/file`}
+                        href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
                       >
                         <ListItemIcon>
                           <AttachmentOutlined />
@@ -1439,6 +1441,7 @@ QuickInjectComponent.propTypes = {
   handleClose: PropTypes.func,
   injectorContract: PropTypes.object,
   fetchDocuments: PropTypes.func,
+  currentUserTenant: PropTypes.object,
 };
 
 const select = (state, ownProps) => {

--- a/openaev-front/src/admin/components/simulations/simulation/injects/QuickInject.jsx
+++ b/openaev-front/src/admin/components/simulations/simulation/injects/QuickInject.jsx
@@ -45,7 +45,7 @@ import OldTextField from '../../../../../components/fields/OldTextField';
 import inject18n from '../../../../../components/i18n';
 import ItemBoolean from '../../../../../components/ItemBoolean';
 import ItemTags from '../../../../../components/ItemTags';
-import { DEFAULT_TENANT_UUID } from '../../../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../../../utils/tenant-url-helper.ts';
 import { secondsFromToNow } from '../../../../../utils/Time';
 import InjectExpectations from '../../../common/injects/expectations/InjectExpectations';
 import InjectAddTeams from '../../../common/injects/form/teams/InjectAddTeams';
@@ -801,7 +801,6 @@ class QuickInjectComponent extends Component {
       teamsMap,
       documentsMap,
       isDisabled,
-      currentUserTenant,
     } = this.props;
     const {
       allTeams,
@@ -1313,7 +1312,7 @@ class QuickInjectComponent extends Component {
                         classes={{ root: classes.item }}
                         divider={true}
                         component="a"
-                        href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+                        href={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
                       >
                         <ListItemIcon>
                           <AttachmentOutlined />

--- a/openaev-front/src/components/fields/FileLoader.tsx
+++ b/openaev-front/src/components/fields/FileLoader.tsx
@@ -10,12 +10,11 @@ import DocumentType from '../../admin/components/components/documents/DocumentTy
 import { useHelper } from '../../store';
 import { type RawDocument } from '../../utils/api-types';
 import { useAppDispatch } from '../../utils/hooks';
-import useAuth from '../../utils/hooks/useAuth';
 import useDataLoader from '../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../utils/permissions/types';
-import { DEFAULT_TENANT_UUID } from '../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../utils/tenant-url-helper';
 import ButtonPopover, { type PopoverEntry } from '../common/ButtonPopover';
 import { useFormatter } from '../i18n';
 import ItemTags from '../ItemTags';
@@ -111,7 +110,6 @@ const FileLoader: FunctionComponent<Props> = ({
   const { t } = useFormatter();
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
-  const { currentUserTenant } = useAuth();
 
   const [open, setOpen] = useState(false);
   const [selectedDocument, setSelectedDocument] = useState<RawDocument | undefined>(undefined);
@@ -165,7 +163,7 @@ const FileLoader: FunctionComponent<Props> = ({
   const handleDownload = (documentId: string | undefined) => {
     setFirstInteraction(true);
     if (documentId) {
-      window.location.href = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${documentId}/file`;
+      window.location.href = buildTenantApiPath(`/api/documents/${documentId}/file`);
     }
   };
 

--- a/openaev-front/src/components/fields/FileLoader.tsx
+++ b/openaev-front/src/components/fields/FileLoader.tsx
@@ -10,10 +10,12 @@ import DocumentType from '../../admin/components/components/documents/DocumentTy
 import { useHelper } from '../../store';
 import { type RawDocument } from '../../utils/api-types';
 import { useAppDispatch } from '../../utils/hooks';
+import useAuth from '../../utils/hooks/useAuth';
 import useDataLoader from '../../utils/hooks/useDataLoader';
 import { AbilityContext } from '../../utils/permissions/permissionsContext';
 import RestrictionAccess from '../../utils/permissions/RestrictionAccess';
 import { ACTIONS, SUBJECTS } from '../../utils/permissions/types';
+import { DEFAULT_TENANT_UUID } from '../../utils/tenant-url-helper';
 import ButtonPopover, { type PopoverEntry } from '../common/ButtonPopover';
 import { useFormatter } from '../i18n';
 import ItemTags from '../ItemTags';
@@ -109,6 +111,7 @@ const FileLoader: FunctionComponent<Props> = ({
   const { t } = useFormatter();
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
+  const { currentUserTenant } = useAuth();
 
   const [open, setOpen] = useState(false);
   const [selectedDocument, setSelectedDocument] = useState<RawDocument | undefined>(undefined);
@@ -162,7 +165,7 @@ const FileLoader: FunctionComponent<Props> = ({
   const handleDownload = (documentId: string | undefined) => {
     setFirstInteraction(true);
     if (documentId) {
-      window.location.href = `/api/documents/${documentId}/file`;
+      window.location.href = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${documentId}/file`;
     }
   };
 

--- a/openaev-front/src/components/fields/SecurityPlatformField.tsx
+++ b/openaev-front/src/components/fields/SecurityPlatformField.tsx
@@ -7,6 +7,8 @@ import { makeStyles } from 'tss-react/mui';
 import { type SecurityPlatformHelper } from '../../actions/assets/asset-helper';
 import { useHelper } from '../../store';
 import { type SecurityPlatform } from '../../utils/api-types';
+import useAuth from '../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../utils/tenant-url-helper';
 
 const useStyles = makeStyles()(() => ({
   icon: {
@@ -57,6 +59,7 @@ const SecurityPlatformField: FunctionComponent<Props> = ({
   // Standard hooks
   const theme = useTheme();
   const { classes } = useStyles();
+  const { currentUserTenant } = useAuth();
 
   // Fetching data
   const { securityPlatforms }: { securityPlatforms: SecurityPlatform[] } = useHelper((helper: SecurityPlatformHelper) => ({ securityPlatforms: helper.getSecurityPlatforms() }));
@@ -86,7 +89,7 @@ const SecurityPlatformField: FunctionComponent<Props> = ({
             <Box component="li" {...props} key={option.id}>
               <div className={classes.icon}>
                 <img
-                  src={`/api/images/security_platforms/id/${option.id}/${theme.palette.mode}`}
+                  src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/security_platforms/id/${option.id}/${theme.palette.mode}`}
                   alt={option.label}
                   style={{
                     width: 25,

--- a/openaev-front/src/components/fields/SecurityPlatformField.tsx
+++ b/openaev-front/src/components/fields/SecurityPlatformField.tsx
@@ -7,8 +7,7 @@ import { makeStyles } from 'tss-react/mui';
 import { type SecurityPlatformHelper } from '../../actions/assets/asset-helper';
 import { useHelper } from '../../store';
 import { type SecurityPlatform } from '../../utils/api-types';
-import useAuth from '../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../utils/tenant-url-helper';
+import { buildTenantApiPath } from '../../utils/tenant-url-helper';
 
 const useStyles = makeStyles()(() => ({
   icon: {
@@ -59,7 +58,6 @@ const SecurityPlatformField: FunctionComponent<Props> = ({
   // Standard hooks
   const theme = useTheme();
   const { classes } = useStyles();
-  const { currentUserTenant } = useAuth();
 
   // Fetching data
   const { securityPlatforms }: { securityPlatforms: SecurityPlatform[] } = useHelper((helper: SecurityPlatformHelper) => ({ securityPlatforms: helper.getSecurityPlatforms() }));
@@ -89,7 +87,7 @@ const SecurityPlatformField: FunctionComponent<Props> = ({
             <Box component="li" {...props} key={option.id}>
               <div className={classes.icon}>
                 <img
-                  src={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/images/security_platforms/id/${option.id}/${theme.palette.mode}`}
+                  src={buildTenantApiPath(`/api/tenants/images/security_platforms/id/${option.id}/${theme.palette.mode}`)}
                   alt={option.label}
                   style={{
                     width: 25,

--- a/openaev-front/src/components/fields/SecurityPlatformField.tsx
+++ b/openaev-front/src/components/fields/SecurityPlatformField.tsx
@@ -87,7 +87,7 @@ const SecurityPlatformField: FunctionComponent<Props> = ({
             <Box component="li" {...props} key={option.id}>
               <div className={classes.icon}>
                 <img
-                  src={buildTenantApiPath(`/api/tenants/images/security_platforms/id/${option.id}/${theme.palette.mode}`)}
+                  src={buildTenantApiPath(`/api/images/security_platforms/id/${option.id}/${theme.palette.mode}`)}
                   alt={option.label}
                   style={{
                     width: 25,

--- a/openaev-front/src/public/components/challenges/ChallengesPlayer.jsx
+++ b/openaev-front/src/public/components/challenges/ChallengesPlayer.jsx
@@ -40,7 +40,9 @@ import ItemTags from '../../../components/ItemTags';
 import Loader from '../../../components/Loader';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
+import useAuth from '../../../utils/hooks/useAuth.ts';
 import useSimulationPermissions from '../../../utils/permissions/useSimulationPermissions';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {
@@ -128,6 +130,7 @@ const ChallengesPlayer = () => {
   const theme = useTheme();
   const { classes } = useStyles();
   const dispatch = useDispatch();
+  const { currentUserTenant } = useAuth();
   const { t } = useFormatter();
   const [currentChallengeEntry, setCurrentChallengeEntry] = useState(null);
   const [currentResult, setCurrentResult] = useState(null);
@@ -385,7 +388,7 @@ const ChallengesPlayer = () => {
                           divider={true}
                           button={true}
                           component="a"
-                          href={`/api/documents/${document.document_id}/file`}
+                          href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
                         >
                           <ListItemIcon>
                             <AttachmentOutlined />

--- a/openaev-front/src/public/components/challenges/ChallengesPlayer.jsx
+++ b/openaev-front/src/public/components/challenges/ChallengesPlayer.jsx
@@ -40,9 +40,8 @@ import ItemTags from '../../../components/ItemTags';
 import Loader from '../../../components/Loader';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
-import useAuth from '../../../utils/hooks/useAuth.ts';
 import useSimulationPermissions from '../../../utils/permissions/useSimulationPermissions';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   root: {
@@ -130,7 +129,6 @@ const ChallengesPlayer = () => {
   const theme = useTheme();
   const { classes } = useStyles();
   const dispatch = useDispatch();
-  const { currentUserTenant } = useAuth();
   const { t } = useFormatter();
   const [currentChallengeEntry, setCurrentChallengeEntry] = useState(null);
   const [currentResult, setCurrentResult] = useState(null);
@@ -388,7 +386,7 @@ const ChallengesPlayer = () => {
                           divider={true}
                           button={true}
                           component="a"
-                          href={`/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/documents/${document.document_id}/file`}
+                          href={buildTenantApiPath(`/api/documents/${document.document_id}/file`)}
                         >
                           <ListItemIcon>
                             <AttachmentOutlined />

--- a/openaev-front/src/public/components/channels/ChannelMicroblogging.jsx
+++ b/openaev-front/src/public/components/channels/ChannelMicroblogging.jsx
@@ -8,8 +8,7 @@ import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../components/i18n';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
-import useAuth from '../../../utils/hooks/useAuth.ts';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   container: {
@@ -39,14 +38,13 @@ const ChannelMicroblogging = ({ channelReader }) => {
   const [userId] = useQueryParameter(['user']);
   const { t, fldt } = useFormatter();
   const isDark = theme.palette.mode === 'dark';
-  const { currentUserTenant } = useAuth();
   const {
     channel_exercise: exercise,
     channel_scenario: scenario,
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
+  const baseUri = buildTenantApiPath(`/api/player/${exercise?.exercise_id ?? scenario?.scenario_id}`);
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const queryParams = userId && userId.length > 0 && userId !== 'null' ? `?userId=${userId}` : '';

--- a/openaev-front/src/public/components/channels/ChannelMicroblogging.jsx
+++ b/openaev-front/src/public/components/channels/ChannelMicroblogging.jsx
@@ -8,6 +8,8 @@ import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../components/i18n';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
+import useAuth from '../../../utils/hooks/useAuth.ts';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   container: {
@@ -37,13 +39,14 @@ const ChannelMicroblogging = ({ channelReader }) => {
   const [userId] = useQueryParameter(['user']);
   const { t, fldt } = useFormatter();
   const isDark = theme.palette.mode === 'dark';
+  const { currentUserTenant } = useAuth();
   const {
     channel_exercise: exercise,
     channel_scenario: scenario,
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = `/api/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
+  const baseUri = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const queryParams = userId && userId.length > 0 && userId !== 'null' ? `?userId=${userId}` : '';

--- a/openaev-front/src/public/components/channels/ChannelNewspaper.jsx
+++ b/openaev-front/src/public/components/channels/ChannelNewspaper.jsx
@@ -45,7 +45,7 @@ const ChannelNewspaper = ({ channelReader }) => {
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = buildTenantApiPath(`/api/tenants/player/${exercise?.exercise_id ?? scenario?.scenario_id}`);
+  const baseUri = buildTenantApiPath(`/api/player/${exercise?.exercise_id ?? scenario?.scenario_id}`);
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const firstArticle = R.head(articles) || null;

--- a/openaev-front/src/public/components/channels/ChannelNewspaper.jsx
+++ b/openaev-front/src/public/components/channels/ChannelNewspaper.jsx
@@ -11,6 +11,8 @@ import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../components/i18n';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
+import useAuth from '../../../utils/hooks/useAuth.ts';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   container: {
@@ -38,13 +40,14 @@ const ChannelNewspaper = ({ channelReader }) => {
   const [userId] = useQueryParameter(['user']);
   const [currentArticle, setCurrentArticle] = useState(null);
   const isDark = theme.palette.mode === 'dark';
+  const { currentUserTenant } = useAuth();
   const {
     channel_exercise: exercise,
     channel_scenario: scenario,
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = `/api/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
+  const baseUri = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const firstArticle = R.head(articles) || null;

--- a/openaev-front/src/public/components/channels/ChannelNewspaper.jsx
+++ b/openaev-front/src/public/components/channels/ChannelNewspaper.jsx
@@ -11,8 +11,7 @@ import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../components/i18n';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
-import useAuth from '../../../utils/hooks/useAuth.ts';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   container: {
@@ -40,14 +39,13 @@ const ChannelNewspaper = ({ channelReader }) => {
   const [userId] = useQueryParameter(['user']);
   const [currentArticle, setCurrentArticle] = useState(null);
   const isDark = theme.palette.mode === 'dark';
-  const { currentUserTenant } = useAuth();
   const {
     channel_exercise: exercise,
     channel_scenario: scenario,
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
+  const baseUri = buildTenantApiPath(`/api/tenants/player/${exercise?.exercise_id ?? scenario?.scenario_id}`);
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const firstArticle = R.head(articles) || null;

--- a/openaev-front/src/public/components/channels/ChannelTvChannel.jsx
+++ b/openaev-front/src/public/components/channels/ChannelTvChannel.jsx
@@ -9,6 +9,8 @@ import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../components/i18n';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
+import useAuth from '../../../utils/hooks/useAuth.ts';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   container: {
@@ -35,13 +37,14 @@ const ChannelTvChannel = ({ channelReader }) => {
   const { t, fldt } = useFormatter();
   const [userId] = useQueryParameter(['user']);
   const isDark = theme.palette.mode === 'dark';
+  const { currentUserTenant } = useAuth();
   const {
     channel_exercise: exercise,
     channel_scenario: scenario,
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = `/api/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
+  const baseUri = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const firstArticle = R.head(articles) || null;

--- a/openaev-front/src/public/components/channels/ChannelTvChannel.jsx
+++ b/openaev-front/src/public/components/channels/ChannelTvChannel.jsx
@@ -9,8 +9,7 @@ import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
 import { useFormatter } from '../../../components/i18n';
 import { useHelper } from '../../../store';
 import { useQueryParameter } from '../../../utils/Environment';
-import useAuth from '../../../utils/hooks/useAuth.ts';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper.ts';
+import { buildTenantApiPath } from '../../../utils/tenant-url-helper.ts';
 
 const useStyles = makeStyles()(() => ({
   container: {
@@ -37,14 +36,13 @@ const ChannelTvChannel = ({ channelReader }) => {
   const { t, fldt } = useFormatter();
   const [userId] = useQueryParameter(['user']);
   const isDark = theme.palette.mode === 'dark';
-  const { currentUserTenant } = useAuth();
   const {
     channel_exercise: exercise,
     channel_scenario: scenario,
     channel_articles: articles,
     channel_information: channel,
   } = channelReader;
-  const baseUri = `/api/tenants/${currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID}/player/${exercise?.exercise_id ?? scenario?.scenario_id}`;
+  const baseUri = buildTenantApiPath(`/api/player/${exercise?.exercise_id ?? scenario?.scenario_id}`);
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
   const logo = isDark ? channel.channel_logo_dark : channel.channel_logo_light;
   const firstArticle = R.head(articles) || null;

--- a/openaev-front/src/utils/tenant-api-migration.ts
+++ b/openaev-front/src/utils/tenant-api-migration.ts
@@ -5,21 +5,12 @@
  * As each BE controller is migrated, remove the corresponding prefix(es).
  * Once this list is empty, all tenant-scoped APIs are fully migrated.
  *
- * PR1 — Tags ✅ DONE
- * PR2 — Scenarios & Exercises core
- * PR3 — Injects & Inject lifecycle
  * PR4 — Teams & Players
- * PR5 — Assets
- * PR6 — Components (Channels, Challenges, Payloads, Documents)
  * PR7 — Findings, Expectations & Lessons
  * PR8 — Integrations (Injectors, Collectors, Executors, Connectors)
  * PR9 — Reference data & Misc
  */
 const TENANT_MIGRATION_TODO: string[] = [
-  // PR3 — Injects & Inject lifecycle
-  '/api/injector_contracts',
-  '/api/atomic-testings',
-  '/api/inject-expectations-traces',
   // PR4 — Teams & Players
   '/api/teams',
   '/api/players',

--- a/openaev-front/src/utils/tenant-api-migration.ts
+++ b/openaev-front/src/utils/tenant-api-migration.ts
@@ -24,11 +24,6 @@ const TENANT_MIGRATION_TODO: string[] = [
   '/api/teams',
   '/api/players',
   '/api/organizations',
-  // PR6 — Components
-  '/api/channels',
-  '/api/challenges',
-  '/api/payloads',
-  '/api/documents',
   // PR7 — Findings, Expectations & Lessons
   '/api/findings',
   '/api/detection-remediations',

--- a/openaev-front/src/utils/tenant-url-helper.ts
+++ b/openaev-front/src/utils/tenant-url-helper.ts
@@ -129,7 +129,6 @@ const TENANT_EXEMPT_PREFIXES = [
   '/api/settings',
   '/api/tenants',
   '/api/logs',
-  '/api/images',
   '/api/platform-groups',
   '/api/platform-roles',
 ];


### PR DESCRIPTION
### Proposed changes

* Manage tenant_id for Back/Front API (/api/channels, /api/challenges, /api/payloads, /api/documents)

### Testing Instructions

1. OpenAEV must work as before
2. If you create a simulation with a channel/document/player for the tenant A, you must not see it for the tenant B

### Related issues

* #4864

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
