### PR TITLE
[backend] fix(multitenancy): fix incorrect minio migration (#109)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ steps:
       SPRING_FLYWAY_USER: openaev
       SPRING_FLYWAY_PASSWORD: openaev
       MINIO_ENDPOINT: minio
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       ENGINE_URL: http://elastic:9200
       OPENBAS_RABBITMQ_HOSTNAME: rabbitmq
     commands:
@@ -53,7 +53,7 @@ steps:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: minio-e2e
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       ENGINE_URL: http://elastic:9200
       MINIO_ACCESS_KEY: minioadmin
       MINIO_ACCESS_SECRET: minioadmin

--- a/.drone.yml
+++ b/.drone.yml
@@ -199,7 +199,7 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-    command: [server, /data]
+    command: [server, /data, --address, ":11000"]
   - name: pgsql-e2e
     image: postgres:17-alpine
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -180,7 +180,7 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-    command: [server, /data]
+    command: [server, /data, --address, ":11000"]
   - name: pgsql
     image: postgres:17-alpine
     environment:

--- a/.github/actions/api-tests/action.yml
+++ b/.github/actions/api-tests/action.yml
@@ -49,7 +49,7 @@ runs:
           -e RABBITMQ_DEFAULT_PASS=guest \
           rabbitmq:4.1-management
         docker run -d --name minio \
-          -p 9000:9000 \
+          -p 11000:9000 \
           -e MINIO_ROOT_USER=minioadmin \
           -e MINIO_ROOT_PASSWORD=minioadmin \
           minio/minio:RELEASE.2025-06-13T11-33-47Z server /data
@@ -193,10 +193,10 @@ runs:
 
         echo "⏳ Waiting for MinIO..."
         for i in $(seq 1 30); do
-          curl -sf http://localhost:9000/minio/health/live && break
+          curl -sf http://localhost:11000/minio/health/live && break
           sleep 1
         done
-        curl -sf http://localhost:9000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+        curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
 
         echo "✅ All services ready"
 

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -44,7 +44,7 @@ runs:
           -e RABBITMQ_DEFAULT_PASS=guest \
           rabbitmq:4.1-management
         docker run -d --name minio \
-          -p 9000:9000 \
+          -p 11000:9000 \
           -e MINIO_ROOT_USER=minioadmin \
           -e MINIO_ROOT_PASSWORD=minioadmin \
           minio/minio:RELEASE.2025-06-13T11-33-47Z server /data
@@ -175,10 +175,10 @@ runs:
 
         echo "⏳ Waiting for MinIO..."
         for i in $(seq 1 30); do
-          curl -sf http://localhost:9000/minio/health/live && break
+          curl -sf http://localhost:11000/minio/health/live && break
           sleep 1
         done
-        curl -sf http://localhost:9000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+        curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
 
         echo "✅ All services ready"
 

--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -100,7 +100,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: localhost
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       ENGINE_URL: http://localhost:9200
       OPENBAS_RABBITMQ_HOSTNAME: localhost
       GH_TOKEN: ${{ github.token }}
@@ -122,7 +122,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: localhost
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_ACCESS_SECRET: minioadmin
       ENGINE_URL: http://localhost:9200

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -83,7 +83,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: localhost
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       ENGINE_URL: http://localhost:9200
       OPENBAS_RABBITMQ_HOSTNAME: localhost
     steps:
@@ -172,7 +172,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: localhost
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       ENGINE_URL: http://localhost:9200
       ENGINE_ENGINESELECTOR: opensearch
       OPENBAS_RABBITMQ_HOSTNAME: localhost
@@ -278,7 +278,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: localhost
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_ACCESS_SECRET: minioadmin
       ENGINE_URL: http://localhost:9200
@@ -515,7 +515,7 @@ jobs:
       SPRING_DATASOURCE_USERNAME: openaev
       SPRING_DATASOURCE_PASSWORD: openaev
       MINIO_ENDPOINT: localhost
-      MINIO_PORT: 9000
+      MINIO_PORT: 11000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_ACCESS_SECRET: minioadmin
       ENGINE_URL: http://localhost:9200

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -99,17 +99,17 @@ jobs:
       - name: Start MinIO
         run: |
           docker run -d --name minio \
-            -p 9000:9000 \
+            -p 11000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio:RELEASE.2025-06-13T11-33-47Z server /data
 
           echo "⏳ Waiting for MinIO..."
           for i in $(seq 1 30); do
-            curl -sf http://localhost:9000/minio/health/live && break
+            curl -sf http://localhost:11000/minio/health/live && break
             sleep 1
           done
-          curl -sf http://localhost:9000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+          curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
           echo "✅ MinIO ready"
 
       - name: Build all modules (skip tests)
@@ -189,17 +189,17 @@ jobs:
       - name: Start MinIO
         run: |
           docker run -d --name minio \
-            -p 9000:9000 \
+            -p 11000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio:RELEASE.2025-06-13T11-33-47Z server /data
 
           echo "⏳ Waiting for MinIO..."
           for i in $(seq 1 30); do
-            curl -sf http://localhost:9000/minio/health/live && break
+            curl -sf http://localhost:11000/minio/health/live && break
             sleep 1
           done
-          curl -sf http://localhost:9000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+          curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
           echo "✅ MinIO ready"
 
       - name: Build all modules (skip tests)
@@ -319,15 +319,15 @@ jobs:
       - name: Start MinIO
         run: |
           docker run -d --name minio \
-            -p 9000:9000 \
+            -p 11000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio:RELEASE.2025-06-13T11-33-47Z server /data
           for i in $(seq 1 30); do
-            curl -sf http://localhost:9000/minio/health/live && break
+            curl -sf http://localhost:11000/minio/health/live && break
             sleep 1
           done
-          curl -sf http://localhost:9000/minio/health/live || { echo "❌ MinIO failed"; exit 1; }
+          curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed"; exit 1; }
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -421,7 +421,7 @@ jobs:
           echo "── Service connectivity ──"
           echo -n "  PostgreSQL (5432): "; curl -sf http://localhost:5432 2>&1 | head -1 || pg_isready -h localhost -p 5432 2>&1 || echo "unreachable"
           echo -n "  Elasticsearch/OpenSearch (9200): "; curl -sf http://localhost:9200 | head -1 || echo "unreachable"
-          echo -n "  MinIO (9000): "; curl -sf http://localhost:9000/minio/health/live && echo "ok" || echo "unreachable"
+          echo -n "  MinIO (11000): "; curl -sf http://localhost:11000/minio/health/live && echo "ok" || echo "unreachable"
           echo -n "  RabbitMQ (5672): "; nc -z localhost 5672 2>&1 && echo "ok" || echo "unreachable"
 
           echo ""
@@ -554,15 +554,15 @@ jobs:
       - name: Start MinIO
         run: |
           docker run -d --name minio \
-            -p 9000:9000 \
+            -p 11000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio:RELEASE.2025-06-13T11-33-47Z server /data
           for i in $(seq 1 30); do
-            curl -sf http://localhost:9000/minio/health/live && break
+            curl -sf http://localhost:11000/minio/health/live && break
             sleep 1
           done
-          curl -sf http://localhost:9000/minio/health/live || { echo "❌ MinIO failed"; exit 1; }
+          curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed"; exit 1; }
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -655,7 +655,7 @@ jobs:
           echo "── Service connectivity ──"
           echo -n "  PostgreSQL (5432): "; curl -sf http://localhost:5432 2>&1 | head -1 || pg_isready -h localhost -p 5432 2>&1 || echo "unreachable"
           echo -n "  Elasticsearch/OpenSearch (9200): "; curl -sf http://localhost:9200 | head -1 || echo "unreachable"
-          echo -n "  MinIO (9000): "; curl -sf http://localhost:9000/minio/health/live && echo "ok" || echo "unreachable"
+          echo -n "  MinIO (11000): "; curl -sf http://localhost:11000/minio/health/live && echo "ok" || echo "unreachable"
           echo -n "  RabbitMQ (5672): "; nc -z localhost 5672 2>&1 && echo "ok" || echo "unreachable"
 
           echo ""

--- a/openaev-api/src/test/java/io/openaev/driver/MinioDriverTest.java
+++ b/openaev-api/src/test/java/io/openaev/driver/MinioDriverTest.java
@@ -1,0 +1,144 @@
+package io.openaev.driver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.minio.*;
+import io.minio.messages.Item;
+import io.openaev.IntegrationTest;
+import io.openaev.config.MinioConfig;
+import io.openaev.config.S3Config;
+import io.openaev.database.model.Tenant;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+@DisplayName("MinioDriver")
+@WithMockUser
+class MinioDriverTest extends IntegrationTest {
+
+  @Autowired private MinioDriver minioDriver;
+  @Autowired private MinioConfig minioConfig;
+  @Autowired private S3Config s3Config;
+
+  private MinioClient minioClient;
+
+  @BeforeAll
+  void setUpAll() {
+    minioClient = minioDriver.getMinioClient();
+  }
+
+  @Nested
+  @DisplayName("getMinioClient")
+  class GetMinioClient {
+
+    @Test
+    @DisplayName("Given valid config, should return a non-null MinioClient")
+    void given_validConfig_should_returnNonNullClient() {
+      // -- ARRANGE --
+      // Config is provided by test application.properties (openaev-test-minio on port 11000)
+
+      // -- ACT --
+      MinioClient result = minioDriver.getMinioClient();
+
+      // -- ASSERT --
+      assertThat(result).isNotNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("minioClient bean")
+  class MinioClientBean {
+
+    @Test
+    @DisplayName("Given application started, should have created the bucket")
+    void given_applicationStarted_should_haveCreatedBucket() throws Exception {
+      // -- ARRANGE --
+      String bucket = minioConfig.getBucket();
+
+      // -- ACT --
+      boolean exists = minioClient.bucketExists(BucketExistsArgs.builder().bucket(bucket).build());
+
+      // -- ASSERT --
+      assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("Given root-level file in bucket, should migrate it to default tenant path")
+    void given_rootLevelFile_should_migrateToDefaultTenantPath() throws Exception {
+      // -- ARRANGE --
+      String bucket = minioConfig.getBucket();
+      String rootFileName = "test-migrate-" + UUID.randomUUID() + ".txt";
+      byte[] content = "test content".getBytes(StandardCharsets.UTF_8);
+
+      minioClient.putObject(
+          PutObjectArgs.builder().bucket(bucket).object(rootFileName).stream(
+                  new ByteArrayInputStream(content), content.length, -1)
+              .contentType("text/plain")
+              .build());
+
+      // -- ACT --
+      // Trigger the migration logic via minioClient() bean creation
+      MinioDriver freshDriver = new MinioDriver(minioConfig, s3Config, tenantRepository);
+      freshDriver.minioClient();
+
+      // -- ASSERT --
+      String expectedPath = Tenant.DEFAULT_TENANT_UUID + "/" + rootFileName;
+      StatObjectResponse stat =
+          minioClient.statObject(
+              StatObjectArgs.builder().bucket(bucket).object(expectedPath).build());
+      assertThat(stat).isNotNull();
+      assertThat(stat.size()).isEqualTo(content.length);
+
+      // Cleanup
+      minioClient.removeObject(
+          RemoveObjectArgs.builder().bucket(bucket).object(expectedPath).build());
+    }
+
+    @Test
+    @DisplayName("Given file already under tenant path, should not move it")
+    void given_fileUnderTenantPath_should_notMoveIt() throws Exception {
+      // -- ARRANGE --
+      String bucket = minioConfig.getBucket();
+      String tenantId = Tenant.DEFAULT_TENANT_UUID;
+      String fileName = tenantId + "/test-no-move-" + UUID.randomUUID() + ".txt";
+      byte[] content = "tenant content".getBytes(StandardCharsets.UTF_8);
+
+      minioClient.putObject(
+          PutObjectArgs.builder().bucket(bucket).object(fileName).stream(
+                  new ByteArrayInputStream(content), content.length, -1)
+              .contentType("text/plain")
+              .build());
+
+      // -- ACT --
+      MinioDriver freshDriver = new MinioDriver(minioConfig, s3Config, tenantRepository);
+      freshDriver.minioClient();
+
+      // -- ASSERT --
+      // File should still be at original path (not double-nested)
+      StatObjectResponse stat =
+          minioClient.statObject(StatObjectArgs.builder().bucket(bucket).object(fileName).build());
+      assertThat(stat).isNotNull();
+
+      // Verify no double-nested copy was created
+      String doubleNested = Tenant.DEFAULT_TENANT_UUID + "/" + fileName;
+      List<String> objects = new ArrayList<>();
+      for (Result<Item> r :
+          minioClient.listObjects(
+              ListObjectsArgs.builder().bucket(bucket).prefix(doubleNested).build())) {
+        objects.add(r.get().objectName());
+      }
+      assertThat(objects).isEmpty();
+
+      // Cleanup
+      minioClient.removeObject(RemoveObjectArgs.builder().bucket(bucket).object(fileName).build());
+    }
+  }
+}

--- a/openaev-api/src/test/resources/application.properties
+++ b/openaev-api/src/test/resources/application.properties
@@ -94,10 +94,12 @@ engine.url=http://localhost:9201
 
 # Minio Properties
 minio.endpoint=localhost
-minio.port=10000
+minio.port=11000
 minio.bucket=openaev
 minio.access-key=minioadmin
 minio.access-secret=minioadmin
+openaev.s3.use-aws-role=false
+openaev.s3.sts-endpoint=
 
 # Telemetry
 telemetry.oaev.endpoint=http://localhost

--- a/openaev-dev/docker-compose.yml
+++ b/openaev-dev/docker-compose.yml
@@ -112,6 +112,23 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  # Test MinIO object storage (S3-compatible)
+  openaev-test-minio:
+    container_name: openaev-test-minio
+    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
+    ports:
+      - "11000:9000"
+      - "11001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    restart: unless-stopped
   # Development OpenSearch (alternative to Elasticsearch, persistent storage)
   # NOTE: OpenSearch and Elasticsearch both use port 9200 by default internally.
   # OpenSearch is mapped to external port 9202 to avoid conflicts.

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -7,7 +7,8 @@ import io.openaev.config.MinioConfig;
 import io.openaev.config.S3Config;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.repository.TenantRepository;
-import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -72,8 +73,10 @@ public class MinioDriver {
   private void moveDefaultTenantFiles(MinioClient minioClient, String bucket) throws Exception {
     String defaultTenantPrefix = Tenant.DEFAULT_TENANT_UUID + "/";
 
-    List<String> tenants =
-        tenantRepository.findAll().stream().map(tenant -> tenant.getId() + "/").toList();
+    Set<String> tenants =
+        tenantRepository.findAll().stream()
+            .map(tenant -> tenant.getId() + "/")
+            .collect(Collectors.toSet());
 
     Iterable<Result<Item>> objects =
         minioClient.listObjects(ListObjectsArgs.builder().bucket(bucket).recursive(true).build());

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -6,6 +6,8 @@ import io.minio.messages.Item;
 import io.openaev.config.MinioConfig;
 import io.openaev.config.S3Config;
 import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.TenantRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +19,8 @@ import org.springframework.stereotype.Component;
 public class MinioDriver {
   private final MinioConfig minioConfig;
   private final S3Config s3Config;
+
+  private final TenantRepository tenantRepository;
 
   /** Create the Minio Client */
   public MinioClient getMinioClient() {
@@ -68,6 +72,9 @@ public class MinioDriver {
   private void moveDefaultTenantFiles(MinioClient minioClient, String bucket) throws Exception {
     String defaultTenantPrefix = Tenant.DEFAULT_TENANT_UUID + "/";
 
+    List<String> tenants =
+        tenantRepository.findAll().stream().map(tenant -> tenant.getId() + "/").toList();
+
     Iterable<Result<Item>> objects =
         minioClient.listObjects(ListObjectsArgs.builder().bucket(bucket).recursive(true).build());
 
@@ -76,7 +83,7 @@ public class MinioDriver {
       String objectName = item.objectName();
 
       // Skip files already under a tenant path
-      if (objectName.startsWith(defaultTenantPrefix)) {
+      if (tenants.stream().anyMatch(objectName::startsWith)) {
         continue;
       }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix on migration in minio moving all the tenants excepts the default one into the default one
*

### Testing Instructions

1. Create a tenant
2. Upload a document
3. Reboot the backend
4. Check that the path of the document hasn't changed and it's still available

### Related issues

* Closes [#109](https://github.com/OpenAEV-Platform/filigran-private/issues/109)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

