### PR TITLE
[backend/frontend] feat(chaining): output propagation to local states based on event conditions (#4824)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/ConditionApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/ConditionApi.java
@@ -8,7 +8,6 @@ import io.openaev.aop.AccessControl;
 import io.openaev.api.chaining.dto.EventInput;
 import io.openaev.api.chaining.dto.EventOutput;
 import io.openaev.database.model.Action;
-import io.openaev.database.model.ConditionType;
 import io.openaev.database.model.ResourceType;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.service.chaining.ConditionService;
@@ -75,8 +74,7 @@ public class ConditionApi extends RestBehavior {
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.SIMULATION_OR_SCENARIO)
   @GetMapping(params = "workflow_id")
   public List<EventOutput> findAllByWorkflow(@RequestParam("workflow_id") String workflowId) {
-    return conditionService.findConditionRootsByWorkflowId(workflowId).stream()
-        .filter(c -> c.getType() != ConditionType.MAPPER)
+    return conditionService.findNonMapperConditionsByWorkflowId(workflowId).stream()
         .map(ConditionMapper::toOutput)
         .toList();
   }

--- a/openaev-api/src/main/java/io/openaev/api/chaining/ConditionApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/ConditionApi.java
@@ -8,6 +8,7 @@ import io.openaev.aop.AccessControl;
 import io.openaev.api.chaining.dto.EventInput;
 import io.openaev.api.chaining.dto.EventOutput;
 import io.openaev.database.model.Action;
+import io.openaev.database.model.ConditionType;
 import io.openaev.database.model.ResourceType;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.service.chaining.ConditionService;
@@ -75,6 +76,7 @@ public class ConditionApi extends RestBehavior {
   @GetMapping(params = "workflow_id")
   public List<EventOutput> findAllByWorkflow(@RequestParam("workflow_id") String workflowId) {
     return conditionService.findConditionRootsByWorkflowId(workflowId).stream()
+        .filter(c -> c.getType() != ConditionType.MAPPER)
         .map(ConditionMapper::toOutput)
         .toList();
   }

--- a/openaev-api/src/main/java/io/openaev/api/chaining/StepMapper.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/StepMapper.java
@@ -35,6 +35,7 @@ public final class StepMapper {
                       MapperConditionOutput.builder()
                           .conditionKeyType(c.getKeyType())
                           .conditionKey(c.getKey())
+                          .conditionValue(c.getValue())
                           .conditionMappingType(c.getMappingType())
                           .build())
               .toList();

--- a/openaev-api/src/main/java/io/openaev/api/chaining/StepMapper.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/StepMapper.java
@@ -2,8 +2,10 @@ package io.openaev.api.chaining;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.api.chaining.dto.MapperConditionOutput;
 import io.openaev.api.chaining.dto.StepOutput;
 import io.openaev.database.model.ConditionStep;
+import io.openaev.database.model.ConditionType;
 import io.openaev.database.model.Step;
 import java.util.List;
 
@@ -19,12 +21,29 @@ public final class StepMapper {
       List<String> rootConditionIds =
           step.getConditionSteps().stream()
               .filter(ConditionStep::isRoot)
+              .filter(cs -> cs.getCondition().getType() != ConditionType.MAPPER)
               .map(cs -> cs.getCondition().getId())
               .toList();
+
+      // Extract mapper conditions linked to this step
+      List<MapperConditionOutput> mapperConditions =
+          step.getConditionSteps().stream()
+              .map(ConditionStep::getCondition)
+              .filter(c -> c.getType() == ConditionType.MAPPER)
+              .map(
+                  c ->
+                      MapperConditionOutput.builder()
+                          .conditionKeyType(c.getKeyType())
+                          .conditionKey(c.getKey())
+                          .conditionMappingType(c.getMappingType())
+                          .build())
+              .toList();
+
       return StepOutput.builder()
           .id(step.getId())
           .status(step.getStatus())
           .conditionIds(rootConditionIds)
+          .mapperConditions(mapperConditions)
           .conditionKeyTypes(step.getConditionKeyTypes())
           .data(step.getData() == null ? null : OBJECT_MAPPER.readTree(step.getData()))
           .createdAt(step.getCreatedAt())

--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/MapperConditionOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/MapperConditionOutput.java
@@ -19,6 +19,9 @@ public class MapperConditionOutput {
   @JsonProperty("condition_key")
   private String conditionKey;
 
+  @JsonProperty("condition_value")
+  private String conditionValue;
+
   @JsonProperty("condition_mapping_type")
   private MappingType conditionMappingType;
 }

--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/MapperConditionOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/MapperConditionOutput.java
@@ -1,0 +1,24 @@
+package io.openaev.api.chaining.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.database.model.ConditionKeyType;
+import io.openaev.database.model.MappingType;
+import lombok.*;
+
+/** Output DTO for mapper conditions attached to a step. */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MapperConditionOutput {
+
+  @JsonProperty("condition_key_type")
+  private ConditionKeyType conditionKeyType;
+
+  @JsonProperty("condition_key")
+  private String conditionKey;
+
+  @JsonProperty("condition_mapping_type")
+  private MappingType conditionMappingType;
+}

--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/StepOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/StepOutput.java
@@ -25,6 +25,9 @@ public class StepOutput {
   @JsonProperty("step_condition_ids")
   private List<String> conditionIds;
 
+  @JsonProperty("step_mapper_conditions")
+  private List<MapperConditionOutput> mapperConditions;
+
   @JsonProperty("step_condition_key_types")
   private List<ConditionKeyType> conditionKeyTypes;
 

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -315,7 +315,8 @@ public class ConditionService {
    */
   @Transactional(readOnly = true)
   public List<Condition> findNonMapperConditionsByWorkflowId(String workflowId) {
-    return conditionRepository.findAllByWorkflowIdAndConditionParentIsNull(workflowId);
+    return conditionRepository.findAllByWorkflowIdAndConditionParentIsNullAndTypeNot(
+        workflowId, ConditionType.MAPPER);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -295,13 +295,26 @@ public class ConditionService {
   }
 
   /**
+   * Returns all event condition tree roots for a given workflow, excluding mapper conditions.
+   *
+   * @param workflowId the workflow identifier
+   * @return list of root event conditions for that workflow
+   */
+  @Transactional(readOnly = true)
+  public List<Condition> findEventRootsByWorkflowId(String workflowId) {
+    return conditionRepository.findAllByWorkflowIdAndConditionParentIsNull(workflowId).stream()
+        .filter(c -> !conditionUtils.isMapperCondition(c))
+        .toList();
+  }
+
+  /**
    * Returns all condition tree roots for a given workflow (conditions with no parent).
    *
    * @param workflowId the workflow identifier
    * @return list of root conditions for that workflow
    */
   @Transactional(readOnly = true)
-  public List<Condition> findConditionRootsByWorkflowId(String workflowId) {
+  public List<Condition> findNonMapperConditionsByWorkflowId(String workflowId) {
     return conditionRepository.findAllByWorkflowIdAndConditionParentIsNull(workflowId);
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowStateService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowStateService.java
@@ -4,6 +4,7 @@ import static io.openaev.utils.JsonUtils.gson;
 
 import com.google.gson.*;
 import io.openaev.database.model.*;
+import io.openaev.database.repository.ConditionRepository;
 import io.openaev.database.repository.WorkflowStateRepository;
 import io.openaev.utils.ConditionUtils;
 import java.util.*;
@@ -21,8 +22,11 @@ public class WorkflowStateService {
 
   private final WorkflowStateRepository workflowStateRepository;
 
+  private final ConditionRepository conditionRepository;
+
   /**
-   * Syncs structured output data into the global workflow state entries.
+   * Syncs structured output data into the global workflow state entries and propagates matching
+   * values to the local pools of steps whose filter conditions are satisfied by the output.
    *
    * @param dataToSync JSON element containing output data to merge
    * @param fieldTypeMap mapping from field name to its contract output type
@@ -37,7 +41,10 @@ public class WorkflowStateService {
 
     // Process traces
     if (dataToSync.isJsonObject()) {
-      saveToEntries(entries, dataToSync.getAsJsonObject(), fieldTypeMap);
+      Map<String, List<String>> parsedValues =
+          saveToEntries(entries, dataToSync.getAsJsonObject(), fieldTypeMap);
+      // Propagate to local pools of steps whose events need this output
+      propagateToLocalPools(parsedValues, workflowRun);
     }
 
     // Save JSON back to DB
@@ -46,19 +53,138 @@ public class WorkflowStateService {
   }
 
   /**
+   * Propagates output values to the local pools of step templates whose filter conditions (events)
+   * are satisfied by the produced output. This ensures that when a step B has an event expecting a
+   * certain value, and another step A produces that value, step B's local pool gets populated with
+   * it.
+   *
+   * @param parsedByType map of output type names to their extracted values
+   * @param workflowRun the running workflow execution
+   */
+  private void propagateToLocalPools(Map<String, List<String>> parsedByType, Workflow workflowRun) {
+
+    if (parsedByType.isEmpty() || workflowRun.getWorkflowTemplate() == null) {
+      return;
+    }
+
+    // Collect the ConditionKeyTypes matching the output types produced
+    Set<ConditionKeyType> outputKeyTypes =
+        parsedByType.keySet().stream()
+            .map(
+                typeName -> {
+                  try {
+                    return ConditionKeyType.valueOf(typeName);
+                  } catch (IllegalArgumentException e) {
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    if (outputKeyTypes.isEmpty()) {
+      return;
+    }
+
+    // Find filter conditions in the workflow template that match the output key types
+    String workflowTemplateId = workflowRun.getWorkflowTemplate().getId();
+    Set<ConditionType> excludedTypes =
+        Set.of(ConditionType.MAPPER, ConditionType.AFTER, ConditionType.BEFORE);
+    List<Condition> matchingConditions =
+        conditionRepository.findFilterConditionsByWorkflowIdAndKeyTypes(
+            workflowTemplateId, outputKeyTypes, excludedTypes);
+
+    if (matchingConditions.isEmpty()) {
+      return;
+    }
+
+    // Group conditions by the step templates they are linked to
+    Map<Step, List<Condition>> stepToConditions = new HashMap<>();
+    for (Condition condition : matchingConditions) {
+      if (condition.getConditionSteps() == null) {
+        continue;
+      }
+      for (ConditionStep conditionStep : condition.getConditionSteps()) {
+        Step step = conditionStep.getStep();
+        if (step != null) {
+          stepToConditions.computeIfAbsent(step, k -> new ArrayList<>()).add(condition);
+        }
+      }
+    }
+
+    // For each interested step, propagate matching output values to its local pool
+    for (Map.Entry<Step, List<Condition>> stepEntry : stepToConditions.entrySet()) {
+      Step stepTemplate = stepEntry.getKey();
+      List<Condition> rootConditions = stepEntry.getValue();
+
+      // Collect the key types from child conditions of the roots
+      Set<String> interestedKeyTypes =
+          rootConditions.stream()
+              .flatMap(
+                  root ->
+                      (root.getConditionChildren() != null
+                              ? root.getConditionChildren().stream()
+                              : java.util.stream.Stream.<Condition>empty())
+                          .filter(child -> child.getKeyType() != null)
+                          .map(child -> child.getKeyType().name()))
+              .collect(Collectors.toSet());
+
+      // Filter output values: keep only those matching interested key types and satisfying filters
+      Map<String, List<String>> valuesToPropagate = new HashMap<>();
+      for (String keyTypeName : interestedKeyTypes) {
+        List<String> values = parsedByType.get(keyTypeName);
+        if (values == null || values.isEmpty()) {
+          continue;
+        }
+
+        // Only propagate values that satisfy at least one root filter condition (event)
+        // isFilterConditionValid recursively checks the tree (AND/OR → leaves)
+        List<String> matchingValues =
+            values.stream()
+                .filter(
+                    val ->
+                        rootConditions.stream()
+                            .anyMatch(root -> conditionUtils.isFilterConditionValid(val, root)))
+                .toList();
+        if (!matchingValues.isEmpty()) {
+          valuesToPropagate.put(keyTypeName, matchingValues);
+        }
+      }
+
+      if (valuesToPropagate.isEmpty()) {
+        continue;
+      }
+
+      // Load or build the local state for this step template and add the values
+      WorkflowState localState = loadOrBuildLocalState(stepTemplate, workflowRun);
+      WorkflowStateEntries localEntries =
+          gson.fromJson(localState.getEntries(), WorkflowStateEntries.class);
+
+      for (Map.Entry<String, List<String>> valueEntry : valuesToPropagate.entrySet()) {
+        String keyTypeName = valueEntry.getKey();
+        List<String> values = valueEntry.getValue();
+        WorkflowStateEntries.Input input = localEntries.getInputByKey(keyTypeName);
+        input.getValues().addAll(values);
+      }
+
+      localState.setEntries(gson.toJson(localEntries));
+      save(localState);
+    }
+  }
+
+  /**
    * Parses structured output fields and adds their values to the state entries.
    *
    * @param entries state entries to populate
    * @param structuredOutput JSON object with field arrays
    * @param fieldTypeMap mapping from field name to contract output type
-   * @return map of field names to extracted values (for diagnostics)
+   * @return map of contract output type names to extracted string values
    */
   private Map<String, List<String>> saveToEntries(
       WorkflowStateEntries entries,
       JsonObject structuredOutput,
       Map<String, ContractOutputType> fieldTypeMap) {
 
-    Map<String, List<String>> currentTraceParsed = new HashMap<>();
+    Map<String, List<String>> parsedByType = new HashMap<>();
 
     structuredOutput
         .entrySet()
@@ -78,13 +204,14 @@ public class WorkflowStateService {
                 if (element.isJsonPrimitive()) {
                   String val = element.getAsString();
                   entries.getInputByKey(type.name()).getValues().add(val);
+                  parsedByType.computeIfAbsent(type.name(), k -> new ArrayList<>()).add(val);
                 } else if (element.isJsonObject()) {
                   // e.g. "portscan": [{"port": 22, "host": "1.1.1.1"}]
                   saveCorrelatedObject(entries, element.getAsJsonObject());
                 }
               }
             });
-    return currentTraceParsed;
+    return parsedByType;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowStateService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowStateService.java
@@ -67,27 +67,58 @@ public class WorkflowStateService {
     if (parsedByType.isEmpty() || workflowRun.getWorkflowTemplate() == null) {
       return;
     }
-
     // Collect the ConditionKeyTypes matching the output types produced
-    Set<ConditionKeyType> outputKeyTypes =
-        parsedByType.keySet().stream()
-            .map(
-                typeName -> {
-                  try {
-                    return ConditionKeyType.valueOf(typeName);
-                  } catch (IllegalArgumentException e) {
-                    return null;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
-
+    Set<ConditionKeyType> outputKeyTypes = resolveOutputKeyTypes(parsedByType.keySet());
     if (outputKeyTypes.isEmpty()) {
       return;
     }
 
+    // Finds steps that match the given output key types and groups them
+    Map<Step, List<Condition>> stepToConditions =
+        findStepsWithMatchingConditions(workflowRun.getWorkflowTemplate().getId(), outputKeyTypes);
+    if (stepToConditions.isEmpty()) {
+      return;
+    }
+
+    // For each interested step, propagate matching output values to its local pool
+    for (Map.Entry<Step, List<Condition>> stepEntry : stepToConditions.entrySet()) {
+      propagateValuesToStep(stepEntry.getKey(), stepEntry.getValue(), parsedByType, workflowRun);
+    }
+  }
+
+  /**
+   * Converts output type name strings to their corresponding {@link ConditionKeyType} enum values,
+   * ignoring any names that don't match a known enum constant.
+   *
+   * @param typeNames set of output type name strings
+   * @return set of resolved ConditionKeyType values
+   */
+  private Set<ConditionKeyType> resolveOutputKeyTypes(Set<String> typeNames) {
+    return typeNames.stream()
+        .map(
+            typeName -> {
+              try {
+                return ConditionKeyType.valueOf(typeName);
+              } catch (IllegalArgumentException e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Finds filter conditions in the workflow template that match the given output key types, and
+   * groups them by the step templates they are linked to.
+   *
+   * @param workflowTemplateId the workflow template ID
+   * @param outputKeyTypes the output key types to match against
+   * @return map of step templates to their matching filter conditions
+   */
+  private Map<Step, List<Condition>> findStepsWithMatchingConditions(
+      String workflowTemplateId, Set<ConditionKeyType> outputKeyTypes) {
+
     // Find filter conditions in the workflow template that match the output key types
-    String workflowTemplateId = workflowRun.getWorkflowTemplate().getId();
     Set<ConditionType> excludedTypes =
         Set.of(ConditionType.MAPPER, ConditionType.AFTER, ConditionType.BEFORE);
     List<Condition> matchingConditions =
@@ -95,7 +126,7 @@ public class WorkflowStateService {
             workflowTemplateId, outputKeyTypes, excludedTypes);
 
     if (matchingConditions.isEmpty()) {
-      return;
+      return Map.of();
     }
 
     // Group conditions by the step templates they are linked to
@@ -111,65 +142,92 @@ public class WorkflowStateService {
         }
       }
     }
+    return stepToConditions;
+  }
 
-    // For each interested step, propagate matching output values to its local pool
-    for (Map.Entry<Step, List<Condition>> stepEntry : stepToConditions.entrySet()) {
-      Step stepTemplate = stepEntry.getKey();
-      List<Condition> rootConditions = stepEntry.getValue();
+  /**
+   * Propagates matching output values to the local state of a single step template, filtering only
+   * values that satisfy the step's filter conditions.
+   *
+   * @param stepTemplate the target step template
+   * @param rootConditions the filter conditions linked to this step
+   * @param parsedByType map of output type names to their extracted values
+   * @param workflowRun the running workflow execution
+   */
+  private void propagateValuesToStep(
+      Step stepTemplate,
+      List<Condition> rootConditions,
+      Map<String, List<String>> parsedByType,
+      Workflow workflowRun) {
 
-      // Collect the key types from child conditions of the roots
-      Set<String> interestedKeyTypes =
-          rootConditions.stream()
-              .flatMap(
-                  root ->
-                      (root.getConditionChildren() != null
-                              ? root.getConditionChildren().stream()
-                              : java.util.stream.Stream.<Condition>empty())
-                          .filter(child -> child.getKeyType() != null)
-                          .map(child -> child.getKeyType().name()))
-              .collect(Collectors.toSet());
+    Map<String, List<String>> valuesToPropagate =
+        filterValuesMatchingConditions(rootConditions, parsedByType);
 
-      // Filter output values: keep only those matching interested key types and satisfying filters
-      Map<String, List<String>> valuesToPropagate = new HashMap<>();
-      for (String keyTypeName : interestedKeyTypes) {
-        List<String> values = parsedByType.get(keyTypeName);
-        if (values == null || values.isEmpty()) {
-          continue;
-        }
+    if (valuesToPropagate.isEmpty()) {
+      return;
+    }
 
-        // Only propagate values that satisfy at least one root filter condition (event)
-        // isFilterConditionValid recursively checks the tree (AND/OR → leaves)
-        List<String> matchingValues =
-            values.stream()
-                .filter(
-                    val ->
-                        rootConditions.stream()
-                            .anyMatch(root -> conditionUtils.isFilterConditionValid(val, root)))
-                .toList();
-        if (!matchingValues.isEmpty()) {
-          valuesToPropagate.put(keyTypeName, matchingValues);
-        }
-      }
+    // Load or build the local state for this step template and add the values
+    WorkflowState localState = loadOrBuildLocalState(stepTemplate, workflowRun);
+    WorkflowStateEntries localEntries =
+        gson.fromJson(localState.getEntries(), WorkflowStateEntries.class);
 
-      if (valuesToPropagate.isEmpty()) {
+    for (Map.Entry<String, List<String>> valueEntry : valuesToPropagate.entrySet()) {
+      String keyTypeName = valueEntry.getKey();
+      List<String> values = valueEntry.getValue();
+      WorkflowStateEntries.Input input = localEntries.getInputByKey(keyTypeName);
+      input.getValues().addAll(values);
+    }
+
+    localState.setEntries(gson.toJson(localEntries));
+    save(localState);
+  }
+
+  /**
+   * Filters output values to keep only those matching the interested key types from the root
+   * conditions' children and satisfying at least one root filter condition.
+   *
+   * @param rootConditions the root filter conditions to check against
+   * @param parsedByType map of output type names to their extracted values
+   * @return map of key type names to values that satisfy the filter conditions
+   */
+  private Map<String, List<String>> filterValuesMatchingConditions(
+      List<Condition> rootConditions, Map<String, List<String>> parsedByType) {
+
+    // Collect the key types from child conditions of the roots
+    Set<String> interestedKeyTypes =
+        rootConditions.stream()
+            .flatMap(
+                root ->
+                    (root.getConditionChildren() != null
+                            ? root.getConditionChildren().stream()
+                            : java.util.stream.Stream.<Condition>empty())
+                        .filter(child -> child.getKeyType() != null)
+                        .map(child -> child.getKeyType().name()))
+            .collect(Collectors.toSet());
+
+    // Filter output values: keep only those matching interested key types and satisfying filters
+    Map<String, List<String>> valuesToPropagate = new HashMap<>();
+    for (String keyTypeName : interestedKeyTypes) {
+      List<String> values = parsedByType.get(keyTypeName);
+      if (values == null || values.isEmpty()) {
         continue;
       }
 
-      // Load or build the local state for this step template and add the values
-      WorkflowState localState = loadOrBuildLocalState(stepTemplate, workflowRun);
-      WorkflowStateEntries localEntries =
-          gson.fromJson(localState.getEntries(), WorkflowStateEntries.class);
-
-      for (Map.Entry<String, List<String>> valueEntry : valuesToPropagate.entrySet()) {
-        String keyTypeName = valueEntry.getKey();
-        List<String> values = valueEntry.getValue();
-        WorkflowStateEntries.Input input = localEntries.getInputByKey(keyTypeName);
-        input.getValues().addAll(values);
+      // Only propagate values that satisfy at least one root filter condition (event)
+      // isFilterConditionValid recursively checks the tree (AND/OR → leaves)
+      List<String> matchingValues =
+          values.stream()
+              .filter(
+                  val ->
+                      rootConditions.stream()
+                          .anyMatch(root -> conditionUtils.isFilterConditionValid(val, root)))
+              .toList();
+      if (!matchingValues.isEmpty()) {
+        valuesToPropagate.put(keyTypeName, matchingValues);
       }
-
-      localState.setEntries(gson.toJson(localEntries));
-      save(localState);
     }
+    return valuesToPropagate;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowStateService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowStateService.java
@@ -26,7 +26,7 @@ public class WorkflowStateService {
 
   /**
    * Syncs structured output data into the global workflow state entries and propagates matching
-   * values to the local pools of steps whose filter conditions are satisfied by the output.
+   * values to the local states of steps whose filter conditions are satisfied by the output.
    *
    * @param dataToSync JSON element containing output data to merge
    * @param fieldTypeMap mapping from field name to its contract output type
@@ -43,8 +43,8 @@ public class WorkflowStateService {
     if (dataToSync.isJsonObject()) {
       Map<String, List<String>> parsedValues =
           saveToEntries(entries, dataToSync.getAsJsonObject(), fieldTypeMap);
-      // Propagate to local pools of steps whose events need this output
-      propagateToLocalPools(parsedValues, workflowRun);
+      // Propagate to local states of steps whose events need this output
+      propagateToLocalStates(parsedValues, workflowRun);
     }
 
     // Save JSON back to DB
@@ -53,7 +53,7 @@ public class WorkflowStateService {
   }
 
   /**
-   * Propagates output values to the local pools of step templates whose filter conditions (events)
+   * Propagates output values to the local states of step templates whose filter conditions (events)
    * are satisfied by the produced output. This ensures that when a step B has an event expecting a
    * certain value, and another step A produces that value, step B's local pool gets populated with
    * it.
@@ -61,7 +61,8 @@ public class WorkflowStateService {
    * @param parsedByType map of output type names to their extracted values
    * @param workflowRun the running workflow execution
    */
-  private void propagateToLocalPools(Map<String, List<String>> parsedByType, Workflow workflowRun) {
+  private void propagateToLocalStates(
+      Map<String, List<String>> parsedByType, Workflow workflowRun) {
 
     if (parsedByType.isEmpty() || workflowRun.getWorkflowTemplate() == null) {
       return;

--- a/openaev-api/src/test/java/io/openaev/api/chaining/ConditionApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/ConditionApiTest.java
@@ -53,14 +53,14 @@ class ConditionApiTest {
   @Test
   void findAllByWorkflow_shouldReturnMappedList() {
     Condition root = conditionTree("c-wf", "wf-9", "ev-9", "d");
-    when(conditionService.findConditionRootsByWorkflowId("wf-9")).thenReturn(List.of(root));
+    when(conditionService.findNonMapperConditionsByWorkflowId("wf-9")).thenReturn(List.of(root));
 
     List<EventOutput> result = conditionApi.findAllByWorkflow("wf-9");
 
     assertEquals(1, result.size());
     assertEquals("c-wf", result.getFirst().getId());
     assertEquals("wf-9", result.getFirst().getWorkflowId());
-    verify(conditionService).findConditionRootsByWorkflowId("wf-9");
+    verify(conditionService).findNonMapperConditionsByWorkflowId("wf-9");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowStateServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowStateServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.gson.Gson;
 import io.openaev.database.model.*;
+import io.openaev.database.repository.ConditionRepository;
 import io.openaev.database.repository.WorkflowStateRepository;
 import io.openaev.utils.ConditionUtils;
 import java.util.*;
@@ -21,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class WorkflowStateServiceTest {
 
   @Mock private WorkflowStateRepository workflowStateRepository;
+  @Mock private ConditionRepository conditionRepository;
   @Mock private ConditionUtils conditionUtils;
 
   @InjectMocks private WorkflowStateService workflowStateService;

--- a/openaev-front/src/admin/components/chaining/logic/Logic.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/Logic.tsx
@@ -116,7 +116,15 @@ const Logic = ({ workflowId }: LogicProps) => {
             inject_assets: assets,
             inject_asset_objects: [],
             step_condition_ids: condIds,
-            step_conditions: [],
+            step_conditions: (((s as unknown as Record<string, unknown>).step_mapper_conditions ?? []) as Array<{
+              condition_key_type?: string;
+              condition_key?: string;
+              condition_mapping_type?: string;
+            }>).map(mc => ({
+              condition_key_type: mc.condition_key_type ?? 'text',
+              condition_key: mc.condition_key ?? '',
+              condition_mapping_type: mc.condition_mapping_type ?? 'GLOBAL',
+            })),
             contract_fields: [],
           };
           return {

--- a/openaev-front/src/admin/components/chaining/logic/Logic.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/Logic.tsx
@@ -152,13 +152,7 @@ const Logic = ({ workflowId }: LogicProps) => {
       }
 
       const newEventMetas: Record<string, EventMeta> = {};
-      // Only display filter events in the graph (exclude MAPPER events which belong to step forms)
-      const filterEvents = events.filter((e) => {
-        const allConds = e.event_conditions ?? [];
-        const rootCond = allConds.find(c => !c.condition_parent_id);
-        return rootCond?.condition_type !== 'MAPPER';
-      });
-      const eventNodes: Node[] = filterEvents.map((e, i) => {
+      const eventNodes: Node[] = events.map((e, i) => {
         const allConds = e.event_conditions ?? [];
         // Find root condition (has no parent) — its type is the logical operator
         const rootCond = allConds.find(c => !c.condition_parent_id);

--- a/openaev-front/src/admin/components/chaining/logic/Logic.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/Logic.tsx
@@ -152,7 +152,13 @@ const Logic = ({ workflowId }: LogicProps) => {
       }
 
       const newEventMetas: Record<string, EventMeta> = {};
-      const eventNodes: Node[] = events.map((e, i) => {
+      // Only display filter events in the graph (exclude MAPPER events which belong to step forms)
+      const filterEvents = events.filter((e) => {
+        const allConds = e.event_conditions ?? [];
+        const rootCond = allConds.find(c => !c.condition_parent_id);
+        return rootCond?.condition_type !== 'MAPPER';
+      });
+      const eventNodes: Node[] = filterEvents.map((e, i) => {
         const allConds = e.event_conditions ?? [];
         // Find root condition (has no parent) — its type is the logical operator
         const rootCond = allConds.find(c => !c.condition_parent_id);

--- a/openaev-front/src/admin/components/chaining/logic/forms/MapperConditionRow.ts
+++ b/openaev-front/src/admin/components/chaining/logic/forms/MapperConditionRow.ts
@@ -8,7 +8,9 @@ export const CONDITION_KEY_TYPES = [
   'text', 'number', 'status', 'port', 'portscan',
   'ipv4', 'ipv6', 'credentials', 'cve', 'username',
   'share', 'admin_username', 'group', 'computer',
-  'password_policy', 'delegation', 'sid', 'vulnerability', 'asset',
+  'password_policy', 'delegation', 'sid', 'vulnerability',
+  'account_with_password_not_required', 'asreproastable_account',
+  'kerberoastable_account', 'asset',
 ] as const;
 
 export const MAPPING_TYPES = ['DEFAULT', 'LOCAL', 'GLOBAL'] as const;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -4910,6 +4910,33 @@ export interface LoginUserInput {
   tenantId?: string;
 }
 
+export interface MapperConditionOutput {
+  condition_key?: string;
+  condition_key_type?:
+    | "execution_time"
+    | "step_template_id"
+    | "text"
+    | "status"
+    | "number"
+    | "port"
+    | "portscan"
+    | "ipv4"
+    | "ipv6"
+    | "credentials"
+    | "cve"
+    | "username"
+    | "share"
+    | "admin_username"
+    | "group"
+    | "computer"
+    | "password_policy"
+    | "delegation"
+    | "sid"
+    | "vulnerability"
+    | "asset";
+  condition_mapping_type?: "DEFAULT" | "LOCAL" | "GLOBAL";
+}
+
 export interface Mitigation {
   listened?: boolean;
   mitigation_attack_patterns?: string[];
@@ -7535,6 +7562,7 @@ export interface StepOutput {
   step_created_at?: string;
   step_data?: JsonNode;
   step_id?: string;
+  step_mapper_conditions?: MapperConditionOutput[];
   step_status?: "TEMPLATE" | "READY" | "RUN" | "END";
   /** @format date-time */
   step_updated_at?: string;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1259,6 +1259,9 @@ export interface ConditionCreateInput {
     | "delegation"
     | "sid"
     | "vulnerability"
+    | "account_with_password_not_required"
+    | "asreproastable_account"
+    | "kerberoastable_account"
     | "asset";
   /** Mapping type: DEFAULT, LOCAL, or GLOBAL. Required when condition type is MAPPER, must be null otherwise. */
   condition_mapping_type?: "DEFAULT" | "LOCAL" | "GLOBAL";
@@ -1315,6 +1318,9 @@ export interface ConditionOutput {
     | "delegation"
     | "sid"
     | "vulnerability"
+    | "account_with_password_not_required"
+    | "asreproastable_account"
+    | "kerberoastable_account"
     | "asset";
   condition_mapping_type?: "DEFAULT" | "LOCAL" | "GLOBAL";
   condition_parent_id?: string;
@@ -4933,8 +4939,12 @@ export interface MapperConditionOutput {
     | "delegation"
     | "sid"
     | "vulnerability"
+    | "account_with_password_not_required"
+    | "asreproastable_account"
+    | "kerberoastable_account"
     | "asset";
   condition_mapping_type?: "DEFAULT" | "LOCAL" | "GLOBAL";
+  condition_value?: string;
 }
 
 export interface Mitigation {
@@ -7556,6 +7566,9 @@ export interface StepOutput {
     | "delegation"
     | "sid"
     | "vulnerability"
+    | "account_with_password_not_required"
+    | "asreproastable_account"
+    | "kerberoastable_account"
     | "asset"
   )[];
   /** @format date-time */

--- a/openaev-model/src/main/java/io/openaev/database/model/ConditionKeyType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ConditionKeyType.java
@@ -65,6 +65,15 @@ public enum ConditionKeyType {
   @JsonProperty("vulnerability")
   Vulnerability,
 
+  @JsonProperty("account_with_password_not_required")
+  AccountWithPasswordNotRequired,
+
+  @JsonProperty("asreproastable_account")
+  AsreproastableAccount,
+
+  @JsonProperty("kerberoastable_account")
+  KerberoastableAccount,
+
   @JsonProperty("asset")
   Asset;
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/ConditionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ConditionRepository.java
@@ -2,6 +2,7 @@ package io.openaev.database.repository;
 
 import io.openaev.database.model.Condition;
 import io.openaev.database.model.ConditionKeyType;
+import io.openaev.database.model.ConditionType;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -37,4 +38,35 @@ public interface ConditionRepository extends JpaRepository<Condition, String> {
   List<Condition> findAllByWorkflowIdAndConditionParentIsNull(String workflowId);
 
   List<Condition> findAllByKeyTypeIn(Set<ConditionKeyType> outputKeyTypes);
+
+  /**
+   * Retrieves root filter conditions for a given workflow that have at least one child condition
+   * with a matching key type. The root condition is linked to steps (via conditionSteps), while the
+   * keyType is on child conditions (the actual filter leaves).
+   *
+   * @param workflowId the workflow identifier
+   * @param keyTypes the key types to look for in child conditions
+   * @param excludedTypes the condition types to exclude from child matching
+   * @return a list of root conditions whose children match the criteria
+   */
+  @Query(
+      """
+          SELECT DISTINCT root
+          FROM Condition root
+          JOIN FETCH root.conditionSteps cs
+          JOIN FETCH cs.step
+          WHERE root.workflowId = :workflowId
+            AND root.conditionParent IS NULL
+            AND root.conditionSteps IS NOT EMPTY
+            AND EXISTS (
+              SELECT 1 FROM Condition child
+              WHERE child.conditionParent = root
+                AND child.keyType IN :keyTypes
+                AND child.type NOT IN :excludedTypes
+            )
+          """)
+  List<Condition> findFilterConditionsByWorkflowIdAndKeyTypes(
+      @Param("workflowId") String workflowId,
+      @Param("keyTypes") Set<ConditionKeyType> keyTypes,
+      @Param("excludedTypes") Set<ConditionType> excludedTypes);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/ConditionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ConditionRepository.java
@@ -37,6 +37,16 @@ public interface ConditionRepository extends JpaRepository<Condition, String> {
    */
   List<Condition> findAllByWorkflowIdAndConditionParentIsNull(String workflowId);
 
+  /**
+   * Retrieves all root conditions (events) for a given workflow, excluding those of type MAPPER.
+   *
+   * @param workflowId the workflow identifier
+   * @param excludedType the condition type to exclude (MAPPER)
+   * @return a list of non-MAPPER root conditions for the given workflow
+   */
+  List<Condition> findAllByWorkflowIdAndConditionParentIsNullAndTypeNot(
+      String workflowId, ConditionType excludedType);
+
   List<Condition> findAllByKeyTypeIn(Set<ConditionKeyType> outputKeyTypes);
 
   /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

**On backend side :** 
* Output propagation: action outputs are now propagated to local pools of steps whose event conditions are satisfied.
* WorkflowStateService:

-  saveToEntries now returns extracted values grouped by type.
- New propagateToLocalPools method: Identifies relevant conditions, Evaluates filters (AND/OR/EQ), Populates the corresponding step local states
* ConditionRepository: New method to fetch relevant filter conditions by workflow and key types

**On frontend side :** 
* MAPPER conditions are excluded from workflow events (no more empty/invalid nodes in the graph)
* Mapper conditions handling: Extracted into a dedicated DTO and exposed via the API, Added to StepOutput
* UI : Existing mapper conditions are now properly preloaded and visible when editing a step

### Testing Instructions

1. Create chaining simulation 
2. On the logic tab : add 2 actions and one event
2.1. First action : "whoami" who its output is a text 
2.2. Second action : "echo #{input}" with text as input 
2.3. Event who is linked to the second action "text=toto" (toto should match the actual output of the whoami action)
3. Launch the simulation 
4. Check workflow_states
- In the global pool (no step_template_id), you should see all action outputs
- After whoami completes successfully:
* A new entry should appear with a step_template_id (local pool)
* This entry contains the output of whoami only if it matches the event condition (text = toto)

### Related issues

* linked #4824 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
