### PR TITLE
[backend] bug(executor-agent): fix relation agent executor using persisted executor entity.

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/crowdstrike/service/CrowdStrikeExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/crowdstrike/service/CrowdStrikeExecutorService.java
@@ -64,6 +64,7 @@ public class CrowdStrikeExecutorService implements Runnable {
 
   @Override
   public void run() {
+    this.executor = this.endpointService.reFetchExecutor(this.executor);
     try {
       log.info(
           "Running CrowdStrike executor endpoints gathering... executorId={}, hostGroup={}",

--- a/openaev-api/src/main/java/io/openaev/executors/paloaltocortex/service/PaloAltoCortexExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/paloaltocortex/service/PaloAltoCortexExecutorService.java
@@ -53,6 +53,7 @@ public class PaloAltoCortexExecutorService implements Runnable {
 
   @Override
   public void run() {
+    this.executor = this.endpointService.reFetchExecutor(this.executor);
     log.info("Running Palo Alto Cortex executor endpoints gathering...");
     List<String> groupNames = Stream.of(this.config.getGroupName().split(",")).distinct().toList();
     for (String groupName : groupNames) {

--- a/openaev-api/src/main/java/io/openaev/executors/sentinelone/service/SentinelOneExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/sentinelone/service/SentinelOneExecutorService.java
@@ -55,6 +55,7 @@ public class SentinelOneExecutorService implements Runnable {
 
   @Override
   public void run() {
+    this.executor = this.endpointService.reFetchExecutor(this.executor);
     log.info("Running SentinelOne executor endpoints gathering...");
     Set<SentinelOneAgent> sentinelOneAgents = this.client.agents();
     if (!sentinelOneAgents.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/executors/tanium/service/TaniumExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/tanium/service/TaniumExecutorService.java
@@ -63,6 +63,7 @@ public class TaniumExecutorService implements Runnable {
 
   @Override
   public void run() {
+    this.executor = this.endpointService.reFetchExecutor(this.executor);
     log.info("Running Tanium executor endpoints gathering...");
     List<String> computerGroupIds =
         Stream.of(this.config.getComputerGroupId().split(",")).distinct().toList();

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegration.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegration.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 public class CrowdStrikeExecutorIntegration extends Integration {
@@ -142,13 +144,20 @@ public class CrowdStrikeExecutorIntegration extends Integration {
         new CrowdStrikeGarbageCollectorService(
             config, crowdStrikeExecutorContextService, agentService, executorId);
 
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            crowdStrikeExecutorService, Duration.ofSeconds(this.config.getApiRegisterInterval())));
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            crowdStrikeGarbageCollectorService,
-            Duration.ofHours(this.config.getCleanImplantInterval())));
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    crowdStrikeExecutorService,
+                    Duration.ofSeconds(config.getApiRegisterInterval())));
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    crowdStrikeGarbageCollectorService,
+                    Duration.ofHours(config.getCleanImplantInterval())));
+          }
+        });
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegration.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegration.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 public class PaloAltoCortexExecutorIntegration extends Integration {
@@ -140,14 +142,20 @@ public class PaloAltoCortexExecutorIntegration extends Integration {
         new PaloAltoCortexGarbageCollectorService(
             config, paloAltoCortexExecutorContextService, agentService, executorId);
 
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            paloAltoCortexExecutorService,
-            Duration.ofSeconds(this.config.getApiRegisterInterval())));
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            paloAltoCortexGarbageCollectorService,
-            Duration.ofHours(this.config.getCleanImplantInterval())));
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    paloAltoCortexExecutorService,
+                    Duration.ofSeconds(config.getApiRegisterInterval())));
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    paloAltoCortexGarbageCollectorService,
+                    Duration.ofHours(config.getCleanImplantInterval())));
+          }
+        });
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegration.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegration.java
@@ -21,6 +21,7 @@ import io.openaev.integration.ComponentRequestEngine;
 import io.openaev.integration.Integration;
 import io.openaev.integration.QualifiedComponent;
 import io.openaev.integration.configuration.BaseIntegrationConfigurationBuilder;
+import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.AgentService;
 import io.openaev.service.AssetGroupService;
 import io.openaev.service.EndpointService;
