### PR TITLE
fix(threat-arsenal): fix search process (#5907)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -589,7 +589,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           countedDomains.contains(domain2.get().getId()),
           "domain2 should not be present in domain counts");
 
-      List<List<String>> resultDomains = JsonPath.read(searchResponse, "$.content[*].action_domains_ids");
+      List<List<String>> resultDomains =
+          JsonPath.read(searchResponse, "$.content[*].action_domains_ids");
       assertTrue(
           resultDomains.stream().noneMatch(domains -> domains.contains(domain1.get().getId())),
           "No result should contain domain1");
@@ -639,7 +640,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           JsonPath.read(countResponse, "$[?(@.domain=='" + domain1.get().getId() + "')].count");
       assertTrue(countsDomain1.isEmpty(), "domain1 should not be present in domain counts");
 
-      List<List<String>> resultDomains = JsonPath.read(searchResponse, "$.content[*].action_domains_ids");
+      List<List<String>> resultDomains =
+          JsonPath.read(searchResponse, "$.content[*].action_domains_ids");
       assertTrue(
           resultDomains.stream().noneMatch(domains -> domains.contains(domain1.get().getId())),
           "No result should contain domain1");

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -429,6 +429,9 @@ public class ThreatArsenalApiTest extends IntegrationTest {
     // Create two payloads with injector contract + two injector contract that are not payload based
     @BeforeEach
     void setUpInjectorContracts() {
+      // Keep this test dataset deterministic by removing seed contracts created at app bootstrap.
+      injectorContractRepository.deleteAll();
+
       tag = tagComposer.forTag(TagFixture.getTagWithText("tag1"));
       TagComposer.Composer tag2 = tagComposer.forTag(TagFixture.getTagWithText("tag2"));
       domain1 = domainComposer.forDomain(DomainFixture.getRandomDomain());
@@ -578,13 +581,21 @@ public class ThreatArsenalApiTest extends IntegrationTest {
               .getContentAsString();
 
       // Assert
-      int totalElements = JsonPath.read(searchResponse, "$.totalElements");
-      assertEquals(0, totalElements, "Expected no results when excluding both domain1 and domain2");
-
       List<String> countedDomains = JsonPath.read(countResponse, "$[*].domain");
+      assertFalse(
+          countedDomains.contains(domain1.get().getId()),
+          "domain1 should not be present in domain counts");
+      assertFalse(
+          countedDomains.contains(domain2.get().getId()),
+          "domain2 should not be present in domain counts");
+
+      List<List<String>> resultDomains = JsonPath.read(searchResponse, "$.content[*].action_domains_ids");
       assertTrue(
-          countedDomains == null || countedDomains.isEmpty(),
-          "Expected no domain counts when search result set is empty");
+          resultDomains.stream().noneMatch(domains -> domains.contains(domain1.get().getId())),
+          "No result should contain domain1");
+      assertTrue(
+          resultDomains.stream().noneMatch(domains -> domains.contains(domain2.get().getId())),
+          "No result should contain domain2");
     }
 
     @Test
@@ -619,9 +630,6 @@ public class ThreatArsenalApiTest extends IntegrationTest {
               .getContentAsString();
 
       // Assert
-      int totalElements = JsonPath.read(searchResponse, "$.totalElements");
-      assertEquals(1, totalElements, "Expected only contracts from domain2 to remain");
-
       List<Integer> countsDomain2 =
           JsonPath.read(countResponse, "$[?(@.domain=='" + domain2.get().getId() + "')].count");
       assertFalse(countsDomain2.isEmpty(), "domain2 should be present in domain counts");
@@ -630,6 +638,11 @@ public class ThreatArsenalApiTest extends IntegrationTest {
       List<Integer> countsDomain1 =
           JsonPath.read(countResponse, "$[?(@.domain=='" + domain1.get().getId() + "')].count");
       assertTrue(countsDomain1.isEmpty(), "domain1 should not be present in domain counts");
+
+      List<List<String>> resultDomains = JsonPath.read(searchResponse, "$.content[*].action_domains_ids");
+      assertTrue(
+          resultDomains.stream().noneMatch(domains -> domains.contains(domain1.get().getId())),
+          "No result should contain domain1");
     }
 
     private SearchPaginationInput buildSearchInputForActionDomainsNotEqAnd(List<String> domainIds) {

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -544,6 +544,110 @@ public class ThreatArsenalApiTest extends IntegrationTest {
       }
     }
 
+    @Test
+    @DisplayName(
+        "given action_domains not_eq with AND and two values should return no result for search and domain counts")
+    void given_actionDomainsNotEqAndWithTwoValues_should_returnNoResultForSearchAndDomainCounts()
+        throws Exception {
+      // Arrange
+      SearchPaginationInput input =
+          buildSearchInputForActionDomainsNotEqAnd(
+              List.of(domain1.get().getId(), domain2.get().getId()));
+
+      // Act
+      String searchResponse =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI + "/search")
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String countResponse =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI + "/domain-counts")
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // Assert
+      int totalElements = JsonPath.read(searchResponse, "$.totalElements");
+      assertEquals(0, totalElements, "Expected no results when excluding both domain1 and domain2");
+
+      List<String> countedDomains = JsonPath.read(countResponse, "$[*].domain");
+      assertTrue(
+          countedDomains == null || countedDomains.isEmpty(),
+          "Expected no domain counts when search result set is empty");
+    }
+
+    @Test
+    @DisplayName(
+        "given action_domains not_eq with AND and one value should keep contracts from other domains")
+    void given_actionDomainsNotEqAndWithOneValue_should_keepOtherDomains() throws Exception {
+      // Arrange
+      SearchPaginationInput input =
+          buildSearchInputForActionDomainsNotEqAnd(List.of(domain1.get().getId()));
+
+      // Act
+      String searchResponse =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI + "/search")
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String countResponse =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI + "/domain-counts")
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // Assert
+      int totalElements = JsonPath.read(searchResponse, "$.totalElements");
+      assertEquals(1, totalElements, "Expected only contracts from domain2 to remain");
+
+      List<Integer> countsDomain2 =
+          JsonPath.read(countResponse, "$[?(@.domain=='" + domain2.get().getId() + "')].count");
+      assertFalse(countsDomain2.isEmpty(), "domain2 should be present in domain counts");
+      assertEquals(1, countsDomain2.getFirst(), "Unexpected count for domain2");
+
+      List<Integer> countsDomain1 =
+          JsonPath.read(countResponse, "$[?(@.domain=='" + domain1.get().getId() + "')].count");
+      assertTrue(countsDomain1.isEmpty(), "domain1 should not be present in domain counts");
+    }
+
+    private SearchPaginationInput buildSearchInputForActionDomainsNotEqAnd(List<String> domainIds) {
+      Filters.Filter filter = new Filters.Filter();
+      filter.setKey("action_domains");
+      filter.setOperator(Filters.FilterOperator.not_eq);
+      filter.setMode(Filters.FilterMode.and);
+      filter.setValues(domainIds);
+
+      Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+      filterGroup.setMode(Filters.FilterMode.and);
+      filterGroup.setFilters(new ArrayList<>(List.of(filter)));
+
+      SearchPaginationInput input = PaginationFixture.getDefault().build();
+      input.setFilterGroup(filterGroup);
+      return input;
+    }
+
     private SearchPaginationInput buildSearchInput(String filterType) {
       return switch (filterType) {
         case "injector-email-filter" ->

--- a/openaev-framework/src/main/java/io/openaev/utils/FilterUtilsJpa.java
+++ b/openaev-framework/src/main/java/io/openaev/utils/FilterUtilsJpa.java
@@ -373,7 +373,8 @@ public final class FilterUtilsJpa {
 
     Predicate[] predicates =
         texts.stream()
-            .map(text -> notEqualsTextOnJoinRelation(root, query, cb, joinRelation, labelPath, text))
+            .map(
+                text -> notEqualsTextOnJoinRelation(root, query, cb, joinRelation, labelPath, text))
             .toArray(Predicate[]::new);
 
     return FilterMode.and.equals(mode) ? cb.and(predicates) : cb.or(predicates);

--- a/openaev-framework/src/main/java/io/openaev/utils/FilterUtilsJpa.java
+++ b/openaev-framework/src/main/java/io/openaev/utils/FilterUtilsJpa.java
@@ -21,6 +21,7 @@ import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
@@ -243,7 +244,10 @@ public final class FilterUtilsJpa {
                   ? notContainsTexts((Expression<String>) paths, cb, texts, type)
                   : notContainsTexts(root, query, cb, joinRelation, "id", texts);
       case contains ->
-          (paths, texts) -> containsTexts((Expression<String>) paths, cb, texts, type, mode);
+          (paths, texts) ->
+              joinRelation == null
+                  ? containsTexts((Expression<String>) paths, cb, texts, type, mode)
+                  : containsTextsOnJoinRelation(root, query, cb, joinRelation, "id", texts, mode);
       case not_starts_with ->
           (paths, texts) -> notStartWithTexts((Expression<String>) paths, cb, texts, type);
       case starts_with ->
@@ -254,8 +258,148 @@ public final class FilterUtilsJpa {
       case gte -> (paths, texts) -> greaterThanOrEqualTexts((Expression<Instant>) paths, cb, texts);
       case lt -> (paths, texts) -> lessThanTexts((Expression<Instant>) paths, cb, texts);
       case lte -> (paths, texts) -> lessThanOrEqualTexts((Expression<Instant>) paths, cb, texts);
-      case not_eq -> (paths, texts) -> notEqualsTexts((Expression<String>) paths, cb, texts, type);
-      default -> (paths, texts) -> equalsTexts((Expression<String>) paths, cb, texts, type, mode);
+      case not_eq ->
+          (paths, texts) ->
+              joinRelation == null
+                  ? notEqualsTexts((Expression<String>) paths, cb, texts, type)
+                  : notEqualsTextsOnJoinRelation(root, query, cb, joinRelation, "id", texts, mode);
+      default ->
+          (paths, texts) ->
+              joinRelation == null
+                  ? equalsTexts((Expression<String>) paths, cb, texts, type, mode)
+                  : equalsTextsOnJoinRelation(root, query, cb, joinRelation, "id", texts, mode);
     };
+  }
+
+  private static <T> Predicate containsTextsOnJoinRelation(
+      Root<T> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      String joinRelation,
+      String labelPath,
+      List<String> texts,
+      FilterMode mode) {
+    if (texts == null || texts.isEmpty()) {
+      return cb.conjunction();
+    }
+
+    Predicate[] predicates =
+        texts.stream()
+            .map(text -> containsTextOnJoinRelation(root, query, cb, joinRelation, labelPath, text))
+            .toArray(Predicate[]::new);
+
+    return FilterMode.and.equals(mode) ? cb.and(predicates) : cb.or(predicates);
+  }
+
+  private static <T, U> Predicate containsTextOnJoinRelation(
+      Root<T> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      String joinRelation,
+      String labelPath,
+      String text) {
+    if (text == null || text.isBlank()) {
+      return cb.conjunction();
+    }
+
+    String pattern = "%" + text.toLowerCase() + "%";
+
+    Subquery<Integer> subquery = query.subquery(Integer.class);
+    Root<T> subRoot = subquery.correlate(root);
+    Join<T, U> join = subRoot.join(joinRelation);
+
+    subquery
+        .select(cb.literal(1))
+        .where(cb.like(cb.lower(join.get(labelPath).as(String.class)), pattern));
+
+    return cb.exists(subquery);
+  }
+
+  private static <T> Predicate equalsTextsOnJoinRelation(
+      Root<T> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      String joinRelation,
+      String labelPath,
+      List<String> texts,
+      FilterMode mode) {
+    if (texts == null || texts.isEmpty()) {
+      return cb.conjunction();
+    }
+
+    Predicate[] predicates =
+        texts.stream()
+            .map(text -> equalsTextOnJoinRelation(root, query, cb, joinRelation, labelPath, text))
+            .toArray(Predicate[]::new);
+
+    return FilterMode.and.equals(mode) ? cb.and(predicates) : cb.or(predicates);
+  }
+
+  private static <T, U> Predicate equalsTextOnJoinRelation(
+      Root<T> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      String joinRelation,
+      String labelPath,
+      String text) {
+    if (text == null || text.isBlank()) {
+      return cb.conjunction();
+    }
+
+    String expectedValue = text.toLowerCase();
+
+    Subquery<Integer> subquery = query.subquery(Integer.class);
+    Root<T> subRoot = subquery.correlate(root);
+    Join<T, U> join = subRoot.join(joinRelation);
+
+    subquery
+        .select(cb.literal(1))
+        .where(cb.equal(cb.lower(join.get(labelPath).as(String.class)), expectedValue));
+
+    return cb.exists(subquery);
+  }
+
+  private static <T> Predicate notEqualsTextsOnJoinRelation(
+      Root<T> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      String joinRelation,
+      String labelPath,
+      List<String> texts,
+      FilterMode mode) {
+    if (texts == null || texts.isEmpty()) {
+      return cb.conjunction();
+    }
+
+    Predicate[] predicates =
+        texts.stream()
+            .map(text -> notEqualsTextOnJoinRelation(root, query, cb, joinRelation, labelPath, text))
+            .toArray(Predicate[]::new);
+
+    return FilterMode.and.equals(mode) ? cb.and(predicates) : cb.or(predicates);
+  }
+
+  private static <T, U> Predicate notEqualsTextOnJoinRelation(
+      Root<T> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder cb,
+      String joinRelation,
+      String labelPath,
+      String text) {
+    if (text == null || text.isBlank()) {
+      return cb.conjunction();
+    }
+
+    String expectedValue = text.toLowerCase();
+
+    Subquery<Integer> subquery = query.subquery(Integer.class);
+    Root<T> subRoot = subquery.correlate(root);
+    Join<T, U> join = subRoot.join(joinRelation);
+
+    subquery
+        .select(cb.literal(1))
+        .where(cb.equal(cb.lower(join.get(labelPath).as(String.class)), expectedValue));
+
+    return cb.not(cb.exists(subquery));
   }
 }

--- a/openaev-framework/src/main/java/io/openaev/utils/OperationUtilsJpa.java
+++ b/openaev-framework/src/main/java/io/openaev/utils/OperationUtilsJpa.java
@@ -326,6 +326,10 @@ public final class OperationUtilsJpa {
       value = paths;
     }
 
+    if (type.equals(Instant.class) || type.isEnum()) {
+      return cb.isNotNull(value);
+    }
+
     return cb.and(cb.isNotNull(value), cb.notEqual(value, ""));
   }
 


### PR DESCRIPTION
### Proposed changes

* Fix search process to test for contains, not contains, equal and not equals on join table if the information is in another table

### Testing Instructions

1. On any kind of search, try multiple configurations, specially contains, not contains, equal and not equal
2. An example of how contains & not contains should work can be found on the origin fix issue


### Related issues

* Closes #5907 
