### PR TITLE
[frontend/backend] feat(multi-tenancy): add tenancy context to some settings (#38)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/mapper/MapperApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/mapper/MapperApi.java
@@ -52,11 +52,12 @@ import org.springframework.web.reactive.function.UnsupportedMediaTypeException;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping({MapperApi.MAPPER_URI, MapperApi.TENANT_MAPPER_URI})
 @Slf4j
 public class MapperApi extends RestBehavior {
 
   public static final String MAPPER_URI = "/api/mappers";
-  private static final String TENANT_MAPPER_URI = TENANT_PREFIX + "/mappers";
+  public static final String TENANT_MAPPER_URI = TENANT_PREFIX + "/mappers";
 
   private final ImportMapperRepository importMapperRepository;
   private final MapperService mapperService;
@@ -66,7 +67,7 @@ public class MapperApi extends RestBehavior {
   private static final int MAXIMUM_FILE_SIZE_ALLOWED = 25 * 1000 * 1000;
   private static final List<String> ACCEPTED_FILE_TYPES = List.of("xls", "xlsx");
 
-  @PostMapping({MAPPER_URI + "/search", TENANT_MAPPER_URI + "/search"})
+  @PostMapping("/search")
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.MAPPER)
   public Page<RawPaginationImportMapper> getImportMapper(
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
@@ -75,7 +76,7 @@ public class MapperApi extends RestBehavior {
         .map(RawPaginationImportMapper::new);
   }
 
-  @GetMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
+  @GetMapping("/{mapperId}")
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.READ,
@@ -86,14 +87,14 @@ public class MapperApi extends RestBehavior {
         .orElseThrow(ElementNotFoundException::new);
   }
 
-  @PostMapping({MAPPER_URI, TENANT_MAPPER_URI})
+  @PostMapping
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.MAPPER)
   public ImportMapper createImportMapper(
       @RequestBody @Valid final ImportMapperAddInput importMapperAddInput) {
     return mapperService.createAndSaveImportMapper(importMapperAddInput);
   }
 
-  @PostMapping(value = {MAPPER_URI + "/export", TENANT_MAPPER_URI + "/export"})
+  @PostMapping(value = "/export")
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.MAPPER)
   public void exportMappers(
       @RequestBody @Valid final ExportMapperInput exportMapperInput, HttpServletResponse response) {
@@ -122,7 +123,7 @@ public class MapperApi extends RestBehavior {
   }
 
   @Operation(description = "Export all datas from a specific target (endpoint,...)")
-  @PostMapping(value = {MAPPER_URI + "/export/csv", TENANT_MAPPER_URI + "/export/csv"})
+  @PostMapping(value = "/export/csv")
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.MAPPER)
   @LogExecutionTime
   public void exportMappersCsv(
@@ -132,7 +133,7 @@ public class MapperApi extends RestBehavior {
     mapperService.exportMappersCsv(targetType, input, response);
   }
 
-  @PostMapping({MAPPER_URI + "/import", TENANT_MAPPER_URI + "/import"})
+  @PostMapping("/import")
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.MAPPER)
   public void importMappers(@RequestPart("file") @NotNull MultipartFile file)
       throws ImportException {
@@ -145,7 +146,7 @@ public class MapperApi extends RestBehavior {
     }
   }
 
-  @PostMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
+  @PostMapping("/{mapperId}")
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.DUPLICATE,
@@ -155,7 +156,7 @@ public class MapperApi extends RestBehavior {
     return mapperService.getDuplicateImportMapper(mapperId);
   }
 
-  @PutMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
+  @PutMapping("/{mapperId}")
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.WRITE,
@@ -166,7 +167,7 @@ public class MapperApi extends RestBehavior {
     return mapperService.updateImportMapper(mapperId, importMapperUpdateInput);
   }
 
-  @DeleteMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
+  @DeleteMapping("/{mapperId}")
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.DELETE,
@@ -175,7 +176,7 @@ public class MapperApi extends RestBehavior {
     importMapperRepository.deleteById(UUID.fromString(mapperId));
   }
 
-  @PostMapping({MAPPER_URI + "/store", TENANT_MAPPER_URI + "/store"})
+  @PostMapping("/store")
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.MAPPER)
   @Transactional(rollbackOn = Exception.class)
   @Operation(summary = "Import injects into an xls file")
@@ -184,7 +185,7 @@ public class MapperApi extends RestBehavior {
     return injectImportService.storeXlsFileForImport(file);
   }
 
