### PR TITLE
[frontend] feat(iconbar): fix selected domains (#103)

### DIFF
--- a/openaev-front/src/admin/components/common/domains/useDomainIconFilter.ts
+++ b/openaev-front/src/admin/components/common/domains/useDomainIconFilter.ts
@@ -46,9 +46,7 @@ const useDomainIconFilter = ({
     if (!filterHelpers) return;
 
     const domainFilter = searchPaginationInput?.filterGroup?.filters?.find(({ key }) => key === domainFilterKey);
-    const currentSelectedDomains = Array.isArray(domainFilter?.values)
-      ? domainFilter.values
-      : [];
+    const currentSelectedDomains = domainFilter?.values ?? [];
 
     const nextSelectedDomains = currentSelectedDomains.includes(domainId)
       ? currentSelectedDomains.filter(id => id !== domainId)
@@ -106,7 +104,7 @@ const useDomainIconFilter = ({
       ({ key }) => key === domainFilterKey,
     );
 
-    setSelectedDomains(Array.isArray(domainFilter?.values) ? (domainFilter.values) : []);
+    setSelectedDomains(domainFilter?.values ?? []);
   }, [domainFilterKey, searchPaginationInput?.filterGroup]);
 
   const iconBarElements = useMemo(

--- a/openaev-front/src/admin/components/common/domains/useDomainIconFilter.ts
+++ b/openaev-front/src/admin/components/common/domains/useDomainIconFilter.ts
@@ -40,35 +40,38 @@ const useDomainIconFilter = ({
 }: UseDomainIconFilterParams): UseDomainIconFilterResult => {
   const [selectedDomains, setSelectedDomains] = useState<string[]>([]);
   const [domainCounts, setDomainCounts] = useState<Record<string, number>>({});
-
   const filterHelpers = queryableHelpers?.filterHelpers;
 
   const handleDomainClick = useCallback((domainId: string) => {
     if (!filterHelpers) return;
 
-    const nextSelectedDomains = selectedDomains.includes(domainId)
-      ? selectedDomains.filter(id => id !== domainId)
-      : [...selectedDomains, domainId];
+    const domainFilter = searchPaginationInput?.filterGroup?.filters?.find(({ key }) => key === domainFilterKey);
+    const currentSelectedDomains = Array.isArray(domainFilter?.values)
+      ? domainFilter.values
+      : [];
+
+    const nextSelectedDomains = currentSelectedDomains.includes(domainId)
+      ? currentSelectedDomains.filter(id => id !== domainId)
+      : [...currentSelectedDomains, domainId];
 
     if (nextSelectedDomains.length === 0) {
       filterHelpers.handleRemoveFilterByKey(domainFilterKey);
       return;
     }
 
-    const hasDomainFilter = searchPaginationInput?.filterGroup?.filters?.some(({ key }) => key === domainFilterKey) ?? false;
-
-    if (hasDomainFilter) {
-      filterHelpers.handleAddMultipleValueFilter(domainFilterKey, nextSelectedDomains);
-    } else {
-      filterHelpers.handleAddFilterWithEmptyValue({
-        id: generateFilterId(),
-        key: domainFilterKey,
-        operator: 'contains',
-        values: nextSelectedDomains,
-        mode: 'or',
-      });
+    if (domainFilter?.id) {
+      filterHelpers.handleUpdateValuesById(domainFilter.id, nextSelectedDomains);
+      return;
     }
-  }, [domainFilterKey, filterHelpers, searchPaginationInput?.filterGroup?.filters, selectedDomains]);
+
+    filterHelpers.handleAddFilterWithEmptyValue({
+      id: generateFilterId(),
+      key: domainFilterKey,
+      operator: 'contains',
+      values: nextSelectedDomains,
+      mode: 'or',
+    });
+  }, [domainFilterKey, filterHelpers, searchPaginationInput?.filterGroup?.filters]);
 
   useEffect(() => {
     if (searchPaginationInput) {
@@ -103,7 +106,7 @@ const useDomainIconFilter = ({
       ({ key }) => key === domainFilterKey,
     );
 
-    setSelectedDomains(Array.isArray(domainFilter?.values) ? (domainFilter.values as string[]) : []);
+    setSelectedDomains(Array.isArray(domainFilter?.values) ? (domainFilter.values) : []);
   }, [domainFilterKey, searchPaginationInput?.filterGroup]);
 
   const iconBarElements = useMemo(


### PR DESCRIPTION
Description
On the new Threat Arsenal page, when I select two domain filters, I can no longer deselect them by clicking on them. It only works with one domain.

Expected Output
The domain filter should deselect when I click on it if it is active, even if several domains are selected


### Testing Instructions

1. Test iconbar behavior to display multiple domains

### Related issues

* Closes [#103](https://github.com/OpenAEV-Platform/filigran-private/issues/103)

