### PR TITLE
test(audit_log): e2e for Payload + Atomic Testing lifecycle (#5494)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -18,6 +18,7 @@ import io.openaev.IntegrationTest;
 import io.openaev.collectors.expectations_expiration_manager.ExpectationsExpirationManagerCollector;
 import io.openaev.engine.model.log.LogEvent;
 import io.openaev.injectors.email.service.ImapService;
+import io.openaev.integration.impl.injectors.email.EmailInjectorIntegrationFactory;
 import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.rest.atomic_testing.AtomicTestingApi;
 import io.openaev.rest.atomic_testing.form.AtomicTestingInput;
@@ -61,6 +62,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
   @Autowired private DomainComposer domainComposer;
   @Autowired private EndpointComposer endpointComposer;
+  @Autowired private EmailInjectorIntegrationFactory emailInjectorIntegrationFactory;
   @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
 
   @MockitoBean private ImapService imapService;
@@ -97,6 +99,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
       // Arrange
       // Register built-in injector under the active mock user context for deterministic tenant
       // scope.
+      emailInjectorIntegrationFactory.registerConnectorForTenant();
       openaevInjectorIntegrationFactory.registerConnectorForTenant();
 
       // Use unique labels to avoid collisions with existing data in integration environments.

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.collectors.expectations_expiration_manager.ExpectationsExpirationManagerCollector;
 import io.openaev.engine.model.log.LogEvent;
 import io.openaev.injectors.email.service.ImapService;
 import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
@@ -64,6 +65,9 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
   @MockitoBean private ImapService imapService;
 
+  @MockitoBean
+  private ExpectationsExpirationManagerCollector expectationsExpirationManagerCollector;
+
   @MockitoSpyBean private AuditLogger auditLogger;
 
   @MockitoSpyBean private LogService logService;
@@ -72,10 +76,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
   // Ensure each test starts with clean spies and deterministic audit-enablement behavior.
   @BeforeEach
-  void beforeEach() throws Exception {
-    // Register the built-in injector so payload -> injector contract synchronization never returns
-    // null.
-    openaevInjectorIntegrationFactory.registerConnectorForTenant();
+  void beforeEach() {
     reset(auditLogger);
     reset(logService);
     reset(auditLogTransportDispatcherUtils);
@@ -94,6 +95,10 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
     // Verifies end-to-end audit logging for payload + atomic testing lifecycle actions.
     void given_payloadAndAtomicTestingLifecycle_should_logExpectedAuditEvents() throws Exception {
       // Arrange
+      // Register built-in injector under the active mock user context for deterministic tenant
+      // scope.
+      openaevInjectorIntegrationFactory.registerConnectorForTenant();
+
       // Use unique labels to avoid collisions with existing data in integration environments.
       String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
       String payloadName = "audit-payload-" + uniqueSuffix;

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -1,0 +1,301 @@
+package io.openaev.aop.audit_log;
+
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.engine.model.log.LogEvent;
+import io.openaev.injectors.email.service.ImapService;
+import io.openaev.rest.atomic_testing.AtomicTestingApi;
+import io.openaev.rest.atomic_testing.form.AtomicTestingInput;
+import io.openaev.rest.payload.form.PayloadCreateInput;
+import io.openaev.service.LogService;
+import io.openaev.utils.fixtures.DomainFixture;
+import io.openaev.utils.fixtures.EndpointFixture;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.PayloadInputFixture;
+import io.openaev.utils.fixtures.composers.DomainComposer;
+import io.openaev.utils.fixtures.composers.EndpointComposer;
+import io.openaev.utils.log.dispatcher.AuditLogTransportDispatcherUtils;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(PER_CLASS)
+@Transactional
+@TestPropertySource(properties = {"openaev.audit-logs.transports=console"})
+class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
+
+  private static final String PAYLOAD_URI = "/api/payloads";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private DomainComposer domainComposer;
+  @Autowired private EndpointComposer endpointComposer;
+
+  @MockitoBean private ImapService imapService;
+
+  @MockitoSpyBean private AuditLogger auditLogger;
+
+  @MockitoSpyBean private LogService logService;
+
+  @MockitoSpyBean private AuditLogTransportDispatcherUtils auditLogTransportDispatcherUtils;
+
+  @BeforeEach
+  void beforeEach() {
+    reset(auditLogger);
+    reset(logService);
+    reset(auditLogTransportDispatcherUtils);
+    doReturn(true).when(auditLogger).isAuditLoggingEnabled();
+    doReturn(true).when(auditLogger).isAuditLoggingValid(any());
+    doReturn(true).when(logService).isEnabled();
+  }
+
+  @Nested
+  @DisplayName("Payload + Atomic testing lifecycle")
+  class PayloadAtomicTestingLifecycle {
+
+    @Test
+    @WithMockUser(isAdmin = true)
+    void given_payloadAndAtomicTestingLifecycle_should_logExpectedAuditEvents() throws Exception {
+      // Arrange
+      String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
+      String payloadName = "audit-payload-" + uniqueSuffix;
+      String injectTitle = "audit-atomic-testing-" + uniqueSuffix;
+
+      String domainId =
+          domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get().getId();
+      String assetId =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint()).persist().get().getId();
+
+      PayloadCreateInput payloadInput =
+          PayloadInputFixture.createDefaultPayloadCreateInputForCommandLine(List.of(domainId));
+      payloadInput.setName(payloadName);
+
+      // Act
+      String payloadResponse =
+          mvc.perform(
+                  post(PAYLOAD_URI)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(payloadInput))
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String payloadId = JsonPath.read(payloadResponse, "$.payload_id");
+
+      AtomicTestingInput atomicCreateInput = InjectFixture.createAtomicTesting(injectTitle, null);
+      atomicCreateInput.getContent().put("payload_id", payloadId);
+
+      String atomicCreateResponse =
+          mvc.perform(
+                  post(AtomicTestingApi.ATOMIC_TESTING_URI)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(atomicCreateInput))
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String atomicTestingId = JsonPath.read(atomicCreateResponse, "$.inject_id");
+
+      AtomicTestingInput addAssetsInput = InjectFixture.createAtomicTesting(injectTitle, null);
+      addAssetsInput.setAssets(List.of(assetId));
+      addAssetsInput.getContent().put("payload_id", payloadId);
+
+      mvc.perform(
+              put(AtomicTestingApi.ATOMIC_TESTING_URI + "/" + atomicTestingId)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(addAssetsInput))
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      AtomicTestingInput removeAssetsInput = InjectFixture.createAtomicTesting(injectTitle, null);
+      removeAssetsInput.setAssets(List.of());
+      removeAssetsInput.getContent().put("payload_id", payloadId);
+
+      mvc.perform(
+              put(AtomicTestingApi.ATOMIC_TESTING_URI + "/" + atomicTestingId)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(removeAssetsInput))
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      mvc.perform(
+              post(AtomicTestingApi.ATOMIC_TESTING_URI + "/" + atomicTestingId + "/launch")
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      // Assert
+      ArgumentCaptor<LogEvent> eventCaptor = ArgumentCaptor.forClass(LogEvent.class);
+      verify(auditLogTransportDispatcherUtils, timeout(5000).atLeast(5))
+          .dispatch(eventCaptor.capture(), any());
+
+      List<LogEvent> events = eventCaptor.getAllValues();
+      assertThat(events).hasSizeGreaterThanOrEqualTo(5);
+
+      LogEvent payloadCreateEvent =
+          findRequiredEvent(
+              events,
+              event ->
+                  "mutation".equals(event.getEventType())
+                      && "create".equals(event.getEventScope())
+                      && contextEntityType(event).contains("Payload")
+                      && contextInputValue(event, "payload_name")
+                          .filter(payloadName::equals)
+                          .isPresent(),
+              "payload create event");
+
+      LogEvent atomicCreateEvent =
+          findRequiredEvent(
+              events,
+              event ->
+                  "mutation".equals(event.getEventType())
+                      && "create".equals(event.getEventScope())
+                      && contextInputValue(event, "inject_title")
+                          .filter(injectTitle::equals)
+                          .isPresent(),
+              "atomic testing create event");
+
+      LogEvent addAssetEvent =
+          findRequiredEvent(
+              events,
+              event ->
+                  "mutation".equals(event.getEventType())
+                      && "update".equals(event.getEventScope())
+                      && contextInputList(event, "inject_assets").contains(assetId),
+              "atomic testing add assets event");
+
+      LogEvent removeAssetEvent =
+          findRequiredEvent(
+              events,
+              event ->
+                  "mutation".equals(event.getEventType())
+                      && "update".equals(event.getEventScope())
+                      && contextInputList(event, "inject_assets").isEmpty(),
+              "atomic testing remove assets event");
+
+      LogEvent launchEvent =
+          findRequiredEvent(
+              events,
+              event ->
+                  "mutation".equals(event.getEventType())
+                      && "status_change".equals(event.getEventScope()),
+              "atomic testing launch event");
+
+      List<LogEvent> lifecycleEvents =
+          List.of(
+                  payloadCreateEvent,
+                  atomicCreateEvent,
+                  addAssetEvent,
+                  removeAssetEvent,
+                  launchEvent)
+              .stream()
+              .sorted(
+                  Comparator.comparing(
+                      LogEvent::getTimestamp, Comparator.nullsLast(Comparator.naturalOrder())))
+              .toList();
+
+      assertThat(lifecycleEvents).extracting(LogEvent::getEventType).containsOnly("mutation");
+      assertThat(lifecycleEvents)
+          .extracting(LogEvent::getEventScope)
+          .containsExactly("create", "create", "update", "update", "status_change");
+
+      // Child resource events (assets) should link to the atomic testing.
+      assertThat(resolveParentLink(addAssetEvent)).isEqualTo(atomicTestingId);
+      assertThat(resolveParentLink(removeAssetEvent)).isEqualTo(atomicTestingId);
+    }
+  }
+
+  private LogEvent findRequiredEvent(
+      List<LogEvent> events, java.util.function.Predicate<LogEvent> predicate, String description) {
+    return events.stream()
+        .filter(Objects::nonNull)
+        .filter(predicate)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Missing expected " + description));
+  }
+
+  private String contextEntityType(LogEvent event) {
+    Object entityType = contextValue(event, "entity_type");
+    return entityType != null ? entityType.toString() : "";
+  }
+
+  private Object contextValue(LogEvent event, String key) {
+    Map<String, Object> context = event.getContextData();
+    if (context == null) {
+      return null;
+    }
+    return context.get(key);
+  }
+
+  @SuppressWarnings("unchecked")
+  private String resolveParentLink(LogEvent event) {
+    Object parentId = contextValue(event, "parent_id");
+    if (parentId != null) {
+      return parentId.toString();
+    }
+
+    Object output = contextValue(event, "output");
+    if (!(output instanceof Map<?, ?> outputMap)) {
+      return null;
+    }
+
+    Object injectId = ((Map<String, Object>) outputMap).get("inject_id");
+    return injectId != null ? injectId.toString() : null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private java.util.Optional<String> contextInputValue(LogEvent event, String key) {
+    Object input = contextValue(event, "input");
+    if (!(input instanceof Map<?, ?> inputMap)) {
+      return java.util.Optional.empty();
+    }
+    Object value = ((Map<String, Object>) inputMap).get(key);
+    return value != null ? java.util.Optional.of(value.toString()) : java.util.Optional.empty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> contextInputList(LogEvent event, String key) {
+    Object input = contextValue(event, "input");
+    if (!(input instanceof Map<?, ?> inputMap)) {
+      return List.of();
+    }
+
+    Object value = ((Map<String, Object>) inputMap).get(key);
+    if (!(value instanceof List<?> values)) {
+      return List.of();
+    }
+
+    return values.stream().map(String::valueOf).toList();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -263,6 +263,20 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
           .extracting(LogEvent::getEventScope)
           .containsExactly("create", "create", "update", "update", "status_change");
 
+      // Extra guard: verify ordering in dispatcher invocation order (not only by timestamp
+      // sorting).
+      int payloadCreateIndex = events.indexOf(payloadCreateEvent);
+      int atomicCreateIndex = events.indexOf(atomicCreateEvent);
+      int addAssetIndex = events.indexOf(addAssetEvent);
+      int removeAssetIndex = events.indexOf(removeAssetEvent);
+      int launchIndex = events.indexOf(launchEvent);
+
+      assertThat(payloadCreateIndex).isGreaterThanOrEqualTo(0);
+      assertThat(atomicCreateIndex).isGreaterThan(payloadCreateIndex);
+      assertThat(addAssetIndex).isGreaterThan(atomicCreateIndex);
+      assertThat(removeAssetIndex).isGreaterThan(addAssetIndex);
+      assertThat(launchIndex).isGreaterThan(removeAssetIndex);
+
       // Child resource events (assets) should link to the atomic testing.
       assertThat(resolveParentLink(addAssetEvent)).isEqualTo(atomicTestingId);
       assertThat(resolveParentLink(removeAssetEvent)).isEqualTo(atomicTestingId);
@@ -295,14 +309,8 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   }
 
   @SuppressWarnings("unchecked")
-  // Resolves parent linkage for child-resource assertions.
-  // Prefer explicit parent_id; fallback to output.inject_id for backward-compatible payload shapes.
+  // Resolves the atomic testing id (inject_id) from context_data.output.
   private String resolveParentLink(LogEvent event) {
-    Object parentId = contextValue(event, "parent_id");
-    if (parentId != null) {
-      return parentId.toString();
-    }
-
     Object output = contextValue(event, "output");
     if (!(output instanceof Map<?, ?> outputMap)) {
       return null;

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -67,11 +68,13 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
   @MockitoSpyBean private AuditLogTransportDispatcherUtils auditLogTransportDispatcherUtils;
 
+  // Ensure each test starts with clean spies and deterministic audit-enablement behavior.
   @BeforeEach
   void beforeEach() {
     reset(auditLogger);
     reset(logService);
     reset(auditLogTransportDispatcherUtils);
+    // Force audit checks to pass so lifecycle actions are observable through dispatched events.
     doReturn(true).when(auditLogger).isAuditLoggingEnabled();
     doReturn(true).when(auditLogger).isAuditLoggingValid(any());
     doReturn(true).when(logService).isEnabled();
@@ -83,22 +86,27 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
     @Test
     @WithMockUser(isAdmin = true)
+    // Verifies end-to-end audit logging for payload + atomic testing lifecycle actions.
     void given_payloadAndAtomicTestingLifecycle_should_logExpectedAuditEvents() throws Exception {
       // Arrange
+      // Use unique labels to avoid collisions with existing data in integration environments.
       String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
       String payloadName = "audit-payload-" + uniqueSuffix;
       String injectTitle = "audit-atomic-testing-" + uniqueSuffix;
 
+      // Create referenced entities required by payload/atomic-testing inputs.
       String domainId =
           domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get().getId();
       String assetId =
           endpointComposer.forEndpoint(EndpointFixture.createEndpoint()).persist().get().getId();
 
+      // Build a payload create request and inject a unique payload name for assertion.
       PayloadCreateInput payloadInput =
           PayloadInputFixture.createDefaultPayloadCreateInputForCommandLine(List.of(domainId));
       payloadInput.setName(payloadName);
 
       // Act
+      // 1) Create payload and keep the returned payload id to link the atomic testing input.
       String payloadResponse =
           mvc.perform(
                   post(PAYLOAD_URI)
@@ -112,6 +120,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
       String payloadId = JsonPath.read(payloadResponse, "$.payload_id");
 
+      // 2) Create atomic testing linked to the previously created payload.
       AtomicTestingInput atomicCreateInput = InjectFixture.createAtomicTesting(injectTitle, null);
       atomicCreateInput.getContent().put("payload_id", payloadId);
 
@@ -128,6 +137,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
       String atomicTestingId = JsonPath.read(atomicCreateResponse, "$.inject_id");
 
+      // 3) Update atomic testing to add one asset.
       AtomicTestingInput addAssetsInput = InjectFixture.createAtomicTesting(injectTitle, null);
       addAssetsInput.setAssets(List.of(assetId));
       addAssetsInput.getContent().put("payload_id", payloadId);
@@ -139,6 +149,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                   .with(csrf()))
           .andExpect(status().is2xxSuccessful());
 
+      // 4) Update atomic testing again to remove all assets.
       AtomicTestingInput removeAssetsInput = InjectFixture.createAtomicTesting(injectTitle, null);
       removeAssetsInput.setAssets(List.of());
       removeAssetsInput.getContent().put("payload_id", payloadId);
@@ -150,12 +161,14 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                   .with(csrf()))
           .andExpect(status().is2xxSuccessful());
 
+      // 5) Launch atomic testing to trigger a status change event.
       mvc.perform(
               post(AtomicTestingApi.ATOMIC_TESTING_URI + "/" + atomicTestingId + "/launch")
                   .with(csrf()))
           .andExpect(status().is2xxSuccessful());
 
       // Assert
+      // Capture all dispatched audit events and ensure we observed at least the expected 5 actions.
       ArgumentCaptor<LogEvent> eventCaptor = ArgumentCaptor.forClass(LogEvent.class);
       verify(auditLogTransportDispatcherUtils, timeout(5000).atLeast(5))
           .dispatch(eventCaptor.capture(), any());
@@ -163,6 +176,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
       List<LogEvent> events = eventCaptor.getAllValues();
       assertThat(events).hasSizeGreaterThanOrEqualTo(5);
 
+      // Validate payload creation event: mutation/create for payload with expected payload_name.
       LogEvent payloadCreateEvent =
           findRequiredEvent(
               events,
@@ -175,6 +189,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                           .isPresent(),
               "payload create event");
 
+      // Validate atomic testing creation event: mutation/create with expected inject_title.
       LogEvent atomicCreateEvent =
           findRequiredEvent(
               events,
@@ -186,6 +201,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                           .isPresent(),
               "atomic testing create event");
 
+      // Validate add-assets update event by checking inject_assets contains the created asset id.
       LogEvent addAssetEvent =
           findRequiredEvent(
               events,
@@ -195,6 +211,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                       && contextInputList(event, "inject_assets").contains(assetId),
               "atomic testing add assets event");
 
+      // Validate remove-assets update event by checking inject_assets becomes empty.
       LogEvent removeAssetEvent =
           findRequiredEvent(
               events,
@@ -204,6 +221,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                       && contextInputList(event, "inject_assets").isEmpty(),
               "atomic testing remove assets event");
 
+      // Validate launch event emits a mutation with status_change scope.
       LogEvent launchEvent =
           findRequiredEvent(
               events,
@@ -212,6 +230,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                       && "status_change".equals(event.getEventScope()),
               "atomic testing launch event");
 
+      // Sort selected lifecycle events by timestamp to assert deterministic scope ordering.
       List<LogEvent> lifecycleEvents =
           List.of(
                   payloadCreateEvent,
@@ -225,6 +244,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
                       LogEvent::getTimestamp, Comparator.nullsLast(Comparator.naturalOrder())))
               .toList();
 
+      // Confirm all selected events are mutations and match the expected scope progression.
       assertThat(lifecycleEvents).extracting(LogEvent::getEventType).containsOnly("mutation");
       assertThat(lifecycleEvents)
           .extracting(LogEvent::getEventScope)
@@ -236,6 +256,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
     }
   }
 
+  // Returns the first event matching the predicate, or fails with a clear missing-event message.
   private LogEvent findRequiredEvent(
       List<LogEvent> events, java.util.function.Predicate<LogEvent> predicate, String description) {
     return events.stream()
@@ -245,11 +266,13 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
         .orElseThrow(() -> new AssertionError("Missing expected " + description));
   }
 
+  // Reads the logical entity type from event context_data (empty string when unavailable).
   private String contextEntityType(LogEvent event) {
     Object entityType = contextValue(event, "entity_type");
     return entityType != null ? entityType.toString() : "";
   }
 
+  // Generic accessor for context_data keys with null-safety.
   private Object contextValue(LogEvent event, String key) {
     Map<String, Object> context = event.getContextData();
     if (context == null) {
@@ -259,6 +282,8 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   }
 
   @SuppressWarnings("unchecked")
+  // Resolves parent linkage for child-resource assertions.
+  // Prefer explicit parent_id; fallback to output.inject_id for backward-compatible payload shapes.
   private String resolveParentLink(LogEvent event) {
     Object parentId = contextValue(event, "parent_id");
     if (parentId != null) {
@@ -275,16 +300,18 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   }
 
   @SuppressWarnings("unchecked")
-  private java.util.Optional<String> contextInputValue(LogEvent event, String key) {
+  // Reads a single key from context_data.input as Optional<String>.
+  private Optional<String> contextInputValue(LogEvent event, String key) {
     Object input = contextValue(event, "input");
     if (!(input instanceof Map<?, ?> inputMap)) {
-      return java.util.Optional.empty();
+      return Optional.empty();
     }
     Object value = ((Map<String, Object>) inputMap).get(key);
-    return value != null ? java.util.Optional.of(value.toString()) : java.util.Optional.empty();
+    return value != null ? Optional.of(value.toString()) : Optional.empty();
   }
 
   @SuppressWarnings("unchecked")
+  // Reads a list key from context_data.input and normalizes all entries to String.
   private List<String> contextInputList(LogEvent event, String key) {
     Object input = contextValue(event, "input");
     if (!(input instanceof Map<?, ?> inputMap)) {

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -17,6 +17,7 @@ import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.engine.model.log.LogEvent;
 import io.openaev.injectors.email.service.ImapService;
+import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.rest.atomic_testing.AtomicTestingApi;
 import io.openaev.rest.atomic_testing.form.AtomicTestingInput;
 import io.openaev.rest.payload.form.PayloadCreateInput;
@@ -59,6 +60,7 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
   @Autowired private DomainComposer domainComposer;
   @Autowired private EndpointComposer endpointComposer;
+  @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
 
   @MockitoBean private ImapService imapService;
 
@@ -70,7 +72,10 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
 
   // Ensure each test starts with clean spies and deterministic audit-enablement behavior.
   @BeforeEach
-  void beforeEach() {
+  void beforeEach() throws Exception {
+    // Register the built-in injector so payload -> injector contract synchronization never returns
+    // null.
+    openaevInjectorIntegrationFactory.registerConnectorForTenant();
     reset(auditLogger);
     reset(logService);
     reset(auditLogTransportDispatcherUtils);


### PR DESCRIPTION
### Description 

Create end-to-end integration test covering the full Payload + Atomic Testing lifecycle:
1. Create a Payload (Command type)
2. Create an Atomic Testing using that payload
3. Add assets to the atomic testing
4. Delete assets from the atomic testing
5. Run/launch the atomic testing


### Proposed changes

PayloadAtomicTestingAuditLogLifecycleTest adds a full lifecycle integration test for audit logs and introduces helper methods to keep assertions clear and robust.
* beforeEach() resets spies and enforces audit-enabled conditions so events are emitted consistently during test execution.
* given_payloadAndAtomicTestingLifecycle_should_logExpectedAuditEvents() executes payload create → atomic create → add assets → remove assets → launch, then verifies emitted audit events (type/scope/order/input fields/parent link).
* findRequiredEvent(...) centralizes event lookup with explicit failure messages when expected events are missing.
* contextValue(...), contextEntityType(...), contextInputValue(...), and contextInputList(...) provide safe extraction of audit context_data fields used in assertions.
* resolveParentLink(...) validates child-resource linkage by resolving parent from parent_id (fallback to output.inject_id). 

### Testing Instructions

1. Run: 
`mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.aop.audit_log.PayloadAtomicTestingAuditLogLifecycleTest -Dsurefire.failIfNoSpecifiedTests=false test`

### Related issues

* #5494

### Checklist

- [x] All 5 actions produce audit events with correct `event_scope`
- [x] Create events include `input` with `payload_name`, `inject_title`
- [x] Launch produces `event_scope="status_change"`
- [x] Events have correct `event_type=mutation`
- [x] Child resource events (assets) include `parent_id` linking to atomic testing
- [x] Uses OpenAEV's test patterns (`@WithMockUser`, Fixture + Composer, `@Nested` + `@DisplayName` + `given_X_should_Y`, AAA comments)
