### PR TITLE
feat(agent): add auto update configuration (#6017)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -471,9 +471,9 @@ public class EndpointService {
     // If agent is not temporary and not the same version as the platform => Create an upgrade task
     // for the agent if auto update is enabled (enabled by default)
     Endpoint endpoint = (Endpoint) agent.getAsset();
-    if (agentAutoUpdateEnabled
-        && agent.getParent() == null
-        && !agent.getVersion().equals(version)) {
+    boolean newAgentVersionAvailable =
+        agent.getParent() == null && !agent.getVersion().equals(version);
+    if (agentAutoUpdateEnabled && newAgentVersionAvailable) {
       if (assetAgentJobRepository
           .findUpgradeJobByAgentIdAndInjectNull(agent.getId(), agent.getTenant().getId())
           .isEmpty()) {
@@ -498,11 +498,7 @@ public class EndpointService {
       } else {
         log.warn("Upgrade job already exists");
       }
-    }
-
-    if (!agentAutoUpdateEnabled
-        && agent.getParent() == null
-        && !agent.getVersion().equals(version)) {
+    } else if (!agentAutoUpdateEnabled && newAgentVersionAvailable) {
       log.warn(
           String.format(
               "A new version for the agent %s is available, his current version is %s and the new version is %s",

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -102,6 +102,9 @@ public class EndpointService {
   @Value("${executor.openaev.agent.max-simultaneous-jobs:5}")
   private int maxSimultaneousJobs;
 
+  @Value("${executor.openaev.agent.auto-update-enabled:true}")
+  private boolean agentAutoUpdateEnabled;
+
   private final EndpointRepository endpointRepository;
   private final ExecutorRepository executorRepository;
   private final AssetGroupRepository assetGroupRepository;
@@ -466,9 +469,11 @@ public class EndpointService {
       }
     }
     // If agent is not temporary and not the same version as the platform => Create an upgrade task
-    // for the agent
+    // for the agent if auto update is enabled (enabled by default)
     Endpoint endpoint = (Endpoint) agent.getAsset();
-    if (agent.getParent() == null && !agent.getVersion().equals(version)) {
+    if (agentAutoUpdateEnabled
+        && agent.getParent() == null
+        && !agent.getVersion().equals(version)) {
       if (assetAgentJobRepository
           .findUpgradeJobByAgentIdAndInjectNull(agent.getId(), agent.getTenant().getId())
           .isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -499,6 +499,16 @@ public class EndpointService {
         log.warn("Upgrade job already exists");
       }
     }
+
+    if (!agentAutoUpdateEnabled
+        && agent.getParent() == null
+        && !agent.getVersion().equals(version)) {
+      log.warn(
+          String.format(
+              "A new version for the agent %s is available, his current version is %s and the new version is %s",
+              agent.getAsset().getName(), agent.getVersion(), version));
+    }
+
     return endpoint;
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -471,38 +471,39 @@ public class EndpointService {
     // If agent is not temporary and not the same version as the platform => Create an upgrade task
     // for the agent if auto update is enabled (enabled by default)
     Endpoint endpoint = (Endpoint) agent.getAsset();
-    boolean newAgentVersionAvailable =
-        agent.getParent() == null && !agent.getVersion().equals(version);
-    if (agentAutoUpdateEnabled && newAgentVersionAvailable) {
-      if (assetAgentJobRepository
-          .findUpgradeJobByAgentIdAndInjectNull(agent.getId(), agent.getTenant().getId())
-          .isEmpty()) {
-        AssetAgentJob assetAgentJob = new AssetAgentJob();
-        assetAgentJob.setCommand(
-            generateUpgradeCommand(
-                endpoint.getPlatform().name(),
-                input.getInstallationMode(),
-                input.getInstallationDirectory(),
-                input.getServiceName(),
-                agent.getTenant().getId()));
-        assetAgentJob.setAgent(agent);
-        assetAgentJob.setTenant(agent.getTenant());
-        assetAgentJob.setCreatedAt(now());
-
-        try {
-          assetAgentJobRepository.save(assetAgentJob);
-        } catch (DataIntegrityViolationException e) {
-          // Concurrent registration already created the upgrade job — safe to ignore
-          log.warn("Upgrade job already exists for agent {} (concurrent insert)", agent.getId(), e);
-        }
+    if (agent.getParent() == null && !agent.getVersion().equals(version)) {
+      if (!agentAutoUpdateEnabled) {
+        log.warn(
+            String.format(
+                "A new version for the agent %s is available, his current version is %s and the new version is %s",
+                agent.getAsset().getName(), agent.getVersion(), version));
       } else {
-        log.warn("Upgrade job already exists");
+        if (assetAgentJobRepository
+            .findUpgradeJobByAgentIdAndInjectNull(agent.getId(), agent.getTenant().getId())
+            .isEmpty()) {
+          AssetAgentJob assetAgentJob = new AssetAgentJob();
+          assetAgentJob.setCommand(
+              generateUpgradeCommand(
+                  endpoint.getPlatform().name(),
+                  input.getInstallationMode(),
+                  input.getInstallationDirectory(),
+                  input.getServiceName(),
+                  agent.getTenant().getId()));
+          assetAgentJob.setAgent(agent);
+          assetAgentJob.setTenant(agent.getTenant());
+          assetAgentJob.setCreatedAt(now());
+
+          try {
+            assetAgentJobRepository.save(assetAgentJob);
+          } catch (DataIntegrityViolationException e) {
+            // Concurrent registration already created the upgrade job — safe to ignore
+            log.warn(
+                "Upgrade job already exists for agent {} (concurrent insert)", agent.getId(), e);
+          }
+        } else {
+          log.warn("Upgrade job already exists");
+        }
       }
-    } else if (!agentAutoUpdateEnabled && newAgentVersionAvailable) {
-      log.warn(
-          String.format(
-              "A new version for the agent %s is available, his current version is %s and the new version is %s",
-              agent.getAsset().getName(), agent.getVersion(), version));
     }
 
     return endpoint;

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -323,6 +323,7 @@ executor.openaev.binaries.version=@project.version@
 
 # Simultaneous jobs execution limitation for agents, to avoid overloading the system.
 executor.openaev.agent.max-simultaneous-jobs=5
+# When disabled, the server will not enqueue agent upgrade jobs (global kill switch).
 executor.openaev.agent.auto-update-enabled=true
 
 #############

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -323,6 +323,7 @@ executor.openaev.binaries.version=@project.version@
 
 # Simultaneous jobs execution limitation for agents, to avoid overloading the system.
 executor.openaev.agent.max-simultaneous-jobs=5
+executor.openaev.agent.auto-update-enabled=true
 
 #############
 # INJECTORS #

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceAutoUpdateDisabledIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceAutoUpdateDisabledIntegrationTest.java
@@ -1,0 +1,125 @@
+package io.openaev.service.endpoint;
+
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.rest.asset.endpoint.EndpointApi.ENDPOINT_URI;
+import static io.openaev.utils.fixtures.EndpointRegisterInputFixture.DEFAULT_ENDPOINT_AGENT_VERSION;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.AssetAgentJob;
+import io.openaev.database.repository.AssetAgentJobRepository;
+import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
+import io.openaev.service.account.ServiceAccountPrivilegeService;
+import io.openaev.utils.fixtures.EndpointRegisterInputFixture;
+import io.openaev.utils.fixtures.ExecutorFixture;
+import io.openaev.utils.fixtures.composers.ExecutorComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@TestPropertySource(properties = "executor.openaev.agent.auto-update-enabled=false")
+class EndpointServiceAutoUpdateDisabledIntegrationTest extends IntegrationTest {
+
+  private static final String MISMATCHED_AGENT_VERSION = "NOMATCH";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private EntityManager entityManager;
+  @Autowired private ObjectMapper mapper;
+  @Autowired private ExecutorComposer executorComposer;
+  @Autowired private ExecutorFixture executorFixture;
+  @Autowired private AssetAgentJobRepository assetAgentJobRepository;
+  @Autowired private ServiceAccountPrivilegeService serviceAccountPrivilegeService;
+
+  @BeforeEach
+  void setUp() {
+    executorComposer.reset();
+    ensureServiceAccount(TenantContext.getCurrentTenant());
+  }
+
+  private void ensureServiceAccount(String tenantId) {
+    serviceAccountPrivilegeService.ensurePrivilegedUserExists(tenantId);
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  @Nested
+  @WithMockUser(isAdmin = true)
+  @DisplayName("When auto-update is disabled")
+  class WhenAutoUpdateDisabled {
+
+    @Test
+    @DisplayName("Registering once with a mismatched version should not create an upgrade job")
+    void given_versionMismatch_when_registeringOnce_should_notCreateUpgradeJob() throws Exception {
+      executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+      EndpointRegisterInput input = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+      input.setAgentVersion(MISMATCHED_AGENT_VERSION);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      mvcRegister(input);
+
+      List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+      assertThat(jobs).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Registering twice with a mismatched version should not create any upgrade job")
+    void given_versionMismatch_when_registeringTwice_should_notCreateUpgradeJob() throws Exception {
+      executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+      EndpointRegisterInput input = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+      input.setAgentVersion(MISMATCHED_AGENT_VERSION);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      mvcRegister(input);
+      mvcRegister(input);
+
+      List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+      assertThat(jobs).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Registering with matching version should not create an upgrade job")
+    void given_versionMatch_when_registering_should_notCreateUpgradeJob() throws Exception {
+      executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+      EndpointRegisterInput input = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+      input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      mvcRegister(input);
+
+      List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+      assertThat(jobs).isEmpty();
+    }
+
+    private void mvcRegister(EndpointRegisterInput input) throws Exception {
+      mockMvc
+          .perform(
+              post(ENDPOINT_URI + "/register")
+                  .content(mapper.writeValueAsString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().isOk());
+    }
+  }
+}
+

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceAutoUpdateDisabledIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceAutoUpdateDisabledIntegrationTest.java
@@ -122,4 +122,3 @@ class EndpointServiceAutoUpdateDisabledIntegrationTest extends IntegrationTest {
     }
   }
 }
-

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.AssetAgentJob;
 import io.openaev.database.repository.AssetAgentJobRepository;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
+import io.openaev.service.EndpointService;
 import io.openaev.service.account.ServiceAccountPrivilegeService;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.EndpointRegisterInputFixture;
@@ -27,6 +28,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +43,7 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
   @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
   @Autowired private AssetAgentJobRepository assetAgentJobRepository;
   @Autowired private ServiceAccountPrivilegeService serviceAccountPrivilegeService;
+  @Autowired private EndpointService endpointService;
 
   @BeforeEach
   void setUp() {
@@ -67,8 +70,9 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
     @Nested
     @DisplayName("Upgrade jobs tests")
     class UpgradeJobsTests {
+
       @Nested
-      @DisplayName("When agent version does not match server version")
+      @DisplayName("When auto-update is enabled (default) and agent version does not match server version")
       class UpgradeAgentVersionDoesNotMatchServerVersion {
         private final String agentVersion = "NOMATCH";
 
@@ -263,7 +267,7 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
       }
 
       @Nested
-      @DisplayName("When agent version matches server version")
+      @DisplayName("When auto-update is enabled (default) and agent version matches server version")
       class UpgradeAgentVersionMatchesServerVersion {
         private final String agentVersion = DEFAULT_ENDPOINT_AGENT_VERSION;
 
@@ -319,6 +323,115 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
           List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
 
+          assertThat(jobs).isEmpty();
+        }
+      }
+
+      @Nested
+      @DisplayName("When auto-update is disabled")
+      class WhenAutoUpdateIsDisabled {
+
+        private static final String MISMATCHED_AGENT_VERSION = "NOMATCH";
+
+        @BeforeEach
+        void disableAutoUpdate() {
+          ReflectionTestUtils.setField(endpointService, "agentAutoUpdateEnabled", false);
+        }
+
+        @AfterEach
+        void restoreAutoUpdate() {
+          ReflectionTestUtils.setField(endpointService, "agentAutoUpdateEnabled", true);
+        }
+
+        @Test
+        @DisplayName(
+            "Registering once with a mismatched version should not create an upgrade job")
+        void given_versionMismatch_when_autoUpdateDisabled_should_notCreateUpgradeJob()
+            throws Exception {
+          // -- ARRANGE --
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(MISMATCHED_AGENT_VERSION);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          // -- ACT --
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          // -- ASSERT --
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+          assertThat(jobs).isEmpty();
+        }
+
+        @Test
+        @DisplayName(
+            "Registering twice with a mismatched version should not create any upgrade job")
+        void given_versionMismatchAndTwoRegistrations_when_autoUpdateDisabled_should_notCreateUpgradeJob()
+            throws Exception {
+          // -- ARRANGE --
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(MISMATCHED_AGENT_VERSION);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          // -- ACT --
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          // -- ASSERT --
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
+          assertThat(jobs).isEmpty();
+        }
+
+        @Test
+        @DisplayName(
+            "Registering with matching version and auto-update disabled should not create an upgrade job")
+        void given_versionMatch_when_autoUpdateDisabled_should_notCreateUpgradeJob()
+            throws Exception {
+          // -- ARRANGE --
+          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+          EndpointRegisterInput input =
+              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+          input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
+
+          entityManager.flush();
+          entityManager.clear();
+
+          // -- ACT --
+          mockMvc
+              .perform(
+                  post(ENDPOINT_URI + "/register")
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+
+          // -- ASSERT --
+          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
           assertThat(jobs).isEmpty();
         }
       }

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -72,7 +72,8 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
     class UpgradeJobsTests {
 
       @Nested
-      @DisplayName("When auto-update is enabled (default) and agent version does not match server version")
+      @DisplayName(
+          "When auto-update is enabled (default) and agent version does not match server version")
       class UpgradeAgentVersionDoesNotMatchServerVersion {
         private final String agentVersion = "NOMATCH";
 
@@ -333,19 +334,23 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
         private static final String MISMATCHED_AGENT_VERSION = "NOMATCH";
 
+        private boolean originalAgentAutoUpdateEnabled;
+
         @BeforeEach
         void disableAutoUpdate() {
+          originalAgentAutoUpdateEnabled =
+              (boolean) ReflectionTestUtils.getField(endpointService, "agentAutoUpdateEnabled");
           ReflectionTestUtils.setField(endpointService, "agentAutoUpdateEnabled", false);
         }
 
         @AfterEach
         void restoreAutoUpdate() {
-          ReflectionTestUtils.setField(endpointService, "agentAutoUpdateEnabled", true);
+          ReflectionTestUtils.setField(
+              endpointService, "agentAutoUpdateEnabled", originalAgentAutoUpdateEnabled);
         }
 
         @Test
-        @DisplayName(
-            "Registering once with a mismatched version should not create an upgrade job")
+        @DisplayName("Registering once with a mismatched version should not create an upgrade job")
         void given_versionMismatch_when_autoUpdateDisabled_should_notCreateUpgradeJob()
             throws Exception {
           // -- ARRANGE --
@@ -374,8 +379,9 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
         @Test
         @DisplayName(
             "Registering twice with a mismatched version should not create any upgrade job")
-        void given_versionMismatchAndTwoRegistrations_when_autoUpdateDisabled_should_notCreateUpgradeJob()
-            throws Exception {
+        void
+            given_versionMismatchAndTwoRegistrations_when_autoUpdateDisabled_should_notCreateUpgradeJob()
+                throws Exception {
           // -- ARRANGE --
           executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
           EndpointRegisterInput input =

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -14,7 +14,6 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.AssetAgentJob;
 import io.openaev.database.repository.AssetAgentJobRepository;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
-import io.openaev.service.EndpointService;
 import io.openaev.service.account.ServiceAccountPrivilegeService;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.EndpointRegisterInputFixture;
@@ -28,7 +27,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,7 +41,6 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
   @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
   @Autowired private AssetAgentJobRepository assetAgentJobRepository;
   @Autowired private ServiceAccountPrivilegeService serviceAccountPrivilegeService;
-  @Autowired private EndpointService endpointService;
 
   @BeforeEach
   void setUp() {
@@ -196,7 +193,6 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
               .satisfiesOnlyOnce(
                   job ->
                       assertThat(job.getTenant().getId()).isEqualTo(tenantWrapper.get().getId()));
-          ;
 
           tenantIsolationTestHelper.switchToTenant(tenantWrapper2.get().getId(), entityManager);
           List<AssetAgentJob> jobTenant2 = fromIterable(assetAgentJobRepository.findAll());
@@ -324,120 +320,6 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
           List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
 
-          assertThat(jobs).isEmpty();
-        }
-      }
-
-      @Nested
-      @DisplayName("When auto-update is disabled")
-      class WhenAutoUpdateIsDisabled {
-
-        private static final String MISMATCHED_AGENT_VERSION = "NOMATCH";
-
-        private boolean originalAgentAutoUpdateEnabled;
-
-        @BeforeEach
-        void disableAutoUpdate() {
-          originalAgentAutoUpdateEnabled =
-              (boolean) ReflectionTestUtils.getField(endpointService, "agentAutoUpdateEnabled");
-          ReflectionTestUtils.setField(endpointService, "agentAutoUpdateEnabled", false);
-        }
-
-        @AfterEach
-        void restoreAutoUpdate() {
-          ReflectionTestUtils.setField(
-              endpointService, "agentAutoUpdateEnabled", originalAgentAutoUpdateEnabled);
-        }
-
-        @Test
-        @DisplayName("Registering once with a mismatched version should not create an upgrade job")
-        void given_versionMismatch_when_autoUpdateDisabled_should_notCreateUpgradeJob()
-            throws Exception {
-          // -- ARRANGE --
-          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
-          EndpointRegisterInput input =
-              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
-          input.setAgentVersion(MISMATCHED_AGENT_VERSION);
-
-          entityManager.flush();
-          entityManager.clear();
-
-          // -- ACT --
-          mockMvc
-              .perform(
-                  post(ENDPOINT_URI + "/register")
-                      .content(mapper.writeValueAsString(input))
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .with(csrf()))
-              .andExpect(status().isOk());
-
-          // -- ASSERT --
-          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
-          assertThat(jobs).isEmpty();
-        }
-
-        @Test
-        @DisplayName(
-            "Registering twice with a mismatched version should not create any upgrade job")
-        void
-            given_versionMismatchAndTwoRegistrations_when_autoUpdateDisabled_should_notCreateUpgradeJob()
-                throws Exception {
-          // -- ARRANGE --
-          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
-          EndpointRegisterInput input =
-              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
-          input.setAgentVersion(MISMATCHED_AGENT_VERSION);
-
-          entityManager.flush();
-          entityManager.clear();
-
-          // -- ACT --
-          mockMvc
-              .perform(
-                  post(ENDPOINT_URI + "/register")
-                      .content(mapper.writeValueAsString(input))
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .with(csrf()))
-              .andExpect(status().isOk());
-
-          mockMvc
-              .perform(
-                  post(ENDPOINT_URI + "/register")
-                      .content(mapper.writeValueAsString(input))
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .with(csrf()))
-              .andExpect(status().isOk());
-
-          // -- ASSERT --
-          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
-          assertThat(jobs).isEmpty();
-        }
-
-        @Test
-        @DisplayName(
-            "Registering with matching version and auto-update disabled should not create an upgrade job")
-        void given_versionMatch_when_autoUpdateDisabled_should_notCreateUpgradeJob()
-            throws Exception {
-          // -- ARRANGE --
-          executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
-          EndpointRegisterInput input =
-              EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
-          input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
-
-          entityManager.flush();
-          entityManager.clear();
-
-          // -- ACT --
-          mockMvc
-              .perform(
-                  post(ENDPOINT_URI + "/register")
-                      .content(mapper.writeValueAsString(input))
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .with(csrf()))
-              .andExpect(status().isOk());
-
-          // -- ASSERT --
-          List<AssetAgentJob> jobs = fromIterable(assetAgentJobRepository.findAll());
           assertThat(jobs).isEmpty();
         }
       }


### PR DESCRIPTION
### Proposed changes

* Auto update process for agent should be activated or disabled by configuration.

### Testing Instructions

1. Set the `executor.openaev.agent.auto-update-enabled` configuration to false.
2. Modify your OpenAEV version from `info.app.version` to make it mismatch with your agent version.
3. Start OpenAEV, no any update command should be sent to the agent.

### Related issues

* Closes #6017 
