### PR TITLE
ci(nightly-ci): missing closing quote on the OPENSEARCH_JAVA_OPTS line (#6013)

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -302,7 +302,7 @@ jobs:
             docker run -d --name search -p 9200:9200 \
               -e discovery.type=single-node \
               -e DISABLE_SECURITY_PLUGIN=true \
-              -e "OPENSEARCH_JAVA_OPTS="-Xms2g -Xmx2g" \
+              -e "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g" \
               ${{ matrix.engine.image }}
           fi
           for i in $(seq 1 60); do
@@ -536,7 +536,7 @@ jobs:
             docker run -d --name search -p 9200:9200 \
               -e discovery.type=single-node \
               -e DISABLE_SECURITY_PLUGIN=true \
-              -e "OPENSEARCH_JAVA_OPTS="-Xms2g -Xmx2g" \
+              -e "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g" \
               ${{ matrix.engine.image }}
           fi
           for i in $(seq 1 60); do


### PR DESCRIPTION
I have manually triggered a nightly build on this branch here: https://github.com/OpenAEV-Platform/openaev/actions/runs/26804402038
Let's see

### Proposed changes

*
*

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes https://github.com/OpenAEV-Platform/openaev/issues/6013 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