@@ -32,6 +33,8 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 public class SentinelOneExecutorIntegration extends Integration {
@@ -140,13 +143,26 @@ public class SentinelOneExecutorIntegration extends Integration {
         new SentinelOneGarbageCollectorService(
             config, sentinelOneExecutorContextService, agentService, executorId);
 
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            sentinelOneExecutorService, Duration.ofSeconds(this.config.getApiRegisterInterval())));
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            sentinelOneGarbageCollectorService,
-            Duration.ofHours(this.config.getCleanImplantInterval())));
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            try {
+              executorService.executor(executor.getId());
+              System.out.println("Executor found after commit, scheduling will be launched");
+            } catch (ElementNotFoundException e) {
+              System.out.println("Executor not found after commit, scheduling will be skipped");
+            }
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    sentinelOneExecutorService,
+                    Duration.ofSeconds(config.getApiRegisterInterval())));
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    sentinelOneGarbageCollectorService,
+                    Duration.ofHours(config.getCleanImplantInterval())));
+          }
+        });
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegration.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegration.java
@@ -21,6 +21,7 @@ import io.openaev.integration.ComponentRequestEngine;
 import io.openaev.integration.Integration;
 import io.openaev.integration.QualifiedComponent;
 import io.openaev.integration.configuration.BaseIntegrationConfigurationBuilder;
+import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.AgentService;
 import io.openaev.service.AssetGroupService;
 import io.openaev.service.EndpointService;
@@ -32,6 +33,8 @@ import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 public class TaniumExecutorIntegration extends Integration {
@@ -139,13 +142,25 @@ public class TaniumExecutorIntegration extends Integration {
         new TaniumGarbageCollectorService(
             config, taniumExecutorContextService, agentService, executorId);
 
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            taniumExecutorService, Duration.ofSeconds(this.config.getApiRegisterInterval())));
-    timers.add(
-        taskScheduler.scheduleAtFixedRate(
-            taniumGarbageCollectorService,
-            Duration.ofHours(this.config.getCleanImplantInterval())));
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            try {
+              executorService.executor(executor.getId());
+              System.out.println("Executor found after commit, scheduling will be launched");
+            } catch (ElementNotFoundException e) {
+              System.out.println("Executor not found after commit, scheduling will be skipped");
+            }
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    taniumExecutorService, Duration.ofSeconds(config.getApiRegisterInterval())));
+            timers.add(
+                taskScheduler.scheduleAtFixedRate(
+                    taniumGarbageCollectorService,
+                    Duration.ofHours(config.getCleanImplantInterval())));
+          }
+        });
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -934,4 +934,11 @@ public class EndpointService {
     }
     return Optional.empty();
   }
+
+  public Executor reFetchExecutor(Executor executor) {
+    return executorRepository
+        .findByIdAndTenantId(executor.getId(), executor.getTenant().getId())
+        .orElseThrow(
+            () -> new ElementNotFoundException("Executor not found with id: " + executor.getId()));
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
@@ -7,10 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.openaev.context.TenantContext;
-import io.openaev.database.model.Agent;
-import io.openaev.database.model.AssetAgentJob;
-import io.openaev.database.model.Endpoint;
-import io.openaev.database.model.Tag;
+import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.rest.asset.endpoint.form.EndpointInput;
 import io.openaev.rest.asset.endpoint.form.EndpointOutput;
@@ -574,6 +571,65 @@ class EndpointServiceTest {
       // -------- Assert --------
       assertEquals(1, result.size());
       assertEquals("ep-2", result.getFirst().getId());
+    }
+  }
+
+  @Nested
+  @DisplayName("reFetchExecutor - Detached executor re-attachment")
+  class ReFetchExecutor {
+
+    @Test
+    @DisplayName(
+        "Given a detached executor, reFetchExecutor should return a different (managed) instance from the repository")
+    void given_detachedExecutor_should_returnManagedInstanceFromRepository() {
+      // -------- Arrange --------
+      // Simulate a detached executor (object stored in memory after transaction closed)
+      Executor detachedExecutor = new Executor();
+      detachedExecutor.setId("exec-001");
+      detachedExecutor.setType("openaev_paloaltocortex_executor");
+      detachedExecutor.setName("PaloAltoCortex");
+      Tenant tenant = new Tenant("tenant-1");
+      detachedExecutor.setTenant(tenant);
+
+      // The managed executor returned by the repository (different object reference)
+      Executor managedExecutor = new Executor();
+      managedExecutor.setId("exec-001");
+      managedExecutor.setType("openaev_paloaltocortex_executor");
+      managedExecutor.setName("PaloAltoCortex");
+      managedExecutor.setTenant(tenant);
+
+      when(executorRepository.findByIdAndTenantId("exec-001", "tenant-1"))
+          .thenReturn(Optional.of(managedExecutor));
+
+      // -------- Act --------
+      Executor result = endpointService.reFetchExecutor(detachedExecutor);
+
+      // -------- Assert --------
+      assertThat(result)
+          .as("reFetchExecutor should return the managed instance from the repository")
+          .isNotNull()
+          .isSameAs(managedExecutor)
+          .isNotSameAs(detachedExecutor);
+      verify(executorRepository).findByIdAndTenantId("exec-001", "tenant-1");
+    }
+
+    @Test
+    @DisplayName(
+        "Given executor not found in DB, reFetchExecutor should throw ElementNotFoundException")
+    void given_executorNotInDb_should_throwElementNotFoundException() {
+      // -------- Arrange --------
+      Executor detachedExecutor = new Executor();
+      detachedExecutor.setId("exec-missing");
+      detachedExecutor.setType("openaev_paloaltocortex_executor");
+      detachedExecutor.setName("PaloAltoCortex");
+      detachedExecutor.setTenant(new Tenant("tenant-1"));
+
+      when(executorRepository.findByIdAndTenantId("exec-missing", "tenant-1"))
+          .thenReturn(Optional.empty());
+
+      // -------- Act / Assert --------
+      assertThrows(
+          ElementNotFoundException.class, () -> endpointService.reFetchExecutor(detachedExecutor));
     }
   }
 }


