### PR TITLE
chore: merge back master → release/current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  slack: circleci/slack@5.2.3
+  slack: circleci/slack@6.1.3
   kubernetes: circleci/kubernetes@2.0.2
 jobs:
   build_frontend:

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: buildpush
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile_ga

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -43,7 +43,7 @@ jobs:
       - run: cp openaev-api/target/openaev-api.jar openaev-build/
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: filigran/openaev-platform
           tags: |
@@ -81,7 +81,7 @@ jobs:
     steps:
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: filigran/openaev-platform
           tags: |

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -53,7 +53,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/Dockerfile_ubi9
+++ b/Dockerfile_ubi9
@@ -1,0 +1,44 @@
+FROM registry.access.redhat.com/ubi9/nodejs-22 AS front-builder
+
+USER root
+
+WORKDIR /opt/openaev-build/openaev-front
+COPY openaev-front ./
+RUN set -eux; \
+    npm install -g corepack; \
+    yarn install; \
+    yarn build;
+
+
+FROM registry.access.redhat.com/ubi9/openjdk-21 AS api-builder
+
+USER root
+
+RUN set -eux; \
+    microdnf install -y maven; \
+    microdnf clean all; \
+    mvn --version;
+
+WORKDIR /opt/openaev-build/openaev
+COPY openaev-model ./openaev-model
+COPY openaev-framework ./openaev-framework
+COPY openaev-api ./openaev-api
+COPY pom.xml ./pom.xml
+COPY --from=front-builder /opt/openaev-build/openaev-front/builder/prod/build ./openaev-front/builder/prod/build
+RUN mvn install -DskipTests -Pdev
+
+
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime AS app
+
+USER root
+
+RUN set -eux; \
+    curl -L -o /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini; \
+    echo "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c /usr/bin/tini" | sha256sum -c -; \
+    chmod +x /usr/bin/tini;
+
+WORKDIR /opt/openaev
+COPY --from=api-builder /opt/openaev-build/openaev/openaev-api/target/openaev-api.jar ./
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["java", "-jar", "openaev-api.jar"]

--- a/openaev-api/pom.xml
+++ b/openaev-api/pom.xml
@@ -23,7 +23,7 @@
         <apache-poi.version>5.5.1</apache-poi.version>
         <opencsv-version>5.12.0</opencsv-version>
         <opentelemetry.version>1.60.1</opentelemetry.version>
-        <elasticsearch.version>8.19.13</elasticsearch.version>
+        <elasticsearch.version>8.19.14</elasticsearch.version>
         <opentelemetry-semconv.version>1.40.0</opentelemetry-semconv.version>
     </properties>
 

--- a/openaev-api/src/main/java/io/openaev/api/custom_dashboard/CustomDashboardApiImporter.java
+++ b/openaev-api/src/main/java/io/openaev/api/custom_dashboard/CustomDashboardApiImporter.java
@@ -41,7 +41,9 @@ public class CustomDashboardApiImporter extends RestBehavior {
   @RBAC(actionPerformed = Action.WRITE, resourceType = ResourceType.DASHBOARD)
   public ResponseEntity<JsonApiDocument<ResourceObject>> importJson(
       @RequestPart("file") @NotNull MultipartFile file) throws IOException {
-    return zipJsonApi.handleImport(
-        file, "custom_dashboard_name", null, CustomDashboardService::sanityCheck);
+    return ResponseEntity.ok(
+        zipJsonApi
+            .handleImport(file, "custom_dashboard_name", null, CustomDashboardService::sanityCheck)
+            .jsonApiDocument());
   }
 }

--- a/openaev-api/src/main/java/io/openaev/api/payload/PayloadApiImporter.java
+++ b/openaev-api/src/main/java/io/openaev/api/payload/PayloadApiImporter.java
@@ -9,7 +9,9 @@ import io.openaev.jsonapi.ResourceObject;
 import io.openaev.jsonapi.ZipJsonApi;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.payload.PayloadApi;
+import io.openaev.rest.payload.service.PayloadService;
 import io.openaev.service.ImportService;
