### PR TITLE
[backend/frontend] chore(prevent-crawling): prevent website crawling and indexation (#5812)

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -100,4 +100,6 @@ public Page<{Entity}Output> search(...) { return service.search(input).map({Enti
 - DTOs: `@Builder` OK, prefer records for new code
 - Never `@Autowired` on fields in new code
 
+## Formatting (Spotless)
 
+- **After editing Java files**, run `.\scripts\hooks\format-java.ps1` (Windows) or `./scripts/hooks/format-java.sh` (Unix). Output: `OK` = success.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -34,7 +34,7 @@ Key checks: tenant-scoped entities extend `TenantBase` + `@Filter("tenantFilter"
 
 > Full rules: [testing.instructions.md](testing.instructions.md)
 
-Key checks: `@Nested` + `@DisplayName` grouping, `given_X_should_Y` naming, AAA comments, OpenAEV's `@WithMockUser` (not Spring's), Fixture + Composer (no inline data).
+Key checks: `@Nested` + `@DisplayName` grouping, `given_X_should_Y` naming, AAA comments, OpenAEV's `@WithMockUser` (not Spring's), Fixture + Composer (no inline data), constants shared via static import (never duplicated between source and test), public endpoints tested without `@WithMockUser`.
 
 ## Frontend
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -15,6 +15,8 @@ description: "Testing conventions: integration tests, unit tests, fixtures, comp
 - **AAA pattern**: `// Arrange` / `// Act` / `// Assert`
 - JSON: `assertThatJson(response).node("field").isEqualTo(...)` (json-unit library)
 - URI constant at class level: `public static final String FEATURE_URI = "/api/..."`
+- **Public endpoints** (`@RBAC(skipRBAC = true)`): test WITHOUT `@WithMockUser` to verify unauthenticated access works
+- **Constant sharing**: reuse constants from the controller via package-private `static final` + `static import` in the test — never duplicate literal values between source and test
 
 ### Tenant Isolation Tests (API)
 

--- a/.github/prompts/format.prompt.md
+++ b/.github/prompts/format.prompt.md
@@ -1,0 +1,11 @@
+---
+description: "Format Java with Spotless. Run after editing .java files."
+---
+
+After editing Java files, run:
+
+- Windows: `.\scripts\hooks\format-java.ps1` (or `-M openaev-api`)
+- Unix: `./scripts/hooks/format-java.sh` (or `openaev-api`)
+
+Output is `OK` on success. Non-zero exit = failure.
+

--- a/.github/skills/add-test/SKILL.md
+++ b/.github/skills/add-test/SKILL.md
@@ -67,7 +67,47 @@ public class {Feature}ApiTest extends IntegrationTest {
 }
 ```
 
-### Step 4 — (Optional) Create Unit Test
+### Step 4 — (Optional) Lightweight Controller Tests (no entity)
+
+For controllers that don't manage entities (e.g. static endpoints, utility APIs, configuration endpoints):
+
+- **Skip Steps 1 & 2** (no Fixture/Composer needed)
+- **Reuse constants** from the controller via package-private static imports — never duplicate string literals
+- **Test public endpoints** without `@WithMockUser` when `@RBAC(skipRBAC = true)` is present
+- **Test HTTP-level concerns**: status code, content-type, response body, custom headers, cache-control
+
+```java
+@TestInstance(PER_CLASS)
+@DisplayName("{Feature} API tests")
+class {Feature}ApiTest extends IntegrationTest {
+  @Autowired private MockMvc mvc;
+
+  @Nested @DisplayName("GET /endpoint")
+  class EndpointGroup {
+
+    @Test @DisplayName("Should respond without authentication")
+    void given_unauthenticatedRequest_should_respondSuccessfully() throws Exception {
+      // Arrange & Act
+      var result = mvc.perform(get("/endpoint"));
+
+      // Assert
+      result
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+          .andExpect(content().string(EXPECTED_BODY))  // static import from controller
+          .andExpect(header().string("Custom-Header", EXPECTED_VALUE));
+    }
+  }
+}
+```
+
+**Key rules for lightweight tests:**
+- Constants must be `static final` (package-private) in the controller, imported via `static import` in the test
+- Group tests by endpoint using `@Nested` + `@DisplayName`
+- Always test both authenticated and unauthenticated access when `@RBAC(skipRBAC = true)`
+- Test HTTP headers (Cache-Control, custom headers) when the controller sets them explicitly
+
+### Step 5 — (Optional) Create Unit Test
 
 For complex service logic:
 ```java
@@ -79,7 +119,7 @@ class {Feature}ServiceUnitTest {
 }
 ```
 
-### Step 5 — Verify
+### Step 6 — Verify
 
 ```bash
 mvn test -pl openaev-api -Dtest="{Feature}ApiTest"

--- a/.github/workflows/auto-close-add-solved.yml
+++ b/.github/workflows/auto-close-add-solved.yml
@@ -1,11 +1,8 @@
 name: Auto Close and Solve Issues
 on:
   pull_request:
-    branches:
-      - release/current
-      - master
-    types:
-      - closed
+    branches: [ main ]
+    types: [ closed ]
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ main ]
   schedule:
     - cron: '44 23 * * 5'
 

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -2,11 +2,11 @@ name: "[Core] CI"
 
 on:
   push:
-    branches: [ master, release/current ]
+    branches: [ main ]
     tags:
       - "[0-9]*.[0-9]*.[0-9]*"
   pull_request:
-    branches: [ master, release/current ]
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -92,9 +92,6 @@ jobs:
             TAG="${GITHUB_REF#refs/tags/}"
             echo "binary_version=${TAG}"   >> "$GITHUB_OUTPUT"
             echo "catalog_version=${TAG}"  >> "$GITHUB_OUTPUT"
-          elif [[ "$GITHUB_REF" == refs/heads/release/current ]]; then
-            echo "binary_version=prerelease"  >> "$GITHUB_OUTPUT"
-            echo "catalog_version=prerelease" >> "$GITHUB_OUTPUT"
           else
             echo "binary_version=latest"   >> "$GITHUB_OUTPUT"
             echo "catalog_version=rolling"  >> "$GITHUB_OUTPUT"

--- a/.github/workflows/openaev-auto-label.yml
+++ b/.github/workflows/openaev-auto-label.yml
@@ -1,7 +1,7 @@
 name: "[OpenAEV] Auto Label"
 on:
   pull_request_target:
-    branches: [master, release/current]
+    branches: [ main ]
     types: [opened, reopened]
 permissions:
   contents: read

--- a/.github/workflows/openaev-check-signed-commit.yml
+++ b/.github/workflows/openaev-check-signed-commit.yml
@@ -1,7 +1,7 @@
 name: "[OpenAEV] Check Signed Commits in PR"
 on:
   pull_request_target:
-    branches: [master, release/current]
+    branches: [ main ]
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/openaev-validate-pr-title.yml
+++ b/.github/workflows/openaev-validate-pr-title.yml
@@ -1,8 +1,8 @@
 name: "[OpenAEV] Validate PR title Worker"
 on:
   pull_request:
-    branches: [master, release/current]
-    types: [opened, edited, reopened, ready_for_review, synchronize]
+    branches: [ main ]
+    types: [ opened, edited, reopened, ready_for_review, synchronize ]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       branch_platform:
         type: string
-        default: 'master'
+        default: 'main'
         required: true
       previous_version:
         type: string

--- a/.github/workflows/test-github-actions.yml
+++ b/.github/workflows/test-github-actions.yml
@@ -2,11 +2,11 @@ name: "Test GitHub Actions scripts"
 
 on:
   pull_request:
-    branches: [master, release/current]
+    branches: [ main ]
     paths:
       - '.github/actions/**'
   push:
-    branches: [master, release/current]
+    branches: [ main ]
     paths:
       - '.github/actions/**'
 

--- a/openaev-api/src/main/java/io/openaev/rest/CrawlerProtectionApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/CrawlerProtectionApi.java
@@ -1,6 +1,6 @@
 package io.openaev.rest;
 
-import io.openaev.aop.RBAC;
+import io.openaev.aop.AccessControl;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -45,7 +45,7 @@ public class CrawlerProtectionApi {
 
   // -- robots.txt: disallow all crawlers on every path
   @GetMapping(path = "/robots.txt", produces = MediaType.TEXT_PLAIN_VALUE)
-  @RBAC(skipRBAC = true)
+  @AccessControl(skipRBAC = true)
   public ResponseEntity<String> robotsTxt() {
     return ResponseEntity.ok()
         .cacheControl(CacheControl.maxAge(java.time.Duration.ofDays(1)).cachePublic())
@@ -54,7 +54,7 @@ public class CrawlerProtectionApi {
 
   // -- sitemap.xml: return an empty sitemap to discourage indexing
   @GetMapping(path = "/sitemap.xml", produces = MediaType.APPLICATION_XML_VALUE)
-  @RBAC(skipRBAC = true)
+  @AccessControl(skipRBAC = true)
   public ResponseEntity<String> sitemapXml() {
     return ResponseEntity.ok()
         .cacheControl(CacheControl.maxAge(java.time.Duration.ofDays(1)).cachePublic())

--- a/openaev-api/src/main/java/io/openaev/rest/CrawlerProtectionApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/CrawlerProtectionApi.java
@@ -1,0 +1,86 @@
+package io.openaev.rest;
+
+import io.openaev.aop.RBAC;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Prevents search engines from crawling and indexing the platform.
+ *
+ * <p>Three layers of protection:
+ *
+ * <ol>
+ *   <li>A {@code <meta name="robots">} tag in index.html (frontend build)
+ *   <li>A global {@code X-Robots-Tag} HTTP header on every response (this filter)
+ *   <li>Explicit {@code /robots.txt} and {@code /sitemap.xml} routes (this controller)
+ * </ol>
+ */
+@RestController
+public class CrawlerProtectionApi {
+
+  static final String NO_INDEX_DIRECTIVES = "noindex, nofollow, noarchive, nosnippet, noimageindex";
+
+  static final String X_ROBOTS_TAG_HEADER = "X-Robots-Tag";
+
+  static final String ROBOTS_TXT_BODY = "User-agent: *\nDisallow: /\n";
+
+  static final String EMPTY_SITEMAP =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>
+      """;
+
+  // -- robots.txt: disallow all crawlers on every path
+  @GetMapping(path = "/robots.txt", produces = MediaType.TEXT_PLAIN_VALUE)
+  @RBAC(skipRBAC = true)
+  public ResponseEntity<String> robotsTxt() {
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.maxAge(java.time.Duration.ofDays(1)).cachePublic())
+        .body(ROBOTS_TXT_BODY);
+  }
+
+  // -- sitemap.xml: return an empty sitemap to discourage indexing
+  @GetMapping(path = "/sitemap.xml", produces = MediaType.APPLICATION_XML_VALUE)
+  @RBAC(skipRBAC = true)
+  public ResponseEntity<String> sitemapXml() {
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.maxAge(java.time.Duration.ofDays(1)).cachePublic())
+        .body(EMPTY_SITEMAP);
+  }
+
+  /**
+   * Registers a servlet filter that adds the {@code X-Robots-Tag} header to every HTTP response.
+   * This reinforces the {@code <meta name="robots">} tag at the HTTP level.
+   */
+  @Bean
+  public FilterRegistrationBean<Filter> xRobotsTagFilter() {
+    FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
+    registration.setFilter(
+        new Filter() {
+          @Override
+          public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+              throws IOException, ServletException {
+            if (response instanceof HttpServletResponse httpResponse) {
+              httpResponse.setHeader(X_ROBOTS_TAG_HEADER, NO_INDEX_DIRECTIVES);
+            }
+            chain.doFilter(request, response);
+          }
+        });
+    registration.addUrlPatterns("/*");
+    registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registration;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/CrawlerProtectionApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/CrawlerProtectionApiTest.java
@@ -1,0 +1,113 @@
+package io.openaev.rest;
+
+import static io.openaev.rest.CrawlerProtectionApi.NO_INDEX_DIRECTIVES;
+import static io.openaev.rest.CrawlerProtectionApi.ROBOTS_TXT_BODY;
+import static io.openaev.rest.CrawlerProtectionApi.X_ROBOTS_TAG_HEADER;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.utils.mockUser.WithMockUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@TestInstance(PER_CLASS)
+@DisplayName("Crawler Protection API tests")
+class CrawlerProtectionApiTest extends IntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Nested
+  @DisplayName("GET /robots.txt")
+  class RobotsTxt {
+
+    @Test
+    @DisplayName("Should return disallow-all robots.txt without authentication")
+    void given_unauthenticatedRequest_should_returnDisallowAll() throws Exception {
+      // Arrange & Act
+      var result = mvc.perform(get("/robots.txt"));
+
+      // Assert
+      result
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+          .andExpect(content().string(ROBOTS_TXT_BODY))
+          .andExpect(header().exists("Cache-Control"))
+          .andExpect(header().string(X_ROBOTS_TAG_HEADER, NO_INDEX_DIRECTIVES));
+    }
+
+    @Test
+    @WithMockUser(isAdmin = true)
+    @DisplayName("Should return disallow-all robots.txt for authenticated user")
+    void given_authenticatedRequest_should_returnDisallowAll() throws Exception {
+      // Arrange & Act
+      var result = mvc.perform(get("/robots.txt"));
+
+      // Assert
+      result.andExpect(status().isOk()).andExpect(content().string(ROBOTS_TXT_BODY));
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /sitemap.xml")
+  class SitemapXml {
+
+    @Test
+    @DisplayName("Should return empty sitemap without authentication")
+    void given_unauthenticatedRequest_should_returnEmptySitemap() throws Exception {
+      // Arrange & Act
+      var result = mvc.perform(get("/sitemap.xml"));
+
+      // Assert
+      result
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+          .andExpect(
+              content()
+                  .xml(
+                      """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>
+              """))
+          .andExpect(header().exists("Cache-Control"))
+          .andExpect(header().string(X_ROBOTS_TAG_HEADER, NO_INDEX_DIRECTIVES));
+    }
+
+    @Test
+    @WithMockUser(isAdmin = true)
+    @DisplayName("Should return empty sitemap for authenticated user")
+    void given_authenticatedRequest_should_returnEmptySitemap() throws Exception {
+      // Arrange & Act
+      var result = mvc.perform(get("/sitemap.xml"));
+
+      // Assert
+      result
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
+    }
+  }
+
+  @Nested
+  @DisplayName("X-Robots-Tag header filter")
+  @WithMockUser(isAdmin = true)
+  class XRobotsTagFilter {
+
+    @Test
+    @DisplayName("Should add X-Robots-Tag header to any API response")
+    void given_anyRequest_should_includeXRobotsTagHeader() throws Exception {
+      // Arrange — use a known public-ish endpoint (platform settings)
+      var result = mvc.perform(get("/api/settings").accept(MediaType.APPLICATION_JSON));
+
+      // Assert — regardless of response status, the header must be present
+      result.andExpect(header().string(X_ROBOTS_TAG_HEADER, NO_INDEX_DIRECTIVES));
+    }
+  }
+}

--- a/openaev-dev/Spotless format.run.xml
+++ b/openaev-dev/Spotless format.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Spotless format" type="MavenRunConfiguration" factoryName="Maven">
+    <MavenSettings>
+      <option name="myGeneralSettings" />
+      <option name="myRunnerSettings" />
+      <option name="myRunnerParameters">
+        <MavenRunnerParameters>
+          <option name="workingDirPath" value="$PROJECT_DIR$" />
+          <option name="goals">
+            <list>
+              <option value="spotless:apply" />
+            </list>
+          </option>
+          <option name="profilesMap">
+            <map />
+          </option>
+        </MavenRunnerParameters>
+      </option>
+    </MavenSettings>
+    <method v="2" />
+  </configuration>
+</component>
+

--- a/openaev-front/builder/dev/index.html
+++ b/openaev-front/builder/dev/index.html
@@ -7,6 +7,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
     <meta name="dеѕсrірtіоn" content="%APP_DESCRIPTION%">
     <link id="favicon" rel="shortcut icon" href="%APP_FAVICON%">
     <link id="manifest" rel="manifest" href="%APP_MANIFEST%">

--- a/openaev-front/builder/prod/prod.js
+++ b/openaev-front/builder/prod/prod.js
@@ -54,6 +54,7 @@ build({
             <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
             <meta http-equiv="X-UA-Compatible" content="IE=edge">
             <meta name="viewport" content="width=device-width,initial-scale=1">
+            <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
             <meta name="dеѕсrірtіоn" content="%APP_DESCRIPTION%">
             <link id="favicon" rel="shortcut icon" href="%APP_FAVICON%">
             <link id="manifest" rel="manifest" href="%APP_MANIFEST%">

--- a/openaev-front/index.html
+++ b/openaev-front/index.html
@@ -9,6 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
     <meta name="dеѕсrірtіоn" content="%APP_DESCRIPTION%">
     <link id="favicon" rel="shortcut icon" href="%APP_FAVICON%">
     <link id="manifest" rel="manifest" href="%APP_MANIFEST%">

--- a/scripts/hooks/format-java.ps1
+++ b/scripts/hooks/format-java.ps1
@@ -1,0 +1,39 @@
+# Post-edit hook: run Spotless format
+param([string]$M="")
+$ErrorActionPreference = 'Stop'
+$ProjectDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..'))
+Push-Location $ProjectDir
+
+# Extract required Java version from pom.xml
+$javaVersion = ([xml](Get-Content 'pom.xml')).project.properties.'java.version'
+if (-not $javaVersion) { Write-Error 'java.version not found in pom.xml'; Pop-Location; exit 1 }
+
+# Resolve JAVA_HOME if not set or wrong version
+$needsJdk = $true
+if ($env:JAVA_HOME) {
+    $verOutput = cmd /c "`"$env:JAVA_HOME\bin\java`" -version 2>&1"
+    if ($verOutput -match $javaVersion) { $needsJdk = $false }
+}
+if ($needsJdk) {
+    $jdk = Get-ChildItem "$env:USERPROFILE\.jdks" -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -match $javaVersion } | Select-Object -First 1
+    if ($jdk) { $env:JAVA_HOME = $jdk.FullName }
+}
+
+# Resolve mvn: PATH > Maven Wrapper local > .m2/wrapper
+$mvn = (Get-Command mvn -ErrorAction SilentlyContinue).Source
+if (-not $mvn -and (Test-Path '.\mvnw.cmd')) { $mvn = '.\mvnw.cmd' }
+if (-not $mvn) {
+    $mvn = Get-ChildItem "$env:USERPROFILE\.m2\wrapper\dists" -Recurse -Filter 'mvn.cmd' -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $mvn) { Write-Error 'mvn not found'; Pop-Location; exit 1 }
+
+$p = if ($M) { @('-pl', $M) } else { @() }
+& $mvn spotless:apply @p -q
+if ($LASTEXITCODE -ne 0) { Write-Error 'spotless:apply failed'; Pop-Location; exit 1 }
+
+# Verify
+& $mvn spotless:check @p -q
+if ($LASTEXITCODE -ne 0) { Write-Error 'spotless:check failed'; Pop-Location; exit 1 }
+
+Write-Host 'OK'
+Pop-Location

--- a/scripts/hooks/format-java.sh
+++ b/scripts/hooks/format-java.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Post-edit hook: run Spotless format
+set -euo pipefail
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$PROJECT_DIR"
+
+# Extract required Java version from pom.xml
+JAVA_VERSION=$(grep -oP '<java.version>\K[^<]+' pom.xml)
+if [ -z "$JAVA_VERSION" ]; then echo "java.version not found in pom.xml" >&2; exit 1; fi
+
+# Resolve JAVA_HOME if not set or wrong version
+if [ -n "${JAVA_HOME:-}" ]; then
+    CURRENT=$("$JAVA_HOME/bin/java" -version 2>&1 || true)
+    echo "$CURRENT" | grep -q "$JAVA_VERSION" || unset JAVA_HOME
+fi
+if [ -z "${JAVA_HOME:-}" ]; then
+    JDK=$(find "$HOME/.jdks" -maxdepth 1 -type d -name "*$JAVA_VERSION*" 2>/dev/null | head -1)
+    if [ -n "$JDK" ]; then export JAVA_HOME="$JDK"; fi
+fi
+
+# Resolve mvn: PATH > Maven Wrapper local > .m2/wrapper
+MVN=$(command -v mvn 2>/dev/null || true)
+if [ -z "$MVN" ] && [ -f "./mvnw" ]; then MVN="./mvnw"; fi
+if [ -z "$MVN" ]; then
+    MVN=$(find "$HOME/.m2/wrapper/dists" -name "mvn" -type f 2>/dev/null | head -1)
+fi
+if [ -z "$MVN" ]; then echo "mvn not found" >&2; exit 1; fi
+
+$MVN spotless:apply ${1:+-pl $1} -q
+$MVN spotless:check ${1:+-pl $1} -q
+echo "OK"


### PR DESCRIPTION
## Summary

This PR introduces comprehensive measures to prevent search engines from indexing the OpenAEV platform. It mirrors [OpenCTI-Platform/opencti#16032](https://github.com/OpenCTI-Platform/opencti/pull/16032), adapted for the Spring Boot stack.

## Changes

### Frontend — `<meta name="robots">` tag

- **`openaev-front/builder/dev/index.html`** — Added `<meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">` to the dev HTML template.
- **`openaev-front/builder/prod/prod.js`** — Added the same meta tag to the production-generated `index.html`.

### Backend — HTTP-level protection (Spring Boot)

New `CrawlerProtectionApi` controller (`openaev-api/src/main/java/io/openaev/rest/CrawlerProtectionApi.java`):

| Layer | What | Details |
|-------|------|---------|
| **Global header** | `X-Robots-Tag` on all responses | Servlet filter registered at highest precedence, reinforces the meta tag at HTTP level |
| **`/robots.txt`** | Disallow all crawlers | `User-agent: * / Disallow: /` with 1-day public cache |
| **`/sitemap.xml`** | Empty sitemap | Returns a valid but empty XML sitemap with 1-day public cache |

Both endpoints use `@RBAC(skipRBAC = true)` to be accessible without authentication (same pattern as `/api/health`).

## Three layers of defense

```
1. <meta name="robots">          → HTML-level (crawlers that parse HTML)
2. X-Robots-Tag HTTP header       → HTTP-level (crawlers that respect headers)
3. /robots.txt + /sitemap.xml     → Protocol-level (well-behaved bots)
```

## Testing

- [ ] Verify `/robots.txt` returns `User-agent: * / Disallow: /`
- [ ] Verify `/sitemap.xml` returns an empty valid sitemap
- [ ] Verify `X-Robots-Tag` header is present on any response
- [ ] Verify the `<meta name="robots">` tag is in the rendered HTML

## Related

- Mirrors: https://github.com/OpenCTI-Platform/opencti/pull/16032
