### PR TITLE
[backend/frontend] fix(domains): make security domains widget display results (#108)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/simulation/SimulationApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/simulation/SimulationApi.java
@@ -11,7 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping(SimulationApi.SIMULATION_URI)
+@RequestMapping({SimulationApi.SIMULATION_URI, SimulationApi.TENANT_SIMULATION_URI})
 @RestController
 @RequiredArgsConstructor
 public class SimulationApi extends RestBehavior {
@@ -23,13 +23,13 @@ public class SimulationApi extends RestBehavior {
 
   // -- OPTION --
 
-  @GetMapping({"/options", TENANT_SIMULATION_URI + "/options"})
+  @GetMapping("/options")
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.SIMULATION)
   public List<Option> optionsByName(@RequestParam(required = false) final String searchText) {
     return this.simulationService.findAllAsOptions(searchText);
   }
 
-  @PostMapping({"/options", TENANT_SIMULATION_URI + "/options"})
+  @PostMapping("/options")
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.SIMULATION)
   public List<Option> optionsById(@RequestBody final List<String> ids) {
     return this.simulationService.findAllByIdsAsOptions(ids);

--- a/openaev-front/src/admin/components/common/entreprise_edition/EnterpriseEditionAgreementDialog.tsx
+++ b/openaev-front/src/admin/components/common/entreprise_edition/EnterpriseEditionAgreementDialog.tsx
@@ -79,28 +79,28 @@ const EnterpriseEditionAgreementDialog = () => {
           <p>
             {t('To obtain a license, please {contact}', {
               contact: (
-                <Link
+                <a
                   href="https://filigran.io/contact/"
                   target="_blank"
                   style={{ textDecoration: 'none' }}
                   rel="noreferrer"
                 >
                   {t('reach out to the Filigran team')}
-                </Link>
+                </a>
               ),
             })}
           </p>
           <p>
             {t('You just need to try ? Get right now {url}.', {
               url: (
-                <Link
+                <a
                   href="https://filigran.io/enterprise-editions-trial/"
                   target="_blank"
                   style={{ textDecoration: 'none' }}
                   rel="noreferrer"
                 >
                   {t('your trial license online')}
-                </Link>
+                </a>
               ),
             })}
           </p>

--- a/openaev-front/src/admin/components/common/entreprise_edition/EnterpriseEditionAgreementDialog.tsx
+++ b/openaev-front/src/admin/components/common/entreprise_edition/EnterpriseEditionAgreementDialog.tsx
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import { Alert, Button, Link, TextField } from '@mui/material';
+import { Alert, Button, TextField } from '@mui/material';
 import { useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
 

--- a/openaev-model/src/main/java/io/openaev/driver/OpenSearchDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/OpenSearchDriver.java
@@ -263,6 +263,7 @@ public class OpenSearchDriver {
     template.meta("version", JsonData.of(version));
     template.indexPatterns(indexName + "*");
     template.composedOf(coreSettings);
+    //mappings.put("base_tenant_side", new Property.Builder().keyword(new KeywordProperty.Builder().build()).build());
     TypeMapping indexMapping =
         new TypeMapping.Builder()
             .dynamic(DynamicMapping.Strict)

--- a/openaev-model/src/main/java/io/openaev/driver/OpenSearchDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/OpenSearchDriver.java
@@ -263,7 +263,6 @@ public class OpenSearchDriver {
     template.meta("version", JsonData.of(version));
     template.indexPatterns(indexName + "*");
     template.composedOf(coreSettings);
-    //mappings.put("base_tenant_side", new Property.Builder().keyword(new KeywordProperty.Builder().build()).build());
     TypeMapping indexMapping =
         new TypeMapping.Builder()
             .dynamic(DynamicMapping.Strict)

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -308,6 +308,7 @@ public class ElasticService implements EngineService {
     filter.setKey("base_id");
     filter.setOperator(Filters.FilterOperator.eq);
     filter.setValues(ids);
+    filter.setMode(Filters.FilterMode.or);
     filterGroup.setFilters(List.of(filter));
     Query query = buildQuery(user, null, filterGroup, new HashMap<>(), new HashMap<>());
     try {

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -358,7 +358,6 @@ public class OpenSearchService implements EngineService {
     Query tenantFilter =
         BoolQuery.of(b -> b.should(matchesTenant, noTenantField).minimumShouldMatch("1")).toQuery();
     mainQuery.filter(tenantFilter);
-
     return mainQuery.must(mainMust).build().toQuery();
   }
 
@@ -375,6 +374,7 @@ public class OpenSearchService implements EngineService {
     filter.setKey("base_id");
     filter.setOperator(Filters.FilterOperator.eq);
     filter.setValues(ids);
+    filter.setMode(Filters.FilterMode.or);
     filterGroup.setFilters(List.of(filter));
     Query query = buildQuery(user, null, filterGroup, new HashMap<>(), new HashMap<>());
     try {
@@ -382,6 +382,8 @@ public class OpenSearchService implements EngineService {
           openSearchClient.search(
               b -> b.index(engineConfig.getIndexPrefix() + "*").size(ids.size()).query(query),
               EsBase.class);
+      log.debug("resolveIdsRepresentative - total hits: {}",
+          response.hits().total() != null ? response.hits().total().value() : "null");
       List<Hit<EsBase>> hits = response.hits().hits();
       return hits.stream()
           .map(Hit::source)

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -382,7 +382,8 @@ public class OpenSearchService implements EngineService {
           openSearchClient.search(
               b -> b.index(engineConfig.getIndexPrefix() + "*").size(ids.size()).query(query),
               EsBase.class);
-      log.debug("resolveIdsRepresentative - total hits: {}",
+      log.debug(
+          "resolveIdsRepresentative - total hits: {}",
           response.hits().total() != null ? response.hits().total().value() : "null");
       List<Hit<EsBase>> hits = response.hits().hits();
       return hits.stream()

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -382,9 +382,6 @@ public class OpenSearchService implements EngineService {
           openSearchClient.search(
               b -> b.index(engineConfig.getIndexPrefix() + "*").size(ids.size()).query(query),
               EsBase.class);
-      log.debug(
-          "resolveIdsRepresentative - total hits: {}",
-          response.hits().total() != null ? response.hits().total().value() : "null");
       List<Hit<EsBase>> hits = response.hits().hits();
       return hits.stream()
           .map(Hit::source)


### PR DESCRIPTION

### Proposed changes

At the moment when you create a security domains widget, all the icons are grey. Also when trying to add a simulation as a filter during the creation, no proposition appears in the select since there is an error. 
I also spoted that the links in the enterprise edition agreement dialog were not obvious enough. I also changed that.

### Testing Instructions

1. Create a dashboard, then choose security domains widget
2. If you try to add simulations, you should have simulations in the select field
3. Your widget should have colors reflecting the results
4. Try with elasticsearch and opensearch engines

Note: Remember that this widget is based on results of inject expectations 
