### PR TITLE
[backend] feat(chaining): add asset to injects based on scope allowlist/denylist (#4824)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -31,6 +31,7 @@ import io.openaev.rest.injector_contract.InjectorContractService;
 import io.openaev.rest.tag.TagService;
 import io.openaev.service.*;
 import io.openaev.service.chaining.ConditionService;
+import io.openaev.service.chaining.ScopeService;
 import io.openaev.service.chaining.StepService;
 import io.openaev.service.chaining.WorkflowStateService;
 import io.openaev.utils.ConditionUtils;
@@ -79,6 +80,7 @@ public class InjectExecutionStep implements ActionStep {
   private final AssetGroupService assetGroupService;
   private final ConditionService conditionService;
   private final WorkflowStateService workflowStateService;
+  private final ScopeService scopeService;
 
   private final InjectorContractRepository injectorContractRepository;
 
@@ -635,6 +637,8 @@ public class InjectExecutionStep implements ActionStep {
       // Modify payload arguments with inputs from step
       ObjectNode updatedContent = updateContentWithInputs(step, injectorContract.getContent());
       inject.setContent(updatedContent);
+
+      inject.setAssets(scopeService.getValidAssets(step.getWorkflow().getId()));
 
       return inject;
 

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
@@ -1,0 +1,159 @@
+package io.openaev.service.chaining;
+
+import io.openaev.database.model.*;
+import io.openaev.database.repository.WorkflowScopeRuleRepository;
+import io.openaev.service.AssetGroupService;
+import io.openaev.service.AssetService;
+import io.openaev.utils.IpAddressUtils;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ScopeService {
+
+  private final WorkflowScopeRuleRepository workflowScopeRuleRepository;
+  private final AssetService assetService;
+  private final AssetGroupService assetGroupService;
+
+  /**
+   * Returns the assets that are in scope for the given workflow and that are not denied by a value
+   * in the denylist
+   *
+   * @param workflowId
+   * @return
+   */
+  public List<Asset> getValidAssets(String workflowId) {
+
+    // get the workflow rules
+    List<WorkflowScopeRule> allRules = workflowScopeRuleRepository.findAllByWorkflowId(workflowId);
+    List<WorkflowScopeRule> allowlistRules =
+        allRules.stream()
+            .filter(rule -> ScopeRuleSelectedMode.ALLOWLIST.equals(rule.getSelectedMode()))
+            .toList();
+    List<WorkflowScopeRule> denylistRules =
+        allRules.stream()
+            .filter(rule -> ScopeRuleSelectedMode.DENYLIST.equals(rule.getSelectedMode()))
+            .toList();
+
+    // build the complete allowed asset set --
+    Set<Asset> allowedByAssetId = getAssetsAllowedByAssetId(allowlistRules);
+    Set<Asset> allowedByAssetGroup = getAssetsAllowedByAssetGroup(allowlistRules);
+    Set<Asset> completeAllowedAssetList = new LinkedHashSet<>();
+    completeAllowedAssetList.addAll(allowedByAssetId);
+    completeAllowedAssetList.addAll(allowedByAssetGroup);
+
+    // apply the denylist
+    if (completeAllowedAssetList.isEmpty() || denylistRules.isEmpty()) {
+      return List.copyOf(completeAllowedAssetList);
+    }
+
+    //  remove any asset matched by a denylist rule  and return
+    Set<String> deniedAssetIds = getDeniedAssetIds(completeAllowedAssetList, denylistRules);
+    return completeAllowedAssetList.stream()
+        .filter(asset -> !deniedAssetIds.contains(asset.getId()))
+        .toList();
+  }
+
+  private Set<Asset> getAssetsAllowedByAssetId(List<WorkflowScopeRule> allowlistRules) {
+    List<String> assetIds =
+        allowlistRules.stream()
+            .filter(rule -> ScopeRuleValueType.ASSET_ID.equals(rule.getValueType()))
+            .map(WorkflowScopeRule::getRuleValue)
+            .toList();
+
+    return assetIds.isEmpty() ? Set.of() : new LinkedHashSet<>(assetService.assets(assetIds));
+  }
+
+  private Set<Asset> getAssetsAllowedByAssetGroup(List<WorkflowScopeRule> allowlistRules) {
+    return allowlistRules.stream()
+        .filter(rule -> ScopeRuleValueType.ASSET_GROUP_ID.equals(rule.getValueType()))
+        .flatMap(rule -> assetGroupService.assetsFromAssetGroup(rule.getRuleValue()).stream())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private Set<String> getDeniedAssetIds(
+      Set<Asset> candidates, List<WorkflowScopeRule> denylistRules) {
+    Set<String> deniedAssetIds = new HashSet<>();
+    for (WorkflowScopeRule rule : denylistRules) {
+      switch (rule.getValueType()) {
+        case ASSET_ID ->
+            candidates.stream()
+                .filter(asset -> asset.getId().equals(rule.getRuleValue()))
+                .map(Asset::getId)
+                .forEach(deniedAssetIds::add);
+
+        case ASSET_GROUP_ID -> {
+          Set<String> groupAssetIds =
+              assetGroupService.assetsFromAssetGroup(rule.getRuleValue()).stream()
+                  .map(Asset::getId)
+                  .collect(Collectors.toSet());
+          candidates.stream()
+              .filter(asset -> groupAssetIds.contains(asset.getId()))
+              .map(Asset::getId)
+              .forEach(deniedAssetIds::add);
+        }
+
+        case IP ->
+            candidates.stream()
+                .filter(asset -> asset instanceof Endpoint)
+                .map(asset -> (Endpoint) asset)
+                .filter(endpoint -> endpointMatchesIp(endpoint, rule.getRuleValue()))
+                .map(Asset::getId)
+                .forEach(deniedAssetIds::add);
+
+        case IP_SUBNET ->
+            candidates.stream()
+                .filter(asset -> asset instanceof Endpoint)
+                .map(asset -> (Endpoint) asset)
+                .filter(endpoint -> endpointMatchesSubnet(endpoint, rule.getRuleValue()))
+                .map(Asset::getId)
+                .forEach(deniedAssetIds::add);
+
+        case DOMAIN ->
+            candidates.stream()
+                .filter(asset -> asset instanceof Endpoint)
+                .map(asset -> (Endpoint) asset)
+                .filter(endpoint -> rule.getRuleValue().equalsIgnoreCase(endpoint.getHostname()))
+                .map(Asset::getId)
+                .forEach(deniedAssetIds::add);
+      }
+    }
+    return deniedAssetIds;
+  }
+
+  /** Returns {@code true} if {@code targetIp} matches any of the endpoint's IPs or its seen IP. */
+  private boolean endpointMatchesIp(Endpoint endpoint, String targetIp) {
+    if (targetIp == null) {
+      return false;
+    }
+    if (endpoint.getIps() != null) {
+      for (String ip : endpoint.getIps()) {
+        if (targetIp.equals(ip)) {
+          return true;
+        }
+      }
+    }
+    return targetIp.equals(endpoint.getSeenIp());
+  }
+
+  /**
+   * Returns {@code true} if any of the endpoint's IPs or its seen IP falls within {@code subnet}.
+   */
+  private boolean endpointMatchesSubnet(Endpoint endpoint, String subnet) {
+    if (subnet == null) {
+      return false;
+    }
+    if (endpoint.getIps() != null) {
+      for (String ip : endpoint.getIps()) {
+        if (IpAddressUtils.isIpInSubnet(ip, subnet)) {
+          return true;
+        }
+      }
+    }
+    return endpoint.getSeenIp() != null
+        && IpAddressUtils.isIpInSubnet(endpoint.getSeenIp(), subnet);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
@@ -111,14 +111,6 @@ public class ScopeService {
                 .filter(endpoint -> endpointMatchesSubnet(endpoint, rule.getRuleValue()))
                 .map(Asset::getId)
                 .forEach(deniedAssetIds::add);
-
-        case DOMAIN ->
-            candidates.stream()
-                .filter(asset -> asset instanceof Endpoint)
-                .map(asset -> (Endpoint) asset)
-                .filter(endpoint -> rule.getRuleValue().equalsIgnoreCase(endpoint.getHostname()))
-                .map(Asset::getId)
-                .forEach(deniedAssetIds::add);
       }
     }
     return deniedAssetIds;

--- a/openaev-api/src/main/java/io/openaev/utils/IpAddressUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/IpAddressUtils.java
@@ -5,6 +5,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Utility class providing IP address validation helpers for the OpenAEV platform.
@@ -14,6 +15,7 @@ import java.util.regex.Pattern;
  *
  * <p>This is a utility class and cannot be instantiated.
  */
+@Slf4j
 public class IpAddressUtils {
 
   private IpAddressUtils() {}
@@ -108,6 +110,49 @@ public class IpAddressUtils {
           && prefixLength <= 128
           && InetAddress.getByName(addressPart) instanceof Inet6Address;
     } catch (NumberFormatException | UnknownHostException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns {@code true} if {@code ip} falls within the CIDR {@code subnet}.
+   *
+   * <p>Supports both IPv4 (e.g. {@code 192.168.1.0/24}) and IPv6 (e.g. {@code 2001:db8::/32}).
+   * Returns {@code false} when the address families differ or parsing fails.
+   *
+   * @param ip the IP address to test
+   * @param cidr the CIDR subnet to test against
+   */
+  public static boolean isIpInSubnet(String ip, String cidr) {
+    try {
+      int slashIndex = cidr.lastIndexOf('/');
+      String subnetAddress = cidr.substring(0, slashIndex);
+      int prefixLength = Integer.parseInt(cidr.substring(slashIndex + 1));
+
+      byte[] ipBytes = InetAddress.getByName(ip).getAddress();
+      byte[] subnetBytes = InetAddress.getByName(subnetAddress).getAddress();
+
+      if (ipBytes.length != subnetBytes.length) {
+        return false; // IPv4 vs IPv6 mismatch
+      }
+
+      int fullBytes = prefixLength / 8;
+      int remainingBits = prefixLength % 8;
+
+      for (int i = 0; i < fullBytes; i++) {
+        if (ipBytes[i] != subnetBytes[i]) {
+          return false;
+        }
+      }
+      if (remainingBits > 0) {
+        int mask = 0xFF & (0xFF << (8 - remainingBits));
+        if ((ipBytes[fullBytes] & mask) != (subnetBytes[fullBytes] & mask)) {
+          return false;
+        }
+      }
+      return true;
+    } catch (Exception e) {
+      log.warn("Failed to evaluate IP {} against subnet {}: {}", ip, cidr, e.getMessage());
       return false;
     }
   }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
@@ -1,0 +1,219 @@
+package io.openaev.service.chaining;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.*;
+import io.openaev.database.repository.WorkflowScopeRuleRepository;
+import io.openaev.service.AssetGroupService;
+import io.openaev.service.AssetService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScopeService - getValidAssets")
+class ScopeServiceTest {
+
+  private static final String WORKFLOW_ID = "workflow-1";
+
+  @Mock private WorkflowScopeRuleRepository workflowScopeRuleRepository;
+  @Mock private AssetService assetService;
+  @Mock private AssetGroupService assetGroupService;
+
+  @InjectMocks private ScopeService scopeService;
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private Endpoint endpointWithSeenIp(String id, String name, String seenIp) {
+    Endpoint endpoint = new Endpoint();
+    endpoint.setId(id);
+    endpoint.setName(name);
+    endpoint.setSeenIp(seenIp);
+    endpoint.setPlatform(Endpoint.PLATFORM_TYPE.Linux);
+    endpoint.setArch(Endpoint.PLATFORM_ARCH.x86_64);
+    return endpoint;
+  }
+
+  private Endpoint endpointWithIps(String id, String name, String... ips) {
+    Endpoint endpoint = new Endpoint();
+    endpoint.setId(id);
+    endpoint.setName(name);
+    endpoint.setIps(ips);
+    endpoint.setPlatform(Endpoint.PLATFORM_TYPE.Linux);
+    endpoint.setArch(Endpoint.PLATFORM_ARCH.x86_64);
+    return endpoint;
+  }
+
+  private WorkflowScopeRule allowlistRule(ScopeRuleValueType type, String value) {
+    return WorkflowScopeRule.builder()
+        .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+        .valueType(type)
+        .ruleValue(value)
+        .build();
+  }
+
+  private WorkflowScopeRule denylistRule(ScopeRuleValueType type, String value) {
+    return WorkflowScopeRule.builder()
+        .selectedMode(ScopeRuleSelectedMode.DENYLIST)
+        .valueType(type)
+        .ruleValue(value)
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("One asset in allowlist and no denylist rules — returns the asset")
+  void givenOneAssetInAllowlist_whenNoDenylistRules_thenReturnsAsset() {
+    Endpoint endpoint = endpointWithSeenIp("asset-1", "host-1", "10.0.0.1");
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(List.of(allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1")));
+    when(assetService.assets(List.of("asset-1"))).thenReturn(List.of(endpoint));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).containsExactly(endpoint);
+  }
+
+  @Test
+  @DisplayName("No allowlist rules but several denylist values — returns empty list")
+  void givenNoAllowlistRules_whenSeveralDenylistValues_thenReturnsEmpty() {
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                denylistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                denylistRule(ScopeRuleValueType.IP, "10.0.0.1"),
+                denylistRule(ScopeRuleValueType.DOMAIN, "host.example.com")));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Asset in allowlist, several non-matching IPs in denylist — returns the asset")
+  void givenOneAssetInAllowlist_whenDenylistIpsDoNotMatch_thenReturnsAsset() {
+    Endpoint endpoint = endpointWithSeenIp("asset-1", "host-1", "10.0.0.1");
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                denylistRule(ScopeRuleValueType.IP, "192.168.1.1"),
+                denylistRule(ScopeRuleValueType.IP, "172.16.0.1")));
+    when(assetService.assets(List.of("asset-1"))).thenReturn(List.of(endpoint));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).containsExactly(endpoint);
+  }
+
+  @Test
+  @DisplayName(
+      "Several assets in allowlist, denylist IP matches one asset's seenIp — that asset is filtered out")
+  void givenSeveralAssetsInAllowlist_whenDenylistIpMatchesSeenIp_thenMatchingAssetIsFilteredOut() {
+    Endpoint targeted = endpointWithSeenIp("asset-1", "host-1", "10.0.0.1");
+    Endpoint other1 = endpointWithSeenIp("asset-2", "host-2", "10.0.0.2");
+    Endpoint other2 = endpointWithSeenIp("asset-3", "host-3", "10.0.0.3");
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-2"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-3"),
+                denylistRule(ScopeRuleValueType.IP, "10.0.0.1")));
+    when(assetService.assets(List.of("asset-1", "asset-2", "asset-3")))
+        .thenReturn(List.of(targeted, other1, other2));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).containsExactlyInAnyOrder(other1, other2);
+    assertThat(result).doesNotContain(targeted);
+  }
+
+  @Test
+  @DisplayName(
+      "Several assets in allowlist, denylist IP matches one of an asset's IPs array — that asset is filtered out")
+  void
+      givenSeveralAssetsInAllowlist_whenDenylistIpMatchesOneOfIpsArray_thenMatchingAssetIsFilteredOut() {
+    Endpoint targeted = endpointWithIps("asset-1", "host-1", "10.0.0.1", "10.0.0.99");
+    Endpoint other1 = endpointWithIps("asset-2", "host-2", "10.0.0.2");
+    Endpoint other2 = endpointWithIps("asset-3", "host-3", "10.0.0.3");
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-2"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-3"),
+                denylistRule(ScopeRuleValueType.IP, "10.0.0.99")));
+    when(assetService.assets(List.of("asset-1", "asset-2", "asset-3")))
+        .thenReturn(List.of(targeted, other1, other2));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).containsExactlyInAnyOrder(other1, other2);
+    assertThat(result).doesNotContain(targeted);
+  }
+
+  @Test
+  @DisplayName(
+      "Several assets in allowlist, denylist subnet covers one asset's seenIp — that asset is filtered out")
+  void
+      givenSeveralAssetsInAllowlist_whenDenylistSubnetMatchesSeenIp_thenMatchingAssetIsFilteredOut() {
+    Endpoint targeted = endpointWithSeenIp("asset-1", "host-1", "192.168.1.50");
+    Endpoint other1 = endpointWithSeenIp("asset-2", "host-2", "10.0.0.1");
+    Endpoint other2 = endpointWithSeenIp("asset-3", "host-3", "10.0.0.2");
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-2"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-3"),
+                denylistRule(ScopeRuleValueType.IP_SUBNET, "192.168.1.0/24")));
+    when(assetService.assets(List.of("asset-1", "asset-2", "asset-3")))
+        .thenReturn(List.of(targeted, other1, other2));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).containsExactlyInAnyOrder(other1, other2);
+    assertThat(result).doesNotContain(targeted);
+  }
+
+  @Test
+  @DisplayName(
+      "Several assets in allowlist, denylist subnet covers one of an asset's IPs array — that asset is filtered out")
+  void
+      givenSeveralAssetsInAllowlist_whenDenylistSubnetMatchesOneOfIpsArray_thenMatchingAssetIsFilteredOut() {
+    Endpoint targeted = endpointWithIps("asset-1", "host-1", "10.0.0.5", "192.168.1.10");
+    Endpoint other1 = endpointWithIps("asset-2", "host-2", "10.0.0.1");
+    Endpoint other2 = endpointWithIps("asset-3", "host-3", "10.0.0.2");
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-2"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-3"),
+                denylistRule(ScopeRuleValueType.IP_SUBNET, "192.168.1.0/24")));
+    when(assetService.assets(List.of("asset-1", "asset-2", "asset-3")))
+        .thenReturn(List.of(targeted, other1, other2));
+
+    List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
+
+    assertThat(result).containsExactlyInAnyOrder(other1, other2);
+    assertThat(result).doesNotContain(targeted);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
@@ -92,8 +92,7 @@ class ScopeServiceTest {
         .thenReturn(
             List.of(
                 denylistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
-                denylistRule(ScopeRuleValueType.IP, "10.0.0.1"),
-                denylistRule(ScopeRuleValueType.DOMAIN, "host.example.com")));
+                denylistRule(ScopeRuleValueType.IP, "10.0.0.1")));
 
     List<Asset> result = scopeService.getValidAssets(WORKFLOW_ID);
 


### PR DESCRIPTION

### Proposed changes
 
* In the chaining adding assets to creaqted inject based on allowlist/denylist


### Testing Instructions

1. Create a chained simulation and add assets in scope, play with the denylist by adding ip/ip subnet 
2. Launch the simulation and make sure they are executed on the right targets

### Related issues

* #4824 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [NA] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [NA] For bug fix -> I implemented a test that covers the bug
