### PR TITLE
[backend] fix(agent): improve implant error reporting to platform (#5915)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
@@ -42,6 +42,43 @@ final class OpenaevImplantCommandBuilder {
     }
   }
 
+  // -- ERROR REPORTING HELPERS --
+
+  /**
+   * Builds a PowerShell snippet that reports an error back to the platform. Uses the existing
+   * inject execution trace endpoint so the error appears in the inject status UI. The snippet is
+   * designed to be embedded inside a catch block.
+   *
+   * @param step human-readable step name (e.g. "Download", "Firewall", "Start")
+   * @return PowerShell code that POSTs an error trace to the platform
+   */
+  private static String psErrorCallback(String step) {
+    // Report the error to the platform via the inject execution endpoint.
+    // $_.Exception.Message contains the PowerShell exception message.
+    // We use Invoke-WebRequest with -Method POST to send the trace.
+    return "$errMsg='" + step + " failed: ' + $_.Exception.Message;"
+        + "$body='{\"execution_message\":\"' + $errMsg + '\",\"execution_status\":\"ERROR\",\"execution_action\":\"complete\",\"execution_duration\":0}';"
+        + "try { Invoke-WebRequest -Uri \"$server/api/agent/#{agent}/inject/#{inject}/execution\" "
+        + "-Method POST -ContentType 'application/json' -Body $body "
+        + "-Headers @{'Authorization'=\"Bearer $token\"} -UseBasicParsing | Out-Null } "
+        + "catch { Write-Host \"[OpenAEV] Failed to report error: $($_.Exception.Message)\" }";
+  }
+
+  /**
+   * Builds a Bash snippet that reports an error back to the platform.
+   *
+   * @param step human-readable step name (e.g. "Download", "Firewall", "Start")
+   * @param errorVar the bash variable containing the error message
+   * @return Bash code that POSTs an error trace to the platform
+   */
+  private static String bashErrorCallback(String step, String errorVar) {
+    return "err_msg=\"" + step + " failed: $" + errorVar + "\";"
+        + "err_body='{\"execution_message\":\"'\"$err_msg\"'\",\"execution_status\":\"ERROR\",\"execution_action\":\"complete\",\"execution_duration\":0}';"
+        + "curl -s -X POST \"$server/api/agent/#{agent}/inject/#{inject}/execution\" "
+        + "-H 'Content-Type: application/json' -H \"Authorization: Bearer $token\" "
+        + "-d \"$err_body\" > /dev/null 2>&1 || true";
+  }
+
   static Map<String, String> buildExecutorCommands(OpenAEVConfig cfg) {
     Map<String, String> commands = new HashMap<>();
     CommandVars vars = new CommandVars(cfg);
@@ -112,33 +149,46 @@ final class OpenaevImplantCommandBuilder {
       OpenAEVConfig cfg,
       Map<String, String> commands,
       CommandVars vars) {
+    // Palo Alto Windows commands use ScheduledTask with SYSTEM privileges.
+    // Error reporting wraps the download step — ScheduledTask failures are harder to catch
+    // because the task runs asynchronously under SYSTEM context.
     commands.put(
         PALOALTOCORTEX_EXECUTOR_NAME
             + "."
             + Endpoint.PLATFORM_TYPE.Windows.name()
             + "."
             + arch.name(),
-        "[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;$x=\"#{location}\";$location=$x.Replace(\"\\oaev-agent-caldera.exe\", \"\");[Environment]::CurrentDirectory = $location;$filename=\"oaev-implant-#{inject}-agent-#{agent}.exe\";$"
-            + vars.tokenVar()
-            + ";$"
-            + vars.serverVar()
-            + ";$"
-            + vars.unsecuredCertificateVar()
-            + ";$"
-            + vars.withProxyVar()
-            + ";$"
-            + vars.maxSizeVar()
-            + ";"
-            + dlVar(cfg, "windows", arch.name())
-            + ";$wc=New-Object System.Net.WebClient;$data=$wc.DownloadData($url);[io.file]::WriteAllBytes($filename,$data) | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -Direction Inbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;"
+        "[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;"
+            + "$x=\"#{location}\";$location=$x.Replace(\"\\oaev-agent-caldera.exe\", \"\");[Environment]::CurrentDirectory = $location;"
+            + "$filename=\"oaev-implant-#{inject}-agent-#{agent}.exe\";"
+            + "$" + vars.tokenVar() + ";"
+            + "$" + vars.serverVar() + ";"
+            + "$" + vars.unsecuredCertificateVar() + ";"
+            + "$" + vars.withProxyVar() + ";"
+            + "$" + vars.maxSizeVar() + ";"
+            + dlVar(cfg, "windows", arch.name()) + ";"
+            // -- DOWNLOAD with error reporting --
+            + "try { $wc=New-Object System.Net.WebClient;$data=$wc.DownloadData($url);[io.file]::WriteAllBytes($filename,$data) | Out-Null; Write-Host '[OpenAEV] Implant binary downloaded successfully' }"
+            + " catch { Write-Host \"[OpenAEV] Download failed: $($_.Exception.Message)\";"
+            + psErrorCallback("Implant download") + "; exit 1 };"
+            // -- FIREWALL with warning (non-blocking for Palo Alto — ScheduledTask runs as SYSTEM) --
+            + "try { Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -ErrorAction SilentlyContinue } catch {};"
+            + "try { New-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -Direction Inbound -Program \"$location\\$filename\" -Action Allow | Out-Null } catch { Write-Host \"[OpenAEV] Warning: Inbound firewall rule failed (non-admin): $($_.Exception.Message)\" };"
+            + "try { Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -ErrorAction SilentlyContinue } catch {};"
+            + "try { New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null } catch { Write-Host \"[OpenAEV] Warning: Outbound firewall rule failed (non-admin): $($_.Exception.Message)\" };"
+            // -- SCHEDULED TASK (Palo Alto specific) --
             + "$taskName = 'OpenAEV-Inject-#{inject}-Agent-#{agent}';"
             + "$taskDescription = 'OpenAEV EDR validation task - inject #{inject} - agent #{agent} - safe to ignore - will self-delete after execution';"
             + "$implantArgs = '--uri ' + $server + ' --token ' + $token + ' --unsecured-certificate ' + $unsecured_certificate + ' --with-proxy ' + $with_proxy + ' --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant}';"
+            + "try {"
             + "$action = New-ScheduledTaskAction -Execute \"$location\\$filename\" -Argument $implantArgs;"
             + "$principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest;"
             + "$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -ExecutionTimeLimit (New-TimeSpan -Hours 0);"
             + "Register-ScheduledTask -TaskName $taskName -Description $taskDescription -Action $action -Principal $principal -Settings $settings -Force | Out-Null;"
             + "Start-ScheduledTask -TaskName $taskName;"
+            + "Write-Host '[OpenAEV] Scheduled task started successfully'"
+            + "} catch { Write-Host \"[OpenAEV] ScheduledTask failed: $($_.Exception.Message)\";"
+            + psErrorCallback("ScheduledTask creation/start") + "; exit 1 };"
             + "$timeout = 300; $elapsed = 0;"
             + "while($elapsed -lt $timeout) {"
             + "  $state = (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue).State;"
@@ -156,21 +206,32 @@ final class OpenaevImplantCommandBuilder {
       OpenAEVConfig cfg,
       Map<String, String> commands,
       CommandVars vars) {
+    // Generic Windows: wrap download, firewall, and start in try/catch blocks
+    // with error reporting back to the platform.
     commands.put(
         Endpoint.PLATFORM_TYPE.Windows.name() + "." + arch.name(),
-        "[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;$x=\"#{location}\";$location=$x.Replace(\"\\oaev-agent-caldera.exe\", \"\");[Environment]::CurrentDirectory = $location;$filename=\"oaev-implant-#{inject}-agent-#{agent}.exe\";$"
-            + vars.tokenVar()
-            + ";$"
-            + vars.serverVar()
-            + ";$"
-            + vars.unsecuredCertificateVar()
-            + ";$"
-            + vars.withProxyVar()
-            + ";$"
-            + vars.maxSizeVar()
-            + ";"
-            + dlVar(cfg, "windows", arch.name())
-            + ";$wc=New-Object System.Net.WebClient;$data=$wc.DownloadData($url);[io.file]::WriteAllBytes($filename,$data) | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -Direction Inbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Start-Process -FilePath \"$location\\$filename\" -ArgumentList \"--uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant}\" -WindowStyle hidden;");
+        "[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;"
+            + "$x=\"#{location}\";$location=$x.Replace(\"\\oaev-agent-caldera.exe\", \"\");[Environment]::CurrentDirectory = $location;"
+            + "$filename=\"oaev-implant-#{inject}-agent-#{agent}.exe\";"
+            + "$" + vars.tokenVar() + ";"
+            + "$" + vars.serverVar() + ";"
+            + "$" + vars.unsecuredCertificateVar() + ";"
+            + "$" + vars.withProxyVar() + ";"
+            + "$" + vars.maxSizeVar() + ";"
+            + dlVar(cfg, "windows", arch.name()) + ";"
+            // -- DOWNLOAD with error reporting --
+            + "try { $wc=New-Object System.Net.WebClient;$data=$wc.DownloadData($url);[io.file]::WriteAllBytes($filename,$data) | Out-Null; Write-Host '[OpenAEV] Implant binary downloaded successfully' }"
+            + " catch { Write-Host \"[OpenAEV] Download failed: $($_.Exception.Message)\";"
+            + psErrorCallback("Implant download") + "; exit 1 };"
+            // -- FIREWALL with warning (non-blocking — implant may still work on localhost without rules) --
+            + "try { Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -ErrorAction SilentlyContinue } catch {};"
+            + "try { New-NetFirewallRule -DisplayName \"Allow OpenAEV Inbound\" -Direction Inbound -Program \"$location\\$filename\" -Action Allow | Out-Null } catch { Write-Host \"[OpenAEV] Warning: Inbound firewall rule failed (non-admin): $($_.Exception.Message)\" };"
+            + "try { Remove-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -ErrorAction SilentlyContinue } catch {};"
+            + "try { New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null } catch { Write-Host \"[OpenAEV] Warning: Outbound firewall rule failed (non-admin): $($_.Exception.Message)\" };"
+            // -- START with error reporting --
+            + "try { Start-Process -FilePath \"$location\\$filename\" -ArgumentList \"--uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant}\" -WindowStyle hidden; Write-Host '[OpenAEV] Implant process started' }"
+            + " catch { Write-Host \"[OpenAEV] Start failed: $($_.Exception.Message)\";"
+            + psErrorCallback("Implant start") + "; exit 1 };");
   }
 
   private static void buildGenericLinuxCommand(
@@ -178,21 +239,34 @@ final class OpenaevImplantCommandBuilder {
       OpenAEVConfig cfg,
       Map<String, String> commands,
       CommandVars vars) {
+    // Linux: check curl exit code and file existence before executing.
+    // Report errors back to the platform via curl POST.
     commands.put(
         Endpoint.PLATFORM_TYPE.Linux.name() + "." + arch.name(),
-        "x=\"#{location}\";location=$(echo \"$x\" | sed \"s#/openaev-caldera-agent##\");filename=oaev-implant-#{inject}-agent-#{agent};"
-            + vars.serverVar()
-            + ";"
-            + vars.tokenVar()
-            + ";"
-            + vars.unsecuredCertificateVar()
-            + ";"
-            + vars.withProxyVar()
-            + ";"
-            + vars.maxSizeVar()
-            + ";curl -s -X GET "
-            + dlUri(cfg, "linux", arch.name())
-            + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} &");
+        "x=\"#{location}\";location=$(echo \"$x\" | sed \"s#/openaev-caldera-agent##\");"
+            + "filename=oaev-implant-#{inject}-agent-#{agent};"
+            + vars.serverVar() + ";"
+            + vars.tokenVar() + ";"
+            + vars.unsecuredCertificateVar() + ";"
+            + vars.withProxyVar() + ";"
+            + vars.maxSizeVar() + ";"
+            // -- DOWNLOAD with error check --
+            + "http_code=$(curl -s -o \"$location/$filename\" -w '%{http_code}' -X GET "
+            + dlUri(cfg, "linux", arch.name()) + ");"
+            + "if [ \"$http_code\" -ne 200 ] || [ ! -s \"$location/$filename\" ]; then "
+            + "dl_err=\"HTTP $http_code or empty file\";"
+            + bashErrorCallback("Implant download", "dl_err") + ";"
+            + "echo \"[OpenAEV] Download failed: $dl_err\"; exit 1; fi;"
+            + "echo '[OpenAEV] Implant binary downloaded successfully';"
+            + "chmod +x $location/$filename;"
+            // -- START with error check --
+            + "$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} &"
+            + " start_pid=$!; sleep 1;"
+            + "if ! kill -0 $start_pid 2>/dev/null; then "
+            + "start_err=\"Implant process exited immediately (PID $start_pid)\";"
+            + bashErrorCallback("Implant start", "start_err") + ";"
+            + "echo \"[OpenAEV] Start failed: $start_err\"; exit 1; fi;"
+            + "echo '[OpenAEV] Implant process started (PID '$start_pid')'");
   }
 
   private static void buildGenericMacOSCommand(
@@ -200,22 +274,33 @@ final class OpenaevImplantCommandBuilder {
       OpenAEVConfig cfg,
       Map<String, String> commands,
       CommandVars vars) {
+    // macOS: same error reporting pattern as Linux.
     commands.put(
         Endpoint.PLATFORM_TYPE.MacOS.name() + "." + arch.name(),
-        "x=\"#{location}\";location=$(echo \"$x\" | sed \"s#/openaev-caldera-agent##\");filename=oaev-implant-#{inject}-agent-#{agent};"
-            + vars.serverVar()
-            + ";"
-            + vars.tokenVar()
-            + ";"
-            + vars.unsecuredCertificateVar()
-            + ";"
-            + vars.withProxyVar()
-            + (Endpoint.PLATFORM_ARCH.x86_64.equals(arch)
-                ? ";"
-                : ";$") // TODO: Should find a way to test on an x86 mac if the diff is necessary
-            + vars.maxSizeVar()
-            + ";curl -s -X GET "
-            + dlUri(cfg, "macos", arch.name())
-            + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} &");
+        "x=\"#{location}\";location=$(echo \"$x\" | sed \"s#/openaev-caldera-agent##\");"
+            + "filename=oaev-implant-#{inject}-agent-#{agent};"
+            + vars.serverVar() + ";"
+            + vars.tokenVar() + ";"
+            + vars.unsecuredCertificateVar() + ";"
+            + vars.withProxyVar() + ";"
+            + (Endpoint.PLATFORM_ARCH.x86_64.equals(arch) ? "" : "$")
+            + vars.maxSizeVar() + ";"
+            // -- DOWNLOAD with error check --
+            + "http_code=$(curl -s -o \"$location/$filename\" -w '%{http_code}' -X GET "
+            + dlUri(cfg, "macos", arch.name()) + ");"
+            + "if [ \"$http_code\" -ne 200 ] || [ ! -s \"$location/$filename\" ]; then "
+            + "dl_err=\"HTTP $http_code or empty file\";"
+            + bashErrorCallback("Implant download", "dl_err") + ";"
+            + "echo \"[OpenAEV] Download failed: $dl_err\"; exit 1; fi;"
+            + "echo '[OpenAEV] Implant binary downloaded successfully';"
+            + "chmod +x $location/$filename;"
+            // -- START with error check --
+            + "$location/$filename --uri $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} &"
+            + " start_pid=$!; sleep 1;"
+            + "if ! kill -0 $start_pid 2>/dev/null; then "
+            + "start_err=\"Implant process exited immediately (PID $start_pid)\";"
+            + bashErrorCallback("Implant start", "start_err") + ";"
+            + "echo \"[OpenAEV] Start failed: $start_err\"; exit 1; fi;"
+            + "echo '[OpenAEV] Implant process started (PID '$start_pid')'");
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
@@ -207,33 +207,13 @@ public class InjectorApi extends RestBehavior {
     if (implantBinaryOrigin.equals("local")) { // if we want the local binaries
       filename = "openaev-implant-" + version + (resolvedPlatform.equals("windows") ? ".exe" : "");
       in = getClass().getResourceAsStream("/implants" + resourcePath + filename);
-      // Report error trace when the binary is not found in resources.
-      // This commonly happens in dev builds where implant binaries are not packaged.
-      if (in == null) {
-        String errorMessage =
-            "Implant binary not found in resources: /implants%s%s (origin=%s, version=%s)"
-                .formatted(resourcePath, filename, implantBinaryOrigin, version);
-        log.error(errorMessage);
-        this.injectStatusService.setImplantErrorTrace(injectId, agentId, errorMessage);
-        throw new ElementNotFoundException(
-            "Implant binary not available for %s/%s".formatted(resolvedPlatform, resolvedArch));
-      }
-    } else if (implantBinaryOrigin.equals("repository")) {
+    } else if (implantBinaryOrigin.equals(
+        "repository")) { // if we want a specific version from artifactory
       filename =
           "openaev-implant-"
               + implantBinaryVersion
               + (resolvedPlatform.equals("windows") ? ".exe" : "");
-      try {
-        in = new BufferedInputStream(validateJFrogUri(resourcePath, filename).toURL().openStream());
-      } catch (IOException e) {
-        // Report error trace when the binary cannot be downloaded from the repository.
-        String errorMessage =
-            "Failed to download implant binary from repository: %s%s (version=%s). Error: %s"
-                .formatted(resourcePath, filename, implantBinaryVersion, e.getMessage());
-        log.error(errorMessage, e);
-        this.injectStatusService.setImplantErrorTrace(injectId, agentId, errorMessage);
-        throw e;
-      }
+      in = new BufferedInputStream(validateJFrogUri(resourcePath, filename).toURL().openStream());
     }
 
     if (in != null) {
@@ -244,13 +224,6 @@ public class InjectorApi extends RestBehavior {
           .contentType(MediaType.APPLICATION_OCTET_STREAM)
           .body(IOUtils.toByteArray(in));
     }
-
-    // Unsupported origin — report and throw
-    String errorMessage =
-        "Unsupported implant binary origin: '%s' for %s/%s"
-            .formatted(implantBinaryOrigin, resolvedPlatform, resolvedArch);
-    log.error(errorMessage);
-    this.injectStatusService.setImplantErrorTrace(injectId, agentId, errorMessage);
     throw new UnsupportedOperationException(
         "Implant " + resolvedPlatform + " executable not supported");
   }

--- a/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
@@ -207,13 +207,33 @@ public class InjectorApi extends RestBehavior {
     if (implantBinaryOrigin.equals("local")) { // if we want the local binaries
       filename = "openaev-implant-" + version + (resolvedPlatform.equals("windows") ? ".exe" : "");
       in = getClass().getResourceAsStream("/implants" + resourcePath + filename);
-    } else if (implantBinaryOrigin.equals(
-        "repository")) { // if we want a specific version from artifactory
+      // Report error trace when the binary is not found in resources.
+      // This commonly happens in dev builds where implant binaries are not packaged.
+      if (in == null) {
+        String errorMessage =
+            "Implant binary not found in resources: /implants%s%s (origin=%s, version=%s)"
+                .formatted(resourcePath, filename, implantBinaryOrigin, version);
+        log.error(errorMessage);
+        this.injectStatusService.setImplantErrorTrace(injectId, agentId, errorMessage);
+        throw new ElementNotFoundException(
+            "Implant binary not available for %s/%s".formatted(resolvedPlatform, resolvedArch));
+      }
+    } else if (implantBinaryOrigin.equals("repository")) {
       filename =
           "openaev-implant-"
               + implantBinaryVersion
               + (resolvedPlatform.equals("windows") ? ".exe" : "");
-      in = new BufferedInputStream(validateJFrogUri(resourcePath, filename).toURL().openStream());
+      try {
+        in = new BufferedInputStream(validateJFrogUri(resourcePath, filename).toURL().openStream());
+      } catch (IOException e) {
+        // Report error trace when the binary cannot be downloaded from the repository.
+        String errorMessage =
+            "Failed to download implant binary from repository: %s%s (version=%s). Error: %s"
+                .formatted(resourcePath, filename, implantBinaryVersion, e.getMessage());
+        log.error(errorMessage, e);
+        this.injectStatusService.setImplantErrorTrace(injectId, agentId, errorMessage);
+        throw e;
+      }
     }
 
     if (in != null) {
@@ -224,6 +244,13 @@ public class InjectorApi extends RestBehavior {
           .contentType(MediaType.APPLICATION_OCTET_STREAM)
           .body(IOUtils.toByteArray(in));
     }
+
+    // Unsupported origin — report and throw
+    String errorMessage =
+        "Unsupported implant binary origin: '%s' for %s/%s"
+            .formatted(implantBinaryOrigin, resolvedPlatform, resolvedArch);
+    log.error(errorMessage);
+    this.injectStatusService.setImplantErrorTrace(injectId, agentId, errorMessage);
     throw new UnsupportedOperationException(
         "Implant " + resolvedPlatform + " executable not supported");
   }


### PR DESCRIPTION
## Problem

When an implant fails to spawn or execute, the inject stays in **Pending** with zero observability. The only trace visible in the UI is `"Implant spawn by the agent"` — after that, it's a black hole until the timeout.

**Root cause:** PowerShell/Bash scripts generated by `OpenaevImplantCommandBuilder` are fire-and-forget — no `try/catch`, no error reporting. Failures (HTTP 500 on download, firewall access denied, binary not found) are silently swallowed.

## Changes

### `OpenaevImplantCommandBuilder.java` — Agent-side error reporting

**All platforms (Windows, Linux, macOS) + Palo Alto variant:**

| Step | Before | After |
|---|---|---|
| **Download** | No error handling — `DownloadData`/`curl` fails silently | `try/catch` (PS) / HTTP code check (Bash) + **POST error trace to platform** |
| **Firewall** | `\| Out-Null` masks all errors | `try/catch` with `Write-Host` warning (non-blocking) |
| **Start** | `-WindowStyle hidden` hides crashes | `try/catch` (PS) / `kill -0` check (Bash) + **POST error trace to platform** |
| **ScheduledTask** (Palo Alto) | No error handling | `try/catch` + **POST error trace to platform** |

**Error reporting mechanism:**
- On failure, the script POSTs the error message to `/api/agent/{agentId}/inject/{injectId}/execution` (existing endpoint used by the implant binary itself)
- The error appears as an `ERROR` trace in the inject status UI
- `[OpenAEV]` prefixed console output for local debugging
- Firewall failures are **non-blocking** (warning only) — they don't always prevent execution (e.g., localhost)
- Download and start failures are **blocking** — script exits with code 1 after reporting

## Before / After

| Scenario | Before | After |
|---|---|---|
| Download HTTP 500 (e.g. binary not packaged in dev build) | Script crashes silently, inject stuck in Pending | Error trace: "Implant download failed: HTTP 500" |
| Firewall access denied (non-admin / session-user) | Errors swallowed by `Out-Null` | Warning in console, continues (non-blocking) |
| Start-Process fails (file missing after failed download) | Silent error | Error trace: "Implant start failed: file not found" |
| Implant crashes immediately (Linux/macOS) | No trace | Error trace: "Implant process exited immediately (PID ...)" |
| ScheduledTask registration fails (Palo Alto) | No trace | Error trace: "ScheduledTask creation/start failed: ..." |

## Testing

- [ ] Windows Standard agent: inject with missing binary → verify error trace appears in UI
- [ ] Windows Standard agent: inject with valid binary → verify happy path unchanged
- [ ] Linux agent: inject with HTTP 500 → verify error trace appears
- [ ] Linux agent: inject with valid binary → verify happy path unchanged
- [ ] Palo Alto Windows: verify ScheduledTask path still works

## Notes

- The error callback endpoint (`/api/agent/{agentId}/inject/{injectId}/execution`) already exists and is used by the implant binary itself. We reuse it from the script layer.
- Firewall failures are intentionally **non-blocking** — on localhost or when rules already exist, the implant can still communicate.
- The `| Out-Null` that was masking firewall errors has been replaced with proper `try/catch` blocks.