### PR TITLE
[frontend] fix(arsenal_update_popup_not_working): when editing an arsenal, the update redirects to the Commands tab… and then nothing happens. Attribute sub_type must be also nullable. Optional is not enough. (#5709)

### DIFF
--- a/openaev-front/src/admin/components/threat_arsenal/ThreatArsenalActionForm.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/ThreatArsenalActionForm.tsx
@@ -100,7 +100,7 @@ const ThreatArsenalActionForm = ({
     default_value: z.string().nonempty(t('Should not be empty')),
     key: z.string().nonempty(t('Should not be empty')),
     type: z.enum(['text', 'number', 'port', 'portscan', 'ipv4', 'ipv6', 'credentials', 'cve', 'document', 'targeted-asset', 'kerberoastable_account', 'asreproastable_account', 'account_with_password_not_required', 'vulnerability', 'sid', 'delegation', 'password_policy', 'computer', 'group', 'admin_username', 'share', 'username'], { error: t('Should not be empty') }),
-    subtype: z.enum(['host', 'port', 'service', 'username', 'password', 'severity', 'domain']).optional(),
+    subtype: z.enum(['host', 'port', 'service', 'username', 'password', 'severity', 'domain']).optional().nullable(),
     description: z.string().optional().nullable(),
     separator: z.string().optional().nullable(),
   }).refine(


### PR DESCRIPTION

### Desciption

When editing an arsenal, the update redirects to the Commands tab… and then nothing happens.
It looks like the validator for this form is expecting an attribute called sub_type, which isn’t present in all versions of the update arsenal form. As a result, it gets submitted as NULL.
The catch is that in the Object base schema for action_arguments, this field is defined as NOT NULL, so the validation fails - and we quietly end up on the Commands tab with no further feedback (a bit of a silent protest from the system :).

### Proposed changes

* Attribute subtype in argumentZodObject must be also nullable. Optional is not enough.

### Testing Instructions

1. Log in to OpenAEV
2. Click on "Threat Arsenals" in the left sidebar
3. Create a new arsenal based on a command line
4. Open it for editing
5. Change something and click Update


### Related issues

* #5709


If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
