### PR TITLE
[frontend] fix(multi-tenancy): shared localStorage (#4864)

### DIFF
--- a/openaev-front/src/__tests__/utils/tenant-url-helper.test.ts
+++ b/openaev-front/src/__tests__/utils/tenant-url-helper.test.ts
@@ -376,107 +376,150 @@ describe('tenant-url-helper', () => {
   // -- getCurrentTenantId --
 
   describe('getCurrentTenantId', () => {
-    it('given valid tenant in storage should return stored tenant id', async () => {
-      // Arrange
-      const tenant = {
-        tenant_id: VALID_UUID,
-        tenant_name: 'Test',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
-      const { getCurrentTenantId } = await importHelper();
+    describe('URL-first resolution (multi-tab safe)', () => {
+      it('given tenant UUID in URL should return it (ignoring localStorage)', async () => {
+        // Arrange — URL has tenant A, localStorage has tenant B
+        setPathname(`/${VALID_UUID}/admin/scenarios`);
+        const tenant = {
+          tenant_id: ANOTHER_UUID,
+          tenant_name: 'Other',
+        };
+        localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+        const { getCurrentTenantId } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(VALID_UUID);
+        // Assert — URL wins over localStorage
+        expect(result).toBe(VALID_UUID);
+      });
+
+      it('given tenant UUID in URL and empty storage should return URL tenant', async () => {
+        // Arrange
+        setPathname(`/${VALID_UUID}/admin`);
+        const { getCurrentTenantId } = await importHelper();
+
+        // Act
+        const result = getCurrentTenantId();
+
+        // Assert
+        expect(result).toBe(VALID_UUID);
+      });
     });
 
-    it('given empty storage should return default tenant UUID', async () => {
-      // Arrange
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+    describe('localStorage fallback (early bootstrap / public pages)', () => {
+      it('given no tenant in URL and valid tenant in storage should return stored tenant id', async () => {
+        // Arrange — public page URL (no tenant segment)
+        setPathname('/login');
+        const tenant = {
+          tenant_id: VALID_UUID,
+          tenant_name: 'Test',
+        };
+        localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+        const { getCurrentTenantId } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
+        // Assert
+        expect(result).toBe(VALID_UUID);
+      });
+
+      it('given no tenant in URL and different tenant stored should return that tenant id', async () => {
+        // Arrange
+        setPathname('/');
+        const tenant = {
+          tenant_id: ANOTHER_UUID,
+          tenant_name: 'Another',
+        };
+        localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+        const { getCurrentTenantId } = await importHelper();
+
+        // Act
+        const result = getCurrentTenantId();
+
+        // Assert
+        expect(result).toBe(ANOTHER_UUID);
+      });
     });
 
-    it('given malformed JSON in storage should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', '{not valid json');
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+    describe('default fallback', () => {
+      it('given no tenant in URL and empty storage should return default tenant UUID', async () => {
+        // Arrange
+        setPathname('/');
+        const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
+        // Assert
+        expect(result).toBe(DEFAULT_TENANT_UUID);
+      });
 
-    it('given stored object without tenant id should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', JSON.stringify({ tenant_name: 'No ID' }));
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+      it('given no tenant in URL and malformed JSON in storage should return default tenant UUID', async () => {
+        // Arrange
+        setPathname('/');
+        localStorage.setItem('current-tenant-storage', '{not valid json');
+        const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
+        // Assert
+        expect(result).toBe(DEFAULT_TENANT_UUID);
+      });
 
-    it('given empty tenant id should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', JSON.stringify({ tenant_id: '' }));
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+      it('given no tenant in URL and stored object without tenant id should return default tenant UUID', async () => {
+        // Arrange
+        setPathname('/');
+        localStorage.setItem('current-tenant-storage', JSON.stringify({ tenant_name: 'No ID' }));
+        const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
+        // Assert
+        expect(result).toBe(DEFAULT_TENANT_UUID);
+      });
 
-    it('given stored null value should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', 'null');
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+      it('given no tenant in URL and empty tenant id in storage should return default tenant UUID', async () => {
+        // Arrange
+        setPathname('/');
+        localStorage.setItem('current-tenant-storage', JSON.stringify({ tenant_id: '' }));
+        const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
+        // Assert
+        expect(result).toBe(DEFAULT_TENANT_UUID);
+      });
 
-    it('given stored empty string should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', '');
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+      it('given no tenant in URL and stored null value should return default tenant UUID', async () => {
+        // Arrange
+        setPathname('/');
+        localStorage.setItem('current-tenant-storage', 'null');
+        const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
+        // Assert
+        expect(result).toBe(DEFAULT_TENANT_UUID);
+      });
 
-    it('given different tenant stored should return that tenant id', async () => {
-      // Arrange
-      const tenant = {
-        tenant_id: ANOTHER_UUID,
-        tenant_name: 'Another',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
-      const { getCurrentTenantId } = await importHelper();
+      it('given no tenant in URL and stored empty string should return default tenant UUID', async () => {
+        // Arrange
+        setPathname('/');
+        localStorage.setItem('current-tenant-storage', '');
+        const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
 
-      // Act
-      const result = getCurrentTenantId();
+        // Act
+        const result = getCurrentTenantId();
 
-      // Assert
-      expect(result).toBe(ANOTHER_UUID);
+        // Assert
+        expect(result).toBe(DEFAULT_TENANT_UUID);
+      });
     });
   });
 

--- a/openaev-front/src/utils/hooks/useTenant.ts
+++ b/openaev-front/src/utils/hooks/useTenant.ts
@@ -6,7 +6,7 @@ import { fetchUserTenants } from '../../actions/user/user-tenant-actions';
 import { TENANT_SWITCH_SUCCESS } from '../../constants/ActionTypes';
 import { type TenantOutput, type User } from '../api-types';
 import { useAppDispatch } from '../hooks';
-import { buildTenantUrl, TENANT_STORAGE_KEY } from '../tenant-url-helper';
+import { buildTenantUrl, extractTenantFromUrl, TENANT_STORAGE_KEY } from '../tenant-url-helper';
 
 /**
  * Internal hook that encapsulates the current-tenant state and
@@ -62,8 +62,12 @@ const useTenant = (me: User | undefined, logged: unknown) => {
         setTenant(newCurrentTenant);
         setCurrentTenantStorage(newCurrentTenant);
       } else {
-        // Otherwise, if local storage tenant is still valid use it, otherwise switch to first tenant in list
-        const currentTenant = tenants.find(tenant => (tenant.tenant_id === currentTenantStorage?.tenant_id));
+        // Resolve tenant: URL first (per-tab, multi-tab safe), then localStorage fallback.
+        // Without this, switching tenant in Tab 1 would corrupt the tenant shown in Tab 2 on refresh
+        // because localStorage is shared across tabs.
+        const urlTenantId = extractTenantFromUrl();
+        const preferredTenantId = urlTenantId ?? currentTenantStorage?.tenant_id;
+        const currentTenant = tenants.find(tenant => tenant.tenant_id === preferredTenantId);
         if (currentTenant) {
           setTenant(currentTenant);
           setCurrentTenantStorage(currentTenant);

--- a/openaev-front/src/utils/tenant-url-helper.ts
+++ b/openaev-front/src/utils/tenant-url-helper.ts
@@ -92,14 +92,29 @@ export const buildTenantUrl = (
 };
 
 // ---------------------------------------------------------------------------
-// Tenant ID resolution — reading tenant from local storage
+// Tenant ID resolution — URL first, localStorage fallback
 // ---------------------------------------------------------------------------
 
 /**
- * Reads the current tenant ID from local storage.
- * Falls back to DEFAULT_TENANT_UUID when nothing is stored.
+ * Returns the current tenant ID.
+ *
+ * Resolution order (first non-null wins):
+ *  1. URL pathname — per-tab, always accurate (multi-tab safe)
+ *  2. localStorage — shared across tabs, used only during early
+ *     bootstrap before the URL contains the tenant segment
+ *  3. DEFAULT_TENANT_UUID — ultimate fallback
+ *
+ * ⚠️  localStorage alone was racy: switching tenant in one tab
+ *     silently affected every other tab's API calls.
  */
 export const getCurrentTenantId = (): string => {
+  // 1. URL is the source of truth (per-tab, no cross-tab leak)
+  const fromUrl = extractTenantFromUrl();
+  if (fromUrl) {
+    return fromUrl;
+  }
+
+  // 2. Fallback to localStorage (early bootstrap / public pages)
   try {
     const tenantRaw = localStorage.getItem(TENANT_STORAGE_KEY);
     if (tenantRaw) {
@@ -111,6 +126,7 @@ export const getCurrentTenantId = (): string => {
   } catch {
     // malformed JSON — fall back
   }
+
   return DEFAULT_TENANT_UUID;
 };
 


### PR DESCRIPTION


### Proposed changes
Fix the multi-tab bug (no fully covered in PR#1
Tab 1: tenant A → localStorage = tenant A
Tab 2: tenant B → localStorage = tenant B  ← overwrites tenant A
Tab 1: makes an API call → reads localStorage → sends to tenant B ❌
localStorage is shared across all tabs of the same origin. As soon as one tab switches tenant, all other tabs use the wrong tenant for their API calls.

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
