### PR TITLE
[frontend] fix(multi-tenancy): remove localStorage (#4864)

### DIFF
--- a/openaev-front/src/__tests__/utils/hooks/UseTenant.test.tsx
+++ b/openaev-front/src/__tests__/utils/hooks/UseTenant.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { type ReactNode } from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TENANT_SWITCH_SUCCESS } from '../../../constants/ActionTypes';
 import { type TenantOutput, type User } from '../../../utils/api-types';

--- a/openaev-front/src/__tests__/utils/hooks/UseTenant.test.tsx
+++ b/openaev-front/src/__tests__/utils/hooks/UseTenant.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TENANT_SWITCH_SUCCESS } from '../../../constants/ActionTypes';
 import { type TenantOutput, type User } from '../../../utils/api-types';
-import { TENANT_STORAGE_KEY } from '../../../utils/tenant-url-helper';
 
 // -- MOCKS --
 
@@ -100,7 +99,7 @@ const mockTenantsResponse = (tenants: TenantOutput[]) => {
 describe('useTenant', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
+    mockExtractTenantFromUrl.mockReturnValue(null);
     // Reset window.location.href tracking
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -109,10 +108,6 @@ describe('useTenant', () => {
         href: '',
       },
     });
-  });
-
-  afterEach(() => {
-    localStorage.clear();
   });
 
   // We must lazily import to ensure mocks are applied before module init
@@ -189,83 +184,11 @@ describe('useTenant', () => {
     });
   });
 
-  // -- LOCAL STORAGE PERSISTENCE --
+  // -- URL-BASED TENANT RESOLUTION (multi-tab safe) --
 
