### PR TITLE
[backend] fix(endpoint): silently drop upgrade job insert if exists (#5927)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V5_10__Constrain_concurrent_upgrade_jobs.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_10__Constrain_concurrent_upgrade_jobs.java
@@ -1,0 +1,27 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V5_10__Constrain_concurrent_upgrade_jobs extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+
+      // -- Prevent multiple concurrent upgrade jobs for same asset --
+      statement.execute(
+          """
+              DELETE from asset_agent_jobs WHERE asset_agent_inject IS NULL;
+              CREATE UNIQUE INDEX idx_unique_upgrade_job_per_asset ON asset_agent_jobs (asset_agent_agent) WHERE (asset_agent_inject IS NULL);
+              """);
+
+      /* rollback
+       * DROP INDEX idx_unique_upgrade_job_per_asset;
+       */
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V5_10__Constrain_concurrent_upgrade_jobs.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_10__Constrain_concurrent_upgrade_jobs.java
@@ -16,11 +16,11 @@ public class V5_10__Constrain_concurrent_upgrade_jobs extends BaseJavaMigration 
       statement.execute(
           """
               DELETE from asset_agent_jobs WHERE asset_agent_inject IS NULL;
-              CREATE UNIQUE INDEX idx_unique_upgrade_job_per_asset ON asset_agent_jobs (asset_agent_agent) WHERE (asset_agent_inject IS NULL);
+              CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_upgrade_job_per_asset ON asset_agent_jobs (asset_agent_agent) WHERE (asset_agent_inject IS NULL);
               """);
 
       /* rollback
-       * DROP INDEX idx_unique_upgrade_job_per_asset;
+       * DROP INDEX IF EXISTS idx_unique_upgrade_job_per_asset;
        */
     }
   }

--- a/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/form/EndpointRegisterInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/form/EndpointRegisterInput.java
@@ -35,4 +35,23 @@ public class EndpointRegisterInput extends EndpointInput {
   private String serviceName;
 
   private String seenIp;
+
+  public static EndpointRegisterInput from(EndpointInput input) {
+    EndpointRegisterInput registerInput = new EndpointRegisterInput();
+    // asset input abstract fields
+    registerInput.setName(input.getName());
+    registerInput.setDescription(input.getDescription());
+    registerInput.setTagIds(input.getTagIds());
+    registerInput.setExternalReference(input.getExternalReference());
+
+    // endpoint input concrete fields
+    registerInput.setPlatform(input.getPlatform());
+    registerInput.setArch(input.getArch());
+    registerInput.setHostname(input.getHostname());
+    registerInput.setAgentVersion(input.getAgentVersion());
+    registerInput.setIps(input.getIps());
+    registerInput.setMacAddresses(input.getMacAddresses());
+    registerInput.setEol(input.isEol());
+    return registerInput;
+  }
 }

--- a/openaev-api/src/main/java/io/openaev/service/AgentService.java
+++ b/openaev-api/src/main/java/io/openaev/service/AgentService.java
@@ -31,7 +31,7 @@ public class AgentService {
       Agent.PRIVILEGE privilege,
       String executorId) {
     return agentRepository.findByAssetExecutorIdUserDeploymentAndPrivilege(
-        assetId, user, deploymentMode.name(), privilege.name(), executorId);
+        assetId, user, deploymentMode, privilege, executorId);
   }
 
   public List<Agent> getAgentsByExecutorId(String executorId) {

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -32,7 +32,6 @@ import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.mapper.EndpointMapper;
 import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.annotation.Resource;
-import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.io.BufferedInputStream;
@@ -53,6 +52,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -477,7 +477,11 @@ public class EndpointService {
               agent.getTenant().getId()));
       assetAgentJob.setAgent(agent);
       assetAgentJob.setTenant(agent.getTenant());
