### PR TITLE
[backend] fix(stix): pull the whole security coverage processing under the lock (#5656)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/stix_process/StixApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/stix_process/StixApi.java
@@ -1,13 +1,13 @@
 package io.openaev.api.stix_process;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.aop.RBAC;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.model.Scenario;
 import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
+import io.openaev.opencti.dto.CTIEvent;
 import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.service.stix.StixService;
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,26 +57,19 @@ public class StixApi extends RestBehavior {
     @ApiResponse(responseCode = "500", description = "Unexpected server error")
   })
   @RBAC(actionPerformed = Action.PROCESS, resourceType = ResourceType.STIX_BUNDLE)
-  public ResponseEntity<?> processBundle(@RequestBody String ctiEvent)
+  public ResponseEntity<?> processBundle(@RequestBody @Validated CTIEvent ctiEvent)
       throws ParsingException, ConnectorError, IOException {
-    String workId = null;
     try {
-      JsonNode root = objectMapper.readTree(ctiEvent);
-      workId = root.path("internal").path("work_id").asText();
-      String stixJson =
-          root.path("event").path("stix_objects").asText(); // As text is required here
-      // Acknowledge the scenario creation / enrichment by sending back the security coverage
       openCTIService.acknowledgeReceivedOfCoverage(
-          workId, "OpenAEV ready to process the operation");
-      // Create scenario from stix bundle
-      // If no simulation for this scenario is in progress, start an execution right away
+          ctiEvent.getInternal().getWorkId(), "OpenAEV ready to process the operation");
 
-      Scenario scenario = stixService.processBundle(stixJson);
+      Scenario scenario = stixService.processBundle(ctiEvent.getEvent().getStixObjects());
+
       openCTIService.acknowledgeProcessedOfCoverage(
-          workId, "Coverage successfully created or updated", false);
-      // Generate response
-      String summary = stixService.generateBundleImportReport(scenario);
-      return ResponseEntity.ok(new BundleImportReport(scenario.getId(), summary));
+          ctiEvent.getInternal().getWorkId(), "Coverage successfully created or updated", false);
+      return ResponseEntity.ok(
+          new BundleImportReport(
+              scenario.getId(), stixService.generateBundleImportReport(scenario)));
     } catch (BundleValidationError e) {
       // OCTI-specific behaviour
       // in the case of a Bundle validation error,
@@ -84,12 +78,12 @@ public class StixApi extends RestBehavior {
       // we will signal the failure with a log in the OAEV process and an "isError" ack
       // for OpenCTI
       log.error(
-          String.format(
-              "OpenAEV did not process this STIX bundle due to processing rules (workId=%s). ctiEvent=%s. Error: %s",
-              workId, ctiEvent, e.getMessage()),
+          "OpenAEV did not process this STIX bundle due to processing rules (workId={}). ctiEvent={}",
+          ctiEvent.getInternal().getWorkId(),
+          ctiEvent,
           e);
       openCTIService.acknowledgeProcessedOfCoverage(
-          workId,
+          ctiEvent.getInternal().getWorkId(),
           "OpenAEV did not process this STIX bundle due to processing rules: %s"
               .formatted(e.getMessage()),
           true);
@@ -98,21 +92,23 @@ public class StixApi extends RestBehavior {
       return ResponseEntity.status(HttpStatus.OK).build();
     } catch (JsonParseException e) {
       log.error(
-          String.format(
-              "Input STIX bundle is malformed (workId=%s). ctiEvent=%s. Error: %s",
-              workId, ctiEvent, e.getMessage()),
+          "Input STIX bundle is malformed (workId={}). ctiEvent={}",
+          ctiEvent.getInternal().getWorkId(),
+          ctiEvent,
           e);
       openCTIService.acknowledgeProcessedOfCoverage(
-          workId, "Input STIX bundle is malformed: %s".formatted(e.getMessage()), true);
+          ctiEvent.getInternal().getWorkId(),
+          "Input STIX bundle is malformed: %s".formatted(e.getMessage()),
+          true);
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     } catch (Exception e) {
       log.error(
-          String.format(
-              "An error occurred while processing STIX bundle (workId=%s). ctiEvent=%s. Error: %s",
-              workId, ctiEvent, e.getMessage()),
+          "An error occurred while processing STIX bundle (workId={}). ctiEvent={}",
+          ctiEvent.getInternal().getWorkId(),
+          ctiEvent,
           e);
       openCTIService.acknowledgeProcessedOfCoverage(
-          workId,
+          ctiEvent.getInternal().getWorkId(),
           "An error occurred while processing STIX bundle: %s".formatted(e.getMessage()),
           true);
       throw e;

--- a/openaev-api/src/main/java/io/openaev/api/stix_process/StixApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/stix_process/StixApi.java
@@ -1,6 +1,5 @@
 package io.openaev.api.stix_process;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.aop.RBAC;
 import io.openaev.database.model.Action;
@@ -90,17 +89,6 @@ public class StixApi extends RestBehavior {
       // here we explicitly return a status of HTTP 200 OK
       // it's a silent error
       return ResponseEntity.status(HttpStatus.OK).build();
-    } catch (JsonParseException e) {
-      log.error(
-          "Input STIX bundle is malformed (workId={}). ctiEvent={}",
-          ctiEvent.getInternal().getWorkId(),
-          ctiEvent,
-          e);
-      openCTIService.acknowledgeProcessedOfCoverage(
-          ctiEvent.getInternal().getWorkId(),
-          "Input STIX bundle is malformed: %s".formatted(e.getMessage()),
-          true);
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     } catch (Exception e) {
       log.error(
           "An error occurred while processing STIX bundle (workId={}). ctiEvent={}",

--- a/openaev-api/src/main/java/io/openaev/opencti/dto/CTIEvent.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/dto/CTIEvent.java
@@ -1,0 +1,33 @@
+package io.openaev.opencti.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Validated
+public class CTIEvent {
+  @Getter
+  public static class Internal {
+    @JsonProperty(value = "work_id", required = true)
+    @NotBlank
+    private String workId;
+  }
+
+  @Getter
+  public static class Event {
+    @JsonProperty(value = "stix_objects", required = true)
+    @NotBlank
+    private String stixObjects;
+  }
+
+  @JsonProperty(value = "internal", required = true)
+  @NotNull
+  private Internal internal;
+
+  @JsonProperty(value = "event", required = true)
+  @NotNull
+  private Event event;
+}

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -3,12 +3,10 @@ package io.openaev.service.stix;
 import static io.openaev.helper.CryptoHelper.md5Hex;
 import static io.openaev.rest.payload.service.PayloadService.DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY;
 import static io.openaev.stix.objects.constants.CommonProperties.MODIFIED;
-import static io.openaev.utils.SecurityCoverageUtils.extractAndValidateCoverage;
 import static io.openaev.utils.SecurityCoverageUtils.extractObjectReferences;
 import static io.openaev.utils.constants.StixConstants.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.aop.lock.Lock;
 import io.openaev.aop.lock.LockResourceType;
@@ -58,6 +56,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -86,25 +85,32 @@ public class SecurityCoverageService {
   private final SecurityCoverageConnector connector;
 
   /**
-   * Parses a STIX JSON string, validates it, and delegates to create and persist a
-   * SecurityCoverage.
+   * Creates or updates a security coverage and the associated scenario, and updates the
+   * corresponding connector.
    *
-   * @param stixJson the STIX bundle as a JSON string
-   * @return the saved {@link SecurityCoverage} object
-   * @throws JsonProcessingException if the input cannot be parsed into JSON
-   * @throws ParsingException if the STIX bundle is obsolete or already stored
-   * @throws BundleValidationError if validation fails
+   * @param securityCoverageStixId the STIX ID of the security-coverage object in the bundle
+   * @param securityCoverageObj the SDO representing the security coverage
+   * @param bundle the full bundle, also containing the security coverage SDO
+   * @throws ParsingException if the STIX bundle is malformed
+   * @throws BundleValidationError if the STIX bundle is obsolete or already stored
+   * @throws ConnectorError there was an issue communicating with the connector
+   * @throws IOException there is an issue with serialisation
    */
-  public SecurityCoverage processAndBuildStixToSecurityCoverage(String stixJson)
-      throws ParsingException, BundleValidationError, JsonProcessingException {
+  @Lock(type = LockResourceType.SECURITY_COVERAGE, key = "#securityCoverageStixId")
+  @Transactional(rollbackFor = Exception.class)
+  public Scenario handleSecurityCoverageProcessing(
+      String securityCoverageStixId, ObjectBase securityCoverageObj, Bundle bundle)
+      throws ParsingException, BundleValidationError, ConnectorError, IOException {
+    String bundleHash = md5Hex(bundle.toStix(objectMapper).toString());
 
-    JsonNode root = objectMapper.readTree(stixJson);
-    String stixJsonHash = md5Hex(stixJson);
-    Bundle bundle = stixParser.parseBundle(root.toString());
-    ObjectBase stixCoverageObj = extractAndValidateCoverage(bundle);
-    String externalId = stixCoverageObj.getRequiredProperty(CommonProperties.ID.toString());
+    SecurityCoverage securityCoverage =
+        buildSecurityCoverageFromStix(
+            securityCoverageObj, bundle, securityCoverageStixId, bundleHash);
+    Scenario scenario = buildScenarioFromSecurityCoverage(securityCoverage);
 
-    return buildSecurityCoverageFromStix(stixCoverageObj, bundle, externalId, stixJsonHash);
+    // FIXME: extract this behaviour into an async worker
+    pushSecurityCoverageBundleWithExternalURI(scenario);
+    return scenario;
   }
 
   /**
@@ -119,7 +125,6 @@ public class SecurityCoverageService {
    * @throws ParsingException if the STIX bundle is malformed
    * @throws BundleValidationError if the STIX bundle is obsolete or already stored
    */
-  @Lock(type = LockResourceType.SECURITY_COVERAGE, key = "#externalId")
   private SecurityCoverage buildSecurityCoverageFromStix(
       ObjectBase stixCoverageObj, Bundle bundle, String externalId, String stixJsonHash)
       throws ParsingException, BundleValidationError {

--- a/openaev-api/src/main/java/io/openaev/service/stix/StixService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/StixService.java
@@ -1,9 +1,15 @@
 package io.openaev.service.stix;
 
+import static io.openaev.utils.SecurityCoverageUtils.extractAndValidateCoverage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.database.model.Scenario;
-import io.openaev.database.model.SecurityCoverage;
 import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.service.stix.error.BundleValidationError;
+import io.openaev.stix.objects.Bundle;
+import io.openaev.stix.objects.ObjectBase;
+import io.openaev.stix.objects.constants.CommonProperties;
+import io.openaev.stix.parsing.Parser;
 import io.openaev.stix.parsing.ParsingException;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class StixService {
-
+  private final Parser stixParser;
+  private final ObjectMapper objectMapper;
   private final SecurityCoverageService securityCoverageService;
 
   /**
@@ -27,16 +34,19 @@ public class StixService {
   @Transactional(rollbackFor = Exception.class)
   public Scenario processBundle(String stixJson)
       throws IOException, ParsingException, ConnectorError, BundleValidationError {
-    // Update securityCoverage with the last bundle
-    SecurityCoverage securityCoverage =
-        securityCoverageService.processAndBuildStixToSecurityCoverage(stixJson);
+    Bundle bundle = stixParser.parseBundle(stixJson);
 
-    // Update Scenario using the last SecurityCoverage
-    Scenario scenario = securityCoverageService.buildScenarioFromSecurityCoverage(securityCoverage);
+    return processSecurityCoverage(bundle);
+  }
 
-    // FIXME: extract this behaviour into an async worker
-    securityCoverageService.pushSecurityCoverageBundleWithExternalURI(scenario);
-    return scenario;
+  private Scenario processSecurityCoverage(Bundle bundle)
+      throws BundleValidationError, ParsingException, ConnectorError, IOException {
+    ObjectBase securityCoverageObj = extractAndValidateCoverage(bundle);
+    String securityCoverageStixId =
+        securityCoverageObj.getRequiredProperty(CommonProperties.ID.toString());
+
+    return securityCoverageService.handleSecurityCoverageProcessing(
+        securityCoverageStixId, securityCoverageObj, bundle);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/stix/StixService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/StixService.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/openaev-api/src/main/java/io/openaev/service/stix/StixService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/StixService.java
@@ -31,7 +31,6 @@ public class StixService {
    * @param stixJson string form of the provided stix bundle
    * @return Scenario
    */
-  @Transactional(rollbackFor = Exception.class)
   public Scenario processBundle(String stixJson)
       throws IOException, ParsingException, ConnectorError, BundleValidationError {
     Bundle bundle = stixParser.parseBundle(stixJson);

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -613,6 +613,11 @@ type BasePayloadPayloadTypeMapping<Key, Type> = {
   payload_type: Key;
 } & Type;
 
+export interface CTIEvent {
+  event: Event;
+  internal: Internal;
+}
+
 export interface CVEBulkInsertInput {
   cves: CveCreateInput[];
   initial_dataset_completed?: boolean;
@@ -2361,6 +2366,10 @@ export interface EvaluationInput {
   evaluation_score?: number;
 }
 
+export interface Event {
+  stix_objects: string;
+}
+
 export interface Executable {
   executable_file: string;
   listened?: boolean;
@@ -3932,6 +3941,10 @@ export interface InjectsImportTestInput {
   sheet_name: string;
   /** @format int32 */
   timezone_offset: number;
+}
+
+export interface Internal {
+  work_id: string;
 }
 
 export interface JsonApiDocumentResourceObject {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Group the whole bundle processing under the scoped lock, so that there is no risk of parallel updating of the same scenario
* Added spring deserialisation validation in the endpoint signature
* Removed a 400 handler that would not work with the OCTI worker anyway

### Testing Instructions

1. Non regression testing on security coverage only

### Related issues

* Closes #5656 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