+import io.openaev.service.ZipJsonService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class PayloadApiImporter extends RestBehavior {
 
   private final ZipJsonApi<Payload> zipJsonApi;
   private final ImportService importService;
+  private final PayloadService payloadService;
 
   @Operation(
       description =
@@ -44,7 +47,9 @@ public class PayloadApiImporter extends RestBehavior {
   public ResponseEntity<JsonApiDocument<ResourceObject>> importJson(
       @RequestPart("file") @NotNull MultipartFile file) throws Exception {
     try {
-      return zipJsonApi.handleImport(file, "payload_name");
+      ZipJsonService.ImportOutput<Payload> response = zipJsonApi.handleImport(file, "payload_name");
+      payloadService.updateInjectorContractsForPayload(response.persistedData());
+      return ResponseEntity.ok(response.jsonApiDocument());
     } catch (Exception ex) {
       log.warn("Fallback to old import due to {}", ex.getMessage(), ex);
       // Fall back to the legacy importer

--- a/openaev-api/src/main/java/io/openaev/datapack/packs/V20260101_Starter_pack.java
+++ b/openaev-api/src/main/java/io/openaev/datapack/packs/V20260101_Starter_pack.java
@@ -192,12 +192,14 @@ public class V20260101_Starter_pack extends DataPack {
             resourceToAdd -> {
               try {
                 JsonApiDocument<ResourceObject> dashboard =
-                    this.zipJsonService.handleImport(
-                        resourceToAdd.getContentAsByteArray(),
-                        "custom_dashboard_name",
-                        null,
-                        CustomDashboardService::sanityCheck,
-                        "");
+                    this.zipJsonService
+                        .handleImport(
+                            resourceToAdd.getContentAsByteArray(),
+                            "custom_dashboard_name",
+                            null,
+                            CustomDashboardService::sanityCheck,
+                            "")
+                        .jsonApiDocument();
                 this.setDefaultDashboard(resourceToAdd.getFilename(), dashboard.data().id());
                 log.info(
                     "Successfully imported StarterPack dashboard file : {}",

--- a/openaev-api/src/main/java/io/openaev/rest/inject/InjectApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/InjectApi.java
@@ -29,6 +29,7 @@ import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.helper.queue.BatchQueueService;
 import io.openaev.rest.helper.queue.executor.BatchExecutionTraceExecutor;
 import io.openaev.rest.inject.form.*;
+import io.openaev.rest.inject.service.BatchingInjectStatusService;
 import io.openaev.rest.inject.service.ExecutableInjectService;
 import io.openaev.rest.inject.service.InjectExecutionService;
 import io.openaev.rest.inject.service.InjectExportService;
@@ -90,6 +91,7 @@ public class InjectApi extends RestBehavior {
   private final UserService userService;
   private final DocumentService documentService;
   private final BatchExecutionTraceExecutor batchExecutionTraceExecutor;
+  private final BatchingInjectStatusService batchingInjectStatusService;
 
   private final RabbitmqConfig rabbitmqConfig;
   private final OpenAEVConfig openAEVConfig;
@@ -113,6 +115,8 @@ public class InjectApi extends RestBehavior {
               objectMapper,
               openAEVConfig.getQueueConfig().get("inject-trace"),
               rabbitMQSslConfiguration);
+      // Share the queue with the batching service so it can requeue delayed callbacks
+      batchingInjectStatusService.setInjectTraceQueueService(injectTraceQueueService);
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/inject/form/InjectExecutionCallback.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/form/InjectExecutionCallback.java
@@ -28,6 +28,9 @@ public class InjectExecutionCallback implements Queueable {
   @JsonProperty("execution_emission_date")
   private long emissionDate;
 
+  @JsonProperty("retry_count")
+  private int retryCount = 0;
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof InjectExecutionCallback) {
@@ -38,6 +41,6 @@ public class InjectExecutionCallback implements Queueable {
 
   @Override
   public String getUniqueElementKey() {
-    return injectId + agentId;
+    return injectId;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
@@ -8,18 +8,22 @@ import io.openaev.database.model.Inject;
 import io.openaev.database.repository.AgentRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.rest.helper.queue.BatchQueueService;
 import io.openaev.rest.inject.form.InjectExecutionAction;
 import io.openaev.rest.inject.form.InjectExecutionCallback;
 import jakarta.annotation.Resource;
 import jakarta.transaction.Transactional;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -28,10 +32,19 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class BatchingInjectStatusService {
 
+  private static final int MAX_RETRIES = 5;
+  // Inmemory queue system to add delay to actual re-queuing mechanism
+  private final Queue<InjectExecutionCallback> callbacksToRequeue = new ConcurrentLinkedQueue<>();
+
   private final InjectRepository injectRepository;
   private final AgentRepository agentRepository;
   private final StructuredOutputUtils structuredOutputUtils;
   private final InjectExecutionService injectExecutionService;
+
+  // Set from InjectApi.init() function. I preferred that to creating a dedicated @Bean instance
+  // to avoid making too big changes.
+  // Also, it can be null when the inject-trace queue is not configured (e.g. legacy mode, tests).
+  @Setter private BatchQueueService<InjectExecutionCallback> injectTraceQueueService;
 
   @Resource protected ObjectMapper mapper;
 
@@ -47,7 +60,7 @@ public class BatchingInjectStatusService {
 
     List<InjectExecutionCallback> successfullyProcessedCallbacks = new ArrayList<>();
 
-    // Getting all the injects needed all at once
+    // Getting all the injects linked to the list of execution traces, all at once
     Map<String, Inject> mapInjectsById =
         injectRepository
             .findAllByIdWithExpectations(
@@ -57,7 +70,7 @@ public class BatchingInjectStatusService {
             .stream()
             .collect(Collectors.toMap(Inject::getId, Function.identity()));
 
-    // Getting all the agents all at once
+    // Getting all the agents linked to the list of execution traces, all at once
     Map<String, Agent> mapAgentsById =
         StreamSupport.stream(
                 agentRepository
@@ -88,19 +101,15 @@ public class BatchingInjectStatusService {
                             new ElementNotFoundException(
                                 "Inject not found: " + callback.getInjectId()));
             // issue/3550: added this condition to ensure we only update statuses if the inject is
-            // in a
-            // coherent state.
+            // in a coherent state.
             // This prevents issues where the PENDING status took more time to persist than it took
-            // for
-            // the agent to send the complete action.
-            // FIXME: At the moment, this whole function is only called by our implant. These
-            // implant are
-            // launched with the async value to true, which force the implant to go from EXECUTING
-            // to
-            // PENDING, before going to EXECUTED.
+            // for the agent to send the complete action.
+            // FIXME: At the moment, this whole function is only called by execution traces created
+            // form our implants.
+            // These implants are launched with the async value to true, which force the implant to
+            // go from EXECUTING to PENDING, before going to EXECUTED.
             // So if in the future, this function is called to update a synchronous inject, we will
-            // need
-            // to find a way to get the async boolean somehow and add it to this condition.
+            // need to find a way to get the async boolean somehow and add it to this condition.
             if (callback
                     .getInjectExecutionInput()
                     .getAction()
@@ -108,37 +117,35 @@ public class BatchingInjectStatusService {
                 && (inject.getStatus().isEmpty()
                     || !inject.getStatus().get().getName().equals(ExecutionStatus.PENDING))) {
               // If we receive a status update with a terminal state status, we must first check
-              // that the
-              // current status is in the PENDING state
+              // that the current status is in the PENDING state
               log.warn(
                   String.format(
-                      "Received a complete action for inject %s with status %s, but current status is not PENDING",
+                      "Received a complete action for inject %s with status %s, but current status is not PENDING (retry %d/%d)",
                       callback.getInjectId(),
-                      inject.getStatus().map(is -> is.getName().toString()).orElse("unknown")));
-              throw new DataIntegrityViolationException(
-                  "Cannot complete inject that is not in PENDING state");
-            }
-            // Get the nullable agent; throw only if ID was supplied and not found
-            Agent agent =
-                Optional.ofNullable(callback.getAgentId())
-                    .map(
-                        id ->
-                            Optional.ofNullable(mapAgentsById.get(callback.getAgentId()))
-                                .orElseThrow(
-                                    () ->
-                                        new ElementNotFoundException(
-                                            "Agent not found: " + callback.getAgentId())))
-                    .orElse(null);
-
-            // Process the execution trace
-            if (agent == null) {
-              injectExecutionService.processInjectExecutionWithInjector(
-                  inject, callback.getInjectExecutionInput());
+                      inject.getStatus().map(is -> is.getName().toString()).orElse("unknown"),
+                      callback.getRetryCount(),
+                      MAX_RETRIES));
+              if (callback.getRetryCount() < MAX_RETRIES && injectTraceQueueService != null) {
+                callback.setRetryCount(callback.getRetryCount() + 1);
+                // We change the emission date to current timestamp here to be more accurate
+                // order has become meaningless in case of re-queueing the message any way
+                callback.setEmissionDate(Instant.now().toEpochMilli());
+                callbacksToRequeue.add(callback);
+              } else {
+                if (callback.getRetryCount() < MAX_RETRIES) {
+                  log.warn(
+                      "Inject trace queue service is not configured, saving trace directly for inject {}",
+                      callback.getInjectId());
+                } else {
+                  log.warn("Max retries reached for inject {}", callback.getInjectId());
+                }
+                // Max retry reached, we save the trace anyway, to make sure no information is lost
+                // and let the expiration manager logic handle the discrepancies if any exists
+                saveExecutionTrace(callback, mapAgentsById, inject, successfullyProcessedCallbacks);
+              }
             } else {
-              injectExecutionService.processInjectExecutionWithAgent(
-                  inject, agent, callback.getInjectExecutionInput());
+              saveExecutionTrace(callback, mapAgentsById, inject, successfullyProcessedCallbacks);
             }
-            successfullyProcessedCallbacks.add(callback);
           } catch (ElementNotFoundException e) {
             injectExecutionService.handleInjectExecutionError(inject, e);
             successfullyProcessedCallbacks.add(callback);
@@ -151,5 +158,61 @@ public class BatchingInjectStatusService {
           }
         });
     return successfullyProcessedCallbacks;
+  }
+
+  /**
+   * Save the execution trace and compute the inject status
+   *
+   * @param callback the execution trace message to handle
+   * @param mapAgentsById map of agents linked to the execution traces
+   * @param inject the inject linked to the given execution trace
+   * @param successfullyProcessedCallbacks list of successfully processed execution trace messages
+   */
+  private void saveExecutionTrace(
+      InjectExecutionCallback callback,
+      Map<String, Agent> mapAgentsById,
+      Inject inject,
+      List<InjectExecutionCallback> successfullyProcessedCallbacks) {
+    // Get the nullable agent; throw only if ID was supplied and not found
+    Agent agent =
+        Optional.ofNullable(callback.getAgentId())
+            .map(
+                id ->
+                    Optional.ofNullable(mapAgentsById.get(callback.getAgentId()))
+                        .orElseThrow(
+                            () ->
+                                new ElementNotFoundException(
+                                    "Agent not found: " + callback.getAgentId())))
+            .orElse(null);
+
+    // Process the execution trace
+    if (agent == null) {
+      injectExecutionService.processInjectExecutionWithInjector(
+          inject, callback.getInjectExecutionInput());
+    } else {
+      injectExecutionService.processInjectExecutionWithAgent(
+          inject, agent, callback.getInjectExecutionInput());
+    }
+    successfullyProcessedCallbacks.add(callback);
+  }
+
+  /**
+   * Requeue all callbacks that were received too soon compared to the inject status This is called
+   * from a quartz job
+   */
+  public void requeueCallbacks() throws IOException {
+    if (injectTraceQueueService == null) {
+      return;
+    }
+    InjectExecutionCallback callback;
+    while ((callback = callbacksToRequeue.peek()) != null) {
+      try {
+        injectTraceQueueService.publish(callback);
+        callbacksToRequeue.poll();
+      } catch (Exception e) {
+        log.warn("Unable to requeue inject execution callback, keeping it in memory for retry", e);
+        break;
+      }
+    }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/PlatformJobDefinitions.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/PlatformJobDefinitions.java
@@ -76,4 +76,17 @@ public class PlatformJobDefinitions {
         .storeDurably()
         .build();
   }
+
+  /**
+   * Create the job for the requeue system of the execution traces
+   *
+   * @return the job
+   */
+  @Bean
+  public JobDetail getExecutionTracesBatchRequeueJob() {
+    return JobBuilder.newJob(ExecutionTracesBatchRequeueJob.class)
+        .withIdentity("executionTracesBatchRequeueJob")
+        .storeDurably()
+        .build();
+  }
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/PlatformTriggers.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/PlatformTriggers.java
@@ -2,8 +2,7 @@ package io.openaev.scheduler;
 
 import static io.openaev.scheduler.jobs.user_event.UserEventRetentionJob.USER_EVENT_RETENTION_TRIGGER;
 import static org.quartz.CronScheduleBuilder.cronSchedule;
-import static org.quartz.SimpleScheduleBuilder.repeatMinutelyForever;
-import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
+import static org.quartz.SimpleScheduleBuilder.*;
 import static org.quartz.TriggerBuilder.newTrigger;
 
 import org.quartz.SimpleScheduleBuilder;
@@ -101,6 +100,20 @@ public class PlatformTriggers {
         .forJob(this.platformJobs.userEventRetentionJobDetail())
         .withIdentity(USER_EVENT_RETENTION_TRIGGER)
         .withSchedule(cronSchedule("0 0 0 * * ?"))
+        .build();
+  }
+
+  /**
+   * Create a trigger to run the requeue system for the execution traces
+   *
+   * @return the trigger
+   */
+  @Bean
+  public Trigger executionTracesBatchRequeueTrigger() {
+    return newTrigger()
+        .forJob(this.platformJobs.getExecutionTracesBatchRequeueJob())
+        .withIdentity("ExecutionTracesBatchRequeueTrigger")
+        .withSchedule(repeatSecondlyForever(15))
         .build();
   }
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/ExecutionTracesBatchRequeueJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/ExecutionTracesBatchRequeueJob.java
@@ -1,0 +1,31 @@
+package io.openaev.scheduler.jobs;
+
+import io.openaev.rest.inject.service.BatchingInjectStatusService;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+/** Job to requeue all execution traces from the batching queue that need it */
+@Component
+@DisallowConcurrentExecution
+@RequiredArgsConstructor
+@Slf4j
+public class ExecutionTracesBatchRequeueJob implements Job {
+
+  private final BatchingInjectStatusService batchingInjectStatusService;
+
+  @Override
+  public void execute(JobExecutionContext context) throws JobExecutionException {
+    try {
+      batchingInjectStatusService.requeueCallbacks();
+    } catch (IOException e) {
+      log.error("Error while requeuing execution traces", e);
+      throw new JobExecutionException("IO error in requeueCallbacks", e, false);
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -161,12 +161,18 @@ public class InjectsExecutionJob implements Job {
                 inject -> {
                   InjectStatus status =
                       inject.getStatus().orElseThrow(ElementNotFoundException::new);
-                  status.setName(ExecutionStatus.MAYBE_PREVENTED);
-                  status.addWarningTrace(
-                      "Execution delay detected: Inject exceeded the "
-                          + this.injectExecutionThreshold
-                          + " minutes threshold.",
-                      ExecutionTraceAction.EXECUTION);
+                  if (status.getTraces() == null
+                      || status.getTraces().isEmpty()
+                      || !injectStatusService.isAllInjectAgentsExecuted(inject)) {
+                    status.setName(ExecutionStatus.MAYBE_PREVENTED);
+                    status.addWarningTrace(
+                        "Execution delay detected: Inject exceeded the "
+                            + this.injectExecutionThreshold
+                            + " minutes threshold.",
+                        ExecutionTraceAction.EXECUTION);
+                  } else {
+                    injectStatusService.updateFinalInjectStatus(status);
+                  }
                   return status;
                 })
             .collect(Collectors.toList());

--- a/openaev-api/src/test/java/io/openaev/api/payload/PayloadApiImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/payload/PayloadApiImporterTest.java
@@ -5,6 +5,7 @@ import static io.openaev.utils.constants.Constants.IMPORTED_OBJECT_NAME_SUFFIX;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -13,17 +14,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.IntegrationTest;
+import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.Payload;
+import io.openaev.database.repository.InjectorContractRepository;
+import io.openaev.database.repository.PayloadRepository;
+import io.openaev.integration.Manager;
+import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.jsonapi.JsonApiDocument;
 import io.openaev.jsonapi.Relationship;
 import io.openaev.jsonapi.ResourceIdentifier;
 import io.openaev.jsonapi.ResourceObject;
 import io.openaev.service.ZipJsonService;
 import io.openaev.utils.mockUser.WithMockUser;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,12 +40,15 @@ import org.springframework.transaction.annotation.Transactional;
 class PayloadApiImporterTest extends IntegrationTest {
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
   @Autowired private ZipJsonService<Payload> zipJsonService;
+  @Autowired private PayloadRepository payloadRepository;
+  @Autowired private InjectorContractRepository injectorContractRepository;
+  @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
 
-  @Test
-  @DisplayName("Import a payload returns complete entity")
-  void import_payload_returns_payload_with_relationship() throws Exception {
-    // -- PREPARE --
+  // -- HELPERS --
+
+  private Map<String, Object> buildDefaultPayloadAttributes() {
     Map<String, Object> attributes = new HashMap<>();
     attributes.put("payload_type", "Command");
     attributes.put("command_executor", "psh");
@@ -54,28 +60,93 @@ class PayloadApiImporterTest extends IntegrationTest {
     attributes.put("payload_expectations", new String[] {"VULNERABILITY"});
     attributes.put("payload_status", "VERIFIED");
     attributes.put("payload_execution_arch", "ALL_ARCHITECTURES");
+    return attributes;
+  }
+
+  private MockMultipartFile buildZipFile(JsonApiDocument<ResourceObject> document)
+      throws Exception {
+    byte[] zip = zipJsonService.writeZip(document, emptyMap());
+    return new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+  }
+
+  private String performImport(MockMultipartFile zipFile) throws Exception {
+    return mockMvc
+        .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
+        .andExpect(status().is2xxSuccessful())
+        .andReturn()
+        .getResponse()
+        .getContentAsString();
+  }
+
+  // -- TESTS --
+
+  @Test
+  @DisplayName("Import payload should create injector contract")
+  void importPayloadShouldCreateInjectorContract() throws Exception {
+    new Manager(List.of(openaevInjectorIntegrationFactory)).monitorIntegrations();
+
+    // -- PREPARE --
+    String domainId = "02e33774-33ae-4d65-91fd-a9c0e1a37c7b";
+    Map<String, Object> domainAttributes = new HashMap<>();
+    domainAttributes.put("domain_id", domainId);
+    domainAttributes.put("domain_name", "Data Exfiltration");
+    domainAttributes.put("domain_color", "#9933CC");
+    domainAttributes.put("domain_created_at", "2026-02-02T14:55:27.442379Z");
+    domainAttributes.put("domain_updated_at", "2026-02-02T14:55:27.442379Z");
+    ResourceObject domainElement =
+        new ResourceObject(domainId, "domains", domainAttributes, emptyMap());
 
     JsonApiDocument<ResourceObject> document =
         new JsonApiDocument<>(
-            new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
+            new ResourceObject(
+                null,
+                "command",
+                buildDefaultPayloadAttributes(),
+                Map.of(
+                    "payload_domains",
+                    new Relationship(List.of(new ResourceIdentifier(domainId, "domains"))))),
+            List.of(domainElement));
 
-    byte[] zip = zipJsonService.writeZip(document, emptyMap());
-    MockMultipartFile zipFile =
-        new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+    MockMultipartFile zipFile = buildZipFile(document);
 
     // -- EXECUTE --
-    String response =
-        mockMvc
-            .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    String response = performImport(zipFile);
 
     // -- ASSERT --
     assertNotNull(response);
 
-    JsonNode json = new ObjectMapper().readTree(response);
+    JsonNode json = objectMapper.readTree(response);
+    String payloadId = json.at("/data/attributes/payload_id").asText();
+    assertNotNull(payloadId);
+
+    Optional<Payload> payloadPersisted = payloadRepository.findById(payloadId);
+    assertFalse(payloadPersisted.isEmpty(), "Payload should have been persisted in the database");
+
+    List<InjectorContract> injectorContracts =
+        injectorContractRepository.findInjectorContractsByPayload(payloadPersisted.get());
+    assertNotNull(injectorContracts);
+    assertEquals(1, injectorContracts.size());
+    assertEquals(payloadId, injectorContracts.getFirst().getPayload().getId());
+  }
+
+  @Test
+  @DisplayName("Import a payload returns complete entity")
+  void importPayloadReturnsPayloadWithRelationship() throws Exception {
+    // -- PREPARE --
+    JsonApiDocument<ResourceObject> document =
+        new JsonApiDocument<>(
+            new ResourceObject(null, "command", buildDefaultPayloadAttributes(), emptyMap()),
+            emptyList());
+
+    MockMultipartFile zipFile = buildZipFile(document);
+
+    // -- EXECUTE --
+    String response = performImport(zipFile);
+
+    // -- ASSERT --
+    assertNotNull(response);
+
+    JsonNode json = objectMapper.readTree(response);
 
     // Payload
     assertEquals("command", json.at("/data/type").asText());
@@ -97,40 +168,22 @@ class PayloadApiImporterTest extends IntegrationTest {
     Map<String, Object> prerequisite1 =
         Map.of("executor", "sh", "get_command", "which curl", "check_command", "curl --version");
 
-    Map<String, Object> attributes = new HashMap<>();
-    attributes.put("payload_type", "Command");
-    attributes.put("command_executor", "psh");
-    attributes.put("command_content", "echo \"toto\"");
-    attributes.put("payload_name", "Echo");
-    attributes.put("payload_description", "");
-    attributes.put("payload_platforms", new String[] {"Windows"});
+    Map<String, Object> attributes = buildDefaultPayloadAttributes();
     attributes.put("payload_arguments", List.of(argument1, argument2));
     attributes.put("payload_prerequisites", List.of(prerequisite1));
-    attributes.put("payload_source", "MANUAL");
-    attributes.put("payload_expectations", new String[] {"VULNERABILITY"});
-    attributes.put("payload_status", "VERIFIED");
-    attributes.put("payload_execution_arch", "ALL_ARCHITECTURES");
 
     JsonApiDocument<ResourceObject> document =
         new JsonApiDocument<>(
             new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
 
-    byte[] zip = zipJsonService.writeZip(document, emptyMap());
-    MockMultipartFile zipFile =
-        new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+    MockMultipartFile zipFile = buildZipFile(document);
 
     // -- EXECUTE --
-    String response =
-        mockMvc
-            .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    String response = performImport(zipFile);
 
     // -- ASSERT --
     assertNotNull(response);
-    JsonNode json = new ObjectMapper().readTree(response);
+    JsonNode json = objectMapper.readTree(response);
     assertEquals("command", json.at("/data/type").asText());
     assertEquals(
         "Echo" + IMPORTED_OBJECT_NAME_SUFFIX, json.at("/data/attributes/payload_name").asText());
@@ -158,38 +211,24 @@ class PayloadApiImporterTest extends IntegrationTest {
   @Test
   @DisplayName("Import payload with empty array fields")
   void importPayloadWithEmptyArrayFields() throws Exception {
-    Map<String, Object> attributes = new HashMap<>();
-    attributes.put("payload_type", "Command");
-    attributes.put("command_executor", "psh");
-    attributes.put("command_content", "echo \"toto\"");
-    attributes.put("payload_name", "Echo");
-    attributes.put("payload_description", "");
+    // -- PREPARE --
+    Map<String, Object> attributes = buildDefaultPayloadAttributes();
     attributes.put("payload_platforms", new String[] {}); // empty array
     attributes.put("payload_arguments", new String[] {}); // empty array
     attributes.put("payload_prerequisites", new String[] {}); // empty array
-    attributes.put("payload_source", "MANUAL");
-    attributes.put("payload_expectations", new String[] {"VULNERABILITY"});
-    attributes.put("payload_status", "VERIFIED");
-    attributes.put("payload_execution_arch", "ALL_ARCHITECTURES");
 
     JsonApiDocument<ResourceObject> document =
         new JsonApiDocument<>(
             new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
 
-    byte[] zip = zipJsonService.writeZip(document, emptyMap());
-    MockMultipartFile zipFile =
-        new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+    MockMultipartFile zipFile = buildZipFile(document);
 
-    String response =
-        mockMvc
-            .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    // -- EXECUTE --
+    String response = performImport(zipFile);
 
+    // -- ASSERT --
     assertNotNull(response);
-    JsonNode json = new ObjectMapper().readTree(response);
+    JsonNode json = objectMapper.readTree(response);
     assertEquals(0, json.at("/data/attributes/payload_platforms").size());
     assertEquals(0, json.at("/data/attributes/payload_arguments").size());
     assertEquals(0, json.at("/data/attributes/payload_prerequisites").size());
@@ -238,17 +277,9 @@ class PayloadApiImporterTest extends IntegrationTest {
                     List.of(new ResourceIdentifier(elementId, "contract_output_elements")))));
 
     // Payload + OutputParser
-    Map<String, Object> payloadAttrs = new HashMap<>();
-    payloadAttrs.put("payload_type", "Command");
-    payloadAttrs.put("command_executor", "psh");
-    payloadAttrs.put("command_content", "ipconfig");
+    Map<String, Object> payloadAttrs = buildDefaultPayloadAttributes();
     payloadAttrs.put("payload_name", "Payload With Output Parser");
-    payloadAttrs.put("payload_description", "");
-    payloadAttrs.put("payload_platforms", new String[] {"Windows"});
-    payloadAttrs.put("payload_source", "MANUAL");
-    payloadAttrs.put("payload_expectations", new String[] {"VULNERABILITY"});
-    payloadAttrs.put("payload_status", "VERIFIED");
-    payloadAttrs.put("payload_execution_arch", "ALL_ARCHITECTURES");
+    payloadAttrs.put("command_content", "ipconfig");
 
     JsonApiDocument<ResourceObject> document =
         new JsonApiDocument<>(
@@ -261,22 +292,14 @@ class PayloadApiImporterTest extends IntegrationTest {
                     new Relationship(List.of(new ResourceIdentifier(parserId, "output_parsers"))))),
             List.of(outputParserResource, contractOutputElementResource, regexGroupResource));
 
-    byte[] zip = zipJsonService.writeZip(document, emptyMap());
-    MockMultipartFile zipFile =
-        new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+    MockMultipartFile zipFile = buildZipFile(document);
 
     // -- EXECUTE --
-    String response =
-        mockMvc
-            .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    String response = performImport(zipFile);
 
     // -- ASSERT --
     assertNotNull(response);
-    JsonNode json = new ObjectMapper().readTree(response);
+    JsonNode json = objectMapper.readTree(response);
 
     assertEquals("command", json.at("/data/type").asText());
     assertEquals(
@@ -402,17 +425,11 @@ class PayloadApiImporterTest extends IntegrationTest {
                         new ResourceIdentifier(element2Id, "contract_output_elements")))));
 
     // Payload + OutputParser
-    Map<String, Object> payloadAttrs = new HashMap<>();
-    payloadAttrs.put("payload_type", "Command");
+    Map<String, Object> payloadAttrs = buildDefaultPayloadAttributes();
+    payloadAttrs.put("payload_name", "Payload With Multiple Elements");
     payloadAttrs.put("command_executor", "bash");
     payloadAttrs.put("command_content", "netstat -an");
-    payloadAttrs.put("payload_name", "Payload With Multiple Elements");
-    payloadAttrs.put("payload_description", "");
     payloadAttrs.put("payload_platforms", new String[] {"Linux"});
-    payloadAttrs.put("payload_source", "MANUAL");
-    payloadAttrs.put("payload_expectations", new String[] {"VULNERABILITY"});
-    payloadAttrs.put("payload_status", "VERIFIED");
-    payloadAttrs.put("payload_execution_arch", "ALL_ARCHITECTURES");
 
     JsonApiDocument<ResourceObject> document =
         new JsonApiDocument<>(
@@ -431,22 +448,14 @@ class PayloadApiImporterTest extends IntegrationTest {
                 regexGroup2,
                 regexGroup3));
 
-    byte[] zip = zipJsonService.writeZip(document, emptyMap());
-    MockMultipartFile zipFile =
-        new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+    MockMultipartFile zipFile = buildZipFile(document);
 
     // -- EXECUTE --
-    String response =
-        mockMvc
-            .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    String response = performImport(zipFile);
 
     // -- ASSERT --
     assertNotNull(response);
-    JsonNode json = new ObjectMapper().readTree(response);
+    JsonNode json = objectMapper.readTree(response);
     assertEquals("command", json.at("/data/type").asText());
     assertEquals(
         "Payload With Multiple Elements" + IMPORTED_OBJECT_NAME_SUFFIX,
@@ -473,36 +482,23 @@ class PayloadApiImporterTest extends IntegrationTest {
   @Test
   @DisplayName("Import payload with null (missing) array fields")
   void importPayloadWithNullArrayFields() throws Exception {
-    Map<String, Object> attributes = new HashMap<>();
-    attributes.put("payload_type", "Command");
-    attributes.put("command_executor", "psh");
-    attributes.put("command_content", "echo \"toto\"");
-    attributes.put("payload_name", "Echo");
-    attributes.put("payload_description", "");
-    // omit payload_platforms, payload_arguments, payload_prerequisites
-    attributes.put("payload_source", "MANUAL");
-    attributes.put("payload_expectations", new String[] {"VULNERABILITY"});
-    attributes.put("payload_status", "VERIFIED");
-    attributes.put("payload_execution_arch", "ALL_ARCHITECTURES");
+    // -- PREPARE --
+    Map<String, Object> attributes = buildDefaultPayloadAttributes();
+    // Remove array fields to simulate missing/null values
+    attributes.remove("payload_platforms");
 
     JsonApiDocument<ResourceObject> document =
         new JsonApiDocument<>(
             new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
 
-    byte[] zip = zipJsonService.writeZip(document, emptyMap());
-    MockMultipartFile zipFile =
-        new MockMultipartFile("file", "payload.zip", "application/zip", zip);
+    MockMultipartFile zipFile = buildZipFile(document);
 
-    String response =
-        mockMvc
-            .perform(multipart(PAYLOAD_URI + "/import").file(zipFile))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+    // -- EXECUTE --
+    String response = performImport(zipFile);
 
+    // -- ASSERT --
     assertNotNull(response);
-    JsonNode json = new ObjectMapper().readTree(response);
+    JsonNode json = objectMapper.readTree(response);
     assertEquals(0, json.at("/data/attributes/payload_platforms").size());
     assertEquals(0, json.at("/data/attributes/payload_arguments").size());
     assertEquals(0, json.at("/data/attributes/payload_prerequisites").size());

--- a/openaev-api/src/test/java/io/openaev/rest/inject/InjectApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/InjectApiTest.java
@@ -38,7 +38,9 @@ import io.openaev.rest.atomic_testing.form.ExecutionTraceOutput;
 import io.openaev.rest.atomic_testing.form.InjectStatusOutput;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exercise.service.ExerciseService;
+import io.openaev.rest.helper.queue.BatchQueueService;
 import io.openaev.rest.inject.form.*;
+import io.openaev.rest.inject.service.BatchingInjectStatusService;
 import io.openaev.rest.inject.service.InjectStatusService;
 import io.openaev.service.scenario.ScenarioService;
 import io.openaev.utils.TargetType;
@@ -61,6 +63,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import net.javacrumbs.jsonunit.core.Option;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -3924,6 +3927,216 @@ class InjectApiTest extends IntegrationTest {
 
       JsonNode collectorNode = rootNode.get(0);
       assertEquals("SENTINEL", collectorNode.get("collector_name").asText());
+    }
+  }
+
+  // ==========================================================================
+  // Integration tests for the retry/requeue behaviour added to
+  // BatchingInjectStatusService + ExecutionTracesBatchRequeueJob.
+  //
+  // These tests drive the batching service directly rather than going through
+  // the MVC callback, because:
+  //  - the MVC-based tests in handleInjectExecutionCallback force the sync path
+  //    (setInjectTraceQueueService(null)) to avoid flaky RabbitMQ consumer
+  //    lifecycle issues, and the retry logic only lives in the async batch path;
+  //  - the sync path still throws DataIntegrityViolationException on a
+  //    complete-before-PENDING race, so the retry branch can only be exercised
+  //    by invoking BatchingInjectStatusService directly.
+  // ==========================================================================
+  @Nested
+  @WithMockUser(isAdmin = true)
+  @DisplayName("Batching inject callback retry/requeue behaviour")
+  @KeepRabbit
+  class BatchingInjectRetryIntegrationTest {
+
+    private static final int MAX_RETRIES = 5;
+
+    @Autowired private BatchingInjectStatusService batchingInjectStatusService;
+
+    @SuppressWarnings("unchecked")
+    private final BatchQueueService<InjectExecutionCallback> mockQueueService =
+        mock(BatchQueueService.class);
+
+    @BeforeEach
+    void wireMockQueueService() {
+      batchingInjectStatusService.setInjectTraceQueueService(mockQueueService);
+    }
+
+    @AfterEach
+    void resetQueueService() {
+      // Drain any leftovers and unwire so other tests keep the default (null) behaviour.
+      try {
+        batchingInjectStatusService.requeueCallbacks();
+      } catch (Exception ignored) {
+        // best-effort cleanup
+      }
+      batchingInjectStatusService.setInjectTraceQueueService(null);
+    }
+
+    private Inject buildPendingInjectWithAgent() {
+      return injectTestHelper.getPendingInjectWithAssets(
+          injectComposer,
+          injectorContractComposer,
+          endpointComposer,
+          agentComposer,
+          injectStatusComposer);
+    }
+
+    private Inject transitionToExecuting(Inject inject) {
+      inject.getStatus().orElseThrow().setName(ExecutionStatus.EXECUTING);
+      return injectTestHelper.forceSaveInject(inject);
+    }
+
+    private InjectExecutionCallback buildCompleteCallback(String injectId, String agentId) {
+      InjectExecutionInput input = new InjectExecutionInput();
+      input.setMessage("complete received");
+      input.setAction(InjectExecutionAction.complete);
+      input.setStatus("INFO");
+      input.setDuration(1000);
+      long emissionDate = Instant.now().toEpochMilli();
+      return InjectExecutionCallback.builder()
+          .injectId(injectId)
+          .agentId(agentId)
+          .injectExecutionInput(input)
+          .emissionDate(emissionDate)
+          .build();
+    }
+
+    @DisplayName(
+        "Should queue a complete callback received before the inject is PENDING for retry, "
+            + "without persisting any trace")
+    @Test
+    void shouldQueueCompleteCallbackForRetryWhenInjectIsNotPending() throws Exception {
+      // -- PREPARE --
+      Inject inject = buildPendingInjectWithAgent();
+      inject = transitionToExecuting(inject);
+      String agentId = ((Endpoint) inject.getAssets().getFirst()).getAgents().getFirst().getId();
+      InjectExecutionCallback callback = buildCompleteCallback(inject.getId(), agentId);
+
+      // -- EXECUTE --
+      List<InjectExecutionCallback> processed =
+          batchingInjectStatusService.handleInjectExecutionCallback(List.of(callback));
+
+      // -- ASSERT --
+      // Callback is not in the successfully-processed list: it was queued for retry.
+      assertTrue(processed.isEmpty());
+      // The retry counter was bumped on the callback instance.
+      assertEquals(1, callback.getRetryCount());
+      // No trace has been written to the DB — the inject is still in its pre-callback state.
+      entityManager.flush();
+      entityManager.clear();
+      Inject reloaded = injectRepository.findById(inject.getId()).orElseThrow();
+      InjectStatus reloadedStatus = reloaded.getStatus().orElseThrow();
+      assertEquals(ExecutionStatus.EXECUTING, reloadedStatus.getName());
+      assertTrue(
+          reloadedStatus.getTraces().isEmpty(),
+          "No execution trace should have been persisted for the rejected callback");
+
+      // Draining the requeue queue publishes the callback to the external queue service.
+      batchingInjectStatusService.requeueCallbacks();
+      ArgumentCaptor<InjectExecutionCallback> captor =
+          ArgumentCaptor.forClass(InjectExecutionCallback.class);
+      verify(mockQueueService).publish(captor.capture());
+      assertEquals(inject.getId(), captor.getValue().getInjectId());
+      assertEquals(1, captor.getValue().getRetryCount());
+    }
+
+    @DisplayName(
+        "Should process a previously retried callback successfully once the inject is PENDING")
+    @Test
+    void shouldProcessRequeuedCallbackAfterStatusTransition() throws Exception {
+      // -- PREPARE --
+      Inject inject = buildPendingInjectWithAgent();
+      inject = transitionToExecuting(inject);
+      String agentId = ((Endpoint) inject.getAssets().getFirst()).getAgents().getFirst().getId();
+      InjectExecutionCallback callback = buildCompleteCallback(inject.getId(), agentId);
+
+      // First attempt: inject still EXECUTING → callback is queued for retry.
+      List<InjectExecutionCallback> firstPass =
+          batchingInjectStatusService.handleInjectExecutionCallback(List.of(callback));
+      assertTrue(firstPass.isEmpty());
+      assertEquals(1, callback.getRetryCount());
+
+      // Simulate the race resolving: inject transitions back to PENDING.
+      inject.getStatus().orElseThrow().setName(ExecutionStatus.PENDING);
+      injectTestHelper.forceSaveInject(inject);
+
+      // Second attempt: equivalent to the Quartz requeue job republishing the callback
+      // and the consumer calling handleInjectExecutionCallback again.
+      List<InjectExecutionCallback> secondPass =
+          batchingInjectStatusService.handleInjectExecutionCallback(List.of(callback));
+
+      // -- ASSERT --
+      assertEquals(1, secondPass.size());
+      entityManager.flush();
+      entityManager.clear();
+      Inject reloaded = injectRepository.findById(inject.getId()).orElseThrow();
+      InjectStatus reloadedStatus = reloaded.getStatus().orElseThrow();
+      assertFalse(
+          reloadedStatus.getTraces().isEmpty(),
+          "A complete trace should have been written after the successful retry");
+      assertTrue(
+          reloadedStatus.getTraces().stream()
+              .anyMatch(t -> ExecutionTraceAction.COMPLETE.equals(t.getAction())),
+          "A trace with action COMPLETE should have been persisted");
+    }
+
+    @DisplayName(
+        "Should persist the execution trace once MAX_RETRIES is reached instead of republishing")
+    @Test
+    void shouldPersistExecutionTraceAfterMaxRetries() throws Exception {
+      // -- PREPARE --
+      Inject inject = buildPendingInjectWithAgent();
+      inject = transitionToExecuting(inject);
+      String agentId = ((Endpoint) inject.getAssets().getFirst()).getAgents().getFirst().getId();
+      InjectExecutionCallback callback = buildCompleteCallback(inject.getId(), agentId);
+      // Pretend this callback has already been retried MAX_RETRIES times.
+      callback.setRetryCount(MAX_RETRIES);
+
+      // -- EXECUTE --
+      List<InjectExecutionCallback> processed =
+          batchingInjectStatusService.handleInjectExecutionCallback(List.of(callback));
+      batchingInjectStatusService.requeueCallbacks();
+
+      // -- ASSERT --
+      // Max retries reached → fall through to persist the trace as a last-ditch effort
+      // (the expiration manager will handle any status discrepancies).
+      assertEquals(1, processed.size());
+      // Retry counter is not re-incremented past MAX_RETRIES.
+      assertEquals(MAX_RETRIES, callback.getRetryCount());
+      // No publish to the external queue — retries are over.
+      verify(mockQueueService, never()).publish(any());
+      // But the trace IS written so no information from the implant is lost.
+      entityManager.flush();
+      entityManager.clear();
+      Inject reloaded = injectRepository.findById(inject.getId()).orElseThrow();
+      InjectStatus reloadedStatus = reloaded.getStatus().orElseThrow();
+      assertFalse(
+          reloadedStatus.getTraces().isEmpty(),
+          "A trace should be persisted even after max retries");
+      assertTrue(
+          reloadedStatus.getTraces().stream()
+              .anyMatch(t -> ExecutionTraceAction.COMPLETE.equals(t.getAction())),
+          "A trace with action COMPLETE should have been persisted after max retries");
+    }
+
+    @DisplayName("requeueCallbacks should be a safe no-op when no queue service is wired")
+    @Test
+    void requeueCallbacksShouldBeSafeNoOpWhenQueueServiceIsNull() throws Exception {
+      // -- PREPARE --
+      Inject inject = buildPendingInjectWithAgent();
+      inject = transitionToExecuting(inject);
+      String agentId = ((Endpoint) inject.getAssets().getFirst()).getAgents().getFirst().getId();
+      InjectExecutionCallback callback = buildCompleteCallback(inject.getId(), agentId);
+
+      // First handle the callback so it lands in the in-memory requeue queue,
+      // then remove the queue service to simulate the legacy / unconfigured path.
+      batchingInjectStatusService.handleInjectExecutionCallback(List.of(callback));
+      batchingInjectStatusService.setInjectTraceQueueService(null);
+
+      // -- EXECUTE + ASSERT --
+      assertDoesNotThrow(() -> batchingInjectStatusService.requeueCallbacks());
+      verifyNoInteractions(mockQueueService);
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/BatchingInjectStatusServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/BatchingInjectStatusServiceTest.java
@@ -1,0 +1,572 @@
+package io.openaev.rest.inject.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.ExecutionStatus;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectStatus;
+import io.openaev.database.repository.AgentRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.rest.helper.queue.BatchQueueService;
+import io.openaev.rest.inject.form.InjectExecutionAction;
+import io.openaev.rest.inject.form.InjectExecutionCallback;
+import io.openaev.rest.inject.form.InjectExecutionInput;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BatchingInjectStatusService Tests")
+class BatchingInjectStatusServiceTest {
+
+  @Mock private InjectRepository injectRepository;
+  @Mock private AgentRepository agentRepository;
+  @Mock private StructuredOutputUtils structuredOutputUtils;
+  @Mock private InjectExecutionService injectExecutionService;
+
+  @Mock private BatchQueueService<InjectExecutionCallback> injectTraceQueueService;
+
+  @InjectMocks private BatchingInjectStatusService service;
+
+  private static final String INJECT_ID = "inject-1";
+  private static final String AGENT_ID = "agent-1";
+  private static final int MAX_RETRIES = 5;
+
+  @BeforeEach
+  void wireQueueService() {
+    // @InjectMocks does not set non-final fields with @Setter; wire it explicitly for the tests
+    // that exercise the requeue path. Tests that want to exercise the null-guard branch can
+    // override this via service.setInjectTraceQueueService(null).
+    service.setInjectTraceQueueService(injectTraceQueueService);
+  }
+
+  private Inject createInjectWithPendingStatus(String injectId) {
+    Inject inject = new Inject();
+    inject.setId(injectId);
+    InjectStatus status = new InjectStatus();
+    status.setName(ExecutionStatus.PENDING);
+    inject.setStatus(status);
+    return inject;
+  }
+
+  private Inject createInjectWithExecutingStatus(String injectId) {
+    Inject inject = new Inject();
+    inject.setId(injectId);
+    InjectStatus status = new InjectStatus();
+    status.setName(ExecutionStatus.EXECUTING);
+    inject.setStatus(status);
+    return inject;
+  }
+
+  private Agent createAgent(String agentId) {
+    Agent agent = new Agent();
+    agent.setId(agentId);
+    return agent;
+  }
+
+  private InjectExecutionCallback createCallback(
+      String injectId, String agentId, InjectExecutionAction action, long emissionDate) {
+    InjectExecutionInput input = new InjectExecutionInput();
+    input.setAction(action);
+    input.setMessage("test message");
+    input.setStatus("SUCCESS");
+    return InjectExecutionCallback.builder()
+        .injectId(injectId)
+        .agentId(agentId)
+        .injectExecutionInput(input)
+        .emissionDate(emissionDate)
+        .build();
+  }
+
+  // ========================================================================
+  // Chronological ordering
+  // ========================================================================
+  @Nested
+  @DisplayName("Chronological ordering")
+  class ChronologicalOrderingTests {
+
+    @Test
+    @DisplayName("should process callbacks in chronological order by emission date")
+    void shouldProcessInChronologicalOrder() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      // Create callbacks out of order
+      InjectExecutionCallback late =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.command_execution, 3000L);
+      InjectExecutionCallback early =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.command_execution, 1000L);
+      InjectExecutionCallback middle =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.command_execution, 2000L);
+
+      service.handleInjectExecutionCallback(List.of(late, early, middle));
+
+      // Verify processInjectExecutionWithAgent was called 3 times in chronological order
+      InOrder inOrder = inOrder(injectExecutionService);
+      inOrder
+          .verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), argThat(input -> input == early.getInjectExecutionInput()));
+      inOrder
+          .verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), argThat(input -> input == middle.getInjectExecutionInput()));
+      inOrder
+          .verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), argThat(input -> input == late.getInjectExecutionInput()));
+    }
+  }
+
+  // ========================================================================
+  // ElementNotFoundException handling
+  // ========================================================================
+  @Nested
+  @DisplayName("ElementNotFoundException handling")
+  class ElementNotFoundTests {
+
+    @Test
+    @DisplayName("should handle missing inject gracefully and add to success list")
+    void shouldHandleMissingInject() {
+      // Return empty list — no inject found
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of());
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+      InjectExecutionCallback callback =
+          createCallback(
+              "non-existent-inject", AGENT_ID, InjectExecutionAction.command_execution, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      // Should be in success list because ElementNotFoundException is caught and handled
+      assertEquals(1, result.size());
+      verify(injectExecutionService).handleInjectExecutionError(isNull(), any(Exception.class));
+    }
+
+    @Test
+    @DisplayName("should handle missing agent gracefully and add to success list")
+    void shouldHandleMissingAgent() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      // Return empty — no agent found
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+      InjectExecutionCallback callback =
+          createCallback(
+              INJECT_ID, "non-existent-agent", InjectExecutionAction.command_execution, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      // Missing agent throws ElementNotFoundException → caught → added to success
+      assertEquals(1, result.size());
+      verify(injectExecutionService).handleInjectExecutionError(eq(inject), any(Exception.class));
+    }
+  }
+
+  // ========================================================================
+  // General exception handling
+  // ========================================================================
+  @Nested
+  @DisplayName("General exception handling")
+  class GeneralExceptionTests {
+
+    @Test
+    @DisplayName("should not add callback to success list when general exception occurs")
+    void shouldNotAddToSuccessListOnGeneralException() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      doThrow(new RuntimeException("Unexpected error"))
+          .when(injectExecutionService)
+          .processInjectExecutionWithAgent(any(), any(), any());
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.command_execution, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      // General exception → NOT added to success list
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  // ========================================================================
+  // PENDING state guard
+  // ========================================================================
+  @Nested
+  @DisplayName("PENDING state guard")
+  class PendingStateGuardTests {
+
+    @Test
+    @DisplayName("should not process complete action for non-PENDING inject and queue it for retry")
+    void shouldRejectCompleteActionForNonPendingInject() {
+      // Inject is in EXECUTING state, not PENDING
+      Inject inject = createInjectWithExecutingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.complete, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      // The callback is queued for retry → NOT added to the successfully-processed list,
+      // and no execution processing happened.
+      assertTrue(result.isEmpty());
+      verify(injectExecutionService, never()).processInjectExecutionWithAgent(any(), any(), any());
+      verify(injectExecutionService, never()).processInjectExecutionWithInjector(any(), any());
+      // retry counter is bumped on the callback instance
+      assertEquals(1, callback.getRetryCount());
+    }
+
+    @Test
+    @DisplayName("should allow complete action for PENDING inject")
+    void shouldAllowCompleteActionForPendingInject() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.complete, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      assertEquals(1, result.size());
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), eq(callback.getInjectExecutionInput()));
+    }
+
+    @Test
+    @DisplayName("should allow non-complete actions regardless of inject status")
+    void shouldAllowNonCompleteActionsRegardlessOfStatus() {
+      Inject inject = createInjectWithExecutingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      // command_execution action should pass regardless of status
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.command_execution, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      assertEquals(1, result.size());
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), eq(callback.getInjectExecutionInput()));
+    }
+  }
+
+  // ========================================================================
+  // Bulk loading optimization
+  // ========================================================================
+  @Nested
+  @DisplayName("Bulk loading optimization")
+  class BulkLoadingTests {
+
+    @Test
+    @DisplayName("should load all injects and agents in a single query each")
+    void shouldBulkLoadInjectsAndAgents() {
+      Inject inject1 = createInjectWithPendingStatus("inject-1");
+      Inject inject2 = createInjectWithPendingStatus("inject-2");
+      Agent agent1 = createAgent("agent-1");
+      Agent agent2 = createAgent("agent-2");
+
+      when(injectRepository.findAllByIdWithExpectations(anyList()))
+          .thenReturn(List.of(inject1, inject2));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent1, agent2));
+
+      InjectExecutionCallback callback1 =
+          createCallback("inject-1", "agent-1", InjectExecutionAction.command_execution, 1000L);
+      InjectExecutionCallback callback2 =
+          createCallback("inject-2", "agent-2", InjectExecutionAction.command_execution, 2000L);
+
+      service.handleInjectExecutionCallback(List.of(callback1, callback2));
+
+      // Verify bulk loads are called exactly once each
+      verify(injectRepository, times(1)).findAllByIdWithExpectations(anyList());
+      verify(agentRepository, times(1)).findAllById(anyList());
+    }
+  }
+
+  // ========================================================================
+  // Successful processing
+  // ========================================================================
+  @Nested
+  @DisplayName("Successful processing")
+  class SuccessfulProcessingTests {
+
+    @Test
+    @DisplayName("should call processInjectExecutionWithAgent with correct arguments")
+    void shouldCallProcessInjectExecutionWithCorrectArgs() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.command_execution, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      assertEquals(1, result.size());
+      assertSame(callback, result.getFirst());
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), eq(callback.getInjectExecutionInput()));
+    }
+
+    @Test
+    @DisplayName("should handle callback with null agentId by passing null agent")
+    void shouldHandleNullAgentId() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, null, InjectExecutionAction.command_execution, 1000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      assertEquals(1, result.size());
+      verify(injectExecutionService)
+          .processInjectExecutionWithInjector(eq(inject), eq(callback.getInjectExecutionInput()));
+    }
+  }
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+  @Nested
+  @DisplayName("Edge cases")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("should handle empty callback list gracefully")
+    void shouldHandleEmptyCallbackList() {
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of());
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+      List<InjectExecutionCallback> result = service.handleInjectExecutionCallback(List.of());
+
+      assertTrue(result.isEmpty());
+      verify(injectExecutionService, never()).processInjectExecutionWithAgent(any(), any(), any());
+      verify(injectExecutionService, never()).processInjectExecutionWithInjector(any(), any());
+    }
+
+    // ------------------------------------------------------------------
+    // Retry / requeue behavior for complete-before-PENDING race condition
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("should drain the requeue queue to the external queue service")
+    void shouldDrainRequeueQueueOnRequeueCallbacks() throws IOException {
+      // First call: inject is not PENDING → callback gets queued for retry
+      Inject inject = createInjectWithExecutingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      long originalEmissionDate = 1000L;
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.complete, originalEmissionDate);
+      long beforeHandle = Instant.now().toEpochMilli();
+      service.handleInjectExecutionCallback(List.of(callback));
+
+      // Drain
+      service.requeueCallbacks();
+
+      ArgumentCaptor<InjectExecutionCallback> captor =
+          ArgumentCaptor.forClass(InjectExecutionCallback.class);
+      verify(injectTraceQueueService).publish(captor.capture());
+      assertSame(callback, captor.getValue());
+      assertEquals(1, captor.getValue().getRetryCount());
+      // emissionDate must be bumped to "now" on retry so the re-queued callback does not
+      // compete for ordering against freshly emitted ones.
+      assertNotEquals(originalEmissionDate, captor.getValue().getEmissionDate());
+      assertTrue(
+          captor.getValue().getEmissionDate() >= beforeHandle,
+          "emissionDate should have been refreshed at retry time");
+    }
+
+    @Test
+    @DisplayName(
+        "should process a mixed batch: queue the non-PENDING complete for retry and process the "
+            + "other callback normally")
+    void shouldHandleMixedBatchOfRetryAndNormalCallbacks() {
+      // inject-1 is in EXECUTING → complete callback must be queued for retry
+      Inject executingInject = createInjectWithExecutingStatus("inject-1");
+      // inject-2 is in PENDING → complete callback must be processed normally
+      Inject pendingInject = createInjectWithPendingStatus("inject-2");
+      Agent agent1 = createAgent("agent-1");
+      Agent agent2 = createAgent("agent-2");
+
+      when(injectRepository.findAllByIdWithExpectations(anyList()))
+          .thenReturn(List.of(executingInject, pendingInject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent1, agent2));
+
+      InjectExecutionCallback retryCallback =
+          createCallback("inject-1", "agent-1", InjectExecutionAction.complete, 1000L);
+      InjectExecutionCallback normalCallback =
+          createCallback("inject-2", "agent-2", InjectExecutionAction.complete, 2000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(retryCallback, normalCallback));
+
+      // Only the normal callback is in the success list; the retry callback is queued instead.
+      assertEquals(1, result.size());
+      assertSame(normalCallback, result.getFirst());
+      assertEquals(1, retryCallback.getRetryCount());
+      assertEquals(0, normalCallback.getRetryCount());
+
+      // Only the pending inject was processed, not the executing one.
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(pendingInject), eq(agent2), eq(normalCallback.getInjectExecutionInput()));
+      verify(injectExecutionService, never())
+          .processInjectExecutionWithAgent(
+              eq(executingInject), any(), eq(retryCallback.getInjectExecutionInput()));
+    }
+
+    @Test
+    @DisplayName(
+        "should stop retrying once MAX_RETRIES is reached and still persist the execution trace")
+    void shouldPersistExecutionTraceAfterMaxRetries() throws IOException {
+      Inject inject = createInjectWithExecutingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.complete, 1000L);
+      // Pretend this callback has already been retried MAX_RETRIES times
+      callback.setRetryCount(MAX_RETRIES);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      // Max retries reached → fall through to persist the trace as a last-ditch effort,
+      // not re-incremented, not re-queued.
+      assertEquals(1, result.size());
+      assertSame(callback, result.getFirst());
+      assertEquals(MAX_RETRIES, callback.getRetryCount());
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(
+              eq(inject), eq(agent), eq(callback.getInjectExecutionInput()));
+      service.requeueCallbacks();
+      verify(injectTraceQueueService, never()).publish(any());
+    }
+
+    @Test
+    @DisplayName(
+        "should persist via injector path when MAX_RETRIES is reached and callback has no agent")
+    void shouldPersistViaInjectorPathAfterMaxRetriesWithNullAgent() throws IOException {
+      Inject inject = createInjectWithExecutingStatus(INJECT_ID);
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, null, InjectExecutionAction.complete, 1000L);
+      // Already exhausted retries
+      callback.setRetryCount(MAX_RETRIES);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback));
+
+      // Max retries reached with no agent → fall through to the injector branch of
+      // saveExecutionTrace and still persist the trace.
+      assertEquals(1, result.size());
+      assertSame(callback, result.getFirst());
+      assertEquals(MAX_RETRIES, callback.getRetryCount());
+      verify(injectExecutionService)
+          .processInjectExecutionWithInjector(eq(inject), eq(callback.getInjectExecutionInput()));
+      verify(injectExecutionService, never()).processInjectExecutionWithAgent(any(), any(), any());
+      service.requeueCallbacks();
+      verify(injectTraceQueueService, never()).publish(any());
+    }
+
+    @Test
+    @DisplayName("requeueCallbacks is a safe no-op when queue service is not configured")
+    void requeueCallbacksIsSafeWhenQueueServiceIsNull() {
+      // Simulate the legacy / unconfigured path: no queue service wired.
+      service.setInjectTraceQueueService(null);
+
+      Inject inject = createInjectWithExecutingStatus(INJECT_ID);
+      Agent agent = createAgent(AGENT_ID);
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+      InjectExecutionCallback callback =
+          createCallback(INJECT_ID, AGENT_ID, InjectExecutionAction.complete, 1000L);
+      service.handleInjectExecutionCallback(List.of(callback));
+
+      // Must not NPE even though the in-memory requeue queue is non-empty.
+      assertDoesNotThrow(() -> service.requeueCallbacks());
+      verifyNoInteractions(injectTraceQueueService);
+    }
+
+    @Test
+    @DisplayName("should process duplicate inject callbacks with the same inject entity")
+    void shouldProcessDuplicateInjectCallbacksWithSameInjectEntity() {
+      Inject inject = createInjectWithPendingStatus(INJECT_ID);
+      Agent agent1 = createAgent("agent-1");
+      Agent agent2 = createAgent("agent-2");
+
+      when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+      when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent1, agent2));
+
+      InjectExecutionCallback callback1 =
+          createCallback(INJECT_ID, "agent-1", InjectExecutionAction.command_execution, 1000L);
+      InjectExecutionCallback callback2 =
+          createCallback(INJECT_ID, "agent-2", InjectExecutionAction.command_execution, 2000L);
+
+      List<InjectExecutionCallback> result =
+          service.handleInjectExecutionCallback(List.of(callback1, callback2));
+
+      assertEquals(2, result.size());
+      // Both callbacks should reference the same Inject entity from the bulk load
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(same(inject), eq(agent1), any());
+      verify(injectExecutionService)
+          .processInjectExecutionWithAgent(same(inject), eq(agent2), any());
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectCallbackContractTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectCallbackContractTest.java
@@ -1,0 +1,250 @@
+package io.openaev.rest.inject.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import io.openaev.database.model.*;
+import io.openaev.database.repository.AgentRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.rest.helper.queue.BatchQueueService;
+import io.openaev.rest.inject.form.InjectExecutionAction;
+import io.openaev.rest.inject.form.InjectExecutionCallback;
+import io.openaev.rest.inject.form.InjectExecutionInput;
+import io.openaev.service.InjectExpectationService;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/**
+ * Contract tests that verify the sync path ({@link
+ * InjectExecutionService#handleInjectExecutionCallback}) and the async batch path ({@link
+ * BatchingInjectStatusService#handleInjectExecutionCallback}) apply the same business rules.
+ *
+ * <p>Each test runs the same assertion against both paths using a functional interface that
+ * abstracts the invocation.
+ */
+@ExtendWith(MockitoExtension.class)
+// this is a contract test only where each parameterization run different code paths, lenient mode
+// is OK in this case.
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Inject Callback Contract Tests")
+class InjectCallbackContractTest {
+
+  @Mock private InjectRepository injectRepository;
+  @Mock private AgentRepository agentRepository;
+  @Mock private InjectExpectationService injectExpectationService;
+  @Mock private InjectStatusService injectStatusService;
+  @Mock private InjectService injectService;
+  @Mock private AgentExecutionProcessingHandler agentExecutionProcessingHandler;
+  @Mock private InjectorExecutionProcessingHandler injectorExecutionProcessingHandler;
+  @Mock private StructuredOutputUtils structuredOutputUtils;
+  @Mock private BatchQueueService<InjectExecutionCallback> injectTraceQueueService;
+
+  private InjectExecutionService injectExecutionService;
+  private BatchingInjectStatusService batchingService;
+
+  @FunctionalInterface
+  interface CallbackInvoker {
+    void invoke(String injectId, String agentId, InjectExecutionInput input) throws Exception;
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    lenient().when(injectService.getValueTargetedAssetMap(any())).thenReturn(Map.of());
+    lenient()
+        .doReturn(Optional.empty())
+        .when(agentExecutionProcessingHandler)
+        .processContext(any());
+    lenient()
+        .doReturn(Optional.empty())
+        .when(injectorExecutionProcessingHandler)
+        .processContext(any());
+
+    // Spy: real object with mock dependencies, so we can verify method calls
+    injectExecutionService =
+        spy(
+            new InjectExecutionService(
+                injectRepository,
+                injectExpectationService,
+                agentRepository,
+                injectStatusService,
+                injectService,
+                agentExecutionProcessingHandler,
+                injectorExecutionProcessingHandler));
+
+    // Can't use @InjectMocks: batchingService needs the spy, not a plain mock
+    batchingService =
+        new BatchingInjectStatusService(
+            injectRepository, agentRepository, structuredOutputUtils, injectExecutionService);
+    batchingService.setInjectTraceQueueService(injectTraceQueueService);
+  }
+
+  private CallbackInvoker syncInvoker() {
+    return (injectId, agentId, input) ->
+        injectExecutionService.handleInjectExecutionCallback(injectId, agentId, input);
+  }
+
+  private CallbackInvoker asyncInvoker() {
+    return (injectId, agentId, input) -> {
+      InjectExecutionCallback callback =
+          InjectExecutionCallback.builder()
+              .injectId(injectId)
+              .agentId(agentId)
+              .injectExecutionInput(input)
+              .emissionDate(System.currentTimeMillis())
+              .build();
+      batchingService.handleInjectExecutionCallback(List.of(callback));
+    };
+  }
+
+  static Stream<Arguments> bothPaths() {
+    return Stream.of(
+        Arguments.of(Named.of("sync", "sync")), Arguments.of(Named.of("async", "async")));
+  }
+
+  private CallbackInvoker invokerFor(String path) {
+    return "sync".equals(path) ? syncInvoker() : asyncInvoker();
+  }
+
+  private Inject createInjectWithStatus(String injectId, ExecutionStatus executionStatus) {
+    Inject inject = new Inject();
+    inject.setId(injectId);
+    InjectStatus status = new InjectStatus();
+    status.setName(executionStatus);
+    inject.setStatus(status);
+    return inject;
+  }
+
+  private Agent createAgent(String agentId) {
+    Agent agent = new Agent();
+    agent.setId(agentId);
+    return agent;
+  }
+
+  private InjectExecutionInput createInput(InjectExecutionAction action) {
+    InjectExecutionInput input = new InjectExecutionInput();
+    input.setAction(action);
+    input.setMessage("test");
+    input.setStatus("SUCCESS");
+    return input;
+  }
+
+  // ========================================================================
+  // Contract: neither path processes a complete action on a non-PENDING inject.
+  //
+  // Note: the two paths diverge on *how* they reject it — the sync path still
+  // throws DataIntegrityViolationException, while the async batch path silently
+  // queues the callback for later retry (handled by ExecutionTracesBatchRequeueJob).
+  // What remains a true contract is that neither path delegates the execution
+  // processing in that situation.
+  // ========================================================================
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothPaths")
+  @DisplayName("should not process complete action for non-PENDING inject")
+  void shouldRejectNonPendingCompleteAction(String path) {
+    Inject inject = createInjectWithStatus("inject-1", ExecutionStatus.EXECUTING);
+
+    when(injectRepository.findById("inject-1")).thenReturn(Optional.of(inject));
+    when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+    when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+    InjectExecutionInput input = createInput(InjectExecutionAction.complete);
+    CallbackInvoker invoker = invokerFor(path);
+
+    if ("sync".equals(path)) {
+      // Sync path still throws DataIntegrityViolationException (not caught internally)
+      assertThrows(
+          DataIntegrityViolationException.class, () -> invoker.invoke("inject-1", null, input));
+    } else {
+      // Async batch path does not throw — it queues the callback for retry instead.
+      assertDoesNotThrow(() -> invoker.invoke("inject-1", null, input));
+    }
+
+    // Neither path should have delegated to execution processing
+    verify(injectExecutionService, never()).processInjectExecutionWithAgent(any(), any(), any());
+    verify(injectExecutionService, never()).processInjectExecutionWithInjector(any(), any());
+  }
+
+  // ========================================================================
+  // Contract: both paths handle missing inject gracefully
+  // ========================================================================
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothPaths")
+  @DisplayName("should handle missing inject gracefully")
+  void shouldHandleMissingInjectGracefully(String path) {
+    when(injectRepository.findById("missing-inject")).thenReturn(Optional.empty());
+    when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of());
+    when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+    InjectExecutionInput input = createInput(InjectExecutionAction.command_execution);
+    CallbackInvoker invoker = invokerFor(path);
+
+    // Both paths should handle the missing inject without uncaught exceptions
+    assertDoesNotThrow(() -> invoker.invoke("missing-inject", null, input));
+
+    // Both paths should call handleInjectExecutionError
+    verify(injectExecutionService).handleInjectExecutionError(isNull(), any(Exception.class));
+  }
+
+  // ========================================================================
+  // Contract: both paths handle missing agent gracefully
+  // ========================================================================
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothPaths")
+  @DisplayName("should handle missing agent gracefully")
+  void shouldHandleMissingAgentGracefully(String path) {
+    Inject inject = createInjectWithStatus("inject-1", ExecutionStatus.PENDING);
+
+    when(injectRepository.findById("inject-1")).thenReturn(Optional.of(inject));
+    when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+    when(agentRepository.findById("missing-agent")).thenReturn(Optional.empty());
+    when(agentRepository.findAllById(anyList())).thenReturn(List.of());
+
+    InjectExecutionInput input = createInput(InjectExecutionAction.command_execution);
+    CallbackInvoker invoker = invokerFor(path);
+
+    // Both paths should handle the missing agent without uncaught exceptions
+    assertDoesNotThrow(() -> invoker.invoke("inject-1", "missing-agent", input));
+
+    // Both paths should call handleInjectExecutionError
+    verify(injectExecutionService).handleInjectExecutionError(eq(inject), any(Exception.class));
+  }
+
+  // ========================================================================
+  // Contract: both paths delegate to processInjectExecution for valid callbacks
+  // ========================================================================
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("bothPaths")
+  @DisplayName("should call processInjectExecution for valid callbacks")
+  void shouldDelegateToProcessInjectExecution(String path) throws Exception {
+    Inject inject = createInjectWithStatus("inject-1", ExecutionStatus.PENDING);
+    Agent agent = createAgent("agent-1");
+
+    when(injectRepository.findById("inject-1")).thenReturn(Optional.of(inject));
+    when(injectRepository.findAllByIdWithExpectations(anyList())).thenReturn(List.of(inject));
+    when(agentRepository.findById("agent-1")).thenReturn(Optional.of(agent));
+    when(agentRepository.findAllById(anyList())).thenReturn(List.of(agent));
+
+    InjectExecutionInput input = createInput(InjectExecutionAction.command_execution);
+    CallbackInvoker invoker = invokerFor(path);
+
+    invoker.invoke("inject-1", "agent-1", input);
+
+    verify(injectExecutionService)
+        .processInjectExecutionWithAgent(eq(inject), eq(agent), eq(input));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTest.java
@@ -46,6 +46,7 @@ class InjectsExecutionJobTest extends IntegrationTest {
   @Autowired private EntityManager entityManager;
   @Autowired private SecurityCoverageSendJobRepository securityCoverageSendJobRepository;
   @Autowired private SecurityCoverageComposer securityCoverageComposer;
+  @Autowired private ExecutionTraceComposer executionTraceComposer;
 
   @Mock private InjectDependenciesRepository injectDependenciesRepository;
 
@@ -231,6 +232,135 @@ class InjectsExecutionJobTest extends IntegrationTest {
       assertThat(e).isInstanceOf(ErrorMessagesPreExecutionException.class);
       assertThat(e.getMessage())
           .isEqualTo("There was an error during the evaluation of the condition of the inject");
+    }
+  }
+
+  @Nested
+  @DisplayName("handlePendingInject")
+  class HandlePendingInjectTest {
+
+    @Test
+    @DisplayName("given pending inject without traces should mark status as maybe prevented")
+    void given_pendingInjectWithoutTraces_should_markStatusAsMaybePrevented() {
+      // Arrange
+      InjectStatus statusToSave = InjectStatusFixture.createPendingInjectStatus();
+      statusToSave.setTrackingSentDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+      Inject inject =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withInjectStatus(injectStatusComposer.forInjectStatus(statusToSave))
+              .persist()
+              .get();
+      entityManager.flush();
+
+      // Act
+      job.handlePendingInject();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Assert
+      Inject savedInject = injectRepository.findById(inject.getId()).orElseThrow();
+      InjectStatus savedStatus = savedInject.getStatus().orElseThrow();
+      assertEquals(ExecutionStatus.MAYBE_PREVENTED, savedStatus.getName());
+      assertTrue(
+          savedStatus.getTraces().stream()
+              .anyMatch(
+                  trace ->
+                      ExecutionTraceStatus.WARNING.equals(trace.getStatus())
+                          && trace
+                              .getMessage()
+                              .contains("Execution delay detected: Inject exceeded the")));
+    }
+
+    @Test
+    @DisplayName(
+        "given pending inject without complete traces should mark status as maybe prevented")
+    void given_pendingInjectWithoutCompleteTraces_should_markStatusAsMaybePrevented() {
+      // Arrange
+      AgentComposer.Composer agentComposerRef =
+          agentComposer.forAgent(AgentFixture.createDefaultAgentService());
+      InjectStatus statusToSave = InjectStatusFixture.createPendingInjectStatus();
+      statusToSave.setTrackingSentDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+      InjectStatusComposer.Composer statusComposer =
+          injectStatusComposer
+              .forInjectStatus(statusToSave)
+              .withExecutionTrace(
+                  executionTraceComposer
+                      .forExecutionTrace(ExecutionTraceFixture.createDefaultExecutionTraceStart())
+                      .withAgent(agentComposerRef));
+
+      Inject inject =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withEndpoint(
+                  endpointComposer
+                      .forEndpoint(EndpointFixture.createEndpoint())
+                      .withAgent(agentComposerRef))
+              .withInjectStatus(statusComposer)
+              .persist()
+              .get();
+      entityManager.flush();
+
+      // Act
+      job.handlePendingInject();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Assert
+      Inject savedInject = injectRepository.findById(inject.getId()).orElseThrow();
+      InjectStatus savedStatus = savedInject.getStatus().orElseThrow();
+      assertEquals(ExecutionStatus.MAYBE_PREVENTED, savedStatus.getName());
+      assertTrue(
+          savedStatus.getTraces().stream()
+              .anyMatch(
+                  trace ->
+                      ExecutionTraceStatus.WARNING.equals(trace.getStatus())
+                          && trace
+                              .getMessage()
+                              .contains("Execution delay detected: Inject exceeded the")));
+    }
+
+    @Test
+    @DisplayName("given pending inject with complete traces should compute final status")
+    void given_pendingInjectWithCompleteTraces_should_computeFinalStatus() {
+      // Arrange
+      AgentComposer.Composer agentComposerRef =
+          agentComposer.forAgent(AgentFixture.createDefaultAgentService());
+      InjectStatus statusToSave = InjectStatusFixture.createPendingInjectStatus();
+      statusToSave.setTrackingSentDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+      InjectStatusComposer.Composer statusComposer =
+          injectStatusComposer
+              .forInjectStatus(statusToSave)
+              .withExecutionTrace(
+                  executionTraceComposer
+                      .forExecutionTrace(
+                          ExecutionTraceFixture.createDefaultExecutionTraceComplete())
+                      .withAgent(agentComposerRef));
+
+      Inject inject =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withEndpoint(
+                  endpointComposer
+                      .forEndpoint(EndpointFixture.createEndpoint())
+                      .withAgent(agentComposerRef))
+              .withInjectStatus(statusComposer)
+              .persist()
+              .get();
+      entityManager.flush();
+
+      // Act
+      job.handlePendingInject();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Assert
+      Inject savedInject = injectRepository.findById(inject.getId()).orElseThrow();
+      InjectStatus savedStatus = savedInject.getStatus().orElseThrow();
+      assertEquals(ExecutionStatus.SUCCESS, savedStatus.getName());
+      assertTrue(
+          savedStatus.getTraces().stream()
+              .noneMatch(trace -> ExecutionTraceStatus.WARNING.equals(trace.getStatus())));
     }
   }
 }

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -88,7 +88,7 @@
     "react-intl": "8.1.4",
     "react-markdown": "10.1.0",
     "react-redux": "9.2.0",