-      assetAgentJobRepository.save(assetAgentJob);
+      if (assetAgentJobRepository.findUpgradeJobByAgentIdAndInjectNull(agent.getId()).isEmpty()) {
+        assetAgentJobRepository.save(assetAgentJob);
+      } else {
+        log.warn("Upgrade job already exists");
+      }
     }
     return endpoint;
   }

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -47,6 +47,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -467,18 +468,26 @@ public class EndpointService {
     // for the agent
     Endpoint endpoint = (Endpoint) agent.getAsset();
     if (agent.getParent() == null && !agent.getVersion().equals(version)) {
-      AssetAgentJob assetAgentJob = new AssetAgentJob();
-      assetAgentJob.setCommand(
-          generateUpgradeCommand(
-              endpoint.getPlatform().name(),
-              input.getInstallationMode(),
-              input.getInstallationDirectory(),
-              input.getServiceName(),
-              agent.getTenant().getId()));
-      assetAgentJob.setAgent(agent);
-      assetAgentJob.setTenant(agent.getTenant());
-      if (assetAgentJobRepository.findUpgradeJobByAgentIdAndInjectNull(agent.getId()).isEmpty()) {
-        assetAgentJobRepository.save(assetAgentJob);
+      if (assetAgentJobRepository
+          .findUpgradeJobByAgentIdAndInjectNull(agent.getId(), agent.getTenant().getId())
+          .isEmpty()) {
+        AssetAgentJob assetAgentJob = new AssetAgentJob();
+        assetAgentJob.setCommand(
+            generateUpgradeCommand(
+                endpoint.getPlatform().name(),
+                input.getInstallationMode(),
+                input.getInstallationDirectory(),
+                input.getServiceName(),
+                agent.getTenant().getId()));
+        assetAgentJob.setAgent(agent);
+        assetAgentJob.setTenant(agent.getTenant());
+
+        try {
+          assetAgentJobRepository.save(assetAgentJob);
+        } catch (DataIntegrityViolationException e) {
+          // Concurrent registration already created the upgrade job — safe to ignore
+          log.warn("Upgrade job already exists for agent {} (concurrent insert)", agent.getId(), e);
+        }
       } else {
         log.warn("Upgrade job already exists");
       }

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -10,15 +10,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.IntegrationTest;
-import io.openaev.context.TenantContext;
 import io.openaev.database.model.AssetAgentJob;
 import io.openaev.database.repository.AssetAgentJobRepository;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
+import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.EndpointRegisterInputFixture;
 import io.openaev.utils.fixtures.ExecutorFixture;
 import io.openaev.utils.fixtures.composers.ExecutorComposer;
 import io.openaev.utils.fixtures.tenants.TenantComposer;
-import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -37,6 +36,7 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
   @Autowired private ExecutorComposer executorComposer;
   @Autowired private TenantComposer tenantComposer;
   @Autowired private ExecutorFixture executorFixture;
+  @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
   @Autowired private AssetAgentJobRepository assetAgentJobRepository;
 
   @BeforeEach
@@ -116,23 +116,29 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
         }
 
         @Test
-        @Disabled(
-            "Multitenant registration does not work because builtin openaev executor can't exist in multiple tenants")
         @DisplayName(
             "Registering same endpoint on different tenants create a single upgrade job in each tenant")
         void registeringSameEndpointOnDifferentTenants() throws Exception {
-          // executor in default tenant
-          executorComposer.forExecutor(executorFixture.createOpenAEVExecutor()).persist();
           TenantComposer.Composer tenantWrapper =
-              tenantComposer.forTenant(TenantFixture.getTenant("additional_tenant")).persist();
-          entityManager.flush();
-          TenantContext.setCurrentTenant(tenantWrapper.get().getId());
-          // executor in other tenant
-          executorComposer.forExecutor(executorFixture.createOpenAEVExecutor()).persist();
+              tenantComposer
+                  .forTenant(
+                      tenantIsolationTestHelper.createTenantWithCurrentUser("additional_tenant_1"))
+                  .persist();
+          tenantIsolationTestHelper.switchToTenant(tenantWrapper.get().getId(), entityManager);
+          // executor in default tenant
+          executorComposer.forExecutor(executorFixture.createOAEVExecutor()).persist();
           entityManager.flush();
           entityManager.clear();
-
-          TenantContext.clearCurrentTenant();
+          TenantComposer.Composer tenantWrapper2 =
+              tenantComposer
+                  .forTenant(
+                      tenantIsolationTestHelper.createTenantWithCurrentUser("additional_tenant_2"))
+                  .persist();
+          tenantIsolationTestHelper.switchToTenant(tenantWrapper2.get().getId(), entityManager);
+          // executor in other tenant
+          executorComposer.forExecutor(executorFixture.createOAEVExecutor()).persist();
+          entityManager.flush();
+          entityManager.clear();
 
           EndpointRegisterInput input =
               EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
@@ -140,27 +146,44 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
           mockMvc
               .perform(
-                  post(ENDPOINT_URI + "/register")
+                  post("/api/tenants/" + tenantWrapper.get().getId() + "/endpoints/register")
                       .content(mapper.writeValueAsString(input))
                       .contentType(MediaType.APPLICATION_JSON)
                       .with(csrf()))
               .andExpect(status().isOk())
               .andReturn();
-
-          TenantContext.setCurrentTenant(tenantWrapper.get().getId());
+          entityManager.flush();
+          entityManager.clear();
 
           mockMvc
               .perform(
-                  post(ENDPOINT_URI + "/register")
+                  post("/api/tenants/" + tenantWrapper2.get().getId() + "/endpoints/register")
                       .content(mapper.writeValueAsString(input))
                       .contentType(MediaType.APPLICATION_JSON)
                       .with(csrf()))
               .andExpect(status().isOk())
               .andReturn();
+          entityManager.flush();
+          entityManager.clear();
 
-          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+          tenantIsolationTestHelper.switchToTenant(tenantWrapper.get().getId(), entityManager);
+          List<AssetAgentJob> jobTenant1 = fromIterable(assetAgentJobRepository.findAll());
 
-          assertThat(jobs).satisfiesOnlyOnce(job -> assertThat(job.getInject()).isNull());
+          assertThat(jobTenant1)
+              .satisfiesOnlyOnce(job -> assertThat(job.getInject()).isNull())
+              .satisfiesOnlyOnce(
+                  job ->
+                      assertThat(job.getTenant().getId()).isEqualTo(tenantWrapper.get().getId()));
+          ;
+
+          tenantIsolationTestHelper.switchToTenant(tenantWrapper2.get().getId(), entityManager);
+          List<AssetAgentJob> jobTenant2 = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobTenant2)
+              .satisfiesOnlyOnce(job -> assertThat(job.getInject()).isNull())
+              .satisfiesOnlyOnce(
+                  job ->
+                      assertThat(job.getTenant().getId()).isEqualTo(tenantWrapper2.get().getId()));
         }
 
         @Test

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -1,0 +1,287 @@
+package io.openaev.service.endpoint;
+
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.rest.asset.endpoint.EndpointApi.ENDPOINT_URI;
+import static io.openaev.utils.fixtures.EndpointRegisterInputFixture.DEFAULT_ENDPOINT_AGENT_VERSION;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.AssetAgentJob;
+import io.openaev.database.repository.AssetAgentJobRepository;
+import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
+import io.openaev.utils.fixtures.EndpointRegisterInputFixture;
+import io.openaev.utils.fixtures.ExecutorFixture;
+import io.openaev.utils.fixtures.composers.ExecutorComposer;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class EndpointServiceIntegrationTest extends IntegrationTest {
+  @Autowired private MockMvc mockMvc;
+  @Autowired private EntityManager entityManager;
+  @Autowired private ObjectMapper mapper;
+  @Autowired private ExecutorComposer executorComposer;
+  @Autowired private TenantComposer tenantComposer;
+  @Autowired private ExecutorFixture executorFixture;
+  @Autowired private AssetAgentJobRepository assetAgentJobRepository;
+
+  @BeforeEach
+  void setUp() {
+    executorComposer.reset();
+    tenantComposer.reset();
+  }
+
+  @Nested
+  @WithMockUser(isAdmin = true)
+  @DisplayName("Endpoint registration")
+  class EndpointRegistration {
+    @Nested
+    @DisplayName("Upgrade jobs tests")
+    class UpgradeJobsTests {
+      @Nested
+      @DisplayName("When agent version does not match server version")
+      class UpgradeAgentVersionDoesNotMatchServerVersion {
+        private final String agentVersion = "NOMATCH";
+
+        @Test
+        @DisplayName("Registering once creates an upgrade job")
+        void registeringOnceCreatesAnUpgradeJob() throws Exception {
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(agentVersion);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobs).satisfiesOnlyOnce(job -> assertThat(job.getInject()).isNull());
+        }
+
+        @Test
+        @DisplayName("Registering twice creates a single upgrade job")
+        void registeringTwiceCreatesASingleUpgradeJob() throws Exception {
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(agentVersion);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobs).satisfiesOnlyOnce(job -> assertThat(job.getInject()).isNull());
+        }
+
+        @Test
+        @Disabled(
+            "Multitenant registration does not work because builtin openaev executor can't exist in multiple tenants")
+        @DisplayName(
+            "Registering same endpoint on different tenants create a single upgrade job in each tenant")
+        void registeringSameEndpointOnDifferentTenants() throws Exception {
+          // executor in default tenant
+          executorComposer.forExecutor(executorFixture.createOpenAEVExecutor()).persist();
+          TenantComposer.Composer tenantWrapper =
+              tenantComposer.forTenant(TenantFixture.getTenant("additional_tenant")).persist();
+          entityManager.flush();
+          TenantContext.setCurrentTenant(tenantWrapper.get().getId());
+          // executor in other tenant
+          executorComposer.forExecutor(executorFixture.createOpenAEVExecutor()).persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          TenantContext.clearCurrentTenant();
+
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(agentVersion);
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+          TenantContext.setCurrentTenant(tenantWrapper.get().getId());
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobs).satisfiesOnlyOnce(job -> assertThat(job.getInject()).isNull());
+        }
+
+        @Test
+        @DisplayName("Registering different endpoints create an upgrade job for each")
+        void registeringDifferentEndpointsCreateAnUpgradeJobForEach() throws Exception {
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input1 =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input1.setAgentVersion(agentVersion);
+          input1.setExternalReference(UUID.randomUUID().toString());
+          input1.setName(UUID.randomUUID().toString());
+
+          EndpointRegisterInput input2 =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input2.setAgentVersion(agentVersion);
+          input2.setExternalReference(UUID.randomUUID().toString());
+          input2.setName(UUID.randomUUID().toString());
+          input2.setMacAddresses(List.of("00:00:ab:ad:1d:ea").toArray(new String[0]));
+
+          entityManager.flush();
+          entityManager.clear();
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input1))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input2))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobs)
+              .satisfiesOnlyOnce(
+                  job ->
+                      assertThat(job)
+                          .satisfies(j -> assertThat(j.getInject()).isNull())
+                          .satisfies(
+                              j ->
+                                  assertThat(j.getAgent().getExternalReference())
+                                      .isEqualTo(input1.getExternalReference())));
+          assertThat(jobs)
+              .satisfiesOnlyOnce(
+                  job ->
+                      assertThat(job)
+                          .satisfies(j -> assertThat(j.getInject()).isNull())
+                          .satisfies(
+                              j ->
+                                  assertThat(j.getAgent().getExternalReference())
+                                      .isEqualTo(input2.getExternalReference())));
+        }
+      }
+
+      @Nested
+      @DisplayName("When agent version matches server version")
+      class UpgradeAgentVersionMatchesServerVersion {
+        private final String agentVersion = DEFAULT_ENDPOINT_AGENT_VERSION;
+
+        @Test
+        @DisplayName("Registering once creates zero upgrade job")
+        void registeringOnceCreatesAnUpgradeJob() throws Exception {
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(agentVersion);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobs).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Registering twice creates zero upgrade job")
+        void registeringTwiceCreatesASingleUpgradeJob() throws Exception {
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(agentVersion);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+
+          assertThat(jobs).isEmpty();
+        }
+      }
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
@@ -1,4 +1,4 @@
-package io.openaev.service;
+package io.openaev.service.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -16,6 +16,9 @@ import io.openaev.rest.asset.endpoint.form.EndpointInput;
 import io.openaev.rest.asset.endpoint.form.EndpointOutput;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.service.AgentService;
