### PR TITLE
chore(launch): added launch configs fetching properties from 1p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 *.bat
 **/application-dev.properties
+**/application-devlocal.properties
 **/application-test.properties
 target/
 !**/src/main/**/target/

--- a/openaev-api/pom.xml
+++ b/openaev-api/pom.xml
@@ -30,6 +30,31 @@
     <profiles>
         <profile>
             <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>fetch-dev-properties</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>sh</executable>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>op read "op://j7lyu4mgrrtqeekhki4c4ch6ry/ewah5jvb7djwfxqd43g4kuxbom/notesPlain" > ${project.basedir}/src/main/resources/application-dev.properties</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/openaev-dev/Backend start (MACOS).run.xml
+++ b/openaev-dev/Backend start (MACOS).run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Backend start (MACOS)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" show_console_on_std_err="true" show_console_on_std_out="true">
+    <option name="ACTIVE_PROFILES" value="dev" />
+    <module name="openaev-api" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.openaev.App" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Fetch 1Password properties (MACOS)" run_configuration_type="ShConfigurationType" />
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/openaev-dev/Backend start (UNIX).run.xml
+++ b/openaev-dev/Backend start (UNIX).run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Backend start (UNIX)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" show_console_on_std_err="true" show_console_on_std_out="true">
+    <option name="ACTIVE_PROFILES" value="dev" />
+    <module name="openaev-api" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.openaev.App" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Fetch 1Password properties (UNIX)" run_configuration_type="ShConfigurationType" />
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/openaev-dev/Backend start (WINDOWS).run.xml
+++ b/openaev-dev/Backend start (WINDOWS).run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Backend start (WINDOWS)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" show_console_on_std_err="true" show_console_on_std_out="true">
+    <option name="ACTIVE_PROFILES" value="dev" />
+    <module name="openaev-api" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.openaev.App" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Fetch 1Password properties (WINDOWS)" run_configuration_type="ShConfigurationType" />
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/openaev-dev/Fetch 1Password properties (MACOS).run.xml
+++ b/openaev-dev/Fetch 1Password properties (MACOS).run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Fetch 1Password properties (MACOS)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="PATH=&quot;/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH&quot;; OP_BIN=&quot;$(command -v op 2&gt;/dev/null || true)&quot;; if [ -z &quot;$OP_BIN&quot; ] &amp;&amp; [ -x &quot;/opt/homebrew/bin/op&quot; ]; then OP_BIN=&quot;/opt/homebrew/bin/op&quot;; fi; if [ -z &quot;$OP_BIN&quot; ] &amp;&amp; [ -x &quot;/usr/local/bin/op&quot; ]; then OP_BIN=&quot;/usr/local/bin/op&quot;; fi; if [ -z &quot;$OP_BIN&quot; ]; then echo &quot;ERROR: op not found&quot; 1&gt;&amp;2; exit 127; fi; &quot;$OP_BIN&quot; read &quot;op://j7lyu4mgrrtqeekhki4c4ch6ry/ewah5jvb7djwfxqd43g4kuxbom/notesPlain&quot; &gt; &quot;./core-engine/openaev-api/src/main/resources/application-dev.properties&quot;" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/sh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/openaev-dev/Fetch 1Password properties (UNIX).run.xml
+++ b/openaev-dev/Fetch 1Password properties (UNIX).run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Fetch 1Password properties (UNIX)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="PATH=&quot;/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH&quot;; OP_BIN=&quot;$(command -v op 2&gt;/dev/null || true)&quot;; if [ -z &quot;$OP_BIN&quot; ] &amp;&amp; [ -x &quot;/opt/homebrew/bin/op&quot; ]; then OP_BIN=&quot;/opt/homebrew/bin/op&quot;; fi; if [ -z &quot;$OP_BIN&quot; ] &amp;&amp; [ -x &quot;/usr/local/bin/op&quot; ]; then OP_BIN=&quot;/usr/local/bin/op&quot;; fi; if [ -z &quot;$OP_BIN&quot; ]; then echo &quot;ERROR: op not found&quot; 1&gt;&amp;2; exit 127; fi; &quot;$OP_BIN&quot; read &quot;op://j7lyu4mgrrtqeekhki4c4ch6ry/ewah5jvb7djwfxqd43g4kuxbom/notesPlain&quot; &gt; &quot;./core-engine/openaev-api/src/main/resources/application-dev.properties&quot;" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/sh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/openaev-dev/Fetch 1Password properties (WINDOWS).run.xml
+++ b/openaev-dev/Fetch 1Password properties (WINDOWS).run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Fetch 1Password properties (WINDOWS)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="$ErrorActionPreference = 'Stop' $env:PATH = &quot;$env:LOCALAPPDATA\1Password\app\8;$env:ProgramFiles\1Password;$env:PATH&quot;  $op = Get-Command op -ErrorAction SilentlyContinue if (-not $op -and (Test-Path &quot;$env:LOCALAPPDATA\1Password\app\8\op.exe&quot;)) { $opPath = &quot;$env:LOCALAPPDATA\1Password\app\8\op.exe&quot; } elseif (-not $op -and (Test-Path &quot;$env:ProgramFiles\1Password\op.exe&quot;)) { $opPath = &quot;$env:ProgramFiles\1Password\op.exe&quot; } elseif ($op) { $opPath = $op.Source } else { throw &quot;op.exe not found in PATH or default locations&quot; }  &amp; $opPath read &quot;op://j7lyu4mgrrtqeekhki4c4ch6ry/ewah5jvb7djwfxqd43g4kuxbom/notesPlain&quot; |   Set-Content -Path &quot;.\core-engine\openaev-api\src\main\resources\application-dev.properties&quot; -NoNewline" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="powershell" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
It's sometimes hard to stay up-to-date with the configuration change done throughout our team.
This PR "fixes" this by adding 6 new intellij launch configuration. 3 shells (one per system) ones downloading a 1p application-de.properties file and 3 launch one having the corresponding script launch configuration as pre launch configs.

This means that if you decide to use one of these launch configuration, it will:
- Ask you to authenticate (touch id, on mac, for example) for 1p CLI
- Overwrite your existing application-dev.properties by the one coming from 1p
- Launch the app with it

Prerequisite: 
- the 1p CLI must be installed and your 1p configured to link with it
- You must have access to the Engineering 1p vault

It's still possible to override certain of the properties with a new application-devlocal.properties file (up to you to create it)
For instance, creating this file and adding just the following line will set the DEBUG level on logs:
`logging.level.io.openaev=debug`

No need to write any other properties, just keep the one you need for your local env.

### Proposed changes

* Added 6 new Intellij launch configurations
* Also added this feature to the maven config for those launching the app through it

### Testing Instructions

1. Checkout the branch and restart Intellij.
2. You should now see 6 new launch configurations in Intellij
3. Run the `Backend start(YOUR SYSTEM)`

### Related issues

* Independent of any issue for now

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
