### PR TITLE
[frontend] Bump @filigran/chatbot to 3.3.5

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.3.4",
+    "@filigran/chatbot": "3.3.5",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.4":
-  version: 3.3.4
-  resolution: "@filigran/chatbot@npm:3.3.4"
+"@filigran/chatbot@npm:3.3.5":
+  version: 3.3.5
+  resolution: "@filigran/chatbot@npm:3.3.5"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/a30da0e6aab12ebb7f92f5df8b325c4592aa0638f0531c34771ecd9911aed6c9fe3bbfd264aa9b40bb5259d15402bc7e76782a3d03abc9b8ba321f12c98d76cd
+  checksum: 10c0/d11a09a7037311708025bc92282ffbf603008f906cc02e1467ef4c542db811e89c7381eba7b0d9105c1c2c320bd95711668a427617cfdb676379e498c6dadfdc
   languageName: node
   linkType: hard
 
@@ -9832,7 +9832,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.4"
+    "@filigran/chatbot": "npm:3.3.5"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
#### Proposed changes

Bumps `@filigran/chatbot` from `3.3.4` to `3.3.5`.

`3.3.5` fixes a regression in the "Ask Ariane" embedded chat where reloading the page **randomly** discarded the previous session and started a brand-new conversation (sometimes the history restored, sometimes it didn't, for the same stored `conversationId`).

Root cause was in the package's history-restore effect (introduced by the `3.3.3` stale-conversation fix): a blanket `cancelled`-on-teardown guard combined with the `historyLoadedRef` latch discarded the in-flight `/chat/sessions` restore whenever the host re-rendered during the request — which the Ask Ariane panel triggers by passing inline `apiEndpoints` / `requestHeaders` props, and which React StrictMode triggers on every double-invoke. `3.3.5` replaces it with a precise staleness check so the restore is dropped only when the conversation actually changed (new chat / agent switch).

Upstream fix: FiligranHQ/filigran-ui#285 (FiligranHQ/filigran-ui#284).

- [x] `package.json` updated to `3.3.5`
- [x] `yarn.lock` refreshed via `yarn install`