-  @PostMapping({MAPPER_URI + "/store/{importId}", TENANT_MAPPER_URI + "/store/{importId}"})
+  @PostMapping("/store/{importId}")
   @AccessControl(
       resourceId = "#importId",
       actionPerformed = Action.WRITE,
@@ -214,7 +215,7 @@ public class MapperApi extends RestBehavior {
   @Operation(
       description = "Import all datas from a specific target (endpoint,...) through a csv file")
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.MAPPER)
-  @PostMapping({MAPPER_URI + "/import/csv", TENANT_MAPPER_URI + "/import/csv"})
+  @PostMapping("/import/csv")
   @LogExecutionTime
   @Transactional(rollbackOn = Exception.class)
   public void importEndpoints(

--- a/openaev-api/src/main/java/io/openaev/rest/mapper/MapperApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/mapper/MapperApi.java
@@ -1,5 +1,6 @@
 package io.openaev.rest.mapper;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -54,6 +55,9 @@ import org.springframework.web.reactive.function.UnsupportedMediaTypeException;
 @Slf4j
 public class MapperApi extends RestBehavior {
 
+  public static final String MAPPER_URI = "/api/mappers";
+  private static final String TENANT_MAPPER_URI = TENANT_PREFIX + "/mappers";
+
   private final ImportMapperRepository importMapperRepository;
   private final MapperService mapperService;
   private final InjectImportService injectImportService;
@@ -62,7 +66,7 @@ public class MapperApi extends RestBehavior {
   private static final int MAXIMUM_FILE_SIZE_ALLOWED = 25 * 1000 * 1000;
   private static final List<String> ACCEPTED_FILE_TYPES = List.of("xls", "xlsx");
 
-  @PostMapping("/api/mappers/search")
+  @PostMapping({MAPPER_URI + "/search", TENANT_MAPPER_URI + "/search"})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.MAPPER)
   public Page<RawPaginationImportMapper> getImportMapper(
       @RequestBody @Valid final SearchPaginationInput searchPaginationInput) {
@@ -71,7 +75,7 @@ public class MapperApi extends RestBehavior {
         .map(RawPaginationImportMapper::new);
   }
 
-  @GetMapping("/api/mappers/{mapperId}")
+  @GetMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.READ,
@@ -82,14 +86,14 @@ public class MapperApi extends RestBehavior {
         .orElseThrow(ElementNotFoundException::new);
   }
 
-  @PostMapping("/api/mappers")
+  @PostMapping({MAPPER_URI, TENANT_MAPPER_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.MAPPER)
   public ImportMapper createImportMapper(
       @RequestBody @Valid final ImportMapperAddInput importMapperAddInput) {
     return mapperService.createAndSaveImportMapper(importMapperAddInput);
   }
 
-  @PostMapping(value = "/api/mappers/export")
+  @PostMapping(value = {MAPPER_URI + "/export", TENANT_MAPPER_URI + "/export"})
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.MAPPER)
   public void exportMappers(
       @RequestBody @Valid final ExportMapperInput exportMapperInput, HttpServletResponse response) {
@@ -118,7 +122,7 @@ public class MapperApi extends RestBehavior {
   }
 
   @Operation(description = "Export all datas from a specific target (endpoint,...)")
-  @PostMapping(value = "/api/mappers/export/csv")
+  @PostMapping(value = {MAPPER_URI + "/export/csv", TENANT_MAPPER_URI + "/export/csv"})
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.MAPPER)
   @LogExecutionTime
   public void exportMappersCsv(
@@ -128,7 +132,7 @@ public class MapperApi extends RestBehavior {
     mapperService.exportMappersCsv(targetType, input, response);
   }
 
-  @PostMapping("/api/mappers/import")
+  @PostMapping({MAPPER_URI + "/import", TENANT_MAPPER_URI + "/import"})
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.MAPPER)
   public void importMappers(@RequestPart("file") @NotNull MultipartFile file)
       throws ImportException {
@@ -141,7 +145,7 @@ public class MapperApi extends RestBehavior {
     }
   }
 
-  @PostMapping("/api/mappers/{mapperId}")
+  @PostMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.DUPLICATE,
@@ -151,7 +155,7 @@ public class MapperApi extends RestBehavior {
     return mapperService.getDuplicateImportMapper(mapperId);
   }
 
-  @PutMapping("/api/mappers/{mapperId}")
+  @PutMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.WRITE,
@@ -162,7 +166,7 @@ public class MapperApi extends RestBehavior {
     return mapperService.updateImportMapper(mapperId, importMapperUpdateInput);
   }
 
-  @DeleteMapping("/api/mappers/{mapperId}")
+  @DeleteMapping({MAPPER_URI + "/{mapperId}", TENANT_MAPPER_URI + "/{mapperId}"})
   @AccessControl(
       resourceId = "#mapperId",
       actionPerformed = Action.DELETE,
@@ -171,7 +175,7 @@ public class MapperApi extends RestBehavior {
     importMapperRepository.deleteById(UUID.fromString(mapperId));
   }
 
-  @PostMapping("/api/mappers/store")
+  @PostMapping({MAPPER_URI + "/store", TENANT_MAPPER_URI + "/store"})
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.MAPPER)
   @Transactional(rollbackOn = Exception.class)
   @Operation(summary = "Import injects into an xls file")
@@ -180,7 +184,7 @@ public class MapperApi extends RestBehavior {
     return injectImportService.storeXlsFileForImport(file);
   }
 
-  @PostMapping("/api/mappers/store/{importId}")
+  @PostMapping({MAPPER_URI + "/store/{importId}", TENANT_MAPPER_URI + "/store/{importId}"})
   @AccessControl(
       resourceId = "#importId",
       actionPerformed = Action.WRITE,
@@ -210,7 +214,7 @@ public class MapperApi extends RestBehavior {
   @Operation(
       description = "Import all datas from a specific target (endpoint,...) through a csv file")
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.MAPPER)
-  @PostMapping("/api/mappers/import/csv")
+  @PostMapping({MAPPER_URI + "/import/csv", TENANT_MAPPER_URI + "/import/csv"})
   @LogExecutionTime
   @Transactional(rollbackOn = Exception.class)
   public void importEndpoints(

--- a/openaev-api/src/main/java/io/openaev/rest/tag_rule/TagRuleApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/tag_rule/TagRuleApi.java
@@ -1,5 +1,7 @@
 package io.openaev.rest.tag_rule;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
+
 import io.openaev.aop.AccessControl;
 import io.openaev.aop.LogExecutionTime;
 import io.openaev.aop.UserRoleDescription;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class TagRuleApi extends RestBehavior {
 
   public static final String TAG_RULE_URI = "/api/tag-rules";
+  private static final String TENANT_TAG_RULE_URI = TENANT_PREFIX + "/tag-rules";
 
   private final TagRuleService tagRuleService;
   private final TagRuleMapper tagRuleMapper;
@@ -43,7 +46,7 @@ public class TagRuleApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @GetMapping(TagRuleApi.TAG_RULE_URI + "/{tagRuleId}")
+  @GetMapping({TagRuleApi.TAG_RULE_URI + "/{tagRuleId}", TENANT_TAG_RULE_URI + "/{tagRuleId}"})
   @AccessControl(
       resourceId = "#tagRuleId",
       actionPerformed = Action.READ,
@@ -56,7 +59,7 @@ public class TagRuleApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @GetMapping(TagRuleApi.TAG_RULE_URI)
+  @GetMapping({TagRuleApi.TAG_RULE_URI, TENANT_TAG_RULE_URI})
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.TAG_RULE)
   @Operation(description = "Get All TagRules", summary = "Get TagRules")
   @ApiResponses(
@@ -66,7 +69,7 @@ public class TagRuleApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @DeleteMapping(TagRuleApi.TAG_RULE_URI + "/{tagRuleId}")
+  @DeleteMapping({TagRuleApi.TAG_RULE_URI + "/{tagRuleId}", TENANT_TAG_RULE_URI + "/{tagRuleId}"})
   @AccessControl(
       resourceId = "#tagRuleId",
       actionPerformed = Action.DELETE,
@@ -84,7 +87,7 @@ public class TagRuleApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @PostMapping(TagRuleApi.TAG_RULE_URI)
+  @PostMapping({TagRuleApi.TAG_RULE_URI, TENANT_TAG_RULE_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.TAG_RULE)
   @Transactional(rollbackFor = Exception.class)
   @Operation(summary = "Create TagRule", description = "Tag and Asset Groups needs to exists")
@@ -99,7 +102,7 @@ public class TagRuleApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @PutMapping(TagRuleApi.TAG_RULE_URI + "/{tagRuleId}")
+  @PutMapping({TagRuleApi.TAG_RULE_URI + "/{tagRuleId}", TENANT_TAG_RULE_URI + "/{tagRuleId}"})
   @AccessControl(
       resourceId = "#tagRuleId",
       actionPerformed = Action.WRITE,
@@ -119,7 +122,7 @@ public class TagRuleApi extends RestBehavior {
   }
 
   @LogExecutionTime
-  @PostMapping(TagRuleApi.TAG_RULE_URI + "/search")
+  @PostMapping({TagRuleApi.TAG_RULE_URI + "/search", TENANT_TAG_RULE_URI + "/search"})
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.TAG_RULE)
   @Operation(
       description = "Search TagRules corresponding to search criteria",

--- a/openaev-api/src/main/java/io/openaev/rest/variable/VariableApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/variable/VariableApi.java
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class VariableApi extends RestBehavior {
 
-  public static final String VARIABLE_URI = "/api/variables";
-
   private final VariableService variableService;
   private final ScenarioService scenarioService;
   private final ExerciseRepository exerciseRepository;

--- a/openaev-api/src/main/java/io/openaev/search/FullTextSearchApi.java
+++ b/openaev-api/src/main/java/io/openaev/search/FullTextSearchApi.java
@@ -1,5 +1,7 @@
 package io.openaev.search;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
+
 import io.openaev.aop.AccessControl;
 import io.openaev.database.model.Base;
 import io.openaev.rest.helper.RestBehavior;
@@ -20,17 +22,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class FullTextSearchApi extends RestBehavior {
 
   public static final String GLOBAL_SEARCH_URI = "/api/fulltextsearch";
+  private static final String TENANT_GLOBAL_SEARCH_URI = TENANT_PREFIX + "/fulltextsearch";
 
   private final FullTextSearchService<? extends Base> fullTextSearchService;
 
-  @PostMapping(GLOBAL_SEARCH_URI)
+  @PostMapping({GLOBAL_SEARCH_URI, TENANT_GLOBAL_SEARCH_URI})
   @AccessControl(skipRBAC = true)
   public Map<? extends Class<? extends Base>, FullTextSearchService.FullTextSearchCountResult>
       fullTextSearch(@Valid @RequestBody final SearchTerm searchTerm) {
     return this.fullTextSearchService.fullTextSearch(searchTerm.getSearchTerm());
   }
 
-  @PostMapping(GLOBAL_SEARCH_URI + "/{clazz}")
+  @PostMapping({GLOBAL_SEARCH_URI + "/{clazz}", TENANT_GLOBAL_SEARCH_URI + "/{clazz}"})
   @AccessControl(skipRBAC = true)
   public Page<FullTextSearchService.FullTextSearchResult> fullTextSearch(
       @PathVariable @NotBlank final String clazz,

--- a/openaev-api/src/main/java/io/openaev/search/FullTextSearchService.java
+++ b/openaev-api/src/main/java/io/openaev/search/FullTextSearchService.java
@@ -8,6 +8,7 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.database.specification.SpecificationUtils;
+import io.openaev.database.specification.TenantSpecification;
 import io.openaev.service.UserService;
 import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.annotation.PostConstruct;
@@ -157,7 +158,7 @@ public class FullTextSearchService<T extends Base> {
                     currentUser.isAdminOrBypass(),
                     currentUser.getCapabilities().contains(capaForClass),
                     Grant.GRANT_TYPE.OBSERVER))
-            .and(SpecificationUtils.fromTenant(TenantContext.getCurrentTenant()));
+            .and(TenantSpecification.fromTenant(TenantContext.getCurrentTenant()));
 
     return buildPaginationJPA(repository::findAll, searchPaginationInput, clazzT, specs)
         .map(this::transform);
@@ -292,7 +293,7 @@ public class FullTextSearchService<T extends Base> {
                               .getCapabilities()
                               .contains(capaByClassMap.get(tClass).orElse(Capability.BYPASS)),
                           Grant.GRANT_TYPE.OBSERVER))
-                  .and(SpecificationUtils.fromTenant(TenantContext.getCurrentTenant()));
+                  .and(TenantSpecification.fromTenant(TenantContext.getCurrentTenant()));
           long count = repository.count(specs);
           results.put(tClass, new FullTextSearchCountResult(tClass.getSimpleName(), count));
         });

--- a/openaev-api/src/main/java/io/openaev/search/FullTextSearchService.java
+++ b/openaev-api/src/main/java/io/openaev/search/FullTextSearchService.java
@@ -4,6 +4,7 @@ import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 import static io.openaev.utils.pagination.SortUtilsRuntime.toSortRuntime;
 import static org.springframework.util.StringUtils.hasText;
 
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.database.specification.SpecificationUtils;
@@ -155,7 +156,8 @@ public class FullTextSearchService<T extends Base> {
                     currentUser.getId(),
                     currentUser.isAdminOrBypass(),
                     currentUser.getCapabilities().contains(capaForClass),
-                    Grant.GRANT_TYPE.OBSERVER));
+                    Grant.GRANT_TYPE.OBSERVER))
+            .and(SpecificationUtils.fromTenant(TenantContext.getCurrentTenant()));
 
     return buildPaginationJPA(repository::findAll, searchPaginationInput, clazzT, specs)
         .map(this::transform);
@@ -289,7 +291,8 @@ public class FullTextSearchService<T extends Base> {
                           currentUser
                               .getCapabilities()
                               .contains(capaByClassMap.get(tClass).orElse(Capability.BYPASS)),
-                          Grant.GRANT_TYPE.OBSERVER));
+                          Grant.GRANT_TYPE.OBSERVER))
+                  .and(SpecificationUtils.fromTenant(TenantContext.getCurrentTenant()));
           long count = repository.count(specs);
           results.put(tClass, new FullTextSearchCountResult(tClass.getSimpleName(), count));
         });

--- a/openaev-front/src/utils/tenant-api-migration.ts
+++ b/openaev-front/src/utils/tenant-api-migration.ts
@@ -13,10 +13,6 @@ const TENANT_MIGRATION_TODO: string[] = [
   // PR4 — Teams & Players
   '/api/players',
   // PR9 — Reference data & Misc
-  '/api/mappers',
-  '/api/tag-rules',
-  '/api/fulltextsearch',
-  '/api/variables',
   '/api/xtmhub',
 ];
 

--- a/openaev-model/src/main/java/io/openaev/database/specification/SpecificationUtils.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/SpecificationUtils.java
@@ -192,4 +192,19 @@ public class SpecificationUtils {
   public static <T extends Base> Specification<T> hasIdIn(List<String> ids) {
     return (root, query, cb) -> root.get("id").in(ids);
   }
+
+  /**
+   * Filters entities by tenant ID. Only applies to entities implementing {@link TenantBase}; for
+   * other entities, returns an always-true predicate.
+   *
+   * @param tenantId the tenant ID to filter on
+   */
+  public static <T extends Base> Specification<T> fromTenant(final String tenantId) {
+    return (root, query, cb) -> {
+      if (TenantBase.class.isAssignableFrom(root.getJavaType())) {
+        return cb.equal(root.get("tenant").get("id"), tenantId);
+      }
+      return cb.conjunction();
+    };
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/database/specification/SpecificationUtils.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/SpecificationUtils.java
@@ -192,19 +192,4 @@ public class SpecificationUtils {
   public static <T extends Base> Specification<T> hasIdIn(List<String> ids) {
     return (root, query, cb) -> root.get("id").in(ids);
   }
-
-  /**
-   * Filters entities by tenant ID. Only applies to entities implementing {@link TenantBase}; for
-   * other entities, returns an always-true predicate.
-   *
-   * @param tenantId the tenant ID to filter on
-   */
-  public static <T extends Base> Specification<T> fromTenant(final String tenantId) {
-    return (root, query, cb) -> {
-      if (TenantBase.class.isAssignableFrom(root.getJavaType())) {
-        return cb.equal(root.get("tenant").get("id"), tenantId);
-      }
-      return cb.conjunction();
-    };
-  }
 }

--- a/openaev-model/src/main/java/io/openaev/database/specification/TenantSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/TenantSpecification.java
@@ -1,0 +1,23 @@
+package io.openaev.database.specification;
+
+import io.openaev.database.model.Base;
+import io.openaev.database.model.TenantBase;
+import org.springframework.data.jpa.domain.Specification;
+
+public class TenantSpecification {
+
+  /**
+   * Filters entities by tenant ID. Only applies to entities implementing {@link TenantBase}; for
+   * other entities, returns an always-true predicate.
+   *
+   * @param tenantId the tenant ID to filter on
+   */
+  public static <T extends Base> Specification<T> fromTenant(final String tenantId) {
+    return (root, query, cb) -> {
+      if (TenantBase.class.isAssignableFrom(root.getJavaType())) {
+        return cb.equal(root.get("tenant").get("id"), tenantId);
+      }
+      return cb.conjunction();
+    };
+  }
+}


### PR DESCRIPTION

### Proposed changes

Add tenant context to xls mappers, tag rules, and fulll text search.

### Testing Instructions

1. For xls mappers, go to Settings -> Data ingestion -> Xls mappers
2. For tag rules, go to Settings -> Customization
3. For the full text search, use the search bar at the top of the app.

All the operations must affect the current tenant only
