### PR TITLE
[backend] fix(multi-tenant): scenario tenant isolation (#4864)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
@@ -386,6 +386,7 @@ public class ChannelApi extends RestBehavior {
   public void deleteArticleForScenario(
       @PathVariable @NotBlank final String scenarioId,
       @PathVariable @NotBlank final String articleId) {
+    this.scenarioService.scenario(scenarioId); // Tenant-scoped validation
     articleRepository.deleteById(articleId);
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/channel/ScenarioArticleApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/channel/ScenarioArticleApi.java
@@ -12,9 +12,11 @@ import io.openaev.database.model.Inject;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.repository.ArticleRepository;
 import io.openaev.database.repository.InjectRepository;
+import io.openaev.database.repository.ScenarioRepository;
 import io.openaev.database.specification.ArticleSpecification;
 import io.openaev.database.specification.InjectSpecification;
 import io.openaev.rest.channel.output.ArticleOutput;
+import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.helper.RestBehavior;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
@@ -30,6 +32,7 @@ public class ScenarioArticleApi extends RestBehavior {
 
   private final InjectRepository injectRepository;
   private final ArticleRepository articleRepository;
+  private final ScenarioRepository scenarioRepository;
 
   @GetMapping({
     SCENARIO_URI + "/{scenarioId}/articles",
@@ -41,6 +44,9 @@ public class ScenarioArticleApi extends RestBehavior {
       resourceType = ResourceType.SCENARIO)
   @Transactional(readOnly = true)
   public Iterable<ArticleOutput> scenarioArticles(@PathVariable @NotBlank final String scenarioId) {
+    this.scenarioRepository
+        .findByIdAndTenant(scenarioId)
+        .orElseThrow(ElementNotFoundException::new); // Tenant-scoped validation
     List<Inject> injects =
         this.injectRepository.findAll(
             InjectSpecification.fromScenario(scenarioId)

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
@@ -248,6 +248,7 @@ public class ScenarioApi extends RestBehavior {
       actionPerformed = Action.READ,
       resourceType = ResourceType.SCENARIO)
   public List<TeamOutput> scenarioTeams(@PathVariable @NotBlank final String scenarioId) {
+    this.scenarioService.scenario(scenarioId); // Tenant-scoped validation
     return this.teamService.find(fromScenario(scenarioId));
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/team/TeamApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/team/TeamApi.java
@@ -119,7 +119,7 @@ public class TeamApi extends RestBehavior {
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The team")})
   @Operation(description = "Get a team", summary = "Get team")
   public Team getTeam(@PathVariable @Schema(description = "ID of the team") String teamId) {
-    return teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
+    return teamRepository.findByIdAndTenant(teamId).orElseThrow(ElementNotFoundException::new);
   }
 
   @GetMapping({"/api/teams/{teamId}/players", TENANT_TEAM_URI + "/{teamId}/players"})
@@ -132,7 +132,10 @@ public class TeamApi extends RestBehavior {
   @Operation(description = "Get the list of players of a team", summary = "Get team's players")
   public Iterable<User> getTeamPlayers(
       @PathVariable @Schema(description = "ID of the team") String teamId) {
-    return teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new).getUsers();
+    return teamRepository
+        .findByIdAndTenant(teamId)
+        .orElseThrow(ElementNotFoundException::new)
+        .getUsers();
   }
 
   @PostMapping({TEAM_URI, TENANT_TEAM_URI})
@@ -194,6 +197,7 @@ public class TeamApi extends RestBehavior {
   @ApiResponses(value = {@ApiResponse(responseCode = "200")})
   @Operation(description = "Delete an existing team", summary = "Delete team")
   public void deleteTeam(@PathVariable @Schema(description = "ID of the team") String teamId) {
+    teamRepository.findByIdAndTenant(teamId).orElseThrow(ElementNotFoundException::new);
     teamRepository.deleteById(teamId);
   }
 
@@ -207,7 +211,7 @@ public class TeamApi extends RestBehavior {
   public Team updateTeam(
       @PathVariable @Schema(description = "ID of the team") String teamId,
       @Valid @RequestBody TeamUpdateInput input) {
-    Team team = teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
+    Team team = teamRepository.findByIdAndTenant(teamId).orElseThrow(ElementNotFoundException::new);
     team.setUpdateAttributes(input);
     team.setUpdatedAt(now());
     team.setTags(iterableToSet(tagRepository.findAllById(input.getTagIds())));
@@ -228,7 +232,7 @@ public class TeamApi extends RestBehavior {
   public Team updateTeamUsers(
       @PathVariable @Schema(description = "ID of the team") String teamId,
       @Valid @RequestBody UpdateUsersTeamInput input) {
-    Team team = teamRepository.findById(teamId).orElseThrow(ElementNotFoundException::new);
+    Team team = teamRepository.findByIdAndTenant(teamId).orElseThrow(ElementNotFoundException::new);
     Iterable<User> teamUsers = userRepository.findAllById(input.getUserIds());
     team.setUsers(fromIterable(teamUsers));
     return teamRepository.save(team);

--- a/openaev-api/src/main/java/io/openaev/rest/variable/VariableApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/variable/VariableApi.java
@@ -122,6 +122,7 @@ public class VariableApi extends RestBehavior {
       actionPerformed = Action.READ,
       resourceType = ResourceType.SCENARIO)
   public Iterable<Variable> variablesFromScenario(@PathVariable @NotBlank final String scenarioId) {
+    this.scenarioService.scenario(scenarioId); // Tenant-scoped validation
     return this.variableService.variablesFromScenario(scenarioId);
   }
 
@@ -137,8 +138,8 @@ public class VariableApi extends RestBehavior {
       @PathVariable @NotBlank final String scenarioId,
       @PathVariable @NotBlank final String variableId,
       @Valid @RequestBody final VariableInput input) {
+    this.scenarioService.scenario(scenarioId); // Tenant-scoped validation
     Variable variable = this.variableService.variable(variableId);
-    assert scenarioId.equals(variable.getScenario().getId());
     variable.setUpdateAttributes(input);
     return this.variableService.updateVariable(variable);
   }
@@ -154,8 +155,7 @@ public class VariableApi extends RestBehavior {
   public void deleteVariableForScenario(
       @PathVariable @NotBlank final String scenarioId,
       @PathVariable @NotBlank final String variableId) {
-    Variable variable = this.variableService.variable(variableId);
-    assert scenarioId.equals(variable.getScenario().getId());
+    this.scenarioService.scenario(scenarioId); // Tenant-scoped validation
     this.variableService.deleteVariable(variableId);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -674,6 +674,7 @@ public class ScenarioService {
   @Transactional(rollbackFor = Exception.class)
   public Iterable<TeamOutput> removeTeams(
       @NotBlank final String scenarioId, @NotNull final List<String> teamIds) {
+    scenario(scenarioId); // Tenant-scoped validation
     // Remove teams from scenario
     this.scenarioRepository.removeTeams(scenarioId, teamIds);
     // Remove only associations for this scenario

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -360,7 +360,7 @@ public class ScenarioService {
 
   public Scenario scenario(@NotBlank final String scenarioId) {
     return this.scenarioRepository
-        .findById(scenarioId)
+        .findByIdAndTenant(scenarioId)
         .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
   }
 
@@ -454,7 +454,8 @@ public class ScenarioService {
   }
 
   public void deleteScenario(@NotBlank final String scenarioId) {
-    this.scenarioRepository.deleteById(scenarioId);
+    Scenario scenario = scenario(scenarioId);
+    this.scenarioRepository.delete(scenario);
   }
 
   // -- EXPORT --

--- a/openaev-api/src/test/java/io/openaev/rest/ChannelApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ChannelApiTest.java
@@ -10,14 +10,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.Channel;
 import io.openaev.database.model.Scenario;
+import io.openaev.database.model.Tenant;
 import io.openaev.database.repository.ArticleRepository;
 import io.openaev.database.repository.ChannelRepository;
 import io.openaev.database.repository.ScenarioRepository;
 import io.openaev.rest.channel.form.ArticleCreateInput;
 import io.openaev.rest.channel.form.ArticleUpdateInput;
 import io.openaev.service.scenario.ScenarioService;
+import io.openaev.utils.fixtures.ScenarioFixture;
+import io.openaev.utils.fixtures.composers.ScenarioComposer;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import io.openaev.utilstest.RabbitMQTestListener;
 import org.junit.jupiter.api.*;
@@ -27,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @TestExecutionListeners(
@@ -43,6 +50,8 @@ class ChannelApiTest extends IntegrationTest {
   @Autowired private ScenarioRepository scenarioRepository;
   @Autowired private ChannelRepository channelRepository;
   @Autowired private ArticleRepository articleRepository;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private TenantComposer tenantComposer;
 
   static String SCENARIO_ID;
   static String CHANNEL_ID;
@@ -50,9 +59,15 @@ class ChannelApiTest extends IntegrationTest {
 
   @AfterAll
   void afterAll() {
-    this.scenarioRepository.deleteById(SCENARIO_ID);
-    this.channelRepository.deleteById(CHANNEL_ID);
-    this.articleRepository.deleteById(ARTICLE_ID);
+    if (SCENARIO_ID != null) {
+      this.scenarioRepository.deleteById(SCENARIO_ID);
+    }
+    if (CHANNEL_ID != null) {
+      this.channelRepository.deleteById(CHANNEL_ID);
+    }
+    if (ARTICLE_ID != null) {
+      this.articleRepository.deleteById(ARTICLE_ID);
+    }
   }
 
   // -- SCENARIOS --
@@ -155,5 +170,165 @@ class ChannelApiTest extends IntegrationTest {
     this.mvc
         .perform(delete(SCENARIO_URI + "/" + SCENARIO_ID + "/articles/" + ARTICLE_ID))
         .andExpect(status().is2xxSuccessful());
+  }
+
+  @Nested
+  @DisplayName("Tenant isolation on scenario articles")
+  @Transactional
+  class TenantIsolation {
+
+    @Test
+    @DisplayName(
+        "given scenario in Tenant XXX, when create article from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_createArticleFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      Channel channel = new Channel();
+      channel.setName("Tenant-Channel");
+      channel = channelRepository.save(channel);
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      ArticleCreateInput input = new ArticleCreateInput();
+      input.setName("Cross-tenant article");
+      input.setChannelId(channel.getId());
+
+      // Assert
+      mvc.perform(
+              post(SCENARIO_URI + "/" + scenarioId + "/articles")
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with article in Tenant XXX, when list articles from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_listArticlesFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert
+      mvc.perform(
+              get(SCENARIO_URI + "/" + scenarioId + "/articles").accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with article in Tenant XXX, when list articles from same tenant, should return 200")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_listArticlesFromSameTenant_should_return200()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act & Assert — reading from same tenant should succeed
+      mvc.perform(
+              get(SCENARIO_URI + "/" + scenarioId + "/articles").accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful());
+
+      // Cleanup
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario in Tenant XXX, when delete article from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_deleteArticleFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert
+      mvc.perform(delete(SCENARIO_URI + "/" + scenarioId + "/articles/fake-article-id"))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/TeamApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/TeamApiTest.java
@@ -11,15 +11,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Capability;
 import io.openaev.database.model.Exercise;
 import io.openaev.database.model.Inject;
 import io.openaev.database.model.Team;
+import io.openaev.database.model.Tenant;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.TeamRepository;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.rest.team.form.TeamCreateInput;
 import io.openaev.utils.fixtures.ExerciseFixture;
 import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.servlet.ServletException;
 import java.util.ArrayList;
@@ -27,6 +32,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.json.JSONArray;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +55,7 @@ class TeamApiTest extends IntegrationTest {
   @Autowired private InjectRepository injectRepository;
   @Autowired private TeamRepository teamRepository;
   @Autowired private InjectorContractFixture injectorContractFixture;
+  @Autowired private TenantComposer tenantComposer;
 
   @DisplayName("Given valid team input, should create a team successfully")
   @Test
@@ -399,5 +406,133 @@ class TeamApiTest extends IntegrationTest {
 
     // --ASSERT--
     assertEquals(expectedNumberOfResults, jsonArray.length());
+  }
+
+  @Nested
+  @DisplayName("Tenant isolation")
+  class TenantIsolation {
+
+    @Test
+    @DisplayName("given team in Tenant XXX, when getTeam from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.ACCESS_TEAMS_AND_PLAYERS})
+    void given_teamInTenantXXX_when_getFromTenantYYY_should_return404() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Team team = new Team();
+      team.setName("XXX-Only-Team");
+      team = teamRepository.save(team);
+      entityManager.flush();
+      entityManager.clear();
+      String teamId = team.getId();
+
+      // Act — switch to Tenant YYY and try to read the team
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert — should NOT find the team (404)
+      mvc.perform(get(TEAM_URI + "/" + teamId).accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName("given team in Tenant XXX, when getTeam from same tenant, should return 200")
+    @WithMockUser(withCapabilities = {Capability.ACCESS_TEAMS_AND_PLAYERS})
+    void given_teamInTenantXXX_when_getFromSameTenant_should_return200() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Team team = new Team();
+      team.setName("XXX-Visible-Team");
+      team = teamRepository.save(team);
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act & Assert — reading from same tenant should succeed
+      mvc.perform(get(TEAM_URI + "/" + team.getId()).accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful());
+
+      // Cleanup
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName("given team in Tenant XXX, when delete from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.DELETE_TEAMS_AND_PLAYERS})
+    void given_teamInTenantXXX_when_deleteFromTenantYYY_should_return404() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Team team = new Team();
+      team.setName("XXX-Delete-Team");
+      team = teamRepository.save(team);
+      entityManager.flush();
+      entityManager.clear();
+      String teamId = team.getId();
+
+      // Act — switch to Tenant YYY and try to delete the team
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert — should NOT find the team (404)
+      mvc.perform(delete(TEAM_URI + "/" + teamId)).andExpect(status().isNotFound());
+
+      // Cleanup
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName("given team in Tenant XXX, when update from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.MANAGE_TEAMS_AND_PLAYERS})
+    void given_teamInTenantXXX_when_updateFromTenantYYY_should_return404() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Team team = new Team();
+      team.setName("XXX-Update-Team");
+      team = teamRepository.save(team);
+      entityManager.flush();
+      entityManager.clear();
+      String teamId = team.getId();
+
+      // Act — switch to Tenant YYY and try to update the team
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      TeamCreateInput input = new TeamCreateInput();
+      input.setName("Hacked name");
+
+      // Assert — should NOT find the team (404)
+      mvc.perform(
+              put(TEAM_URI + "/" + teamId)
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/VariableApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/VariableApiTest.java
@@ -11,11 +11,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.Scenario;
+import io.openaev.database.model.Tenant;
 import io.openaev.database.model.Variable;
 import io.openaev.database.repository.ScenarioRepository;
 import io.openaev.database.repository.VariableRepository;
+import io.openaev.rest.variable.form.VariableInput;
 import io.openaev.service.scenario.ScenarioService;
+import io.openaev.utils.fixtures.ScenarioFixture;
+import io.openaev.utils.fixtures.composers.ScenarioComposer;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import io.openaev.utilstest.RabbitMQTestListener;
 import org.junit.jupiter.api.*;
@@ -25,6 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @TestExecutionListeners(
@@ -40,14 +48,20 @@ public class VariableApiTest extends IntegrationTest {
   @Autowired private ScenarioService scenarioService;
   @Autowired private ScenarioRepository scenarioRepository;
   @Autowired private VariableRepository variableRepository;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private TenantComposer tenantComposer;
 
   static String VARIABLE_ID;
   static String SCENARIO_ID;
 
   @AfterAll
   void afterAll() {
-    this.scenarioRepository.deleteById(SCENARIO_ID);
-    this.variableRepository.deleteById(VARIABLE_ID);
+    if (SCENARIO_ID != null) {
+      this.scenarioRepository.deleteById(SCENARIO_ID);
+    }
+    if (VARIABLE_ID != null) {
+      this.variableRepository.deleteById(VARIABLE_ID);
+    }
   }
 
   // -- SCENARIOS --
@@ -165,5 +179,226 @@ public class VariableApiTest extends IntegrationTest {
     this.mvc
         .perform(delete(SCENARIO_URI + "/" + SCENARIO_ID + "/variables/" + VARIABLE_ID))
         .andExpect(status().is2xxSuccessful());
+  }
+
+  @Nested
+  @DisplayName("Tenant isolation on scenario variables")
+  @Transactional
+  class TenantIsolation {
+
+    @Test
+    @DisplayName(
+        "given scenario in Tenant XXX, when create variable from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_createVariableFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY and try to create a variable
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      VariableInput input = new VariableInput();
+      input.setKey("cross_tenant_key");
+
+      // Assert
+      mvc.perform(
+              post(SCENARIO_URI + "/" + scenarioId + "/variables")
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with variable in Tenant XXX, when list variables from same tenant, should return 200")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_listVariablesFromSameTenant_should_return200()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      Variable variable = new Variable();
+      variable.setKey("same_tenant_var");
+      variable.setScenario(scenario);
+      variableRepository.save(variable);
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act & Assert — reading from same tenant should succeed
+      mvc.perform(
+              get(SCENARIO_URI + "/" + scenarioId + "/variables")
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(jsonPath("$[0].variable_key").value("same_tenant_var"));
+
+      // Cleanup
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with variable in Tenant XXX, when list variables from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_listVariablesFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      Variable variable = new Variable();
+      variable.setKey("tenant_var");
+      variable.setScenario(scenario);
+      variableRepository.save(variable);
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert
+      mvc.perform(
+              get(SCENARIO_URI + "/" + scenarioId + "/variables")
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with variable in Tenant XXX, when update variable from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_updateVariableFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      Variable variable = new Variable();
+      variable.setKey("update_var");
+      variable.setScenario(scenario);
+      variable = variableRepository.save(variable);
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+      String variableId = variable.getId();
+
+      // Act — switch to Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      VariableInput input = new VariableInput();
+      input.setKey("update_var");
+      input.setValue("hacked");
+
+      // Assert
+      mvc.perform(
+              put(SCENARIO_URI + "/" + scenarioId + "/variables/" + variableId)
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with variable in Tenant XXX, when delete variable from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_deleteVariableFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      Variable variable = new Variable();
+      variable.setKey("delete_var");
+      variable.setScenario(scenario);
+      variable = variableRepository.save(variable);
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+      String variableId = variable.getId();
+
+      // Act — switch to Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert
+      mvc.perform(delete(SCENARIO_URI + "/" + scenarioId + "/variables/" + variableId))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiSearchTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiSearchTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.GrantRepository;
 import io.openaev.database.repository.GroupRepository;
@@ -20,9 +21,13 @@ import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.scenario.form.GetScenariosInput;
 import io.openaev.utils.fixtures.PaginationFixture;
 import io.openaev.utils.fixtures.ScenarioFixture;
+import io.openaev.utils.fixtures.composers.ScenarioComposer;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import io.openaev.utils.pagination.SearchPaginationInput;
 import io.openaev.utils.pagination.SortField;
+import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.*;
@@ -39,6 +44,8 @@ public class ScenarioApiSearchTest extends IntegrationTest {
   @Autowired private GroupRepository groupRepository;
   @Autowired private GrantRepository grantRepository;
   @Autowired private UserRepository userRepository;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private TenantComposer tenantComposer;
 
   private static final List<String> SCENARIO_IDS = new ArrayList<>();
 
@@ -285,6 +292,61 @@ public class ScenarioApiSearchTest extends IntegrationTest {
 
         scenarioRepository.delete(scenarioGranted);
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("Tenant isolation on search/pagination")
+  @Transactional
+  class TenantIsolation {
+
+    @Test
+    @DisplayName(
+        "given scenarios in two tenants, search from Tenant YYY should not return Tenant XXX scenarios")
+    @WithMockUser(withCapabilities = {Capability.ACCESS_ASSESSMENT})
+    void given_scenariosInTwoTenants_when_searchFromTenantYYY_should_notReturnTenantXXX()
+        throws Exception {
+      // Arrange — create two tenants
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      // Create a scenario in Tenant XXX
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenarioXXX = ScenarioFixture.createDefaultCrisisScenario();
+      scenarioXXX.setName("XXX Only Scenario");
+      scenarioComposer.forScenario(scenarioXXX).persist();
+
+      // Create a scenario in Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      Scenario scenarioYYY = ScenarioFixture.createDefaultIncidentResponseScenario();
+      scenarioYYY.setName("YYY Only Scenario");
+      scenarioComposer.forScenario(scenarioYYY).persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — search from Tenant YYY
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      SearchPaginationInput searchPaginationInput =
+          PaginationFixture.getDefault().textSearch("Only Scenario").build();
+
+      // Assert — should only find the YYY scenario
+      mvc.perform(
+              post(SCENARIO_URI + "/search")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(searchPaginationInput)))
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(jsonPath("$.numberOfElements").value(1))
+          .andExpect(jsonPath("$.content.[0].scenario_name").value("YYY Only Scenario"));
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.model.Tag;
 import io.openaev.database.repository.*;
@@ -23,6 +24,8 @@ import io.openaev.rest.scenario.form.ScenarioUpdateTeamsInput;
 import io.openaev.service.AssetGroupService;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.*;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.annotation.Nullable;
 import jakarta.transaction.Transactional;
@@ -45,6 +48,7 @@ public class ScenarioApiTest extends IntegrationTest {
   @Autowired private InjectComposer injectComposer;
   @Autowired private InjectStatusComposer injectStatusComposer;
   @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private TenantComposer tenantComposer;
   @Autowired private ExecutorFixture executorFixture;
 
   @Autowired private MockMvc mvc;
@@ -68,6 +72,8 @@ public class ScenarioApiTest extends IntegrationTest {
     injectComposer.reset();
     injectStatusComposer.reset();
     scenarioComposer.reset();
+    tenantComposer.reset();
+    TenantContext.clearCurrentTenant();
   }
 
   private Scenario getScenario(@Nullable Scenario scenario, @Nullable Executor executor) {
@@ -489,5 +495,63 @@ public class ScenarioApiTest extends IntegrationTest {
     assertEquals(scenarioSaved.getId(), link.getScenario().getId());
     assertEquals(teamB.getId(), link.getTeam().getId());
     assertEquals(userBen.getId(), link.getUser().getId());
+  }
+
+  @Nested
+  @DisplayName("Tenant isolation")
+  class TenantIsolation {
+
+    @Test
+    @DisplayName(
+        "given scenario in Tenant XXX, when getScenarioById from Tenant YYY, should return 404")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_getByIdFromTenantYYY_should_return404() throws Exception {
+      // Arrange — create two tenants and a scenario in Tenant XXX
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — switch to Tenant YYY and try to read the scenario
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert — should NOT find the scenario (404)
+      mvc.perform(get(SCENARIO_URI + "/" + scenario.getId()).accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario in Tenant XXX, when getScenarioById from same tenant, should return 200")
+    @WithMockUser(isAdmin = true)
+    void given_scenarioInTenantXXX_when_getByIdFromSameTenant_should_return200() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act & Assert — reading from the same tenant should succeed
+      mvc.perform(get(SCENARIO_URI + "/" + scenario.getId()).accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -504,7 +504,7 @@ public class ScenarioApiTest extends IntegrationTest {
     @Test
     @DisplayName(
         "given scenario in Tenant XXX, when getScenarioById from Tenant YYY, should return 404")
-    @WithMockUser(isAdmin = true)
+    @WithMockUser(withCapabilities = {Capability.ACCESS_ASSESSMENT})
     void given_scenarioInTenantXXX_when_getByIdFromTenantYYY_should_return404() throws Exception {
       // Arrange — create two tenants and a scenario in Tenant XXX
       Tenant tenantXXX =
@@ -533,7 +533,7 @@ public class ScenarioApiTest extends IntegrationTest {
     @Test
     @DisplayName(
         "given scenario in Tenant XXX, when getScenarioById from same tenant, should return 200")
-    @WithMockUser(isAdmin = true)
+    @WithMockUser(withCapabilities = {Capability.ACCESS_ASSESSMENT})
     void given_scenarioInTenantXXX_when_getByIdFromSameTenant_should_return200() throws Exception {
       // Arrange
       Tenant tenantXXX =
@@ -552,6 +552,67 @@ public class ScenarioApiTest extends IntegrationTest {
       // Act & Assert — reading from the same tenant should succeed
       mvc.perform(get(SCENARIO_URI + "/" + scenario.getId()).accept(MediaType.APPLICATION_JSON))
           .andExpect(status().is2xxSuccessful());
+    }
+
+    @Test
+    @DisplayName("given scenario in Tenant XXX, when update from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.MANAGE_ASSESSMENT})
+    void given_scenarioInTenantXXX_when_updateFromTenantYYY_should_return404() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — switch to Tenant YYY and try to update the scenario
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      ScenarioInput input = new ScenarioInput();
+      input.setName("Updated name");
+
+      // Assert — should NOT find the scenario (404)
+      mvc.perform(
+              put(SCENARIO_URI + "/" + scenario.getId())
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("given scenario in Tenant XXX, when delete from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.DELETE_ASSESSMENT})
+    void given_scenarioInTenantXXX_when_deleteFromTenantYYY_should_return404() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .persist()
+              .get();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — switch to Tenant YYY and try to delete the scenario
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert — should NOT find the scenario (404)
+      mvc.perform(delete(SCENARIO_URI + "/" + scenario.getId())).andExpect(status().isNotFound());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioTeamApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioTeamApiTest.java
@@ -17,9 +17,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Capability;
 import io.openaev.database.model.Scenario;
 import io.openaev.database.model.ScenarioTeamUser;
 import io.openaev.database.model.Team;
+import io.openaev.database.model.Tenant;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.ScenarioRepository;
 import io.openaev.database.repository.ScenarioTeamUserRepository;
@@ -29,9 +32,14 @@ import io.openaev.rest.exercise.form.ExerciseTeamPlayersEnableInput;
 import io.openaev.rest.exercise.form.ScenarioTeamPlayersEnableInput;
 import io.openaev.rest.scenario.form.ScenarioUpdateTeamsInput;
 import io.openaev.utils.fixtures.PaginationFixture;
+import io.openaev.utils.fixtures.ScenarioFixture;
 import io.openaev.utils.fixtures.UserFixture;
+import io.openaev.utils.fixtures.composers.ScenarioComposer;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import io.openaev.utils.pagination.SearchPaginationInput;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +63,8 @@ class ScenarioTeamApiTest extends IntegrationTest {
   @Autowired private ScenarioTeamUserRepository scenarioTeamUserRepository;
   @Autowired private TeamRepository teamRepository;
   @Autowired private UserRepository userRepository;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private TenantComposer tenantComposer;
 
   @DisplayName("Given a valid scenario and team input, should add team to scenario successfully")
   @Test
@@ -516,6 +526,135 @@ class ScenarioTeamApiTest extends IntegrationTest {
       assertFalse(
           teamIds.contains(teamToRemove.getId()),
           "teamToRemove should have been removed from the scenario");
+    }
+  }
+
+  @Nested
+  @DisplayName("Tenant isolation on scenario teams")
+  class TenantIsolation {
+
+    @Test
+    @DisplayName(
+        "given scenario with team in Tenant XXX, when listing teams from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.ACCESS_ASSESSMENT})
+    void given_scenarioInTenantXXX_when_listTeamsFromTenantYYY_should_return404() throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Team team = new Team();
+      team.setName("XXX-Team");
+      teamRepository.save(team);
+
+      Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
+      scenario.setTeams(new ArrayList<>(List.of(team)));
+      scenarioComposer.forScenario(scenario).persist();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY and try to list teams of the scenario
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+
+      // Assert — scenario lookup should fail with 404 (tenant-scoped)
+      mvc.perform(
+              get(SCENARIO_URI + "/" + scenarioId + "/teams").accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with team in Tenant XXX, when replacing teams from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.MANAGE_ASSESSMENT})
+    void given_scenarioInTenantXXX_when_replaceTeamsFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
+      scenarioComposer.forScenario(scenario).persist();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY and try to replace teams
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      ScenarioUpdateTeamsInput input = new ScenarioUpdateTeamsInput();
+      input.setTeamIds(List.of());
+
+      // Assert — should return 404
+      mvc.perform(
+              put(SCENARIO_URI + "/" + scenarioId + "/teams/replace")
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
+    }
+
+    @Test
+    @DisplayName(
+        "given scenario with team in Tenant XXX, when removing teams from Tenant YYY, should return 404")
+    @WithMockUser(withCapabilities = {Capability.MANAGE_ASSESSMENT})
+    void given_scenarioInTenantXXX_when_removeTeamsFromTenantYYY_should_return404()
+        throws Exception {
+      // Arrange
+      Tenant tenantXXX =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant XXX")).persist().get();
+      Tenant tenantYYY =
+          tenantComposer.forTenant(TenantFixture.getTenant("Tenant YYY")).persist().get();
+      entityManager.flush();
+
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      Team team = new Team();
+      team.setName("XXX-Team-Remove");
+      teamRepository.save(team);
+
+      Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
+      scenario.setTeams(new ArrayList<>(List.of(team)));
+      scenarioComposer.forScenario(scenario).persist();
+      entityManager.flush();
+      entityManager.clear();
+      String scenarioId = scenario.getId();
+
+      // Act — switch to Tenant YYY and try to remove teams
+      TenantContext.setCurrentTenant(tenantYYY.getId());
+      ScenarioUpdateTeamsInput input = new ScenarioUpdateTeamsInput();
+      input.setTeamIds(List.of(team.getId()));
+
+      // Assert — should return 404
+      mvc.perform(
+              put(SCENARIO_URI + "/" + scenarioId + "/teams/remove")
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+
+      // Cleanup
+      TenantContext.setCurrentTenant(tenantXXX.getId());
+      scenarioComposer.reset();
+      tenantComposer.reset();
+      TenantContext.clearCurrentTenant();
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
@@ -288,12 +288,19 @@ class ScenarioServiceTest extends IntegrationTest {
     assertNull(healthchecks);
   }
 
+  private Scenario createValidScenario() {
+    Scenario scenario = new Scenario();
+    scenario.setName("Test Scenario");
+    scenario.setFrom("test@openaev.io");
+    return scenario;
+  }
+
   @Test
   @Transactional
   public void testRunChecksForSmtpIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = createValidScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -328,7 +335,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForImapIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = createValidScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -363,7 +370,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForExecutorIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = createValidScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -397,7 +404,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForCollectorIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = createValidScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -431,7 +438,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForMissingContentIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = createValidScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -464,7 +471,7 @@ class ScenarioServiceTest extends IntegrationTest {
   @Transactional
   public void testRunChecksForTeamsIssue() {
     // PREPARE
-    Scenario scenario = new Scenario();
+    Scenario scenario = createValidScenario();
 
     Injector injector = new Injector();
     injector.setDependencies(

--- a/openaev-api/src/test/java/io/openaev/service/ScenarioServiceUnitTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ScenarioServiceUnitTest.java
@@ -20,6 +20,7 @@ import io.openaev.utils.fixtures.TagFixture;
 import io.openaev.utils.mapper.ExerciseMapper;
 import io.openaev.utils.mapper.ScenarioMapper;
 import java.util.*;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("ScenarioService Unit Tests")
 class ScenarioServiceUnitTest {
 
   @Mock private EnterpriseEditionService enterpriseEditionService;
@@ -54,84 +56,101 @@ class ScenarioServiceUnitTest {
   @Mock private HealthCheckUtils healthCheckUtils;
   @InjectMocks private ScenarioService scenarioService;
 
-  @Test
-  public void testUpdateScenario_WITH_applyRule_true() {
-    AssetGroup assetGroup1 = getAssetGroup("assetgroup1");
-    AssetGroup assetGroup2 = getAssetGroup("assetgroup2");
-    Tag tag1 = TagFixture.getTag("Tag1");
-    Tag tag2 = TagFixture.getTag("Tag2");
-    Tag tag3 = TagFixture.getTag("Tag3");
-    Inject inject1 = new Inject();
-    inject1.setId("1");
-    Inject inject2 = new Inject();
-    inject1.setId("2");
-    Scenario scenario = ScenarioFixture.getScenario(null, Set.of(inject1, inject2));
-    scenario.setTags(Set.of(tag1, tag2));
-    Set<Tag> currentTags = Set.of(tag2, tag3);
-    List<AssetGroup> assetGroupsToAdd = List.of(assetGroup1, assetGroup2);
+  @Nested
+  @DisplayName("Update scenario")
+  class UpdateScenario {
 
-    when(tagRuleService.getAssetGroupsFromTagIds(List.of(tag1.getId())))
-        .thenReturn(assetGroupsToAdd);
-    when(scenarioRepository.save(scenario)).thenReturn(scenario);
-    when(injectService.canApplyTargetType(any(), eq(TargetType.ASSETS_GROUPS))).thenReturn(true);
+    @Test
+    @DisplayName("Given applyRule true, should apply asset groups to injects")
+    void given_applyRuleTrue_should_applyAssetGroupsToInjects() {
+      // Arrange
+      AssetGroup assetGroup1 = getAssetGroup("assetgroup1");
+      AssetGroup assetGroup2 = getAssetGroup("assetgroup2");
+      Tag tag1 = TagFixture.getTag("Tag1");
+      Tag tag2 = TagFixture.getTag("Tag2");
+      Tag tag3 = TagFixture.getTag("Tag3");
+      Inject inject1 = new Inject();
+      inject1.setId("1");
+      Inject inject2 = new Inject();
+      inject2.setId("2");
+      Scenario scenario = ScenarioFixture.getScenario(null, Set.of(inject1, inject2));
+      scenario.setTags(Set.of(tag1, tag2));
+      Set<Tag> currentTags = Set.of(tag2, tag3);
+      List<AssetGroup> assetGroupsToAdd = List.of(assetGroup1, assetGroup2);
 
-    scenarioService.updateScenario(scenario, currentTags, true);
+      when(tagRuleService.getAssetGroupsFromTagIds(List.of(tag1.getId())))
+          .thenReturn(assetGroupsToAdd);
+      when(scenarioRepository.save(scenario)).thenReturn(scenario);
+      when(injectService.canApplyTargetType(any(), eq(TargetType.ASSETS_GROUPS))).thenReturn(true);
 
-    scenario
-        .getInjects()
-        .forEach(
-            inject ->
-                verify(injectService)
-                    .applyDefaultAssetGroupsToInject(inject.getId(), assetGroupsToAdd));
-    verify(scenarioRepository).save(scenario);
-  }
+      // Act
+      scenarioService.updateScenario(scenario, currentTags, true);
 
-  @Test
-  public void testUpdateScenario_WITH_applyRule_true_and_manual_inject() {
-    AssetGroup assetGroup1 = getAssetGroup("assetgroup1");
-    AssetGroup assetGroup2 = getAssetGroup("assetgroup2");
-    Tag tag1 = TagFixture.getTag("Tag1");
-    Tag tag2 = TagFixture.getTag("Tag2");
-    Tag tag3 = TagFixture.getTag("Tag3");
-    Inject inject1 = new Inject();
-    inject1.setId("1");
-    Inject inject2 = new Inject();
-    inject1.setId("2");
-    Scenario scenario = ScenarioFixture.getScenario(null, Set.of(inject1, inject2));
-    scenario.setTags(Set.of(tag1, tag2));
-    Set<Tag> currentTags = Set.of(tag2, tag3);
-    List<AssetGroup> assetGroupsToAdd = List.of(assetGroup1, assetGroup2);
+      // Assert
+      scenario
+          .getInjects()
+          .forEach(
+              inject ->
+                  verify(injectService)
+                      .applyDefaultAssetGroupsToInject(inject.getId(), assetGroupsToAdd));
+      verify(scenarioRepository).save(scenario);
+    }
 
-    when(tagRuleService.getAssetGroupsFromTagIds(List.of(tag1.getId())))
-        .thenReturn(assetGroupsToAdd);
-    when(scenarioRepository.save(scenario)).thenReturn(scenario);
-    when(injectService.canApplyTargetType(any(), eq(TargetType.ASSETS_GROUPS))).thenReturn(false);
+    @Test
+    @DisplayName("Given applyRule true and manual inject, should not apply asset groups")
+    void given_applyRuleTrueAndManualInject_should_notApplyAssetGroups() {
+      // Arrange
+      AssetGroup assetGroup1 = getAssetGroup("assetgroup1");
+      AssetGroup assetGroup2 = getAssetGroup("assetgroup2");
+      Tag tag1 = TagFixture.getTag("Tag1");
+      Tag tag2 = TagFixture.getTag("Tag2");
+      Tag tag3 = TagFixture.getTag("Tag3");
+      Inject inject1 = new Inject();
+      inject1.setId("1");
+      Inject inject2 = new Inject();
+      inject2.setId("2");
+      Scenario scenario = ScenarioFixture.getScenario(null, Set.of(inject1, inject2));
+      scenario.setTags(Set.of(tag1, tag2));
+      Set<Tag> currentTags = Set.of(tag2, tag3);
+      List<AssetGroup> assetGroupsToAdd = List.of(assetGroup1, assetGroup2);
 
-    scenarioService.updateScenario(scenario, currentTags, true);
+      when(tagRuleService.getAssetGroupsFromTagIds(List.of(tag1.getId())))
+          .thenReturn(assetGroupsToAdd);
+      when(scenarioRepository.save(scenario)).thenReturn(scenario);
+      when(injectService.canApplyTargetType(any(), eq(TargetType.ASSETS_GROUPS))).thenReturn(false);
 
-    verify(injectService, never()).applyDefaultAssetGroupsToInject(any(), any());
-    verify(scenarioRepository).save(scenario);
-  }
+      // Act
+      scenarioService.updateScenario(scenario, currentTags, true);
 
-  @Test
-  public void testUpdateScenario_WITH_applyRule_false() {
-    Tag tag1 = TagFixture.getTag("Tag1");
-    Tag tag2 = TagFixture.getTag("Tag2");
-    Tag tag3 = TagFixture.getTag("Tag3");
-    Inject inject1 = new Inject();
-    inject1.setId("1");
-    Inject inject2 = new Inject();
-    inject2.setId("2");
-    Scenario scenario = ScenarioFixture.getScenario(null, Set.of(inject1, inject2));
-    scenario.setTags(Set.of(tag1, tag2));
-    Set<Tag> currentTags = Set.of(tag2, tag3);
+      // Assert
+      verify(injectService, never()).applyDefaultAssetGroupsToInject(any(), any());
+      verify(scenarioRepository).save(scenario);
+    }
 
-    when(scenarioRepository.save(scenario)).thenReturn(scenario);
+    @Test
+    @DisplayName("Given applyRule false, should not apply asset groups")
+    void given_applyRuleFalse_should_notApplyAssetGroups() {
+      // Arrange
+      Tag tag1 = TagFixture.getTag("Tag1");
+      Tag tag2 = TagFixture.getTag("Tag2");
+      Tag tag3 = TagFixture.getTag("Tag3");
+      Inject inject1 = new Inject();
+      inject1.setId("1");
+      Inject inject2 = new Inject();
+      inject2.setId("2");
+      Scenario scenario = ScenarioFixture.getScenario(null, Set.of(inject1, inject2));
+      scenario.setTags(Set.of(tag1, tag2));
+      Set<Tag> currentTags = Set.of(tag2, tag3);
 
-    scenarioService.updateScenario(scenario, currentTags, false);
+      when(scenarioRepository.save(scenario)).thenReturn(scenario);
 
-    verify(injectService, never()).applyDefaultAssetGroupsToInject(any(), any());
-    verify(scenarioRepository).save(scenario);
+      // Act
+      scenarioService.updateScenario(scenario, currentTags, false);
+
+      // Assert
+      verify(injectService, never()).applyDefaultAssetGroupsToInject(any(), any());
+      verify(scenarioRepository).save(scenario);
+    }
   }
 
   private AssetGroup getAssetGroup(String name) {
@@ -141,181 +160,245 @@ class ScenarioServiceUnitTest {
   }
 
   @Nested
+  @DisplayName("Create scenario")
   class CreateScenario {
 
     @Test
-    void shouldSaveScenario_andKeepExistingFrom() {
+    @DisplayName("Given scenario with existing from, should save and keep from")
+    void given_scenarioWithExistingFrom_should_saveAndKeepFrom() {
+      // Arrange
       Scenario scenario = ScenarioFixture.getScenario();
       when(scenarioRepository.save(any(Scenario.class)))
           .thenAnswer(invocation -> invocation.getArgument(0));
 
+      // Act
       Scenario result = scenarioService.createScenario(scenario);
 
+      // Assert
       assertNotNull(result);
       assertEquals("simulation@mail.fr", result.getFrom());
     }
 
     @Test
-    void shouldReturnSavedScenario() {
+    @DisplayName("Given scenario, should return saved scenario")
+    void given_scenario_should_returnSavedScenario() {
+      // Arrange
       Scenario scenario = ScenarioFixture.getScenario();
       Scenario saved = ScenarioFixture.getScenario();
       saved.setId("saved-id");
       when(scenarioRepository.save(any(Scenario.class))).thenReturn(saved);
 
+      // Act
       Scenario result = scenarioService.createScenario(scenario);
 
+      // Assert
       assertNotNull(result);
       assertEquals("saved-id", result.getId());
     }
   }
 
   @Nested
+  @DisplayName("Compute emails")
   class ComputeEmails {
 
     @Test
-    void shouldKeepExistingFrom_whenAlreadySet() {
+    @DisplayName("Given existing from, should keep it unchanged")
+    void given_existingFrom_should_keepItUnchanged() {
+      // Arrange
       Scenario scenario = new Scenario();
       scenario.setFrom("existing@mail.com");
 
+      // Act
       scenarioService.computeEmails(scenario);
 
+      // Assert
       assertEquals("existing@mail.com", scenario.getFrom());
     }
   }
 
   @Nested
+  @DisplayName("Retrieve scenario")
   class RetrieveScenario {
 
     @Test
-    void shouldReturnScenario_whenFound() {
+    @DisplayName("Given existing scenario id, should return scenario")
+    void given_existingScenarioId_should_returnScenario() {
+      // Arrange
       Scenario scenario = new Scenario();
       scenario.setId("sc-1");
-      when(scenarioRepository.findById("sc-1")).thenReturn(Optional.of(scenario));
+      when(scenarioRepository.findByIdAndTenant("sc-1")).thenReturn(Optional.of(scenario));
 
+      // Act
       Scenario result = scenarioService.scenario("sc-1");
 
+      // Assert
       assertNotNull(result);
       assertEquals("sc-1", result.getId());
     }
 
     @Test
-    void shouldThrowElementNotFoundException_whenNotFound() {
-      when(scenarioRepository.findById("missing")).thenReturn(Optional.empty());
+    @DisplayName("Given missing scenario id, should throw ElementNotFoundException")
+    void given_missingScenarioId_should_throwElementNotFoundException() {
+      // Arrange
+      when(scenarioRepository.findByIdAndTenant("missing")).thenReturn(Optional.empty());
 
+      // Act & Assert
       assertThrows(
           io.openaev.rest.exception.ElementNotFoundException.class,
           () -> scenarioService.scenario("missing"));
     }
 
     @Test
-    void shouldDeleteScenarioById() {
+    @DisplayName("Given existing scenario id, should delete scenario")
+    void given_existingScenarioId_should_deleteScenario() {
+      // Arrange
+      Scenario scenario = new Scenario();
+      scenario.setId("sc-1");
+      when(scenarioRepository.findByIdAndTenant("sc-1")).thenReturn(Optional.of(scenario));
+
+      // Act
       scenarioService.deleteScenario("sc-1");
 
-      verify(scenarioRepository).deleteById("sc-1");
+      // Assert
+      verify(scenarioRepository).delete(scenario);
     }
   }
 
   @Nested
+  @DisplayName("Recurring scenarios")
   class RecurringScenarios {
 
     @Test
-    void shouldReturnRecurringScenarios_afterInstant() {
+    @DisplayName("Given instant, should return recurring scenarios after that instant")
+    void given_instant_should_returnRecurringScenariosAfterInstant() {
+      // Arrange
       Scenario scenario = new Scenario();
       when(scenarioRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class)))
           .thenReturn(List.of(scenario));
 
+      // Act
       List<Scenario> result = scenarioService.recurringScenarios(java.time.Instant.now());
 
+      // Assert
       assertEquals(1, result.size());
     }
 
     @Test
-    void shouldReturnPotentiallyOutdatedScenarios() {
+    @DisplayName("Given instant, should return empty list when no outdated scenarios")
+    void given_instant_should_returnEmptyListWhenNoOutdatedScenarios() {
+      // Arrange
       when(scenarioRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class)))
           .thenReturn(Collections.emptyList());
 
+      // Act
       List<Scenario> result =
           scenarioService.potentialOutdatedRecurringScenario(java.time.Instant.now());
 
+      // Assert
       assertNotNull(result);
       assertTrue(result.isEmpty());
     }
   }
 
   @Nested
+  @DisplayName("Team management")
   class TeamManagement {
 
     @Test
-    void shouldDisablePlayers() {
+    @DisplayName("Given scenario with players, should disable players")
+    void given_scenarioWithPlayers_should_disablePlayers() {
+      // Arrange
       Scenario scenario = new Scenario();
       scenario.setId("sc-1");
       scenario.setInjects(new HashSet<>());
-      when(scenarioRepository.findById("sc-1")).thenReturn(Optional.of(scenario));
+      when(scenarioRepository.findByIdAndTenant("sc-1")).thenReturn(Optional.of(scenario));
 
+      // Act
       Scenario result = scenarioService.disablePlayers("sc-1", "team-id", List.of("player-1"));
 
+      // Assert
       assertNotNull(result);
       assertEquals("sc-1", result.getId());
     }
   }
 
   @Nested
+  @DisplayName("Tag rules")
   class TagRules {
 
     @Test
-    void shouldReturnTrue_whenNewTagsAdded() {
+    @DisplayName("Given new tags added, should return true")
+    void given_newTagsAdded_should_returnTrue() {
+      // Arrange
       Tag existingTag = TagFixture.getTag("Existing");
       Scenario scenario = ScenarioFixture.getScenario();
       scenario.setTags(Set.of(existingTag));
       when(tagRuleService.checkIfRulesApply(any(), any())).thenReturn(true);
 
+      // Act
       boolean result = scenarioService.checkIfTagRulesApplies(scenario, List.of("new-tag-id"));
 
+      // Assert
       assertTrue(result);
     }
 
     @Test
-    void shouldReturnFalse_whenNoNewTags() {
+    @DisplayName("Given no new tags, should return false")
+    void given_noNewTags_should_returnFalse() {
+      // Arrange
       Scenario scenario = ScenarioFixture.getScenario();
       scenario.setTags(Set.of());
       when(tagRuleService.checkIfRulesApply(any(), any())).thenReturn(false);
 
+      // Act
       boolean result = scenarioService.checkIfTagRulesApplies(scenario, List.of());
 
+      // Assert
       assertFalse(result);
     }
   }
 
   @Nested
+  @DisplayName("Launch validation")
   class LaunchValidation {
 
     @Test
-    void shouldNotThrow_whenLicenseActive() {
+    @DisplayName("Given active license, should not throw")
+    void given_activeLicense_should_notThrow() {
+      // Arrange
       when(enterpriseEditionService.isLicenseActive(any())).thenReturn(true);
       Scenario scenario = new Scenario();
       scenario.setInjects(new HashSet<>());
 
+      // Act & Assert
       assertDoesNotThrow(() -> scenarioService.throwIfScenarioNotLaunchable(scenario));
     }
 
     @Test
-    void shouldDelegateToInjectService_whenLicenseNotActive() {
+    @DisplayName("Given inactive license, should delegate to inject service")
+    void given_inactiveLicense_should_delegateToInjectService() {
+      // Arrange
       when(enterpriseEditionService.isLicenseActive(any())).thenReturn(false);
       Inject inject = new Inject();
       Scenario scenario = new Scenario();
       scenario.setInjects(new HashSet<>(List.of(inject)));
 
+      // Act
       scenarioService.throwIfScenarioNotLaunchable(scenario);
 
+      // Assert
       verify(injectService).throwIfInjectNotLaunchable(inject);
     }
   }
 
   @Nested
+  @DisplayName("Replace teams")
   class ReplaceTeams {
 
     @Test
-    void shouldFullyRemoveDeselectedTeamAndEnableOnlyNewTeams() {
+    @DisplayName("Given deselected team, should fully remove it and enable only new teams")
+    void given_deselectedTeam_should_fullyRemoveAndEnableOnlyNewTeams() {
+      // Arrange
       String scenarioId = "scenario-123";
 
       Team existingTeam1 = new Team();
@@ -337,7 +420,7 @@ class ScenarioServiceUnitTest {
       scenario.setId(scenarioId);
       scenario.setTeams(new ArrayList<>(List.of(existingTeam1, existingTeam2)));
 
-      when(scenarioRepository.findById(scenarioId)).thenReturn(Optional.of(scenario));
+      when(scenarioRepository.findByIdAndTenant(scenarioId)).thenReturn(Optional.of(scenario));
       when(teamRepository.findAllById(any()))
           .thenAnswer(
               invocation -> {
@@ -359,8 +442,10 @@ class ScenarioServiceUnitTest {
           .thenReturn(false);
       when(teamService.find(any())).thenReturn(List.of());
 
+      // Act
       scenarioService.replaceTeams(scenarioId, List.of("team-2", "team-3", "team-3"));
 
+      // Assert
       verify(scenarioTeamUserRepository)
           .deleteByScenarioIdAndTeamIds(
               eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
@@ -382,7 +467,9 @@ class ScenarioServiceUnitTest {
     }
 
     @Test
-    void shouldNotCallCleanupWhenNoTeamIsRemoved() {
+    @DisplayName("Given no team removed, should not call cleanup")
+    void given_noTeamRemoved_should_notCallCleanup() {
+      // Arrange
       String scenarioId = "scenario-123";
 
       Team existingTeam = new Team();
@@ -393,12 +480,14 @@ class ScenarioServiceUnitTest {
       scenario.setId(scenarioId);
       scenario.setTeams(new ArrayList<>(List.of(existingTeam)));
 
-      when(scenarioRepository.findById(scenarioId)).thenReturn(Optional.of(scenario));
+      when(scenarioRepository.findByIdAndTenant(scenarioId)).thenReturn(Optional.of(scenario));
       when(teamRepository.findAllById(any())).thenReturn(List.of(existingTeam));
       when(teamService.find(any())).thenReturn(List.of());
 
+      // Act
       scenarioService.replaceTeams(scenarioId, List.of("team-1"));
 
+      // Assert
       verify(scenarioTeamUserRepository, never()).deleteByScenarioIdAndTeamIds(any(), any());
       verify(injectRepository, never()).removeTeamsForScenario(any(), any());
       verify(lessonsCategoryRepository, never()).removeTeamsForScenario(any(), any());

--- a/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
@@ -225,7 +225,7 @@ public interface ScenarioRepository
               + "LEFT JOIN platforms pf ON pf.scenario_id = s.scenario_id "
               + "LEFT JOIN tags tg ON tg.scenario_id = s.scenario_id "
               + "LEFT JOIN workflows w ON w.workflow_scenario_id = s.scenario_id "
-              + "WHERE s.scenario_id = :scenarioId",
+              + "WHERE s.scenario_id = :scenarioId AND s.tenant_id = :#{#tenantContext.currentTenant}",
       nativeQuery = true)
   RawScenario getScenarioById(@Param("scenarioId") final String scenarioId);
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
@@ -254,4 +254,8 @@ public interface ScenarioRepository
       @Param("scenarioId") final String scenarioId, @Param("teamIds") final List<String> teamIds);
 
   Optional<Scenario> findByExercises_Id(String exerciseId);
+
+  @Query(
+      "SELECT s FROM Scenario s WHERE s.id = :scenarioId AND s.tenant.id = :#{#tenantContext.currentTenant}")
+  Optional<Scenario> findByIdAndTenant(@Param("scenarioId") String scenarioId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/TeamRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TeamRepository.java
@@ -106,4 +106,8 @@ public interface TeamRepository
               + "WHERE t.team_updated_at > :from ORDER BY t.team_updated_at LIMIT :limit;",
       nativeQuery = true)
   List<RawTeamIndexing> findForIndexing(@Param("from") Instant from, @Param("limit") int limit);
+
+  @Query(
+      "SELECT t FROM Team t WHERE t.id = :teamId AND t.tenant.id = :#{#tenantContext.currentTenant}")
+  Optional<Team> findByIdAndTenant(@Param("teamId") String teamId);
 }


### PR DESCRIPTION
This pull request introduces comprehensive tenant isolation for team and scenario operations throughout the API, ensuring that all relevant endpoints enforce tenant scoping. This is achieved by updating repository calls to use tenant-aware queries, adding explicit tenant-scoped validation in services and controllers, and expanding integration tests to verify correct isolation and error handling.

**Tenant Isolation Enforcement:**

* Updated all **team-related endpoints in `TeamApi`**  ensuring that teams can only be accessed, updated, or deleted within the current tenant context. 
* Updated **scenario-related service `ScenarioApi`** and dependent API 
  * [x] Teams
  * [x] Variable API Tenant Validation
  * [ ] Channel: 
  * [ ] Articles
  * [ ] Documents
  * [ ] Challenges


.<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add WHERE clause when missing
* Add integration test to test tenant isolation

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