-    "react-router": "7.13.2",
+    "react-router": "7.14.0",
     "react-syntax-highlighter": "16.1.1",
     "redux": "5.0.1",
     "redux-thunk": "3.1.0",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -52,7 +52,7 @@
     "@uiw/react-md-editor": "4.1.0",
     "@xyflow/react": "12.10.2",
     "apexcharts": "5.3.6",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "ckeditor5": "47.6.1",
     "classcat": "5.0.5",
     "cronstrue": "3.14.0",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -84,7 +84,7 @@
     "react-final-form": "6.5.9",
     "react-final-form-arrays": "4.0.0",
     "react-grid-layout": "2.2.3",
-    "react-hook-form": "7.72.0",
+    "react-hook-form": "7.72.1",
     "react-intl": "8.1.4",
     "react-markdown": "10.1.0",
     "react-redux": "9.2.0",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -66,7 +66,7 @@
     "html-react-parser": "5.2.17",
     "html-to-image": "1.11.13",
     "http-proxy-middleware": "3.0.5",
-    "immutable": "5.1.4",
+    "immutable": "5.1.5",
     "js-file-download": "0.4.12",
     "mdi-material-ui": "7.9.4",
     "moment": "2.30.1",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -118,7 +118,7 @@
     "@types/react-dom": "19.2.3",
     "@types/react-syntax-highlighter": "15",
     "@typescript-eslint/utils": "8.57.0",
