### PR TITLE
feat(audit-log): critical log write failure (#5793)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -12,7 +12,6 @@ import io.openaev.service.LogService;
 import io.openaev.utils.log.LogUtils;
 import java.lang.annotation.Annotation;
 import java.util.UUID;
-import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
@@ -133,30 +132,15 @@ public class AccessControlAuditLogAspect {
       JsonNode inputNode = getInputNode(joinPoint, eventScope);
       JsonNode signatureNode = getMethodSignature(joinPoint, inputNode);
 
-      BiConsumer<Boolean, Throwable> logCompletion =
-          (success, throwable) -> {
-            if (throwable != null || (success != null && !success)) {
-              log.warn(
-                  "[AUDIT] Failed to log access control event for {}.{}", resourceType, eventScope);
-              if (throwable != null) {
-                log.warn(LOG_ERROR_MSG, throwable);
-              }
-
-              auditLogger.prepareLogFailure();
-            }
-          };
-
-      auditLogger
-          .logAccessControlEvent(
-              eventScope,
-              eventStatus,
-              resourceType,
-              resourceId,
-              inputNode,
-              outputNode,
-              signatureNode,
-              logUUID)
-          .whenComplete(logCompletion);
+      auditLogger.logAccessControlEvent(
+          eventScope,
+          eventStatus,
+          resourceType,
+          resourceId,
+          inputNode,
+          outputNode,
+          signatureNode,
+          logUUID);
     } catch (Exception ex) {
       log.warn(LOG_ERROR_MSG, ex);
     }

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -141,6 +141,8 @@ public class AccessControlAuditLogAspect {
               if (throwable != null) {
                 log.warn(LOG_ERROR_MSG, throwable);
               }
+
+              accessControlAuditLogger.prepareLogFailure();
             }
           };
 

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -155,7 +155,6 @@ public class AccessControlAuditLogAspect {
               signatureNode,
               logUUID)
           .whenComplete(logCompletion);
-      ;
     } catch (Exception ex) {
       log.warn(LOG_ERROR_MSG, ex);
     }

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -12,6 +12,7 @@ import io.openaev.service.LogService;
 import io.openaev.utils.log.LogUtils;
 import java.lang.annotation.Annotation;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
@@ -132,15 +133,29 @@ public class AccessControlAuditLogAspect {
       JsonNode inputNode = getInputNode(joinPoint, eventScope);
       JsonNode signatureNode = getMethodSignature(joinPoint, inputNode);
 
-      auditLogger.logAccessControlEvent(
-          eventScope,
-          eventStatus,
-          resourceType,
-          resourceId,
-          inputNode,
-          outputNode,
-          signatureNode,
-          logUUID);
+      BiConsumer<Boolean, Throwable> logCompletion =
+          (success, throwable) -> {
+            if (throwable != null || (success != null && !success)) {
+              log.warn(
+                  "[AUDIT] Failed to log access control event for {}.{}", resourceType, eventScope);
+              if (throwable != null) {
+                log.warn(LOG_ERROR_MSG, throwable);
+              }
+            }
+          };
+
+      auditLogger
+          .logAccessControlEvent(
+              eventScope,
+              eventStatus,
+              resourceType,
+              resourceId,
+              inputNode,
+              outputNode,
+              signatureNode,
+              logUUID)
+          .whenComplete(logCompletion);
+      ;
     } catch (Exception ex) {
       log.warn(LOG_ERROR_MSG, ex);
     }

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -142,7 +142,7 @@ public class AccessControlAuditLogAspect {
                 log.warn(LOG_ERROR_MSG, throwable);
               }
 
-              accessControlAuditLogger.prepareLogFailure();
+              auditLogger.prepareLogFailure();
             }
           };
 

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.openaev.aop.AccessControl;
 import io.openaev.aop.AccessControlAspect;
 import io.openaev.config.ThreadPoolTaskLoggerConfig;
