### PR TITLE
[backend] fix(injcts): fix delete inject statuses on simulation reset (#5608)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -75,6 +75,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hibernate.Hibernate;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.AccessDeniedException;
@@ -113,6 +115,13 @@ public class InjectService {
   private final ImapService imapService;
   private final HealthCheckUtils healthCheckUtils;
   private final InjectorContractContentUtils injectorContractContentUtils;
+
+  private InjectStatusService injectStatusService;
+
+  @Autowired
+  public void setInjectStatusService(@Lazy InjectStatusService injectStatusService) {
+    this.injectStatusService = injectStatusService;
+  }
 
   private final LicenseCacheManager licenseCacheManager;
   @Resource protected ObjectMapper mapper;
@@ -835,6 +844,7 @@ public class InjectService {
     List<Inject> injects = injectRepository.findAllInjectBySimulationId(simulationId);
     if (injects.isEmpty()) return;
     injects.forEach(Inject::clean);
+    injectStatusService.deleteAllInjectStatusByInjects(injects);
     injectRepository.saveAll(injects);
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
@@ -11,7 +11,6 @@ import io.openaev.database.model.*;
 import io.openaev.database.repository.AgentRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectStatusRepository;
-import io.openaev.integration.ManagerFactory;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.inject.form.InjectExecutionAction;
 import io.openaev.rest.inject.form.InjectExecutionInput;
@@ -44,11 +43,6 @@ public class InjectStatusService {
   private final ExecutionTraceRepositoryHelper executionTraceRepositoryHelper;
 
   private final EntityManager entityManager;
-  private final ManagerFactory managerFactory;
-
-  public List<InjectStatus> findPendingInjectStatusByType(String injectType) {
-    return this.injectStatusRepository.pendingForInjectType(injectType);
-  }
 
   public InjectStatus findInjectStatusByInjectId(final String injectId) {
     if (!hasText(injectId)) {

--- a/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseApiStatusTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseApiStatusTest.java
@@ -5,6 +5,7 @@ import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static io.openaev.utils.fixtures.InjectFixture.getInjectForEmailContract;
 import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -22,7 +23,12 @@ import io.openaev.execution.ExecutableInject;
 import io.openaev.helper.InjectHelper;
 import io.openaev.injectors.email.model.EmailContent;
 import io.openaev.rest.exercise.form.ExerciseUpdateStatusInput;
+import io.openaev.rest.exercise.service.ExerciseService;
+import io.openaev.rest.inject.service.InjectService;
 import io.openaev.utils.fixtures.*;
+import io.openaev.utils.fixtures.composers.ExerciseComposer;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectStatusComposer;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.annotation.Resource;
 import jakarta.servlet.ServletException;
@@ -83,6 +89,10 @@ public class ExerciseApiStatusTest extends IntegrationTest {
   @Autowired private InjectHelper injectHelper;
   @Autowired private InjectorContractFixture injectorContractFixture;
   @Resource protected ObjectMapper mapper;
+  @Autowired private ExerciseService exerciseService;
+  @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectStatusComposer injectStatusComposer;
 
   @BeforeEach
   void beforeAll() {
@@ -228,13 +238,25 @@ public class ExerciseApiStatusTest extends IntegrationTest {
   @WithMockUser(isAdmin = true)
   void rescheduledExerciseTest() throws Exception {
     // --PREPARE--
+    ExerciseComposer.Composer exerciseWrapper =
+        exerciseComposer
+            .forExercise(ExerciseFixture.createCanceledAttackExercise(REFERENCE_TIME))
+            .withInject(
+                injectComposer
+                    .forInject(InjectFixture.getDefaultInject())
+                    .withInjectStatus(
+                        injectStatusComposer.forInjectStatus(
+                            InjectStatusFixture.createSuccessStatus())))
+            .persist();
     ExerciseUpdateStatusInput input = new ExerciseUpdateStatusInput();
     input.setStatus(ExerciseStatus.SCHEDULED);
 
+    entityManager.flush();
+    entityManager.clear();
     // --EXECUTE--
     String response =
         mvc.perform(
-                put(EXERCISE_URI + "/" + CANCELED_EXERCISE.getId() + "/status")
+                put(EXERCISE_URI + "/" + exerciseWrapper.get().getId() + "/status")
                     .content(asJsonString(input))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -243,13 +265,18 @@ public class ExerciseApiStatusTest extends IntegrationTest {
             .andReturn()
             .getResponse()
             .getContentAsString();
-
+    entityManager.flush();
+    entityManager.clear();
     // --ASSERT--
     assertNull(JsonPath.read(response, "$.exercise_start_date"));
     assertNull(JsonPath.read(response, "$.exercise_end_date"));
     assertEquals(
         List.of(ExerciseStatus.RUNNING.name()),
         JsonPath.read(response, "$.exercise_next_possible_status"));
+
+    List<Inject> resetInjects =
+        exerciseService.exercise(exerciseWrapper.get().getId()).getInjects();
+    assertThat(resetInjects).allSatisfy(inject -> assertThat(inject.getStatus()).isEmpty());
   }
 
   @DisplayName("Check an exercise from finished to scheduled")
@@ -257,13 +284,25 @@ public class ExerciseApiStatusTest extends IntegrationTest {
   @WithMockUser(isAdmin = true)
   void rescheduledExerciseFromFinishedStateTest() throws Exception {
     // --PREPARE--
+    ExerciseComposer.Composer exerciseWrapper =
+        exerciseComposer
+            .forExercise(ExerciseFixture.createFinishedAttackExercise(REFERENCE_TIME))
+            .withInject(
+                injectComposer
+                    .forInject(InjectFixture.getDefaultInject())
+                    .withInjectStatus(
+                        injectStatusComposer.forInjectStatus(
+                            InjectStatusFixture.createSuccessStatus())))
+            .persist();
+    entityManager.flush();
+    entityManager.clear();
     ExerciseUpdateStatusInput input = new ExerciseUpdateStatusInput();
     input.setStatus(ExerciseStatus.SCHEDULED);
 
     // --EXECUTE--
     String response =
         mvc.perform(
-                put(EXERCISE_URI + "/" + FINISHED_EXERCISE.getId() + "/status")
+                put(EXERCISE_URI + "/" + exerciseWrapper.get().getId() + "/status")
                     .content(asJsonString(input))
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
@@ -272,6 +311,8 @@ public class ExerciseApiStatusTest extends IntegrationTest {
             .andReturn()
             .getResponse()
             .getContentAsString();
+    entityManager.flush();
+    entityManager.clear();
 
     // --ASSERT--
     assertNull(JsonPath.read(response, "$.exercise_start_date"));
@@ -279,6 +320,10 @@ public class ExerciseApiStatusTest extends IntegrationTest {
     assertEquals(
         List.of(ExerciseStatus.RUNNING.name()),
         JsonPath.read(response, "$.exercise_next_possible_status"));
+
+    List<Inject> resetInjects =
+        exerciseService.exercise(exerciseWrapper.get().getId()).getInjects();
+    assertThat(resetInjects).allSatisfy(inject -> assertThat(inject.getStatus()).isEmpty());
   }
 
   @DisplayName("Check an exercise from pause to running")

--- a/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseApiStatusTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseApiStatusTest.java
@@ -24,7 +24,6 @@ import io.openaev.helper.InjectHelper;
 import io.openaev.injectors.email.model.EmailContent;
 import io.openaev.rest.exercise.form.ExerciseUpdateStatusInput;
 import io.openaev.rest.exercise.service.ExerciseService;
-import io.openaev.rest.inject.service.InjectService;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.ExerciseComposer;
 import io.openaev.utils.fixtures.composers.InjectComposer;

--- a/openaev-model/src/main/java/io/openaev/database/model/Inject.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Inject.java
@@ -352,7 +352,7 @@ public class Inject implements GrantableBase, Injection {
 
   @JsonIgnore
   public void clean() {
-    this.status = null;
+    this.setStatus(null); // note this does not delete the status record in the db
     this.communications.clear();
     this.expectations.clear();
     this.findings.clear();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Actually delete the inject statuses when simulation reset

### Testing Instructions

1. Start a simulation and let some injects complete (canceled state)
2. reset the simulation
3. Inject statuses are all deleted (back to draft status)
4. repeat with finished simulation

### Related issues

* Closes #5608 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
