### PR TITLE
[backend/frontend] feat(ask-ariane): support agent-generated file downloads from XTM One (#5992)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/xtmone/XtmOneChatApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/xtmone/XtmOneChatApi.java
@@ -7,11 +7,15 @@ import io.openaev.xtmone.XtmOneConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,6 +31,9 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 public class XtmOneChatApi extends RestBehavior {
 
   private static final String XTM_ONE_URI = "/api/xtmone";
+  private static final Pattern FILE_ID_PATTERN =
+      Pattern.compile(
+          "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
   private final XtmOneClient client;
   private final XtmOneConfig config;
 
@@ -139,5 +146,43 @@ public class XtmOneChatApi extends RestBehavior {
       return ResponseEntity.internalServerError().build();
     }
     return ResponseEntity.ok(Map.of("file_ids", fileIds));
+  }
+
+  /**
+   * Downloads an agent-generated file from XTM One.
+   *
+   * <p>The OpenAEV user is authenticated here (platform session + CSRF); the XTM One JWT is minted
+   * server-side by {@link XtmOneClient#downloadChatFile}. The end user therefore never
+   * authenticates to XTM One directly — the embedded chatbot points its download URL at this proxy
+   * (relative to its {@code apiBaseUrl} of {@code /api/xtmone/chat}).
+   */
+  @GetMapping(XTM_ONE_URI + "/chat/files/{fileId}/download")
+  public ResponseEntity<byte[]> downloadFile(@PathVariable String fileId) {
+    if (!config.isConfigured()) {
+      return ResponseEntity.badRequest().build();
+    }
+    if (fileId == null || !FILE_ID_PATTERN.matcher(fileId).matches()) {
+      return ResponseEntity.badRequest().build();
+    }
+
+    XtmOneClient.DownloadedFile file = client.downloadChatFile(fileId);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(parseContentType(file.contentType()));
+    if (file.contentDisposition() != null && !file.contentDisposition().isBlank()) {
+      headers.set(HttpHeaders.CONTENT_DISPOSITION, file.contentDisposition());
+    }
+    return new ResponseEntity<>(file.content(), headers, HttpStatus.OK);
+  }
+
+  private MediaType parseContentType(String contentType) {
+    if (contentType == null || contentType.isBlank()) {
+      return MediaType.APPLICATION_OCTET_STREAM;
+    }
+    try {
+      return MediaType.parseMediaType(contentType);
+    } catch (Exception ignored) {
+      return MediaType.APPLICATION_OCTET_STREAM;
+    }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/xtmone/XtmOneClient.java
+++ b/openaev-api/src/main/java/io/openaev/xtmone/XtmOneClient.java
@@ -310,6 +310,55 @@ public class XtmOneClient {
   }
 
   /**
+   * An agent-generated file fetched from XTM One, buffered in memory together with the upstream
+   * content headers so the API layer can relay it to the browser.
+   */
+  public record DownloadedFile(byte[] content, String contentType, String contentDisposition) {}
+
+  /**
+   * Downloads an agent-generated file from XTM One on behalf of the current user.
+   *
+   * <p>The XTM One JWT is minted server-side from the current OpenAEV user, so the browser only
+   * ever authenticates against OpenAEV — it never logs in to XTM One. The file is buffered in
+   * memory (chat-generated files are small and capped upstream) and returned with the upstream
+   * {@code Content-Type} / {@code Content-Disposition} headers for the API layer to relay.
+   *
+   * @param fileId the XTM One file attachment id (validated as a UUID by the caller)
+   * @return the downloaded file bytes + content headers
+   */
+  public DownloadedFile downloadChatFile(String fileId) {
+    if (!config.isConfigured()) {
+      throw new ResponseStatusException(
+          HttpStatus.SERVICE_UNAVAILABLE, "[XTM One] Service is not configured");
+    }
+    try (CloseableHttpClient httpClient = httpClientFactory.httpClientNoRetry()) {
+      String jwt = issueJwtForCurrentUser();
+      HttpGet httpGet = chatGetBuilder("/api/v1/chat/files/" + fileId + "/download", jwt);
+      httpGet.setConfig(RequestConfig.custom().setResponseTimeout(Timeout.ofMinutes(2)).build());
+
+      return httpClient.execute(
+          httpGet,
+          response -> {
+            if (response.getCode() != 200) {
+              throw mapUpstreamError(response);
+            }
+            String contentType =
+                response.getEntity() != null ? response.getEntity().getContentType() : null;
+            var cdHeader = response.getFirstHeader("Content-Disposition");
+            String contentDisposition = cdHeader != null ? cdHeader.getValue() : null;
+            byte[] content = EntityUtils.toByteArray(response.getEntity());
+            return new DownloadedFile(content, contentType, contentDisposition);
+          });
+    } catch (ResponseStatusException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("[XTM One] Download chat file error, fileId={}.", fileId, e);
+      throw new ResponseStatusException(
+          HttpStatus.SERVICE_UNAVAILABLE, "[XTM One] File download failed", e);
+    }
+  }
+
+  /**
    * Streams a chat message response from XTM One. The provided consumer receives the SSE input
    * stream and is responsible for reading it. The HTTP client and stream are automatically closed
    * when the consumer returns or throws.

--- a/openaev-api/src/test/java/io/openaev/rest/xtmone/XtmOneChatApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/xtmone/XtmOneChatApiTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -109,6 +111,72 @@ class XtmOneChatApiTest extends IntegrationTest {
       // -- ACT & ASSERT --
       mvc.perform(get(CHAT_AGENTS_URL).accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/xtmone/chat/files/{fileId}/download")
+  class DownloadFile {
+
+    private static final String VALID_FILE_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String DOWNLOAD_URL =
+        "/api/xtmone/chat/files/" + VALID_FILE_ID + "/download";
+
+    @Test
+    @WithMockUser
+    @DisplayName("Given XTM One not configured should return 400")
+    void given_notConfigured_should_returnBadRequest() throws Exception {
+      // -- ARRANGE --
+      when(xtmOneConfig.isConfigured()).thenReturn(false);
+
+      // -- ACT & ASSERT --
+      mvc.perform(get(DOWNLOAD_URL)).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("Given a non-UUID file id should return 400 without calling XTM One")
+    void given_invalidFileId_should_returnBadRequest() throws Exception {
+      // -- ARRANGE --
+      when(xtmOneConfig.isConfigured()).thenReturn(true);
+
+      // -- ACT & ASSERT --
+      mvc.perform(get("/api/xtmone/chat/files/not-a-uuid/download"))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("Given XTM One returns a file should stream the bytes and headers")
+    void given_configured_should_streamFile() throws Exception {
+      // -- ARRANGE --
+      when(xtmOneConfig.isConfigured()).thenReturn(true);
+      byte[] data = "type,value\nip,1.2.3.4".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+      when(xtmOneClient.downloadChatFile(VALID_FILE_ID))
+          .thenReturn(
+              new XtmOneClient.DownloadedFile(
+                  data, "text/csv", "attachment; filename=\"iocs.csv\""));
+
+      // -- ACT & ASSERT --
+      mvc.perform(get(DOWNLOAD_URL))
+          .andExpect(status().isOk())
+          .andExpect(header().string("Content-Disposition", "attachment; filename=\"iocs.csv\""))
+          .andExpect(content().bytes(data));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("Given XTM One returns 503 should propagate 503 to client")
+    void given_xtmOneReturns503_should_return503() throws Exception {
+      // -- ARRANGE --
+      when(xtmOneConfig.isConfigured()).thenReturn(true);
+      when(xtmOneClient.downloadChatFile(VALID_FILE_ID))
+          .thenThrow(
+              new ResponseStatusException(
+                  HttpStatus.SERVICE_UNAVAILABLE, "[XTM One] File download failed"));
+
+      // -- ACT & ASSERT --
+      mvc.perform(get(DOWNLOAD_URL)).andExpect(status().isServiceUnavailable());
     }
   }
 }

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.2.2",
+    "@filigran/chatbot": "3.3.0",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.3.0",
+    "@filigran/chatbot": "3.3.1",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
@@ -152,6 +152,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
         messages: '/messages',
         sessions: '/sessions',
         upload: '/upload',
+        download: '/files',
       }}
       user={{ firstName }}
       disableFileManagement={false}

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.2.2":
-  version: 3.2.2
-  resolution: "@filigran/chatbot@npm:3.2.2"
+"@filigran/chatbot@npm:3.3.1":
+  version: 3.3.1
+  resolution: "@filigran/chatbot@npm:3.3.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/7ba9ad5a560dbd4077682cfcd509d6ea90d101c0f080d620da83fb6e28f6cda66be5a36dc8a569598e2adaa20c93562c52be8185451a00d94a84cc291213ef5f
+  checksum: 10c0/9d0c71c52fb010326b2e947ce9bcadcfe5d998003ebfcab28cfa480d3ddf3c0ee2a8ebf4caf72583e108a2b2c2558cf084e9e77d48650496302f2b181aa6eeb4
   languageName: node
   linkType: hard
 
@@ -9832,7 +9832,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.2.2"
+    "@filigran/chatbot": "npm:3.3.1"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

Closes #5992.

XTM One agents can now produce downloadable files (`generate_file` / `$output_files`, XTM One #810 + XTM-One-Platform/xtm-one#1120, both merged). This adds the OpenAEV side so the embedded **Ask Ariane** chatbot can render and download those files — **without the user ever authenticating to XTM One**.

## What changed

- **`XtmOneClient`** — `downloadChatFile(fileId)`: mints the user JWT server-side (same path as `streamChatMessage`), GETs XTM One `/api/v1/chat/files/{id}/download`, and returns the bytes + upstream content headers (`DownloadedFile` record).
- **`XtmOneChatApi`** — `GET /api/xtmone/chat/files/{fileId}/download`: gated on `config.isConfigured()`, validates `fileId` as a UUID, relays the bytes with the upstream `Content-Type` / `Content-Disposition`.
- **`XtmOneChatApiTest`** — covers not-configured (400), invalid id (400), success (bytes + disposition), and upstream 503.
- **`AskArianePanel.tsx`** — points the chatbot at the new route via `apiEndpoints.download = '/files'`.
- Bumps `@filigran/chatbot` to **3.3.1** (renders download cards + strips `[[FILE:]]` markers); `yarn.lock` refreshed.

## Auth model — no XTM One login

The chatbot downloads from `/api/xtmone/chat/files/{id}/download` (this proxy) with the OpenAEV session + CSRF header; the XTM One JWT is minted server-side. The end user authenticates only to OpenAEV.

## Supply-chain age gate

OpenAEV's `npmMinimalAgeGate: 4320` (3-day) policy is **kept intact**. `@filigran/chatbot@3.3.1` is freshly published, but the gate is only enforced during dependency *resolution*, not during `yarn install --immutable` validation of an already-pinned lockfile. Since `yarn.lock` already pins 3.3.1 (a first-party package we publish), CI's `--immutable` install passes without weakening the gate for any third-party dependency.

## Cross-repo
- XTM One backend: XTM-One-Platform/xtm-one#1120 (merged)
- filigran-ui (`@filigran/chatbot@3.3.1`): FiligranHQ/filigran-ui#278 (merged, published to npm)
- OpenCTI (sibling proxy): OpenCTI-Platform/opencti#16295
