### PR TITLE
fix(executor-agent): fix relation agent executor (#5985)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
@@ -167,9 +167,11 @@ public class ExecutorService extends AbstractConnectorService<Executor, Executor
     Executor executor =
         executorRepository.findByIdAndTenantId(id, TenantContext.getCurrentTenant()).orElse(null);
     if (executor == null) {
+      Tenant tenant = new Tenant(TenantContext.getCurrentTenant());
       executor = new Executor();
       executor.setId(id);
-      executor.setTenant(new Tenant(TenantContext.getCurrentTenant()));
+      executor.setTenant(tenant);
+      executor.setTenantId(tenant.getId());
     }
 
     executor.setName(name);

--- a/openaev-api/src/test/java/io/openaev/executors/ExecutorServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/ExecutorServiceTest.java
@@ -1,0 +1,136 @@
+package io.openaev.executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Executor;
+import io.openaev.database.repository.ExecutorRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutorServiceTest {
+
+  @Mock private ExecutorRepository executorRepository;
+  @InjectMocks private ExecutorService executorService;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenant("tenant-001");
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clearCurrentTenant();
+  }
+
+  @Nested
+  @DisplayName("register - Composite join fix (executor_id + tenant_id)")
+  class Register {
+
+    @Test
+    @DisplayName(
+        "Given new executor, register should set tenantId so @JoinColumnsOrFormulas resolves correctly")
+    void given_newExecutor_should_setTenantIdForCompositeJoinResolution() throws Exception {
+      // -------- Arrange --------
+      when(executorRepository.findByIdAndTenantId("exec-new", "tenant-001"))
+          .thenReturn(Optional.empty());
+      when(executorRepository.save(any(Executor.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      // -------- Act --------
+      Executor result =
+          executorService.register(
+              "exec-new",
+              "openaev_paloaltocortex_executor",
+              "PaloAltoCortex",
+              "https://docs.example.com",
+              "#00CC66",
+              null,
+              null,
+              new String[] {"Linux", "Windows"});
+
+      // -------- Assert --------
+      assertThat(result.getTenant()).as("Executor should have tenant set").isNotNull();
+      assertThat(result.getTenant().getId())
+          .as("Executor tenant ID should match current tenant")
+          .isEqualTo("tenant-001");
+      assertThat(result.getTenantId())
+          .as(
+              "Executor.tenantId (read-only field) must be set explicitly for "
+                  + "@JoinColumnsOrFormulas composite join resolution when persisting Agent")
+          .isNotNull()
+          .isEqualTo("tenant-001");
+    }
+
+    @Test
+    @DisplayName(
+        "Given existing executor, register should not overwrite tenant and should update fields")
+    void given_existingExecutor_should_updateFieldsWithoutChangingTenant() throws Exception {
+      // -------- Arrange --------
+      Executor existing = new Executor();
+      existing.setId("exec-existing");
+      existing.setName("OldName");
+      existing.setType("openaev_crowdstrike_executor");
+      existing.setTenantId("tenant-001");
+
+      when(executorRepository.findByIdAndTenantId("exec-existing", "tenant-001"))
+          .thenReturn(Optional.of(existing));
+      when(executorRepository.save(any(Executor.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      // -------- Act --------
+      Executor result =
+          executorService.register(
+              "exec-existing",
+              "openaev_crowdstrike_executor",
+              "NewName",
+              "https://docs.example.com",
+              "#E12E37",
+              null,
+              null,
+              new String[] {"Windows"});
+
+      // -------- Assert --------
+      assertThat(result.getName()).isEqualTo("NewName");
+      assertThat(result.getTenantId())
+          .as("Existing executor tenantId should remain unchanged")
+          .isEqualTo("tenant-001");
+    }
+
+    @Test
+    @DisplayName("Given new executor, saved entity should have both tenant and tenantId consistent")
+    void given_newExecutor_savedEntity_should_haveTenantAndTenantIdConsistent() throws Exception {
+      // -------- Arrange --------
+      ArgumentCaptor<Executor> captor = ArgumentCaptor.forClass(Executor.class);
+      when(executorRepository.findByIdAndTenantId("exec-cap", "tenant-001"))
+          .thenReturn(Optional.empty());
+      when(executorRepository.save(captor.capture()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      // -------- Act --------
+      executorService.register(
+          "exec-cap",
+          "openaev_test_executor",
+          "TestExecutor",
+          null,
+          null,
+          null,
+          null,
+          new String[] {"Linux"});
+
+      // -------- Assert --------
+      Executor saved = captor.getValue();
+      assertThat(saved.getTenant().getId())
+          .as("tenant.getId() and tenantId must be the same value for composite join")
+          .isEqualTo(saved.getTenantId());
+    }
+  }
+}


### PR DESCRIPTION
### Proposed changes

* Fix agents being persisted with `agent_executor = NULL` when created by external executor integrations (PaloAltoCortex, CrowdStrike, SentinelOne, Tanium)
* Ensure the `tenantId` read-only field is populated on newly created `Executor` entities so Hibernate can resolve the composite `@JoinColumnsOrFormulas` join

### Root cause

The `Agent → Executor` relationship uses a **composite join**:

```java
@JoinColumnsOrFormulas({
    @JoinColumnOrFormula(
        column = @JoinColumn(name = "agent_executor", referencedColumnName = "executor_id")),
    @JoinColumnOrFormula(
        formula = @JoinFormula(value = "tenant_id", referencedColumnName = "tenant_id"))
})
private Executor executor;
```

Hibernate resolves this by matching the agent's `tenant_id` with the executor's `tenant_id` **and** `agent_executor` with `executor_id`.

The `Executor` entity has two tenant-related fields:
```java
@ManyToOne
@JoinColumn(name = "tenant_id", updatable = false, nullable = false)
private Tenant tenant;           // ← the relation (used for write)

@Column(name = "tenant_id", insertable = false, updatable = false)
private String tenantId;         // ← read-only scalar (used by @JoinFormula resolution)
```

When creating a new executor, only `tenant` was set but **not** `tenantId`. After `save()`, the `tenantId` field remained `null` in memory until the entity was re-read from DB. When the scheduler passed this executor object to `agent.setExecutor(executor)`, Hibernate couldn't match the composite join (`referencedColumnName = "tenant_id"` was null) → `agent_executor = NULL`.

### Fix

Set `tenantId` explicitly when creating a new executor, so the in-memory entity is fully consistent:

```java
Tenant tenant = new Tenant(TenantContext.getCurrentTenant());
executor.setTenant(tenant);
executor.setTenantId(tenant.getId());  // ← ensures composite join resolves immediately
```

### Testing Instructions

1. Configure a PaloAltoCortex (or any external) executor integration
2. Wait for the first scheduler tick to sync agents
3. Verify: `SELECT agent_id, agent_executor FROM agents WHERE agent_executor IS NULL` — should return no results for agents linked to external executors
4. Verify on the **first** sync (not only after the second tick)

### Related issues

* Closes #5985 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

One-line fix. The `tenantId` field is mapped as `insertable = false, updatable = false` (read-only from DB perspective), but its **in-memory value** is used by Hibernate to resolve `@JoinFormula(value = "tenant_id", referencedColumnName = "tenant_id")` when persisting an `Agent`. Without it set, the composite FK is unresolvable → NULL.
