### PR TITLE
feat(audit-log): adding more user fields to be redacted (#6032)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -88,7 +88,6 @@ public class AccessControlAuditLogAspect {
             String eventStatus = LogUtils.getEventStatus(EventStatus.ERROR);
             JsonNode errorNode = buildErrorNode(null, ex);
 
-            // TODO AUDIT: Move this to enum just like in the issue/5483
             logAccessControlEvent(joinPoint, accessControl, eventScope, eventStatus, errorNode);
           } else if (isActionActive) {
             String eventScope = LogUtils.getEventScope(action);

--- a/openaev-api/src/main/java/io/openaev/service/LogService.java
+++ b/openaev-api/src/main/java/io/openaev/service/LogService.java
@@ -152,7 +152,7 @@ public class LogService {
       if ("status_change".equals(eventScope)) {
         message = LogUtils.buildStatusChangeMessage(input, entityTypeName, displayName);
       } else {
-        message = eventScope + "s " + entityTypeName + " `" + displayName + "`";
+        message = LogUtils.buildRequestLogMessage(eventScope, entityTypeName, displayName);
       }
 
       String eventType = LogUtils.getEventType(EventType.MUTATION);

--- a/openaev-api/src/main/java/io/openaev/utils/log/LogUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/log/LogUtils.java
@@ -7,6 +7,7 @@ import io.openaev.database.model.EventStatus;
 import io.openaev.database.model.EventType;
 import io.openaev.database.model.ResourceType;
 import io.openaev.rest.log.form.LogDetailsInput;
+import io.openaev.utils.object.ObjectRedactionUtils;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.logging.Level;
@@ -103,26 +104,30 @@ public class LogUtils {
    */
   public static String buildStatusChangeMessage(
       JsonNode input, String entityTypeName, String displayName) {
+    String dn = displayName != null && !displayName.isBlank() ? " `" + displayName + "`" : "";
+
     if (input == null) {
-      return "changes status of " + entityTypeName + " `" + displayName + "`";
+      return "changes status of " + entityTypeName + dn;
     }
     if (input.has("exercise_status")) {
       String newStatus = input.get("exercise_status").asText().toLowerCase();
-      return "changes status of "
-          + entityTypeName
-          + " `"
-          + displayName
-          + "` to `"
-          + newStatus
-          + "`";
+      return "changes status of " + entityTypeName + dn + " to `" + newStatus + "`";
     }
     if (input.has("action") && "launch".equals(input.get("action").asText())) {
-      return "launches " + entityTypeName + " `" + displayName + "`";
+      return "launches " + entityTypeName + dn;
     }
     if (input.has("scenario_recurrence")) {
-      return "updates recurrence of " + entityTypeName + " `" + displayName + "`";
+      return "updates recurrence of " + entityTypeName + dn;
     }
-    return "changes status of " + entityTypeName + " `" + displayName + "`";
+    return "changes status of " + entityTypeName + dn;
+  }
+
+  public static String buildRequestLogMessage(
+      String eventScope, String entityTypeName, String displayName) {
+    return eventScope
+        + "s "
+        + entityTypeName
+        + (displayName != null && !displayName.isBlank() ? " `" + displayName + "`" : "");
   }
 
   public static String buildAuthLogMessage(String eventScope, String eventStatus, String provider) {
@@ -210,7 +215,7 @@ public class LogUtils {
         }) {
       JsonNode node = snapshot.get(field);
       if (node != null && node.isTextual()) {
-        return node.asText();
+        return (String) ObjectRedactionUtils.redactFieldValue(node.asText(), field);
       }
     }
     return null;

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
@@ -29,7 +29,17 @@ public class ObjectRedactionUtils {
       Set.of(Pattern.compile(".*_date"), Pattern.compile(".*_time"), Pattern.compile(".*_at"));
 
   /** Fields redacted only when the entity type is User (PII protection). */
-  private static final Set<String> USER_PII_FIELDS = Set.of("name", "user_email");
+  private static final Set<String> USER_PII_FIELDS =
+      Set.of(
+          "name",
+          "user_firstname",
+          "user_lastname",
+          "user_email",
+          "user_phone",
+          "user_phone2",
+          "user_pgp_key",
+          "user_password",
+          "communications_users");
 
   private static final Set<ResourceType> USER_ENTITY_TYPES =
       Set.of(ResourceType.USER, ResourceType.PLATFORM_USER);

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
@@ -45,7 +45,7 @@ public class ObjectRedactionUtils {
   private static final Set<String> USER_PII_FIELDS_TO_HIDE = Set.of("user_pgp_key");
 
   private static final Set<ResourceType> USER_ENTITY_TYPES =
-      Set.of(ResourceType.USER, ResourceType.PLATFORM_USER);
+      Set.of(ResourceType.USER, ResourceType.PLATFORM_USER, ResourceType.PLAYER);
 
   /**
    * Redacts sensitive field values in a JSON tree. Operates on a deep copy — the original is never

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
@@ -41,6 +41,9 @@ public class ObjectRedactionUtils {
           "user_password",
           "communications_users");
 
+  /** Fields to hide only when the entity type is User (PII protection). */
+  private static final Set<String> USER_PII_FIELDS_TO_HIDE = Set.of("user_pgp_key");
+
   private static final Set<ResourceType> USER_ENTITY_TYPES =
       Set.of(ResourceType.USER, ResourceType.PLATFORM_USER);
 
@@ -74,10 +77,10 @@ public class ObjectRedactionUtils {
                             && !matchesAnyRegex(fieldName, ALLOWED_SENSITIVE_FIELDS_REGEX))
                         || (isUserEntity && USER_PII_FIELDS.contains(fieldName));
 
-                if (redact) {
-                  result.put(key, REDACTED);
-                } else {
+                if (!redact) {
                   result.set(key, redactNode(entry.getValue(), isUserEntity));
+                } else if (!isUserEntity || !USER_PII_FIELDS_TO_HIDE.contains(fieldName)) {
+                  result.put(key, REDACTED);
                 }
               });
       return result;

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectRedactionUtils.java
@@ -1,5 +1,7 @@
 package io.openaev.utils.object;
 
+import static io.openaev.helper.CryptoHelper.hashWithSHA256;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -15,21 +17,30 @@ public class ObjectRedactionUtils {
   private static final String REDACTED = "*** Redacted ***";
 
   /** Fields whose values are replaced with {@link #REDACTED} before logging. */
-  private static final Set<Pattern> SENSITIVE_FIELDS_REGEX =
+  private static final Set<Pattern> SENSITIVE_FIELDS_REGEX_TO_REDACT =
       Set.of(
           Pattern.compile(".*password.*"),
-          Pattern.compile(".*token.*"),
           Pattern.compile(".*secret.*"),
-          Pattern.compile(".*apikey.*"),
-          Pattern.compile(".*api_key.*"),
           Pattern.compile(".*credential.*"));
 
   /** Sensitive-like fields that are explicitly allowed and therefore not redacted. */
-  private static final Set<Pattern> ALLOWED_SENSITIVE_FIELDS_REGEX =
+  private static final Set<Pattern> ALLOWED_SENSITIVE_FIELDS_REGEX_TO_REDACT =
       Set.of(Pattern.compile(".*_date"), Pattern.compile(".*_time"), Pattern.compile(".*_at"));
 
-  /** Fields redacted only when the entity type is User (PII protection). */
-  private static final Set<String> USER_PII_FIELDS =
+  /** Fields whose values are replaced with Hash before logging. */
+  private static final Set<Pattern> SENSITIVE_FIELDS_REGEX_TO_HASH =
+      Set.of(
+          Pattern.compile(".*token.*"),
+          Pattern.compile(".*apikey.*"),
+          Pattern.compile(".*api_key.*"),
+          Pattern.compile("^user_pgp_key$"));
+
+  /** Sensitive-like fields that are explicitly allowed and therefore not Hashed. */
+  private static final Set<Pattern> ALLOWED_SENSITIVE_FIELDS_REGEX_TO_HASH =
+      ALLOWED_SENSITIVE_FIELDS_REGEX_TO_REDACT;
+
+  /** Fields to remove only when the entity type is USER_ENTITY_TYPES (PII protection). */
+  private static final Set<String> USER_PII_FIELDS_TO_REMOVE =
       Set.of(
           "name",
           "user_firstname",
@@ -37,12 +48,11 @@ public class ObjectRedactionUtils {
           "user_email",
           "user_phone",
           "user_phone2",
-          "user_pgp_key",
           "user_password",
-          "communications_users");
-
-  /** Fields to hide only when the entity type is User (PII protection). */
-  private static final Set<String> USER_PII_FIELDS_TO_HIDE = Set.of("user_pgp_key");
+          "communications_users",
+          "user_lang",
+          "user_country",
+          "user_city");
 
   private static final Set<ResourceType> USER_ENTITY_TYPES =
       Set.of(ResourceType.USER, ResourceType.PLATFORM_USER, ResourceType.PLAYER);
@@ -59,46 +69,100 @@ public class ObjectRedactionUtils {
     return redactNode(node, isUserEntity);
   }
 
+  public static Object redactFieldValue(Object value, String fieldName) {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof String stringValue && !stringValue.isBlank()) {
+      fieldName = fieldName.toLowerCase(Locale.ROOT);
+
+      if (USER_PII_FIELDS_TO_REMOVE.contains(fieldName)) {
+        return null;
+      }
+
+      if (shouldHash(fieldName)) {
+        return hashWithSHA256(stringValue);
+      }
+
+      if (shouldRedact(fieldName)) {
+        return REDACTED;
+      }
+    }
+    return value;
+  }
+
   private static JsonNode redactNode(JsonNode node, boolean isUserEntity) {
     if (node == null || node.isNull()) {
       return node;
     }
 
     if (node instanceof ObjectNode original) {
-      ObjectNode result = original.objectNode();
-      original
-          .properties()
-          .forEach(
-              entry -> {
-                String key = entry.getKey();
-                String fieldName = key.toLowerCase(Locale.ROOT);
-                boolean redact =
-                    (matchesAnyRegex(fieldName, SENSITIVE_FIELDS_REGEX)
-                            && !matchesAnyRegex(fieldName, ALLOWED_SENSITIVE_FIELDS_REGEX))
-                        || (isUserEntity && USER_PII_FIELDS.contains(fieldName));
-
-                if (!redact) {
-                  result.set(key, redactNode(entry.getValue(), isUserEntity));
-                } else if (!isUserEntity || !USER_PII_FIELDS_TO_HIDE.contains(fieldName)) {
-                  result.put(key, REDACTED);
-                }
-              });
-      return result;
+      return redactObjectNode(original, isUserEntity);
     }
 
     if (node instanceof ArrayNode original) {
-      ArrayNode result = original.arrayNode();
-      for (JsonNode element : original) {
-        result.add(redactNode(element, isUserEntity));
-      }
-      return result;
+      return redactArrayNode(original, isUserEntity);
     }
 
     // Scalar nodes are immutable; returning as-is preserves value and avoids unnecessary copies.
     return node;
   }
 
+  private static ObjectNode redactObjectNode(ObjectNode original, boolean isUserEntity) {
+    ObjectNode result = original.objectNode();
+    original
+        .properties()
+        .forEach(entry -> redactProperty(result, entry.getKey(), entry.getValue(), isUserEntity));
+    return result;
+  }
+
+  private static ArrayNode redactArrayNode(ArrayNode original, boolean isUserEntity) {
+    ArrayNode result = original.arrayNode();
+    for (JsonNode element : original) {
+      result.add(redactNode(element, isUserEntity));
+    }
+    return result;
+  }
+
+  private static void redactProperty(
+      ObjectNode result, String key, JsonNode value, boolean isUserEntity) {
+    String fieldName = key.toLowerCase(Locale.ROOT);
+    if (isUserEntity && USER_PII_FIELDS_TO_REMOVE.contains(fieldName)) {
+      return;
+    }
+
+    if (shouldHash(fieldName)) {
+      result.put(key, hashWithSHA256(toHashInput(value)));
+      return;
+    }
+
+    if (shouldRedact(fieldName)) {
+      result.put(key, REDACTED);
+      return;
+    }
+
+    result.set(key, redactNode(value, isUserEntity));
+  }
+
+  private static boolean shouldHash(String fieldName) {
+    return matchesAnyRegex(fieldName, SENSITIVE_FIELDS_REGEX_TO_HASH)
+        && !matchesAnyRegex(fieldName, ALLOWED_SENSITIVE_FIELDS_REGEX_TO_HASH);
+  }
+
+  private static boolean shouldRedact(String fieldName) {
+    return matchesAnyRegex(fieldName, SENSITIVE_FIELDS_REGEX_TO_REDACT)
+        && !matchesAnyRegex(fieldName, ALLOWED_SENSITIVE_FIELDS_REGEX_TO_REDACT);
+  }
+
   private static boolean matchesAnyRegex(String value, Set<Pattern> patterns) {
     return patterns.stream().anyMatch(pattern -> pattern.matcher(value).matches());
+  }
+
+  private static String toHashInput(JsonNode value) {
+    if (value == null || value.isNull()) {
+      return "";
+    }
+    return value.isTextual() ? value.textValue() : value.toString();
   }
 }


### PR DESCRIPTION
As a platform administrator, I want to the user PIIS to be either hashed or redacted so that I can comply with data minimisation requirements (GDPR, internal PII policies).

### Proposed changes

* Adding more fields to ObjectRedactionUtils.java file

### Testing Instructions

1. Change some user fields and check if in the console logs the sensitive fields were redacted.

### Related issues

* #6032 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

Instead of redacting this fields, we should just remove (not include) them in the logs. This way, we avoid adding unnecessary dummy data and prevent overloading the logs.