-  describe('Local storage persistence', () => {
-    it('given_validTenantInStorage_should_selectStoredTenant', async () => {
-      // Arrange
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_BETA));
-      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA, TENANT_GAMMA]);
-      const useTenant = await importUseTenant();
-
-      // Act
-      const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
-
-      // Assert
-      await waitFor(() => {
-        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_BETA.tenant_id);
-      });
-    });
-
-    it('given_invalidTenantInStorage_should_fallbackToFirstTenant', async () => {
-      // Arrange
-      const stale: TenantOutput = {
-        tenant_id: 'stale-tenant-id',
-        tenant_name: 'Stale',
-      };
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(stale));
-      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
-      const useTenant = await importUseTenant();
-
-      // Act
-      const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
-
-      // Assert
-      await waitFor(() => {
-        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
-      });
-    });
-
-    it('given_selectedTenant_should_persistToLocalStorage', async () => {
-      // Arrange
-      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
-      const useTenant = await importUseTenant();
-
-      // Act
-      renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
-
-      // Assert
-      await waitFor(() => {
-        const stored = localStorage.getItem(TENANT_STORAGE_KEY);
-        expect(stored).not.toBeNull();
-        const parsed = JSON.parse(stored!);
-        expect(parsed.tenant_id).toBe(TENANT_ALPHA.tenant_id);
-      });
-    });
-
-    it('given_emptyTenants_should_clearLocalStorage', async () => {
-      // Arrange
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_ALPHA));
-      mockTenantsResponse([]);
-      const useTenant = await importUseTenant();
-
-      // Act
-      renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
-
-      // Assert
-      await waitFor(() => {
-        const stored = localStorage.getItem(TENANT_STORAGE_KEY);
-        expect(stored === null || stored === 'null').toBe(true);
-      });
-    });
-  });
-
-  // -- DISPATCH TENANT_SWITCH_SUCCESS --
-
-  describe('URL-based tenant resolution (cross-tab)', () => {
-    it('given_urlTenantDiffersFromStorage_should_selectUrlTenant', async () => {
-      // Arrange — simulate: Tab 2 switched to BETA (localStorage), but Tab 1 URL has ALPHA
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_BETA));
+  describe('URL-based tenant resolution', () => {
+    it('given_tenantInUrl_should_selectUrlTenant', async () => {
+      // Arrange — URL has ALPHA tenant
       mockExtractTenantFromUrl.mockReturnValue(TENANT_ALPHA.tenant_id);
       mockTenantsResponse([TENANT_ALPHA, TENANT_BETA, TENANT_GAMMA]);
       const useTenant = await importUseTenant();
@@ -273,15 +196,29 @@ describe('useTenant', () => {
       // Act
       const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
 
-      // Assert — URL tenant (ALPHA) must win over localStorage (BETA)
+      // Assert — should select URL tenant (ALPHA)
       await waitFor(() => {
         expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
       });
     });
 
-    it('given_noTenantInUrl_should_fallbackToStorage', async () => {
-      // Arrange — no tenant UUID in URL, valid tenant in localStorage
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_BETA));
+    it('given_differentTenantInUrl_should_selectUrlTenant', async () => {
+      // Arrange — URL has BETA tenant
+      mockExtractTenantFromUrl.mockReturnValue(TENANT_BETA.tenant_id);
+      mockTenantsResponse([TENANT_ALPHA, TENANT_BETA, TENANT_GAMMA]);
+      const useTenant = await importUseTenant();
+
+      // Act
+      const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
+
+      // Assert — should select URL tenant (BETA)
+      await waitFor(() => {
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_BETA.tenant_id);
+      });
+    });
+
+    it('given_noTenantInUrl_should_fallbackToFirstTenant', async () => {
+      // Arrange — no tenant UUID in URL (e.g. post-login at "/")
       mockExtractTenantFromUrl.mockReturnValue(null);
       mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
       const useTenant = await importUseTenant();
@@ -289,15 +226,14 @@ describe('useTenant', () => {
       // Act
       const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
 
-      // Assert — should fall back to localStorage (BETA)
+      // Assert — should fall back to first tenant (ALPHA)
       await waitFor(() => {
-        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_BETA.tenant_id);
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
       });
     });
 
-    it('given_urlTenantNotInList_should_fallbackToStorage', async () => {
+    it('given_urlTenantNotInList_should_fallbackToFirstTenant', async () => {
       // Arrange — URL has a tenant UUID that is not in the user's tenant list
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_ALPHA));
       mockExtractTenantFromUrl.mockReturnValue('unknown-tenant-id');
       mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
       const useTenant = await importUseTenant();
@@ -305,12 +241,14 @@ describe('useTenant', () => {
       // Act
       const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
 
-      // Assert — should fall back to localStorage (ALPHA)
+      // Assert — should fall back to first tenant (ALPHA)
       await waitFor(() => {
         expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
       });
     });
   });
+
+  // -- DISPATCH TENANT_SWITCH_SUCCESS --
 
   describe('Dispatch TENANT_SWITCH_SUCCESS', () => {
     it('given_tenantLoad_should_dispatchTenantSwitchSuccess', async () => {
@@ -455,16 +393,15 @@ describe('useTenant', () => {
       });
     });
 
-    it('given_reloadWithNonexistentPreferredId_should_keepStoredTenant', async () => {
+    it('given_reloadWithNonexistentPreferredId_should_fallbackToFirstTenant', async () => {
       // Arrange
-      localStorage.setItem(TENANT_STORAGE_KEY, JSON.stringify(TENANT_BETA));
       mockTenantsResponse([TENANT_ALPHA, TENANT_BETA]);
       const useTenant = await importUseTenant();
 
       const { result } = renderHook(() => useTenant(MOCK_USER, true), { wrapper: createWrapper() });
 
       await waitFor(() => {
-        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_BETA.tenant_id);
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
       });
 
       // Arrange — reload with a nonexistent preferred tenant
@@ -475,10 +412,10 @@ describe('useTenant', () => {
         await result.current.reloadUserTenants('nonexistent-id');
       });
 
-      // Assert
+      // Assert — should fall back to first tenant since preferred doesn't exist
+      // and URL has no tenant (mockExtractTenantFromUrl returns null)
       await waitFor(() => {
-        // Should fall back to the stored tenant (TENANT_BETA) since preferred doesn't exist
-        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_BETA.tenant_id);
+        expect(result.current.currentUserTenant?.tenant_id).toBe(TENANT_ALPHA.tenant_id);
       });
     });
   });

--- a/openaev-front/src/__tests__/utils/tenant-url-helper.test.ts
+++ b/openaev-front/src/__tests__/utils/tenant-url-helper.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // -- MOCKS --
 

--- a/openaev-front/src/__tests__/utils/tenant-url-helper.test.ts
+++ b/openaev-front/src/__tests__/utils/tenant-url-helper.test.ts
@@ -33,13 +33,8 @@ const setPathname = (pathname: string) => {
 describe('tenant-url-helper', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
     mockAppBasePath = '';
     setPathname('/');
-  });
-
-  afterEach(() => {
-    localStorage.clear();
   });
 
   // Lazy import so mocks are applied
@@ -48,14 +43,6 @@ describe('tenant-url-helper', () => {
   // -- CONSTANTS --
 
   describe('Constants', () => {
-    it('given import should export TenantStorageKey', async () => {
-      // Act
-      const { TENANT_STORAGE_KEY } = await importHelper();
-
-      // Assert
-      expect(TENANT_STORAGE_KEY).toBe('current-tenant-storage');
-    });
-
     it('given import should export DefaultTenantUuid', async () => {
       // Act
       const { DEFAULT_TENANT_UUID } = await importHelper();
@@ -373,16 +360,12 @@ describe('tenant-url-helper', () => {
     });
   });
 
-  // -- getCurrentTenantId --
+  // -- getCurrentTenantId (URL-only, no localStorage) --
 
   describe('getCurrentTenantId', () => {
-    it('given valid tenant in storage should return stored tenant id', async () => {
+    it('given tenant UUID in URL should return it', async () => {
       // Arrange
-      const tenant = {
-        tenant_id: VALID_UUID,
-        tenant_name: 'Test',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+      setPathname(`/${VALID_UUID}/admin/scenarios`);
       const { getCurrentTenantId } = await importHelper();
 
       // Act
@@ -392,84 +375,9 @@ describe('tenant-url-helper', () => {
       expect(result).toBe(VALID_UUID);
     });
 
-    it('given empty storage should return default tenant UUID', async () => {
+    it('given different tenant UUID in URL should return it', async () => {
       // Arrange
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
-
-      // Act
-      const result = getCurrentTenantId();
-
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
-
-    it('given malformed JSON in storage should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', '{not valid json');
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
-
-      // Act
-      const result = getCurrentTenantId();
-
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
-
-    it('given stored object without tenant id should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', JSON.stringify({ tenant_name: 'No ID' }));
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
-
-      // Act
-      const result = getCurrentTenantId();
-
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
-
-    it('given empty tenant id should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', JSON.stringify({ tenant_id: '' }));
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
-
-      // Act
-      const result = getCurrentTenantId();
-
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
-
-    it('given stored null value should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', 'null');
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
-
-      // Act
-      const result = getCurrentTenantId();
-
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
-
-    it('given stored empty string should return default tenant UUID', async () => {
-      // Arrange
-      localStorage.setItem('current-tenant-storage', '');
-      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
-
-      // Act
-      const result = getCurrentTenantId();
-
-      // Assert
-      expect(result).toBe(DEFAULT_TENANT_UUID);
-    });
-
-    it('given different tenant stored should return that tenant id', async () => {
-      // Arrange
-      const tenant = {
-        tenant_id: ANOTHER_UUID,
-        tenant_name: 'Another',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+      setPathname(`/${ANOTHER_UUID}/admin`);
       const { getCurrentTenantId } = await importHelper();
 
       // Act
@@ -478,18 +386,51 @@ describe('tenant-url-helper', () => {
       // Assert
       expect(result).toBe(ANOTHER_UUID);
     });
+
+    it('given no tenant in URL should return default tenant UUID', async () => {
+      // Arrange
+      setPathname('/login');
+      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+
+      // Act
+      const result = getCurrentTenantId();
+
+      // Assert
+      expect(result).toBe(DEFAULT_TENANT_UUID);
+    });
+
+    it('given root path should return default tenant UUID', async () => {
+      // Arrange
+      setPathname('/');
+      const { getCurrentTenantId, DEFAULT_TENANT_UUID } = await importHelper();
+
+      // Act
+      const result = getCurrentTenantId();
+
+      // Assert
+      expect(result).toBe(DEFAULT_TENANT_UUID);
+    });
+
+    it('given base path with tenant UUID should return it', async () => {
+      // Arrange
+      mockAppBasePath = '/app';
+      setPathname(`/app/${VALID_UUID}/admin`);
+      const { getCurrentTenantId } = await importHelper();
+
+      // Act
+      const result = getCurrentTenantId();
+
+      // Assert
+      expect(result).toBe(VALID_UUID);
+    });
   });
 
   // -- buildTenantApiPath --
 
   describe('buildTenantApiPath', () => {
-    it('given API path and stored tenant should build scoped API URI', async () => {
+    it('given API path and tenant in URL should build scoped API URI', async () => {
       // Arrange
-      const tenant = {
-        tenant_id: VALID_UUID,
-        tenant_name: 'Test',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+      setPathname(`/${VALID_UUID}/admin/tags`);
       const { buildTenantApiPath } = await importHelper();
 
       // Act
@@ -499,8 +440,9 @@ describe('tenant-url-helper', () => {
       expect(result).toBe(`/api/tenants/${VALID_UUID}/tags`);
     });
 
-    it('given API path and no stored tenant should use default tenant UUID', async () => {
+    it('given API path and no tenant in URL should use default tenant UUID', async () => {
       // Arrange
+      setPathname('/');
       const { buildTenantApiPath, DEFAULT_TENANT_UUID } = await importHelper();
 
       // Act
@@ -512,11 +454,7 @@ describe('tenant-url-helper', () => {
 
     it('given nested API path should build correct URI', async () => {
       // Arrange
-      const tenant = {
-        tenant_id: VALID_UUID,
-        tenant_name: 'Test',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+      setPathname(`/${VALID_UUID}/admin`);
       const { buildTenantApiPath } = await importHelper();
 
       // Act
@@ -528,11 +466,7 @@ describe('tenant-url-helper', () => {
 
     it('given API path with id parameter should build correct URI', async () => {
       // Arrange
-      const tenant = {
-        tenant_id: VALID_UUID,
-        tenant_name: 'Test',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+      setPathname(`/${VALID_UUID}/admin`);
       const tagId = faker.string.uuid();
       const { buildTenantApiPath } = await importHelper();
 
@@ -556,11 +490,7 @@ describe('tenant-url-helper', () => {
 
     it('given exempt prefix should return unchanged', async () => {
       // Arrange
-      const tenant = {
-        tenant_id: VALID_UUID,
-        tenant_name: 'Test',
-      };
-      localStorage.setItem('current-tenant-storage', JSON.stringify(tenant));
+      setPathname(`/${VALID_UUID}/admin`);
       const { buildTenantApiPath } = await importHelper();
 
       // Act

--- a/openaev-front/src/root.tsx
+++ b/openaev-front/src/root.tsx
@@ -23,7 +23,7 @@ import { UserContext } from './utils/hooks/useAuth';
 import useNetworkCheck from './utils/hooks/useCheckNetwork';
 import useTenant from './utils/hooks/useTenant';
 import PermissionsProvider from './utils/permissions/PermissionsProvider';
-import { buildTenantUrl, extractTenantFromUrl } from './utils/tenant-url-helper';
+import { buildTenantUrl, DEFAULT_TENANT_UUID, extractTenantFromUrl } from './utils/tenant-url-helper';
 
 const RootPublic = lazy(() => import('./public/Root'));
 const IndexPrivate = lazy(() => import('./private/Index'));
@@ -71,11 +71,8 @@ const Root = () => {
   // (e.g. first visit at "/", or right after login), hard-redirect to
   // the tenant-prefixed URL so BrowserRouter picks up the correct basename.
   if (!extractTenantFromUrl()) {
-    if (!currentUserTenant) {
-      // useTenant is still fetching — show loader until we have a tenant
-      return <Loader />;
-    }
-    window.location.href = buildTenantUrl(currentUserTenant.tenant_id);
+    const tenantId = currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID;
+    window.location.href = buildTenantUrl(tenantId);
     return <Loader />;
   }
 

--- a/openaev-front/src/root.tsx
+++ b/openaev-front/src/root.tsx
@@ -23,7 +23,7 @@ import { UserContext } from './utils/hooks/useAuth';
 import useNetworkCheck from './utils/hooks/useCheckNetwork';
 import useTenant from './utils/hooks/useTenant';
 import PermissionsProvider from './utils/permissions/PermissionsProvider';
-import { buildTenantUrl, extractTenantFromUrl, getCurrentTenantId } from './utils/tenant-url-helper';
+import { buildTenantUrl, extractTenantFromUrl } from './utils/tenant-url-helper';
 
 const RootPublic = lazy(() => import('./public/Root'));
 const IndexPrivate = lazy(() => import('./private/Index'));
@@ -70,10 +70,12 @@ const Root = () => {
   // When the user is authenticated but the URL has no tenant prefix
   // (e.g. first visit at "/", or right after login), hard-redirect to
   // the tenant-prefixed URL so BrowserRouter picks up the correct basename.
-  // buildTenantUrl() preserves the current deep link path, search and hash.
   if (!extractTenantFromUrl()) {
-    const tenantId = currentUserTenant?.tenant_id ?? getCurrentTenantId();
-    window.location.href = buildTenantUrl(tenantId);
+    if (!currentUserTenant) {
+      // useTenant is still fetching — show loader until we have a tenant
+      return <Loader />;
+    }
+    window.location.href = buildTenantUrl(currentUserTenant.tenant_id);
     return <Loader />;
   }
 

--- a/openaev-front/src/utils/hooks/useTenant.ts
+++ b/openaev-front/src/utils/hooks/useTenant.ts
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
-import { useLocalStorage } from 'usehooks-ts';
 
 import { fetchUserTenants } from '../../actions/user/user-tenant-actions';
 import { TENANT_SWITCH_SUCCESS } from '../../constants/ActionTypes';
 import { type TenantOutput, type User } from '../api-types';
 import { useAppDispatch } from '../hooks';
-import { buildTenantUrl, extractTenantFromUrl, TENANT_STORAGE_KEY } from '../tenant-url-helper';
+import { buildTenantUrl, extractTenantFromUrl } from '../tenant-url-helper';
 
 /**
  * Internal hook that encapsulates the current-tenant state and
@@ -37,12 +36,14 @@ const useTenantState = () => {
 /**
  * Hook that manages the full tenant lifecycle:
  * - Fetches the tenants accessible to the current user
- * - Persists the selected tenant in local storage
- * - Provides a switch function to change the active tenant
+ * - Resolves the current tenant from the URL (per-tab, multi-tab safe)
+ * - Provides a switch function that navigates to the new tenant URL
+ *
+ * After login (when the URL has no tenant segment yet), the hook
+ * falls back to the first tenant in the user's tenant list.
  */
 const useTenant = (me: User | undefined, logged: unknown) => {
   const [userTenants, setUserTenants] = useState<TenantOutput[]>([]);
-  const [currentTenantStorage, setCurrentTenantStorage] = useLocalStorage<TenantOutput | null>(TENANT_STORAGE_KEY, null);
   const { currentUserTenant, setTenant } = useTenantState();
   const location = useLocation();
 
@@ -60,32 +61,25 @@ const useTenant = (me: User | undefined, logged: unknown) => {
         : undefined;
       if (newCurrentTenant) {
         setTenant(newCurrentTenant);
-        setCurrentTenantStorage(newCurrentTenant);
       } else {
-        // Otherwise, if local storage tenant is still valid use it, otherwise switch to first tenant in list
-        const currentTenant = tenants.find(tenant => (tenant.tenant_id === currentTenantStorage?.tenant_id));
-        if (currentTenant) {
-          setTenant(currentTenant);
-          setCurrentTenantStorage(currentTenant);
-        } else {
-          setTenant(tenants[0]);
-          setCurrentTenantStorage(tenants[0]);
-        }
+        // Resolve tenant from URL (per-tab, multi-tab safe).
+        // Falls back to the first tenant in the list (post-login / public pages).
+        const urlTenantId = extractTenantFromUrl();
+        const currentTenant = urlTenantId
+          ? tenants.find(tenant => tenant.tenant_id === urlTenantId)
+          : undefined;
+        setTenant(currentTenant ?? tenants[0]);
       }
     } else {
       setUserTenants([]);
       setTenant(null);
-      setCurrentTenantStorage(null);
     }
   }, [me]);
 
   useEffect(() => {
     if (me && logged) {
-      // On page load / hard refresh the URL is the source of truth for
-      // which tenant the user is working in.  localStorage is shared
-      // across tabs, so another tab's tenant switch can leave a stale
-      // value there.  By reading the tenant UUID from the URL we make
-      // sure TenantSwitcher displays the tenant that matches the URL.
+      // On page load / hard refresh the URL is the source of truth.
+      // Pass the URL tenant ID so loadUserTenants selects the right one.
       const urlTenantId = extractTenantFromUrl() ?? undefined;
       loadUserTenants(urlTenantId);
     }
@@ -103,10 +97,9 @@ const useTenant = (me: User | undefined, logged: unknown) => {
     const current = userTenants.find(t => (t.tenant_id === tenantId));
     if (current) {
       setTenant(current);
-      setCurrentTenantStorage(current);
       window.location.href = buildTenantUrl(tenantId, location.pathname, location.search, location.hash);
     }
-  }, [currentUserTenant, userTenants, setCurrentTenantStorage, setTenant, location]);
+  }, [currentUserTenant, userTenants, setTenant, location]);
 
   return {
     userTenants,

--- a/openaev-front/src/utils/tenant-url-helper.ts
+++ b/openaev-front/src/utils/tenant-url-helper.ts
@@ -8,7 +8,6 @@ import TENANT_MIGRATION_TODO from './tenant-api-migration';
  */
 export const TENANT_URI = '/api/tenants';
 
-
 /**
  * Default tenant UUID used as fallback when no tenant has been selected yet.
  * Must match Tenant.DEFAULT_TENANT_UUID on the backend.

--- a/openaev-front/src/utils/tenant-url-helper.ts
+++ b/openaev-front/src/utils/tenant-url-helper.ts
@@ -8,11 +8,6 @@ import TENANT_MIGRATION_TODO from './tenant-api-migration';
  */
 export const TENANT_URI = '/api/tenants';
 
-/**
- * Local-storage key used to persist the selected tenant.
- * Shared between tenant-url-helper and useTenant hook.
- */
-export const TENANT_STORAGE_KEY = 'current-tenant-storage';
 
 /**
  * Default tenant UUID used as fallback when no tenant has been selected yet.
@@ -92,26 +87,16 @@ export const buildTenantUrl = (
 };
 
 // ---------------------------------------------------------------------------
-// Tenant ID resolution — reading tenant from local storage
+// Tenant ID resolution — URL only (no localStorage)
 // ---------------------------------------------------------------------------
 
 /**
- * Reads the current tenant ID from local storage.
- * Falls back to DEFAULT_TENANT_UUID when nothing is stored.
+ * Returns the current tenant ID from the URL pathname.
+ * Falls back to DEFAULT_TENANT_UUID when the URL has no tenant segment
+ * (e.g. public routes, early bootstrap before redirect).
  */
 export const getCurrentTenantId = (): string => {
-  try {
-    const tenantRaw = localStorage.getItem(TENANT_STORAGE_KEY);
-    if (tenantRaw) {
-      const tenant = JSON.parse(tenantRaw);
-      if (tenant?.tenant_id) {
-        return tenant.tenant_id;
-      }
-    }
-  } catch {
-    // malformed JSON — fall back
-  }
-  return DEFAULT_TENANT_UUID;
+  return extractTenantFromUrl() ?? DEFAULT_TENANT_UUID;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

The fix: instead of reading localStorage, just use the first tenant from the user's tenant list (which useTenant already fetches). Later, a preferred_tenant field on the user profile can replace this.
Here's the flow after removal:

Login → URL is "/" → root.tsx sees no tenant in URL
  → useTenant fetches user tenants → picks tenants[0]
  → redirects to /{tenants[0].tenant_id}/admin

Hard refresh on /{tenantA}/admin → URL has tenant A
  → useTenant reads URL → picks tenant A ✅
  → no localStorage involved
The only behavioral change: if you log out and log back in, you'll land on your first tenant instead of the last tenant you visited. That's acceptable and will be replaced by a preferred_tenant profile setting.


### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
