### PR TITLE
fix(scenario): deletion take too long (#5208)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -326,7 +326,7 @@ public class InjectService {
    *
    * @param scenarioId the scenario whose inject dependencies must be cleared
    */
-  @Transactional(rollbackOn = Exception.class)
+  @org.springframework.transaction.annotation.Transactional(rollbackFor = Exception.class)
   public void clearInjectDependenciesByScenarioId(String scenarioId) {
     injectDependenciesRepository.deleteAllByScenarioId(scenarioId);
   }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -319,19 +319,6 @@ public class InjectService {
   }
 
   /**
-   * Deletes all inject dependencies (rows in injects_dependencies) for every inject belonging to
-   * the given scenario. Must be called before deleting the scenario to prevent Hibernate
-   * StaleStateException caused by CascadeType.ALL trying to delete the same dependency row twice
-   * when multiple injects in the scenario have cross-dependencies.
-   *
-   * @param scenarioId the scenario whose inject dependencies must be cleared
-   */
-  @org.springframework.transaction.annotation.Transactional(rollbackFor = Exception.class)
-  public void clearInjectDependenciesByScenarioId(String scenarioId) {
-    injectDependenciesRepository.deleteAllByScenarioId(scenarioId);
-  }
-
-  /**
    * Delete all injects given as params
    *
    * @param injects the injects to delete

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -104,6 +104,7 @@ public class InjectService {
   private final EnterpriseEditionService enterpriseEditionService;
   private final EndpointService endpointService;
   private final InjectRepository injectRepository;
+  private final InjectDependenciesRepository injectDependenciesRepository;
   private final InjectDocumentRepository injectDocumentRepository;
   private final InjectorService injectorService;
   private final InjectStatusRepository injectStatusRepository;
@@ -315,6 +316,19 @@ public class InjectService {
     if (!CollectionUtils.isEmpty(injectIds)) {
       injectRepository.deleteByAllIdsNative(injectIds);
     }
+  }
+
+  /**
+   * Deletes all inject dependencies (rows in injects_dependencies) for every inject belonging to
+   * the given scenario. Must be called before deleting the scenario to prevent Hibernate
+   * StaleStateException caused by CascadeType.ALL trying to delete the same dependency row twice
+   * when multiple injects in the scenario have cross-dependencies.
+   *
+   * @param scenarioId the scenario whose inject dependencies must be cleared
+   */
+  @Transactional(rollbackOn = Exception.class)
+  public void clearInjectDependenciesByScenarioId(String scenarioId) {
+    injectDependenciesRepository.deleteAllByScenarioId(scenarioId);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -494,6 +494,7 @@ public class ScenarioService {
     }
   }
 
+  @Transactional(rollbackFor = Exception.class)
   public void deleteScenario(@NotBlank final String scenarioId) {
     existsByIdAndTenantId(scenarioId);
     this.scenarioRepository.deleteById(scenarioId);

--- a/openaev-api/src/test/java/io/openaev/engine/EngineListenerTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/EngineListenerTest.java
@@ -27,6 +27,8 @@ class EngineListenerTest {
 
   @AfterEach
   void cleanupSynchronization() {
+    TransactionSynchronizationManager.unbindResourceIfPossible(
+        EngineListener.PENDING_DELETE_IDS_RESOURCE_KEY);
     if (TransactionSynchronizationManager.isSynchronizationActive()) {
       TransactionSynchronizationManager.clearSynchronization();
     }
@@ -88,6 +90,22 @@ class EngineListenerTest {
 
     // Assert
     verify(engineService, never()).bulkDelete(List.of("inject-1"));
+  }
+
+  @Test
+  @DisplayName("given_deleteEventInTransaction_should_bindPendingIdsAsTransactionResource")
+  void given_deleteEventInTransaction_should_bindPendingIdsAsTransactionResource() {
+    // Arrange
+    TransactionSynchronizationManager.initSynchronization();
+
+    // Act
+    engineListener.listenIndexEvent(new IndexEvent(DATA_DELETE, "inject-1"));
+
+    // Assert
+    assertThat(
+            TransactionSynchronizationManager.hasResource(
+                EngineListener.PENDING_DELETE_IDS_RESOURCE_KEY))
+        .isTrue();
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/engine/EngineListenerTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/EngineListenerTest.java
@@ -1,0 +1,105 @@
+package io.openaev.engine;
+
+import static io.openaev.database.audit.ModelBaseListener.DATA_DELETE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.openaev.database.audit.IndexEvent;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class EngineListenerTest {
+
+  @Mock private EngineService engineService;
+
+  @InjectMocks private EngineListener engineListener;
+
+  @AfterEach
+  void cleanupSynchronization() {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  @DisplayName("given_deleteEventOutsideTransaction_should_deleteImmediately")
+  void given_deleteEventOutsideTransaction_should_deleteImmediately() {
+    // Arrange
+    IndexEvent event = new IndexEvent(DATA_DELETE, "inject-1");
+
+    // Act
+    engineListener.listenIndexEvent(event);
+
+    // Assert
+    verify(engineService).bulkDelete(List.of("inject-1"));
+  }
+
+  @Test
+  @DisplayName("given_multipleDeleteEventsInTransaction_should_flushOnceAfterCommit")
+  void given_multipleDeleteEventsInTransaction_should_flushOnceAfterCommit() {
+    // Arrange
+    TransactionSynchronizationManager.initSynchronization();
+
+    // Act
+    engineListener.listenIndexEvent(new IndexEvent(DATA_DELETE, "inject-1"));
+    engineListener.listenIndexEvent(new IndexEvent(DATA_DELETE, "inject-2"));
+    engineListener.listenIndexEvent(new IndexEvent(DATA_DELETE, "inject-1"));
+
+    List<TransactionSynchronization> synchronizations =
+        TransactionSynchronizationManager.getSynchronizations();
+    synchronizations.forEach(TransactionSynchronization::afterCommit);
+    synchronizations.forEach(
+        synchronization ->
+            synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
+    TransactionSynchronizationManager.clearSynchronization();
+
+    // Assert
+    ArgumentCaptor<List<String>> idsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(engineService).bulkDelete(idsCaptor.capture());
+    assertThat(idsCaptor.getValue()).containsExactly("inject-1", "inject-2");
+  }
+
+  @Test
+  @DisplayName("given_deleteEventsInTransactionRollback_should_notFlush")
+  void given_deleteEventsInTransactionRollback_should_notFlush() {
+    // Arrange
+    TransactionSynchronizationManager.initSynchronization();
+
+    // Act
+    engineListener.listenIndexEvent(new IndexEvent(DATA_DELETE, "inject-1"));
+
+    List<TransactionSynchronization> synchronizations =
+        TransactionSynchronizationManager.getSynchronizations();
+    synchronizations.forEach(
+        synchronization ->
+            synchronization.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK));
+    TransactionSynchronizationManager.clearSynchronization();
+
+    // Assert
+    verify(engineService, never()).bulkDelete(List.of("inject-1"));
+  }
+
+  @Test
+  @DisplayName("given_nonDeleteEvent_should_ignore")
+  void given_nonDeleteEvent_should_ignore() {
+    // Arrange
+    IndexEvent event = new IndexEvent("DATA_UPDATE", "inject-1");
+
+    // Act
+    engineListener.listenIndexEvent(event);
+
+    // Assert
+    verify(engineService, never()).bulkDelete(List.of("inject-1"));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/engine/EngineServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/EngineServiceIntegrationTest.java
@@ -101,8 +101,7 @@ class EngineServiceIntegrationTest extends IntegrationTest {
   class BulkDelete {
 
     @Test
-    @DisplayName(
-        "given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete")
+    @DisplayName("given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete")
     void given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete()
         throws InterruptedException {
       // Arrange: persist one endpoint and index it
@@ -165,10 +164,8 @@ class EngineServiceIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName(
-        "given_bulkDeleteOnlyOneShouldLeaveOtherIntact")
-    void given_bulkDeleteOnlyOneId_should_leaveOtherDocumentIntact()
-        throws InterruptedException {
+    @DisplayName("given_bulkDeleteOnlyOneShouldLeaveOtherIntact")
+    void given_bulkDeleteOnlyOneId_should_leaveOtherDocumentIntact() throws InterruptedException {
       // Arrange
       String endpointToDeleteId =
           endpointComposer
@@ -176,9 +173,7 @@ class EngineServiceIntegrationTest extends IntegrationTest {
               .persist()
               .get()
               .getId();
-      endpointComposer
-          .forEndpoint(EndpointFixture.createEndpoint("ep-to-keep"))
-          .persist();
+      endpointComposer.forEndpoint(EndpointFixture.createEndpoint("ep-to-keep")).persist();
 
       indexAndWait();
 
@@ -196,6 +191,3 @@ class EngineServiceIntegrationTest extends IntegrationTest {
     }
   }
 }
-
-
-

--- a/openaev-api/src/test/java/io/openaev/engine/EngineServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/EngineServiceIntegrationTest.java
@@ -1,0 +1,201 @@
+package io.openaev.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.raw.RawGrant;
+import io.openaev.database.raw.RawUserAuth;
+import io.openaev.engine.api.ListConfiguration;
+import io.openaev.engine.api.ListRuntime;
+import io.openaev.engine.query.EsEntities;
+import io.openaev.utils.CustomDashboardTimeRange;
+import io.openaev.utils.fixtures.EndpointFixture;
+import io.openaev.utils.fixtures.composers.EndpointComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import io.openaev.utils.pagination.Pagination;
+import io.openaev.utilstest.RabbitMQTestListener;
+import jakarta.transaction.Transactional;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestExecutionListeners;
+
+@SpringBootTest
+@Transactional
+@WithMockUser(isAdmin = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestExecutionListeners(
+    value = {RabbitMQTestListener.class},
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@DisplayName("EngineService integration tests — actual ES/OpenSearch deletion")
+class EngineServiceIntegrationTest extends IntegrationTest {
+
+  @Autowired private EngineService engineService;
+  @Autowired private EngineContext engineContext;
+  @Autowired private EndpointComposer endpointComposer;
+
+  /** An admin RawUserAuth used to call engineService.entities() directly. */
+  private static final RawUserAuth ADMIN_USER =
+      new RawUserAuth() {
+        @Override
+        public String getUser_id() {
+          return "test-admin-" + UUID.randomUUID();
+        }
+
+        @Override
+        public boolean getUser_admin() {
+          return true;
+        }
+
+        @Override
+        public Set<RawGrant> getUser_grants() {
+          return Set.of();
+        }
+      };
+
+  @BeforeEach
+  void resetIndex() throws IOException {
+    endpointComposer.reset();
+    for (EsModel<?> model : engineContext.getModels()) {
+      engineService.cleanUpIndex(model.getName());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------
+
+  private EsEntities queryEndpoints() {
+    ListConfiguration config = engineService.createListConfiguration("endpoint", Map.of());
+    // ALL_TIME avoids the DEFAULT branch that requires a dashboard timeRange parameter
+    config.setTimeRange(CustomDashboardTimeRange.ALL_TIME);
+    ListRuntime runtime = new ListRuntime(config, Map.of(), Map.of(), new Pagination(0, 100));
+    return engineService.entities(ADMIN_USER, runtime);
+  }
+
+  private void indexAndWait() throws InterruptedException {
+    entityManager.flush();
+    entityManager.clear();
+    engineService.bulkProcessing(engineContext.getModels().stream());
+    // ES processes indexing asynchronously — give it time
+    Thread.sleep(1_000);
+  }
+
+  private void deleteAndWait(List<String> ids) throws InterruptedException {
+    engineService.bulkDelete(ids);
+    // ES processes deletion asynchronously — give it time
+    Thread.sleep(1_000);
+  }
+
+  @Nested
+  @DisplayName("bulkDelete")
+  class BulkDelete {
+
+    @Test
+    @DisplayName(
+        "given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete")
+    void given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete()
+        throws InterruptedException {
+      // Arrange: persist one endpoint and index it
+      String endpointId =
+          endpointComposer
+              .forEndpoint(EndpointFixture.createEndpoint("ep-delete-single"))
+              .persist()
+              .get()
+              .getId();
+
+      indexAndWait();
+
+      assertThat(queryEndpoints().getTotal())
+          .as("endpoint should be present in engine before deletion")
+          .isEqualTo(1);
+
+      // Act
+      deleteAndWait(List.of(endpointId));
+
+      // Assert
+      assertThat(queryEndpoints().getTotal())
+          .as("endpoint should have been removed from the engine index after bulkDelete")
+          .isZero();
+    }
+
+    @Test
+    @DisplayName(
+        "given_multipleIndexedEndpoints_should_removeAllDocumentsFromEngineAfterBulkDelete")
+    void given_multipleIndexedEndpoints_should_removeAllDocumentsFromEngineAfterBulkDelete()
+        throws InterruptedException {
+      // Arrange — persist two endpoints and index them
+      String endpointAId =
+          endpointComposer
+              .forEndpoint(EndpointFixture.createEndpoint("ep-delete-a"))
+              .persist()
+              .get()
+              .getId();
+      String endpointBId =
+          endpointComposer
+              .forEndpoint(EndpointFixture.createEndpoint("ep-delete-b"))
+              .persist()
+              .get()
+              .getId();
+
+      indexAndWait();
+
+      assertThat(queryEndpoints().getTotal())
+          .as("both endpoints should be present in engine before deletion")
+          .isEqualTo(2);
+
+      // Act — delete both in a single bulk call (covers the ids.getFirst() regression)
+      deleteAndWait(List.of(endpointAId, endpointBId));
+
+      // Assert
+      assertThat(queryEndpoints().getTotal())
+          .as(
+              "all endpoints should have been removed from the engine index after"
+                  + " bulkDelete with multiple IDs")
+          .isZero();
+    }
+
+    @Test
+    @DisplayName(
+        "given_bulkDeleteOnlyOneShouldLeaveOtherIntact")
+    void given_bulkDeleteOnlyOneId_should_leaveOtherDocumentIntact()
+        throws InterruptedException {
+      // Arrange
+      String endpointToDeleteId =
+          endpointComposer
+              .forEndpoint(EndpointFixture.createEndpoint("ep-to-delete"))
+              .persist()
+              .get()
+              .getId();
+      endpointComposer
+          .forEndpoint(EndpointFixture.createEndpoint("ep-to-keep"))
+          .persist();
+
+      indexAndWait();
+
+      assertThat(queryEndpoints().getTotal())
+          .as("both endpoints should be present before partial deletion")
+          .isEqualTo(2);
+
+      // Act — delete only one
+      deleteAndWait(List.of(endpointToDeleteId));
+
+      // Assert
+      assertThat(queryEndpoints().getTotal())
+          .as("only the targeted endpoint should have been deleted; the other must remain")
+          .isEqualTo(1);
+    }
+  }
+}
+
+
+

--- a/openaev-api/src/test/java/io/openaev/engine/EngineServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/EngineServiceIntegrationTest.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.TestExecutionListeners;
 @TestExecutionListeners(
     value = {RabbitMQTestListener.class},
     mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@DisplayName("EngineService integration tests — actual ES/OpenSearch deletion")
+@DisplayName("EngineService integration tests - actual ES/OpenSearch deletion")
 class EngineServiceIntegrationTest extends IntegrationTest {
 
   @Autowired private EngineService engineService;
@@ -101,7 +101,7 @@ class EngineServiceIntegrationTest extends IntegrationTest {
   class BulkDelete {
 
     @Test
-    @DisplayName("given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete")
+    @DisplayName("Indexed endpoint should remove document from engine after bulk delete")
     void given_indexedEndpoint_should_removeDocumentFromEngineAfterBulkDelete()
         throws InterruptedException {
       // Arrange: persist one endpoint and index it
@@ -129,7 +129,7 @@ class EngineServiceIntegrationTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "given_multipleIndexedEndpoints_should_removeAllDocumentsFromEngineAfterBulkDelete")
+        "Multiple indexed endpoints should remove all documents from engine after bulk delete")
     void given_multipleIndexedEndpoints_should_removeAllDocumentsFromEngineAfterBulkDelete()
         throws InterruptedException {
       // Arrange — persist two endpoints and index them
@@ -164,7 +164,7 @@ class EngineServiceIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("given_bulkDeleteOnlyOneShouldLeaveOtherIntact")
+    @DisplayName("Bulk delete only one element should leave other intact")
     void given_bulkDeleteOnlyOneId_should_leaveOtherDocumentIntact() throws InterruptedException {
       // Arrange
       String endpointToDeleteId =

--- a/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ScenarioServiceTest.java
@@ -35,6 +35,7 @@ import io.openaev.utils.fixtures.composers.ScenarioComposer;
 import io.openaev.utils.fixtures.composers.SecurityCoverageComposer;
 import io.openaev.utils.mapper.ExerciseMapper;
 import io.openaev.utils.mapper.ScenarioMapper;
+import io.openaev.utils.mockUser.WithMockUser;
 import io.openaev.utilstest.RabbitMQTestListener;
 import java.util.*;
 import org.junit.jupiter.api.*;
@@ -61,6 +62,7 @@ class ScenarioServiceTest extends IntegrationTest {
   @Autowired private ScenarioTeamUserRepository scenarioTeamUserRepository;
   @Autowired private ArticleRepository articleRepository;
   @Autowired InjectRepository injectRepository;
+  @Autowired private InjectDependenciesRepository injectDependenciesRepository;
   @Autowired private LessonsCategoryRepository lessonsCategoryRepository;
   @Autowired private TagRepository tagRepository;
   @Autowired private HealthCheckUtils healthCheckUtils;
@@ -83,6 +85,7 @@ class ScenarioServiceTest extends IntegrationTest {
   @Mock private CustomDashboardService customDashboardService;
   @Mock private InjectorContractService injectorContractService;
   @InjectMocks private ScenarioService scenarioService;
+  @Autowired private ScenarioService scenarioServiceBean;
   @Autowired private ScenarioMapper scenarioMapper;
 
   @Mock private WorkflowService workflowService;
@@ -160,6 +163,65 @@ class ScenarioServiceTest extends IntegrationTest {
 
     assertThat(injectRepository.findById(injectWrapper.get().getId())).isEmpty();
     assertThatThrownBy(() -> scenarioService.getScenarioById(scenarioId))
+        .isInstanceOf(ElementNotFoundException.class);
+  }
+
+  @DisplayName(
+      "given scenario with cross inject dependencies should delete without exception and clear dependency rows")
+  @Test
+  @Transactional
+  @WithMockUser
+  void
+      given_scenarioWithCrossInjectDependencies_should_deleteScenarioWithoutException_and_clearDependencies() {
+    // Arrange
+    Scenario scenario =
+        scenarioComposer
+            .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+            .persist()
+            .get();
+
+    Inject injectA = InjectFixture.getDefaultInject();
+    injectA.setScenario(scenario);
+    injectA.setTitle("inject-a-" + UUID.randomUUID());
+    Inject injectB = InjectFixture.getDefaultInject();
+    injectB.setScenario(scenario);
+    injectB.setTitle("inject-b-" + UUID.randomUUID());
+
+    Inject persistedInjectA = injectComposer.forInject(injectA).persist().get();
+    Inject persistedInjectB = injectComposer.forInject(injectB).persist().get();
+
+    InjectDependencyId dependencyAtoBId = new InjectDependencyId();
+    dependencyAtoBId.setInjectParent(persistedInjectA);
+    dependencyAtoBId.setInjectChildren(persistedInjectB);
+    InjectDependency dependencyAtoB = new InjectDependency();
+    dependencyAtoB.setCompositeId(dependencyAtoBId);
+
+    InjectDependencyId dependencyBtoAId = new InjectDependencyId();
+    dependencyBtoAId.setInjectParent(persistedInjectB);
+    dependencyBtoAId.setInjectChildren(persistedInjectA);
+    InjectDependency dependencyBtoA = new InjectDependency();
+    dependencyBtoA.setCompositeId(dependencyBtoAId);
+
+    injectDependenciesRepository.save(dependencyAtoB);
+    injectDependenciesRepository.save(dependencyBtoA);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    // Act
+    assertDoesNotThrow(() -> scenarioServiceBean.deleteScenario(scenario.getId()));
+
+    entityManager.flush();
+    entityManager.clear();
+
+    // Assert
+    assertThat(
+            injectDependenciesRepository.findParents(
+                List.of(persistedInjectA.getId(), persistedInjectB.getId())))
+        .isEmpty();
+    assertThat(injectRepository.findById(persistedInjectA.getId())).isEmpty();
+    assertThat(injectRepository.findById(persistedInjectB.getId())).isEmpty();
+    assertThatThrownBy(() -> scenarioServiceBean.getScenarioById(scenario.getId()))
         .isInstanceOf(ElementNotFoundException.class);
   }
 

--- a/openaev-model/src/main/java/io/openaev/database/model/Inject.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Inject.java
@@ -147,9 +147,8 @@ public class Inject implements GrantableBase, Injection, TenantBase {
   @Getter
   @OneToMany(
       mappedBy = "compositeId.injectChildren",
-      fetch = FetchType.EAGER,
-      orphanRemoval = true,
-      cascade = CascadeType.ALL)
+      fetch = FetchType.LAZY,
+      cascade = {CascadeType.MERGE, CascadeType.PERSIST})
   @JsonProperty("inject_depends_on")
   @JsonDeserialize(contentUsing = MonoIdDeserializerHelper.class)
   private List<InjectDependency> dependsOn = new ArrayList<>();

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
@@ -29,27 +29,4 @@ public interface InjectDependenciesRepository
               + "WHERE inject_children_id IN :childrens",
       nativeQuery = true)
   List<InjectDependency> findParents(@NotNull List<String> childrens);
-
-  /**
-   * Deletes all inject dependency rows where either side of the dependency belongs to a given
-   * scenario. This must be called before deleting the scenario to avoid Hibernate
-   * StaleStateException caused by CascadeType.ALL trying to delete the same row twice when multiple
-   * injects in the scenario have cross-dependencies.
-   *
-   * @param scenarioId the scenario whose inject dependencies must be cleared
-   */
-  @Modifying
-  @Query(
-      value =
-          "DELETE FROM injects_dependencies d "
-              + "USING ("
-              + "  SELECT inject_id FROM injects i "
-              + "  JOIN scenarios s ON s.scenario_id = i.inject_scenario "
-              + "  WHERE i.inject_scenario = :scenarioId "
-              + "  AND s.tenant_id = :#{#tenantContext.currentTenant}"
-              + ") scenario_injects "
-              + "WHERE d.inject_children_id = scenario_injects.inject_id "
-              + "OR d.inject_parent_id = scenario_injects.inject_id",
-      nativeQuery = true)
-  void deleteAllByScenarioId(@Param("scenarioId") String scenarioId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
@@ -6,8 +6,10 @@ import io.openaev.database.model.Injector;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,4 +29,21 @@ public interface InjectDependenciesRepository
               + "WHERE inject_children_id IN :childrens",
       nativeQuery = true)
   List<InjectDependency> findParents(@NotNull List<String> childrens);
+
+  /**
+   * Deletes all inject dependency rows where either side of the dependency belongs to a given
+   * scenario. This must be called before deleting the scenario to avoid Hibernate
+   * StaleStateException caused by CascadeType.ALL trying to delete the same row twice when multiple
+   * injects in the scenario have cross-dependencies.
+   *
+   * @param scenarioId the scenario whose inject dependencies must be cleared
+   */
+  @Modifying
+  @Query(
+      value =
+          "DELETE FROM injects_dependencies "
+              + "WHERE inject_children_id IN (SELECT inject_id FROM injects i WHERE i.inject_scenario = :scenarioId) "
+              + "OR inject_parent_id IN (SELECT inject_id FROM injects i WHERE i.inject_scenario = :scenarioId)",
+      nativeQuery = true)
+  void deleteAllByScenarioId(@Param("scenarioId") String scenarioId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
@@ -6,10 +6,8 @@ import io.openaev.database.model.Injector;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
@@ -41,19 +41,15 @@ public interface InjectDependenciesRepository
   @Modifying
   @Query(
       value =
-          "DELETE FROM injects_dependencies "
-              + "WHERE inject_children_id IN ("
+          "DELETE FROM injects_dependencies d "
+              + "USING ("
               + "  SELECT inject_id FROM injects i "
               + "  JOIN scenarios s ON s.scenario_id = i.inject_scenario "
               + "  WHERE i.inject_scenario = :scenarioId "
               + "  AND s.tenant_id = :#{#tenantContext.currentTenant}"
-              + ") "
-              + "OR inject_parent_id IN ("
-              + "  SELECT inject_id FROM injects i "
-              + "  JOIN scenarios s ON s.scenario_id = i.inject_scenario "
-              + "  WHERE i.inject_scenario = :scenarioId "
-              + "  AND s.tenant_id = :#{#tenantContext.currentTenant}"
-              + ")",
+              + ") scenario_injects "
+              + "WHERE d.inject_children_id = scenario_injects.inject_id "
+              + "OR d.inject_parent_id = scenario_injects.inject_id",
       nativeQuery = true)
   void deleteAllByScenarioId(@Param("scenarioId") String scenarioId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectDependenciesRepository.java
@@ -42,8 +42,18 @@ public interface InjectDependenciesRepository
   @Query(
       value =
           "DELETE FROM injects_dependencies "
-              + "WHERE inject_children_id IN (SELECT inject_id FROM injects i WHERE i.inject_scenario = :scenarioId) "
-              + "OR inject_parent_id IN (SELECT inject_id FROM injects i WHERE i.inject_scenario = :scenarioId)",
+              + "WHERE inject_children_id IN ("
+              + "  SELECT inject_id FROM injects i "
+              + "  JOIN scenarios s ON s.scenario_id = i.inject_scenario "
+              + "  WHERE i.inject_scenario = :scenarioId "
+              + "  AND s.tenant_id = :#{#tenantContext.currentTenant}"
+              + ") "
+              + "OR inject_parent_id IN ("
+              + "  SELECT inject_id FROM injects i "
+              + "  JOIN scenarios s ON s.scenario_id = i.inject_scenario "
+              + "  WHERE i.inject_scenario = :scenarioId "
+              + "  AND s.tenant_id = :#{#tenantContext.currentTenant}"
+              + ")",
       nativeQuery = true)
   void deleteAllByScenarioId(@Param("scenarioId") String scenarioId);
 }

--- a/openaev-model/src/main/java/io/openaev/engine/EngineListener.java
+++ b/openaev-model/src/main/java/io/openaev/engine/EngineListener.java
@@ -3,27 +3,68 @@ package io.openaev.engine;
 import static io.openaev.database.audit.ModelBaseListener.DATA_DELETE;
 
 import io.openaev.database.audit.IndexEvent;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
+@RequiredArgsConstructor
 public class EngineListener {
 
-  private EngineService esService;
+  private static final ThreadLocal<Set<String>> PENDING_DELETE_IDS =
+      ThreadLocal.withInitial(LinkedHashSet::new);
+  private static final ThreadLocal<Boolean> SYNC_REGISTERED = ThreadLocal.withInitial(() -> false);
 
-  @Autowired
-  public void setEsService(EngineService esService) {
-    this.esService = esService;
-  }
+  private final EngineService esService;
 
   @EventListener
   public void listenIndexEvent(IndexEvent event) {
-    if (Objects.equals(event.getType(), DATA_DELETE)) {
-      // TODO Combine through time to generate a real bulk delete
-      this.esService.bulkDelete(List.of(event.getId()));
+    if (!Objects.equals(event.getType(), DATA_DELETE) || event.getId() == null) {
+      return;
     }
+
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      this.esService.bulkDelete(List.of(event.getId()));
+      return;
+    }
+
+    PENDING_DELETE_IDS.get().add(event.getId());
+    if (Boolean.TRUE.equals(SYNC_REGISTERED.get())) {
+      return;
+    }
+
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            flushPendingDeletes();
+          }
+
+          @Override
+          public void afterCompletion(int status) {
+            clearPendingDeletes();
+          }
+        });
+    SYNC_REGISTERED.set(true);
+  }
+
+  private void flushPendingDeletes() {
+    Set<String> pendingDeleteIds = PENDING_DELETE_IDS.get();
+    if (pendingDeleteIds.isEmpty()) {
+      return;
+    }
+    this.esService.bulkDelete(new ArrayList<>(pendingDeleteIds));
+  }
+
+  private void clearPendingDeletes() {
+    PENDING_DELETE_IDS.remove();
+    SYNC_REGISTERED.remove();
   }
 }

--- a/openaev-model/src/main/java/io/openaev/engine/EngineListener.java
+++ b/openaev-model/src/main/java/io/openaev/engine/EngineListener.java
@@ -18,9 +18,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @RequiredArgsConstructor
 public class EngineListener {
 
-  private static final ThreadLocal<Set<String>> PENDING_DELETE_IDS =
-      ThreadLocal.withInitial(LinkedHashSet::new);
-  private static final ThreadLocal<Boolean> SYNC_REGISTERED = ThreadLocal.withInitial(() -> false);
+  static final String PENDING_DELETE_IDS_RESOURCE_KEY =
+      EngineListener.class.getName() + ".PENDING_DELETE_IDS";
 
   private final EngineService esService;
 
@@ -35,8 +34,9 @@ public class EngineListener {
       return;
     }
 
-    PENDING_DELETE_IDS.get().add(event.getId());
-    if (Boolean.TRUE.equals(SYNC_REGISTERED.get())) {
+    Set<String> pendingDeleteIds = getOrCreatePendingDeleteIds();
+    pendingDeleteIds.add(event.getId());
+    if (pendingDeleteIds.size() > 1) {
       return;
     }
 
@@ -52,11 +52,29 @@ public class EngineListener {
             clearPendingDeletes();
           }
         });
-    SYNC_REGISTERED.set(true);
+  }
+
+  private Set<String> getOrCreatePendingDeleteIds() {
+    if (TransactionSynchronizationManager.hasResource(PENDING_DELETE_IDS_RESOURCE_KEY)) {
+      return getBoundPendingDeleteIds();
+    }
+    Set<String> pendingDeleteIds = new LinkedHashSet<>();
+    TransactionSynchronizationManager.bindResource(
+        PENDING_DELETE_IDS_RESOURCE_KEY, pendingDeleteIds);
+    return pendingDeleteIds;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<String> getBoundPendingDeleteIds() {
+    return (Set<String>)
+        TransactionSynchronizationManager.getResource(PENDING_DELETE_IDS_RESOURCE_KEY);
   }
 
   private void flushPendingDeletes() {
-    Set<String> pendingDeleteIds = PENDING_DELETE_IDS.get();
+    if (!TransactionSynchronizationManager.hasResource(PENDING_DELETE_IDS_RESOURCE_KEY)) {
+      return;
+    }
+    Set<String> pendingDeleteIds = getBoundPendingDeleteIds();
     if (pendingDeleteIds.isEmpty()) {
       return;
     }
@@ -64,7 +82,6 @@ public class EngineListener {
   }
 
   private void clearPendingDeletes() {
-    PENDING_DELETE_IDS.remove();
-    SYNC_REGISTERED.remove();
+    TransactionSynchronizationManager.unbindResourceIfPossible(PENDING_DELETE_IDS_RESOURCE_KEY);
   }
 }

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -400,6 +400,9 @@ public class ElasticService implements EngineService {
   }
 
   public void bulkDelete(List<String> ids) {
+    if (ids == null || ids.isEmpty()) {
+      return;
+    }
     try {
       List<FieldValue> values = ids.stream().map(FieldValue::of).toList();
       // Delete the direct document corresponding to the id
@@ -433,19 +436,17 @@ public class ElasticService implements EngineService {
                                   """
                                           // For each EsBase attribute of each document
                                           for (String key : ctx._source.keySet().toArray()) {
-                                            // If it's a "base_XXX_side" (means String id or List of ids), we delete only in the "base_XXX_side" of the EsBase the object id deleted before with the deleteByQuery
+                                            // If it's a "base_XXX_side" (means String id or List of ids), remove all deleted ids from this field.
                                             if(key.startsWith("base_") && key.endsWith("_side") && ctx._source[key] != null) {
                                                 if (ctx._source[key] instanceof List) {
-                                                    ctx._source[key].removeIf(item -> item == params.valueToRemove);
-                                                } else if (ctx._source[key] instanceof String && ctx._source[key] == params.valueToRemove) {
+                                                    ctx._source[key].removeIf(item -> params.valuesToRemove.contains(item));
+                                                } else if (ctx._source[key] instanceof String && params.valuesToRemove.contains(ctx._source[key])) {
                                                     ctx._source.remove(key);
                                                 }
                                             }
                                           }
                                         """)
-                              .params(
-                                  "valueToRemove",
-                                  JsonData.of(ids.getFirst())) // Only 1 id in this list
+                              .params("valuesToRemove", JsonData.of(ids))
                               .lang("painless")))
               .refresh(true)
               .conflicts(Conflicts.Proceed)

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -462,6 +462,9 @@ public class OpenSearchService implements EngineService {
   }
 
   public void bulkDelete(List<String> ids) {
+    if (ids == null || ids.isEmpty()) {
+      return;
+    }
     try {
       List<FieldValue> values = ids.stream().map(FieldValue::of).toList();
       // Delete the direct document corresponding to the id
@@ -498,20 +501,17 @@ public class OpenSearchService implements EngineService {
                                               """
                                                       // For each EsBase attribute of each document
                                                       for (String key : ctx._source.keySet().toArray()) {
-                                                        // If it's a "base_XXX_side" (means String id or List of ids), we delete only in the "base_XXX_side" of the EsBase the object id deleted before with the deleteByQuery
+                                                        // If it's a "base_XXX_side" (means String id or List of ids), remove all deleted ids from this field.
                                                         if(key.startsWith("base_") && key.endsWith("_side") && ctx._source[key] != null) {
                                                             if (ctx._source[key] instanceof List) {
-                                                                ctx._source[key].removeIf(item -> item == params.valueToRemove);
-                                                            } else if (ctx._source[key] instanceof String && ctx._source[key] == params.valueToRemove) {
+                                                                ctx._source[key].removeIf(item -> params.valuesToRemove.contains(item));
+                                                            } else if (ctx._source[key] instanceof String && params.valuesToRemove.contains(ctx._source[key])) {
                                                                 ctx._source.remove(key);
                                                             }
                                                         }
                                                       }
                                                     """)
-                                          .params(
-                                              "valueToRemove",
-                                              JsonData.of(
-                                                  ids.getFirst())))))) // Only 1 id in this list
+                                          .params("valuesToRemove", JsonData.of(ids))))))
               .refresh(Refresh.True)
               .conflicts(Conflicts.Proceed)
               .build());


### PR DESCRIPTION
### Proposed changes

* Implement bulk deletion on ES when a scenario is deleted

### Testing Instructions

1. Delete a scenario shoudn't take more than a few seconds

### Related issues

* Closes #5208 