### PR TITLE
[backend/frontend] fix(multi_tenancy): scope stream by tenant (#5823)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
@@ -107,37 +107,49 @@ public class StreamApi extends RestBehavior {
           // FIXME find a way to cache user
           // -> close session when user se login
 
-          FluxSink<Object> fluxSink = consumer.fluxSink();
-          if (!permissionService.hasPermission(
-              user,
-              Optional.empty(),
-              event.getInstance().getId(),
-              event.getInstance().getResourceType(),
-              Action.READ)) {
-            // If user as no visibility, we can send a "delete" userEvent with only the internal
-            // id
-            // TODO -> rethink this logic -> do we need to send DELETE events
-            try {
-              String propertyId =
-                  event
-                      .getInstance()
-                      .getClass()
-                      .getDeclaredField("id")
-                      .getAnnotation(JsonProperty.class)
-                      .value();
-              ObjectNode deleteNode = mapper.createObjectNode();
-              deleteNode.set(
-                  propertyId, mapper.convertValue(event.getInstance().getId(), JsonNode.class));
-              BaseEvent userEvent = event.clone();
-              userEvent.setInstanceData(deleteNode);
-              userEvent.setType(DATA_DELETE);
-              sendStreamEvent(fluxSink, userEvent);
-            } catch (Exception e) {
-              String simpleName = event.getInstance().getClass().getSimpleName();
-              log.warn(String.format("Class %s can't be streamed", simpleName), e);
+          // Set the tenant context for permission checks on the async thread.
+          // Without this, TenantContext defaults to DEFAULT_TENANT_UUID, causing
+          // tenant-scoped capabilities to be invisible and incorrect DELETE events
+          // to be sent for entities on non-default tenants.
+          if (consumer.tenantId() != null && !consumer.tenantId().isBlank()) {
+            TenantContext.setCurrentTenant(consumer.tenantId());
+          }
+
+          try {
+            FluxSink<Object> fluxSink = consumer.fluxSink();
+            if (!permissionService.hasPermission(
+                user,
+                Optional.empty(),
+                event.getInstance().getId(),
+                event.getInstance().getResourceType(),
+                Action.READ)) {
+              try {
+                String propertyId =
+                    event
+                        .getInstance()
+                        .getClass()
+                        .getDeclaredField("id")
+                        .getAnnotation(JsonProperty.class)
+                        .value();
+                ObjectNode deleteNode = mapper.createObjectNode();
+                deleteNode.set(
+                    propertyId, mapper.convertValue(event.getInstance().getId(), JsonNode.class));
+                BaseEvent userEvent = event.clone();
+                userEvent.setInstanceData(deleteNode);
+                userEvent.setType(DATA_DELETE);
+                sendStreamEvent(fluxSink, userEvent);
+              } catch (Exception e) {
+                String simpleName = event.getInstance().getClass().getSimpleName();
+                log.warn(String.format("Class %s can't be streamed", simpleName), e);
+              }
+            } else {
+              sendStreamEvent(fluxSink, event);
             }
-          } else {
-            sendStreamEvent(fluxSink, event);
+          } finally {
+            // Reset tenant context to avoid leaking into other consumers in the loop
+            if (consumer.tenantId() != null && !consumer.tenantId().isBlank()) {
+              TenantContext.clearCurrentTenant();
+            }
           }
         });
   }

--- a/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
@@ -1,6 +1,7 @@
 package io.openaev.rest.stream;
 
 import static io.openaev.config.SessionHelper.currentUser;
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.database.audit.ModelBaseListener.DATA_DELETE;
 import static java.time.Instant.now;
 
@@ -9,9 +10,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.aop.AccessControl;
 import io.openaev.config.OpenAEVPrincipal;
+import io.openaev.context.TenantContext;
 import io.openaev.database.audit.BaseEvent;
 import io.openaev.database.model.Action;
+import io.openaev.database.model.DualScopeBase;
 import io.openaev.database.model.ResourceType;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.TenantBase;
 import io.openaev.database.model.User;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.service.PermissionService;
@@ -37,8 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.RequestContextHolder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 @RestController
 @Slf4j
@@ -47,12 +50,15 @@ public class StreamApi extends RestBehavior {
   public static final String EVENT_TYPE_MESSAGE = "message";
   public static final String EVENT_TYPE_PING = "ping";
   public static final String X_ACCEL_BUFFERING = "X-Accel-Buffering";
-  private final Map<String, Tuple2<OpenAEVPrincipal, FluxSink<Object>>> consumers = new HashMap<>();
+  private final Map<String, StreamConsumer> consumers = new HashMap<>();
 
   private final PermissionService permissionService;
   private final UserService userService;
 
   private Instant lastUpdate = Instant.now();
+
+  private record StreamConsumer(
+      OpenAEVPrincipal principal, String tenantId, FluxSink<Object> fluxSink) {}
 
   public StreamApi(PermissionService permissionService, UserService userService) {
     this.permissionService = permissionService;
@@ -84,7 +90,7 @@ public class StreamApi extends RestBehavior {
           "There are currently {} users connected to the stream. The id of the users connected : {}",
           consumers.size(),
           consumers.values().stream()
-              .map(Tuple2::getT1)
+              .map(StreamConsumer::principal)
               .map(OpenAEVPrincipal::getId)
               .collect(Collectors.joining(", ")));
 
@@ -92,12 +98,16 @@ public class StreamApi extends RestBehavior {
     }
 
     consumers.forEach(
-        (key, tupleFlux) -> {
-          User user = userService.user(tupleFlux.getT1().getId());
+        (key, consumer) -> {
+          if (!isVisibleForTenant(event, consumer.tenantId())) {
+            return;
+          }
+
+          User user = userService.user(consumer.principal().getId());
           // FIXME find a way to cache user
           // -> close session when user se login
 
-          FluxSink<Object> fluxSink = tupleFlux.getT2();
+          FluxSink<Object> fluxSink = consumer.fluxSink();
           if (!permissionService.hasPermission(
               user,
               Optional.empty(),
@@ -132,8 +142,25 @@ public class StreamApi extends RestBehavior {
         });
   }
 
+  private boolean isVisibleForTenant(BaseEvent event, String consumerTenantId) {
+    // Keep legacy behavior for /api/stream consumers (no explicit tenant in the URL).
+    if (consumerTenantId == null || consumerTenantId.isBlank()) {
+      return true;
+    }
+    if (event.getInstance() instanceof TenantBase tenantScoped) {
+      return consumerTenantId.equals(tenantScoped.getTenant().getId());
+    }
+    if (event.getInstance() instanceof DualScopeBase dualScope) {
+      Tenant tenant = dualScope.getTenant();
+      return tenant != null && consumerTenantId.equals(tenant.getId());
+    }
+    return true;
+  }
+
   /** Create a flux for current user & session */
-  @GetMapping(path = "/api/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  @GetMapping(
+      path = {"/api/stream", TENANT_PREFIX + "/stream"},
+      produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   @AccessControl(
       skipRBAC = true) // TODO RBAC check must be done manually for every event in this method
   public ResponseEntity<Flux<Object>> streamFlux() {
@@ -142,7 +169,10 @@ public class StreamApi extends RestBehavior {
     Flux<Object> dataFlux =
         Flux.create(
                 fluxSinkConsumer ->
-                    consumers.put(sessionId, Tuples.of(currentUser(), fluxSinkConsumer)))
+                    consumers.put(
+                        sessionId,
+                        new StreamConsumer(
+                            currentUser(), TenantContext.getCurrentTenant(), fluxSinkConsumer)))
             .doAfterTerminate(() -> consumers.remove(sessionId));
     // Build the health check flux.
     Flux<Object> ping =

--- a/openaev-api/src/test/java/io/openaev/rest/stream/StreamApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/stream/StreamApiTest.java
@@ -3,6 +3,7 @@ package io.openaev.rest.stream;
 import static io.openaev.database.audit.ModelBaseListener.DATA_DELETE;
 import static io.openaev.database.audit.ModelBaseListener.DATA_UPDATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -15,7 +16,10 @@ import io.openaev.rest.helper.RestBehavior;
 import io.openaev.service.PermissionService;
 import io.openaev.service.UserService;
 import io.openaev.utils.fixtures.ScenarioFixture;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,8 +33,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.codec.ServerSentEvent;
 import reactor.core.publisher.FluxSink;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 @MockitoSettings(strictness = Strictness.LENIENT) // class-wide
 @ExtendWith(MockitoExtension.class)
@@ -39,6 +41,8 @@ public class StreamApiTest {
   private static final String RESOURCE_ID = "id";
   private static final String USER_ID = "userid";
   private static final String SESSION_ID = "sessionid";
+  private static final String TENANT_ID = "tenant-a";
+  private static final String OTHER_TENANT_ID = "tenant-b";
 
   @Mock private User mockUser;
 
@@ -53,7 +57,7 @@ public class StreamApiTest {
   @InjectMocks private StreamApi streamApi;
 
   @BeforeEach
-  public void setup() throws NoSuchFieldException, IllegalAccessException {
+  public void setup() throws Exception {
     // mock consumer
     OpenAEVPrincipal mockPrincipal = mock(OpenAEVPrincipal.class);
     when(mockPrincipal.getId()).thenReturn(USER_ID);
@@ -67,9 +71,35 @@ public class StreamApiTest {
     // inject into consumers using reflection
     Field consumersField = StreamApi.class.getDeclaredField("consumers");
     consumersField.setAccessible(true);
-    Map<String, Tuple2<OpenAEVPrincipal, FluxSink<Object>>> consumers =
-        (Map<String, Tuple2<OpenAEVPrincipal, FluxSink<Object>>>) consumersField.get(streamApi);
-    consumers.put(SESSION_ID, Tuples.of(mockPrincipal, mockSink));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> consumers = (Map<String, Object>) consumersField.get(streamApi);
+    consumers.put(SESSION_ID, buildStreamConsumer(mockPrincipal, null, mockSink));
+  }
+
+  private static Object buildStreamConsumer(
+      OpenAEVPrincipal principal, String tenantId, FluxSink<Object> sink) throws Exception {
+    Class<?> streamConsumerClass = Class.forName("io.openaev.rest.stream.StreamApi$StreamConsumer");
+    RecordComponent[] components = streamConsumerClass.getRecordComponents();
+    Class<?>[] parameterTypes =
+        new Class<?>[] {
+          components[0].getType(), components[1].getType(), components[2].getType(),
+        };
+    Constructor<?> constructor = streamConsumerClass.getDeclaredConstructor(parameterTypes);
+    constructor.setAccessible(true);
+    return constructor.newInstance(principal, tenantId, sink);
+  }
+
+  private boolean invokeIsVisibleForTenant(BaseEvent event, String tenantId) throws Exception {
+    Method method =
+        StreamApi.class.getDeclaredMethod("isVisibleForTenant", BaseEvent.class, String.class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(streamApi, event, tenantId);
+  }
+
+  private static Tenant tenant(String id) {
+    Tenant tenant = new Tenant();
+    tenant.setId(id);
+    return tenant;
   }
 
   @Test
@@ -134,5 +164,62 @@ public class StreamApiTest {
     streamApi.listenDatabaseUpdate(event);
 
     verify(mockSink, never()).next(any());
+  }
+
+  @Test
+  public void given_tenantScopedEvent_when_tenantMatches_should_beVisible() throws Exception {
+    // Arrange
+    Scenario scenario = ScenarioFixture.getScenario();
+    scenario.setTenant(tenant(TENANT_ID));
+    BaseEvent event = new BaseEvent(DATA_UPDATE, scenario, mock(ObjectMapper.class));
+
+    // Act
+    boolean visible = invokeIsVisibleForTenant(event, TENANT_ID);
+
+    // Assert
+    assertTrue(visible);
+  }
+
+  @Test
+  public void given_tenantScopedEvent_when_tenantDiffers_should_notBeVisible() throws Exception {
+    // Arrange
+    Scenario scenario = ScenarioFixture.getScenario();
+    scenario.setTenant(tenant(TENANT_ID));
+    BaseEvent event = new BaseEvent(DATA_UPDATE, scenario, mock(ObjectMapper.class));
+
+    // Act
+    boolean visible = invokeIsVisibleForTenant(event, OTHER_TENANT_ID);
+
+    // Assert
+    assertFalse(visible);
+  }
+
+  @Test
+  public void given_dualScopeEventWithoutTenant_when_consumerHasTenant_should_notBeVisible()
+      throws Exception {
+    // Arrange
+    Setting setting = new Setting();
+    setting.setId("setting-id");
+    BaseEvent event = new BaseEvent(DATA_UPDATE, setting, mock(ObjectMapper.class));
+
+    // Act
+    boolean visible = invokeIsVisibleForTenant(event, TENANT_ID);
+
+    // Assert
+    assertFalse(visible);
+  }
+
+  @Test
+  public void given_tenantScopedEvent_when_consumerHasNoTenant_should_beVisible() throws Exception {
+    // Arrange
+    Scenario scenario = ScenarioFixture.getScenario();
+    scenario.setTenant(tenant(TENANT_ID));
+    BaseEvent event = new BaseEvent(DATA_UPDATE, scenario, mock(ObjectMapper.class));
+
+    // Act
+    boolean visible = invokeIsVisibleForTenant(event, null);
+
+    // Assert
+    assertTrue(visible);
   }
 }

--- a/openaev-front/src/utils/url-helper.ts
+++ b/openaev-front/src/utils/url-helper.ts
@@ -152,7 +152,6 @@ const TENANT_EXEMPT_PREFIXES = [
   '/api/xtmhub/contact-us',
   '/api/xtmhub/auto-register',
   '/api/xtm-composer',
-  '/api/stream',
   '/api/schemas',
   '/api/engine',
 ];


### PR DESCRIPTION
### Proposed changes

* Manage the Stream API by tenant because a user connected to a tenant want to see only elements from this tenant

### Testing Instructions

1. See in the issue

### Related issues

* Closes #5823 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