### PR DESCRIPTION
### Proposed changes

* Fix agents being persisted with `executor_id = NULL` when created by external executor integrations (PaloAltoCortex, CrowdStrike, SentinelOne, Tanium)
* In each executor service's `run()`, re-fetch the executor from the database to obtain a managed entity instead of using the detached reference stored in memory
* Schedule executor tasks only after the transaction commits (`afterCommit`) to avoid race conditions

### Testing Instructions

1. Configure a PaloAltoCortex (or any external) executor integration
2. Wait for the first scheduler tick to sync agents
3. Verify that newly created agents have their `executor_id` correctly set in the database on the **first** sync (not only after the second tick)
4. Check logs for any `"Executor not found"` errors, should not appear under normal conditions

### Related issues



### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

**Root cause:** External executor integrations (`PaloAltoCortexExecutorIntegration`, etc.) call `executorService.register()` during `innerStart()`, which persists the executor and returns a managed entity. However, the transaction commits immediately after, and the returned object becomes **detached**. This object is then stored as a field in the executor service (e.g., `PaloAltoCortexExecutorService`).

When the scheduler triggers `run()` in a **new thread with a new persistence context**, the executor object is no longer attached to any Hibernate session. Calling `agent.setExecutor(detachedExecutor)` then `save(agent)` causes Hibernate to silently ignore the foreign key (no cascade configured), resulting in `executor_id = NULL`.

On the **second** scheduler tick, the agent already exists (found by `externalReference`) and goes through the update path where the merge resolves correctly, giving the false impression of an intermittent/self-healing bug.

**Fix (two-part):**
1. **`reFetchExecutor()`** : Each executor service calls `endpointService.reFetchExecutor(executor)` at the start of `run()` to get a managed entity in the current persistence context.
2. **`afterCommit` scheduling** : Tasks are scheduled only after the transaction that persists the executor has committed, preventing the scheduler from running before the executor is visible in DB.

```mermaid
sequenceDiagram
    participant Init as 🚀 start (innerStart)
    participant Scheduler as ⏰ Scheduler (new thread)
    participant Service as EndpointService
    participant DB as Database

    Init->>DB: save(executor) → committed ✅
    Init->>Init: store executor object in memory
    Note over Init: ⚠️ Transaction ends → object becomes DETACHED

    Scheduler->>Service: run() → create agent with detached executor
    Service->>DB: save(agent, executor=DETACHED)
    Note over DB: Hibernate ignores detached FK<br/>→ executor_id = NULL ❌

    Note over Scheduler,DB: ─── After fix ───

    Scheduler->>Service: run() → reFetchExecutor(detached)
    Service->>DB: SELECT executor WHERE id=? AND tenant_id=? ✅
    Service-->>Scheduler: managed executor
    Scheduler->>Service: create agent with managed executor
    Service->>DB: save(agent, executor=MANAGED)
    Note over DB: executor_id = 'xxx' ✅
```

