### PR TITLE
[backend] fix(docker-compose): changing port of the openaev-test-pgsql container to 5433 (#000)

### DIFF
--- a/openaev-dev/docker-compose.yml
+++ b/openaev-dev/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: openaev
     ports:
-      - "5433:5432"
+      - "5433:5433"
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d openaev"]


### PR DESCRIPTION
### Issue Description

During the local installation process in my laptop (MacOS), after I install IntelliJ IDE and run it, I tried to execute all the containers inside of openaev-dev/docker-compose.yml. 
However it was giving me an error saying I had a repeated port, that was already being used, this is, the containers openaev-dev-pgsql and openaev-test-pgsql add the same port number which was preventing to this process to go forward.
So I changed the port of openaev-test-pgsql from 5432 to 5433.

### Proposed changes

* Change 5432 to 5433 port in openaev-dev/docker-compose.yml for the openaev-test-pgsql container

### Testing Instructions

1. Step-by-step how to test:
- Open IntelliJ IDE and click in the play button that appears in the openaev-dev/docker-compose.yml - top-left corner.
- Or execute this in your terminal inside of the openaev-dev/ folder: 
     docker compose up -d
     #or if using podman:
     podman compose up -d

### Related issues

* New bug, that is not related with any created issue.
