### PR TITLE
[backend] fix(storage): correctly handle aws s3 file paths with leading slash for migration (#5906)

### DIFF
--- a/openaev-model/src/main/java/io/minio/custom/CopySource.java
+++ b/openaev-model/src/main/java/io/minio/custom/CopySource.java
@@ -1,0 +1,41 @@
+package io.minio.custom;
+
+import com.google.common.collect.Multimap;
+import io.minio.ObjectConditionalReadArgs;
+
+/**
+ * Cloned class to work around a MinIO limitation with handling copy
+ * of paths with leading slash when interacting with actual AWS S3 buckets.
+ * It overrides a single method to restore a non escaped path as copy source.
+ */
+public class CopySource extends io.minio.CopySource {
+  public CopySource() {
+    super();
+  }
+
+  public CopySource(ObjectConditionalReadArgs args) {
+    super(args);
+  }
+
+  public static Builder customBuilder() {
+    return new Builder();
+  }
+
+  /** Argument builder of {@link CopySource}. */
+  public static final class Builder
+      extends ObjectConditionalReadArgs.Builder<Builder, CopySource> {}
+
+  /**
+   * Force restoring the full AWS-compatible source path
+   *
+   * @return AWS S3 copy headers
+   */
+  @Override
+  public Multimap<String, String> genCopyHeaders() {
+    Multimap<String, String> minioHeaders = super.genCopyHeaders();
+
+    // restore the original copy path with bucket name prefix
+    minioHeaders.put("x-amz-copy-source", "/" + bucketName + "/" + objectName);
+    return minioHeaders;
+  }
+}

--- a/openaev-model/src/main/java/io/minio/custom/CopySource.java
+++ b/openaev-model/src/main/java/io/minio/custom/CopySource.java
@@ -4,9 +4,9 @@ import com.google.common.collect.Multimap;
 import io.minio.ObjectConditionalReadArgs;
 
 /**
- * Cloned class to work around a MinIO limitation with handling copy
- * of paths with leading slash when interacting with actual AWS S3 buckets.
- * It overrides a single method to restore a non escaped path as copy source.
+ * Cloned class to work around a MinIO limitation with handling copy of paths with leading slash
+ * when interacting with actual AWS S3 buckets. It overrides a single method to restore a non
+ * escaped path as copy source.
  */
 public class CopySource extends io.minio.CopySource {
   public CopySource() {
@@ -35,7 +35,9 @@ public class CopySource extends io.minio.CopySource {
     Multimap<String, String> minioHeaders = super.genCopyHeaders();
 
     // restore the original copy path with bucket name prefix
-    minioHeaders.put("x-amz-copy-source", "/" + bucketName + "/" + objectName);
+    String copySourceHeader = "x-amz-copy-source";
+    minioHeaders.removeAll(copySourceHeader);
+    minioHeaders.put(copySourceHeader, "/" + bucketName + "/" + objectName);
     return minioHeaders;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -71,8 +71,6 @@ public class MinioDriver {
    * tenant isolation.
    */
   private void moveDefaultTenantFiles(MinioClient minioClient, String bucket) throws Exception {
-    String defaultTenantPrefix = Tenant.DEFAULT_TENANT_UUID + "/";
-
     Set<String> tenants =
         tenantRepository.findAll().stream()
             .map(tenant -> tenant.getId() + "/")
@@ -90,7 +88,10 @@ public class MinioDriver {
         continue;
       }
 
-      String newObjectName = defaultTenantPrefix + objectName;
+      String newObjectName =
+          objectName.startsWith("/")
+              ? Tenant.DEFAULT_TENANT_UUID + objectName
+              : Tenant.DEFAULT_TENANT_UUID + "/" + objectName;
 
       log.info("Migrating file '{}' to '{}'", objectName, newObjectName);
 

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -2,12 +2,12 @@ package io.openaev.driver;
 
 import io.minio.*;
 import io.minio.credentials.*;
-import io.minio.custom.CopySource;
 import io.minio.messages.Item;
 import io.openaev.config.MinioConfig;
 import io.openaev.config.S3Config;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.repository.TenantRepository;
+import io.openaev.minio.CopySource;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -109,7 +109,11 @@ public class MinioDriver {
             CopyObjectArgs.builder()
                 .bucket(bucket)
                 .object(newObjectName)
-                .source(CopySource.builder().bucket(bucket).object(objectName).build())
+                .source(
+                    CopySource.builder()
+                        .bucket(bucket)
+                        .object(objectName.startsWith("/") ? objectName.substring(1) : objectName)
+                        .build())
                 .build());
 
       } catch (Exception e) {

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -95,17 +95,36 @@ public class MinioDriver {
 
       log.info("Migrating file '{}' to '{}'", objectName, newObjectName);
 
+      // debug stuff
+      try {
+        minioClient.getObject(GetObjectArgs.builder().bucket(bucket).object(objectName).build());
+      } catch (Exception e) {
+        log.error("GET {} FAILED", objectName, e);
+        // do nothing
+      }
+
       // Copy to new path under default tenant
-      minioClient.copyObject(
-          CopyObjectArgs.builder()
-              .bucket(bucket)
-              .object(newObjectName)
-              .source(CopySource.builder().bucket(bucket).object(objectName).build())
-              .build());
+      try {
+        minioClient.copyObject(
+            CopyObjectArgs.builder()
+                .bucket(bucket)
+                .object(newObjectName)
+                .source(CopySource.builder().bucket(bucket).object(objectName).build())
+                .build());
+
+      } catch (Exception e) {
+        log.error("COPY {} to {} FAILED", objectName, newObjectName, e);
+        throw e;
+      }
 
       // Remove original
-      minioClient.removeObject(
-          RemoveObjectArgs.builder().bucket(bucket).object(objectName).build());
+      try {
+        minioClient.removeObject(
+            RemoveObjectArgs.builder().bucket(bucket).object(objectName).build());
+      } catch (Exception e) {
+        log.error("REMOVE {} FAILED", objectName, e);
+        throw e;
+      }
     }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -2,6 +2,7 @@ package io.openaev.driver;
 
 import io.minio.*;
 import io.minio.credentials.*;
+import io.minio.custom.CopySource;
 import io.minio.messages.Item;
 import io.openaev.config.MinioConfig;
 import io.openaev.config.S3Config;
@@ -95,40 +96,18 @@ public class MinioDriver {
 
       log.info("Migrating file '{}' to '{}'", objectName, newObjectName);
 
-      // debug stuff
-      try {
-        minioClient.getObject(GetObjectArgs.builder().bucket(bucket).object(objectName).build());
-      } catch (Exception e) {
-        log.error("GET {} FAILED", objectName, e);
-        // do nothing
-      }
-
       // Copy to new path under default tenant
-      try {
-        minioClient.copyObject(
-            CopyObjectArgs.builder()
-                .bucket(bucket)
-                .object(newObjectName)
-                .source(
-                    CopySource.builder()
-                        .bucket(bucket)
-                        .object(objectName.startsWith("/") ? objectName.substring(1) : objectName)
-                        .build())
-                .build());
 
-      } catch (Exception e) {
-        log.error("COPY {} to {} FAILED", objectName, newObjectName, e);
-        throw e;
-      }
+      minioClient.copyObject(
+          CopyObjectArgs.builder()
+              .bucket(bucket)
+              .object(newObjectName)
+              .source(CopySource.customBuilder().bucket(bucket).object(objectName).build())
+              .build());
 
       // Remove original
-      try {
-        minioClient.removeObject(
-            RemoveObjectArgs.builder().bucket(bucket).object(objectName).build());
-      } catch (Exception e) {
-        log.error("REMOVE {} FAILED", objectName, e);
-        throw e;
-      }
+      minioClient.removeObject(
+          RemoveObjectArgs.builder().bucket(bucket).object(objectName).build());
     }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/minio/CopySource.java
+++ b/openaev-model/src/main/java/io/openaev/minio/CopySource.java
@@ -1,7 +1,8 @@
-package io.minio.custom;
+package io.openaev.minio;
 
 import com.google.common.collect.Multimap;
 import io.minio.ObjectConditionalReadArgs;
+import io.minio.S3Escaper;
 
 /**
  * Cloned class to work around a MinIO limitation with handling copy of paths with leading slash
@@ -37,7 +38,9 @@ public class CopySource extends io.minio.CopySource {
     // restore the original copy path with bucket name prefix
     String copySourceHeader = "x-amz-copy-source";
     minioHeaders.removeAll(copySourceHeader);
-    minioHeaders.put(copySourceHeader, "/" + bucketName + "/" + objectName);
+    minioHeaders.put(
+        copySourceHeader,
+        S3Escaper.encodePath("/" + bucketName + "/") + S3Escaper.encodePath(objectName));
     return minioHeaders;
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not normalise "double slashes" when migrating files over to the tenant-scoped dir hierarchy

AWS S3 supports leading slashes in file paths, while our more used MinIO-based solution silently strips them. This is a problem with how we historically set up the directory hierarchy. This issue occurs on the Copy function, not Get or Remove for example.

### Testing Instructions

1. Set up OAEV 2.3.5 on AWS
2. Upgrade OAEV to this version

### Related issues

* Closes #5906
