### PR TITLE
[backend] test(multi-tenancy): scenario API for multi-tenancy (#5718)

### DIFF
--- a/.github/skills/add-test/TENANT_ISOLATION.md
+++ b/.github/skills/add-test/TENANT_ISOLATION.md
@@ -69,13 +69,8 @@ class TenantIsolation {
 
 ### Step 4 — Evict Hibernate L1 Cache Between Create and Cross-Tenant Access
 
-**Critical**: When a test creates an entity and then reads it within the same `@Transactional`
-test, Hibernate's L1 (session) cache may return the entity directly **without hitting the
-database**. Since RLS filtering happens at the PostgreSQL level, a cached `findById()` bypasses
-RLS entirely — making the test pass even when isolation is broken.
-
 **Always call `entityManager.flush()` + `entityManager.clear()` between the create and the
-cross-tenant access** to force Hibernate to issue a real SQL query that goes through RLS.
+cross-tenant access** to force Hibernate to issue a real SQL query.
 
 > NOTE: this is done in switchToTenant() for example.
 ```java

--- a/.github/skills/add-test/TENANT_ISOLATION.md
+++ b/.github/skills/add-test/TENANT_ISOLATION.md
@@ -82,9 +82,12 @@ public void switchToTenant(String tenantId, EntityManager entityManager) {
 ```
 ### Step 5 — Implement Test Methods
 
-> **Template**: All 5 test templates (READ, same-tenant READ, SEARCH, UPDATE, DELETE) are in
+> **Template**: All 6 test templates (READ, same-tenant READ, SEARCH, UPDATE, DELETE,
+> search-by-IDs) are in
 > [`examples/tenant-isolation-templates.md`](examples/tenant-isolation-templates.md).
 > Read that file for the full code templates with placeholder documentation.
+> Test 6 (search-by-IDs) is only needed when the API has a batch-lookup endpoint
+> (e.g., `POST /{entities}/search-by-id`).
 
 > **Real-world examples** (read these for patterns to follow):
 > - [`AssetGroupApiTest.TenantIsolation`](../../../openaev-api/src/test/java/io/openaev/rest/asset_group/AssetGroupApiTest.java) — fixture + REST API create

--- a/.github/skills/add-test/examples/tenant-isolation-templates.md
+++ b/.github/skills/add-test/examples/tenant-isolation-templates.md
@@ -67,8 +67,51 @@ void given_{entity}InTenantX_should_notBeReadableFromTenantY() throws Exception 
 }
 ```
 
-## Test 2 — Same-tenant READ works
+## Test 6 — Cross-tenant search-by-IDs filtered
 
+> This test targets "batch fetch" endpoints (e.g., `POST /search-by-id`) where the client
+> provides a list of entity IDs. Without tenant filtering on the native query, an attacker
+> in tenant Y could enumerate entities from tenant X by guessing UUIDs.
+> Only applicable when the API has a `search-by-id` or similar batch-lookup endpoint.
+
+```java
+@Test
+@DisplayName("Fetching {entities} by IDs should NOT return {entities} from another tenant")
+void given_{entity}InTenantX_should_notBeReturnedByIdFromTenantY() throws Exception {
+  Tenant tenantX = tenantIsolationHelper.createTenantWithCapabilities(
+      "Tenant X", Set.of({MANAGE_CAP}, {ACCESS_CAP}));
+  Tenant tenantY = tenantIsolationHelper.createTenantWithCapabilities(
+      "Tenant Y", Set.of({ACCESS_CAP}));
+
+  {CreateInput} input = {EntityFixture}.createDefault{CreateInput}("SearchById Isolation");
+
+  String createResponse = mvc.perform(
+          post("/api/tenants/" + tenantX.getId() + "/{entities}")
+              .content(asJsonString(input))
+              .contentType(MediaType.APPLICATION_JSON)
+              .accept(MediaType.APPLICATION_JSON)
+              .with(csrf()))
+      .andExpect(status().is2xxSuccessful())
+      .andReturn().getResponse().getContentAsString();
+
+  String entityId = JsonPath.read(createResponse, "{entity_id_json_path}");
+
+  entityManager.flush();
+  entityManager.clear();
+
+  String searchByIdResponse = mvc.perform(
+          post("/api/tenants/" + tenantY.getId() + "/{entities}/search-by-id")
+              .content(asJsonString(Map.of("{entity}_ids", List.of(entityId))))
+              .contentType(MediaType.APPLICATION_JSON)
+              .accept(MediaType.APPLICATION_JSON)
+              .with(csrf()))
+      .andExpect(status().is2xxSuccessful())
+      .andReturn().getResponse().getContentAsString();
+
+  List<Object> results = JsonPath.read(searchByIdResponse, "$");
+  assertThat(results.size()).isEqualTo(0);
+}
+```
 ```java
 @Test
 @DisplayName("{Entity} created in tenant X should be readable from tenant X")

--- a/.github/skills/add-test/examples/tenant-isolation-templates.md
+++ b/.github/skills/add-test/examples/tenant-isolation-templates.md
@@ -25,7 +25,7 @@
 
 ## Status code expectations
 
-Cross-tenant access typically returns **404** (Hibernate `@Filter` or RLS blocks the SELECT →
+Cross-tenant access typically returns **404** (Hibernate `@Filter` blocks the SELECT →
 `ElementNotFoundException`).
 
 ---
@@ -41,7 +41,7 @@ void given_{entity}InTenantX_should_notBeReadableFromTenantY() throws Exception 
   Tenant tenantY = tenantIsolationHelper.createTenantWithCapabilities(
       "Tenant Y", Set.of({ACCESS_CAP}));
 
-  {CreateInput} input = {EntityFixture}.createDefault{CreateInput}("RLS Isolation Test");
+  {CreateInput} input = {EntityFixture}.createDefault{CreateInput}("Isolation Test");
 
   String createResponse = mvc.perform(
           post("/api/tenants/" + tenantX.getId() + "/{entities}")

--- a/openaev-api/src/main/java/io/openaev/notification/handler/ScenarioNotificationEventHandler.java
+++ b/openaev-api/src/main/java/io/openaev/notification/handler/ScenarioNotificationEventHandler.java
@@ -8,7 +8,6 @@ import io.openaev.notification.model.NotificationEventType;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.rest.scenario.service.ScenarioStatisticService;
 import io.openaev.service.NotificationRuleService;
-import io.openaev.service.scenario.ScenarioService;
 import io.openaev.utils.InjectExpectationResultUtils.ExpectationResultsByType;
 import jakarta.validation.constraints.NotNull;
 import java.time.ZoneId;
@@ -24,7 +23,6 @@ import org.springframework.stereotype.Component;
 public class ScenarioNotificationEventHandler implements NotificationEventHandler {
   private final OpenAEVConfig openAEVConfig;
   private final ExerciseService exerciseService;
-  private final ScenarioService scenarioService;
   private final NotificationRuleService notificationRuleService;
 
   @Override
@@ -60,7 +58,7 @@ public class ScenarioNotificationEventHandler implements NotificationEventHandle
             lastSimulation.getScenario().getId(),
             NotificationRuleTrigger.DIFFERENCE,
             buildScenarioNotificationData(
-                lastSimulation.getScenario().getId(),
+                lastSimulation.getScenario(),
                 lastSimulation,
                 secondLastSimulation,
                 lastSimulationResultsMap,
@@ -70,7 +68,7 @@ public class ScenarioNotificationEventHandler implements NotificationEventHandle
   }
 
   private Map<String, String> buildScenarioNotificationData(
-      @NotNull final String scenarioId,
+      @NotNull final Scenario scenario,
       @NotNull final Exercise lastSimulation,
       @NotNull final Exercise secondLastSimulation,
       @NotNull final Map<ExpectationType, ExpectationResultsByType> lastSimulationResultsMap,
@@ -80,7 +78,7 @@ public class ScenarioNotificationEventHandler implements NotificationEventHandle
     DateTimeFormatter formatter =
         DateTimeFormatter.ofPattern("yyyy/MM/dd").withZone(ZoneId.systemDefault());
 
-    Scenario scenario = scenarioService.scenario(scenarioId);
+    String scenarioId = scenario.getId();
     String url = openAEVConfig.getBaseUrl();
     float lastSimulationPrevScore =
         ScenarioStatisticService.getRoundedPercentage(

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -531,7 +531,7 @@ public class DocumentApi extends RestBehavior {
   public List<Document> playerDocuments(
       @PathVariable String exerciseOrScenarioId, @RequestParam Optional<String> userId) {
     Optional<Exercise> exerciseOpt = this.exerciseRepository.findById(exerciseOrScenarioId);
-    Optional<Scenario> scenarioOpt = this.scenarioRepository.findById(exerciseOrScenarioId);
+    Optional<Scenario> scenarioOpt = this.scenarioRepository.findByIdAndTenantId(exerciseOrScenarioId, TenantContext.getCurrentTenant());
 
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {
@@ -567,7 +567,7 @@ public class DocumentApi extends RestBehavior {
       HttpServletResponse response)
       throws IOException {
     Optional<Exercise> exerciseOpt = this.exerciseRepository.findById(exerciseOrScenarioId);
-    Optional<Scenario> scenarioOpt = this.scenarioRepository.findById(exerciseOrScenarioId);
+    Optional<Scenario> scenarioOpt = this.scenarioRepository.findByIdAndTenantId(exerciseOrScenarioId, TenantContext.getCurrentTenant());
 
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -531,7 +531,9 @@ public class DocumentApi extends RestBehavior {
   public List<Document> playerDocuments(
       @PathVariable String exerciseOrScenarioId, @RequestParam Optional<String> userId) {
     Optional<Exercise> exerciseOpt = this.exerciseRepository.findById(exerciseOrScenarioId);
-    Optional<Scenario> scenarioOpt = this.scenarioRepository.findByIdAndTenantId(exerciseOrScenarioId, TenantContext.getCurrentTenant());
+    Optional<Scenario> scenarioOpt =
+        this.scenarioRepository.findByIdAndTenantId(
+            exerciseOrScenarioId, TenantContext.getCurrentTenant());
 
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {
@@ -567,7 +569,9 @@ public class DocumentApi extends RestBehavior {
       HttpServletResponse response)
       throws IOException {
     Optional<Exercise> exerciseOpt = this.exerciseRepository.findById(exerciseOrScenarioId);
-    Optional<Scenario> scenarioOpt = this.scenarioRepository.findByIdAndTenantId(exerciseOrScenarioId, TenantContext.getCurrentTenant());
+    Optional<Scenario> scenarioOpt =
+        this.scenarioRepository.findByIdAndTenantId(
+            exerciseOrScenarioId, TenantContext.getCurrentTenant());
 
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectDuplicateService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectDuplicateService.java
@@ -3,6 +3,7 @@ package io.openaev.rest.inject.service;
 import static io.openaev.utils.StringUtils.duplicateString;
 
 import io.openaev.database.model.Exercise;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.Inject;
 import io.openaev.database.model.Scenario;
 import io.openaev.database.repository.ExerciseRepository;
@@ -36,7 +37,7 @@ public class InjectDuplicateService {
   public Inject duplicateInjectForScenarioWithDuplicateWordInTitle(
       final String scenarioId, final String injectId) {
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     Inject inject = injectRepository.findById(injectId).orElseThrow(ElementNotFoundException::new);
     Inject duplicatedInject = getDuplicatedInjectWithScenario(scenario, inject);
     duplicatedInject.setTitle(duplicateString(duplicatedInject.getTitle()));

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectDuplicateService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectDuplicateService.java
@@ -2,8 +2,8 @@ package io.openaev.rest.inject.service;
 
 import static io.openaev.utils.StringUtils.duplicateString;
 
-import io.openaev.database.model.Exercise;
 import io.openaev.context.TenantContext;
+import io.openaev.database.model.Exercise;
 import io.openaev.database.model.Inject;
 import io.openaev.database.model.Scenario;
 import io.openaev.database.repository.ExerciseRepository;
@@ -37,7 +37,9 @@ public class InjectDuplicateService {
   public Inject duplicateInjectForScenarioWithDuplicateWordInTitle(
       final String scenarioId, final String injectId) {
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     Inject inject = injectRepository.findById(injectId).orElseThrow(ElementNotFoundException::new);
     Inject duplicatedInject = getDuplicatedInjectWithScenario(scenario, inject);
     duplicatedInject.setTitle(duplicateString(duplicatedInject.getTitle()));

--- a/openaev-api/src/main/java/io/openaev/rest/lessons/ScenarioLessonsApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/lessons/ScenarioLessonsApi.java
@@ -56,7 +56,9 @@ public class ScenarioLessonsApi extends RestBehavior {
   public Iterable<LessonsCategory> applyScenarioLessonsTemplate(
       @PathVariable String scenarioId, @PathVariable String lessonsTemplateId) {
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     LessonsTemplate lessonsTemplate =
         lessonsTemplateRepository
             .findById(lessonsTemplateId)
@@ -99,7 +101,9 @@ public class ScenarioLessonsApi extends RestBehavior {
   public LessonsCategory createScenarioLessonsCategory(
       @PathVariable String scenarioId, @Valid @RequestBody LessonsCategoryCreateInput input) {
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     LessonsCategory lessonsCategory = new LessonsCategory();
     lessonsCategory.setUpdateAttributes(input);
     lessonsCategory.setScenario(scenario);

--- a/openaev-api/src/main/java/io/openaev/rest/lessons/ScenarioLessonsApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/lessons/ScenarioLessonsApi.java
@@ -6,6 +6,7 @@ import static io.openaev.rest.scenario.ScenarioApi.TENANT_SCENARIO_URI;
 import static java.time.Instant.now;
 
 import io.openaev.aop.AccessControl;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.database.specification.LessonsCategorySpecification;
@@ -55,7 +56,7 @@ public class ScenarioLessonsApi extends RestBehavior {
   public Iterable<LessonsCategory> applyScenarioLessonsTemplate(
       @PathVariable String scenarioId, @PathVariable String lessonsTemplateId) {
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     LessonsTemplate lessonsTemplate =
         lessonsTemplateRepository
             .findById(lessonsTemplateId)
@@ -98,7 +99,7 @@ public class ScenarioLessonsApi extends RestBehavior {
   public LessonsCategory createScenarioLessonsCategory(
       @PathVariable String scenarioId, @Valid @RequestBody LessonsCategoryCreateInput input) {
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     LessonsCategory lessonsCategory = new LessonsCategory();
     lessonsCategory.setUpdateAttributes(input);
     lessonsCategory.setScenario(scenario);

--- a/openaev-api/src/main/java/io/openaev/rest/objective/ScenarioObjectiveApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/objective/ScenarioObjectiveApi.java
@@ -7,6 +7,7 @@ import static io.openaev.rest.scenario.ScenarioApi.TENANT_SCENARIO_URI;
 import static java.time.Instant.now;
 
 import io.openaev.aop.AccessControl;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.EvaluationRepository;
 import io.openaev.database.repository.ObjectiveRepository;
@@ -57,7 +58,7 @@ public class ScenarioObjectiveApi extends RestBehavior {
   public Objective createObjective(
       @PathVariable String scenarioId, @Valid @RequestBody ObjectiveInput input) {
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     Objective objective = new Objective();
     objective.setUpdateAttributes(input);
     objective.setScenario(scenario);
@@ -148,7 +149,7 @@ public class ScenarioObjectiveApi extends RestBehavior {
     objective.setUpdatedAt(now());
     objectiveRepository.save(objective);
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     scenario.setUpdatedAt(now());
     scenarioRepository.save(scenario);
     return result;
@@ -176,7 +177,7 @@ public class ScenarioObjectiveApi extends RestBehavior {
     objective.setUpdatedAt(now());
     objectiveRepository.save(objective);
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     scenario.setUpdatedAt(now());
     scenarioRepository.save(scenario);
     return result;

--- a/openaev-api/src/main/java/io/openaev/rest/objective/ScenarioObjectiveApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/objective/ScenarioObjectiveApi.java
@@ -58,7 +58,9 @@ public class ScenarioObjectiveApi extends RestBehavior {
   public Objective createObjective(
       @PathVariable String scenarioId, @Valid @RequestBody ObjectiveInput input) {
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     Objective objective = new Objective();
     objective.setUpdateAttributes(input);
     objective.setScenario(scenario);
@@ -149,7 +151,9 @@ public class ScenarioObjectiveApi extends RestBehavior {
     objective.setUpdatedAt(now());
     objectiveRepository.save(objective);
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     scenario.setUpdatedAt(now());
     scenarioRepository.save(scenario);
     return result;
@@ -177,7 +181,9 @@ public class ScenarioObjectiveApi extends RestBehavior {
     objective.setUpdatedAt(now());
     objectiveRepository.save(objective);
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     scenario.setUpdatedAt(now());
     scenarioRepository.save(scenario);
     return result;

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
@@ -4,6 +4,7 @@ import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
 import static io.openaev.helper.StreamHelper.fromIterable;
 
 import io.openaev.aop.AccessControl;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ScenarioRepository;
 import io.openaev.database.repository.UserRepository;
@@ -41,7 +42,7 @@ public class ScenarioChallengesApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   public List<Document> playerDocuments(
       @PathVariable String scenarioId, @RequestParam Optional<String> userId) {
-    Optional<Scenario> scenarioOpt = this.scenarioRepository.findById(scenarioId);
+    Optional<Scenario> scenarioOpt = this.scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant());
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {
       throw new UnsupportedOperationException("User must be logged or dynamic player is required");
@@ -64,7 +65,7 @@ public class ScenarioChallengesApi extends RestBehavior {
       resourceType = ResourceType.SCENARIO)
   public ScenarioChallengesReader observerChallenges(@PathVariable String scenarioId) {
     Scenario scenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
     ScenarioChallengesReader scenarioChallengesReader = new ScenarioChallengesReader(scenario);
     Iterable<Challenge> challenges = challengeService.getScenarioChallenges(scenario);
     scenarioChallengesReader.setScenarioChallenges(

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
@@ -42,7 +42,8 @@ public class ScenarioChallengesApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   public List<Document> playerDocuments(
       @PathVariable String scenarioId, @RequestParam Optional<String> userId) {
-    Optional<Scenario> scenarioOpt = this.scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant());
+    Optional<Scenario> scenarioOpt =
+        this.scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant());
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {
       throw new UnsupportedOperationException("User must be logged or dynamic player is required");
@@ -65,7 +66,9 @@ public class ScenarioChallengesApi extends RestBehavior {
       resourceType = ResourceType.SCENARIO)
   public ScenarioChallengesReader observerChallenges(@PathVariable String scenarioId) {
     Scenario scenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
     ScenarioChallengesReader scenarioChallengesReader = new ScenarioChallengesReader(scenario);
     Iterable<Challenge> challenges = challengeService.getScenarioChallenges(scenario);
     scenarioChallengesReader.setScenarioChallenges(

--- a/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.openaev.database.model.*;
 import io.openaev.context.TenantContext;
+import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
@@ -1227,7 +1227,9 @@ public class InjectImportService {
 
   public void importInjectsForScenario(MultipartFile file, String scenarioId) throws Exception {
     Scenario targetScenario =
-        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository
+            .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+            .orElseThrow(ElementNotFoundException::new);
 
     this.importService.handleFileImport(file, null, targetScenario);
   }

--- a/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
+import io.openaev.context.TenantContext;
 import io.openaev.database.repository.*;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
@@ -1226,7 +1227,7 @@ public class InjectImportService {
 
   public void importInjectsForScenario(MultipartFile file, String scenarioId) throws Exception {
     Scenario targetScenario =
-        scenarioRepository.findById(scenarioId).orElseThrow(ElementNotFoundException::new);
+        scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant()).orElseThrow(ElementNotFoundException::new);
 
     this.importService.handleFileImport(file, null, targetScenario);
   }

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -820,7 +820,10 @@ public class ScenarioService {
   @Transactional
   public Scenario getDuplicateScenario(@NotBlank String scenarioId) {
     if (StringUtils.isNotBlank(scenarioId)) {
-      Scenario scenarioOrigin = scenarioRepository.findById(scenarioId).orElseThrow();
+      Scenario scenarioOrigin =
+          scenarioRepository
+              .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
+              .orElseThrow();
       Scenario scenario = copyScenario(scenarioOrigin);
       Scenario scenarioDuplicate = scenarioRepository.save(scenario);
       getListOfDuplicatedInjects(scenarioDuplicate, scenarioOrigin);

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -399,7 +399,7 @@ public class ScenarioService {
 
   public ScenarioOutput getScenarioById(@NotBlank final String scenarioId) {
     ObjectMapper objectMapper = new ObjectMapper();
-    RawScenario rawScenario = this.scenarioRepository.getScenarioById(scenarioId);
+    RawScenario rawScenario = this.scenarioRepository.getScenarioByIdAndTenantId(scenarioId);
     if (rawScenario == null) {
       throw new ElementNotFoundException("Scenario not found");
     }

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.cache.LicenseCacheManager;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.raw.RawExerciseSimple;
 import io.openaev.database.raw.RawPaginationScenario;
@@ -392,7 +393,7 @@ public class ScenarioService {
 
   public Scenario scenario(@NotBlank final String scenarioId) {
     return this.scenarioRepository
-        .findById(scenarioId)
+        .findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant())
         .orElseThrow(() -> new ElementNotFoundException("Scenario not found"));
   }
 
@@ -486,6 +487,8 @@ public class ScenarioService {
   }
 
   public void deleteScenario(@NotBlank final String scenarioId) {
+    // Verify scenario belongs to current tenant before deleting
+    scenario(scenarioId);
     this.scenarioRepository.deleteById(scenarioId);
   }
 

--- a/openaev-api/src/test/java/io/openaev/rest/group/TenantGroupApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/group/TenantGroupApiTest.java
@@ -479,7 +479,7 @@ public class TenantGroupApiTest extends IntegrationTest {
               "Tenant Y", Set.of(Capability.ACCESS_TENANT_SETTINGS));
 
       TenantGroupCreateInput input = new TenantGroupCreateInput();
-      input.setName("RLS Isolated Group");
+      input.setName("Isolated Group");
 
       String createResponse =
           mvc.perform(

--- a/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
@@ -432,7 +432,7 @@ public class TenantRoleApiTest extends IntegrationTest {
 
       RoleInput input =
           RoleInput.builder()
-              .name("RLS Isolated Role")
+              .name("Isolated Role")
               .capabilities(Set.of(Capability.ACCESS_ASSETS))
               .build();
 

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -902,5 +902,54 @@ public class ScenarioApiTest extends IntegrationTest {
       // -------- Assert --------
       assertThat(responseStatus).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
+
+    @Test
+    @DisplayName("Fetching scenarios by IDs should NOT return scenarios from another tenant")
+    void given_scenarioInTenantX_should_notBeReturnedByIdFromTenantY() throws Exception {
+      // -------- Arrange --------
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+      Tenant tenantY =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant Y", Set.of(Capability.ACCESS_ASSESSMENT));
+
+      ScenarioInput input = new ScenarioInput();
+      input.setName("SearchById Isolation Scenario");
+
+      String createResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantX.getId() + "/scenarios")
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String scenarioId = JsonPath.read(createResponse, "$.scenario_id");
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // -------- Act — fetch by IDs from tenant Y --------
+      String searchByIdResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantY.getId() + "/scenarios/search-by-id")
+                      .content(asJsonString(Map.of("scenario_ids", List.of(scenarioId))))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -------- Assert — result should be empty --------
+      List<Object> results = JsonPath.read(searchByIdResponse, "$");
+      assertThat(results.size()).isEqualTo(0);
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -697,7 +697,7 @@ public class ScenarioApiTest extends IntegrationTest {
               "Tenant Y", Set.of(Capability.ACCESS_ASSESSMENT));
 
       ScenarioInput input = new ScenarioInput();
-      input.setName("solation Test Scenario");
+      input.setName("Isolation Test Scenario");
 
       String createResponse =
           mvc.perform(

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -738,7 +738,6 @@ public class ScenarioApiTest extends IntegrationTest {
           tenantIsolationHelper.createTenantWithCapabilities(
               "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
 
-
       ScenarioInput input = new ScenarioInput();
       input.setName("Same Tenant Scenario");
 

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -4,6 +4,7 @@ import static io.openaev.database.model.TenantSettingKeys.TENANT_SCENARIO_DASHBO
 import static io.openaev.rest.scenario.ScenarioApi.SCENARIO_URI;
 import static io.openaev.service.UserService.buildAuthenticationToken;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -28,15 +29,18 @@ import io.openaev.rest.scenario.form.ScenarioInput;
 import io.openaev.rest.scenario.form.ScenarioRecurrenceInput;
 import io.openaev.rest.scenario.form.ScenarioUpdateTeamsInput;
 import io.openaev.service.AssetGroupService;
+import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.*;
 import io.openaev.utils.mockUser.WithMockUser;
+import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.annotation.Nullable;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.*;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
@@ -72,6 +76,7 @@ public class ScenarioApiTest extends IntegrationTest {
   @Autowired private SettingRepository settingRepository;
   @Autowired private CustomDashboardRepository customDashboardRepository;
   @Autowired private AssetGroupService assetGroupService;
+  @Autowired private TenantIsolationTestHelper tenantIsolationHelper;
 
   @AfterEach
   void afterEach() {
@@ -673,5 +678,230 @@ public class ScenarioApiTest extends IntegrationTest {
     paginationInput.setInjectorContractIdsToProcess(
         List.of(injectorContractFixture.getWellKnownSingleEmailContract().getId()));
     return paginationInput;
+  }
+
+  @Nested
+  @DisplayName("Tenant Isolation")
+  @WithMockUser
+  class TenantIsolation {
+
+    @Test
+    @DisplayName("Scenario created in tenant X should NOT be readable from tenant Y")
+    void given_scenarioInTenantX_should_notBeReadableFromTenantY() throws Exception {
+      // -------- Arrange --------
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+      Tenant tenantY =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant Y", Set.of(Capability.ACCESS_ASSESSMENT));
+
+      ScenarioInput input = new ScenarioInput();
+      input.setName("solation Test Scenario");
+
+      String createResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantX.getId() + "/scenarios")
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String scenarioId = JsonPath.read(createResponse, "$.scenario_id");
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // -------- Act — read from tenant Y (expect 404) --------
+      int responseStatus =
+          mvc.perform(
+                  get("/api/tenants/" + tenantY.getId() + "/scenarios/" + scenarioId)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andReturn()
+              .getResponse()
+              .getStatus();
+
+      // -------- Assert --------
+      assertThat(responseStatus).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("Scenario created in tenant X should be readable from tenant X")
+    void given_scenarioInTenantX_should_beReadableFromTenantX() throws Exception {
+      // -------- Arrange --------
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+
+
+      ScenarioInput input = new ScenarioInput();
+      input.setName("Same Tenant Scenario");
+
+      String createResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantX.getId() + "/scenarios")
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String scenarioId = JsonPath.read(createResponse, "$.scenario_id");
+
+      // -------- Act & Assert — read from same tenant should succeed --------
+      mvc.perform(
+              get("/api/tenants/" + tenantX.getId() + "/scenarios/" + scenarioId)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.scenario_name").value("Same Tenant Scenario"));
+    }
+
+    @Test
+    @DisplayName("Scenario search in tenant Y should NOT return scenarios from tenant X")
+    void given_scenarioInTenantX_should_notAppearInTenantYSearch() throws Exception {
+      // -------- Arrange --------
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+      Tenant tenantY =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant Y", Set.of(Capability.ACCESS_ASSESSMENT));
+
+      ScenarioInput input = new ScenarioInput();
+      input.setName("CrossTenantSearchScenario");
+
+      mvc.perform(
+              post("/api/tenants/" + tenantX.getId() + "/scenarios")
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // -------- Act — search from tenant Y --------
+      SearchPaginationInput searchInput =
+          PaginationFixture.simpleTextSearch("CrossTenantSearchScenario");
+
+      String searchResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantY.getId() + "/scenarios/search")
+                      .content(asJsonString(searchInput))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -------- Assert --------
+      assertEquals(Integer.valueOf(0), JsonPath.read(searchResponse, "$.totalElements"));
+    }
+
+    @Test
+    @DisplayName("Scenario created in tenant X should NOT be updatable from tenant Y")
+    void given_scenarioInTenantX_should_notBeUpdatableFromTenantY() throws Exception {
+      // -------- Arrange --------
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+      Tenant tenantY =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant Y", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+
+      ScenarioInput input = new ScenarioInput();
+      input.setName("Update Isolation Test Scenario");
+
+      String createResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantX.getId() + "/scenarios")
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String scenarioId = JsonPath.read(createResponse, "$.scenario_id");
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // -------- Act — update from tenant Y (expect 404) --------
+      ScenarioInput updateInput = new ScenarioInput();
+      updateInput.setName("Hijacked Name");
+
+      int responseStatus =
+          mvc.perform(
+                  put("/api/tenants/" + tenantY.getId() + "/scenarios/" + scenarioId)
+                      .content(asJsonString(updateInput))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andReturn()
+              .getResponse()
+              .getStatus();
+
+      // -------- Assert --------
+      assertThat(responseStatus).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("Scenario created in tenant X should NOT be deletable from tenant Y")
+    void given_scenarioInTenantX_should_notBeDeletableFromTenantY() throws Exception {
+      // -------- Arrange --------
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X", Set.of(Capability.MANAGE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+      Tenant tenantY =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant Y", Set.of(Capability.DELETE_ASSESSMENT, Capability.ACCESS_ASSESSMENT));
+
+      ScenarioInput input = new ScenarioInput();
+      input.setName("Delete Isolation Test Scenario");
+
+      String createResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantX.getId() + "/scenarios")
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String scenarioId = JsonPath.read(createResponse, "$.scenario_id");
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // -------- Act — delete from tenant Y (expect 404) --------
+      int responseStatus =
+          mvc.perform(
+                  delete("/api/tenants/" + tenantY.getId() + "/scenarios/" + scenarioId)
+                      .with(csrf()))
+              .andReturn()
+              .getResponse()
+              .getStatus();
+
+      // -------- Assert --------
+      assertThat(responseStatus).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/InjectImportServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectImportServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.Exercise;
 import io.openaev.database.model.RuleAttribute;
 import io.openaev.database.model.Scenario;
@@ -30,6 +31,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -350,15 +352,19 @@ public class InjectImportServiceTest {
       // -------- Prepare --------
       Scenario scenario = new Scenario();
       scenario.setId("sc-1");
-      when(scenarioRepository.findById("sc-1")).thenReturn(Optional.of(scenario));
-
       MultipartFile file = mock(MultipartFile.class);
 
-      // -------- Act --------
-      injectImportService.importInjectsForScenario(file, "sc-1");
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId("sc-1", "tenant-1"))
+            .thenReturn(Optional.of(scenario));
 
-      // -------- Assert --------
-      verify(importService).handleFileImport(file, null, scenario);
+        // -------- Act --------
+        injectImportService.importInjectsForScenario(file, "sc-1");
+
+        // -------- Assert --------
+        verify(importService).handleFileImport(file, null, scenario);
+      }
     }
 
     @Test
@@ -392,13 +398,18 @@ public class InjectImportServiceTest {
     @Test
     void shouldThrowElementNotFound_whenScenarioMissing() {
       // -------- Prepare --------
-      when(scenarioRepository.findById("missing")).thenReturn(Optional.empty());
       MultipartFile file = mock(MultipartFile.class);
 
-      // -------- Act / Assert --------
-      assertThrows(
-          ElementNotFoundException.class,
-          () -> injectImportService.importInjectsForScenario(file, "missing"));
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId("missing", "tenant-1"))
+            .thenReturn(Optional.empty());
+
+        // -------- Act / Assert --------
+        assertThrows(
+            ElementNotFoundException.class,
+            () -> injectImportService.importInjectsForScenario(file, "missing"));
+      }
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
@@ -132,9 +132,9 @@ class ScenarioServiceTest extends IntegrationTest {
 
   @AfterAll
   public void teardown() {
-    this.userRepository.deleteById(USER_ID);
-    this.teamRepository.deleteById(TEAM_ID);
-    this.injectRepository.deleteById(INJECT_ID);
+    if (USER_ID != null) this.userRepository.deleteById(USER_ID);
+    if (TEAM_ID != null) this.teamRepository.deleteById(TEAM_ID);
+    if (INJECT_ID != null) this.injectRepository.deleteById(INJECT_ID);
   }
 
   @DisplayName("Should delete injects at the same time as the scenario itself")
@@ -214,11 +214,15 @@ class ScenarioServiceTest extends IntegrationTest {
     scenarioTeams.add(noContextualTeam);
 
     Inject inject = new Inject();
+    inject.setTitle("test-inject");
+    inject.setDependsDuration(0L);
     inject.setTeams(scenarioTeams);
     Set<Inject> scenarioInjects = new HashSet<>();
     scenarioInjects.add(this.injectRepository.save(inject));
     Scenario scenario =
         this.scenarioRepository.save(ScenarioFixture.getScenario(scenarioTeams, scenarioInjects));
+
+    entityManager.flush();
 
     // -- EXECUTE --
     Scenario scenarioDuplicated = scenarioService.getDuplicateScenario(scenario.getId());
@@ -304,7 +308,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForSmtpIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -339,7 +343,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForImapIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -374,7 +378,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForExecutorIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -408,7 +412,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForCollectorIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -442,7 +446,7 @@ class ScenarioServiceTest extends IntegrationTest {
   public void testRunChecksForMissingContentIssue() {
     // PREPARE
     Inject inject = new Inject();
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -477,7 +481,7 @@ class ScenarioServiceTest extends IntegrationTest {
     // Arrange
     Inject inject = new Inject();
     inject.setEnabled(false);
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
     scenario.setInjects(new HashSet<>(List.of(inject)));
     this.scenarioRepository.save(scenario);
 
@@ -499,7 +503,7 @@ class ScenarioServiceTest extends IntegrationTest {
   @Transactional
   public void testRunChecksForTeamsIssue() {
     // PREPARE
-    Scenario scenario = new Scenario();
+    Scenario scenario = ScenarioFixture.createDefaultCrisisScenario();
 
     Injector injector = new Injector();
     injector.setDependencies(

--- a/openaev-api/src/test/java/io/openaev/service/ScenarioServiceUnitTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ScenarioServiceUnitTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import io.openaev.config.cache.LicenseCacheManager;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.ee.EnterpriseEditionService;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -190,28 +192,44 @@ class ScenarioServiceUnitTest {
     void shouldReturnScenario_whenFound() {
       Scenario scenario = new Scenario();
       scenario.setId("sc-1");
-      when(scenarioRepository.findById("sc-1")).thenReturn(Optional.of(scenario));
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId("sc-1", "tenant-1"))
+            .thenReturn(Optional.of(scenario));
 
-      Scenario result = scenarioService.scenario("sc-1");
+        Scenario result = scenarioService.scenario("sc-1");
 
-      assertNotNull(result);
-      assertEquals("sc-1", result.getId());
+        assertNotNull(result);
+        assertEquals("sc-1", result.getId());
+      }
     }
 
     @Test
     void shouldThrowElementNotFoundException_whenNotFound() {
-      when(scenarioRepository.findById("missing")).thenReturn(Optional.empty());
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId("missing", "tenant-1"))
+            .thenReturn(Optional.empty());
 
-      assertThrows(
-          io.openaev.rest.exception.ElementNotFoundException.class,
-          () -> scenarioService.scenario("missing"));
+        assertThrows(
+            io.openaev.rest.exception.ElementNotFoundException.class,
+            () -> scenarioService.scenario("missing"));
+      }
     }
 
     @Test
     void shouldDeleteScenarioById() {
-      scenarioService.deleteScenario("sc-1");
+      Scenario scenario = new Scenario();
+      scenario.setId("sc-1");
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId("sc-1", "tenant-1"))
+            .thenReturn(Optional.of(scenario));
 
-      verify(scenarioRepository).deleteById("sc-1");
+        scenarioService.deleteScenario("sc-1");
+
+        verify(scenarioRepository).deleteById("sc-1");
+      }
     }
   }
 
@@ -250,12 +268,16 @@ class ScenarioServiceUnitTest {
       Scenario scenario = new Scenario();
       scenario.setId("sc-1");
       scenario.setInjects(new HashSet<>());
-      when(scenarioRepository.findById("sc-1")).thenReturn(Optional.of(scenario));
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId("sc-1", "tenant-1"))
+            .thenReturn(Optional.of(scenario));
 
-      Scenario result = scenarioService.disablePlayers("sc-1", "team-id", List.of("player-1"));
+        Scenario result = scenarioService.disablePlayers("sc-1", "team-id", List.of("player-1"));
 
-      assertNotNull(result);
-      assertEquals("sc-1", result.getId());
+        assertNotNull(result);
+        assertEquals("sc-1", result.getId());
+      }
     }
   }
 
@@ -337,48 +359,52 @@ class ScenarioServiceUnitTest {
       scenario.setId(scenarioId);
       scenario.setTeams(new ArrayList<>(List.of(existingTeam1, existingTeam2)));
 
-      when(scenarioRepository.findById(scenarioId)).thenReturn(Optional.of(scenario));
-      when(teamRepository.findAllById(any()))
-          .thenAnswer(
-              invocation -> {
-                Iterable<String> ids = invocation.getArgument(0);
-                Map<String, Team> teamsById = Map.of("team-2", existingTeam2, "team-3", newTeam);
-                List<Team> result = new ArrayList<>();
-                ids.forEach(
-                    id -> {
-                      Team team = teamsById.get(id);
-                      if (team != null) {
-                        result.add(team);
-                      }
-                    });
-                return result;
-              });
-      when(userRepository.findById("user-1")).thenReturn(Optional.of(newPlayer));
-      when(scenarioTeamUserRepository.existsByScenarioIdAndTeamIdAndUserId(
-              scenarioId, "team-3", "user-1"))
-          .thenReturn(false);
-      when(teamService.find(any())).thenReturn(List.of());
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId(scenarioId, "tenant-1"))
+            .thenReturn(Optional.of(scenario));
+        when(teamRepository.findAllById(any()))
+            .thenAnswer(
+                invocation -> {
+                  Iterable<String> ids = invocation.getArgument(0);
+                  Map<String, Team> teamsById = Map.of("team-2", existingTeam2, "team-3", newTeam);
+                  List<Team> result = new ArrayList<>();
+                  ids.forEach(
+                      id -> {
+                        Team team = teamsById.get(id);
+                        if (team != null) {
+                          result.add(team);
+                        }
+                      });
+                  return result;
+                });
+        when(userRepository.findById("user-1")).thenReturn(Optional.of(newPlayer));
+        when(scenarioTeamUserRepository.existsByScenarioIdAndTeamIdAndUserId(
+                scenarioId, "team-3", "user-1"))
+            .thenReturn(false);
+        when(teamService.find(any())).thenReturn(List.of());
 
-      scenarioService.replaceTeams(scenarioId, List.of("team-2", "team-3", "team-3"));
+        scenarioService.replaceTeams(scenarioId, List.of("team-2", "team-3", "team-3"));
 
-      verify(scenarioTeamUserRepository)
-          .deleteByScenarioIdAndTeamIds(
-              eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
-      verify(injectRepository)
-          .removeTeamsForScenario(
-              eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
-      verify(lessonsCategoryRepository)
-          .removeTeamsForScenario(
-              eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
+        verify(scenarioTeamUserRepository)
+            .deleteByScenarioIdAndTeamIds(
+                eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
+        verify(injectRepository)
+            .removeTeamsForScenario(
+                eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
+        verify(lessonsCategoryRepository)
+            .removeTeamsForScenario(
+                eq(scenarioId), argThat(ids -> ids.size() == 1 && ids.contains("team-1")));
 
-      verify(scenarioTeamUserRepository)
-          .existsByScenarioIdAndTeamIdAndUserId(scenarioId, "team-3", "user-1");
-      verify(scenarioTeamUserRepository, never())
-          .existsByScenarioIdAndTeamIdAndUserId(scenarioId, "team-2", "user-1");
+        verify(scenarioTeamUserRepository)
+            .existsByScenarioIdAndTeamIdAndUserId(scenarioId, "team-3", "user-1");
+        verify(scenarioTeamUserRepository, never())
+            .existsByScenarioIdAndTeamIdAndUserId(scenarioId, "team-2", "user-1");
 
-      assertEquals(2, scenario.getTeams().size());
-      assertTrue(scenario.getTeams().stream().anyMatch(t -> "team-2".equals(t.getId())));
-      assertTrue(scenario.getTeams().stream().anyMatch(t -> "team-3".equals(t.getId())));
+        assertEquals(2, scenario.getTeams().size());
+        assertTrue(scenario.getTeams().stream().anyMatch(t -> "team-2".equals(t.getId())));
+        assertTrue(scenario.getTeams().stream().anyMatch(t -> "team-3".equals(t.getId())));
+      }
     }
 
     @Test
@@ -393,15 +419,19 @@ class ScenarioServiceUnitTest {
       scenario.setId(scenarioId);
       scenario.setTeams(new ArrayList<>(List.of(existingTeam)));
 
-      when(scenarioRepository.findById(scenarioId)).thenReturn(Optional.of(scenario));
-      when(teamRepository.findAllById(any())).thenReturn(List.of(existingTeam));
-      when(teamService.find(any())).thenReturn(List.of());
+      try (MockedStatic<TenantContext> tc = mockStatic(TenantContext.class)) {
+        tc.when(TenantContext::getCurrentTenant).thenReturn("tenant-1");
+        when(scenarioRepository.findByIdAndTenantId(scenarioId, "tenant-1"))
+            .thenReturn(Optional.of(scenario));
+        when(teamRepository.findAllById(any())).thenReturn(List.of(existingTeam));
+        when(teamService.find(any())).thenReturn(List.of());
 
-      scenarioService.replaceTeams(scenarioId, List.of("team-1"));
+        scenarioService.replaceTeams(scenarioId, List.of("team-1"));
 
-      verify(scenarioTeamUserRepository, never()).deleteByScenarioIdAndTeamIds(any(), any());
-      verify(injectRepository, never()).removeTeamsForScenario(any(), any());
-      verify(lessonsCategoryRepository, never()).removeTeamsForScenario(any(), any());
+        verify(scenarioTeamUserRepository, never()).deleteByScenarioIdAndTeamIds(any(), any());
+        verify(injectRepository, never()).removeTeamsForScenario(any(), any());
+        verify(lessonsCategoryRepository, never()).removeTeamsForScenario(any(), any());
+      }
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/xtmhub/collector/XtmHubConnectivityCollectorServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/xtmhub/collector/XtmHubConnectivityCollectorServiceTest.java
@@ -50,7 +50,7 @@ class XtmHubConnectivityCollectorServiceTest extends IntegrationTest {
 
   @AfterEach
   void cleanup() {
-    // Delete each registration while the tenant context matches its tenant_id (required by RLS).
+    // Delete each registration while the tenant context matches its tenant_id.
     createdRegistrationIdToTenantId.forEach(
         (registrationId, tenantId) -> {
           TenantContext.setCurrentTenant(tenantId);

--- a/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
@@ -227,7 +227,7 @@ public interface ScenarioRepository
               + "LEFT JOIN workflows w ON w.workflow_scenario_id = s.scenario_id "
               + "WHERE s.scenario_id = :scenarioId AND s.tenant_id = :#{#tenantContext.currentTenant}",
       nativeQuery = true)
-  RawScenario getScenarioById(@Param("scenarioId") final String scenarioId);
+  RawScenario getScenarioByIdAndTenantId(@Param("scenarioId") final String scenarioId);
 
   // -- CATEGORY --
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
@@ -130,6 +130,7 @@ public interface ScenarioRepository
               + "INNER JOIN users_groups ON groups.group_id = users_groups.group_id "
               + "WHERE users_groups.user_id = :userId "
               + "AND sce.scenario_id IN :scenarioIds "
+              + "AND sce.tenant_id = :#{#tenantContext.currentTenant} "
               + "GROUP BY sce.scenario_id",
       nativeQuery = true)
   List<RawScenarioSimpleIndexing> rawGrantedByScenarioIds(
@@ -151,6 +152,7 @@ public interface ScenarioRepository
               + "FROM scenarios sce "
               + "LEFT JOIN scenarios_tags sct ON sct.scenario_id = sce.scenario_id "
               + "WHERE sce.scenario_id IN :scenarioIds "
+              + "AND sce.tenant_id = :#{#tenantContext.currentTenant} "
               + "GROUP BY sce.scenario_id",
       nativeQuery = true)
   List<RawScenarioSimpleIndexing> rawByScenarioIds(@Param("scenarioIds") List<String> scenarioIds);

--- a/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
@@ -225,7 +225,7 @@ public interface ScenarioRepository
               + "LEFT JOIN platforms pf ON pf.scenario_id = s.scenario_id "
               + "LEFT JOIN tags tg ON tg.scenario_id = s.scenario_id "
               + "LEFT JOIN workflows w ON w.workflow_scenario_id = s.scenario_id "
-              + "WHERE s.scenario_id = :scenarioId",
+              + "WHERE s.scenario_id = :scenarioId AND s.tenant_id = :#{#tenantContext.currentTenant}",
       nativeQuery = true)
   RawScenario getScenarioById(@Param("scenarioId") final String scenarioId);
 
@@ -254,4 +254,6 @@ public interface ScenarioRepository
       @Param("scenarioId") final String scenarioId, @Param("teamIds") final List<String> teamIds);
 
   Optional<Scenario> findByExercises_Id(String exerciseId);
+
+  Optional<Scenario> findByIdAndTenantId(String id, String tenantId);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

Add multi-tenant API integration test for scenario

#### Summary of `scenarioService.scenario()` callers

| Caller | Context | TenantContext set? |
|--------|---------|-------------------|
| `ScenarioApi` | REST controller | ✅ Yes |
| `ScenarioImportApi` | REST controller | ✅ Yes |
| `ScenarioInjectApi` | REST controller | ✅ Yes |
| `ScenarioInjectService` | Called from controllers | ✅ Yes |
| `ChannelApi` / `ChannelService` | REST controller | ✅ Yes |
| `VariableApi` | REST controller | ✅ Yes |
| `NotificationRuleService.createNotificationRule()` | REST controller (`NotificationRuleApi`) | ✅ Yes |
| `ScenarioService` internal (self-calls: `deleteScenario`, `enablePlayers`, `disablePlayers`, `replaceTeams`, `exportScenario`, `runChecks`) | Called from controllers | ✅ Yes |

> No background job calls `scenarioService.scenario()` directly. The `ScenarioNotificationEventHandler` was the only risky caller, and we already fixed it. All other callers are in HTTP request context where `TenantContext` is set.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
