### PR TITLE
[backend] fix(agents): limit jobs executions and review cleanup (#5962 & #5963)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/openaev/service/OpenAEVExecutorContextService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/openaev/service/OpenAEVExecutorContextService.java
@@ -2,6 +2,7 @@ package io.openaev.executors.openaev.service;
 
 import static io.openaev.executors.ExecutorHelper.replaceArgs;
 import static io.openaev.integration.impl.executors.openaev.OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_NAME;
+import static java.time.Instant.now;
 
 import io.openaev.database.model.*;
 import io.openaev.database.repository.AssetAgentJobRepository;
@@ -67,6 +68,7 @@ public class OpenAEVExecutorContextService extends ExecutorContextService {
     assetAgentJob.setAgent(agent);
     assetAgentJob.setInject(inject);
     assetAgentJob.setTenant(inject.getTenant());
+    assetAgentJob.setCreatedAt(now());
     assetAgentJobRepository.save(assetAgentJob);
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/EndpointApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/EndpointApi.java
@@ -81,9 +81,7 @@ public class EndpointApi extends RestBehavior {
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.JOB)
   @Transactional(rollbackFor = Exception.class)
   public List<AssetAgentJob> getEndpointJobs(@RequestBody final EndpointRegisterInput input) {
-    List<AssetAgentJob> jobs = this.endpointService.getEndpointJobs(input);
-    this.injectStatusService.addJobRetrievalTraces(jobs);
-    return jobs;
+    return this.endpointService.getEndpointJobs(input);
   }
 
   @Deprecated(since = "1.11.0")
@@ -107,7 +105,13 @@ public class EndpointApi extends RestBehavior {
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.JOB)
   @Transactional(rollbackFor = Exception.class)
   public void cleanupAssetAgentJob(@PathVariable @NotBlank final String assetAgentJobId) {
-    this.assetAgentJobRepository.deleteById(assetAgentJobId);
+    this.assetAgentJobRepository
+        .findById(assetAgentJobId)
+        .ifPresent(
+            assetAgentJob -> {
+              this.injectStatusService.addJobRetrievalTraces(assetAgentJob);
+              this.assetAgentJobRepository.deleteById(assetAgentJobId);
+            });
   }
 
   @Deprecated(since = "1.11.0")

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
@@ -24,8 +24,6 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -87,10 +85,13 @@ public class InjectStatusService {
   public void addJobRetrievalTraces(AssetAgentJob job) {
     if (job.getInject() != null && job.getAgent() != null) {
       String injectId = job.getInject().getId();
-      injectStatusRepository.findByInjectId(injectId).ifPresent(status -> {
-        ExecutionTraceUtils.addJobRetrievalTrace(status, job.getAgent());
-        injectStatusRepository.save(status);
-      });
+      injectStatusRepository
+          .findByInjectId(injectId)
+          .ifPresent(
+              status -> {
+                ExecutionTraceUtils.addJobRetrievalTrace(status, job.getAgent());
+                injectStatusRepository.save(status);
+              });
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
@@ -24,8 +24,8 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -84,22 +84,14 @@ public class InjectStatusService {
     injectStatusRepository.save(injectStatus);
   }
 
-  public void addJobRetrievalTraces(List<AssetAgentJob> jobs) {
-    Map<String, List<AssetAgentJob>> jobsByInjectId =
-        jobs.stream()
-            .filter(j -> j.getInject() != null && j.getAgent() != null)
-            .collect(Collectors.groupingBy(j -> j.getInject().getId()));
-    if (jobsByInjectId.isEmpty()) {
-      return;
-    }
-    List<InjectStatus> statuses =
-        injectStatusRepository.findAllByInjectIdIn(jobsByInjectId.keySet());
-    for (InjectStatus status : statuses) {
-      for (AssetAgentJob job : jobsByInjectId.getOrDefault(status.getInject().getId(), List.of())) {
+  public void addJobRetrievalTraces(AssetAgentJob job) {
+    if (job.getInject() != null && job.getAgent() != null) {
+      String injectId = job.getInject().getId();
+      injectStatusRepository.findByInjectId(injectId).ifPresent(status -> {
         ExecutionTraceUtils.addJobRetrievalTrace(status, job.getAgent());
-      }
+        injectStatusRepository.save(status);
+      });
     }
-    injectStatusRepository.saveAll(statuses);
   }
 
   private int getCompleteTrace(Inject inject) {

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -61,9 +61,6 @@ public class EndpointService {
 
   private static final String ASSET_GROUP_FILTER = "assetGroups";
 
-  @Value("${openaev.agent.max-simultaneous-jobs:5}")
-  private int maxSimultaneousJobs;
-
   public static final int DELETE_TTL = 86400000; // 24 hours
   public static final String OPENAEV_AGENT_INSTALLER = "openaev-agent-installer";
   public static final String OPENAEV_AGENT_UPGRADE = "openaev-agent-upgrade";
@@ -101,6 +98,9 @@ public class EndpointService {
   @Value(
       "${executor.openaev-agent.binaries.version:${executor.openaev.binaries.version:${info.app.version:unknown}}}")
   private String agentBinaryVersion;
+
+  @Value("${executor.openaev.agent.max-simultaneous-jobs:5}")
+  private int maxSimultaneousJobs;
 
   private final EndpointRepository endpointRepository;
   private final ExecutorRepository executorRepository;

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -507,7 +507,7 @@ public class EndpointService {
                     : Agent.DEPLOYMENT_MODE.session.name(),
                 input.isElevated() ? Agent.PRIVILEGE.admin.name() : Agent.PRIVILEGE.standard.name(),
                 input.getExecutedByUser()),
-            PageRequest.of(0, maxSimultaneousJobs, Sort.by(Sort.Direction.DESC, "createdAt")))
+            PageRequest.of(0, maxSimultaneousJobs, Sort.by(Sort.Direction.ASC, "createdAt")))
         .getContent();
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -49,9 +49,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +60,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class EndpointService {
 
   private static final String ASSET_GROUP_FILTER = "assetGroups";
+
+  @Value("${openaev.agent.max-simultaneous-jobs:5}")
+  private int maxSimultaneousJobs;
 
   public static final int DELETE_TTL = 86400000; // 24 hours
   public static final String OPENAEV_AGENT_INSTALLER = "openaev-agent-installer";
@@ -481,6 +482,7 @@ public class EndpointService {
                 agent.getTenant().getId()));
         assetAgentJob.setAgent(agent);
         assetAgentJob.setTenant(agent.getTenant());
+        assetAgentJob.setCreatedAt(now());
 
         try {
           assetAgentJobRepository.save(assetAgentJob);
@@ -496,14 +498,17 @@ public class EndpointService {
   }
 
   public List<AssetAgentJob> getEndpointJobs(final EndpointRegisterInput input) {
-    return this.assetAgentJobRepository.findAll(
-        AssetAgentJobSpecification.forEndpoint(
-            input.getExternalReference(),
-            input.isService()
-                ? Agent.DEPLOYMENT_MODE.service.name()
-                : Agent.DEPLOYMENT_MODE.session.name(),
-            input.isElevated() ? Agent.PRIVILEGE.admin.name() : Agent.PRIVILEGE.standard.name(),
-            input.getExecutedByUser()));
+    return this.assetAgentJobRepository
+        .findAll(
+            AssetAgentJobSpecification.forEndpoint(
+                input.getExternalReference(),
+                input.isService()
+                    ? Agent.DEPLOYMENT_MODE.service.name()
+                    : Agent.DEPLOYMENT_MODE.session.name(),
+                input.isElevated() ? Agent.PRIVILEGE.admin.name() : Agent.PRIVILEGE.standard.name(),
+                input.getExecutedByUser()),
+            PageRequest.of(0, maxSimultaneousJobs, Sort.by(Sort.Direction.DESC, "createdAt")))
+        .getContent();
   }
 
   private void addSourceTagToEndpoint(Endpoint endpoint, AgentRegisterInput input) {

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -124,9 +124,6 @@ openaev.queue-config.workflows-update.publisher-qos=0
 
 openaev.cron.config.steps.delay.queue.polling.interval=10000
 
-# Simultaneous jobs execution limitation for agents, to avoid overloading the system.
-openaev.agent.max-simultaneous-jobs=5
-
 # Web server configuration
 server.address=0.0.0.0
 server.port=8080
@@ -329,6 +326,9 @@ executor.openaev.binaries.version=@project.version@
 # Implant-specific overrides
 #executor.openaev-implant.binaries.origin=local
 #executor.openaev-implant.binaries.version=@project.version@
+
+# Simultaneous jobs execution limitation for agents, to avoid overloading the system.
+executor.openaev.agent.max-simultaneous-jobs=5
 
 #############
 # INJECTORS #

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -124,6 +124,9 @@ openaev.queue-config.workflows-update.publisher-qos=0
 
 openaev.cron.config.steps.delay.queue.polling.interval=10000
 
+# Simultaneous jobs execution limitation for agents, to avoid overloading the system.
+openaev.agent.max-simultaneous-jobs=5
+
 # Web server configuration
 server.address=0.0.0.0
 server.port=8080

--- a/openaev-api/src/test/java/io/openaev/rest/EndpointApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/EndpointApiTest.java
@@ -23,6 +23,7 @@ import io.openaev.IntegrationTest;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.model.Tag;
+import io.openaev.database.repository.AssetAgentJobRepository;
 import io.openaev.database.repository.AssetGroupRepository;
 import io.openaev.database.repository.EndpointRepository;
 import io.openaev.database.repository.InjectRepository;
@@ -30,6 +31,7 @@ import io.openaev.database.repository.TagRepository;
 import io.openaev.rest.asset.endpoint.form.EndpointInput;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
 import io.openaev.rest.exercise.service.ExerciseService;
+import io.openaev.rest.inject.service.InjectStatusService;
 import io.openaev.service.EndpointService;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.EndpointFixture;
@@ -75,6 +77,8 @@ class EndpointApiTest extends IntegrationTest {
   @Autowired private AgentComposer agentComposer;
 
   @MockitoSpyBean private EndpointService endpointService;
+  @MockitoSpyBean private AssetAgentJobRepository assetAgentJobRepository;
+  @MockitoSpyBean private InjectStatusService injectStatusService;
   @Autowired private AssetGroupRepository assetGroupRepository;
 
   @BeforeEach
@@ -798,6 +802,93 @@ class EndpointApiTest extends IntegrationTest {
             .as("Returned agent_id should match tenant A's agent and not a cross-tenant agent")
             .isEqualTo(executorA.getId());
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("Agent jobs")
+  @WithMockUser(isAdmin = true)
+  class AgentJobs {
+
+    @Test
+    @DisplayName("Given endpoint register input, should return endpoint jobs from service")
+    void given_endpointRegisterInput_should_returnEndpointJobsFromService() throws Exception {
+      // -- PREPARE --
+      EndpointRegisterInput input = createWindowsEndpointRegisterInput(List.of(), "jobs-ext-ref");
+      input.setExecutedByUser("jobs-user");
+      input.setService(true);
+      input.setElevated(false);
+
+      Agent agent = new Agent();
+      agent.setId("agent-1");
+
+      AssetAgentJob assetAgentJob = new AssetAgentJob();
+      assetAgentJob.setId("job-1");
+      assetAgentJob.setCommand("whoami");
+      assetAgentJob.setAgent(agent);
+
+      Mockito.doReturn(List.of(assetAgentJob))
+          .when(endpointService)
+          .getEndpointJobs(Mockito.any(EndpointRegisterInput.class));
+
+      // -- EXECUTE --
+      mvc.perform(
+              post(ENDPOINT_URI + "/jobs")
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(jsonPath("$[0].asset_agent_id").value("job-1"))
+          .andExpect(jsonPath("$[0].asset_agent_command").value("whoami"));
+
+      // -- ASSERT --
+      Mockito.verify(endpointService).getEndpointJobs(Mockito.any(EndpointRegisterInput.class));
+    }
+
+    @Test
+    @DisplayName("Given existing asset agent job id, should trace retrieval and delete job")
+    void given_existingAssetAgentJobId_should_traceRetrievalAndDeleteJob() throws Exception {
+      // -- PREPARE --
+      String assetAgentJobId = "job-to-clean";
+      AssetAgentJob assetAgentJob = new AssetAgentJob();
+      assetAgentJob.setId(assetAgentJobId);
+      assetAgentJob.setCommand("command");
+
+      Mockito.doReturn(java.util.Optional.of(assetAgentJob))
+          .when(assetAgentJobRepository)
+          .findById(assetAgentJobId);
+
+      // -- EXECUTE --
+      mvc.perform(delete(ENDPOINT_URI + "/jobs/" + assetAgentJobId).with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      // -- ASSERT --
+      Mockito.verify(assetAgentJobRepository).findById(assetAgentJobId);
+      Mockito.verify(injectStatusService).addJobRetrievalTraces(assetAgentJob);
+      Mockito.verify(assetAgentJobRepository).deleteById(assetAgentJobId);
+    }
+
+    @Test
+    @DisplayName(
+        "Given unknown asset agent job id, should not trace retrieval and should not delete")
+    void given_unknownAssetAgentJobId_should_notTraceRetrievalAndShouldNotDelete()
+        throws Exception {
+      // -- PREPARE --
+      String assetAgentJobId = "job-missing";
+      Mockito.doReturn(java.util.Optional.empty())
+          .when(assetAgentJobRepository)
+          .findById(assetAgentJobId);
+
+      // -- EXECUTE --
+      mvc.perform(delete(ENDPOINT_URI + "/jobs/" + assetAgentJobId).with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      // -- ASSERT --
+      Mockito.verify(assetAgentJobRepository).findById(assetAgentJobId);
+      Mockito.verify(injectStatusService, Mockito.never())
+          .addJobRetrievalTraces(Mockito.any(AssetAgentJob.class));
+      Mockito.verify(assetAgentJobRepository, Mockito.never()).deleteById(assetAgentJobId);
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
@@ -19,12 +19,14 @@ import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.AgentService;
 import io.openaev.service.AssetService;
 import io.openaev.service.EndpointService;
+import io.openaev.service.account.ServiceAccountPrivilegeService;
 import io.openaev.utils.fixtures.AgentFixture;
 import io.openaev.utils.fixtures.AssetAgentJobFixture;
 import io.openaev.utils.mapper.EndpointMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,10 +34,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class EndpointServiceTest {
+
+  private static final int MAX_SIMULTANEOUS_JOBS = 5;
 
   @Mock private EndpointRepository endpointRepository;
   @Mock private ExecutorRepository executorRepository;
@@ -45,8 +52,14 @@ class EndpointServiceTest {
   @Mock private AgentService agentService;
   @Mock private AssetService assetService;
   @Mock private EndpointMapper endpointMapper;
+  @Mock private ServiceAccountPrivilegeService privilegeService;
 
   @InjectMocks private EndpointService endpointService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(endpointService, "maxSimultaneousJobs", MAX_SIMULTANEOUS_JOBS);
+  }
 
   @Nested
   class CreateEndpoint {
@@ -317,7 +330,8 @@ class EndpointServiceTest {
       input.setElevated(true);
       input.setExecutedByUser(Agent.ADMIN_SYSTEM_WINDOWS);
 
-      when(assetAgentJobRepository.findAll(any(Specification.class))).thenReturn(List.of(job));
+      when(assetAgentJobRepository.findAll(any(Specification.class), any(Pageable.class)))
+          .thenReturn(new PageImpl<>(List.of(job)));
 
       // Act
       List<AssetAgentJob> result = endpointService.getEndpointJobs(input);
@@ -335,7 +349,8 @@ class EndpointServiceTest {
       input.setElevated(true);
       input.setExecutedByUser(Agent.ADMIN_SYSTEM_WINDOWS);
 
-      when(assetAgentJobRepository.findAll(any(Specification.class))).thenReturn(List.of());
+      when(assetAgentJobRepository.findAll(any(Specification.class), any(Pageable.class)))
+          .thenReturn(new PageImpl<>(List.of()));
 
       // Act
       List<AssetAgentJob> result = endpointService.getEndpointJobs(input);

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/AssetAgentJobFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/AssetAgentJobFixture.java
@@ -1,5 +1,7 @@
 package io.openaev.utils.fixtures;
 
+import static java.time.Instant.now;
+
 import io.openaev.database.model.Agent;
 import io.openaev.database.model.AssetAgentJob;
 
@@ -9,6 +11,7 @@ public class AssetAgentJobFixture {
     AssetAgentJob assetAgentJob = new AssetAgentJob();
     assetAgentJob.setCommand("whoami");
     assetAgentJob.setAgent(agent);
+    assetAgentJob.setCreatedAt(now());
     return assetAgentJob;
   }
 }

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -13,7 +13,7 @@
     "sort-translation": "node scripts/sort-translation-files.js",
     "i18n-checker": "npm run generate-i18n-checker-constant && node scripts/i18n-checker.js",
     "generate-i18n-checker-constant": "tsc src/constants/Lang.ts --outDir scripts/constants --skipLibCheck --module ES6 --target ES6",
-    "start": "vite",
+    "start": "vite --host",
     "deprecated-start": "node builder/dev/dev.js",
     "build": "vite build",
     "deprecated-build": "node builder/prod/prod.js",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -13,7 +13,7 @@
     "sort-translation": "node scripts/sort-translation-files.js",
     "i18n-checker": "npm run generate-i18n-checker-constant && node scripts/i18n-checker.js",
     "generate-i18n-checker-constant": "tsc src/constants/Lang.ts --outDir scripts/constants --skipLibCheck --module ES6 --target ES6",
-    "start": "vite --host",
+    "start": "vite",
     "deprecated-start": "node builder/dev/dev.js",
     "build": "vite build",
     "deprecated-build": "node builder/prod/prod.js",

--- a/openaev-model/src/main/java/io/openaev/database/model/AssetAgentJob.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/AssetAgentJob.java
@@ -9,6 +9,7 @@ import io.openaev.helper.MonoIdSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
 import java.util.Objects;
 import lombok.Data;
 import lombok.Getter;
@@ -56,6 +57,11 @@ public class AssetAgentJob implements TenantBase {
   @JoinColumn(name = "tenant_id", updatable = false, nullable = false)
   @JsonIgnore
   private Tenant tenant;
+
+  @Getter
+  @Column(name = "asset_agent_created_at")
+  @JsonIgnore
+  private Instant createdAt;
 
   @Override
   public String toString() {

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
@@ -20,8 +20,6 @@ public interface InjectStatusRepository
 
   Optional<InjectStatus> findByInjectId(@NotNull String injectId);
 
-  List<InjectStatus> findAllByInjectId(String injectId);
-
   @Query(
       value =
           "SELECT ins.*, t.*"

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
@@ -2,7 +2,6 @@ package io.openaev.database.repository;
 
 import io.openaev.database.model.InjectStatus;
 import jakarta.validation.constraints.NotNull;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -21,7 +20,7 @@ public interface InjectStatusRepository
 
   Optional<InjectStatus> findByInjectId(@NotNull String injectId);
 
-  List<InjectStatus> findAllByInjectIdIn(Collection<String> injectIds);
+  List<InjectStatus> findAllByInjectId(String injectId);
 
   @Query(
       value =


### PR DESCRIPTION
### Proposed changes

* Send limited jobs amount by call from an agent
* Add the traces for a job at cleanup instead at call

### Testing Instructions

1. In local run a scenario with multiple inject, more than the limit (by default 5)
2. check for the agent installation folder, limited amount of implant should pop every 30seconds
3. check the inject traces at the end of execution, at cleanup

### Related issues

* Closes #5962 & #5963 
