### PR TITLE
[frontend/backend] fix(healthcheck): placeholder inject must remain disabled (#5424)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/healthcheck/utils/HealthCheckUtils.java
+++ b/openaev-api/src/main/java/io/openaev/healthcheck/utils/HealthCheckUtils.java
@@ -166,7 +166,9 @@ public class HealthCheckUtils {
   public List<HealthCheck> runMissingContentChecks(@NotNull final Scenario scenario) {
     List<HealthCheck> result = new ArrayList<>();
     boolean atLeastOneInjectIsNotReady =
-        scenario.getInjects().stream().anyMatch(inject -> !inject.isReady());
+        scenario.getInjects().stream()
+            .filter(Inject::isEnabled)
+            .anyMatch(inject -> !inject.isReady());
 
     if (atLeastOneInjectIsNotReady) {
       result.add(

--- a/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
@@ -495,6 +495,30 @@ class ScenarioServiceTest extends IntegrationTest {
 
   @Test
   @Transactional
+  public void given_disabledInject_should_notReturnMissingContent() {
+    // Arrange
+    Inject inject = new Inject();
+    inject.setEnabled(false);
+    Scenario scenario = new Scenario();
+    scenario.setInjects(new HashSet<>(List.of(inject)));
+    this.scenarioRepository.save(scenario);
+
+    // Act
+    when(this.injectService.runChecks(any())).thenReturn(List.of());
+    List<HealthCheck> healthchecks = scenarioService.runChecks(scenario.getId());
+
+    // Assert
+    boolean hasMissingContent =
+        healthchecks.stream()
+            .anyMatch(
+                hc ->
+                    HealthCheck.Type.INJECT.equals(hc.getType())
+                        && HealthCheck.Detail.NOT_READY.equals(hc.getDetail()));
+    assertFalse(hasMissingContent, "Disabled inject should not trigger MISSING_CONTENT check");
+  }
+
+  @Test
+  @Transactional
   public void testRunChecksForTeamsIssue() {
     // PREPARE
     Scenario scenario = new Scenario();

--- a/openaev-front/src/admin/components/common/injects/InjectPopover.tsx
+++ b/openaev-front/src/admin/components/common/injects/InjectPopover.tsx
@@ -39,6 +39,7 @@ interface Props {
   inject: InjectPopoverType;
   setSelectedInjectId: (injectId: Inject['inject_id']) => void;
   isDisabled?: boolean;
+  isUpdateDisabled?: boolean;
   canBeTested?: boolean;
   canDone?: boolean;
   canTriggerNow?: boolean;
@@ -57,6 +58,7 @@ const InjectPopover: FunctionComponent<Props> = ({
   inject,
   setSelectedInjectId,
   isDisabled = false,
+  isUpdateDisabled = true,
   canBeTested = false,
   canDone = false,
   canTriggerNow = false,
@@ -218,7 +220,7 @@ const InjectPopover: FunctionComponent<Props> = ({
   entries.push({
     label: 'Update',
     action: () => handleOpenEditContent(),
-    disabled: isDisabled,
+    disabled: isDisabled || isUpdateDisabled,
     userRight: permissions.canManage,
   });
   entries.push({

--- a/openaev-front/src/admin/components/common/injects/Injects.tsx
+++ b/openaev-front/src/admin/components/common/injects/Injects.tsx
@@ -196,11 +196,13 @@ const Injects: FunctionComponent<Props> = ({
       label: 'Status',
       isSortable: false,
       value: (inject: InjectOutputType, _: InjectorContractConverted['convertedContent']) => {
-        let injectStatus = inject.inject_enabled
-          ? t('Enabled')
-          : t('Disabled');
-        if (!inject.inject_ready) {
+        let injectStatus;
+        if (!inject.inject_enabled) {
+          injectStatus = t('Disabled');
+        } else if (!inject.inject_ready) {
           injectStatus = t('Missing content');
+        } else {
+          injectStatus = t('Enabled');
         }
         return (
           <ItemBoolean
@@ -608,6 +610,7 @@ const Injects: FunctionComponent<Props> = ({
                         canBeTested
                         setSelectedInjectId={setSelectedInjectId}
                         isDisabled={!injectContract}
+                        isUpdateDisabled={!inject.inject_enabled}
                         onCreate={onCreate}
                         onUpdate={onUpdate}
                         onDelete={onDelete}

--- a/openaev-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openaev-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -184,7 +184,8 @@ const UpdateInject: React.FC<Props> = ({
             <InjectForm
               handleClose={handleClose}
               disabled={
-                !injectorContractContent
+                !inject.inject_enabled
+                || !injectorContractContent
                 || permissions.readOnly
                 || (inherited_context === INHERITED_CONTEXT.NONE
                   && ability.cannot(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId))
@@ -222,8 +223,9 @@ const UpdateInject: React.FC<Props> = ({
               onUpdateInject={massUpdateInject}
               injects={injects}
               isDisabled={
-                !permissions.canManage
-                && ability.cannot(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId)
+                !inject.inject_enabled
+                || (!permissions.canManage
+                  && ability.cannot(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId))
               }
             />
           )}

--- a/openaev-front/src/admin/components/common/injects/expectations/InjectAddExpectation.tsx
+++ b/openaev-front/src/admin/components/common/injects/expectations/InjectAddExpectation.tsx
@@ -19,11 +19,13 @@ const useStyles = makeStyles()(theme => ({
 interface InjectAddExpectationProps {
   predefinedExpectations: ExpectationInput[];
   handleAddExpectation: (data: ExpectationInput) => void;
+  disabled?: boolean;
 }
 
 const InjectAddExpectation: FunctionComponent<InjectAddExpectationProps> = ({
   predefinedExpectations,
   handleAddExpectation,
+  disabled,
 }) => {
   // Standard hooks
   const { classes } = useStyles();
@@ -52,6 +54,7 @@ const InjectAddExpectation: FunctionComponent<InjectAddExpectationProps> = ({
         divider={true}
         onClick={handleOpen}
         color="primary"
+        disabled={disabled}
       >
         <ListItemIcon color="primary">
           <ControlPointOutlined color="primary" />

--- a/openaev-front/src/admin/components/common/injects/expectations/InjectExpectations.tsx
+++ b/openaev-front/src/admin/components/common/injects/expectations/InjectExpectations.tsx
@@ -35,6 +35,7 @@ const InjectExpectations: FunctionComponent<InjectExpectationsProps> = ({
   handleExpectations,
   injectId,
   injectorContractId,
+  readOnly,
 }) => {
   // Standard hooks
   const { classes } = useStyles();
@@ -147,6 +148,7 @@ const InjectExpectations: FunctionComponent<InjectExpectationsProps> = ({
       { userCanAddExpectations && predefinedExpectations?.length !== 0
         && (
           <InjectAddExpectation
+            disabled={readOnly}
             handleAddExpectation={handleAddExpectation}
             predefinedExpectations={predefinedExpectations}
           />

--- a/openaev-front/src/admin/components/common/injects/form/InjectContentForm.tsx
+++ b/openaev-front/src/admin/components/common/injects/form/InjectContentForm.tsx
@@ -54,8 +54,13 @@ const InjectContentForm = ({
   const ability = useContext(AbilityContext);
 
   const renderTitle = (title: string, required: boolean = false, err: boolean = false) => {
+    const getTitleColor = () => {
+      if (err) return 'error';
+      if (readOnly) return 'text.disabled';
+      return 'textPrimary';
+    };
     return (
-      <Typography variant="h5" color={err ? 'error' : 'textPrimary'}>
+      <Typography variant="h5" color={getTitleColor()}>
         {title}
         {required ? '*' : '' }
       </Typography>

--- a/openaev-front/src/admin/components/common/injects/form/InjectForm.tsx
+++ b/openaev-front/src/admin/components/common/injects/form/InjectForm.tsx
@@ -483,9 +483,9 @@ const InjectForm = ({
         {!isAtomic && (
           <div className={`${classes.triggerBox} ${isSubmitting || disabled || permissions.readOnly ? classes.triggerBoxColorDisabled : classes.triggerBoxColor}`}>
             <div className={`${classes.triggerText} ${isSubmitting || disabled || permissions.readOnly ? classes.triggerTextColorDisabled : classes.triggerTextColor}`}>{t('Trigger after')}</div>
-            <TextFieldController name="inject_depends_duration_days" label={t('Days')} type="number" disabled={permissions.readOnly} />
-            <TextFieldController name="inject_depends_duration_hours" label={t('Hours')} type="number" disabled={permissions.readOnly} />
-            <TextFieldController name="inject_depends_duration_minutes" label={t('Minutes')} type="number" disabled={permissions.readOnly} />
+            <TextFieldController name="inject_depends_duration_days" label={t('Days')} type="number" disabled={permissions.readOnly || disabled} />
+            <TextFieldController name="inject_depends_duration_hours" label={t('Hours')} type="number" disabled={permissions.readOnly || disabled} />
+            <TextFieldController name="inject_depends_duration_minutes" label={t('Minutes')} type="number" disabled={permissions.readOnly || disabled} />
           </div>
         )}
 

--- a/openaev-front/src/admin/components/common/injects/form/teams/InjectTeamsList.tsx
+++ b/openaev-front/src/admin/components/common/injects/form/teams/InjectTeamsList.tsx
@@ -1,5 +1,5 @@
 import { GroupsOutlined } from '@mui/icons-material';
-import { FormHelperText, List, ListItem, ListItemIcon, ListItemText, Tooltip } from '@mui/material';
+import { FormHelperText, List, ListItem, ListItemIcon, ListItemText, Tooltip, Typography } from '@mui/material';
 import { type FunctionComponent, useContext, useEffect, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { makeStyles } from 'tss-react/mui';
@@ -63,6 +63,8 @@ const InjectTeamsList: FunctionComponent<Props> = ({ readOnly = false, hideEnabl
     setValue('inject_teams', updatedTeamIds, { shouldValidate: true });
   };
 
+  const textColor = readOnly ? 'text.disabled' : 'text.primary';
+
   const teamListItem = (team: TeamOutput, userEnabled: number) => (
     <ListItem
       key={team.team_id}
@@ -76,20 +78,20 @@ const InjectTeamsList: FunctionComponent<Props> = ({ readOnly = false, hideEnabl
       )}
     >
       <ListItemIcon>
-        <GroupsOutlined />
+        <GroupsOutlined color={readOnly ? 'disabled' : 'inherit'} />
       </ListItemIcon>
       <ListItemText
         primary={(
           <div className={classes.column}>
-            <div className={classes.bodyItem}>
+            <Typography color={textColor} className={classes.bodyItem}>
               {team.team_name}
-            </div>
-            <Tooltip title={t('Number of users')} className={classes.bodyItem}>
-              <span>{team.team_users_number}</span>
+            </Typography>
+            <Tooltip color={textColor} title={t('Number of users')} className={classes.bodyItem}>
+              <Typography>{team.team_users_number}</Typography>
             </Tooltip>
             {!hideEnabledUsersNumber && (
-              <Tooltip title={t('Number of enable user')} className={classes.bodyItem}>
-                <span>{userEnabled}</span>
+              <Tooltip color={textColor} title={t('Number of enable user')} className={classes.bodyItem}>
+                <Typography>{userEnabled}</Typography>
               </Tooltip>
             )}
             <div className={classes.bodyItem}>


### PR DESCRIPTION
### Proposed changes

-  Injects called "placeholder" remain disabled and cannot have a "missing content" status
- Disabled injects should not be editable
- The scenario health check should not take into account the missing content of disabled injects

### Testing Instructions

1. Create a placeholder inject :
    - Create a scenario
    - Generate injects using the scenario assistant by selecting a TTP that has no injector contract linked to it
    - The scenario assistant could not match any injector contract to the selected TTP, so it will create a placeholder inject

2. Check the status of the placeholder inject — it should be disabled
3. Check that this inject is not editable
4. Verify the health check behavior — if the scenario contains only this placeholder inject, the health check information should not appear on the overview tab

### Related issues

* Closes #5424 