### PR TITLE
[backend] fix(multi-tenancy): fix connector/injector icons fail to load after switching tenants on the same page (#118)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/catalog_connector/CatalogConnectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/catalog_connector/CatalogConnectorApi.java
@@ -61,7 +61,7 @@ public class CatalogConnectorApi extends RestBehavior {
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   public ResponseEntity<byte[]> getCatalogLogo(@PathVariable String fileName) throws IOException {
-    Optional<InputStream> fileStream = fileService.getCatalogConnectorImage(fileName);
+    Optional<InputStream> fileStream = fileService.getCatalogConnectorImage(fileName, false);
 
     if (fileStream.isPresent()) {
       byte[] bytes = IOUtils.toByteArray(fileStream.get());

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -318,10 +318,11 @@ public class DocumentApi extends RestBehavior {
   public @ResponseBody ResponseEntity<byte[]> getInjectorImage(@PathVariable String injectorType)
       throws IOException {
     Injector injector =
-            this.injectorRepository
-                    .findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant())
-                    .orElseThrow(() -> new ElementNotFoundException("Injector not found"));
-    Optional<InputStream> fileStream = fileService.getInjectorImage(injector.getType(), injector.isExternal());
+        this.injectorRepository
+            .findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant())
+            .orElseThrow(() -> new ElementNotFoundException("Injector not found"));
+    Optional<InputStream> fileStream =
+        fileService.getInjectorImage(injector.getType(), injector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -343,7 +344,8 @@ public class DocumentApi extends RestBehavior {
         this.injectorRepository
             .findByIdAndTenantId(injectorId, TenantContext.getCurrentTenant())
             .orElseThrow(() -> new ElementNotFoundException("Injector not found"));
-    Optional<InputStream> fileStream = fileService.getInjectorImage(injector.getType(), injector.isExternal());
+    Optional<InputStream> fileStream =
+        fileService.getInjectorImage(injector.getType(), injector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -362,10 +364,11 @@ public class DocumentApi extends RestBehavior {
   public @ResponseBody ResponseEntity<byte[]> getCollectorImage(@PathVariable String collectorType)
       throws IOException {
     Collector collector =
-            this.collectorRepository
-                    .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
-                    .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
-    Optional<InputStream> fileStream = fileService.getCollectorImage(collector.getType(), collector.isExternal());
+        this.collectorRepository
+            .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
+            .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
+    Optional<InputStream> fileStream =
+        fileService.getCollectorImage(collector.getType(), collector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -381,9 +384,9 @@ public class DocumentApi extends RestBehavior {
     response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE);
     response.setStatus(HttpServletResponse.SC_OK);
     Collector collector =
-            this.collectorRepository
-                    .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
-                    .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
+        this.collectorRepository
+            .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
+            .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
     try (InputStream fileStream =
         fileService
             .getCollectorImage(collectorType, collector.isExternal())
@@ -405,7 +408,8 @@ public class DocumentApi extends RestBehavior {
         this.collectorRepository
             .findByIdAndTenantId(collectorId, TenantContext.getCurrentTenant())
             .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
-    Optional<InputStream> fileStream = fileService.getCollectorImage(collector.getType(), collector.isExternal());
+    Optional<InputStream> fileStream =
+        fileService.getCollectorImage(collector.getType(), collector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -317,7 +317,11 @@ public class DocumentApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getInjectorImage(@PathVariable String injectorType)
       throws IOException {
-    Optional<InputStream> fileStream = fileService.getInjectorImage(injectorType);
+    Injector injector =
+            this.injectorRepository
+                    .findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant())
+                    .orElseThrow(() -> new ElementNotFoundException("Injector not found"));
+    Optional<InputStream> fileStream = fileService.getInjectorImage(injector.getType(), injector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -339,7 +343,7 @@ public class DocumentApi extends RestBehavior {
         this.injectorRepository
             .findByIdAndTenantId(injectorId, TenantContext.getCurrentTenant())
             .orElseThrow(() -> new ElementNotFoundException("Injector not found"));
-    Optional<InputStream> fileStream = fileService.getInjectorImage(injector.getType());
+    Optional<InputStream> fileStream = fileService.getInjectorImage(injector.getType(), injector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -357,7 +361,11 @@ public class DocumentApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getCollectorImage(@PathVariable String collectorType)
       throws IOException {
-    Optional<InputStream> fileStream = fileService.getCollectorImage(collectorType);
+    Collector collector =
+            this.collectorRepository
+                    .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
+                    .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
+    Optional<InputStream> fileStream = fileService.getCollectorImage(collector.getType(), collector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -372,9 +380,13 @@ public class DocumentApi extends RestBehavior {
         HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + collectorType + ".png");
     response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE);
     response.setStatus(HttpServletResponse.SC_OK);
+    Collector collector =
+            this.collectorRepository
+                    .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
+                    .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
     try (InputStream fileStream =
         fileService
-            .getCollectorImage(collectorType)
+            .getCollectorImage(collectorType, collector.isExternal())
             .orElseThrow(() -> new ElementNotFoundException("File not found"))) {
       fileStream.transferTo(response.getOutputStream());
     }
@@ -393,7 +405,7 @@ public class DocumentApi extends RestBehavior {
         this.collectorRepository
             .findByIdAndTenantId(collectorId, TenantContext.getCurrentTenant())
             .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
-    Optional<InputStream> fileStream = fileService.getCollectorImage(collector.getType());
+    Optional<InputStream> fileStream = fileService.getCollectorImage(collector.getType(), collector.isExternal());
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -462,7 +474,7 @@ public class DocumentApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getExecutorIconImage(@PathVariable String executorId)
       throws IOException {
-    Optional<InputStream> fileStream = fileService.getExecutorIconImage(executorId);
+    Optional<InputStream> fileStream = fileService.getExecutorIconImage(executorId, false);
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
@@ -480,7 +492,7 @@ public class DocumentApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   public @ResponseBody ResponseEntity<byte[]> getExecutorBannerImage(
       @PathVariable String executorId) throws IOException {
-    Optional<InputStream> fileStream = fileService.getExecutorBannerImage(executorId);
+    Optional<InputStream> fileStream = fileService.getExecutorBannerImage(executorId, false);
     if (fileStream.isPresent()) {
       return ResponseEntity.ok()
           .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))

--- a/openaev-api/src/test/java/io/openaev/rest/CatalogConnectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/CatalogConnectorApiTest.java
@@ -9,15 +9,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.CatalogConnector;
 import io.openaev.database.model.CatalogConnectorConfiguration;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.FileService;
+import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.ConnectorInstanceFixture;
 import io.openaev.utils.fixtures.composers.CatalogConnectorComposer;
 import io.openaev.utils.fixtures.composers.CatalogConnectorConfigurationComposer;
 import io.openaev.utils.fixtures.composers.ConnectorInstanceComposer;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.transaction.Transactional;
+import java.io.ByteArrayInputStream;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +41,8 @@ public class CatalogConnectorApiTest extends IntegrationTest {
   @Autowired private CatalogConnectorComposer catalogConnectorComposer;
   @Autowired private ConnectorInstanceComposer connectorInstanceComposer;
   @Autowired private CatalogConnectorConfigurationComposer catalogConfigurationComposer;
+  @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
+  @Autowired private FileService fileService;
 
   @Test
   @DisplayName(
@@ -128,5 +135,28 @@ public class CatalogConnectorApiTest extends IntegrationTest {
         .inPath("[*].catalog_connector_title")
         .isArray()
         .containsExactlyInAnyOrderElementsOf(List.of("Collector1", "Collector2"));
+  }
+
+  @Test
+  @DisplayName("Given non-default tenant should retrieve catalog logo from default tenant storage")
+  void given_nonDefaultTenant_should_retrieveCatalogLogoFromDefaultTenantStorage()
+      throws Exception {
+    // Arrange
+    String fileName = "tenant-fallback-logo.png";
+    TenantContext.setCurrentTenant(Tenant.DEFAULT_TENANT_UUID);
+    try {
+      fileService.uploadStream(
+          FileService.CONNECTORS_LOGO_PATH,
+          fileName,
+          new ByteArrayInputStream(new byte[] {1, 2, 3}));
+    } finally {
+      TenantContext.clearCurrentTenant();
+    }
+    Tenant tenant = tenantIsolationTestHelper.createTenantWithCurrentUser("logo-fallback");
+
+    // Act / Assert
+    mvc.perform(
+            get("/api/tenants/" + tenant.getId() + "/images/catalog/connectors/logos/" + fileName))
+        .andExpect(status().isOk());
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/CollectorRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/CollectorRepository.java
@@ -47,4 +47,6 @@ public interface CollectorRepository
       nativeQuery = true,
       value = "DELETE FROM collectors WHERE collector_id = :id AND tenant_id = :tenantId")
   void deleteByIdAndTenantId(@Param("id") String id, @Param("tenantId") String tenantId);
+
+  Optional<Collector> findByTypeAndTenantId(@NotNull String type, @NotNull String tenantId);
 }

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -73,7 +73,7 @@ public class FileService {
    * @throws Exception if the upload fails
    */
   public String uploadStream(String path, String name, InputStream data) throws Exception {
-    String file = path.endsWith("/") ? path + name :  path + "/" + name;
+    String file = path.endsWith("/") ? path + name : path + "/" + name;
     minioService.uploadStreamInTenantPath(file, name, data);
     return file;
   }
@@ -136,7 +136,8 @@ public class FileService {
    * Retrieves an injector's image file.
    *
    * @param injectType the injector type identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
+   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getInjectorImage(String injectType, boolean isExternal) {
@@ -147,7 +148,8 @@ public class FileService {
    * Retrieves a collector's image file.
    *
    * @param collectorId the collector identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
+   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getCollectorImage(String collectorId, boolean isExternal) {
@@ -158,7 +160,8 @@ public class FileService {
    * Retrieves an executor's icon image file.
    *
    * @param executorId the executor identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
+   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getExecutorIconImage(String executorId, boolean isExternal) {
@@ -169,7 +172,8 @@ public class FileService {
    * Retrieves an executor's banner image file.
    *
    * @param executorId the executor identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
+   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getExecutorBannerImage(String executorId, boolean isExternal) {
@@ -180,7 +184,8 @@ public class FileService {
    * Retrieves a catalog connector's logo image file.
    *
    * @param fileName the logo filename
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
+   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getCatalogConnectorImage(String fileName, boolean isExternal) {
@@ -192,7 +197,8 @@ public class FileService {
    * should fall back to specific tenant if isExternal is true.
    *
    * @param filePath to retrieve
-   * @param isExternal indicates if the file is a built-in asset (false) or from an external asset (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or from an external asset
+   *     (true)
    * @return finded file
    */
   private Optional<InputStream> getPlatformImage(String filePath, boolean isExternal) {
@@ -200,7 +206,8 @@ public class FileService {
     if (tenantFile.isPresent()) {
       return tenantFile;
     }
-    return minioService.getFilePathForTenant(isExternal ? TenantContext.getCurrentTenant() : Tenant.DEFAULT_TENANT_UUID, filePath);
+    return minioService.getFilePathForTenant(
+        isExternal ? TenantContext.getCurrentTenant() : Tenant.DEFAULT_TENANT_UUID, filePath);
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -73,7 +73,7 @@ public class FileService {
    * @throws Exception if the upload fails
    */
   public String uploadStream(String path, String name, InputStream data) throws Exception {
-    String file = path + "/" + name;
+    String file = path.endsWith("/") ? path + name :  path + "/" + name;
     minioService.uploadStreamInTenantPath(file, name, data);
     return file;
   }

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -188,11 +188,11 @@ public class FileService {
   }
 
   /**
-   * Platform assets are written once under the default tenant during startup; non-default tenants
-   * should transparently fall back to that location.
+   * Platform assets are written once under the default tenant during startup for built in assets
+   * should fall back to specific tenant if isExternal is true.
    *
    * @param filePath to retrieve
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @param isExternal indicates if the file is a built-in asset (false) or from an external asset (true)
    * @return finded file
    */
   private Optional<InputStream> getPlatformImage(String filePath, boolean isExternal) {

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -1,6 +1,7 @@
 package io.openaev.service;
 
 import io.openaev.database.model.Document;
+import io.openaev.database.model.Tenant;
 import java.io.InputStream;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -137,7 +138,7 @@ public class FileService {
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getInjectorImage(String injectType) {
-    return getFilePath(INJECTORS_IMAGES_BASE_PATH + injectType + EXT_PNG);
+    return getPlatformImage(INJECTORS_IMAGES_BASE_PATH + injectType + EXT_PNG);
   }
 
   /**
@@ -147,7 +148,7 @@ public class FileService {
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getCollectorImage(String collectorId) {
-    return getFilePath(COLLECTORS_IMAGES_BASE_PATH + collectorId + EXT_PNG);
+    return getPlatformImage(COLLECTORS_IMAGES_BASE_PATH + collectorId + EXT_PNG);
   }
 
   /**
@@ -157,7 +158,7 @@ public class FileService {
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getExecutorIconImage(String executorId) {
-    return getFilePath(EXECUTORS_IMAGES_ICONS_BASE_PATH + executorId + EXT_PNG);
+    return getPlatformImage(EXECUTORS_IMAGES_ICONS_BASE_PATH + executorId + EXT_PNG);
   }
 
   /**
@@ -167,7 +168,7 @@ public class FileService {
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getExecutorBannerImage(String executorId) {
-    return getFilePath(EXECUTORS_IMAGES_BANNERS_BASE_PATH + executorId + EXT_PNG);
+    return getPlatformImage(EXECUTORS_IMAGES_BANNERS_BASE_PATH + executorId + EXT_PNG);
   }
 
   /**
@@ -177,7 +178,19 @@ public class FileService {
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getCatalogConnectorImage(String fileName) {
-    return getFilePath(CONNECTORS_LOGO_PATH + fileName);
+    return getPlatformImage(CONNECTORS_LOGO_PATH + fileName);
+  }
+
+  /**
+   * Platform assets are written once under the default tenant during startup; non-default tenants
+   * should transparently fall back to that location.
+   */
+  private Optional<InputStream> getPlatformImage(String filePath) {
+    Optional<InputStream> tenantFile = getFilePath(filePath);
+    if (tenantFile.isPresent()) {
+      return tenantFile;
+    }
+    return minioService.getFilePathForTenant(Tenant.DEFAULT_TENANT_UUID, filePath);
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -1,5 +1,6 @@
 package io.openaev.service;
 
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.Document;
 import io.openaev.database.model.Tenant;
 import java.io.InputStream;
@@ -135,62 +136,71 @@ public class FileService {
    * Retrieves an injector's image file.
    *
    * @param injectType the injector type identifier
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getInjectorImage(String injectType) {
-    return getPlatformImage(INJECTORS_IMAGES_BASE_PATH + injectType + EXT_PNG);
+  public Optional<InputStream> getInjectorImage(String injectType, boolean isExternal) {
+    return getPlatformImage(INJECTORS_IMAGES_BASE_PATH + injectType + EXT_PNG, isExternal);
   }
 
   /**
    * Retrieves a collector's image file.
    *
    * @param collectorId the collector identifier
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getCollectorImage(String collectorId) {
-    return getPlatformImage(COLLECTORS_IMAGES_BASE_PATH + collectorId + EXT_PNG);
+  public Optional<InputStream> getCollectorImage(String collectorId, boolean isExternal) {
+    return getPlatformImage(COLLECTORS_IMAGES_BASE_PATH + collectorId + EXT_PNG, isExternal);
   }
 
   /**
    * Retrieves an executor's icon image file.
    *
    * @param executorId the executor identifier
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getExecutorIconImage(String executorId) {
-    return getPlatformImage(EXECUTORS_IMAGES_ICONS_BASE_PATH + executorId + EXT_PNG);
+  public Optional<InputStream> getExecutorIconImage(String executorId, boolean isExternal) {
+    return getPlatformImage(EXECUTORS_IMAGES_ICONS_BASE_PATH + executorId + EXT_PNG, isExternal);
   }
 
   /**
    * Retrieves an executor's banner image file.
    *
    * @param executorId the executor identifier
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getExecutorBannerImage(String executorId) {
-    return getPlatformImage(EXECUTORS_IMAGES_BANNERS_BASE_PATH + executorId + EXT_PNG);
+  public Optional<InputStream> getExecutorBannerImage(String executorId, boolean isExternal) {
+    return getPlatformImage(EXECUTORS_IMAGES_BANNERS_BASE_PATH + executorId + EXT_PNG, isExternal);
   }
 
   /**
    * Retrieves a catalog connector's logo image file.
    *
    * @param fileName the logo filename
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getCatalogConnectorImage(String fileName) {
-    return getPlatformImage(CONNECTORS_LOGO_PATH + fileName);
+  public Optional<InputStream> getCatalogConnectorImage(String fileName, boolean isExternal) {
+    return getPlatformImage(CONNECTORS_LOGO_PATH + fileName, isExternal);
   }
 
   /**
    * Platform assets are written once under the default tenant during startup; non-default tenants
    * should transparently fall back to that location.
+   *
+   * @param filePath to retrieve
+   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file (true)
+   * @return finded file
    */
-  private Optional<InputStream> getPlatformImage(String filePath) {
+  private Optional<InputStream> getPlatformImage(String filePath, boolean isExternal) {
     Optional<InputStream> tenantFile = getFilePath(filePath);
     if (tenantFile.isPresent()) {
       return tenantFile;
     }
-    return minioService.getFilePathForTenant(Tenant.DEFAULT_TENANT_UUID, filePath);
+    return minioService.getFilePathForTenant(isExternal ? TenantContext.getCurrentTenant() : Tenant.DEFAULT_TENANT_UUID, filePath);
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/service/MinioService.java
+++ b/openaev-model/src/main/java/io/openaev/service/MinioService.java
@@ -105,7 +105,7 @@ public class MinioService implements DependenciesManager {
       InputStreamResource streamResource = new InputStreamResource(objectStream);
       return Optional.of(streamResource.getInputStream());
     } catch (Exception e) {
-      log.error("Error during file access", e);
+      log.info("Error during file access", e);
       return Optional.empty();
     }
   }

--- a/openaev-model/src/main/java/io/openaev/service/MinioService.java
+++ b/openaev-model/src/main/java/io/openaev/service/MinioService.java
@@ -94,6 +94,22 @@ public class MinioService implements DependenciesManager {
     }
   }
 
+  public Optional<InputStream> getFilePathForTenant(String tenantId, String name) {
+    try {
+      GetObjectResponse objectStream =
+          minioClient.getObject(
+              GetObjectArgs.builder()
+                  .bucket(bucket())
+                  .object(getPathForTenant(tenantId, name))
+                  .build());
+      InputStreamResource streamResource = new InputStreamResource(objectStream);
+      return Optional.of(streamResource.getInputStream());
+    } catch (Exception e) {
+      log.error("Error during file access", e);
+      return Optional.empty();
+    }
+  }
+
   public Optional<FileContainer> getFileContainerInTenant(String fileTarget) {
     try {
       StatObjectResponse response = objectExists(getTenantPath(fileTarget));
@@ -246,6 +262,10 @@ public class MinioService implements DependenciesManager {
   /** Returns the tenant-prefixed path for the given object name. */
   private String getTenantPath(String objectName) {
     String tenantId = TenantContext.getCurrentTenant();
+    return getPathForTenant(tenantId, objectName);
+  }
+
+  private String getPathForTenant(String tenantId, String objectName) {
     if (objectName.startsWith("/")) {
       return tenantId + objectName;
     }


### PR DESCRIPTION

Description:
When switching between tenants while on the connector or injector page, some icons fail to load properly.

### Testing Instructions

1. Log in as a user with the appropriate capabilities on Tenant A
2. Navigate to the catalog/connector/injector page
3. Switch to Tenant B (with appropriate capabilities) while staying on the same page

Expected Output:
Icons should display correctly on both tenants without any issue.

### Related issues

* [#118](https://github.com/orgs/OpenAEV-Platform/projects/2/views/49?pane=issue&itemId=187062537&issue=OpenAEV-Platform%7Cfiligran-private%7C118)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
