### PR TITLE
[backend/frontend] feat(ask-ariane): make the agent aware of the current page (#5995)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/xtmone/XtmOneChatApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/xtmone/XtmOneChatApi.java
@@ -69,6 +69,12 @@ public class XtmOneChatApi extends RestBehavior {
     String conversationId =
         body.get("conversation_id") != null ? body.get("conversation_id").toString() : null;
     String agentSlug = body.get("agent_slug") != null ? body.get("agent_slug").toString() : null;
+    // Arbitrary host page/application context (e.g. current URL) forwarded so
+    // the agent is aware of where the user is. Optional and flexible — only
+    // passed upstream when present.
+    @SuppressWarnings("unchecked")
+    Map<String, Object> context =
+        body.get("context") instanceof Map ? (Map<String, Object>) body.get("context") : null;
 
     StreamingResponseBody responseBody =
         outputStream -> {
@@ -77,6 +83,7 @@ public class XtmOneChatApi extends RestBehavior {
                 content,
                 conversationId,
                 agentSlug,
+                context,
                 sseStream -> {
                   byte[] buf = new byte[4096];
                   int n;

--- a/openaev-api/src/main/java/io/openaev/xtmone/XtmOneClient.java
+++ b/openaev-api/src/main/java/io/openaev/xtmone/XtmOneClient.java
@@ -370,6 +370,27 @@ public class XtmOneClient {
    */
   public void streamChatMessage(
       String content, String conversationId, String agentSlug, StreamConsumer streamConsumer) {
+    streamChatMessage(content, conversationId, agentSlug, null, streamConsumer);
+  }
+
+  /**
+   * Streams a chat message response from XTM One, forwarding an optional arbitrary page/application
+   * {@code context} object so the agent is aware of where the user is (e.g. the current URL). The
+   * context shape is decided by the caller (today the embedded chatbot sends {@code {"url": ...}});
+   * it is omitted from the upstream body when {@code null} or empty.
+   *
+   * @param content message content
+   * @param conversationId optional conversation ID
+   * @param agentSlug optional agent slug
+   * @param context optional host page/application context (forwarded verbatim)
+   * @param streamConsumer callback that receives the SSE {@link InputStream}
+   */
+  public void streamChatMessage(
+      String content,
+      String conversationId,
+      String agentSlug,
+      Map<String, Object> context,
+      StreamConsumer streamConsumer) {
     if (!config.isConfigured()) {
       log.warn("[XTM One] Chat message skipped: not configured");
       return;
@@ -380,6 +401,7 @@ public class XtmOneClient {
       body.put("content", content);
       if (conversationId != null) body.put("conversation_id", conversationId);
       if (agentSlug != null) body.put("agent_slug", agentSlug);
+      if (context != null && !context.isEmpty()) body.put("context", context);
       String json = objectMapper.writeValueAsString(body);
 
       HttpPost httpPost = chatPostBuilder("/api/v1/platform/chat/messages", jwt, json);

--- a/openaev-api/src/test/java/io/openaev/rest/xtmone/XtmOneChatApiUnitTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/xtmone/XtmOneChatApiUnitTest.java
@@ -1,0 +1,72 @@
+package io.openaev.rest.xtmone;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.xtmone.XtmOneClient;
+import io.openaev.xtmone.XtmOneConfig;
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+/**
+ * Unit test for the {@code /api/xtmone/chat/messages} proxy forwarding contract. Executes the
+ * returned {@link StreamingResponseBody} so the controller body actually runs and we can verify the
+ * arguments handed to {@link XtmOneClient#streamChatMessage}. Pure POJO (no Spring / async dispatch)
+ * to keep the contract check fast and deterministic.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("XTM One Chat API forwarding tests")
+class XtmOneChatApiUnitTest {
+
+  @Mock private XtmOneClient client;
+  @Mock private XtmOneConfig config;
+  @InjectMocks private XtmOneChatApi api;
+
+  @Test
+  @DisplayName("Given a context in the request body should forward it to streamChatMessage")
+  void given_context_should_forwardToClient() throws Exception {
+    // -- ARRANGE --
+    when(config.isConfigured()).thenReturn(true);
+    Map<String, Object> context = Map.of("url", "/dashboard/reports/1");
+    Map<String, Object> body = new HashMap<>();
+    body.put("content", "hello");
+    body.put("agent_slug", "agent-1");
+    body.put("context", context);
+
+    // -- ACT --
+    ResponseEntity<StreamingResponseBody> response = api.sendMessage(body);
+    response.getBody().writeTo(new ByteArrayOutputStream());
+
+    // -- ASSERT --
+    verify(client).streamChatMessage(eq("hello"), isNull(), eq("agent-1"), eq(context), any());
+  }
+
+  @Test
+  @DisplayName("Given no context in the request body should forward a null context")
+  void given_noContext_should_forwardNull() throws Exception {
+    // -- ARRANGE --
+    when(config.isConfigured()).thenReturn(true);
+    Map<String, Object> body = new HashMap<>();
+    body.put("content", "hello");
+    body.put("agent_slug", "agent-1");
+
+    // -- ACT --
+    ResponseEntity<StreamingResponseBody> response = api.sendMessage(body);
+    response.getBody().writeTo(new ByteArrayOutputStream());
+
+    // -- ASSERT --
+    verify(client).streamChatMessage(eq("hello"), isNull(), eq("agent-1"), isNull(), any());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/xtmone/XtmOneChatApiUnitTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/xtmone/XtmOneChatApiUnitTest.java
@@ -23,8 +23,8 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 /**
  * Unit test for the {@code /api/xtmone/chat/messages} proxy forwarding contract. Executes the
  * returned {@link StreamingResponseBody} so the controller body actually runs and we can verify the
- * arguments handed to {@link XtmOneClient#streamChatMessage}. Pure POJO (no Spring / async dispatch)
- * to keep the contract check fast and deterministic.
+ * arguments handed to {@link XtmOneClient#streamChatMessage}. Pure POJO (no Spring / async
+ * dispatch) to keep the contract check fast and deterministic.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("XTM One Chat API forwarding tests")

--- a/openaev-api/src/test/java/io/openaev/xtmone/XtmOneClientTest.java
+++ b/openaev-api/src/test/java/io/openaev/xtmone/XtmOneClientTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -212,6 +213,82 @@ class XtmOneClientTest {
                 when(httpResponse.getEntity()).thenReturn(entity);
                 return handler.handleResponse(httpResponse);
               });
+    }
+  }
+
+  @Nested
+  @DisplayName("streamChatMessage")
+  class StreamChatMessage {
+
+    @SuppressWarnings("unchecked")
+    private ArgumentCaptor<Map<String, Object>> stubRequestBodyCapture() throws Exception {
+      when(config.isConfigured()).thenReturn(true);
+      when(config.getUrl()).thenReturn("http://localhost:8080");
+      when(httpClientFactory.httpClientNoRetry()).thenReturn(httpClient);
+      doReturn("fake-jwt").when(xtmOneClient).issueJwtForCurrentUser();
+      ArgumentCaptor<Map<String, Object>> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+      when(objectMapper.writeValueAsString(bodyCaptor.capture())).thenReturn("{}");
+      return bodyCaptor;
+    }
+
+    @Test
+    @DisplayName("Given a non-empty context should include it in the upstream request body")
+    void given_context_should_includeItInBody() throws Exception {
+      // -- ARRANGE --
+      ArgumentCaptor<Map<String, Object>> bodyCaptor = stubRequestBodyCapture();
+      Map<String, Object> context = Map.of("url", "/dashboard/reports/1");
+
+      // -- ACT --
+      xtmOneClient.streamChatMessage("hello", "conv-1", "agent-1", context, stream -> {});
+
+      // -- ASSERT --
+      Map<String, Object> body = bodyCaptor.getValue();
+      assertEquals("hello", body.get("content"));
+      assertEquals("conv-1", body.get("conversation_id"));
+      assertEquals("agent-1", body.get("agent_slug"));
+      assertEquals(context, body.get("context"));
+    }
+
+    @Test
+    @DisplayName("Given a null context should omit it from the upstream request body")
+    void given_nullContext_should_omitFromBody() throws Exception {
+      // -- ARRANGE --
+      ArgumentCaptor<Map<String, Object>> bodyCaptor = stubRequestBodyCapture();
+
+      // -- ACT --
+      xtmOneClient.streamChatMessage("hello", null, "agent-1", null, stream -> {});
+
+      // -- ASSERT --
+      Map<String, Object> body = bodyCaptor.getValue();
+      assertEquals("hello", body.get("content"));
+      assertFalse(body.containsKey("context"));
+      assertFalse(body.containsKey("conversation_id"));
+    }
+
+    @Test
+    @DisplayName("Given an empty context should omit it from the upstream request body")
+    void given_emptyContext_should_omitFromBody() throws Exception {
+      // -- ARRANGE --
+      ArgumentCaptor<Map<String, Object>> bodyCaptor = stubRequestBodyCapture();
+
+      // -- ACT --
+      xtmOneClient.streamChatMessage("hello", null, "agent-1", Map.of(), stream -> {});
+
+      // -- ASSERT --
+      assertFalse(bodyCaptor.getValue().containsKey("context"));
+    }
+
+    @Test
+    @DisplayName("Given a context via the 4-arg overload should default to null context (omitted)")
+    void given_legacyOverload_should_omitContext() throws Exception {
+      // -- ARRANGE --
+      ArgumentCaptor<Map<String, Object>> bodyCaptor = stubRequestBodyCapture();
+
+      // -- ACT --
+      xtmOneClient.streamChatMessage("hello", null, "agent-1", stream -> {});
+
+      // -- ASSERT --
+      assertFalse(bodyCaptor.getValue().containsKey("context"));
     }
   }
 }

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.4.0",
+    "@filigran/chatbot": "3.3.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.3.1",
+    "@filigran/chatbot": "3.4.0",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
@@ -6,6 +6,7 @@ import { LogoXtmOneIcon } from 'filigran-icon';
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useLocation } from 'react-router';
 
 import { useFormatter } from '../../../components/i18n';
 import { api } from '../../../network';
@@ -33,6 +34,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
 }) => {
   const theme = useTheme<Theme>();
   const { t } = useFormatter();
+  const location = useLocation();
   const { me, settings } = useAuth();
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [agentFetchState, setAgentFetchState] = useState<AgentFetchState>('loading');
@@ -60,6 +62,12 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
     t('How do I configure detection rules?'),
     t('Summarize my recent findings'),
   ];
+
+  // Forward the user's current in-app location so the agent is always aware
+  // of the page (URI) the question is being asked from, e.g.
+  // `/admin/atomic_testings/<id>`. The shape is intentionally extensible —
+  // more context (page title, selected entity, etc.) can be added later.
+  const pageContext = { url: `${location.pathname}${location.search}` };
 
   useEffect(() => {
     installChatbotCsrf();
@@ -161,6 +169,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
       logoIcon={logoIcon}
       agentDashboardUrl={xtmOneUrl || undefined}
       promptSuggestions={promptSuggestions}
+      pageContext={pageContext}
       resizable={mode === 'sidebar'}
       onWidthChange={onWidthChange}
       onResizeStart={onResizeStart}

--- a/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
@@ -65,9 +65,12 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
 
   // Forward the user's current in-app location so the agent is always aware
   // of the page (URI) the question is being asked from, e.g.
-  // `/admin/atomic_testings/<id>`. The shape is intentionally extensible —
-  // more context (page title, selected entity, etc.) can be added later.
-  const pageContext = { url: `${location.pathname}${location.search}` };
+  // `/admin/atomic_testings/<id>`. Only the pathname is sent — the query
+  // string is intentionally omitted to avoid forwarding UI state (filters,
+  // view settings, …) that would bloat the payload and could leak more than
+  // the agent needs. The shape is extensible — more context (page title,
+  // selected entity, etc.) can be added later.
+  const pageContext = { url: location.pathname };
 
   useEffect(() => {
     installChatbotCsrf();

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.1":
-  version: 3.3.1
-  resolution: "@filigran/chatbot@npm:3.3.1"
+"@filigran/chatbot@npm:3.3.2":
+  version: 3.3.2
+  resolution: "@filigran/chatbot@npm:3.3.2"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/9d0c71c52fb010326b2e947ce9bcadcfe5d998003ebfcab28cfa480d3ddf3c0ee2a8ebf4caf72583e108a2b2c2558cf084e9e77d48650496302f2b181aa6eeb4
+  checksum: 10c0/603d18358c9fb9a60c0e383bbec25fd1e60c2eace79e991be6d3275155d7c5add397c1d69e7a772718ef0097edd5d193f75e81ee0fdd8f0c45bf7d7b855cf832
   languageName: node
   linkType: hard
 
@@ -9832,7 +9832,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.1"
+    "@filigran/chatbot": "npm:3.3.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

Makes the XTM One "Ask Ariane" agent aware of the user's current page by forwarding it as a flexible `context` JSON object on every chat message.

- **front** (`AskArianePanel`): passes `pageContext={{ url: location.pathname }}` to `ChatPanel`, kept fresh via `useLocation` as the user navigates. **Only the pathname is sent** — `location.search` is intentionally omitted to avoid forwarding query-string UI state (filters, view settings, …) that would bloat each message and could leak more than the agent needs. Pins `@filigran/chatbot` to `3.3.2`.
- **api** (`XtmOneChatApi.sendMessage`): extracts the optional `context` map from the request body and forwards it.
- **api** (`XtmOneClient.streamChatMessage`): new context-aware overload that includes `context` in the upstream `/api/v1/platform/chat/messages` body when present (the existing 4-arg signature is kept and delegates with `null`, so `XtmOneProxyApi` is unchanged).

The shape is intentionally generic (today just the URL; extensible later). Optional everywhere and omitted when absent — no behavior change otherwise.

Closes #5995

## Dependency / ordering

Requires `@filigran/chatbot@3.3.2` (FiligranHQ/filigran-ui PR #280, merged + published), and is consumed end-to-end by `XTM-One-Platform/xtm-one` #1122 which injects the `context` into the agent system prompt.

## Test plan

- [x] `cd openaev-front && yarn lint && yarn check-ts`
- [x] `mvn spotless:check` and `mvn test -Dtest=XtmOneChatApiTest,XtmOneClientTest,XtmOneChatApiUnitTest`
- [ ] Open "Ask Ariane", navigate to a page, send a message → upstream body includes `context: { url: <pathname> }` matching the current page
- [ ] `XtmOneProxyApi` (`/agent/stream`) still works unchanged (delegates to the 4-arg overload)
