### PR TITLE
[backend/frontend] fix(settings): split settings into public & private api

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
@@ -84,7 +84,7 @@ public class AppSecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/player/**")
                     .permitAll()
-                    .requestMatchers("/api/settings")
+                    .requestMatchers("/api/settings/public")
                     .permitAll()
                     .requestMatchers("/api/agent/**")
                     .permitAll()

--- a/openaev-api/src/main/java/io/openaev/rest/settings/PlatformSettingsApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/settings/PlatformSettingsApi.java
@@ -17,6 +17,7 @@ import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.settings.form.*;
 import io.openaev.rest.settings.response.CalderaSettings;
 import io.openaev.rest.settings.response.PlatformSettings;
+import io.openaev.rest.settings.response.PublicPlatformSettings;
 import io.openaev.service.CalderaSettingsService;
 import io.openaev.service.PlatformSettingsService;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
@@ -49,10 +50,30 @@ public class PlatformSettingsApi extends RestBehavior {
   private final CalderaSettingsService calderaSettingsService;
   private final CustomDashboardService customDashboardService;
 
-  @GetMapping()
+  // -- READ --
+
+  @GetMapping("/public")
   @RBAC(skipRBAC = true)
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Non-sensitive settings for login page and initial rendering")
+      })
+  @Operation(
+      summary = "List public settings",
+      description =
+          "Return only non-sensitive settings (auth providers, theme, language, policies)")
+  public PublicPlatformSettings publicSettings() {
+    return platformSettingsService.findPublicSettings();
+  }
+
+  @GetMapping()
+  @RBAC(actionPerformed = Action.READ, resourceType = ResourceType.PLATFORM_SETTING)
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The list of settings")})
-  @Operation(summary = "List settings", description = "Return the settings")
+  @Operation(
+      summary = "List settings",
+      description = "Return the full settings (authenticated users only)")
   public PlatformSettings settings() {
     return platformSettingsService.findSettings();
   }

--- a/openaev-api/src/main/java/io/openaev/rest/settings/response/PlatformSettings.java
+++ b/openaev-api/src/main/java/io/openaev/rest/settings/response/PlatformSettings.java
@@ -1,6 +1,7 @@
 package io.openaev.rest.settings.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.ee.License;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -208,4 +209,8 @@ public class PlatformSettings extends PublicPlatformSettings {
   @JsonProperty("imap_service_available")
   @Schema(description = "IMAP Service availability")
   private String imapServiceAvailable;
+
+  @JsonProperty("platform_license")
+  @Schema(description = "Platform licensing information")
+  private License platformLicense;
 }

--- a/openaev-api/src/main/java/io/openaev/rest/settings/response/PlatformSettings.java
+++ b/openaev-api/src/main/java/io/openaev/rest/settings/response/PlatformSettings.java
@@ -1,20 +1,10 @@
 package io.openaev.rest.settings.response;
 
-import static lombok.AccessLevel.NONE;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.openaev.ee.License;
-import io.openaev.rest.settings.PreviewFeature;
-import io.openaev.rest.settings.form.PolicyInput;
-import io.openaev.rest.settings.form.ThemeInput;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +14,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class PlatformSettings {
+public class PlatformSettings extends PublicPlatformSettings {
 
   @JsonProperty("platform_id")
   @Schema(description = "id of the platform")
@@ -43,16 +33,6 @@ public class PlatformSettings {
   @Schema(description = "Agent URL of the platform")
   private String platformAgentUrl;
 
-  @NotBlank
-  @JsonProperty("platform_theme")
-  @Schema(description = "Theme of the platform")
-  private String platformTheme;
-
-  @NotBlank
-  @JsonProperty("platform_lang")
-  @Schema(description = "Language of the platform")
-  private String platformLang;
-
   @JsonProperty("platform_home_dashboard")
   @Schema(description = "Default home dashboard of the platform")
   private String platformHomeDashboard;
@@ -64,30 +44,6 @@ public class PlatformSettings {
   @JsonProperty("platform_simulation_dashboard")
   @Schema(description = "Default simulation dashboard of the platform")
   private String platformSimulationDashboard;
-
-  @JsonProperty("platform_whitemark")
-  @Schema(description = "'true' if the platform has the whitemark activated")
-  private String platformWhitemark;
-
-  @JsonProperty("platform_openid_providers")
-  @Schema(description = "List of OpenID providers")
-  private List<OAuthProvider> platformOpenIdProviders;
-
-  @JsonProperty("platform_saml2_providers")
-  @Schema(description = "List of Saml2 providers")
-  private List<OAuthProvider> platformSaml2Providers;
-
-  @JsonProperty("auth_openid_enable")
-  @Schema(description = "True if OpenID is enabled")
-  private Boolean authOpenidEnable;
-
-  @JsonProperty("auth_saml2_enable")
-  @Schema(description = "True if Saml2 is enabled")
-  private Boolean authSaml2Enable;
-
-  @JsonProperty("auth_local_enable")
-  @Schema(description = "True if local authentication is enabled")
-  private Boolean authLocalEnable;
 
   @JsonProperty("map_tile_server_light")
   @Schema(description = "URL of the server containing the map tile with light theme")
@@ -159,45 +115,6 @@ public class PlatformSettings {
   @Schema(description = "True if the Tanium Executor is enabled")
   private Boolean executorTaniumEnable;
 
-  // THEME
-
-  @JsonProperty("platform_light_theme")
-  @Schema(description = "Definition of the light theme")
-  private ThemeInput themeLight;
-
-  @JsonProperty("platform_dark_theme")
-  @Schema(description = "Definition of the dark theme")
-  private ThemeInput themeDark;
-
-  // POLICIES
-
-  @JsonProperty("platform_policies")
-  @Schema(description = "Policies of the platform")
-  private PolicyInput policies;
-
-  // FEATURE FLAG
-  @JsonProperty("enabled_dev_features")
-  @Schema(description = "List of enabled dev features")
-  private List<PreviewFeature> enabledDevFeatures = new ArrayList<>();
-
-  // PLATFORM MESSAGE
-  @JsonProperty("platform_banner_by_level")
-  @Getter(NONE)
-  @Schema(
-      description =
-          "Map of the messages to display on the screen by their level (the level available are DEBUG, INFO, WARN, ERROR, FATAL)")
-  private Map<String, List<String>> platformBannerByLevel;
-
-  public Map<String, List<String>> getPlatformBannerByLevel() {
-    Map<String, List<String>> platformBannerByLevelLowerCase = new HashMap<>();
-    if (this.platformBannerByLevel != null) {
-      this.platformBannerByLevel.forEach(
-          (key, value) -> platformBannerByLevelLowerCase.put(key.toLowerCase(), value));
-      return platformBannerByLevelLowerCase;
-    }
-    return null;
-  }
-
   // EXPECTATION
   @NotNull
   @JsonProperty("expectation_detection_expiration_time")
@@ -242,11 +159,6 @@ public class PlatformSettings {
   @JsonProperty("default_reply_to")
   @Schema(description = "Reply to mail to use by default for injects")
   private String defaultReplyTo;
-
-  // LICENSE
-  @JsonProperty("platform_license")
-  @Schema(description = "Platform licensing")
-  private License platformLicense;
 
   // XTM Hub
   @JsonProperty("xtm_hub_enable")

--- a/openaev-api/src/main/java/io/openaev/rest/settings/response/PublicPlatformSettings.java
+++ b/openaev-api/src/main/java/io/openaev/rest/settings/response/PublicPlatformSettings.java
@@ -1,0 +1,92 @@
+package io.openaev.rest.settings.response;
+
+import static lombok.AccessLevel.NONE;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.ee.License;
+import io.openaev.rest.settings.PreviewFeature;
+import io.openaev.rest.settings.form.PolicyInput;
+import io.openaev.rest.settings.form.ThemeInput;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class PublicPlatformSettings {
+
+  @JsonProperty("platform_theme")
+  @Schema(description = "Theme of the platform")
+  private String platformTheme;
+
+  @JsonProperty("platform_lang")
+  @Schema(description = "Language of the platform")
+  private String platformLang;
+
+  @JsonProperty("platform_openid_providers")
+  @Schema(description = "List of OpenID providers")
+  private List<OAuthProvider> platformOpenIdProviders;
+
+  @JsonProperty("platform_saml2_providers")
+  @Schema(description = "List of Saml2 providers")
+  private List<OAuthProvider> platformSaml2Providers;
+
+  @JsonProperty("auth_openid_enable")
+  @Schema(description = "True if OpenID is enabled")
+  private Boolean authOpenidEnable;
+
+  @JsonProperty("auth_saml2_enable")
+  @Schema(description = "True if Saml2 is enabled")
+  private Boolean authSaml2Enable;
+
+  @JsonProperty("auth_local_enable")
+  @Schema(description = "True if local authentication is enabled")
+  private Boolean authLocalEnable;
+
+  @JsonProperty("platform_light_theme")
+  @Schema(description = "Definition of the light theme")
+  private ThemeInput themeLight;
+
+  @JsonProperty("platform_dark_theme")
+  @Schema(description = "Definition of the dark theme")
+  private ThemeInput themeDark;
+
+  @JsonProperty("platform_policies")
+  @Schema(description = "Policies of the platform")
+  private PolicyInput policies;
+
+  @JsonProperty("platform_banner_by_level")
+  @Getter(NONE)
+  @Schema(
+      description =
+          "Map of the messages to display on the screen by their level (the level available are DEBUG, INFO, WARN, ERROR, FATAL)")
+  private Map<String, List<String>> platformBannerByLevel;
+
+  public Map<String, List<String>> getPlatformBannerByLevel() {
+    Map<String, List<String>> platformBannerByLevelLowerCase = new HashMap<>();
+    if (this.platformBannerByLevel != null) {
+      this.platformBannerByLevel.forEach(
+          (key, value) -> platformBannerByLevelLowerCase.put(key.toLowerCase(), value));
+      return platformBannerByLevelLowerCase;
+    }
+    return null;
+  }
+
+  @JsonProperty("enabled_dev_features")
+  @Schema(description = "List of enabled dev features")
+  private List<PreviewFeature> enabledDevFeatures = new ArrayList<>();
+
+  @JsonProperty("platform_whitemark")
+  @Schema(description = "'true' if the platform has the whitemark activated")
+  private String platformWhitemark;
+
+  @JsonProperty("platform_license")
+  @Schema(description = "Platform licensing (public subset for login page rendering)")
+  private License platformLicense;
+}

--- a/openaev-api/src/main/java/io/openaev/rest/settings/response/PublicPlatformSettings.java
+++ b/openaev-api/src/main/java/io/openaev/rest/settings/response/PublicPlatformSettings.java
@@ -7,6 +7,7 @@ import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.rest.settings.form.PolicyInput;
 import io.openaev.rest.settings.form.ThemeInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,10 +21,12 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PublicPlatformSettings {
 
+  @NotBlank
   @JsonProperty("platform_theme")
   @Schema(description = "Theme of the platform")
   private String platformTheme;
 
+  @NotBlank
   @JsonProperty("platform_lang")
   @Schema(description = "Language of the platform")
   private String platformLang;

--- a/openaev-api/src/main/java/io/openaev/rest/settings/response/PublicPlatformSettings.java
+++ b/openaev-api/src/main/java/io/openaev/rest/settings/response/PublicPlatformSettings.java
@@ -3,7 +3,6 @@ package io.openaev.rest.settings.response;
 import static lombok.AccessLevel.NONE;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.openaev.ee.License;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.rest.settings.form.PolicyInput;
 import io.openaev.rest.settings.form.ThemeInput;
@@ -85,8 +84,4 @@ public class PublicPlatformSettings {
   @JsonProperty("platform_whitemark")
   @Schema(description = "'true' if the platform has the whitemark activated")
   private String platformWhitemark;
-
-  @JsonProperty("platform_license")
-  @Schema(description = "Platform licensing (public subset for login page rendering)")
-  private License platformLicense;
 }

--- a/openaev-api/src/main/java/io/openaev/service/PlatformSettingsService.java
+++ b/openaev-api/src/main/java/io/openaev/service/PlatformSettingsService.java
@@ -241,12 +241,11 @@ public class PlatformSettingsService {
     }
     settings.setPlatformBannerByLevel(platformBannerByLevel);
 
-    // Whitemark & License
+    // Whitemark
     settings.setPlatformWhitemark(
         ofNullable(dbSettings.get(PLATFORM_WHITEMARK.key()))
             .map(Setting::getValue)
             .orElse(PLATFORM_WHITEMARK.defaultValue()));
-    settings.setPlatformLicense(licenseCacheManager.getEnterpriseEditionInfo());
   }
 
   /** Return only non-sensitive settings suitable for unauthenticated (public) access. */
