### PR TITLE
[backend] fix(xtmhub): use native query when unregister platform (#5777)

### DIFF
--- a/openaev-model/src/main/java/io/openaev/database/repository/TenantXtmHubRegistrationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TenantXtmHubRegistrationRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,10 @@ public interface TenantXtmHubRegistrationRepository
   @Query("SELECT r FROM TenantXtmHubRegistration r JOIN FETCH r.tenant t WHERE t.deletedAt IS NULL")
   List<TenantXtmHubRegistration> findAllByTenantNotDeleted();
 
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Transactional
+  @Query(
+      value = "DELETE FROM tenant_xtmhub_registrations WHERE tenant_id = :tenantId",
+      nativeQuery = true)
   void deleteByTenantId(String tenantId);
 }


### PR DESCRIPTION
### Proposed changes
Use a native query when unregistering the platform: Issue symptoms are the same as a previous issue that was solved with this solution. 
Note: this issue is not reproducible in local, it happens only on pre-release.

### Testing Instructions

1. register a platform on xtmhub
2. unregister the platform
3. the popup should disappear quickly, and there should be no regression

### Related issues

* Closes [#5777](https://github.com/OpenAEV-Platform/openaev/issues/5777)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...