### PR TITLE
[frontend] feat(threat-arsenal): fix toolbar behavior (#5822)

### DIFF
--- a/openaev-front/src/admin/components/threat_arsenal/ThreatArsenal.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/ThreatArsenal.tsx
@@ -232,8 +232,8 @@ const ThreatArsenal = () => {
         <ListItem
           classes={{ root: classes.itemHead }}
           divider={false}
-          style={{ paddingTop: 0 }}
-          secondaryAction={<>&nbsp;</>}
+          style={{ ...(numberOfSelectedElements > 0 ? { backgroundColor: 'rgb(15, 30, 56)' } : {}) }}
+          {...(numberOfSelectedElements === 0 ? { secondaryAction: <>&nbsp;</> } : {})}
         >
           <ListItemIcon style={{ minWidth: 40 }}>
             <Checkbox
@@ -244,17 +244,42 @@ const ThreatArsenal = () => {
               disabled={typeof handleToggleSelectAll !== 'function'}
             />
           </ListItemIcon>
-
-          <ListItemIcon />
-          <ListItemText
-            primary={(
-              <SortHeadersComponentV2
-                headers={headers}
-                inlineStylesHeaders={inlineStyles}
-                sortHelpers={queryableHelpers.sortHelpers}
+          {numberOfSelectedElements > 0 ? (
+            <ListItemText
+              primary={(
+                <ToolBar
+                  numberOfSelectedElements={numberOfSelectedElements}
+                  handleClearSelectedElements={handleClearSelectedElements}
+                  teamsFromExerciseOrScenario={[]}
+                  customAction={(
+                    <Tooltip title={t('Run a test')}>
+                      <IconButton
+                        aria-label="run-a-test"
+                        onClick={() => setRunTestDrawerOpened(true)}
+                        color="primary"
+                        size="small"
+                      >
+                        <MovieFilterOutlined fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                />
+              )}
+            />
+          ) : (
+            <>
+              <ListItemIcon />
+              <ListItemText
+                primary={(
+                  <SortHeadersComponentV2
+                    headers={headers}
+                    inlineStylesHeaders={inlineStyles}
+                    sortHelpers={queryableHelpers.sortHelpers}
+                  />
+                )}
               />
-            )}
-          />
+            </>
+          )}
         </ListItem>
         {loading
           ? <PaginatedListLoader Icon={HelpOutlineOutlined} headers={headers} headerStyles={inlineStyles} />
@@ -371,27 +396,7 @@ const ThreatArsenal = () => {
           onClose={() => setRunTestDrawerOpened(false)}
         />
       )}
-      {
-        numberOfSelectedElements > 0 && (
-          <ToolBar
-            numberOfSelectedElements={numberOfSelectedElements}
-            handleClearSelectedElements={handleClearSelectedElements}
-            teamsFromExerciseOrScenario={[]}
-            customAction={(
-              <Tooltip title={t('Run a test')}>
-                <IconButton
-                  aria-label="run-a-test"
-                  onClick={() => setRunTestDrawerOpened(true)}
-                  color="primary"
-                  size="small"
-                >
-                  <MovieFilterOutlined fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            )}
-          />
-        )
-      }
+
     </Stack>
   );
 };


### PR DESCRIPTION
Move bulk toolbar into the header in new threat arsenal page

<img width="1549" height="575" alt="image" src="https://github.com/user-attachments/assets/03e2e316-4e30-4097-b37c-615e77531859" />

Expected Output
Bulk toolbar with selected element must appear instead of grid header

<img width="1547" height="650" alt="image" src="https://github.com/user-attachments/assets/814385e7-8519-48cc-a2ba-d16e6afc2c87" />


### Testing Instructions

1. Go to threat arsenal page, select one or more contract

### Related issues

* Closes #5822
