### PR TITLE
[backend] fix(multi-tenancy): prevent data leak on date histograms (#4864)

### DIFF
--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -780,7 +780,6 @@ public class ElasticService implements EngineService {
     Map<String, String> parameters = runtime.getParameters();
     Map<String, CustomDashboardParameters> definitionParameters = runtime.getDefinitionParameters();
     return runtime.getWidget().getSeries().stream()
-        .parallel()
         .map(c -> termHistogram(user, runtime.getWidget(), c, parameters, definitionParameters))
         .toList();
   }

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -866,7 +866,6 @@ public class OpenSearchService implements EngineService {
     Map<String, String> parameters = runtime.getParameters();
     Map<String, CustomDashboardParameters> definitionParameters = runtime.getDefinitionParameters();
     return runtime.getWidget().getSeries().stream()
-        .parallel()
         .map(c -> termHistogram(user, runtime.getWidget(), c, parameters, definitionParameters))
         .toList();
   }
@@ -939,7 +938,6 @@ public class OpenSearchService implements EngineService {
     Map<String, String> parameters = runtime.getParameters();
     Map<String, CustomDashboardParameters> definitionParameters = runtime.getDefinitionParameters();
     return runtime.getWidget().getSeries().stream()
-        .parallel()
         .map(c -> dateHistogram(user, runtime.getWidget(), c, parameters, definitionParameters))
         .toList();
   }


### PR DESCRIPTION

### Proposed changes

Infos from structural histograms of the default tenant appear in the other tenants.

### Testing Instructions

1. Check the dashboard **Technical home**  deploy automatically at tenant creation
2. Go to the widget **Most undetected TTPS**

The widget displays the same data, this PR must fix that.