+import io.openaev.config.audit_log.AuditLogProperties;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.service.LogService;
@@ -11,7 +12,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.ApplicationContext;
@@ -33,11 +33,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AuditLogger {
 
-  @Value("${openaev.audit-logs.stop-the-world:false}")
-  private boolean stw;
-
   private final ApplicationContext context;
   private final AuditRequestValidator auditRequestValidator;
+  private final AuditLogProperties auditLogProperties;
   private final LogService logService;
 
   public boolean isAuditLoggingEnabled() {
@@ -53,18 +51,18 @@ public class AuditLogger {
   }
 
   public void prepareLogFailure() {
-    // Halt the application when stop-the-world is enabled and a log failure occurs.
-    if (stw) {
-      log.error("[AUDIT] Stop-the-world triggered — shutting down application.");
+    // Halt the application when Halt-on-failure is enabled and a log failure occurs.
+    try {
+      if (auditLogProperties.isHaltOnFailure()) {
+        log.error("[AUDIT] Halt-on-failure triggered — shutting down application.");
 
-      try {
         int exitCode = SpringApplication.exit(context, () -> 1);
-        System.exit(exitCode);
-      } catch (Exception e) {
-        log.warn("[AUDIT] Failed to stop application after log failure: {}", e.getMessage(), e);
+        log.error("[AUDIT] Spring shutdown initiated with exit code {}.", exitCode);
+      } else {
+        log.warn("[AUDIT] Halt-on-failure disabled, application continue running...");
       }
-    } else {
-      log.warn("[AUDIT] Stop-the-world disabled, application continue running...");
+    } catch (Exception e) {
+      log.warn("[AUDIT] Failed to execute log failure action: {}", e.getMessage(), e);
     }
   }
 
@@ -108,6 +106,8 @@ public class AuditLogger {
     }
 
     if (!status) {
+      log.warn("[AUDIT] Failed to log auth event for {}.{}", provider, eventScope);
+
       prepareLogFailure();
     }
 
@@ -150,6 +150,8 @@ public class AuditLogger {
     }
 
     if (!status) {
+      log.warn("[AUDIT] Failed to log access control event for {}.{}", resourceType, eventScope);
+
       prepareLogFailure();
     }
 

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
@@ -9,6 +9,7 @@ import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.service.LogService;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ public class AuditLogger {
   private final AuditRequestValidator auditRequestValidator;
   private final AuditLogProperties auditLogProperties;
   private final LogService logService;
+  private final AtomicBoolean shutdownTriggered = new AtomicBoolean(false);
 
   public boolean isAuditLoggingEnabled() {
     return logService.isEnabled();
@@ -53,14 +55,19 @@ public class AuditLogger {
   public void prepareLogFailure() {
     // Halt the application when Halt-on-failure is enabled and a log failure occurs.
     try {
-      if (auditLogProperties.isHaltOnFailure()) {
-        log.error("[AUDIT] Halt-on-failure triggered — shutting down application.");
-
-        int exitCode = SpringApplication.exit(context, () -> 1);
-        log.error("[AUDIT] Spring shutdown initiated with exit code {}.", exitCode);
-      } else {
-        log.warn("[AUDIT] Halt-on-failure disabled, application continue running...");
+      if (!auditLogProperties.isHaltOnFailure()) {
+        log.info("[AUDIT] Halt-on-failure disabled, application continue running...");
+        return;
       }
+
+      if (!shutdownTriggered.compareAndSet(false, true)) {
+        log.debug("[AUDIT] Shutdown already triggered by another thread.");
+        return;
+      }
+
+      log.error("[AUDIT] Halt-on-failure triggered - shutting down application.");
+      int exitCode = SpringApplication.exit(context, () -> 1);
+      log.error("[AUDIT] Spring shutdown initiated with exit code {}.", exitCode);
     } catch (Exception e) {
       log.warn("[AUDIT] Failed to execute log failure action: {}", e.getMessage(), e);
     }

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
@@ -53,6 +53,7 @@ public class AuditLogger {
   }
 
   public void prepareLogFailure() {
+    // Halt the application when stop-the-world is enabled and a log failure occurs.
     if (stw) {
       log.error("[AUDIT] Stop-the-world triggered — shutting down application.");
 
@@ -67,7 +68,10 @@ public class AuditLogger {
     }
   }
 
-  /** Wraps the audit service call in try/catch — audit must never break the business flow. */
+  /**
+   * Log Authentication events Wraps the audit service call in try/catch — non-blocking by default,
+   * but may terminate the process when stop-the-world audit failure handling is enabled.
+   */
   @Async("taskLoggerExecutor")
   public CompletableFuture<Boolean> logAuthEventWithRequestContext(
       ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData rcd,
@@ -84,7 +88,10 @@ public class AuditLogger {
     return logAuthEvent(eventScope, eventStatus, provider, reason, logUUID);
   }
 
-  /** Wraps the audit service call in try/catch — audit must never break the business flow. */
+  /**
+   * Log Authentication events Wraps the audit service call in try/catch — non-blocking by default,
+   * but may terminate the process when stop-the-world audit failure handling is enabled.
+   */
   @Async("taskLoggerExecutor")
   public CompletableFuture<Boolean> logAuthEvent(
       String eventScope, String eventStatus, String provider, String reason, String logUUID) {
@@ -107,6 +114,10 @@ public class AuditLogger {
     return CompletableFuture.completedFuture(status);
   }
 
+  /**
+   * Log Mutation events Wraps the audit service call in try/catch — non-blocking by default, but
+   * may terminate the process when stop-the-world audit failure handling is enabled.
+   */
   @Async("taskLoggerExecutor")
   public CompletableFuture<Boolean> logAccessControlEvent(
       String eventScope,

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
@@ -66,7 +66,12 @@ public class AuditLogger {
       }
 
       log.error("[AUDIT] Halt-on-failure triggered - shutting down application.");
-      int exitCode = SpringApplication.exit(context, () -> 1);
+      int exitCode = SpringApplication.exit(context);
+      if (exitCode == 0) {
+        exitCode = 1; // optional fallback policy
+      }
+
+      System.exit(exitCode);
       log.error("[AUDIT] Spring shutdown initiated with exit code {}.", exitCode);
     } catch (Exception e) {
       log.warn("[AUDIT] Failed to execute log failure action: {}", e.getMessage(), e);

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
@@ -11,7 +11,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
@@ -30,8 +33,11 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AuditLogger {
 
-  private final AuditRequestValidator auditRequestValidator;
+  @Value("${openaev.audit-logs.stop-the-world:false}")
+  private boolean stw;
 
+  private final ApplicationContext context;
+  private final AuditRequestValidator auditRequestValidator;
   private final LogService logService;
 
   public boolean isAuditLoggingEnabled() {
@@ -44,6 +50,21 @@ public class AuditLogger {
 
   public boolean isAuditUnauthorizedLoggingValid() {
     return auditRequestValidator.validUnauthorized();
+  }
+
+  public void prepareLogFailure() {
+    if (stw) {
+      log.error("[AUDIT] Stop-the-world triggered — shutting down application.");
+
+      try {
+        int exitCode = SpringApplication.exit(context, () -> 1);
+        System.exit(exitCode);
+      } catch (Exception e) {
+        log.warn("[AUDIT] Failed to stop application after log failure: {}", e.getMessage(), e);
+      }
+    } else {
+      log.warn("[AUDIT] Stop-the-world disabled, application continue running...");
+    }
   }
 
   /** Wraps the audit service call in try/catch — audit must never break the business flow. */
@@ -79,6 +100,10 @@ public class AuditLogger {
       log.warn("[AUDIT] Audit auth logging failed (non-blocking): {}", e.getMessage(), e);
     }
 
+    if (!status) {
+      prepareLogFailure();
+    }
+
     return CompletableFuture.completedFuture(status);
   }
 
@@ -111,6 +136,10 @@ public class AuditLogger {
 
     } catch (Exception e) {
       log.warn("[AUDIT] Audit logging failed (non-blocking): {}", e.getMessage(), e);
+    }
+
+    if (!status) {
+      prepareLogFailure();
     }
 
     return CompletableFuture.completedFuture(status);

--- a/openaev-api/src/main/java/io/openaev/config/audit_log/AuditLogProperties.java
+++ b/openaev-api/src/main/java/io/openaev/config/audit_log/AuditLogProperties.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,10 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class AuditLogProperties {
+
+  @Getter
+  @Value("${openaev.audit-logs.halt-on-failure:false}")
+  private boolean haltOnFailure;
 
   @Value("${openaev.audit-logs.transports:}")
   private Set<String> transports;

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -244,6 +244,7 @@ logging.logback.rollingpolicy.max-history=7
 # Active transports (comma-separated): console, file, engine
 # Audit logging is enabled when at least one transport is configured; leave empty to disable.
 openaev.audit-logs.transports=
+openaev.audit-logs.stop-the-world=false
 
 # Audit-log index lifecycle ? separate from the shared rollover policy.
 # Retention: number of days before old audit-log indexes are deleted (0 = no dedicated policy).

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -237,7 +237,6 @@ logging.logback.rollingpolicy.file-name-pattern=${LOG_FILE}.-%d{yyyy-MM-dd}.%i
 logging.logback.rollingpolicy.max-file-size=10MB
 logging.logback.rollingpolicy.max-history=7
 
-
 ################
 # AUDIT LOGGING #
 ################

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -243,7 +243,7 @@ logging.logback.rollingpolicy.max-history=7
 # Active transports (comma-separated): console, file, engine
 # Audit logging is enabled when at least one transport is configured; leave empty to disable.
 openaev.audit-logs.transports=
-openaev.audit-logs.stop-the-world=false
+openaev.audit-logs.halt-on-failure=false
 
 # Audit-log index lifecycle ? separate from the shared rollover policy.
 # Retention: number of days before old audit-log indexes are deleted (0 = no dedicated policy).


### PR DESCRIPTION
As a platform administrator, I want the OpenAEV stack to stop if a critical-level audit log fails to be written, so that the platform never operates in a state where critical security events are silently lost.

### Proposed changes

* Add a new method called prepareLogFailure that simply calls the spring exit method

### Testing Instructions

1. Currently, since the search engine does not yet implement any engine throwing an exception, this method is being called every time the audit logging process runs, causing it to fail and stop the application.
2. To reproduce the issue, simply go to the platform and update something. For example, an organization name.

### Related issues

* #5793