### PR TITLE
[frontend] fix(xtm-hub): add tenant_id and rename oaev_instance_id to platform_id in import from hub URL (#5529)

### DIFF
--- a/openaev-front/src/admin/components/common/ImportFromHubButton.tsx
+++ b/openaev-front/src/admin/components/common/ImportFromHubButton.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@mui/material/styles';
 
 import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
-import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper';
+import { getCurrentTenantId } from '../../../utils/tenant-url-helper';
 import { getUrl, isNotEmptyField } from '../../../utils/utils';
 import GradientButton from './GradientButton';
 
@@ -12,12 +12,12 @@ interface ImportFromHubButtonProps extends ButtonProps { serviceIdentifier: stri
 const ImportFromHubButton = ({ serviceIdentifier }: ImportFromHubButtonProps) => {
   const { t } = useFormatter();
   const theme = useTheme();
-  const { settings, currentUserTenant } = useAuth();
+  const { settings } = useAuth();
   if (!settings.xtm_hub_enable) {
     return null;
   }
 
-  const tenantId = currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID;
+  const tenantId = getCurrentTenantId();
   const importFromHubUrl = isNotEmptyField(settings?.xtm_hub_url)
     ? getUrl(
         `/redirect/${serviceIdentifier}?platform_id=${settings.platform_id}&tenant_id=${tenantId}`,

--- a/openaev-front/src/admin/components/common/ImportFromHubButton.tsx
+++ b/openaev-front/src/admin/components/common/ImportFromHubButton.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '@mui/material/styles';
 
 import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
+import { DEFAULT_TENANT_UUID } from '../../../utils/tenant-url-helper';
 import { getUrl, isNotEmptyField } from '../../../utils/utils';
 import GradientButton from './GradientButton';
 
@@ -11,13 +12,17 @@ interface ImportFromHubButtonProps extends ButtonProps { serviceIdentifier: stri
 const ImportFromHubButton = ({ serviceIdentifier }: ImportFromHubButtonProps) => {
   const { t } = useFormatter();
   const theme = useTheme();
-  const { settings } = useAuth();
+  const { settings, currentUserTenant } = useAuth();
   if (!settings.xtm_hub_enable) {
     return null;
   }
 
+  const tenantId = currentUserTenant?.tenant_id ?? DEFAULT_TENANT_UUID;
   const importFromHubUrl = isNotEmptyField(settings?.xtm_hub_url)
-    ? getUrl(`/redirect/${serviceIdentifier}?oaev_instance_id=${settings.platform_id}`, settings?.xtm_hub_url)
+    ? getUrl(
+        `/redirect/${serviceIdentifier}?platform_id=${settings.platform_id}&tenant_id=${tenantId}`,
+        settings?.xtm_hub_url,
+      )
     : '';
 
   return (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!
Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* `ImportFromHubButton` now includes `tenant_id` in the redirect URL built to the XTM Hub (from `useAuth().currentUserTenant`, with `DEFAULT_TENANT_UUID` as fallback — same pattern as `InstructionSelector.tsx` and `root.tsx`)
* Fixed bug: the query param was `oaev_instance_id` which is not recognized by the Hub (causing the "Import from Hub" button to redirect users to their personal space instead of the requested scenario). Renamed to `platform_id` to match the Hub's convention, aligning with other XTM Hub URL constructions in the codebase (e.g. `XtmHubTab.tsx`)

### Testing Instructions

Locally:
1. Set `openaev.enabled-dev-features=MULTI_TENANCY` in `application-dev.properties`
2. Point `openaev.xtm.hub.url` to the XTM Hub feature env: `https://dev-pr-2183.hub.staging.filigran.io/`
3. Go to `/admin/scenarios`, open DevTools Network, click "Import from Hub"
4. Verify the outbound URL contains `platform_id=<uuid>&tenant_id=<uuid>` and NOT `oaev_instance_id`

End-to-end test with two registered tenants is pending the OpenAEV feature env deployment (AWX issue, in progress with the Ops team). Reviewers with EE license can also validate the registered case in their environment.

### Related issues

* Closes https://github.com/OpenAEV-Platform/filigran-private/issues/80
* Companion XTM Hub PR: https://github.com/FiligranHQ/xtm-hub/pull/2183 (multi-tenant support for `platformAssociatedOrganization`, `oaev_instance_id` alias, and `selected_organization` fallback)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments
