### PR TITLE
[frontend] fix(people): manage search with tags in teams players list (#4864)

### DIFF
--- a/openaev-front/src/admin/components/components/teams/TeamPlayers.tsx
+++ b/openaev-front/src/admin/components/components/teams/TeamPlayers.tsx
@@ -160,7 +160,7 @@ const TeamPlayers: FunctionComponent<Props> = ({ teamId, handleClose, canManage 
   const [keyword, setKeyword] = useState('');
   const [sortBy, setSortby] = useState('user_email');
   const [orderAsc, setOrderAsc] = useState(true);
-  const [tags, setTags] = useState<Option['id'][]>([]);
+  const [tags, setTags] = useState<Option[]>([]);
 
   const { organizationsMap, team, users }: {
     organizationsMap: Record<string, Organization>;
@@ -254,13 +254,13 @@ const TeamPlayers: FunctionComponent<Props> = ({ teamId, handleClose, canManage 
         <div className={classes.parameters}>
           <div className={classes.tags}>
             <TagsFilter
-              onAddTag={(value: Option['id']) => {
+              onAddTag={(value: Option) => {
                 if (value) {
                   setTags([...tags, value]);
                 }
               }}
               onRemoveTag={(value: Option['id']) => {
-                setTags(tags.splice(tags.indexOf(value), 1));
+                setTags(tags.filter((t: Option) => t.id !== value));
               }}
               currentTags={tags}
               thin={true}


### PR DESCRIPTION

### Proposed changes

When navigating to People > Teams and managing players of a team, there is a tag filtering option. When only one tag is selected, the selection does not reflect visually. When selecting multiple tags and trying to remove them, there is still one appearing.


### Testing Instructions

1. Go to People > Teams and manage players
2. Add a tag in the filter field
3. Delete the tag, it should disappear