+import io.openaev.service.AssetService;
+import io.openaev.service.EndpointService;
 import io.openaev.utils.fixtures.AgentFixture;
 import io.openaev.utils.fixtures.AssetAgentJobFixture;
 import io.openaev.utils.mapper.EndpointMapper;

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/EndpointRegisterInputFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/EndpointRegisterInputFixture.java
@@ -1,0 +1,67 @@
+package io.openaev.utils.fixtures;
+
+import io.openaev.database.model.Endpoint;
+import io.openaev.rest.asset.endpoint.form.EndpointInput;
+import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
+import java.util.List;
+
+public class EndpointRegisterInputFixture {
+  // asset input defaults
+  public static final String DEFAULT_ASSET_NAME = "openaev-default-asset-name";
+  public static final String DEFAULT_ASSET_DESCRIPTION = "Description of default asset for OpenAEV";
+  public static final List<String> DEFAULT_ASSET_TAGS = List.of();
+  public static final String DEFAULT_ASSET_EXTERNAL_REFERENCE =
+      "dd96ad6f-f82e-4606-98a4-60dc862a8c99";
+
+  // endpoint input defaults
+  public static final Endpoint.PLATFORM_TYPE DEFAULT_ENDPOINT_PLATFORM =
+      Endpoint.PLATFORM_TYPE.Linux;
+  public static final Endpoint.PLATFORM_ARCH DEFAULT_ENDPOINT_ARCH = Endpoint.PLATFORM_ARCH.x86_64;
+  public static final List<String> DEFAULT_ENDPOINT_IPS = List.of("120.0.0.1");
+  public static final String DEFAULT_ENDPOINT_HOSTNAME = "openaev-default-endpoint-hostname";
+  public static final String DEFAULT_ENDPOINT_AGENT_VERSION = "Testing";
+  public static final List<String> DEFAULT_ENDPOINT_MACS = List.of("00:ab:ad:c0:ff:ee");
+  public static final Boolean DEFAULT_ENDPOINT_EOL = false;
+
+  // register input defaults
+  public static final Boolean DEFAULT_ENDPOINT_IS_SERVICE = true;
+  public static final Boolean DEFAULT_ENDPOINT_IS_ELEVATED = false;
+  public static final String DEFAULT_ENDPOINT_EXECUTED_BY_USER = "openaev-root";
+  // would use the AgentUtils.INSTALLATION_MODE enum but currently private and not worth exposing
+  // yet
+  public static final String DEFAULT_ENDPOINT_INSTALLATION_MODE = "service";
+  public static final String DEFAULT_ENDPOINT_INSTALLATION_DIRECTORY =
+      "local-openaev-agent-service-dir";
+  public static final String DEFAULT_ENDPOINT_SERVICE_NAME = "openaev-agent-for-test-service";
+
+  public static EndpointInput getDefaultEndpointInput() {
+    EndpointInput input = new EndpointInput();
+    // asset input parts
+    input.setExternalReference(DEFAULT_ASSET_EXTERNAL_REFERENCE);
+    input.setName(DEFAULT_ASSET_NAME);
+    input.setDescription(DEFAULT_ASSET_DESCRIPTION);
+    input.setTagIds(DEFAULT_ASSET_TAGS);
+
+    // endpoint input parts
+    input.setPlatform(DEFAULT_ENDPOINT_PLATFORM);
+    input.setArch(DEFAULT_ENDPOINT_ARCH);
+    input.setHostname(DEFAULT_ENDPOINT_HOSTNAME);
+    input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
+    input.setIps(DEFAULT_ENDPOINT_IPS.toArray(new String[0]));
+    input.setMacAddresses(DEFAULT_ENDPOINT_MACS.toArray(new String[0]));
+    input.setEol(DEFAULT_ENDPOINT_EOL);
+    return input;
+  }
+
+  public static EndpointRegisterInput getDefaultEndpointRegisterInput() {
+    EndpointRegisterInput input = EndpointRegisterInput.from(getDefaultEndpointInput());
+    input.setElevated(DEFAULT_ENDPOINT_IS_ELEVATED);
+    input.setService(DEFAULT_ENDPOINT_IS_SERVICE);
+    input.setExternalReference(DEFAULT_ASSET_EXTERNAL_REFERENCE); // repeated in subclass
+    input.setExecutedByUser(DEFAULT_ENDPOINT_EXECUTED_BY_USER);
+    input.setInstallationMode(DEFAULT_ENDPOINT_INSTALLATION_MODE);
+    input.setInstallationDirectory(DEFAULT_ENDPOINT_INSTALLATION_DIRECTORY);
+    input.setServiceName(DEFAULT_ENDPOINT_SERVICE_NAME);
+    return input;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/ExecutorFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/ExecutorFixture.java
@@ -44,6 +44,14 @@ public class ExecutorFixture {
     return executorOptional.orElseGet(() -> executorRepository.save(createOAEVExecutor()));
   }
 
+  public Executor createOpenAEVExecutor() {
+    Executor executor = new Executor();
+    executor.setType(OPENAEV_EXECUTOR_TYPE);
+    executor.setName(OPENAEV_EXECUTOR_NAME);
+    executor.setId(OPENAEV_EXECUTOR_ID);
+    return executor;
+  }
+
   public Executor createCrowdstrikeExecutor() {
     Executor executor = new Executor();
     executor.setType(CROWDSTRIKE_EXECUTOR_TYPE);

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/ExecutorFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/ExecutorFixture.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class ExecutorFixture {
   @Autowired ExecutorRepository executorRepository;
 
-  private Executor createOAEVExecutor() {
+  public Executor createOAEVExecutor() {
     Executor executor = new Executor();
     executor.setType(OPENAEV_EXECUTOR_TYPE);
     executor.setId(OPENAEV_EXECUTOR_ID);
@@ -42,10 +42,6 @@ public class ExecutorFixture {
         executorRepository.findByTypeAndTenantId(
             OPENAEV_EXECUTOR_TYPE, TenantContext.getCurrentTenant());
     return executorOptional.orElseGet(() -> executorRepository.save(createOAEVExecutor()));
-  }
-
-  public Executor createOpenAEVExecutor() {
-    return createOAEVExecutor();
   }
 
   public Executor createCrowdstrikeExecutor() {

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/ExecutorFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/ExecutorFixture.java
@@ -45,11 +45,7 @@ public class ExecutorFixture {
   }
 
   public Executor createOpenAEVExecutor() {
-    Executor executor = new Executor();
-    executor.setType(OPENAEV_EXECUTOR_TYPE);
-    executor.setName(OPENAEV_EXECUTOR_NAME);
-    executor.setId(OPENAEV_EXECUTOR_ID);
-    return executor;
+    return createOAEVExecutor();
   }
 
   public Executor createCrowdstrikeExecutor() {

--- a/openaev-api/src/test/resources/agents/openaev-agent/linux/openaev-agent-upgrade-Testing.sh
+++ b/openaev-api/src/test/resources/agents/openaev-agent/linux/openaev-agent-upgrade-Testing.sh
@@ -1,0 +1,1 @@
+# imagine there is a command here

--- a/openaev-model/src/main/java/io/openaev/database/repository/AgentRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/AgentRepository.java
@@ -17,17 +17,21 @@ public interface AgentRepository
 
   @Query(
       value =
-          "SELECT a.* FROM agents a "
-              + "WHERE a.agent_asset = :assetId AND a.agent_executed_by_user = :user "
-              + "AND a.agent_deployment_mode = :deployment AND a.agent_privilege = :privilege "
-              + "AND a.agent_parent IS NULL AND a.agent_inject IS NULL "
-              + "AND a.agent_executor = :executorId",
-      nativeQuery = true)
+          """
+          SELECT a FROM Agent a
+            WHERE a.asset.id = :assetId
+              AND a.executedByUser = :user
+              AND a.deploymentMode = :deployment
+              AND a.privilege = :privilege
+              AND a.parent IS NULL
+              AND a.inject IS NULL
+              AND a.executor.id = :executorId
+          """)
   Optional<Agent> findByAssetExecutorIdUserDeploymentAndPrivilege(
       @Param("assetId") String assetId,
       @Param("user") String user,
-      @Param("deployment") String deployment,
-      @Param("privilege") String privilege,
+      @Param("deployment") Agent.DEPLOYMENT_MODE deployment,
+      @Param("privilege") Agent.PRIVILEGE privilege,
       @Param("executorId") String executorId);
 
   List<Agent> findByExecutorId(String executorId);

--- a/openaev-model/src/main/java/io/openaev/database/repository/AssetAgentJobRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/AssetAgentJobRepository.java
@@ -23,4 +23,11 @@ public interface AssetAgentJobRepository
       value = "DELETE FROM asset_agent_jobs j WHERE j.asset_agent_id = :assetAgentJobId",
       nativeQuery = true)
   void deleteById(@Param("assetAgentJobId") @NotBlank String assetAgentJobId);
+
+  @Query(
+      value =
+          """
+    SELECT j FROM AssetAgentJob j WHERE j.agent.id = :agentId AND j.inject IS NULL
+    """)
+  Optional<AssetAgentJob> findUpgradeJobByAgentIdAndInjectNull(@Param("agentId") String agentId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/AssetAgentJobRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/AssetAgentJobRepository.java
@@ -27,7 +27,8 @@ public interface AssetAgentJobRepository
   @Query(
       value =
           """
-    SELECT j FROM AssetAgentJob j WHERE j.agent.id = :agentId AND j.inject IS NULL
+    SELECT j FROM AssetAgentJob j WHERE j.agent.id = :agentId AND j.tenant.id = :tenantId AND j.inject IS NULL
     """)
-  Optional<AssetAgentJob> findUpgradeJobByAgentIdAndInjectNull(@Param("agentId") String agentId);
+  Optional<AssetAgentJob> findUpgradeJobByAgentIdAndInjectNull(
+      @Param("agentId") String agentId, @Param("tenantId") String tenantId);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not insert upgrade job if endpoint registers and should create a job, when there is already one pending

### Testing Instructions
Do this multiple times
```shell
$ curl -X POST "{openaev url}/api/endpoints/register"   -H "Authorization: Bearer {redacted}"   -H "Content-Type: application/json"  --data '{
  "seenIp" : null,
  "service" : true,
  "elevated" : false,
  "asset_name" : "openaev-default-asset-name",
  "asset_description" : "Description of default asset for OpenAEV",
  "asset_tags" : [ ],
  "asset_external_reference" : "dd96ad6f-f82e-4606-98a4-60dc862a8c99",
  "endpoint_platform" : "Linux",
  "endpoint_arch" : "x86_64",
  "endpoint_ips" : [ "120.0.0.1" ],
  "endpoint_hostname" : "openaev-default-endpoint-hostname",
  "endpoint_agent_version" : "NOMATCH",
  "endpoint_mac_addresses" : [ "00:ab:ad:c0:ff:ee" ],
  "endpoint_is_eol" : false,
  "agent_is_service" : true,
  "agent_is_elevated" : false,
  "agent_executed_by_user" : "openaev-root",
  "agent_installation_mode" : "service",
  "agent_installation_directory" : "local-openaev-agent-service-dir",
  "agent_service_name" : "openaev-agent-for-test-service"
}'

```
Check the database:
```sql
select asset_agent_agent, asset_agent_inject, count(1) from asset_agent_jobs group by 1, 2;
```

### Related issues

* Closes #5927