### PR TITLE
[frontend] fix(ask-ariane): bump @filigran/chatbot to 3.3.3 to recover from a stale conversation id

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.3.2",
+    "@filigran/chatbot": "3.3.3",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@filigran/chatbot@npm:3.3.2"
+"@filigran/chatbot@npm:3.3.3":
+  version: 3.3.3
+  resolution: "@filigran/chatbot@npm:3.3.3"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/603d18358c9fb9a60c0e383bbec25fd1e60c2eace79e991be6d3275155d7c5add397c1d69e7a772718ef0097edd5d193f75e81ee0fdd8f0c45bf7d7b855cf832
+  checksum: 10c0/08b015995ebbeca4fbe06185892a9d8de680d9e327925c35b4657fa77325507132823e48adc31f551f4d8c8cd216113da12f56355d7fb7cd077812c110296d5c
   languageName: node
   linkType: hard
 
@@ -9832,7 +9832,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.2"
+    "@filigran/chatbot": "npm:3.3.3"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
### Proposed changes

* Bump `@filigran/chatbot` from `3.3.2` to `3.3.3` in `openaev-front`.
* This release ([FiligranHQ/filigran-ui#281](https://github.com/FiligranHQ/filigran-ui/pull/281)) makes the "Ask Ariane" chatbot recover gracefully from a **stale** conversation id stored in `localStorage` (e.g. when the same URL is reused for a fresh/reset platform). Instead of showing `conversation does not exist` and forcing the user to click **New conversation**, the chatbot now adopts the conversation id resolved by the backend (or silently starts a fresh one) and persists it.

No OpenAEV code change is needed: `AskArianePanel.tsx` only passes props and `XtmOneChatApi.createSession` already returns the resolved `conversation_id`.

### Testing Instructions

1. Open Ask Ariane and start a conversation so a `filigranChatConversationId` is stored in `localStorage`.
2. Point the same browser/URL at a fresh platform (or delete the conversation server-side) so the stored id no longer exists.
3. Reopen Ask Ariane → the chatbot silently uses a fresh conversation; the first message sends successfully with **no error** and without having to click **New conversation**.

### Related issues

* Closes #5999

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

Dependency bump only (`package.json` + `yarn.lock`); the underlying fix and its test plan live in the upstream PR FiligranHQ/filigran-ui#281.

> **Note on `npmMinimalAgeGate`:** `openaev-front/.yarnrc.yml` quarantines npm packages younger than 3 days (`npmMinimalAgeGate: 4320`). `3.3.3` was just published, so `yarn install --immutable` may flag it as quarantined in CI until the package is ~3 days old. The lockfile is already in sync — re-running CI once the package ages past the gate (or if maintainers prefer, after the gate clears) will pass without further changes. The age-gate policy itself was intentionally left untouched.
