### PR TITLE
[frontend] fix(inject): avoid DOM pollution between inject targets (#5080)

### DIFF
--- a/openaev-front/src/actions/Schema.js
+++ b/openaev-front/src/actions/Schema.js
@@ -363,8 +363,8 @@ export const storeHelper = state => ({
   getExerciseInjectExpectations: id => entities('injectexpectations', state).filter(
     i => i.get('inject_expectation_exercise') === id,
   ),
-  getInjectExpectationsByAsset: (id, type) => entities('injectexpectations', state).filter(
-    i => (i.get('inject_expectation_asset') === id && i.get('inject_expectation_type') === type),
+  getInjectExpectationsByAssetAndInject: (asset_id, inject_id, type) => entities('injectexpectations', state).filter(
+    i => (i.get('inject_expectation_asset') === asset_id && i.get('inject_expectation_inject') === inject_id && i.get('inject_expectation_type') === type),
   ),
   getInjectExpectationsMap: () => maps('injectexpectations', state),
   // documents

--- a/openaev-front/src/actions/injects/inject-helper.d.ts
+++ b/openaev-front/src/actions/injects/inject-helper.d.ts
@@ -18,5 +18,5 @@ export interface InjectHelper {
   getScenarioInjects: (scenarioId: Scenario['scenario_id']) => Inject[];
   getTeamScenarioInjects: (teamId: Team['team_id']) => Inject[];
 
-  getInjectExpectationsByAsset: (targetId: InjectTarget['target_id'], expectationType: string) => InjectExpectationAgentOutput[];
+  getInjectExpectationsByAssetAndInject: (targetId: InjectTarget['target_id'], injectId: Inject['inject_id'], expectationType: string) => InjectExpectationAgentOutput[];
 }

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationAggregatedAgentsView.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationAggregatedAgentsView.tsx
@@ -38,7 +38,7 @@ const InjectExpectationAggregatedAgentsView = ({ inject, expectationType, target
   });
 
   const { injectExpectationsWithAgents } = useHelper((helper: InjectHelper) =>
-    ({ injectExpectationsWithAgents: helper.getInjectExpectationsByAsset(target.target_id, expectationType) }));
+    ({ injectExpectationsWithAgents: helper.getInjectExpectationsByAssetAndInject(target.target_id, inject.inject_id, expectationType) }));
 
   if (loading) {
     return <Loader />;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Introduce inject filter to store query for iject expectation results

### Testing Instructions

1. Create scenario with multiple payload injects (e.g. 3) and assign a single endpoint to each inject
2. Run multiple simulations of that scenario
3. Manually assign results to each Detection, Prevention expectations on each inject for the endpoint
4. In a given simulation: in targets, navigate down to the agent, display the Detection tab
5. Navigate to another inject, same agent target, display the Detection tab
6. It only shows the results for the Detection expectation of the current inject, not from any other

### Related issues

* Closes #5080

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
