### PR TITLE
[backend/frontend] feat(chaining): added default simulation timeout value and relevant tests (#5966)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowConfigurationInput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowConfigurationInput.java
@@ -54,6 +54,7 @@ public class WorkflowConfigurationInput {
   @JsonSetter(nulls = Nulls.SKIP)
   @Min(value = 60, message = "Timeout seconds must be at least 60 (1 min)")
   @Max(value = 86400, message = "Timeout seconds must be at most 86400 (24 h)")
+  @Builder.Default
   private Long timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
 
   // -- Safe mode --

--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowConfigurationInput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowConfigurationInput.java
@@ -1,6 +1,10 @@
 package io.openaev.api.chaining.dto;
 
+import static io.openaev.service.chaining.WorkflowService.DEFAULT_TIMEOUT_SECONDS;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -43,11 +47,14 @@ public class WorkflowConfigurationInput {
   @JsonProperty("workflow_configuration_timeout_enabled")
   private boolean timeoutEnabled;
 
-  @Schema(description = "Total timeout in seconds for the attack workflow scenario (60–86400).")
+  @Schema(
+      description = "Total timeout in seconds for the attack workflow scenario (60–86400).",
+      defaultValue = "" + DEFAULT_TIMEOUT_SECONDS)
   @JsonProperty("workflow_configuration_timeout_seconds")
+  @JsonSetter(nulls = Nulls.SKIP)
   @Min(value = 60, message = "Timeout seconds must be at least 60 (1 min)")
   @Max(value = 86400, message = "Timeout seconds must be at most 86400 (24 h)")
-  private Long timeoutSeconds;
+  private Long timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
 
   // -- Safe mode --
 

--- a/openaev-api/src/main/java/io/openaev/migration/V5_15__Set_default_timeout_seconds.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_15__Set_default_timeout_seconds.java
@@ -1,0 +1,18 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V5_15__Set_default_timeout_seconds extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement stmt = context.getConnection().createStatement()) {
+      stmt.execute(
+          "UPDATE workflows SET workflow_timeout_seconds = 3600 WHERE workflow_timeout_seconds IS NULL");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -29,6 +29,8 @@ import org.springframework.util.CollectionUtils;
 @Service
 public class WorkflowService {
 
+  public static final long DEFAULT_TIMEOUT_SECONDS = 3600L;
+
   private static final Gson GSON = new Gson();
 
   private final StepService stepService;
@@ -98,6 +100,7 @@ public class WorkflowService {
             .simulation(simulation)
             .rateLimitEnabled(false)
             .timeoutEnabled(false)
+            .timeoutSeconds(DEFAULT_TIMEOUT_SECONDS)
             .safeModeEnabled(true)
             .build();
     workflowRepository.save(workflow);
@@ -116,6 +119,7 @@ public class WorkflowService {
             .scenario(scenario)
             .rateLimitEnabled(false)
             .timeoutEnabled(false)
+            .timeoutSeconds(DEFAULT_TIMEOUT_SECONDS)
             .safeModeEnabled(true)
             .build();
     workflowRepository.save(workflow);

--- a/openaev-api/src/test/java/io/openaev/api/chaining/WorkflowApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/WorkflowApiTest.java
@@ -18,6 +18,7 @@ import io.openaev.config.OpenAEVConfig;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.rest.settings.PreviewFeature;
+import io.openaev.service.chaining.WorkflowService;
 import io.openaev.utils.fixtures.ExerciseFixture;
 import io.openaev.utils.fixtures.WorkflowFixture;
 import io.openaev.utils.fixtures.composers.ExerciseComposer;
@@ -443,6 +444,91 @@ class WorkflowApiTest extends IntegrationTest {
             .findFirst()
             .orElseThrow();
     assertEquals(ScopeRuleValueType.ASSET_GROUP_ID, assetGroupRule.getValueType());
+  }
+
+  @Test
+  @DisplayName(
+      "Update Workflow Configuration should use default timeout when timeoutSeconds is omitted from JSON")
+  void updateWorkflowConfiguration_shouldUseDefaultTimeoutWhenOmitted() throws Exception {
+    // -- PREPARE --
+    Workflow workflow = createTemplateWorkflow();
+
+    // JSON payload without workflow_configuration_timeout_seconds
+    String jsonWithoutTimeout =
+        """
+        {
+          "workflow_configuration_rate_limit_enabled": false,
+          "workflow_configuration_timeout_enabled": true,
+          "workflow_configuration_safe_mode_enabled": true
+        }
+        """;
+
+    // -- EXECUTE --
+    String response =
+        mockMvc
+            .perform(
+                put(workflowConfigurationUri(workflow.getId()))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonWithoutTimeout)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // -- ASSERT -- timeoutSeconds must fall back to DEFAULT_TIMEOUT_SECONDS (3600)
+    JsonNode body = new ObjectMapper().readTree(response);
+    assertEquals(
+        WorkflowService.DEFAULT_TIMEOUT_SECONDS,
+        body.get("workflow_configuration_timeout_seconds").asLong(),
+        "Omitted timeoutSeconds should default to DEFAULT_TIMEOUT_SECONDS");
+
+    Workflow saved = workflowRepository.findById(workflow.getId()).orElseThrow();
+    assertEquals(WorkflowService.DEFAULT_TIMEOUT_SECONDS, saved.getTimeoutSeconds());
+  }
+
+  @Test
+  @DisplayName(
+      "Update Workflow Configuration should use default timeout when timeoutSeconds is explicit null in JSON")
+  void updateWorkflowConfiguration_shouldUseDefaultTimeoutWhenExplicitNull() throws Exception {
+    // -- PREPARE --
+    Workflow workflow = createTemplateWorkflow();
+
+    // JSON payload with explicit null for timeout_seconds
+    String jsonWithNullTimeout =
+        """
+        {
+          "workflow_configuration_rate_limit_enabled": false,
+          "workflow_configuration_timeout_enabled": true,
+          "workflow_configuration_timeout_seconds": null,
+          "workflow_configuration_safe_mode_enabled": true
+        }
+        """;
+
+    // -- EXECUTE --
+    String response =
+        mockMvc
+            .perform(
+                put(workflowConfigurationUri(workflow.getId()))
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(jsonWithNullTimeout)
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // -- ASSERT -- @JsonSetter(nulls = Nulls.SKIP) should keep the default
+    JsonNode body = new ObjectMapper().readTree(response);
+    assertEquals(
+        WorkflowService.DEFAULT_TIMEOUT_SECONDS,
+        body.get("workflow_configuration_timeout_seconds").asLong(),
+        "Explicit null timeoutSeconds should default to DEFAULT_TIMEOUT_SECONDS");
+
+    Workflow saved = workflowRepository.findById(workflow.getId()).orElseThrow();
+    assertEquals(WorkflowService.DEFAULT_TIMEOUT_SECONDS, saved.getTimeoutSeconds());
   }
 
   // -- Helpers --

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingIntegrationTest.java
@@ -186,6 +186,12 @@ class ChainingIntegrationTest extends IntegrationTest {
       assertEquals(WorkflowStatus.TEMPLATE, workflowTemplate.getStatus());
       assertNull(
           workflowTemplate.getSimulation(), "The Workflow TEMPLATE must not have a simulation");
+      // Timeout defaults must be set on creation
+      assertFalse(workflowTemplate.isTimeoutEnabled(), "Timeout must be disabled by default");
+      assertEquals(
+          WorkflowService.DEFAULT_TIMEOUT_SECONDS,
+          workflowTemplate.getTimeoutSeconds(),
+          "Timeout seconds must default to DEFAULT_TIMEOUT_SECONDS");
     }
 
     // -------------------------------------------------------------------------
@@ -622,6 +628,12 @@ class ChainingIntegrationTest extends IntegrationTest {
       assertNull(
           workflowTemplate.getScenario(),
           "Template workflow for simulation must not link scenario");
+      // Timeout defaults must be set on creation
+      assertFalse(workflowTemplate.isTimeoutEnabled(), "Timeout must be disabled by default");
+      assertEquals(
+          WorkflowService.DEFAULT_TIMEOUT_SECONDS,
+          workflowTemplate.getTimeoutSeconds(),
+          "Timeout seconds must default to DEFAULT_TIMEOUT_SECONDS");
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -109,7 +109,7 @@ class WorkflowServiceTest {
     @Captor private ArgumentCaptor<Workflow> workflowCaptor;
 
     @Test
-    @DisplayName("should create workflow template with inline configuration defaults")
+    @DisplayName("should create simulation workflow template with inline configuration defaults")
     void shouldCreateWorkflowTemplateWithInlineConfigurationDefaults() {
       // Prepare
       Exercise exercise = mock(Exercise.class);
@@ -126,7 +126,41 @@ class WorkflowServiceTest {
       // Configuration defaults stored inline on the workflow row
       assertFalse(savedWorkflow.isRateLimitEnabled());
       assertFalse(savedWorkflow.isTimeoutEnabled());
+      assertEquals(
+          WorkflowService.DEFAULT_TIMEOUT_SECONDS,
+          savedWorkflow.getTimeoutSeconds(),
+          "Timeout seconds must default to DEFAULT_TIMEOUT_SECONDS");
       assertTrue(savedWorkflow.isSafeModeEnabled());
+    }
+
+    @Test
+    @DisplayName("should create scenario workflow template with default timeout seconds")
+    void shouldCreateScenarioWorkflowTemplateWithDefaultTimeoutSeconds() {
+      // Prepare
+      Scenario scenario = mock(Scenario.class);
+
+      // Act
+      workflowService.creationWorkflow(scenario);
+
+      // Assert
+      verify(workflowRepository).save(workflowCaptor.capture());
+      Workflow savedWorkflow = workflowCaptor.getValue();
+      assertEquals(0, savedWorkflow.getVersion());
+      assertEquals(WorkflowStatus.TEMPLATE, savedWorkflow.getStatus());
+      assertEquals(scenario, savedWorkflow.getScenario());
+      assertFalse(savedWorkflow.isRateLimitEnabled());
+      assertFalse(savedWorkflow.isTimeoutEnabled());
+      assertEquals(
+          WorkflowService.DEFAULT_TIMEOUT_SECONDS,
+          savedWorkflow.getTimeoutSeconds(),
+          "Timeout seconds must default to DEFAULT_TIMEOUT_SECONDS");
+      assertTrue(savedWorkflow.isSafeModeEnabled());
+    }
+
+    @Test
+    @DisplayName("DEFAULT_TIMEOUT_SECONDS constant should be 3600")
+    void defaultTimeoutConstantShouldBe3600() {
+      assertEquals(3600L, WorkflowService.DEFAULT_TIMEOUT_SECONDS);
     }
   }
 
@@ -710,7 +744,12 @@ class WorkflowServiceTest {
     private Workflow buildTemplate(boolean stubSave) {
       String workflowId = UUID.randomUUID().toString();
       Workflow workflow =
-          Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+          Workflow.builder()
+              .id(workflowId)
+              .status(WorkflowStatus.TEMPLATE)
+              .version(0)
+              .timeoutSeconds(WorkflowService.DEFAULT_TIMEOUT_SECONDS)
+              .build();
       when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
           .thenReturn(Optional.of(workflow));
       if (stubSave) {
@@ -914,7 +953,12 @@ class WorkflowServiceTest {
     private Workflow buildTemplate() {
       String workflowId = UUID.randomUUID().toString();
       Workflow workflow =
-          Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+          Workflow.builder()
+              .id(workflowId)
+              .status(WorkflowStatus.TEMPLATE)
+              .version(0)
+              .timeoutSeconds(WorkflowService.DEFAULT_TIMEOUT_SECONDS)
+              .build();
       when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
           .thenReturn(Optional.of(workflow));
       lenient()

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowTimeoutIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowTimeoutIntegrationTest.java
@@ -312,6 +312,97 @@ class WorkflowTimeoutIntegrationTest extends IntegrationTest {
   }
 
   // ========================================================================
+  // End-to-end timeout flow (detect → force-complete)
+  // ========================================================================
+  @Nested
+  @DisplayName("end-to-end timeout flow")
+  class EndToEndTimeoutFlowTests {
+
+    @Test
+    @DisplayName(
+        "given_expiredRunWorkflowWithActiveStepsAndDelayQueue_should_detectAndForceCompleteEverything")
+    void
+        given_expiredRunWorkflowWithActiveStepsAndDelayQueue_should_detectAndForceCompleteEverything() {
+      // Arrange — workflow created 2 hours ago with a 60s timeout → already expired
+      Workflow workflowRun =
+          createPersistedRunWorkflowWithTimeout(
+              true, 60L, Instant.now().minus(2, ChronoUnit.HOURS));
+
+      // Add active steps and a delay queue entry
+      Step stepReady = createPersistedStep(workflowRun, StepStatus.READY);
+      Step stepRun = createPersistedStep(workflowRun, StepStatus.RUN);
+      Step stepAlreadyEnded = createPersistedStep(workflowRun, StepStatus.END);
+      Step stepTemplate = createPersistedStep(workflowRun, StepStatus.TEMPLATE);
+
+      StepDelayQueue delayEntry =
+          StepDelayQueue.builder()
+              .workflowRun(workflowRun)
+              .stepTemplate(stepTemplate)
+              .input("{}")
+              .now(Instant.now())
+              .goal(Instant.now().plus(1, ChronoUnit.HOURS))
+              .delay(3600000L)
+              .build();
+      stepDelayQueueRepository.save(delayEntry);
+
+      // Precondition: workflow is detected as expired
+      List<Workflow> expired = workflowTimeoutService.findAllExpiredRunWorkflows();
+      assertTrue(
+          expired.stream().anyMatch(w -> w.getId().equals(workflowRun.getId())),
+          "Workflow must be detected as expired");
+
+      // Act — simulate what the timeout scheduled job does
+      workflowTimeoutService.forceCompleteWorkflow(workflowRun);
+
+      // Assert — workflow status is END
+      Workflow result = workflowRepository.findById(workflowRun.getId()).orElseThrow();
+      assertEquals(WorkflowStatus.END, result.getStatus());
+
+      // Assert — all active steps are END
+      assertEquals(
+          StepStatus.END, stepRepository.findById(stepReady.getId()).orElseThrow().getStatus());
+      assertEquals(
+          StepStatus.END, stepRepository.findById(stepRun.getId()).orElseThrow().getStatus());
+      assertEquals(
+          StepStatus.END,
+          stepRepository.findById(stepAlreadyEnded.getId()).orElseThrow().getStatus());
+
+      // Assert — delay queue is purged
+      assertTrue(stepDelayQueueRepository.findAllByWorkflowRun(workflowRun).isEmpty());
+
+      // Assert — workflow is no longer detected as expired (status is now END, not RUN)
+      List<Workflow> expiredAfter = workflowTimeoutService.findAllExpiredRunWorkflows();
+      assertTrue(
+          expiredAfter.stream().noneMatch(w -> w.getId().equals(workflowRun.getId())),
+          "Force-completed workflow must no longer appear in expired list");
+    }
+
+    @Test
+    @DisplayName("given_nonExpiredWorkflow_should_notBeDetectedOrTerminated")
+    void given_nonExpiredWorkflow_should_notBeDetectedOrTerminated() {
+      // Arrange — workflow just created with a long timeout → not expired
+      Workflow workflowRun = createPersistedRunWorkflowWithTimeout(true, 7200L, Instant.now());
+
+      Step stepRun = createPersistedStep(workflowRun, StepStatus.RUN);
+
+      // Act
+      List<Workflow> expired = workflowTimeoutService.findAllExpiredRunWorkflows();
+
+      // Assert — not detected
+      assertTrue(
+          expired.stream().noneMatch(w -> w.getId().equals(workflowRun.getId())),
+          "Non-expired workflow must not appear in expired list");
+
+      // Assert — step and workflow untouched
+      assertEquals(
+          WorkflowStatus.RUN,
+          workflowRepository.findById(workflowRun.getId()).orElseThrow().getStatus());
+      assertEquals(
+          StepStatus.RUN, stepRepository.findById(stepRun.getId()).orElseThrow().getStatus());
+    }
+  }
+
+  // ========================================================================
   // Helpers
   // ========================================================================
 

--- a/openaev-front/src/admin/components/chaining/ScopeTimeOut.tsx
+++ b/openaev-front/src/admin/components/chaining/ScopeTimeOut.tsx
@@ -25,7 +25,7 @@ const ScopeTimeOut = ({ workflowConfiguration, onUpdate }: Props) => {
   const theme = useTheme();
 
   const timeoutEnabled = workflowConfiguration?.workflow_configuration_timeout_enabled ?? false;
-  const totalSeconds = workflowConfiguration?.workflow_configuration_timeout_seconds ?? 5400;
+  const totalSeconds = workflowConfiguration?.workflow_configuration_timeout_seconds ?? 3600;
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
 

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -8928,6 +8928,7 @@ export interface WorkflowConfigurationInput {
    * @format int64
    * @min 60
    * @max 86400
+   * @default 3600
    */
   workflow_configuration_timeout_seconds?: number;
   /** List scope rules. */


### PR DESCRIPTION
### Proposed changes

* Update code and tests to enforce default timeout value of 3600 seconds
* Added migration script to pdate already existing simulations to the default value as well

### Testing Instructions

1. Create a simulation and a scenario using the chaining engine
2. Check on the scope page that the timeout is disabled AND set to 1 hour by default
3. Change the timeout value to somthing else to make sure default is overwritten by selected value.

### Related issues

* Closes #5966 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