-    "@vitejs/plugin-react": "5.2.0",
+    "@vitejs/plugin-react": "6.0.1",
     "@vitest/eslint-plugin": "1.6.12",
     "chokidar": "5.0.0",
     "cross-env": "10.1.0",
@@ -141,7 +141,7 @@
     "swagger-typescript-api": "13.6.3",
     "typescript": "5.9.3",
     "typescript-eslint": "8.57.0",
-    "vite": "npm:rolldown-vite@7.3.1",
+    "vite": "8.0.7",
     "vitest": "4.1.0"
   },
   "resolutions": {

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -48,7 +48,7 @@
     "@mui/material": "7.3.9",
     "@mui/system": "7.3.9",
     "@mui/x-date-pickers": "8.27.2",
-    "@redux-devtools/extension": "3.3.0",
+    "@redux-devtools/extension": "4.0.0",
     "@uiw/react-md-editor": "4.1.0",
     "@xyflow/react": "12.10.2",
     "apexcharts": "5.3.6",

--- a/openaev-front/src/admin/components/lessons/simulations/Lessons.tsx
+++ b/openaev-front/src/admin/components/lessons/simulations/Lessons.tsx
@@ -549,8 +549,7 @@ const Lessons: FunctionComponent<Props> = ({
           <SendLessonsForm
             onSubmit={handleSubmitSendLessons}
             initialValues={{
-              // eslint-disable-next-line no-template-curly-in-string
-              subject: t('[${exercise.name}] Lessons learned questionnaire'),
+              subject: t('[{exerciseName}] Lessons learned questionnaire', { exerciseName: source.name }),
               body: `${t('Hello')},<br /><br />${t(
                 // eslint-disable-next-line no-template-curly-in-string
                 'We would like thank your for your participation in this simulation. You are kindly requested to fill this lessons learned questionnaire: <a href="${lessons_uri}">${lessons_uri}</a>.',

--- a/openaev-front/src/components/CKEditor.tsx
+++ b/openaev-front/src/components/CKEditor.tsx
@@ -64,9 +64,9 @@ const LazyCKEditorComponent = lazy(async () => {
       TodoList,
       Underline,
     },
-    { defautl: en },
-    { defautl: fr },
-    { defautl: zh },
+    { default: en },
+    { default: fr },
+    { default: zh },
   ] = await Promise.all([
     import('@ckeditor/ckeditor5-react'),
     import('ckeditor5'),

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(letzte 180 Tage)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] Gelernte Lektionen Fragebogen",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Gelernte Lektionen Fragebogen",
   "{executor_name} documentation": "{executor_name} Dokumentation",
   "{executor_name} documentation.": "{executor_name} Dokumentation.",
   "&": "&",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(last 180 days)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] Lessons learned questionnaire",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Lessons learned questionnaire",
   "{executor_name} documentation": "{executor_name} documentation",
   "{executor_name} documentation.": "{executor_name} documentation.",
   "&": "&",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(últimos 180 días)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] Cuestionario de lecciones aprendidas",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Cuestionario de lecciones aprendidas",
   "{executor_name} documentation": "{executor_name} documentación",
   "{executor_name} documentation.": "{executor_name} documentación.",
   "&": "&",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(180 derniers jours)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] Questionnaire de retour d'expérience",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Questionnaire de retour d'expérience",
   "{executor_name} documentation": "documentation {executor_name}",
   "{executor_name} documentation.": "documentation {executor_name}.",
   "&": "& ;",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(ultimi 180 giorni)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] Lezioni apprese questionario",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Lezioni apprese questionario",
   "{executor_name} documentation": "{executor_name} documentazione",
   "{executor_name} documentation.": "{executor_name} documentazione.",
   "&": "&",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(過去180日)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] 教訓アンケート",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] 教訓アンケート",
   "{executor_name} documentation": "{executor_name} ドキュメント",
   "{executor_name} documentation.": "{executor_name} ドキュメンテーション",
   "&": "&；",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(지난 180일)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] 교훈을 얻은 설문지",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] 교훈을 얻은 설문지",
   "{executor_name} documentation": "{executor_name} 문서",
   "{executor_name} documentation.": "{executor_name} 문서",
   "&": "&",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(последние 180 дней)",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] Опросник \"Извлеченные уроки",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Опросник \"Извлеченные уроки",
   "{executor_name} documentation": "{executor_name} документация",
   "{executor_name} documentation.": "{executor_name} документация.",
   "&": "&",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -10,7 +10,7 @@
   ",": ",",
   ".": ".",
   "(last 180 days)": "(过去 180 天）",
-  "[${exercise.name}] Lessons learned questionnaire": "[${exercise.name}] 经验教训调查问卷",
+  "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] 经验教训调查问卷",
   "{executor_name} documentation": "{executor_name}文件",
   "{executor_name} documentation.": "{executor_name} 文档。",
   "&": "&；",

--- a/openaev-front/tsconfig.json
+++ b/openaev-front/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -12129,15 +12129,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.10
-  resolution: "tar@npm:7.5.10"
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/ed905e4b33886377df6e9206e5d1bd34458c21666e27943f946799416f86348c938590d573d6a69312cb29c583b122647a64ec92782f2b7e24e68d985dd72531
+  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -10315,7 +10315,7 @@ __metadata:
     react-intl: "npm:8.1.4"
     react-markdown: "npm:10.1.0"
     react-redux: "npm:9.2.0"
-    react-router: "npm:7.13.2"
+    react-router: "npm:7.14.0"
     react-syntax-highlighter: "npm:16.1.1"
     redux: "npm:5.0.1"
     redux-thunk: "npm:3.1.0"
@@ -11100,9 +11100,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:7.13.2":
-  version: 7.13.2
-  resolution: "react-router@npm:7.13.2"
+"react-router@npm:7.14.0":
+  version: 7.14.0
+  resolution: "react-router@npm:7.14.0"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -11112,7 +11112,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/c7620565df0b444507cfceb76733adbd26e28a72fc4d52d344190bcb2e6483427313a3b6076c53d362e2682ccdb1262731bcaa6c3577cbbeea130291a38715f1
+  checksum: 10c0/a496489973cd5e87dcc5c1c7312f4cc99463eb5e0a0f97b3f298467531b754a3227562a83e0c9019b9d2452fd0681d05882ee061af2e0cafb0818f857578b805
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -89,47 +89,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.28.6, @babel/code-frame@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/code-frame@npm:7.29.0"
-  dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-    js-tokens: "npm:^4.0.0"
-    picocolors: "npm:^1.1.1"
-  checksum: 10c0/d34cc504e7765dfb576a663d97067afb614525806b5cad1a5cc1a7183b916fec8ff57fa233585e3926fd5a9e6b31aae6df91aa81ae9775fb7a28f658d3346f0d
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^7.28.6":
-  version: 7.29.0
-  resolution: "@babel/compat-data@npm:7.29.0"
-  checksum: 10c0/08f348554989d23aa801bf1405aa34b15e841c0d52d79da7e524285c77a5f9d298e70e11d91cc578d8e2c9542efc586d50c5f5cf8e1915b254a9dcf786913a94
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/core@npm:7.29.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-compilation-targets": "npm:^7.28.6"
-    "@babel/helper-module-transforms": "npm:^7.28.6"
-    "@babel/helpers": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    "@jridgewell/remapping": "npm:^2.3.5"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/5127d2e8e842ae409e11bcbb5c2dff9874abf5415e8026925af7308e903f4f43397341467a130490d1a39884f461bc2b67f3063bce0be44340db89687fd852aa
-  languageName: node
-  linkType: hard
-
 "@babel/generator@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/generator@npm:7.28.5"
@@ -140,32 +99,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10c0/9f219fe1d5431b6919f1a5c60db8d5d34fe546c0d8f5a8511b32f847569234ffc8032beb9e7404649a143f54e15224ecb53a3d11b6bb85c3203e573d91fca752
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.29.0":
-  version: 7.29.1
-  resolution: "@babel/generator@npm:7.29.1"
-  dependencies:
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
-    "@jridgewell/gen-mapping": "npm:^0.3.12"
-    "@jridgewell/trace-mapping": "npm:^0.3.28"
-    jsesc: "npm:^3.0.2"
-  checksum: 10c0/349086e6876258ef3fb2823030fee0f6c0eb9c3ebe35fc572e16997f8c030d765f636ddc6299edae63e760ea6658f8ee9a2edfa6d6b24c9a80c917916b973551
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helper-compilation-targets@npm:7.28.6"
-  dependencies:
-    "@babel/compat-data": "npm:^7.28.6"
-    "@babel/helper-validator-option": "npm:^7.27.1"
-    browserslist: "npm:^4.24.0"
-    lru-cache: "npm:^5.1.1"
-    semver: "npm:^6.3.1"
-  checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
   languageName: node
   linkType: hard
 
@@ -186,36 +119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helper-module-imports@npm:7.28.6"
-  dependencies:
-    "@babel/traverse": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/b49d8d8f204d9dbfd5ac70c54e533e5269afb3cea966a9d976722b13e9922cc773a653405f53c89acb247d5aebdae4681d631a3ae3df77ec046b58da76eda2ac
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-transforms@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helper-module-transforms@npm:7.28.6"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.28.6"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@babel/traverse": "npm:^7.28.6"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-plugin-utils@npm:7.27.1"
-  checksum: 10c0/94cf22c81a0c11a09b197b41ab488d416ff62254ce13c57e62912c85700dc2e99e555225787a4099ff6bae7a1812d622c80fbaeda824b79baa10a6c5ac4cf69b
-  languageName: node
-  linkType: hard
-
 "@babel/helper-string-parser@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-string-parser@npm:7.27.1"
@@ -230,34 +133,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/helper-validator-option@npm:7.27.1"
-  checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helpers@npm:7.28.6"
-  dependencies:
-    "@babel/template": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/c4a779c66396bb0cf619402d92f1610601ff3832db2d3b86b9c9dd10983bf79502270e97ac6d5280cea1b1a37de2f06ecbac561bd2271545270407fbe64027cb
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/parser@npm:7.28.5"
-  dependencies:
-    "@babel/types": "npm:^7.28.5"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/5bbe48bf2c79594ac02b490a41ffde7ef5aa22a9a88ad6bcc78432a6ba8a9d638d531d868bd1f104633f1f6bba9905746e15185b8276a3756c42b765d131b1ef
-  languageName: node
-  linkType: hard
-
 "@babel/parser@npm:^7.27.2":
   version: 7.27.5
   resolution: "@babel/parser@npm:7.27.5"
@@ -269,36 +144,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/parser@npm:7.29.0"
+"@babel/parser@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/parser@npm:7.28.5"
   dependencies:
-    "@babel/types": "npm:^7.29.0"
+    "@babel/types": "npm:^7.28.5"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/333b2aa761264b91577a74bee86141ef733f9f9f6d4fc52548e4847dc35dfbf821f58c46832c637bfa761a6d9909d6a68f7d1ed59e17e4ffbb958dc510c17b62
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-self@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/00a4f917b70a608f9aca2fb39aabe04a60aa33165a7e0105fd44b3a8531630eb85bf5572e9f242f51e6ad2fa38c2e7e780902176c863556c58b5ba6f6e164031
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-source@npm:^7.27.1":
-  version: 7.27.1
-  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.27.1"
-  dependencies:
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 10c0/5e67b56c39c4d03e59e03ba80692b24c5a921472079b63af711b1d250fc37c1733a17069b63537f750f3e937ec44a42b1ee6a46cd23b1a0df5163b17f741f7f2
+  checksum: 10c0/5bbe48bf2c79594ac02b490a41ffde7ef5aa22a9a88ad6bcc78432a6ba8a9d638d531d868bd1f104633f1f6bba9905746e15185b8276a3756c42b765d131b1ef
   languageName: node
   linkType: hard
 
@@ -343,17 +196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/template@npm:7.28.6"
-  dependencies:
-    "@babel/code-frame": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/66d87225ed0bc77f888181ae2d97845021838c619944877f7c4398c6748bcf611f216dfd6be74d39016af502bca876e6ce6873db3c49e4ac354c56d34d57e9f5
-  languageName: node
-  linkType: hard
-
 "@babel/traverse@npm:^7.27.1":
   version: 7.28.5
   resolution: "@babel/traverse@npm:7.28.5"
@@ -369,31 +211,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/traverse@npm:7.29.0"
-  dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-globals": "npm:^7.28.0"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/types": "npm:^7.29.0"
-    debug: "npm:^4.3.1"
-  checksum: 10c0/f63ef6e58d02a9fbf3c0e2e5f1c877da3e0bc57f91a19d2223d53e356a76859cbaf51171c9211c71816d94a0e69efa2732fd27ffc0e1bbc84b636e60932333eb
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/types@npm:7.28.5"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10c0/a5a483d2100befbf125793640dec26b90b95fd233a94c19573325898a5ce1e52cdfa96e495c7dcc31b5eca5b66ce3e6d4a0f5a4a62daec271455959f208ab08a
-  languageName: node
-  linkType: hard
-
 "@babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3":
   version: 7.27.6
   resolution: "@babel/types@npm:7.27.6"
@@ -404,13 +221,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/types@npm:7.29.0"
+"@babel/types@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/types@npm:7.28.5"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
-  checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  checksum: 10c0/a5a483d2100befbf125793640dec26b90b95fd233a94c19573325898a5ce1e52cdfa96e495c7dcc31b5eca5b66ce3e6d4a0f5a4a62daec271455959f208ab08a
   languageName: node
   linkType: hard
 
@@ -1421,6 +1238,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@emnapi/core@npm:1.9.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/00e7a99a2bc3ad908ca8272ba861a934da87dffa8797a41316c4a3b571a1e4d2743e2fa14b1a0f131fa4a3c2018ddb601cd2a8cb7f574fa940af696df3c2fe8d
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3, @emnapi/core@npm:^1.7.1":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
@@ -1428,6 +1255,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.1.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/f3740be23440b439333e3ae3832163f60c96c4e35337f3220ceba88f36ee89a57a871d27c94eb7a9ff98a09911ed9a2089e477ab549f4d30029f8b907f84a351
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@emnapi/runtime@npm:1.9.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/750edca117e0363ab2de10622f8ee60e57d8690c2f29c49704813da5cd627c641798d7f3cb0d953c62fdc71688e02e333ddbf2c1204f38b47e3e40657332a6f5
   languageName: node
   linkType: hard
 
@@ -1446,6 +1282,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@emnapi/wasi-threads@npm:1.2.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/1e3724b5814b06c14782fda87eee9b9aa68af01576c81ffeaefdf621ddb74386e419d5b3b1027b6a8172397729d95a92f814fc4b8d3c224376428faa07a6a01a
   languageName: node
   linkType: hard
 
@@ -2204,45 +2049,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.5":
-  version: 0.3.8
-  resolution: "@jridgewell/gen-mapping@npm:0.3.8"
-  dependencies:
-    "@jridgewell/set-array": "npm:^1.2.1"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-    "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10c0/c668feaf86c501d7c804904a61c23c67447b2137b813b9ce03eca82cb9d65ac7006d766c218685d76e3d72828279b6ee26c347aa1119dab23fbaf36aed51585a
-  languageName: node
-  linkType: hard
-
-"@jridgewell/remapping@npm:^2.3.5":
-  version: 2.3.5
-  resolution: "@jridgewell/remapping@npm:2.3.5"
-  dependencies:
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10c0/3de494219ffeb2c5c38711d0d7bb128097edf91893090a2dbc8ee0b55d092bb7347b1fd0f478486c5eab010e855c73927b1666f2107516d472d24a73017d1194
-  languageName: node
-  linkType: hard
-
 "@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
-  languageName: node
-  linkType: hard
-
-"@jridgewell/set-array@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@jridgewell/set-array@npm:1.2.1"
-  checksum: 10c0/2a5aa7b4b5c3464c895c802d8ae3f3d2b92fcbe84ad12f8d0bfbb1f5ad006717e7577ee1fd2eac00c088abe486c7adb27976f45d2941ff6b0b92b2c3302c60f4
-  languageName: node
-  linkType: hard
-
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
-  version: 1.5.0
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
-  checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
   languageName: node
   linkType: hard
 
@@ -2688,7 +2498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.0, @napi-rs/wasm-runtime@npm:^1.1.1":
+"@napi-rs/wasm-runtime@npm:^1.1.1":
   version: 1.1.1
   resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
   dependencies:
@@ -2696,6 +2506,18 @@ __metadata:
     "@emnapi/runtime": "npm:^1.7.1"
     "@tybys/wasm-util": "npm:^0.10.1"
   checksum: 10c0/04d57b67e80736e41fe44674a011878db0a8ad893f4d44abb9d3608debb7c174224cba2796ed5b0c1d367368159f3ca6be45f1c59222f70e32ddc880f803d447
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.3"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/745bb32a023b95095a18d93658bf4564403c2283ca0500a043afcf566ac6082bd0611792f14636276bab07dc2ce6d862591c8aabddae02ec697245b05bc6f144
   languageName: node
   linkType: hard
 
@@ -2735,24 +2557,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/runtime@npm:0.101.0":
-  version: 0.101.0
-  resolution: "@oxc-project/runtime@npm:0.101.0"
-  checksum: 10c0/86fd7bb37e94986e7a09bde07a16fa63cebeaada6bcb8963bc07087d54c107d1a128e1c4a5d27b9b593354c092b8976d7653b6700fbb0da0a2b925fb3de4b34c
-  languageName: node
-  linkType: hard
-
-"@oxc-project/types@npm:=0.101.0":
-  version: 0.101.0
-  resolution: "@oxc-project/types@npm:0.101.0"
-  checksum: 10c0/e4e98da6e34ef0163a652e842e795bda77b703d8282fed4984292ff7b289c4e03d848ed8762e549445e33a142d3883e1013cd9ed43156f6eba34c151b8f599c1
-  languageName: node
-  linkType: hard
-
 "@oxc-project/types@npm:=0.120.0":
   version: 0.120.0
   resolution: "@oxc-project/types@npm:0.120.0"
   checksum: 10c0/3090ca95ed1467ae790a79cf7aa49d1ea4ac390dbfccb7afb914c138034d01e72115e2e137a3cc76f409ba424e4d2b160a599fe137c88033ad68ba2df1e40b29
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.123.0":
+  version: 0.123.0
+  resolution: "@oxc-project/types@npm:0.123.0"
+  checksum: 10c0/7f71f9fa38796e6e5431390c213ec9626a3972feec07b513c513828bbfba5f6d908b04e8c679ae2b30b49cc1dee2dc0b2f1012f38ed1cb9e54bfeba09119f36d
   languageName: node
   linkType: hard
 
@@ -2866,13 +2681,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-beta.53"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.10":
   version: 1.0.0-rc.10
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.10"
@@ -2880,10 +2688,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-beta.53"
-  conditions: os=darwin & cpu=arm64
+"@rolldown/binding-android-arm64@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.13"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2894,10 +2702,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-beta.53"
-  conditions: os=darwin & cpu=x64
+"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.13"
+  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2908,10 +2716,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-beta.53"
-  conditions: os=freebsd & cpu=x64
+"@rolldown/binding-darwin-x64@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.13"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2922,10 +2730,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-beta.53"
-  conditions: os=linux & cpu=arm
+"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.13"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2936,10 +2744,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-beta.53"
-  conditions: os=linux & cpu=arm64 & libc=glibc
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.13"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -2950,16 +2758,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-beta.53"
-  conditions: os=linux & cpu=arm64 & libc=musl
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.13"
+  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
 "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.10":
   version: 1.0.0-rc.10
   resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.10"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.13"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -2971,6 +2786,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.13"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.10":
   version: 1.0.0-rc.10
   resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.10"
@@ -2978,10 +2800,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-beta.53"
-  conditions: os=linux & cpu=x64 & libc=glibc
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.13"
+  conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
@@ -2992,10 +2814,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-beta.53"
-  conditions: os=linux & cpu=x64 & libc=musl
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.13"
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -3006,10 +2828,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-beta.53"
-  conditions: os=openharmony & cpu=arm64
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.13"
+  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3020,12 +2842,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-beta.53"
-  dependencies:
-    "@napi-rs/wasm-runtime": "npm:^1.1.0"
-  conditions: cpu=wasm32
+"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.13"
+  conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -3038,10 +2858,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-beta.53"
-  conditions: os=win32 & cpu=arm64
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.13"
+  dependencies:
+    "@emnapi/core": "npm:1.9.1"
+    "@emnapi/runtime": "npm:1.9.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.2"
+  conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
@@ -3052,10 +2876,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-beta.53"
-  conditions: os=win32 & cpu=x64
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.13"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -3066,10 +2890,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.53"
-  checksum: 10c0/e8b0a7eb76be22f6f103171f28072de821525a4e400454850516da91a7381957932ff0ce495f227bcb168e86815788b0c1d249ca9e34dca366a82c8825b714ce
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.13"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3080,10 +2904,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-rc.3":
-  version: 1.0.0-rc.3
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.3"
-  checksum: 10c0/3928b6282a30f307d1b075d2f217180ae173ea9e00638ce46ab65f089bd5f7a0b2c488ae1ce530f509387793c656a2910337c4cd68fa9d37d7e439365989e699
+"@rolldown/pluginutils@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.13"
+  checksum: 10c0/5ba268706b43ca0c05eed50b16a077cc014453077f70f9cdc652180561c85b0477cf073053c166016a33182021e320335832e36d9bf51b8c79799c6433018d95
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:1.0.0-rc.7":
+  version: 1.0.0-rc.7
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.7"
+  checksum: 10c0/9d5490b5805b25bcd1720ca01c4c032b55a0ef953dab36a8dd42c568e82214576baa464f3027cd5dff3fabcfbe3bf3db2251d12b60220f5d1cd2ffde5ee37082
   languageName: node
   linkType: hard
 
@@ -3233,47 +3064,6 @@ __metadata:
   version: 5.0.4
   resolution: "@types/aria-query@npm:5.0.4"
   checksum: 10c0/dc667bc6a3acc7bba2bccf8c23d56cb1f2f4defaa704cfef595437107efaa972d3b3db9ec1d66bc2711bfc35086821edd32c302bffab36f2e79b97f312069f08
-  languageName: node
-  linkType: hard
-
-"@types/babel__core@npm:^7.20.5":
-  version: 7.20.5
-  resolution: "@types/babel__core@npm:7.20.5"
-  dependencies:
-    "@babel/parser": "npm:^7.20.7"
-    "@babel/types": "npm:^7.20.7"
-    "@types/babel__generator": "npm:*"
-    "@types/babel__template": "npm:*"
-    "@types/babel__traverse": "npm:*"
-  checksum: 10c0/bdee3bb69951e833a4b811b8ee9356b69a61ed5b7a23e1a081ec9249769117fa83aaaf023bb06562a038eb5845155ff663e2d5c75dd95c1d5ccc91db012868ff
-  languageName: node
-  linkType: hard
-
-"@types/babel__generator@npm:*":
-  version: 7.27.0
-  resolution: "@types/babel__generator@npm:7.27.0"
-  dependencies:
-    "@babel/types": "npm:^7.0.0"
-  checksum: 10c0/9f9e959a8792df208a9d048092fda7e1858bddc95c6314857a8211a99e20e6830bdeb572e3587ae8be5429e37f2a96fcf222a9f53ad232f5537764c9e13a2bbd
-  languageName: node
-  linkType: hard
-
-"@types/babel__template@npm:*":
-  version: 7.4.4
-  resolution: "@types/babel__template@npm:7.4.4"
-  dependencies:
-    "@babel/parser": "npm:^7.1.0"
-    "@babel/types": "npm:^7.0.0"
-  checksum: 10c0/cc84f6c6ab1eab1427e90dd2b76ccee65ce940b778a9a67be2c8c39e1994e6f5bbc8efa309f6cea8dc6754994524cd4d2896558df76d92e7a1f46ecffee7112b
-  languageName: node
-  linkType: hard
-
-"@types/babel__traverse@npm:*":
-  version: 7.28.0
-  resolution: "@types/babel__traverse@npm:7.28.0"
-  dependencies:
-    "@babel/types": "npm:^7.28.2"
-  checksum: 10c0/b52d7d4e8fc6a9018fe7361c4062c1c190f5778cf2466817cb9ed19d69fbbb54f9a85ffedeb748ed8062d2cf7d4cc088ee739848f47c57740de1c48cbf0d0994
   languageName: node
   linkType: hard
 
@@ -4057,19 +3847,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:5.2.0":
-  version: 5.2.0
-  resolution: "@vitejs/plugin-react@npm:5.2.0"
+"@vitejs/plugin-react@npm:6.0.1":
+  version: 6.0.1
+  resolution: "@vitejs/plugin-react@npm:6.0.1"
   dependencies:
-    "@babel/core": "npm:^7.29.0"
-    "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
-    "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.3"
-    "@types/babel__core": "npm:^7.20.5"
-    react-refresh: "npm:^0.18.0"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.7"
   peerDependencies:
-    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10c0/bac0a409e71eee954a05bc41580411c369bd5f9ef0586a1f9743fba76ad6603c437d93d407d230780015361f93d1592c55e53314813cded6369c36d3c1e8edbf
+    "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+    babel-plugin-react-compiler: ^1.0.0
+    vite: ^8.0.0
+  peerDependenciesMeta:
+    "@rolldown/plugin-babel":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+  checksum: 10c0/6c42f53a970cb6b0776ba5b4203bb01690ac564c56fca706d4037b50aec965ddc0f11530ab58ab2cd0fbe8c12e14cff6966b22d90391283b4a53294e3ddd478d
   languageName: node
   linkType: hard
 
@@ -4613,15 +4405,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.8.19":
-  version: 2.8.21
-  resolution: "baseline-browser-mapping@npm:2.8.21"
-  bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/61f69897e6c6f429991a08c2228ff5398eb2397124f9458ea3d1f1b09d79141cbe6bc11df55c12b3d95da7f25cae576dd17323509edcefd5e9373ecab0085808
-  languageName: node
-  linkType: hard
-
 "bcp-47-match@npm:^2.0.0":
   version: 2.0.3
   resolution: "bcp-47-match@npm:2.0.3"
@@ -4719,21 +4502,6 @@ __metadata:
   dependencies:
     base64-js: "npm:^1.1.2"
   checksum: 10c0/9d24e24f8b7eabf44af034ed5f7d5530008b835f09a107a84ac060723e86dd43c6aa68958691fe5df524f59473b35f5ce2e0854aa1152c0a254d1010f51bcf22
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.24.0":
-  version: 4.27.0
-  resolution: "browserslist@npm:4.27.0"
-  dependencies:
-    baseline-browser-mapping: "npm:^2.8.19"
-    caniuse-lite: "npm:^1.0.30001751"
-    electron-to-chromium: "npm:^1.5.238"
-    node-releases: "npm:^2.0.26"
-    update-browserslist-db: "npm:^1.1.4"
-  bin:
-    browserslist: cli.js
-  checksum: 10c0/395611e54374da9171cdbe7e3704ab426e0f1d622751392df6d6cbf60c539bf06cf2407e9dd769bc01ee2abca6a14af6509a2e0bbb448ba75a054db6c1840643
   languageName: node
   linkType: hard
 
@@ -4839,13 +4607,6 @@ __metadata:
   version: 3.1.0
   resolution: "callsites@npm:3.1.0"
   checksum: 10c0/fff92277400eb06c3079f9e74f3af120db9f8ea03bad0e84d9aede54bbe2d44a56cccb5f6cf12211f93f52306df87077ecec5b712794c5a9b5dac6d615a3f301
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001751":
-  version: 1.0.30001751
-  resolution: "caniuse-lite@npm:1.0.30001751"
-  checksum: 10c0/c3f2d448f3569004ace160fd9379ea0def8e7a7bc6e65611baadb57d24e1f418258647a6210e46732419f5663e2356c22aa841f92449dd3849eb6471bb7ad592
   languageName: node
   linkType: hard
 
@@ -5455,7 +5216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -5756,13 +5517,6 @@ __metadata:
   version: 1.3.1
   resolution: "eight-colors@npm:1.3.1"
   checksum: 10c0/af37c6302b4879e1d756d3fcf9dbf21b0e8bb95d662e2725700aa451a756c9996d37a66cb05cbdbd156663e93398b8224199180f3683d1780542f3c9fd553d7d
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.5.238":
-  version: 1.5.243
-  resolution: "electron-to-chromium@npm:1.5.243"
-  checksum: 10c0/04a609027a63cb9527d9963fb230b5456d678f88278c919374c35e766be42d19b6b28c25c94ae366e31d154e611a670f3e0890f2526c69e215e51709565a3ecc
   languageName: node
   linkType: hard
 
@@ -6124,7 +5878,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.1.1, escalade@npm:^3.2.0":
+"escalade@npm:^3.1.1":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
@@ -6904,13 +6658,6 @@ __metadata:
   version: 2.0.1
   resolution: "generator-function@npm:2.0.1"
   checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
-  languageName: node
-  linkType: hard
-
-"gensync@npm:^1.0.0-beta.2":
-  version: 1.0.0-beta.2
-  resolution: "gensync@npm:1.0.0-beta.2"
-  checksum: 10c0/782aba6cba65b1bb5af3b095d96249d20edbe8df32dbf4696fd49be2583faf676173bf4809386588828e4dd76a3354fcbeb577bab1c833ccd9fc4577f26103f8
   languageName: node
   linkType: hard
 
@@ -8462,15 +8209,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "json5@npm:2.2.3"
-  bin:
-    json5: lib/cli.js
-  checksum: 10c0/5a04eed94810fa55c5ea138b2f7a5c12b97c3750bc63d11e511dcecbfef758003861522a070c2272764ee0f4e3e323862f386945aeb5b85b87ee43f084ba586c
-  languageName: node
-  linkType: hard
-
 "jsonfile@npm:^6.0.1":
   version: 6.2.0
   resolution: "jsonfile@npm:6.2.0"
@@ -8592,24 +8330,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-android-arm64@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-android-arm64@npm:1.30.2"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "lightningcss-android-arm64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-android-arm64@npm:1.32.0"
   conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"lightningcss-darwin-arm64@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-darwin-arm64@npm:1.30.2"
-  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8620,24 +8344,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-x64@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-darwin-x64@npm:1.30.2"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
 "lightningcss-darwin-x64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-darwin-x64@npm:1.32.0"
   conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss-freebsd-x64@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-freebsd-x64@npm:1.30.2"
-  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -8648,24 +8358,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm-gnueabihf@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.30.2"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
 "lightningcss-linux-arm-gnueabihf@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
   conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-arm64-gnu@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-linux-arm64-gnu@npm:1.30.2"
-  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -8676,24 +8372,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-musl@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-linux-arm64-musl@npm:1.30.2"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "lightningcss-linux-arm64-musl@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
   conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"lightningcss-linux-x64-gnu@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-linux-x64-gnu@npm:1.30.2"
-  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -8704,24 +8386,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-musl@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-linux-x64-musl@npm:1.30.2"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "lightningcss-linux-x64-musl@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
   conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"lightningcss-win32-arm64-msvc@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-win32-arm64-msvc@npm:1.30.2"
-  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8732,60 +8400,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-win32-x64-msvc@npm:1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss-win32-x64-msvc@npm:1.30.2"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "lightningcss-win32-x64-msvc@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"lightningcss@npm:^1.30.2":
-  version: 1.30.2
-  resolution: "lightningcss@npm:1.30.2"
-  dependencies:
-    detect-libc: "npm:^2.0.3"
-    lightningcss-android-arm64: "npm:1.30.2"
-    lightningcss-darwin-arm64: "npm:1.30.2"
-    lightningcss-darwin-x64: "npm:1.30.2"
-    lightningcss-freebsd-x64: "npm:1.30.2"
-    lightningcss-linux-arm-gnueabihf: "npm:1.30.2"
-    lightningcss-linux-arm64-gnu: "npm:1.30.2"
-    lightningcss-linux-arm64-musl: "npm:1.30.2"
-    lightningcss-linux-x64-gnu: "npm:1.30.2"
-    lightningcss-linux-x64-musl: "npm:1.30.2"
-    lightningcss-win32-arm64-msvc: "npm:1.30.2"
-    lightningcss-win32-x64-msvc: "npm:1.30.2"
-  dependenciesMeta:
-    lightningcss-android-arm64:
-      optional: true
-    lightningcss-darwin-arm64:
-      optional: true
-    lightningcss-darwin-x64:
-      optional: true
-    lightningcss-freebsd-x64:
-      optional: true
-    lightningcss-linux-arm-gnueabihf:
-      optional: true
-    lightningcss-linux-arm64-gnu:
-      optional: true
-    lightningcss-linux-arm64-musl:
-      optional: true
-    lightningcss-linux-x64-gnu:
-      optional: true
-    lightningcss-linux-x64-musl:
-      optional: true
-    lightningcss-win32-arm64-msvc:
-      optional: true
-    lightningcss-win32-x64-msvc:
-      optional: true
-  checksum: 10c0/5c0c73a33946dab65908d5cd1325df4efa290efb77f940b60f40448b5ab9a87d3ea665ef9bcf00df4209705050ecf2f7ecc649f44d6dfa5905bb50f15717e78d
   languageName: node
   linkType: hard
 
@@ -8946,15 +8564,6 @@ __metadata:
   version: 11.2.7
   resolution: "lru-cache@npm:11.2.7"
   checksum: 10c0/549cdb59488baa617135fc12159cafb1a97f91079f35093bb3bcad72e849fc64ace636d244212c181dfdf1a99bbfa90757ff303f98561958ee4d0f885d9bd5f7
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "lru-cache@npm:5.1.1"
-  dependencies:
-    yallist: "npm:^3.0.2"
-  checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
   languageName: node
   linkType: hard
 
@@ -9986,13 +9595,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.26":
-  version: 2.0.26
-  resolution: "node-releases@npm:2.0.26"
-  checksum: 10c0/033539b947ad329e0c996e563a97cdf295163ecbfd500edc3e5bc19d1a854d9515fcaae3967ac07243aff5378f572f18b36c5f50c3aa1fc3aac43fc9c4924e4d
-  languageName: node
-  linkType: hard
-
 "nodemailer@npm:^7.0.6":
   version: 7.0.13
   resolution: "nodemailer@npm:7.0.13"
@@ -10257,7 +9859,7 @@ __metadata:
     "@types/react-syntax-highlighter": "npm:15"
     "@typescript-eslint/utils": "npm:8.57.0"
     "@uiw/react-md-editor": "npm:4.1.0"
-    "@vitejs/plugin-react": "npm:5.2.0"
+    "@vitejs/plugin-react": "npm:6.0.1"
     "@vitest/eslint-plugin": "npm:1.6.12"
     "@xyflow/react": "npm:12.10.2"
     apexcharts: "npm:5.3.6"
@@ -10329,7 +9931,7 @@ __metadata:
     typescript-eslint: "npm:8.57.0"
     usehooks-ts: "npm:3.1.1"
     uuid: "npm:13.0.0"
-    vite: "npm:rolldown-vite@7.3.1"
+    vite: "npm:8.0.7"
     vitest: "npm:4.1.0"
     zod: "npm:3.25.76"
     zustand: "npm:5.0.12"
@@ -10590,6 +10192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
 "pkg-types@npm:^2.3.0":
   version: 2.3.0
   resolution: "pkg-types@npm:2.3.0"
@@ -10636,17 +10245,6 @@ __metadata:
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
   checksum: 10c0/c810983414142071da1d644662ce4caebce890203eb2bc7bf119f37f3fe5796226e117e6cca146b521921fa6531072674174a3325066ac66fce089a53e1e5196
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.6":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
   languageName: node
   linkType: hard
 
@@ -11077,13 +10675,6 @@ __metadata:
     redux:
       optional: true
   checksum: 10c0/00d485f9d9219ca1507b4d30dde5f6ff8fb68ba642458f742e0ec83af052f89e65cd668249b99299e1053cc6ad3d2d8ac6cb89e2f70d2ac5585ae0d7fa0ef259
-  languageName: node
-  linkType: hard
-
-"react-refresh@npm:^0.18.0":
-  version: 0.18.0
-  resolution: "react-refresh@npm:0.18.0"
-  checksum: 10c0/34a262f7fd803433a534f50deb27a148112a81adcae440c7d1cbae7ef14d21ea8f2b3d783e858cb7698968183b77755a38b4d4b5b1d79b4f4689c2f6d358fff2
   languageName: node
   linkType: hard
 
@@ -11661,58 +11252,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-beta.53":
-  version: 1.0.0-beta.53
-  resolution: "rolldown@npm:1.0.0-beta.53"
-  dependencies:
-    "@oxc-project/types": "npm:=0.101.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-beta.53"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-beta.53"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-beta.53"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-beta.53"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-beta.53"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-beta.53"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-beta.53"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-beta.53"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-beta.53"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-beta.53"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-beta.53"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-beta.53"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-beta.53"
-    "@rolldown/pluginutils": "npm:1.0.0-beta.53"
-  dependenciesMeta:
-    "@rolldown/binding-android-arm64":
-      optional: true
-    "@rolldown/binding-darwin-arm64":
-      optional: true
-    "@rolldown/binding-darwin-x64":
-      optional: true
-    "@rolldown/binding-freebsd-x64":
-      optional: true
-    "@rolldown/binding-linux-arm-gnueabihf":
-      optional: true
-    "@rolldown/binding-linux-arm64-gnu":
-      optional: true
-    "@rolldown/binding-linux-arm64-musl":
-      optional: true
-    "@rolldown/binding-linux-x64-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-musl":
-      optional: true
-    "@rolldown/binding-openharmony-arm64":
-      optional: true
-    "@rolldown/binding-wasm32-wasi":
-      optional: true
-    "@rolldown/binding-win32-arm64-msvc":
-      optional: true
-    "@rolldown/binding-win32-x64-msvc":
-      optional: true
-  bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/363109aa38b31254e682e69aa9f199074d98b823b437faac6d05fd1b4a2b73168b9434043a060fecfc25d3e1d441e2d3b757e92621bc1e843a3e916e2b0d3f58
-  languageName: node
-  linkType: hard
-
 "rolldown@npm:1.0.0-rc.10":
   version: 1.0.0-rc.10
   resolution: "rolldown@npm:1.0.0-rc.10"
@@ -11768,6 +11307,64 @@ __metadata:
   bin:
     rolldown: bin/cli.mjs
   checksum: 10c0/3d7970ce31bb4b267c3240a1c03f275483f8523484b1218b75a4cc3ddffa188e58f73b9b3e0bec850544db3839754015959fdea87278c9ccf93ab76b4fb8672a
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "rolldown@npm:1.0.0-rc.13"
+  dependencies:
+    "@oxc-project/types": "npm:=0.123.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.13"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.13"
+    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.13"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.13"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.13"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.13"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.13"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.13"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.13"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.13"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: 10c0/fc091b7df634c0b181a28914da708376e009092c67e98f1b062f216066f790d69c6b2adc6cb044741cbe4a93d944d222e599578019da090cb66d7bd91f3730a3
   languageName: node
   linkType: hard
 
@@ -13162,20 +12759,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "update-browserslist-db@npm:1.1.4"
-  dependencies:
-    escalade: "npm:^3.2.0"
-    picocolors: "npm:^1.1.1"
-  peerDependencies:
-    browserslist: ">= 4.21.0"
-  bin:
-    update-browserslist-db: cli.js
-  checksum: 10c0/db0c9aaecf1258a6acda5e937fc27a7996ccca7a7580a1b4aa8bba6a9b0e283e5e65c49ebbd74ec29288ef083f1b88d4da13e3d4d326c1e5fc55bf72d7390702
-  languageName: node
-  linkType: hard
-
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
@@ -13265,6 +12848,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:8.0.7":
+  version: 8.0.7
+  resolution: "vite@npm:8.0.7"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.8"
+    rolldown: "npm:1.0.0-rc.13"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.1.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/88f8ec4e86275f32e88ae98df3bfda7e25f12e33e06b868b1abeee57740c9f043c9feaa3e5e993a903d6949e5cece358f7a527e6c19d9670d7401fded6d2f201
+  languageName: node
+  linkType: hard
+
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0-0":
   version: 8.0.1
   resolution: "vite@npm:8.0.1"
@@ -13319,62 +12959,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/f1379726cfd50f3f12d172cf6f61b7b067521bd92955176d0bc6e6e9dd538fe76c87e7f7102d5815e4f83f6795e8ba95502fd442507dc8574ba13bcb7230b2c3
-  languageName: node
-  linkType: hard
-
-"vite@npm:rolldown-vite@7.3.1":
-  version: 7.3.1
-  resolution: "rolldown-vite@npm:7.3.1"
-  dependencies:
-    "@oxc-project/runtime": "npm:0.101.0"
-    fdir: "npm:^6.5.0"
-    fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.30.2"
-    picomatch: "npm:^4.0.3"
-    postcss: "npm:^8.5.6"
-    rolldown: "npm:1.0.0-beta.53"
-    tinyglobby: "npm:^0.2.15"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    esbuild: ^0.27.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    esbuild:
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/01b6af00aabbdfbb59a069e5b932336769b1a8effd0fbea0e6ea78b0c3b97ff5be721f3d16b3cd5928444e22566e5850e12eee53b5d9101e98e52828e6e53e00
   languageName: node
   linkType: hard
 
@@ -13674,13 +13258,6 @@ __metadata:
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 10c0/4df2842c36e468590c3691c894bc9cdbac41f520566e76e24f59401ba7d8b4811eb1e34524d57e54bc6d864bcb66baab7ffd9ca42bf1eda596618f9162b91249
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^3.0.2":
-  version: 3.1.1
-  resolution: "yallist@npm:3.1.1"
-  checksum: 10c0/c66a5c46bc89af1625476f7f0f2ec3653c1a1791d2f9407cfb4c2ba812a1e1c9941416d71ba9719876530e3340a99925f697142989371b72d93b9ee628afd8c1
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -2000,22 +2000,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -4466,21 +4450,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+"brace-expansion@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "brace-expansion@npm:2.0.3"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "brace-expansion@npm:5.0.5"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
   languageName: node
   linkType: hard
 
@@ -6781,8 +6765,8 @@ __metadata:
   linkType: hard
 
 "glob@npm:^10.2.2":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
   dependencies:
     foreground-child: "npm:^3.1.0"
     jackspeak: "npm:^3.1.2"
@@ -6792,7 +6776,7 @@ __metadata:
     path-scurry: "npm:^1.11.1"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
   languageName: node
   linkType: hard
 
@@ -9253,34 +9237,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.3":
-  version: 10.1.1
-  resolution: "minimatch@npm:10.1.1"
+"minimatch@npm:^10.0.3, minimatch@npm:^10.2.2":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
   dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.0"
-  checksum: 10c0/c85d44821c71973d636091fddbfbffe62370f5ee3caf0241c5b60c18cd289e916200acb2361b7e987558cd06896d153e25d505db9fc1e43e6b4b6752e2702902
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
-  dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.5":
+"minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
@@ -9290,11 +9256,11 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -4897,12 +4897,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:~0.5.4":
-  version: 0.5.4
-  resolution: "content-disposition@npm:0.5.4"
-  dependencies:
-    safe-buffer: "npm:5.2.1"
-  checksum: 10c0/bac0316ebfeacb8f381b38285dc691c9939bf0a78b0b7c2d5758acadad242d04783cee5337ba7d12a565a19075af1b3c11c728e1e4946de73c6ff7ce45f3f1bb
+"content-disposition@npm:~1.0.1":
+  version: 1.0.1
+  resolution: "content-disposition@npm:1.0.1"
+  checksum: 10c0/bd7ff1fe8d2542d3a2b9a29428cc3591f6ac27bb5595bba2c69664408a68f9538b14cbd92479796ea835b317a09a527c8c7209c4200381dedb0c34d3b658849e
   languageName: node
   linkType: hard
 
@@ -8269,11 +8267,11 @@ __metadata:
   linkType: hard
 
 "koa@npm:^3.0.1":
-  version: 3.1.1
-  resolution: "koa@npm:3.1.1"
+  version: 3.2.0
+  resolution: "koa@npm:3.2.0"
   dependencies:
     accepts: "npm:^1.3.8"
-    content-disposition: "npm:~0.5.4"
+    content-disposition: "npm:~1.0.1"
     content-type: "npm:^1.0.5"
     cookies: "npm:~0.9.1"
     delegates: "npm:^1.0.0"
@@ -8290,7 +8288,7 @@ __metadata:
     statuses: "npm:^2.0.1"
     type-is: "npm:^2.0.1"
     vary: "npm:^1.1.2"
-  checksum: 10c0/2329fa9b2352dbbed8b5073b3b0d5b71678357222c7b8bc4d29e3383fa31c3dc23c6648a3445efa0e6b01e44de0349f8ec2f43d70cd0d37ce7ba1ce50337be15
+  checksum: 10c0/15f5e51ba2dd3e8bb35934e49cc6b05e3831b4e89b5f5037247d1908ec23087fc9f570e90e1e7d55845696777d0324538a66f8665acc35780ad84f586098271f
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -155,7 +155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.19.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
@@ -2669,15 +2669,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redux-devtools/extension@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@redux-devtools/extension@npm:3.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.2"
-    immutable: "npm:^4.3.4"
+"@redux-devtools/extension@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@redux-devtools/extension@npm:4.0.0"
   peerDependencies:
     redux: ^3.1.0 || ^4.0.0 || ^5.0.0
-  checksum: 10c0/a582d26687fdcbb9fc98181a6a28c7e286a6a74f35f5bba181b9b8b766029d34754bd8f8e60acaa757a34aca385056783d2efb95f943282f2ee66039931c942f
+  checksum: 10c0/bb3b5b48245f4eb40ffc4384df31f7fe1a14cff2749f8a4058ae5d266436f33e1e97f633daf724e131fc69edfa5c2bcd0f9562bdf9493058fec813641961ccb6
   languageName: node
   linkType: hard
 
@@ -7579,13 +7576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^4.3.4":
-  version: 4.3.7
-  resolution: "immutable@npm:4.3.7"
-  checksum: 10c0/9b099197081b22f6433003e34929da8ecddbbdc1474cdc8aa3b7669dee4adda349c06143de22def36016d1b6de5322b043eccd7a11db1dad2ca85dad4fff5435
-  languageName: node
-  linkType: hard
-
 "import-fresh@npm:^3.2.1":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
@@ -9845,7 +9835,7 @@ __metadata:
     "@mui/system": "npm:7.3.9"
     "@mui/x-date-pickers": "npm:8.27.2"
     "@playwright/test": "npm:1.58.2"
-    "@redux-devtools/extension": "npm:3.3.0"
+    "@redux-devtools/extension": "npm:4.0.0"
     "@stylistic/eslint-plugin": "npm:5.10.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -10311,7 +10311,7 @@ __metadata:
     react-final-form: "npm:6.5.9"
     react-final-form-arrays: "npm:4.0.0"
     react-grid-layout: "npm:2.2.3"
-    react-hook-form: "npm:7.72.0"
+    react-hook-form: "npm:7.72.1"
     react-intl: "npm:8.1.4"
     react-markdown: "npm:10.1.0"
     react-redux: "npm:9.2.0"
@@ -10973,12 +10973,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:7.72.0":
-  version: 7.72.0
-  resolution: "react-hook-form@npm:7.72.0"
+"react-hook-form@npm:7.72.1":
+  version: 7.72.1
+  resolution: "react-hook-form@npm:7.72.1"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 10c0/c689992ef95fcf6a7e622aba447756c5d770b8f89efbd700e9432e127185cff687f8dd7439e235c177371abf5595a7c8dae6c6220b9c3ab29ccfdd543b0b5b9e
+  checksum: 10c0/b96fb9c10893fd5b31151c412fe3dd475a207e2ca7e7d41f0b3d98c05e3d6e556b9c2edfb568820fcbf598f257871a87b91c9909cc6e07a7ab7bf6b36e22035a
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -5536,9 +5536,9 @@ __metadata:
   linkType: hard
 
 "defu@npm:^6.1.4":
-  version: 6.1.4
-  resolution: "defu@npm:6.1.4"
-  checksum: 10c0/2d6cc366262dc0cb8096e429368e44052fdf43ed48e53ad84cc7c9407f890301aa5fcb80d0995abaaf842b3949f154d060be4160f7a46cb2bc2f7726c81526f5
+  version: 6.1.6
+  resolution: "defu@npm:6.1.6"
+  checksum: 10c0/6755a914d4d1b40346d582cadf3af0c4efb1b89c462631f4c8a20c933da88d5da674344dd0856426d611d5fc0c65a3ffa82388519127b06f1a688dc103ddf5ba
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -4345,14 +4345,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.14.0":
-  version: 1.14.0
-  resolution: "axios@npm:1.14.0"
+"axios@npm:1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2541f4aa215a7d1842429dad006fc682d82bc0e74bd14500823f7d8cce3bbae0e0a8c328c8538946718f366ab8ce5a4c12e9ad40e5a0f3482ff8bff0cd115d45
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -9853,7 +9853,7 @@ __metadata:
     "@vitest/eslint-plugin": "npm:1.6.12"
     "@xyflow/react": "npm:12.10.2"
     apexcharts: "npm:5.3.6"
-    axios: "npm:1.14.0"
+    axios: "npm:1.15.0"
     chokidar: "npm:5.0.0"
     ckeditor5: "npm:47.6.1"
     classcat: "npm:5.0.5"

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1248,7 +1248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:^1.4.3, @emnapi/core@npm:^1.7.1":
+"@emnapi/core@npm:^1.4.3":
   version: 1.7.1
   resolution: "@emnapi/core@npm:1.7.1"
   dependencies:
@@ -1267,7 +1267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.4.3, @emnapi/runtime@npm:^1.7.1":
+"@emnapi/runtime@npm:^1.4.3":
   version: 1.7.1
   resolution: "@emnapi/runtime@npm:1.7.1"
   dependencies:
@@ -2482,17 +2482,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
-  dependencies:
-    "@emnapi/core": "npm:^1.7.1"
-    "@emnapi/runtime": "npm:^1.7.1"
-    "@tybys/wasm-util": "npm:^0.10.1"
-  checksum: 10c0/04d57b67e80736e41fe44674a011878db0a8ad893f4d44abb9d3608debb7c174224cba2796ed5b0c1d367368159f3ca6be45f1c59222f70e32ddc880f803d447
-  languageName: node
-  linkType: hard
-
 "@napi-rs/wasm-runtime@npm:^1.1.2":
   version: 1.1.3
   resolution: "@napi-rs/wasm-runtime@npm:1.1.3"
@@ -2538,13 +2527,6 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 10c0/c90935d5ce670c87b6b14fab04a965a3b8137e585f8b2a6257263bd7f97756dd736cb165bb470e5156a9e718ecd99413dccc54b1138c1a46d6ec7cf325982fe5
-  languageName: node
-  linkType: hard
-
-"@oxc-project/types@npm:=0.120.0":
-  version: 0.120.0
-  resolution: "@oxc-project/types@npm:0.120.0"
-  checksum: 10c0/3090ca95ed1467ae790a79cf7aa49d1ea4ac390dbfccb7afb914c138034d01e72115e2e137a3cc76f409ba424e4d2b160a599fe137c88033ad68ba2df1e40b29
   languageName: node
   linkType: hard
 
@@ -2662,24 +2644,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.10"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.13"
   conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.10"
-  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2690,24 +2658,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.10"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-darwin-x64@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.13"
   conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.10"
-  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2718,24 +2672,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.13"
   conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -2746,24 +2686,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.13"
   conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -2774,24 +2700,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.13"
   conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -2802,13 +2714,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.10"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.13"
@@ -2816,26 +2721,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.10"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.13"
   conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.10"
-  dependencies:
-    "@napi-rs/wasm-runtime": "npm:^1.1.1"
-  conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
@@ -2850,13 +2739,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.10"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.13"
@@ -2864,24 +2746,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.10"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.13"
   conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rolldown/pluginutils@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.10"
-  checksum: 10c0/7478f982d2705fef5f844e714aa264571d30368ef90883642fdc9eb869613c0c3060e8a8f69255e37a6fb600cbe4be35ce273d1f808fa6fe2a4b4e72116caf29
   languageName: node
   linkType: hard
 
@@ -11199,64 +11067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-rc.10":
-  version: 1.0.0-rc.10
-  resolution: "rolldown@npm:1.0.0-rc.10"
-  dependencies:
-    "@oxc-project/types": "npm:=0.120.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.10"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.10"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.10"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.10"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.10"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.10"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.10"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.10"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.10"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.10"
-  dependenciesMeta:
-    "@rolldown/binding-android-arm64":
-      optional: true
-    "@rolldown/binding-darwin-arm64":
-      optional: true
-    "@rolldown/binding-darwin-x64":
-      optional: true
-    "@rolldown/binding-freebsd-x64":
-      optional: true
-    "@rolldown/binding-linux-arm-gnueabihf":
-      optional: true
-    "@rolldown/binding-linux-arm64-gnu":
-      optional: true
-    "@rolldown/binding-linux-arm64-musl":
-      optional: true
-    "@rolldown/binding-linux-ppc64-gnu":
-      optional: true
-    "@rolldown/binding-linux-s390x-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-gnu":
-      optional: true
-    "@rolldown/binding-linux-x64-musl":
-      optional: true
-    "@rolldown/binding-openharmony-arm64":
-      optional: true
-    "@rolldown/binding-wasm32-wasi":
-      optional: true
-    "@rolldown/binding-win32-arm64-msvc":
-      optional: true
-    "@rolldown/binding-win32-x64-msvc":
-      optional: true
-  bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/3d7970ce31bb4b267c3240a1c03f275483f8523484b1218b75a4cc3ddffa188e58f73b9b3e0bec850544db3839754015959fdea87278c9ccf93ab76b4fb8672a
-  languageName: node
-  linkType: hard
-
 "rolldown@npm:1.0.0-rc.13":
   version: 1.0.0-rc.13
   resolution: "rolldown@npm:1.0.0-rc.13"
@@ -12795,7 +12605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:8.0.7":
+"vite@npm:8.0.7, vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0-0":
   version: 8.0.7
   resolution: "vite@npm:8.0.7"
   dependencies:
@@ -12849,63 +12659,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/88f8ec4e86275f32e88ae98df3bfda7e25f12e33e06b868b1abeee57740c9f043c9feaa3e5e993a903d6949e5cece358f7a527e6c19d9670d7401fded6d2f201
-  languageName: node
-  linkType: hard
-
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0-0":
-  version: 8.0.1
-  resolution: "vite@npm:8.0.1"
-  dependencies:
-    fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.3"
-    postcss: "npm:^8.5.8"
-    rolldown: "npm:1.0.0-rc.10"
-    tinyglobby: "npm:^0.2.15"
-  peerDependencies:
-    "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.0
-    esbuild: ^0.27.0
-    jiti: ">=1.21.0"
-    less: ^4.0.0
-    sass: ^1.70.0
-    sass-embedded: ^1.70.0
-    stylus: ">=0.54.8"
-    sugarss: ^5.0.0
-    terser: ^5.16.0
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    "@vitejs/devtools":
-      optional: true
-    esbuild:
-      optional: true
-    jiti:
-      optional: true
-    less:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/f1379726cfd50f3f12d172cf6f61b7b067521bd92955176d0bc6e6e9dd538fe76c87e7f7102d5815e4f83f6795e8ba95502fd442507dc8574ba13bcb7230b2c3
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -10169,20 +10169,13 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -8467,9 +8467,9 @@ __metadata:
   linkType: hard
 
 "lodash-es@npm:^4.17.15":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
   languageName: node
   linkType: hard
 
@@ -8495,9 +8495,9 @@ __metadata:
   linkType: hard
 
 "lodash@npm:^4.0.1, lodash@npm:^4.17.15, lodash@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -7825,10 +7825,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:5.1.4":
-  version: 5.1.4
-  resolution: "immutable@npm:5.1.4"
-  checksum: 10c0/f1c98382e4cde14a0b218be3b9b2f8441888da8df3b8c064aa756071da55fbed6ad696e5959982508456332419be9fdeaf29b2e58d0eadc45483cc16963c0446
+"immutable@npm:5.1.5":
+  version: 5.1.5
+  resolution: "immutable@npm:5.1.5"
+  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
   languageName: node
   linkType: hard
 
@@ -10290,7 +10290,7 @@ __metadata:
     html-to-image: "npm:1.11.13"
     http-proxy-middleware: "npm:3.0.5"
     i18n-auto-translation: "npm:2.2.3"
-    immutable: "npm:5.1.4"
+    immutable: "npm:5.1.5"
     js-file-download: "npm:0.4.12"
     jsdom: "npm:29.0.1"
     mdi-material-ui: "npm:7.9.4"

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
-            <version>2.42.23</version>
+            <version>2.42.24</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.42.23</version>
+            <version>2.42.24</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -14,7 +14,7 @@
     <description>OpenAEV model</description>
 
     <properties>
-        <elasticsearch.version>8.19.13</elasticsearch.version>
+        <elasticsearch.version>8.19.14</elasticsearch.version>
         <opensearch.version>3.8.0</opensearch.version>
     </properties>
 

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
-            <version>2.42.29</version>
+            <version>2.42.33</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.42.29</version>
+            <version>2.42.33</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
-            <version>2.42.28</version>
+            <version>2.42.29</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.42.28</version>
+            <version>2.42.29</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
-            <version>2.42.24</version>
+            <version>2.42.28</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.42.24</version>
+            <version>2.42.28</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/openaev-model/src/main/java/io/openaev/jsonapi/ZipJsonApi.java
+++ b/openaev-model/src/main/java/io/openaev/jsonapi/ZipJsonApi.java
@@ -59,23 +59,22 @@ public class ZipJsonApi<T extends Base> {
 
   // -- IMPORT --
 
-  public ResponseEntity<JsonApiDocument<ResourceObject>> handleImport(
-      MultipartFile file, String nameAttributeKey) throws IOException {
+  public ZipJsonService.ImportOutput<T> handleImport(MultipartFile file, String nameAttributeKey)
+      throws IOException {
     return handleImport(file, nameAttributeKey, null, null);
   }
 
-  public ResponseEntity<JsonApiDocument<ResourceObject>> handleImport(
+  public ZipJsonService.ImportOutput<T> handleImport(
       MultipartFile file,
       String nameAttributeKey,
       IncludeOptions includeOptions,
       Function<T, T> sanityCheck)
       throws IOException {
-    return ResponseEntity.ok(
-        this.zipJsonService.handleImport(
-            file.getBytes(),
-            nameAttributeKey,
-            includeOptions,
-            sanityCheck,
-            IMPORTED_OBJECT_NAME_SUFFIX));
+    return this.zipJsonService.handleImport(
+        file.getBytes(),
+        nameAttributeKey,
+        includeOptions,
+        sanityCheck,
+        IMPORTED_OBJECT_NAME_SUFFIX);
   }
 }

--- a/openaev-model/src/main/java/io/openaev/service/ZipJsonService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ZipJsonService.java
@@ -18,10 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -105,6 +102,14 @@ public class ZipJsonService<T extends Base> {
   }
 
   /**
+   * Result of an import operation.
+   *
+   * @param jsonApiDocument JSON:API representation exported from the persisted entity
+   * @param persistedData persisted root entity instance
+   */
+  public record ImportOutput<T>(JsonApiDocument<ResourceObject> jsonApiDocument, T persistedData) {}
+
+  /**
    * Imports an entity from a ZIP archive.
    *
    * <p>This method parses the ZIP archive, extracts the JSON API document and associated files,
@@ -115,10 +120,10 @@ public class ZipJsonService<T extends Base> {
    * @param includeOptions options controlling which relationships to include
    * @param sanityCheck function to validate/modify the entity before persistence
    * @param suffix suffix to append to the entity name (e.g., " (copy)")
-   * @return the JSON API document for the imported entity
+   * @return import output containing the exported JSON:API document and persisted entity
    * @throws IOException if reading the archive fails
    */
-  public JsonApiDocument<ResourceObject> handleImport(
+  public ImportOutput<T> handleImport(
       byte[] fileBytes,
       String nameAttributeKey,
       IncludeOptions includeOptions,
@@ -138,7 +143,7 @@ public class ZipJsonService<T extends Base> {
     importer.handleImportDocument(doc, parsed.extras);
     T persisted = importer.handleImportEntity(doc, includeOptions, sanityCheck);
 
-    return exporter.handleExport(persisted, includeOptions);
+    return new ImportOutput<>(exporter.handleExport(persisted, includeOptions), persisted);
   }
 
   private void addDocumentToExtras(Document doc, Map<String, byte[]> out) {

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
             </snapshots>
         </repository>
         <repository>
-            <id>shibboleth_repository</id>
-            <name>Shibboleth Maven Repository</name>
-            <url>https://build.shibboleth.net/nexus/content/repositories/releases/</url>
+            <id>jboss-public</id>
+            <name>JBoss Public Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## 🔄 Merge back master → release/current

### Objectif
Synchroniser `release/current` avec les derniers commits de `master` pour éviter la divergence entre les deux branches.

### Commits récents sur master (non présents sur release/current)
- `[tool] chore(deps): replace Shibboleth Maven repo with JBoss public` — @RomuDeuxfois (15 avr.)
- `[backend] fix: fix lesson learned tab (#5443)` — @Hedi (15 avr.)
- `[backend] chore(deps): update elasticsearch client` — renovate (15 avr.)
- `[backend] chore(deps): update aws-java-sdk-v2 monorepo` — renovate (14 avr.)
- `[docker] chore: create UBI9 Docker image (#5303)` — @XavierFournet (13 avr.)
- ... et d'autres commits antérieurs

### ⚠️ Conflits potentiels
Les deux branches ont divergé significativement. Des conflits de merge sont possibles et devront être résolus manuellement.

### Checklist
- [ ] Vérifier les conflits de merge
- [ ] Résoudre les conflits si nécessaire
- [ ] Valider le build après merge
- [ ] Review par un pair