### PR TITLE
[frontend] feat(dashboard): fix form validation vertical and list chart (#114)

### DIFF
--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/WidgetForm.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/WidgetForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@mui/material';
 import { type FunctionComponent, useState } from 'react';
-import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { Controller, FormProvider, useForm, type FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 
 import Dialog from '../../../../../../components/common/dialog/Dialog';
@@ -26,12 +26,11 @@ const ActionsComponent: FunctionComponent<{
 }> = ({ disabled, onCancel, onSubmit, editing }) => {
   // Standard hooks
   const { t } = useFormatter();
-  const { formState: { errors } } = useFormContext();
 
   return (
     <>
       <Button onClick={onCancel}>{t('Cancel')}</Button>
-      <Button color="secondary" onClick={onSubmit} disabled={disabled || Object.keys(errors).length > 0}>
+      <Button color="secondary" onClick={onSubmit} disabled={disabled}>
         {editing ? t('Update') : t('Create')}
       </Button>
     </>
@@ -207,10 +206,26 @@ const WidgetForm: FunctionComponent<Props> = ({
   };
 
   const handleSubmitWithoutPropagation = () => {
-    handleSubmit((values) => {
-      onSubmit(values);
-      onClose();
-    })();
+    handleSubmit(
+      (values) => {
+        onSubmit(values);
+        onClose();
+      },
+      (errors: FieldErrors<WidgetInputWithoutLayout>) => {
+        if (errors.widget_type) {
+          setActiveStep(0);
+          return;
+        }
+
+        const widgetConfigErrors = errors.widget_config;
+        if (widgetConfigErrors && typeof widgetConfigErrors === 'object' && ('series' in widgetConfigErrors || 'perspective' in widgetConfigErrors)) {
+          setActiveStep(1);
+          return;
+        }
+
+        setActiveStep(lastStepIndex);
+      },
+    )();
   };
 
   const getSeriesComponent = (widgetType: Widget['widget_type']) => {

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/WidgetForm.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/WidgetForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@mui/material';
-import { type FunctionComponent, useState } from 'react';
-import { Controller, FormProvider, useForm, type FieldErrors } from 'react-hook-form';
+import { type FunctionComponent, useEffect, useState } from 'react';
+import { Controller, type FieldErrors, FormProvider, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import Dialog from '../../../../../../components/common/dialog/Dialog';
@@ -10,7 +10,7 @@ import { useFormatter } from '../../../../../../components/i18n';
 import { type Widget } from '../../../../../../utils/api-types';
 import { type WidgetInputWithoutLayout } from '../../../../../../utils/api-types-custom';
 import { zodImplement } from '../../../../../../utils/Zod';
-import { getAvailableSteps, lastStepIndex, steps } from '../WidgetUtils';
+import { getAvailableModes, getAvailableSteps, lastStepIndex, steps } from '../WidgetUtils';
 import WidgetSecurityDomainsSeriesSelection from './domains/WidgetSecurityDomainsSeriesSelection';
 import WidgetMultiSeriesSelection from './histogram/WidgetMultiSeriesSelection';
 import WidgetSecurityCoverageSeriesSelection from './histogram/WidgetSecurityCoverageSeriesSelection';
@@ -161,14 +161,33 @@ const WidgetForm: FunctionComponent<Props> = ({
     handleSubmit,
     watch,
     reset,
+    setError,
+    clearErrors,
+    formState: { isValid },
     setValue,
   } = methods;
 
   const widgetType = watch('widget_type');
+  const widgetMode = watch('widget_config.mode');
+  const widgetField = watch('widget_config.field');
 
   // Stepper
   const availableSteps = getAvailableSteps(widgetType);
   const [activeStep, setActiveStep] = useState(editing ? 2 : 0);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  useEffect(() => {
+    if (widgetMode) {
+      clearErrors('widget_config.mode');
+    }
+  }, [widgetMode, clearErrors]);
+
+  useEffect(() => {
+    if (widgetField) {
+      clearErrors('widget_config.field');
+    }
+  }, [widgetField, clearErrors]);
+
   const nextStep = () => {
     for (let i = activeStep + 1; i < steps.length; i++) {
       if (availableSteps.includes(steps[i])) {
@@ -196,16 +215,19 @@ const WidgetForm: FunctionComponent<Props> = ({
 
   const onClose = () => {
     setActiveStep(editing ? lastStepIndex : 0);
+    setSubmitAttempted(false);
     toggleDialog();
   };
 
   const onCancel = () => {
     reset(initialValues);
     setActiveStep(0);
+    setSubmitAttempted(false);
     onClose();
   };
 
   const handleSubmitWithoutPropagation = () => {
+    setSubmitAttempted(true);
     handleSubmit(
       (values) => {
         onSubmit(values);
@@ -218,6 +240,26 @@ const WidgetForm: FunctionComponent<Props> = ({
         }
 
         const widgetConfigErrors = errors.widget_config;
+
+        if (
+          widgetConfigErrors
+          && typeof widgetConfigErrors === 'object'
+          && 'widget_configuration_type' in widgetConfigErrors
+        ) {
+          const hasVisibleMode = getAvailableModes(widgetType).length > 1;
+          const currentMode = watch('widget_config.mode');
+          if (hasVisibleMode && !currentMode) {
+            setError('widget_config.mode', {
+              type: 'manual',
+              message: t('Should not be empty'),
+            });
+            setError('widget_config.field', {
+              type: 'manual',
+              message: t('Should not be empty'),
+            });
+          }
+        }
+
         if (widgetConfigErrors && typeof widgetConfigErrors === 'object' && ('series' in widgetConfigErrors || 'perspective' in widgetConfigErrors)) {
           setActiveStep(1);
           return;
@@ -227,6 +269,8 @@ const WidgetForm: FunctionComponent<Props> = ({
       },
     )();
   };
+
+  const isCreateDisabled = !isLastStep() || (submitAttempted && !isValid);
 
   const getSeriesComponent = (widgetType: Widget['widget_type']) => {
     switch (widgetType) {
@@ -298,7 +342,7 @@ const WidgetForm: FunctionComponent<Props> = ({
           title={<StepperComponent widgetType={widgetType} steps={steps} activeStep={activeStep} handlePrevious={goToStep} />}
           actions={(
             <ActionsComponent
-              disabled={!isLastStep()}
+              disabled={isCreateDisabled}
               onCancel={onCancel}
               onSubmit={handleSubmitWithoutPropagation}
               editing={editing}

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/histogram/HistogramParameters.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/histogram/HistogramParameters.tsx
@@ -28,6 +28,10 @@ const HistogramParameters = ({ widgetType, control, setValue }: Props) => {
     control,
     name: 'widget_config.mode',
   });
+  const widgetConfigurationType = useWatch({
+    control,
+    name: 'widget_config.widget_configuration_type',
+  });
   const widgetTimeRange = useWatch({
     control,
     name: 'widget_config.time_range',
@@ -86,10 +90,21 @@ const HistogramParameters = ({ widgetType, control, setValue }: Props) => {
   };
 
   useEffect(() => {
-    if (availableModes.length === 1) {
-      setModeAndConfigType(availableModes[0]); // If only one mode is available, hide the field and set it automatically
+    const expectedConfigType = mode === 'temporal' ? 'temporal-histogram' : 'structural-histogram';
+
+    // Auto-set only when mode is hidden (single-mode widgets).
+    if (availableModes.length === 1 && (!mode || !availableModes.includes(mode))) {
+      const defaultMode = availableModes[0];
+      setValue('widget_config.mode', defaultMode);
+      setValue('widget_config.widget_configuration_type', defaultMode === 'temporal' ? 'temporal-histogram' : 'structural-histogram');
+      return;
     }
-  }, []);
+
+    // Keep discriminator in sync when user explicitly selected a valid mode.
+    if (mode && availableModes.includes(mode) && widgetConfigurationType !== expectedConfigType) {
+      setValue('widget_config.widget_configuration_type', expectedConfigType);
+    }
+  }, [availableModes, mode, setValue, widgetConfigurationType]);
 
   const hasLimit = getLimit(widgetType);
 

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/histogram/HistogramParameters.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/configuration/histogram/HistogramParameters.tsx
@@ -44,7 +44,7 @@ const HistogramParameters = ({ widgetType, control, setValue }: Props) => {
     control,
     name: 'widget_config.end',
   });
-  const entities = series.map(v => getBaseEntities(v.filter)).flat();
+  const entities = series.flatMap(v => getBaseEntities(v.filter));
 
   const { setError, clearErrors } = useFormContext();
 
@@ -73,27 +73,25 @@ const HistogramParameters = ({ widgetType, control, setValue }: Props) => {
   // -- HANDLE MODE --
   const availableModes = getAvailableModes(widgetType);
 
+  const setModeAndConfigType = (newMode: string) => {
+    setValue('widget_config.mode', newMode as 'temporal' | 'structural');
+    switch (newMode) {
+      case 'temporal':
+        setValue('widget_config.widget_configuration_type', 'temporal-histogram');
+        break;
+      case 'structural':
+      default:
+        setValue('widget_config.widget_configuration_type', 'structural-histogram');
+    }
+  };
+
   useEffect(() => {
     if (availableModes.length === 1) {
-      setValue('widget_config.mode', availableModes[0]); // If only one mode is available, hide the field and set it automatically
+      setModeAndConfigType(availableModes[0]); // If only one mode is available, hide the field and set it automatically
     }
   }, []);
 
   const hasLimit = getLimit(widgetType);
-
-  // -- HANDLE widget config type --
-  useEffect(() => {
-    switch (mode) {
-      case 'structural':
-        setValue('widget_config.widget_configuration_type', 'structural-histogram');
-        break;
-      case 'temporal':
-        setValue('widget_config.widget_configuration_type', 'temporal-histogram');
-        break;
-      default:
-        setValue('widget_config.widget_configuration_type', 'structural-histogram');
-    }
-  }, [mode]);
 
   // -- HANDLE FIELDS --
   const [fieldOptions, setFieldOptions] = useState<GroupOption[]>([]);
@@ -146,7 +144,7 @@ const HistogramParameters = ({ widgetType, control, setValue }: Props) => {
                 value={field.value ?? ''}
                 error={!!fieldState.error}
                 helperText={fieldState.error?.message}
-                onChange={e => field.onChange(e.target.value)}
+                onChange={e => setModeAndConfigType(e.target.value)}
                 required
               >
                 {availableModes.map(mode => <MenuItem key={mode} value={mode}>{t(mode)}</MenuItem>)}


### PR DESCRIPTION
When creating a dashboard widget, if the user tries to proceed without filling mandatory fields, the form correctly highlights them in red. However, after the user fills in the missing fields, the "Create" button remains disabled and never re-enables.

The user is stuck and cannot complete the widget creation despite all fields being correctly filled.

### Proposed changes

After correcting all mandatory fields, the form validation should re-evaluate and the "Create" button should re-enable immediately

### Testing Instructions

1. Go to dashboard and create a vertical bar chart or list chart, try to create without mandatory inputs

### Related issues

* Closes [#114](https://github.com/orgs/OpenAEV-Platform/projects/2/views/49?pane=issue&itemId=184868816&issue=OpenAEV-Platform%7Cfiligran-private%7C114)

