### PR TITLE
[backend] fix(xtm-one): send tenant-scoped platform name on registration

### DIFF
--- a/openaev-api/src/main/java/io/openaev/xtmone/XtmOneService.java
+++ b/openaev-api/src/main/java/io/openaev/xtmone/XtmOneService.java
@@ -1,8 +1,12 @@
 package io.openaev.xtmone;
 
+import static io.openaev.database.model.TenantSettingKeys.PLATFORM_NAME;
+
+import io.openaev.context.TenantContext;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.rest.settings.response.PlatformSettings;
 import io.openaev.service.PlatformSettingsService;
+import io.openaev.service.settings.TenantSettingsService;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +22,7 @@ public class XtmOneService {
   private final XtmOneConfig config;
   private final XtmOneClient client;
   private final PlatformSettingsService platformSettingsService;
+  private final TenantSettingsService tenantSettingsService;
   private final EnterpriseEditionService eeService;
 
   private static final List<Map<String, String>> DEFAULT_INTENTS =
@@ -83,8 +88,16 @@ public class XtmOneService {
       String version = platformSettingsService.getPlatformVersion();
       String platformUrl =
           settings.getPlatformBaseUrl() != null ? settings.getPlatformBaseUrl() : "";
+      // The platform name is stored per-tenant (Settings → Parameters), but
+      // PlatformSettings#getPlatformName only reads the platform-level (tenant-null) value, so a
+      // rename would never reach XTM One. Resolve it the same way the UI does: tenant override →
+      // platform fallback → default.
       String platformName =
-          settings.getPlatformName() != null ? settings.getPlatformName() : "OpenAEV Platform";
+          tenantSettingsService.resolveSettingValue(
+              TenantContext.getCurrentTenant(), PLATFORM_NAME);
+      if (platformName == null || platformName.isBlank()) {
+        platformName = "OpenAEV Platform";
+      }
 
       config.setPlatformUrl(platformUrl);
       config.setPlatformVersion(version != null ? version : "");

--- a/openaev-api/src/main/java/io/openaev/xtmone/XtmOneService.java
+++ b/openaev-api/src/main/java/io/openaev/xtmone/XtmOneService.java
@@ -2,7 +2,7 @@ package io.openaev.xtmone;
 
 import static io.openaev.database.model.TenantSettingKeys.PLATFORM_NAME;
 
-import io.openaev.context.TenantContext;
+import io.openaev.database.model.Tenant;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.rest.settings.response.PlatformSettings;
 import io.openaev.service.PlatformSettingsService;
@@ -90,13 +90,14 @@ public class XtmOneService {
           settings.getPlatformBaseUrl() != null ? settings.getPlatformBaseUrl() : "";
       // The platform name is stored per-tenant (Settings → Parameters), but
       // PlatformSettings#getPlatformName only reads the platform-level (tenant-null) value, so a
-      // rename would never reach XTM One. Resolve it the same way the UI does: tenant override →
-      // platform fallback → default.
+      // rename would never reach XTM One. Resolve it the same way the UI does (tenant override →
+      // platform fallback → default). This runs on a background scheduler thread with no request
+      // scope, so resolve against the default tenant explicitly rather than relying on the
+      // (possibly stale) TenantContext ThreadLocal.
       String platformName =
-          tenantSettingsService.resolveSettingValue(
-              TenantContext.getCurrentTenant(), PLATFORM_NAME);
+          tenantSettingsService.resolveSettingValue(Tenant.DEFAULT_TENANT_UUID, PLATFORM_NAME);
       if (platformName == null || platformName.isBlank()) {
-        platformName = "OpenAEV Platform";
+        platformName = PLATFORM_NAME.defaultValue();
       }
 
       config.setPlatformUrl(platformUrl);

--- a/openaev-api/src/test/java/io/openaev/xtmone/XtmOneServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/xtmone/XtmOneServiceTest.java
@@ -1,0 +1,129 @@
+package io.openaev.xtmone;
+
+import static io.openaev.database.model.TenantSettingKeys.PLATFORM_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Tenant;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.rest.settings.response.PlatformSettings;
+import io.openaev.service.PlatformSettingsService;
+import io.openaev.service.settings.TenantSettingsService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("XTM One Service tests")
+class XtmOneServiceTest {
+
+  @Mock private XtmOneConfig config;
+  @Mock private XtmOneClient client;
+  @Mock private PlatformSettingsService platformSettingsService;
+  @Mock private TenantSettingsService tenantSettingsService;
+  @Mock private EnterpriseEditionService eeService;
+
+  @InjectMocks private XtmOneService xtmOneService;
+
+  @BeforeEach
+  @AfterEach
+  void resetTenantContext() {
+    // The background tick runs without a request, so the default tenant must be resolved.
+    TenantContext.clearCurrentTenant();
+  }
+
+  private PlatformSettings stubPlatformSettings() {
+    PlatformSettings settings = new PlatformSettings();
+    settings.setPlatformBaseUrl("https://openaev.example.com");
+    settings.setPlatformId("platform-instance-id");
+    // Stale platform-level (tenant-null) name: this is what the bug used to send.
+    settings.setPlatformName("OpenAEV - Open Adversarial Exposure Validation Platform");
+    return settings;
+  }
+
+  private void arrangeConfigured(String resolvedName) {
+    when(config.isConfigured()).thenReturn(true);
+    when(platformSettingsService.findSettings()).thenReturn(stubPlatformSettings());
+    when(platformSettingsService.getPlatformVersion()).thenReturn("1.0.0");
+    when(tenantSettingsService.resolveSettingValue(anyString(), eq(PLATFORM_NAME)))
+        .thenReturn(resolvedName);
+  }
+
+  @Test
+  @DisplayName("Given a tenant-scoped rename should register with the renamed platform name")
+  void given_tenantScopedRename_should_registerWithRenamedName() {
+    // -- ARRANGE --
+    String renamed = "Filigran Adversarial Exposure Validation Platform";
+    arrangeConfigured(renamed);
+
+    // -- ACT --
+    xtmOneService.autoRegister();
+
+    // -- ASSERT --
+    ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
+    verify(client)
+        .register(
+            eq("openaev"),
+            anyString(),
+            nameCaptor.capture(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            eq("aev"),
+            any());
+    assertEquals(renamed, nameCaptor.getValue());
+    // The tenant-aware resolution is scoped to the default tenant on the background tick.
+    verify(tenantSettingsService).resolveSettingValue(Tenant.DEFAULT_TENANT_UUID, PLATFORM_NAME);
+  }
+
+  @Test
+  @DisplayName("Given a blank resolved name should fall back to a sensible default")
+  void given_blankResolvedName_should_useFallback() {
+    // -- ARRANGE --
+    arrangeConfigured("  ");
+
+    // -- ACT --
+    xtmOneService.autoRegister();
+
+    // -- ASSERT --
+    ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
+    verify(client)
+        .register(
+            eq("openaev"),
+            anyString(),
+            nameCaptor.capture(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            eq("aev"),
+            any());
+    assertEquals("OpenAEV Platform", nameCaptor.getValue());
+  }
+
+  @Test
+  @DisplayName("Given XTM One is not configured should not register")
+  void given_notConfigured_should_notRegister() {
+    // -- ARRANGE --
+    when(config.isConfigured()).thenReturn(false);
+
+    // -- ACT --
+    xtmOneService.autoRegister();
+
+    // -- ASSERT --
+    verifyNoInteractions(client);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/xtmone/XtmOneServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/xtmone/XtmOneServiceTest.java
@@ -9,14 +9,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.openaev.context.TenantContext;
 import io.openaev.database.model.Tenant;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.rest.settings.response.PlatformSettings;
 import io.openaev.service.PlatformSettingsService;
 import io.openaev.service.settings.TenantSettingsService;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,19 +34,12 @@ class XtmOneServiceTest {
 
   @InjectMocks private XtmOneService xtmOneService;
 
-  @BeforeEach
-  @AfterEach
-  void resetTenantContext() {
-    // The background tick runs without a request, so the default tenant must be resolved.
-    TenantContext.clearCurrentTenant();
-  }
-
   private PlatformSettings stubPlatformSettings() {
     PlatformSettings settings = new PlatformSettings();
     settings.setPlatformBaseUrl("https://openaev.example.com");
     settings.setPlatformId("platform-instance-id");
-    // Stale platform-level (tenant-null) name: this is what the bug used to send.
-    settings.setPlatformName("OpenAEV - Open Adversarial Exposure Validation Platform");
+    // Stale platform-level (tenant-null) name the bug used to send; it must never be used now.
+    settings.setPlatformName("Stale platform-level name (must be ignored)");
     return settings;
   }
 
@@ -111,7 +101,7 @@ class XtmOneServiceTest {
             any(),
             eq("aev"),
             any());
-    assertEquals("OpenAEV Platform", nameCaptor.getValue());
+    assertEquals(PLATFORM_NAME.defaultValue(), nameCaptor.getValue());
   }
 
   @Test


### PR DESCRIPTION
## Summary

When the OpenAEV platform is renamed in **Settings → Parameters**, the new name was never propagated to XTM One. XTM One kept showing the old/default name (`OpenAEV`) for the connected platform even though registrations kept succeeding. A connected **OpenCTI** platform updated correctly, which made the asymmetry confusing.

**Root cause:** the platform name is stored **per-tenant** (the Parameters form persists `platform_name` via `TenantSettingsService.updateSettings()` → `upsert(tenant, PLATFORM_NAME.key(), ...)`), but `XtmOneService.autoRegister()` read it from the **platform-level (tenant-null)** settings (`PlatformSettingsService.findSettings()` → `getPlatformName()`). The tenant-null row is never written by a rename, so `getPlatformName()` always returned the default value, and XTM One faithfully stored that stale name on every 5-minute registration. OpenCTI has no such tenant/platform split for its `platform_title`.

## Changes

- `XtmOneService.autoRegister()` now resolves the platform name through the tenant-aware path (tenant override → platform fallback → default) via `TenantSettingsService.resolveSettingValue(...)`, the same resolution the admin UI uses.
- The resolution is scoped explicitly to `Tenant.DEFAULT_TENANT_UUID`. `autoRegister()` runs on a pooled scheduler thread with no request scope, so resolving against the default tenant explicitly — rather than reading the `TenantContext` ThreadLocal — avoids picking up a stale tenant left on the thread by a previous task.
- The blank-name fallback now uses `PLATFORM_NAME.defaultValue()` instead of a hard-coded literal, keeping a single source of truth (the previous literal `"OpenAEV Platform"` also diverged from the real default).
- Added `XtmOneServiceTest` covering: registration sends the renamed (tenant-scoped) name, the blank-name fallback uses the canonical default, and no registration happens when XTM One is not configured. The stale platform-level name is stubbed with a distinct sentinel to prove it is never sent.

## Test plan

- [x] CI: `XtmOneServiceTest` passes (verified locally and on CI).
- [ ] Manual: connect OpenAEV to XTM One, rename the platform in Settings → Parameters, wait for the next registration tick, and confirm the new name appears in XTM One's connected platforms.

Closes #6015