@@ -266,6 +265,7 @@ public class PlatformSettingsService {
     populatePublicSettings(platformSettings, dbSettings);
 
     // Authenticated-only fields
+    platformSettings.setPlatformLicense(licenseCacheManager.getEnterpriseEditionInfo());
     platformSettings.setPlatformHomeDashboard(
         ofNullable(dbSettings.get(DEFAULT_HOME_DASHBOARD.key()))
             .map(Setting::getValue)

--- a/openaev-api/src/main/java/io/openaev/service/PlatformSettingsService.java
+++ b/openaev-api/src/main/java/io/openaev/service/PlatformSettingsService.java
@@ -11,7 +11,10 @@ import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.OpenAEVPrincipal;
 import io.openaev.config.RabbitmqConfig;
 import io.openaev.config.cache.LicenseCacheManager;
-import io.openaev.database.model.*;
+import io.openaev.database.model.BannerMessage;
+import io.openaev.database.model.Setting;
+import io.openaev.database.model.SettingKeys;
+import io.openaev.database.model.Theme;
 import io.openaev.database.repository.SettingRepository;
 import io.openaev.ee.Ee;
 import io.openaev.ee.License;
@@ -24,6 +27,7 @@ import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.rest.settings.form.*;
 import io.openaev.rest.settings.response.OAuthProvider;
 import io.openaev.rest.settings.response.PlatformSettings;
+import io.openaev.rest.settings.response.PublicPlatformSettings;
 import io.openaev.rest.stream.ai.AiConfig;
 import io.openaev.xtmhub.XtmHubConnectivityService;
 import io.openaev.xtmhub.XtmHubRegistererRecord;
@@ -170,23 +174,98 @@ public class PlatformSettingsService {
   }
 
   // -- FIND SETTINGS --
-  public PlatformSettings findSettings() {
-    Map<String, Setting> dbSettings = mapOfSettings(fromIterable(this.settingRepository.findAll()));
-    PlatformSettings platformSettings = new PlatformSettings();
-    // Build anonymous settings
-    platformSettings.setPlatformOpenIdProviders(buildOpenIdProviders());
-    platformSettings.setPlatformSaml2Providers(buildSaml2Providers());
-    platformSettings.setAuthOpenidEnable(openAEVConfig.isAuthOpenidEnable());
-    platformSettings.setAuthSaml2Enable(openAEVConfig.isAuthSaml2Enable());
-    platformSettings.setAuthLocalEnable(openAEVConfig.isAuthLocalEnable());
-    platformSettings.setPlatformTheme(
+
+  /** Populate the public (non-sensitive) fields on any {@link PublicPlatformSettings} instance. */
+  private void populatePublicSettings(
+      PublicPlatformSettings settings, Map<String, Setting> dbSettings) {
+    // Auth providers
+    settings.setPlatformOpenIdProviders(buildOpenIdProviders());
+    settings.setPlatformSaml2Providers(buildSaml2Providers());
+    settings.setAuthOpenidEnable(openAEVConfig.isAuthOpenidEnable());
+    settings.setAuthSaml2Enable(openAEVConfig.isAuthSaml2Enable());
+    settings.setAuthLocalEnable(openAEVConfig.isAuthLocalEnable());
+
+    // Theme & language
+    settings.setPlatformTheme(
         ofNullable(dbSettings.get(DEFAULT_THEME.key()))
             .map(Setting::getValue)
             .orElse(DEFAULT_THEME.defaultValue()));
-    platformSettings.setPlatformLang(
+    settings.setPlatformLang(
         ofNullable(dbSettings.get(DEFAULT_LANG.key()))
             .map(Setting::getValue)
             .orElse(DEFAULT_LANG.defaultValue()));
+    settings.setThemeLight(createThemeInput(dbSettings, THEME_TYPE_LIGHT));
+    settings.setThemeDark(createThemeInput(dbSettings, THEME_TYPE_DARK));
+
+    // Policies
+    PolicyInput policies = new PolicyInput();
+    policies.setLoginMessage(getValueFromMapOfSettings(dbSettings, PLATFORM_LOGIN_MESSAGE.key()));
+    policies.setConsentMessage(
+        getValueFromMapOfSettings(dbSettings, PLATFORM_CONSENT_MESSAGE.key()));
+    policies.setConsentConfirmText(
+        getValueFromMapOfSettings(dbSettings, PLATFORM_CONSENT_CONFIRM_TEXT.key()));
+    settings.setPolicies(policies);
+
+    // Feature flags
+    if (!StringUtils.hasText(openAEVConfig.getEnabledDevFeatures())) {
+      settings.setEnabledDevFeatures(new ArrayList<>());
+    } else {
+      settings.setEnabledDevFeatures(
+          Arrays.stream(openAEVConfig.getEnabledDevFeatures().split(","))
+              .map(
+                  featureStr -> {
+                    try {
+                      return PreviewFeature.fromStringIgnoreCase(featureStr.strip());
+                    } catch (IllegalArgumentException e) {
+                      log.warn(String.format("Unrecognised feature flag: %s", e.getMessage()), e);
+                      return null;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .distinct()
+              .toList());
+    }
+
+    // Platform banners
+    Map<String, List<String>> platformBannerByLevel = new HashMap<>();
+    for (BannerMessage.BANNER_KEYS bannerKey : BannerMessage.BANNER_KEYS.values()) {
+      String value = getValueFromMapOfSettings(dbSettings, PLATFORM_BANNER + "." + bannerKey.key());
+      if (value != null) {
+        if (platformBannerByLevel.get(bannerKey.level().name()) == null) {
+          platformBannerByLevel.put(
+              bannerKey.level().name(), new ArrayList<>(Arrays.asList(bannerKey.message())));
+        } else {
+          platformBannerByLevel.get(bannerKey.level().name()).add(bannerKey.message());
+        }
+      }
+    }
+    settings.setPlatformBannerByLevel(platformBannerByLevel);
+
+    // Whitemark & License
+    settings.setPlatformWhitemark(
+        ofNullable(dbSettings.get(PLATFORM_WHITEMARK.key()))
+            .map(Setting::getValue)
+            .orElse(PLATFORM_WHITEMARK.defaultValue()));
+    settings.setPlatformLicense(licenseCacheManager.getEnterpriseEditionInfo());
+  }
+
+  /** Return only non-sensitive settings suitable for unauthenticated (public) access. */
+  public PublicPlatformSettings findPublicSettings() {
+    Map<String, Setting> dbSettings = mapOfSettings(fromIterable(this.settingRepository.findAll()));
+    PublicPlatformSettings settings = new PublicPlatformSettings();
+    populatePublicSettings(settings, dbSettings);
+    return settings;
+  }
+
+  /** Return the full platform settings. Must only be called from authenticated endpoints. */
+  public PlatformSettings findSettings() {
+    Map<String, Setting> dbSettings = mapOfSettings(fromIterable(this.settingRepository.findAll()));
+    PlatformSettings platformSettings = new PlatformSettings();
+
+    // Populate public fields (shared with findPublicSettings)
+    populatePublicSettings(platformSettings, dbSettings);
+
+    // Authenticated-only fields
     platformSettings.setPlatformHomeDashboard(
         ofNullable(dbSettings.get(DEFAULT_HOME_DASHBOARD.key()))
             .map(Setting::getValue)
@@ -215,95 +294,38 @@ public class PlatformSettingsService {
             .map(Setting::getValue)
             .orElse(IMAP_SERVICE_AVAILABLE.defaultValue()));
 
-    // Build authenticated user settings
+    // Authenticated user settings
+    platformSettings.setMapTileServerLight(openAEVConfig.getMapTileServerLight());
+    platformSettings.setMapTileServerDark(openAEVConfig.getMapTileServerDark());
+    platformSettings.setPlatformId(
+        ofNullable(dbSettings.get(PLATFORM_INSTANCE.key()))
+            .map(Setting::getValue)
+            .orElse(PLATFORM_INSTANCE.defaultValue()));
+    platformSettings.setPlatformName(
+        ofNullable(dbSettings.get(PLATFORM_NAME.key()))
+            .map(Setting::getValue)
+            .orElse(PLATFORM_NAME.defaultValue()));
+    platformSettings.setPlatformBaseUrl(openAEVConfig.getBaseUrl());
+    platformSettings.setPlatformAgentUrl(openAEVConfig.getBaseUrlForAgent());
+    platformSettings.setXtmOpenctiEnable(openCTIConfig.getEnable());
+    platformSettings.setXtmOpenctiUrl(openCTIConfig.getUrl());
+    platformSettings.setAiEnabled(aiConfig.isEnabled());
+    platformSettings.setAiHasToken(StringUtils.hasText(aiConfig.getToken()));
+    platformSettings.setAiType(aiConfig.getType());
+    platformSettings.setAiModel(aiConfig.getModel());
+    platformSettings.setExecutorTaniumEnable(false);
+    platformSettings.setTelemetryManagerEnable(true);
+
+    // Admin-only settings
     OpenAEVPrincipal user = currentUser();
-    if (user != null) {
-      platformSettings.setPlatformWhitemark(
-          ofNullable(dbSettings.get(PLATFORM_WHITEMARK.key()))
-              .map(Setting::getValue)
-              .orElse(PLATFORM_WHITEMARK.defaultValue()));
-      platformSettings.setMapTileServerLight(openAEVConfig.getMapTileServerLight());
-      platformSettings.setMapTileServerDark(openAEVConfig.getMapTileServerDark());
-      platformSettings.setPlatformId(
-          ofNullable(dbSettings.get(PLATFORM_INSTANCE.key()))
-              .map(Setting::getValue)
-              .orElse(PLATFORM_INSTANCE.defaultValue()));
-      platformSettings.setPlatformName(
-          ofNullable(dbSettings.get(PLATFORM_NAME.key()))
-              .map(Setting::getValue)
-              .orElse(PLATFORM_NAME.defaultValue()));
-      platformSettings.setPlatformBaseUrl(openAEVConfig.getBaseUrl());
-      platformSettings.setPlatformAgentUrl(openAEVConfig.getBaseUrlForAgent());
-      platformSettings.setXtmOpenctiEnable(openCTIConfig.getEnable());
-      platformSettings.setXtmOpenctiUrl(openCTIConfig.getUrl());
-      platformSettings.setAiEnabled(aiConfig.isEnabled());
-      platformSettings.setAiHasToken(StringUtils.hasText(aiConfig.getToken()));
-      platformSettings.setAiType(aiConfig.getType());
-      platformSettings.setAiModel(aiConfig.getModel());
-      platformSettings.setExecutorTaniumEnable(false);
-      platformSettings.setTelemetryManagerEnable(true);
-
-      // Build admin settings
-      if (user.isAdmin()) {
-        platformSettings.setPlatformVersion(openAEVConfig.getVersion());
-        platformSettings.setPostgreVersion(settingRepository.getServerVersion());
-        platformSettings.setJavaVersion(Runtime.version().toString());
-        platformSettings.setRabbitMQVersion(RabbitMQHelper.getRabbitMQVersion(rabbitmqConfig));
-        platformSettings.setAnalyticsEngineType(engineConfig.getEngineSelector());
-        platformSettings.setAnalyticsEngineVersion(engineService.getEngineVersion());
-      }
+    if (user != null && user.isAdmin()) {
+      platformSettings.setPlatformVersion(openAEVConfig.getVersion());
+      platformSettings.setPostgreVersion(settingRepository.getServerVersion());
+      platformSettings.setJavaVersion(Runtime.version().toString());
+      platformSettings.setRabbitMQVersion(RabbitMQHelper.getRabbitMQVersion(rabbitmqConfig));
+      platformSettings.setAnalyticsEngineType(engineConfig.getEngineSelector());
+      platformSettings.setAnalyticsEngineVersion(engineService.getEngineVersion());
     }
-
-    // THEME
-    ThemeInput themeLight = createThemeInput(dbSettings, THEME_TYPE_LIGHT);
-    platformSettings.setThemeLight(themeLight);
-
-    ThemeInput themeDark = createThemeInput(dbSettings, THEME_TYPE_DARK);
-    platformSettings.setThemeDark(themeDark);
-
-    // POLICIES
-    PolicyInput policies = new PolicyInput();
-    policies.setLoginMessage(getValueFromMapOfSettings(dbSettings, PLATFORM_LOGIN_MESSAGE.key()));
-    policies.setConsentMessage(
-        getValueFromMapOfSettings(dbSettings, PLATFORM_CONSENT_MESSAGE.key()));
-    policies.setConsentConfirmText(
-        getValueFromMapOfSettings(dbSettings, PLATFORM_CONSENT_CONFIRM_TEXT.key()));
-    platformSettings.setPolicies(policies);
-
-    // FEATURE FLAG
-    if (!StringUtils.hasText(openAEVConfig.getEnabledDevFeatures())) {
-      platformSettings.setEnabledDevFeatures(new ArrayList<>());
-    } else {
-      platformSettings.setEnabledDevFeatures(
-          Arrays.stream(openAEVConfig.getEnabledDevFeatures().split(","))
-              .map(
-                  featureStr -> {
-                    try {
-                      return PreviewFeature.fromStringIgnoreCase(featureStr.strip());
-                    } catch (IllegalArgumentException e) {
-                      log.warn(String.format("Unrecognised feature flag: %s", e.getMessage()), e);
-                      return null;
-                    }
-                  })
-              .filter(Objects::nonNull)
-              .distinct()
-              .toList());
-    }
-
-    // PLATFORM MESSAGE
-    Map<String, List<String>> platformBannerByLevel = new HashMap<>();
-    for (BannerMessage.BANNER_KEYS bannerKey : BannerMessage.BANNER_KEYS.values()) {
-      String value = getValueFromMapOfSettings(dbSettings, PLATFORM_BANNER + "." + bannerKey.key());
-      if (value != null) {
-        if (platformBannerByLevel.get(bannerKey.level().name()) == null) {
-          platformBannerByLevel.put(
-              bannerKey.level().name(), new ArrayList<>(Arrays.asList(bannerKey.message())));
-        } else {
-          platformBannerByLevel.get(bannerKey.level().name()).add(bannerKey.message());
-        }
-      }
-    }
-    platformSettings.setPlatformBannerByLevel(platformBannerByLevel);
 
     // EXPECTATION
     platformSettings.setDetectionExpirationTime(
@@ -319,9 +341,6 @@ public class PlatformSettingsService {
     platformSettings.setManualExpirationTime(expectationPropertiesConfig.getManualExpirationTime());
     platformSettings.setExpectationDefaultScoreValue(
         expectationPropertiesConfig.getDefaultExpectationScoreValue());
-
-    // License
-    platformSettings.setPlatformLicense(licenseCacheManager.getEnterpriseEditionInfo());
 
     // XTM Hub
     platformSettings.setXtmHubEnable(xtmHubConfig.getEnable());

--- a/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
@@ -30,11 +30,12 @@ class PlatformSettingsApiTest extends IntegrationTest {
           "platform_light_theme",
           "platform_dark_theme",
           "enabled_dev_features",
-          "platform_whitemark",
-          "platform_license");
+          "platform_whitemark");
 
   private static final List<String> PRIVATE_FIELDS =
       List.of(
+          // License
+          "platform_license",
           // Tokens and secrets
           "xtm_hub_token",
           "xtm_hub_url",

--- a/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @TestInstance(PER_CLASS)
+@DisplayName("Platform Settings API")
 class PlatformSettingsApiTest extends IntegrationTest {
 
   @Autowired private MockMvc mvc;
@@ -69,9 +70,11 @@ class PlatformSettingsApiTest extends IntegrationTest {
   }
 
   @Nested
+  @DisplayName("Public settings endpoint")
   class PublicSettingsEndpoint {
 
     @Test
+    @DisplayName("Given unauthenticated user should return public settings")
     void given_unauthenticated_user_should_return_public_settings() throws Exception {
       // -- ARRANGE --
 
@@ -85,6 +88,7 @@ class PlatformSettingsApiTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Given unauthenticated user should not return sensitive fields")
     void given_unauthenticated_user_should_not_return_sensitive_fields() throws Exception {
       // -- ARRANGE --
 
@@ -99,9 +103,11 @@ class PlatformSettingsApiTest extends IntegrationTest {
   }
 
   @Nested
+  @DisplayName("Private settings endpoint")
   class PrivateSettingsEndpoint {
 
     @Test
+    @DisplayName("Given unauthenticated user should return 401")
     void given_unauthenticated_user_should_return_401() throws Exception {
       // -- ARRANGE --
 
@@ -113,6 +119,7 @@ class PlatformSettingsApiTest extends IntegrationTest {
 
     @Test
     @WithMockUser
+    @DisplayName("Given authenticated admin should return full settings")
     void given_authenticated_admin_should_return_full_settings() throws Exception {
       // -- ARRANGE --
 

--- a/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
@@ -1,0 +1,129 @@
+package io.openaev.rest;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.util.List;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@TestInstance(PER_CLASS)
+class PlatformSettingsApiTest extends IntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  private static final List<String> PUBLIC_FIELDS =
+      List.of(
+          "platform_theme",
+          "platform_lang",
+          "auth_openid_enable",
+          "auth_saml2_enable",
+          "auth_local_enable",
+          "platform_policies",
+          "platform_light_theme",
+          "platform_dark_theme",
+          "enabled_dev_features",
+          "platform_whitemark",
+          "platform_license");
+
+  private static final List<String> PRIVATE_FIELDS =
+      List.of(
+          // Tokens and secrets
+          "xtm_hub_token",
+          "xtm_hub_url",
+          "xtm_opencti_url",
+          "xtm_opencti_enable",
+          // AI config
+          "platform_ai_type",
+          "platform_ai_model",
+          "platform_ai_enabled",
+          "platform_ai_has_token",
+          // Email config
+          "default_mailer",
+          "default_reply_to",
+          // Platform identity
+          "platform_id",
+          "platform_name",
+          "platform_base_url");
+
+  private static void assertFieldsExist(ResultActions result, List<String> fields)
+      throws Exception {
+    for (String field : fields) {
+      result.andExpect(jsonPath("$." + field).exists());
+    }
+  }
+
+  private static void assertFieldsDoNotExist(ResultActions result, List<String> fields)
+      throws Exception {
+    for (String field : fields) {
+      result.andExpect(jsonPath("$." + field).doesNotExist());
+    }
+  }
+
+  @Nested
+  class PublicSettingsEndpoint {
+
+    @Test
+    void given_unauthenticated_user_should_return_public_settings() throws Exception {
+      // -- ARRANGE --
+
+      // -- ACT --
+      ResultActions result =
+          mvc.perform(get("/api/settings/public").accept(MediaType.APPLICATION_JSON));
+
+      // -- ASSERT --
+      result.andExpect(status().isOk());
+      assertFieldsExist(result, PUBLIC_FIELDS);
+    }
+
+    @Test
+    void given_unauthenticated_user_should_not_return_sensitive_fields() throws Exception {
+      // -- ARRANGE --
+
+      // -- ACT --
+      ResultActions result =
+          mvc.perform(get("/api/settings/public").accept(MediaType.APPLICATION_JSON));
+
+      // -- ASSERT --
+      result.andExpect(status().isOk());
+      assertFieldsDoNotExist(result, PRIVATE_FIELDS);
+    }
+  }
+
+  @Nested
+  class PrivateSettingsEndpoint {
+
+    @Test
+    void given_unauthenticated_user_should_return_401() throws Exception {
+      // -- ARRANGE --
+
+      // -- ACT --
+      mvc.perform(get("/api/settings").accept(MediaType.APPLICATION_JSON))
+          // -- ASSERT --
+          .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void given_authenticated_admin_should_return_full_settings() throws Exception {
+      // -- ARRANGE --
+
+      // -- ACT --
+      ResultActions result = mvc.perform(get("/api/settings").accept(MediaType.APPLICATION_JSON));
+
+      // -- ASSERT --
+      result.andExpect(status().isOk());
+      // Public fields (inherited) should be present
+      assertFieldsExist(result, PUBLIC_FIELDS);
+      // Private fields should also be present
+      assertFieldsExist(result, PRIVATE_FIELDS);
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlatformSettingsApiTest.java
@@ -35,25 +35,25 @@ class PlatformSettingsApiTest extends IntegrationTest {
 
   private static final List<String> PRIVATE_FIELDS =
       List.of(
-          // License
-          "platform_license",
-          // Tokens and secrets
-          "xtm_hub_token",
-          "xtm_hub_url",
-          "xtm_opencti_url",
-          "xtm_opencti_enable",
-          // AI config
-          "platform_ai_type",
-          "platform_ai_model",
-          "platform_ai_enabled",
-          "platform_ai_has_token",
-          // Email config
-          "default_mailer",
-          "default_reply_to",
           // Platform identity
           "platform_id",
           "platform_name",
-          "platform_base_url");
+          "platform_base_url",
+          // OpenCTI
+          "xtm_opencti_enable",
+          "xtm_opencti_url",
+          // XTM Hub (config-driven, always present)
+          "xtm_hub_enable",
+          "xtm_hub_url",
+          "xtm_hub_reachable",
+          // AI config
+          "platform_ai_enabled",
+          "platform_ai_has_token",
+          "platform_ai_type",
+          "platform_ai_model",
+          // Email config
+          "default_mailer",
+          "default_reply_to");
 
   private static void assertFieldsExist(ResultActions result, List<String> fields)
       throws Exception {
@@ -128,9 +128,7 @@ class PlatformSettingsApiTest extends IntegrationTest {
 
       // -- ASSERT --
       result.andExpect(status().isOk());
-      // Public fields (inherited) should be present
       assertFieldsExist(result, PUBLIC_FIELDS);
-      // Private fields should also be present
       assertFieldsExist(result, PRIVATE_FIELDS);
     }
   }

--- a/openaev-api/src/test/resources/application.properties
+++ b/openaev-api/src/test/resources/application.properties
@@ -130,14 +130,21 @@ http.enable=false
 # Injector Caldera config
 injector.caldera.enable=false
 
+# AI configuration
+ai.enabled=true
+ai.type=openai
+ai.model=gpt-4
+ai.token=test-ai-token
+ai.endpoint=http://localhost/ai
+
 # Extra XTM configuration
 openaev.xtm.opencti.enable=false
-openaev.xtm.opencti.url=<opencti-url>
+openaev.xtm.opencti.url=http://opencti.test
 openaev.xtm.opencti.token=<opencti-token>
 
 # XTM Hub configuration
 openaev.xtm.hub.enable=false
-openaev.xtm.hub.url=<xtm-hub-url>
+openaev.xtm.hub.url=http://xtm-hub.test
 openaev.xtm.hub.collector.id=b402f1f5-29ba-4ee3-b366-f0467754cf4e
 
 # XLS Import

--- a/openaev-front/src/actions/Schema.js
+++ b/openaev-front/src/actions/Schema.js
@@ -283,7 +283,9 @@ export const storeHelper = state => ({
     t => t.get('token_user') === me(state)?.get('user_id'),
   ),
   getUserLang: () => {
-    const rawPlatformLang = state.referential.getIn(['entities', 'platformParameters', 'parameters', 'platform_lang']) ?? 'auto';
+    const publicParams = state.referential.getIn(['entities', 'publicPlatformParameters', 'parameters']);
+    const privateParams = state.referential.getIn(['entities', 'platformParameters', 'parameters']);
+    const rawPlatformLang = (privateParams ?? publicParams)?.get('platform_lang') ?? 'auto';
     const rawUserLang = me(state)?.get('user_lang') ?? 'auto';
     const platformLang = rawPlatformLang !== 'auto' ? rawPlatformLang : locale;
     const userLang = rawUserLang !== 'auto' ? rawUserLang : platformLang;
@@ -383,10 +385,13 @@ export const storeHelper = state => ({
   getTeams: () => entities('teams', state),
   getTeamsMap: () => maps('teams', state),
   getPlatformSettings: () => {
-    return state.referential.getIn(['entities', 'platformParameters', 'parameters']) || Map({});
+    const publicParams = state.referential.getIn(['entities', 'publicPlatformParameters', 'parameters']) || Map({});
+    const privateParams = state.referential.getIn(['entities', 'platformParameters', 'parameters']) || Map({});
+    return publicParams.merge(privateParams);
   },
   getPlatformName: () => {
-    return state.referential.getIn(['entities', 'platformParameters', 'parameters', 'platform_name']) || 'OpenAEV - Open Adversarial Exposure Validation Platform';
+    const privateParams = state.referential.getIn(['entities', 'platformParameters', 'parameters']);
+    return privateParams?.get('platform_name') || 'OpenAEV - Open Adversarial Exposure Validation Platform';
   },
   // kill chain phases
   getKillChainPhase: id => entity(id, 'killchainphases', state),

--- a/openaev-front/src/actions/settings/platform-settings-action.ts
+++ b/openaev-front/src/actions/settings/platform-settings-action.ts
@@ -1,0 +1,14 @@
+import type { Dispatch } from 'redux';
+
+import { getReferential } from '../../utils/Action';
+import publicPlatformParameters from './platform-settings-schema';
+
+const SETTINGS_URI = '/api/settings';
+
+// -- PUBLIC (unauthenticated) --
+
+const fetchPublicPlatformParameters = () => (dispatch: Dispatch) => {
+  return getReferential(publicPlatformParameters, `${SETTINGS_URI}/public`)(dispatch);
+};
+
+export default fetchPublicPlatformParameters;

--- a/openaev-front/src/actions/settings/platform-settings-helper.d.ts
+++ b/openaev-front/src/actions/settings/platform-settings-helper.d.ts
@@ -1,0 +1,7 @@
+import type { PlatformSettings, PublicPlatformSettings } from '../../utils/api-types';
+
+export interface PlatformSettingsHelper {
+  getPlatformSettings: () => PlatformSettings;
+  getPublicSettings: () => PublicPlatformSettings;
+  getPlatformName: () => string;
+}

--- a/openaev-front/src/actions/settings/platform-settings-schema.ts
+++ b/openaev-front/src/actions/settings/platform-settings-schema.ts
@@ -1,0 +1,9 @@
+import { schema } from 'normalizr';
+
+const publicPlatformParameters = new schema.Entity(
+  'publicPlatformParameters',
+  {},
+  { idAttribute: () => 'parameters' },
+);
+
+export default publicPlatformParameters;

--- a/openaev-front/src/public/components/login/Login.tsx
+++ b/openaev-front/src/public/components/login/Login.tsx
@@ -81,10 +81,10 @@ const Login = () => {
   useEffect(() => {
     window.addEventListener('resize', updateWindowDimensions);
     return () => window.removeEventListener('resize', updateWindowDimensions);
-  });
+  }, []);
   useEffect(() => {
     dispatch(checkKerberos());
-  });
+  }, []);
   const onSubmit = (data: {
     username: string;
     password: string;

--- a/openaev-front/src/reducers/Referential.ts
+++ b/openaev-front/src/reducers/Referential.ts
@@ -31,6 +31,7 @@ export const entitiesInitializer = Map({
     tags: Map({}),
     documents: Map({}),
     platformParameters: Map({}),
+    publicPlatformParameters: Map({}),
     channels: Map({}),
     payloads: Map({}),
     challenges: Map({}),
@@ -108,14 +109,14 @@ const referential = (state: any = Map({}), action: any = {}) => {
     case Constants.DATA_FETCH_ERROR: {
       if (action.payload.status === 401) {
         // If unauthorized, reset all entities except platform parameters.
-        return entitiesInitializer.setIn(['entities', 'platformParameters'], state.getIn(['entities', 'platformParameters']));
+        return entitiesInitializer.setIn(['entities', 'publicPlatformParameters'], state.getIn(['entities', 'publicPlatformParameters']));
       }
       return state;
     }
 
     case Constants.IDENTITY_LOGOUT_SUCCESS: {
       // Upon logout, reset all entities except for platform parameters.
-      return entitiesInitializer.setIn(['entities', 'platformParameters'], state.getIn(['entities', 'platformParameters']));
+      return entitiesInitializer.setIn(['entities', 'publicPlatformParameters'], state.getIn(['entities', 'publicPlatformParameters']));
     }
     default: {
       return state;

--- a/openaev-front/src/root.tsx
+++ b/openaev-front/src/root.tsx
@@ -5,6 +5,7 @@ import { Navigate, Route, Routes } from 'react-router';
 
 import { fetchMe, fetchPlatformParameters } from './actions/Application';
 import { type LoggedHelper } from './actions/helper';
+import fetchPublicPlatformParameters from './actions/settings/platform-settings-action';
 import EnterpriseEditionAgreementDialog from './admin/components/common/entreprise_edition/EnterpriseEditionAgreementDialog';
 import ConnectedIntlProvider from './components/AppIntlProvider';
 import ConnectedThemeProvider from './components/AppThemeProvider';
@@ -45,9 +46,18 @@ const Root = () => {
   });
   const dispatch = useAppDispatch();
   useEffect(() => {
+    dispatch(fetchPublicPlatformParameters());
     dispatch(fetchMe());
-    dispatch(fetchPlatformParameters());
   }, []);
+
+  // Fetch full settings once authenticated, re-fetch public settings on logout
+  useEffect(() => {
+    if (logged && me) {
+      dispatch(fetchPlatformParameters());
+    } else if (logged === null) {
+      dispatch(fetchPublicPlatformParameters());
+    }
+  }, [logged, me]);
 
   const { isReachable } = useNetworkCheck(settings?.xtm_hub_url && `${settings?.xtm_hub_url}/health`);
   if (logged && typeof logged === 'object' && Object.keys(logged).length === 0) {

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -5383,7 +5383,7 @@ export interface PlatformSettings {
   /** id of the platform */
   platform_id?: string;
   /** Language of the platform */
-  platform_lang?: string;
+  platform_lang: string;
   /** Platform licensing information */
   platform_license?: License;
   /** Definition of the dark theme */
@@ -5399,7 +5399,7 @@ export interface PlatformSettings {
   /** Default simulation dashboard of the platform */
   platform_simulation_dashboard?: string;
   /** Theme of the platform */
-  platform_theme?: string;
+  platform_theme: string;
   /** Current version of the platform */
   platform_version?: string;
   /** 'true' if the platform has the whitemark activated */
@@ -5590,7 +5590,7 @@ export interface PublicPlatformSettings {
   /** Definition of the dark theme */
   platform_dark_theme?: ThemeInput;
   /** Language of the platform */
-  platform_lang?: string;
+  platform_lang: string;
   /** Definition of the dark theme */
   platform_light_theme?: ThemeInput;
   /** List of OpenID providers */
@@ -5598,7 +5598,7 @@ export interface PublicPlatformSettings {
   /** Policies of the platform */
   platform_policies?: PolicyInput;
   /** Theme of the platform */
-  platform_theme?: string;
+  platform_theme: string;
   /** 'true' if the platform has the whitemark activated */
   platform_whitemark?: string;
 }

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -4178,7 +4178,7 @@ export interface LessonsTemplateQuestionInput {
   lessons_template_question_order: number;
 }
 
-/** Platform licensing */
+/** Platform licensing information */
 export interface License {
   license_creator?: string;
   license_customer?: string;
@@ -5383,8 +5383,8 @@ export interface PlatformSettings {
   /** id of the platform */
   platform_id?: string;
   /** Language of the platform */
-  platform_lang: string;
-  /** Platform licensing */
+  platform_lang?: string;
+  /** Platform licensing information */
   platform_license?: License;
   /** Definition of the dark theme */
   platform_light_theme?: ThemeInput;
@@ -5399,7 +5399,7 @@ export interface PlatformSettings {
   /** Default simulation dashboard of the platform */
   platform_simulation_dashboard?: string;
   /** Theme of the platform */
-  platform_theme: string;
+  platform_theme?: string;
   /** Current version of the platform */
   platform_version?: string;
   /** 'true' if the platform has the whitemark activated */
@@ -5568,6 +5568,39 @@ export interface PublicExercise {
   description?: string;
   id?: string;
   name?: string;
+}
+
+export interface PublicPlatformSettings {
+  /** True if Saml2 is enabled */
+  auth_saml2_enable?: boolean;
+  /** List of Saml2 providers */
+  platform_saml2_providers?: OAuthProvider[];
+  /** True if local authentication is enabled */
+  auth_local_enable?: boolean;
+  /** True if OpenID is enabled */
+  auth_openid_enable?: boolean;
+  /** List of enabled dev features */
+  enabled_dev_features?: (
+    | "_RESERVED"
+    | "STIX_SECURITY_COVERAGE_FOR_VULNERABILITIES"
+    | "LEGACY_INGESTION_EXECUTION_TRACE"
+  )[];
+  /** Map of the messages to display on the screen by their level (the level available are DEBUG, INFO, WARN, ERROR, FATAL) */
+  platform_banner_by_level?: Record<string, string[]>;
+  /** Definition of the dark theme */
+  platform_dark_theme?: ThemeInput;
+  /** Language of the platform */
+  platform_lang?: string;
+  /** Definition of the dark theme */
+  platform_light_theme?: ThemeInput;
+  /** List of OpenID providers */
+  platform_openid_providers?: OAuthProvider[];
+  /** Policies of the platform */
+  platform_policies?: PolicyInput;
+  /** Theme of the platform */
+  platform_theme?: string;
+  /** 'true' if the platform has the whitemark activated */
+  platform_whitemark?: string;
 }
 
 export interface PublicScenario {


### PR DESCRIPTION
### Proposed changes

* split settings into public & private api

Public API (not authenticated)
<img width="1282" height="334" alt="{EA72197E-E9C8-4109-9452-8960CCF3BC54}" src="https://github.com/user-attachments/assets/e6747209-9d57-43ef-bf09-d7b7e5282d23" />

Private API (authenticated)
Current API

### Related issues

* Closes [#ISSUE-NUMBER](https://github.com/OpenAEV-Platform/filigran-private/issues/84)