### PR TITLE
docs: align copyright year and unify contact email to contact@filigran.io (#6040)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at contact@openaev.io. All
+reported by contacting the project team at contact@filigran.io. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2023 Filigran SAS
+Copyright (c) 2021-2026 Filigran SAS
 
 -----------------------------------------------------------------
 
@@ -350,7 +350,7 @@ Examples of License Headers in File
 
 OpenAEV Community Edition License
 -----------------------------------------------------------------
-Copyright (c) 2021-2024 Filigran SAS
+Copyright (c) 2021-2026 Filigran SAS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -367,7 +367,7 @@ limitations under the License.
 
 OpenAEV Enterprise Edition License
 -----------------------------------------------------------------
-Copyright (c) 2021-2024 Filigran SAS
+Copyright (c) 2021-2026 Filigran SAS
 
 This file is part of the OpenAEV Enterprise Edition ("EE") and is
 licensed under the OpenAEV Enterprise Edition License (the "License");

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Only the current stable major release (ie. X.X) is supported for update and bug fixes (as of October 2023, 3.2.X). Any previous versions are currently not supported and users are advised to use them "at their own risk".
+Only the current stable major release (ie. X.X) is supported for update and bug fixes. Any previous versions are currently not supported and users are advised to use them "at their own risk".
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Aligns the open-source meta files with the other Filigran platforms (OpenCTI, XTM One):

- **`LICENSE`** — bump the copyright year to `2021-2026`.
- **`CODE_OF_CONDUCT.md`** — unify the contact email to `contact@filigran.io` (instead of `contact@openaev.io`).
- **`SECURITY.md`** — remove the stale `(as of October 2023, 3.2.X)` reference so the supported-versions statement stays accurate over time.

No functional or code changes.

## Test plan

- [ ] Files render correctly on GitHub.
- [ ] No remaining `contact@openaev.io` references in the policy files.

Closes #6040
