### PR TITLE
[frontend] feat(inject): fix multi target chip (#111)

### DIFF
--- a/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
+++ b/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
@@ -35,7 +35,7 @@ const InjectIcon: FunctionComponent<Props> = ({
 
   const iconSelector = (type: string, isPayload: boolean, variant: string, fontSize: string, done: boolean, disabled: boolean) => {
     const style = {
-      marginTop: variant === 'list' ? theme.spacing(1) : 0,
+      marginTop: variant === 'list' ? theme.spacing(0.5) : 0,
       padding: variant === 'timeline' ? 1 : 0,
       width: fontSize === 'small' || variant === 'inline' ? 20 : 24,
       height: fontSize === 'small' || variant === 'inline' ? 20 : 24,

--- a/openaev-front/src/admin/components/threat_arsenal/ThreatArsenal.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/ThreatArsenal.tsx
@@ -316,13 +316,13 @@ const ThreatArsenal = () => {
 
                       <ListItemIcon style={{ minWidth: 56 }}>
                         <InjectIcon
-                          variant="list"
                           type={
                             action.action_payload != null
                               ? action.action_payload.payload_collector_type ?? action.action_payload.payload_type
                               : action.action_injector_type
                           }
                           isPayload={action.action_payload != null}
+                          variant="list"
                         />
                       </ListItemIcon>
 

--- a/openaev-front/src/components/ItemTargets.tsx
+++ b/openaev-front/src/components/ItemTargets.tsx
@@ -8,7 +8,7 @@ import { type TargetSimple } from '../utils/api-types';
 import { getLabelOfRemainingItems, getRemainingItemsCount, getVisibleItems, truncate } from '../utils/String';
 
 const useStyles = makeStyles()(() => ({
-  inline: { display: 'inline-block' },
+  inline: { display: 'flex' },
   target: {
     fontSize: 12,
     height: 20,

--- a/openaev-front/src/components/ItemTargets.tsx
+++ b/openaev-front/src/components/ItemTargets.tsx
@@ -35,8 +35,8 @@ const ItemTargets: FunctionComponent<Props> = ({
   }
 
   // Extract the first two targets as visible chips
-  const visibleTargets = getVisibleItems(targets, 2);
-  const tooltipLabel = getLabelOfRemainingItems(targets, 2, 'target_name');
+  const visibleTargets = getVisibleItems(targets, 1);
+  const tooltipLabel = getLabelOfRemainingItems(targets, 1, 'target_name');
   const remainingTargetsCount = getRemainingItemsCount(targets, visibleTargets);
 
   if (!targets || targets.length === 0) {

--- a/openaev-front/src/components/common/queryable/style/style.ts
+++ b/openaev-front/src/components/common/queryable/style/style.ts
@@ -10,6 +10,7 @@ const useBodyItemsStyles: () => {
   return ({
     bodyItems: {
       display: 'flex',
+      alignItems: 'center',
       flexWrap: 'nowrap',
       maxWidth: '100%',
     },


### PR DESCRIPTION
fix chips display to target column

### Testing Instructions

1. Go to Atomic Testing, add an inject with multiple target “asset groups”; only the first chip should appear, followed by a “+N” chip.


### Related issues

* Closes [#111](https://github.com/orgs/OpenAEV-Platform/projects/2/views/49?pane=issue&itemId=184852329&issue=OpenAEV-Platform%7Cfiligran-private%7C111)
