### PR TITLE
[backend] fix(threat-arsenal): payload creation take too long (#100)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -109,12 +109,8 @@ public class PayloadService {
         injectorContractRepository.save(injectorContractToUpdate);
 
     // Link contract to all payload-supporting injectors via the owning side
-    for (Injector injector : injectors) {
-      if (!injector.getContracts().contains(injectorContractSaved)) {
-        injector.getContracts().add(injectorContractSaved);
-        injectorRepository.save(injector);
-      }
-    }
+    injectorContractRepository.addContractToInjectorsWithoutIt(
+        true, payload.getTenant().getId(), injectorContractSaved.getId());
 
     return injectorContractSaved;
   }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -109,8 +109,9 @@ public class PayloadService {
         injectorContractRepository.save(injectorContractToUpdate);
 
     // Link contract to all payload-supporting injectors via the owning side
+    Set<String> injectorIds = injectors.stream().map(Injector::getId).collect(Collectors.toSet());
     injectorContractRepository.addContractToPayloadsInjectors(
-        payload.getTenant().getId(), injectorContractSaved.getCompositeId().getId());
+        injectorIds, injectorContractSaved.getCompositeId().getId());
 
     return injectorContractSaved;
   }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -109,8 +109,8 @@ public class PayloadService {
         injectorContractRepository.save(injectorContractToUpdate);
 
     // Link contract to all payload-supporting injectors via the owning side
-    injectorContractRepository.addContractToInjectorsWithoutIt(
-        true, payload.getTenant().getId(), injectorContractSaved.getId());
+    injectorContractRepository.addContractToPayloadsInjectors(
+        payload.getTenant().getId(), injectorContractSaved.getCompositeId().getId());
 
     return injectorContractSaved;
   }

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiImporterTest.java
@@ -42,6 +42,8 @@ import io.openaev.utils.fixtures.composers.DomainComposer;
 import io.openaev.utils.fixtures.composers.InjectorContractComposer;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.util.*;
