### PR TITLE
[backend/frontend] fix(cannot_delete_teams_with_dependencies): getting an ugly server exception - hibernate.TransientObjectException - when trying to delete a team that is still linked to a simulation, scenario, atomic testing, or another dependency. As a result, the Delete button keeps loading indefinitely instead of showing a proper validation message. (#5715)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/exception/ResourceInUseException.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exception/ResourceInUseException.java
@@ -1,0 +1,12 @@
+package io.openaev.rest.exception;
+
+public class ResourceInUseException extends Exception {
+
+  public ResourceInUseException(String errorMessage) {
+    super(errorMessage);
+  }
+
+  public ResourceInUseException(String errorMessage, Exception cause) {
+    super(errorMessage, cause);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -117,6 +117,21 @@ public class RestBehavior {
     return bag;
   }
 
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(ResourceInUseException.class)
+  public ViolationErrorBag handleResourceInUseExceptions(Exception ex) {
+    ViolationErrorBag bag = new ViolationErrorBag();
+    bag.setType(ex.getClass().getSimpleName());
+    bag.setMessage(ex.getMessage());
+
+    if (ex.getCause() instanceof Exception) {
+      bag.setError(ex.getCause().getMessage());
+    } else {
+      bag.setError("Resource still linked to other components.");
+    }
+    return bag;
+  }
+
   @ExceptionHandler(FileTooBigException.class)
   public ResponseEntity<ErrorMessage> handleFileTooBigException(FileTooBigException ex) {
     ErrorMessage message = new ErrorMessage(ex.getMessage());

--- a/openaev-api/src/main/java/io/openaev/rest/team/TeamApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/team/TeamApi.java
@@ -19,6 +19,7 @@ import io.openaev.database.repository.*;
 import io.openaev.rest.exception.AlreadyExistingException;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.rest.exception.ResourceInUseException;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.helper.TeamHelper;
 import io.openaev.rest.team.form.TeamCreateInput;
@@ -43,6 +44,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.TransientObjectException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.annotation.Transactional;
@@ -193,8 +196,15 @@ public class TeamApi extends RestBehavior {
       resourceType = ResourceType.TEAM)
   @ApiResponses(value = {@ApiResponse(responseCode = "200")})
   @Operation(description = "Delete an existing team", summary = "Delete team")
-  public void deleteTeam(@PathVariable @Schema(description = "ID of the team") String teamId) {
-    teamRepository.deleteById(teamId);
+  public void deleteTeam(@PathVariable @Schema(description = "ID of the team") String teamId)
+      throws ResourceInUseException {
+    try {
+      teamRepository.deleteById(teamId);
+    } catch (InvalidDataAccessApiUsageException | TransientObjectException ex) {
+      throw new ResourceInUseException(
+          "Cannot delete this team because it is still in use. Please remove its dependencies first.",
+          ex);
+    }
   }
 
   @PutMapping({"/api/teams/{teamId}", TENANT_TEAM_URI + "/{teamId}"})

--- a/openaev-front/src/admin/components/components/teams/TeamPopover.tsx
+++ b/openaev-front/src/admin/components/components/teams/TeamPopover.tsx
@@ -99,15 +99,19 @@ const TeamPopover: FunctionComponent<TeamPopoverProps> = ({
 
   const handleCloseDelete = () => setOpenDelete(false);
 
-  const submitDelete = () => {
+  const submitDelete = (resetLoading?: () => void) => { // Optional parameter
     dispatch(deleteTeam(team.team_id)).then(
-      () => {
-        if (onDelete) {
-          onDelete(team.team_id);
-        }
-        handleCloseDelete();
-      },
-    );
+        () => {
+          if (onDelete) {
+            onDelete(team.team_id);
+          }
+          handleCloseDelete();
+          resetLoading?.(); // Call it if provided (safe with optional chaining)
+        },
+    ).catch(() => {
+      handleCloseDelete();
+      resetLoading?.(); // Call it if provided
+    });
   };
 
   // Remove

--- a/openaev-front/src/admin/components/components/teams/TeamPopover.tsx
+++ b/openaev-front/src/admin/components/components/teams/TeamPopover.tsx
@@ -101,13 +101,13 @@ const TeamPopover: FunctionComponent<TeamPopoverProps> = ({
 
   const submitDelete = (resetLoading?: () => void) => { // Optional parameter
     dispatch(deleteTeam(team.team_id)).then(
-        () => {
-          if (onDelete) {
-            onDelete(team.team_id);
-          }
-          handleCloseDelete();
-          resetLoading?.(); // Call it if provided (safe with optional chaining)
-        },
+      () => {
+        if (onDelete) {
+          onDelete(team.team_id);
+        }
+        handleCloseDelete();
+        resetLoading?.(); // Call it if provided (safe with optional chaining)
+      },
     ).catch(() => {
       handleCloseDelete();
       resetLoading?.(); // Call it if provided

--- a/openaev-front/src/components/common/DialogConfirmation.tsx
+++ b/openaev-front/src/components/common/DialogConfirmation.tsx
@@ -9,7 +9,7 @@ import Transition from './Transition';
 interface DialogConfirmationProps {
   open: boolean;
   handleClose: () => void;
-  handleSubmit: (() => void) | (() => Promise<void>) | null | undefined;
+  handleSubmit: ((resetLoading?: () => void) => void | Promise<void>) | null | undefined; // Updated: Callback is now optional
   text: string;
   submitLabel: string;
   richContent?: React.ReactNode;
@@ -27,8 +27,10 @@ const DialogConfirmation: FunctionComponent<DialogConfirmationProps> = ({
   const [loading, setLoading] = useState(false);
 
   const handleLoadingAndSubmit = () => {
-    setLoading(true);
-    if (handleSubmit) handleSubmit();
+    if (handleSubmit) {
+      setLoading(true);
+      handleSubmit(() => setLoading(false));
+    }
   };
 
   return (

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -297,6 +297,7 @@
   "Can't be tested": "Kann'nicht getestet werden",
   "Cancel": "Abbrechen",
   "Canceled": "Abgebrochen",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "Dieses Team kann nicht gelöscht werden, da es noch verwendet wird. Bitte entfernen Sie zuerst seine Abhängigkeiten.",
   "capture-the-flag": "Erobere die Flagge",
   "Catalog": "Katalog",
   "Categories and questions": "Kategorien und Fragen",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -297,6 +297,7 @@
   "Can't be tested": "Can't be tested",
   "Cancel": "Cancel",
   "Canceled": "Canceled",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "Cannot delete this team because it is still in use. Please remove its dependencies first.",
   "capture-the-flag": "Capture The Flag",
   "Catalog": "Catalog",
   "Categories and questions": "Categories and questions",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -297,6 +297,7 @@
   "Can't be tested": "No se puede probar",
   "Cancel": "Cancelar",
   "Canceled": "Cancelado",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "No se puede eliminar este equipo porque todavía está en uso. Primero, elimine sus dependencias.",
   "capture-the-flag": "Capturar la bandera",
   "Catalog": "Catálogo",
   "Categories and questions": "Categorías y preguntas",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -297,6 +297,7 @@
   "Can't be tested": "Ne peut pas être testé",
   "Cancel": "Annuler",
   "Canceled": "Annulé",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "Impossible de supprimer cette équipe car elle est toujours utilisée. Veuillez d'abord supprimer ses dépendances.",
   "capture-the-flag": "Capture de drapeau",
   "Catalog": "Catalogue",
   "Categories and questions": "Catégories et questions",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -297,6 +297,7 @@
   "Can't be tested": "Non può essere testato",
   "Cancel": "Annullamento",
   "Canceled": "Annullato",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "Impossibile eliminare questo team perché è ancora in uso. Rimuovere prima le dipendenze.",
   "capture-the-flag": "Cattura la bandiera",
   "Catalog": "Catalogo",
   "Categories and questions": "Categorie e domande",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -297,6 +297,7 @@
   "Can't be tested": "テスト不可",
   "Cancel": "キャンセル",
   "Canceled": "キャンセル",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "このチームは現在使用中のため削除できません。まず依存関係を削除してください。",
   "capture-the-flag": "キャプチャー・ザ・フラッグ",
   "Catalog": "カタログ",
   "Categories and questions": "カテゴリーと質問",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -297,6 +297,7 @@
   "Can't be tested": "테스트할 수 없음",
   "Cancel": "취소",
   "Canceled": "취소됨",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "이 팀은 현재 사용 중이므로 삭제할 수 없습니다. 먼저 해당 팀의 종속 항목을 제거해 주세요.",
   "capture-the-flag": "깃발 캡처",
   "Catalog": "카탈로그",
   "Categories and questions": "카테고리 및 질문",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -297,6 +297,7 @@
   "Can't be tested": "Не может быть проверено",
   "Cancel": "Отменить",
   "Canceled": "Отменено",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "Удалить эту команду невозможно, так как она всё ещё используется. Пожалуйста, сначала удалите её зависимости.",
   "capture-the-flag": "Захват флага",
   "Catalog": "Каталог",
   "Categories and questions": "Категории и вопросы",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -297,6 +297,7 @@
   "Can't be tested": "無法測試",
   "Cancel": "取消",
   "Canceled": "已取消",
+  "Cannot delete this team because it is still in use. Please remove its dependencies first.": "由于该团队仍在被使用，因此无法删除。请先移除其依赖项。",
   "capture-the-flag": "获得flag",
   "Catalog": "目录",
   "Categories and questions": "分类和问题",


### PR DESCRIPTION
When trying to delete a team that is still linked to a simulation, scenario, atomic testing, or other dependencies, we get a server exception (hibernate.TransientObjectException) that is not handled by the front-end.
As a result, the Delete button keeps loading indefinitely instead of showing a proper validation message.

### Proposed changes

**Frontend changes:**
* Update the delete flow in TeamPopover.submitDelete to properly catch server exceptions and ensure the popup is closed afterwards.
* Fix the loading state in DialogConfirmation.tsx so the delete button spinner stops correctly. This likely requires updating the component to accept a new handleSubmit with an onComplete callback.
* Pass onComplete on TeamPopover.submitDelete, and extend it to handle both success and failure cases so the popup can be closed in all scenarios and stop the loading icon in the delete button - previously set.
* Add error messages to translations files.

**Backend changes:**
* Update TeamApi.deleteTeam to catch Hibernate exceptions and throw a dedicated, user-friendly exception.
Ensure this exception integrates with the existing error handling flow so users get a clear message explaining why the team cannot be deleted (e.g., due to existing dependencies).


### Testing Instructions

1. Log in to OpenAEV
2. Click on "People" -> "Teams" in the left sidebar
3. Create a new team with an user
4. Click on "Atomic Testing" in the left sidebar
5. Create a new atomic testing for the team you created (eg: send email inject)
6. Go back to "People" -> "Teams" in the left sidebar and try to delete the team you created.
7. A confirmation popup is shown with the DELETE button. Click on it.
8. Confirmation popup gets closed, DELETE button stops loading and an error message is displayed correctly.
9. If you have your browser developer tools open - network tab, you will see you received a 400 error json object from the server - with the right error message.


### Related issues

* #5715