+
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -290,11 +292,10 @@ class ThreatArsenalApiImporterTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("Import payload with empty array fields")
-    void importPayloadWithEmptyArrayFields() throws Exception {
+    @DisplayName("Import payload with optional empty array fields")
+    void importPayloadWithOptionalEmptyArrayFields() throws Exception {
       // -- PREPARE --
       Map<String, Object> attributes = buildDefaultPayloadAttributes();
-      attributes.put("payload_platforms", new String[] {}); // empty array
       attributes.put("payload_arguments", new String[] {}); // empty array
       attributes.put("payload_prerequisites", new String[] {}); // empty array
 
@@ -310,9 +311,27 @@ class ThreatArsenalApiImporterTest extends IntegrationTest {
       // -- ASSERT --
       assertNotNull(response);
       JsonNode json = objectMapper.readTree(response);
-      assertEquals(0, json.at("/data/attributes/payload_platforms").size());
       assertEquals(0, json.at("/data/attributes/payload_arguments").size());
       assertEquals(0, json.at("/data/attributes/payload_prerequisites").size());
+    }
+
+    @Test
+    @DisplayName("Import payload with mandatory empty array fields")
+    void importPayloadWithMandatoryEmptyArrayFields() throws Exception {
+      // -- PREPARE --
+      Map<String, Object> attributes = buildDefaultPayloadAttributes();
+      attributes.put("payload_platforms", new String[] {}); // empty array
+
+      JsonApiDocument<ResourceObject> document =
+              new JsonApiDocument<>(
+                      new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
+
+      MockMultipartFile zipFile = buildZipFile(document);
+
+      // -- EXECUTE --
+      assertThrows(ServletException.class,
+        () -> mockMvc.perform(multipart(THREAT_ARSENAL_URL + "/import").file(zipFile).with(csrf()))
+      );
     }
 
     @Test
@@ -469,14 +488,9 @@ class ThreatArsenalApiImporterTest extends IntegrationTest {
       MockMultipartFile zipFile = buildZipFile(document);
 
       // -- EXECUTE --
-      String response = performImport(zipFile);
-
-      // -- ASSERT --
-      assertNotNull(response);
-      JsonNode json = objectMapper.readTree(response);
-      assertEquals(0, json.at("/data/attributes/payload_platforms").size());
-      assertEquals(0, json.at("/data/attributes/payload_arguments").size());
-      assertEquals(0, json.at("/data/attributes/payload_prerequisites").size());
+      assertThrows(ServletException.class,
+        () -> mockMvc.perform(multipart(THREAT_ARSENAL_URL + "/import").file(zipFile).with(csrf()))
+      );
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiImporterTest.java
@@ -41,9 +41,8 @@ import io.openaev.utils.fixtures.ThreatArsenalInputFixture;
 import io.openaev.utils.fixtures.composers.DomainComposer;
 import io.openaev.utils.fixtures.composers.InjectorContractComposer;
 import io.openaev.utils.mockUser.WithMockUser;
-import java.util.*;
-
 import jakarta.servlet.ServletException;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -323,15 +322,17 @@ class ThreatArsenalApiImporterTest extends IntegrationTest {
       attributes.put("payload_platforms", new String[] {}); // empty array
 
       JsonApiDocument<ResourceObject> document =
-              new JsonApiDocument<>(
-                      new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
+          new JsonApiDocument<>(
+              new ResourceObject(null, "command", attributes, emptyMap()), emptyList());
 
       MockMultipartFile zipFile = buildZipFile(document);
 
       // -- EXECUTE --
-      assertThrows(ServletException.class,
-        () -> mockMvc.perform(multipart(THREAT_ARSENAL_URL + "/import").file(zipFile).with(csrf()))
-      );
+      assertThrows(
+          ServletException.class,
+          () ->
+              mockMvc.perform(
+                  multipart(THREAT_ARSENAL_URL + "/import").file(zipFile).with(csrf())));
     }
 
     @Test
@@ -488,9 +489,11 @@ class ThreatArsenalApiImporterTest extends IntegrationTest {
       MockMultipartFile zipFile = buildZipFile(document);
 
       // -- EXECUTE --
-      assertThrows(ServletException.class,
-        () -> mockMvc.perform(multipart(THREAT_ARSENAL_URL + "/import").file(zipFile).with(csrf()))
-      );
+      assertThrows(
+          ServletException.class,
+          () ->
+              mockMvc.perform(
+                  multipart(THREAT_ARSENAL_URL + "/import").file(zipFile).with(csrf())));
     }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -175,7 +175,7 @@ public interface InjectorContractRepository
    * and matching the {@code payloads} flag, a new row is inserted only if no association with the
    * given contract already exists (idempotent by design).
    *
-   * @param tenantId the identifier of the tenant whose injectors should be considered.
+   * @param injectorIds the identifier of the injectors who should be considered.
    * @param contractId the identifier of the injector contract to associate with the matching
    *     injectors.
    */
@@ -183,18 +183,17 @@ public interface InjectorContractRepository
   @Query(
       value =
           """
-    INSERT INTO injectors_injector_contracts (injector_id, injector_contract_id, tenant_id)
-    SELECT i.injector_id, :contractId, i.tenant_id
-    FROM injectors i
-    WHERE i.injector_payloads = TRUE
-    AND i.tenant_id = :tenantId
-    AND NOT EXISTS (
-        SELECT 1 FROM injectors_injector_contracts ic
-        WHERE ic.injector_id = i.injector_id
-        AND ic.injector_contract_id = :contractId
-    )
-    """,
+          INSERT INTO injectors_injector_contracts (injector_id, injector_contract_id, tenant_id)
+          SELECT i.injector_id, :contractId, i.tenant_id
+          FROM injectors i
+          WHERE i.injector_id IN (:injectorIds)
+          AND NOT EXISTS (
+            SELECT 1 FROM injectors_injector_contracts ic
+            WHERE ic.injector_id = i.injector_id
+            AND ic.injector_contract_id = :contractId
+          )
+        """,
       nativeQuery = true)
   void addContractToPayloadsInjectors(
-      @Param("tenantId") String tenantId, @Param("contractId") String contractId);
+      @Param("injectorIds") Set<String> injectorIds, @Param("contractId") String contractId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -175,8 +175,6 @@ public interface InjectorContractRepository
    * and matching the {@code payloads} flag, a new row is inserted only if no association with the
    * given contract already exists (idempotent by design).
    *
-   * @param payloads {@code true} to target injectors flagged as payload-based, {@code false} for
-   *     non-payload injectors.
    * @param tenantId the identifier of the tenant whose injectors should be considered.
    * @param contractId the identifier of the injector contract to associate with the matching
    *     injectors.
@@ -188,7 +186,7 @@ public interface InjectorContractRepository
     INSERT INTO injectors_injector_contracts (injector_id, injector_contract_id, tenant_id)
     SELECT i.injector_id, :contractId, i.tenant_id
     FROM injectors i
-    WHERE i.injector_payloads = :payloads
+    WHERE i.injector_payloads = TRUE
     AND i.tenant_id = :tenantId
     AND NOT EXISTS (
         SELECT 1 FROM injectors_injector_contracts ic
@@ -197,8 +195,6 @@ public interface InjectorContractRepository
     )
     """,
       nativeQuery = true)
-  void addContractToInjectorsWithoutIt(
-      @Param("payloads") Boolean payloads,
-      @Param("tenantId") String tenantId,
-      @Param("contractId") String contractId);
+  void addContractToPayloadsInjectors(
+      @Param("tenantId") String tenantId, @Param("contractId") String contractId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -166,6 +166,21 @@ public interface InjectorContractRepository
       @Param("externalIds") Set<String> externalIds,
       @Param("contractsPerVulnerability") Integer contractsPerVulnerability);
 
+  /**
+   * Associates an injector contract to all injectors matching the given criteria, skipping those
+   * that already have the contract assigned.
+   *
+   * <p>This method executes a native SQL {@code INSERT} that targets the {@code
+   * injectors_injector_contracts} join table. For each injector belonging to the specified tenant
+   * and matching the {@code payloads} flag, a new row is inserted only if no association with the
+   * given contract already exists (idempotent by design).
+   *
+   * @param payloads {@code true} to target injectors flagged as payload-based, {@code false} for
+   *     non-payload injectors.
+   * @param tenantId the identifier of the tenant whose injectors should be considered.
+   * @param contractId the identifier of the injector contract to associate with the matching
+   *     injectors.
+   */
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(
       value =

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -165,4 +165,25 @@ public interface InjectorContractRepository
   Set<InjectorContract> findInjectorContractsByVulnerabilityIdIn(
       @Param("externalIds") Set<String> externalIds,
       @Param("contractsPerVulnerability") Integer contractsPerVulnerability);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      value =
+          """
+    INSERT INTO injectors_injector_contracts (injector_id, injector_contract_id, tenant_id)
+    SELECT i.injector_id, :contractId, i.tenant_id
+    FROM injectors i
+    WHERE i.injector_payloads = :payloads
+    AND i.tenant_id = :tenantId
+    AND NOT EXISTS (
+        SELECT 1 FROM injectors_injector_contracts ic
+        WHERE ic.injector_id = i.injector_id
+        AND ic.injector_contract_id = :contractId
+    )
+    """,
+      nativeQuery = true)
+  void addContractToInjectorsWithoutIt(
+      @Param("payloads") Boolean payloads,
+      @Param("tenantId") String tenantId,
+      @Param("contractId") String contractId);
 }


### PR DESCRIPTION
### Proposed changes

* Review the process to implement a basic data creation process to database instead of the java runtime process, to avoid time consuming and performance issues
* Payload creation should take less than 3 seconds, in local, from 5seconds to process to 260ms

### Testing Instructions

Everything should work as usual, only performance have been fixed.

1. Create a payload from the Threat Arsenal page
2. API should create the payload in less than 3seconds
3. Verify that your payload is created into injectors with payload value at true, on your tenant
