### PR TITLE
feat(chaining): added safety policy telemetry (#5969)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -12,6 +12,7 @@ import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.PreviewFeatureService;
+import io.openaev.telemetry.metric_collectors.ChainingSafetyPolicyMetricCollector;
 import io.openaev.telemetry.metric_collectors.ScopeMetricCollector;
 import io.openaev.utils.IpAddressUtils;
 import jakarta.validation.constraints.NotBlank;
@@ -43,6 +44,7 @@ public class WorkflowService {
   private final ScopeVariableRepository scopeVariableRepository;
 
   private final ScopeMetricCollector scopeMetricCollector;
+  private final ChainingSafetyPolicyMetricCollector chainingSafetyPolicyMetricCollector;
 
   // -- READ --
 
@@ -458,25 +460,33 @@ public class WorkflowService {
    */
   private boolean applyConfigurationInput(WorkflowConfigurationInput input, Workflow workflow) {
     boolean changed = false;
+    boolean rateLimitChanged = false;
+    boolean timeoutChanged = false;
+
     if (workflow.isRateLimitEnabled() != input.isRateLimitEnabled()) {
       workflow.setRateLimitEnabled(input.isRateLimitEnabled());
       changed = true;
+      rateLimitChanged = true;
     }
     if (!Objects.equals(workflow.getMaxAttempts(), input.getMaxAttempts())) {
       workflow.setMaxAttempts(input.getMaxAttempts());
       changed = true;
+      rateLimitChanged = true;
     }
     if (!Objects.equals(workflow.getMaxTemporalRateSeconds(), input.getMaxTemporalRateSeconds())) {
       workflow.setMaxTemporalRateSeconds(input.getMaxTemporalRateSeconds());
       changed = true;
+      rateLimitChanged = true;
     }
     if (workflow.isTimeoutEnabled() != input.isTimeoutEnabled()) {
       workflow.setTimeoutEnabled(input.isTimeoutEnabled());
       changed = true;
+      timeoutChanged = true;
     }
     if (!Objects.equals(workflow.getTimeoutSeconds(), input.getTimeoutSeconds())) {
       workflow.setTimeoutSeconds(input.getTimeoutSeconds());
       changed = true;
+      timeoutChanged = true;
     }
     if (workflow.isSafeModeEnabled() != input.isSafeModeEnabled()) {
       workflow.setSafeModeEnabled(input.isSafeModeEnabled());
@@ -484,6 +494,20 @@ public class WorkflowService {
     }
     boolean rulesChanged = applyScopeRules(input.getWorkflowScopeRules(), workflow);
     boolean variablesChanged = applyScopeVariables(input.getWorkflowScopeVariables(), workflow);
+
+    if (timeoutChanged) {
+      long timeoutSec = input.getTimeoutSeconds() != null ? input.getTimeoutSeconds() : 0L;
+      chainingSafetyPolicyMetricCollector.recordTimeoutConfigured(
+          timeoutSec / 3600, (timeoutSec % 3600) / 60, timeoutSec == DEFAULT_TIMEOUT_SECONDS);
+    }
+    if (rateLimitChanged) {
+      int attempts = input.getMaxAttempts() != null ? input.getMaxAttempts() : 0;
+      long seconds =
+          input.getMaxTemporalRateSeconds() != null ? input.getMaxTemporalRateSeconds() : 0L;
+      chainingSafetyPolicyMetricCollector.recordRateLimitConfigured(
+          attempts, seconds, !input.isRateLimitEnabled());
+    }
+
     return rulesChanged || variablesChanged || changed;
   }
 

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/ChainingSafetyPolicyMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/ChainingSafetyPolicyMetricCollector.java
@@ -1,0 +1,89 @@
+package io.openaev.telemetry.metric_collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+
+import io.opentelemetry.api.common.Attributes;
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Collects metrics related to safety policy configuration changes (timeout and rate limit).
+ *
+ * <p>Each metric is a multi-dimensional gauge keyed by the configured values and an {@code
+ * is_default} flag. Metrics are delta-based: they report the number of changes per collection
+ * interval, not cumulative totals.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChainingSafetyPolicyMetricCollector {
+  private final MetricRegistry metricRegistry;
+
+  private final Map<Attributes, AtomicLong> timeoutStats = new ConcurrentHashMap<>();
+  private final Map<Attributes, AtomicLong> rateLimitStats = new ConcurrentHashMap<>();
+
+  @PostConstruct
+  public void init() {
+    metricRegistry.registerMultiGauge(
+        "safety_timeout_configured",
+        "Number of times the workflow timeout safety policy was configured during the collection interval",
+        () -> collectAndReset(timeoutStats));
+    metricRegistry.registerMultiGauge(
+        "safety_ratelimit_configured",
+        "Number of times the workflow rate limit safety policy was configured during the collection interval",
+        () -> collectAndReset(rateLimitStats));
+  }
+
+  /**
+   * Records a timeout configuration change with the configured values as dimensions.
+   *
+   * @param valueHours the configured timeout value in whole hours
+   * @param valueMinutes the configured timeout value in whole minutes
+   * @param isDefault whether the configured value matches the platform default
+   */
+  public void recordTimeoutConfigured(long valueHours, long valueMinutes, boolean isDefault) {
+    Attributes attrs =
+        Attributes.of(
+            longKey("value_hours"), valueHours,
+            longKey("value_minutes"), valueMinutes,
+            booleanKey("is_default"), isDefault);
+    timeoutStats.computeIfAbsent(attrs, k -> new AtomicLong(0)).incrementAndGet();
+    log.info("Increment Safety Timeout Configured Counter");
+  }
+
+  /**
+   * Records a rate-limit configuration change with the configured values as dimensions.
+   *
+   * @param maxAttempts the configured maximum number of attempts
+   * @param seconds the configured temporal rate in seconds
+   * @param isDefault whether rate limiting is disabled (i.e. the platform default)
+   */
+  public void recordRateLimitConfigured(long maxAttempts, long seconds, boolean isDefault) {
+    Attributes attrs =
+        Attributes.of(
+            longKey("max_attempts"), maxAttempts,
+            longKey("seconds"), seconds,
+            booleanKey("is_default"), isDefault);
+    rateLimitStats.computeIfAbsent(attrs, k -> new AtomicLong(0)).incrementAndGet();
+    log.info("Increment Safety Rate Limit Configured Counter");
+  }
+
+  private Map<Attributes, Long> collectAndReset(Map<Attributes, AtomicLong> stats) {
+    Map<Attributes, Long> snap = new HashMap<>();
+    stats.forEach(
+        (k, v) -> {
+          long val = v.getAndSet(0);
+          if (val > 0) {
+            snap.put(k, val);
+          }
+        });
+    return snap;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/config/NoOpOpenTelemetryConfig.java
+++ b/openaev-api/src/test/java/io/openaev/config/NoOpOpenTelemetryConfig.java
@@ -6,6 +6,7 @@ import io.openaev.service.AgentService;
 import io.openaev.telemetry.OpenTelemetryConfig;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.telemetry.metric_collectors.AgentMetricCollector;
+import io.openaev.telemetry.metric_collectors.ChainingSafetyPolicyMetricCollector;
 import io.openaev.telemetry.metric_collectors.MetricRegistry;
 import io.openaev.telemetry.metric_collectors.ScopeMetricCollector;
 import io.opentelemetry.api.OpenTelemetry;
@@ -40,6 +41,12 @@ public class NoOpOpenTelemetryConfig {
   @Bean
   public ScopeMetricCollector scopeMetricCollector(MetricRegistry metricRegistry) {
     return Mockito.mock(ScopeMetricCollector.class);
+  }
+
+  @Bean
+  public ChainingSafetyPolicyMetricCollector chainingSafetyPolicyMetricCollector(
+      MetricRegistry metricRegistry) {
+    return Mockito.mock(ChainingSafetyPolicyMetricCollector.class);
   }
 
   @Bean

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -12,6 +12,7 @@ import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.PreviewFeatureService;
+import io.openaev.telemetry.metric_collectors.ChainingSafetyPolicyMetricCollector;
 import io.openaev.telemetry.metric_collectors.ScopeMetricCollector;
 import io.openaev.utils.fixtures.WorkflowFixture;
 import java.util.Collections;
@@ -45,6 +46,7 @@ class WorkflowServiceTest {
   @Mock private StepDelayQueueService stepDelayQueueService;
   @Mock private WorkflowStateService workflowStateService;
   @Mock private ScopeMetricCollector scopeMetricCollector;
+  @Mock private ChainingSafetyPolicyMetricCollector chainingSafetyPolicyMetricCollector;
 
   @InjectMocks private WorkflowService workflowService;
 
@@ -734,7 +736,8 @@ class WorkflowServiceTest {
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
-              scopeMetricCollector);
+              scopeMetricCollector,
+              chainingSafetyPolicyMetricCollector);
     }
 
     private Workflow buildTemplate() {
@@ -947,7 +950,8 @@ class WorkflowServiceTest {
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
-              scopeMetricCollector);
+              scopeMetricCollector,
+              chainingSafetyPolicyMetricCollector);
     }
 
     private Workflow buildTemplate() {
@@ -1102,6 +1106,133 @@ class WorkflowServiceTest {
 
       // Assert
       verifyNoInteractions(scopeMetricCollector);
+    }
+  }
+
+  // ========================================================================
+  // Safety Policy Metrics Tests
+  // ========================================================================
+  @Nested
+  @DisplayName("updateWorkflowConfiguration – safety policy metrics")
+  class SafetyPolicyMetrics {
+
+    private WorkflowService service;
+
+    @BeforeEach
+    void setUp() {
+      service =
+          new WorkflowService(
+              stepService,
+              previewFeatureService,
+              workflowStateService,
+              stepDelayQueueService,
+              workflowRepository,
+              workflowScopeRuleRepository,
+              scopeVariableRepository,
+              scopeMetricCollector,
+              chainingSafetyPolicyMetricCollector);
+    }
+
+    private Workflow buildTemplate() {
+      String workflowId = UUID.randomUUID().toString();
+      Workflow workflow =
+          Workflow.builder()
+              .id(workflowId)
+              .status(WorkflowStatus.TEMPLATE)
+              .version(0)
+              .timeoutEnabled(false)
+              .timeoutSeconds(WorkflowService.DEFAULT_TIMEOUT_SECONDS)
+              .rateLimitEnabled(false)
+              .build();
+      when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
+          .thenReturn(Optional.of(workflow));
+      lenient()
+          .when(workflowRepository.save(any(Workflow.class)))
+          .thenAnswer(i -> i.getArgument(0));
+      return workflow;
+    }
+
+    @Test
+    @DisplayName("should emit timeout metric when timeout fields changed")
+    void shouldEmitTimeoutMetric_whenTimeoutFieldsChanged() {
+      // Arrange
+      Workflow workflow = buildTemplate();
+      WorkflowConfigurationInput input =
+          WorkflowConfigurationInput.builder().timeoutEnabled(true).timeoutSeconds(3600L).build();
+
+      // Act
+      service.updateWorkflowConfiguration(workflow.getId(), input);
+
+      // Assert
+      verify(chainingSafetyPolicyMetricCollector).recordTimeoutConfigured(1L, 0L, true);
+      verify(chainingSafetyPolicyMetricCollector, never())
+          .recordRateLimitConfigured(anyLong(), anyLong(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("should emit rate limit metric when rate limit fields changed")
+    void shouldEmitRateLimitMetric_whenRateLimitFieldsChanged() {
+      // Arrange
+      Workflow workflow = buildTemplate();
+      WorkflowConfigurationInput input =
+          WorkflowConfigurationInput.builder()
+              .rateLimitEnabled(true)
+              .maxAttempts(5)
+              .maxTemporalRateSeconds(60L)
+              .timeoutSeconds(WorkflowService.DEFAULT_TIMEOUT_SECONDS)
+              .build();
+
+      // Act
+      service.updateWorkflowConfiguration(workflow.getId(), input);
+
+      // Assert
+      verify(chainingSafetyPolicyMetricCollector).recordRateLimitConfigured(5L, 60L, false);
+      verify(chainingSafetyPolicyMetricCollector, never())
+          .recordTimeoutConfigured(anyLong(), anyLong(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("should emit both metrics when both groups changed")
+    void shouldEmitBothMetrics_whenBothGroupsChanged() {
+      // Arrange
+      Workflow workflow = buildTemplate();
+      WorkflowConfigurationInput input =
+          WorkflowConfigurationInput.builder()
+              .timeoutEnabled(true)
+              .timeoutSeconds(7200L)
+              .rateLimitEnabled(true)
+              .maxAttempts(5)
+              .maxTemporalRateSeconds(60L)
+              .build();
+
+      // Act
+      service.updateWorkflowConfiguration(workflow.getId(), input);
+
+      // Assert
+      verify(chainingSafetyPolicyMetricCollector).recordTimeoutConfigured(2L, 0L, false);
+      verify(chainingSafetyPolicyMetricCollector).recordRateLimitConfigured(5L, 60L, false);
+    }
+
+    @Test
+    @DisplayName("should emit no metric when no fields changed")
+    void shouldEmitNoMetric_whenNoFieldsChanged() {
+      // Arrange
+      Workflow workflow = buildTemplate();
+      WorkflowConfigurationInput input =
+          WorkflowConfigurationInput.builder()
+              .timeoutEnabled(false)
+              .timeoutSeconds(WorkflowService.DEFAULT_TIMEOUT_SECONDS)
+              .rateLimitEnabled(false)
+              .build();
+
+      // Act
+      service.updateWorkflowConfiguration(workflow.getId(), input);
+
+      // Assert
+      verify(chainingSafetyPolicyMetricCollector, never())
+          .recordTimeoutConfigured(anyLong(), anyLong(), anyBoolean());
+      verify(chainingSafetyPolicyMetricCollector, never())
+          .recordRateLimitConfigured(anyLong(), anyLong(), anyBoolean());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/ChainingSafetyPolicyMetricCollectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/ChainingSafetyPolicyMetricCollectorTest.java
@@ -1,0 +1,138 @@
+package io.openaev.telemetry.metric_collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.opentelemetry.api.common.Attributes;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChainingSafetyPolicyMetricCollector Tests")
+class ChainingSafetyPolicyMetricCollectorTest {
+
+  @Mock private MetricRegistry metricRegistry;
+
+  @InjectMocks private ChainingSafetyPolicyMetricCollector collector;
+
+  @Captor private ArgumentCaptor<Supplier<Map<Attributes, Long>>> supplierCaptor;
+
+  @Nested
+  @DisplayName("RecordTimeoutConfigured")
+  class RecordTimeoutConfigured {
+
+    @Test
+    @DisplayName(
+        "should register multi-gauge with value_hours, value_minutes, is_default dimensions")
+    void shouldIncrementCounter_whenRecordTimeoutConfiguredCalled() {
+      // Arrange — record three timeout configurations (1h default, i.e. 1h 0min)
+      collector.recordTimeoutConfigured(1L, 0L, true);
+      collector.recordTimeoutConfigured(1L, 0L, true);
+      collector.recordTimeoutConfigured(1L, 0L, true);
+
+      // Act
+      collector.init();
+
+      // Assert
+      verify(metricRegistry)
+          .registerMultiGauge(eq("safety_timeout_configured"), any(), supplierCaptor.capture());
+      Map<Attributes, Long> snapshot = supplierCaptor.getValue().get();
+      assertThat(snapshot).hasSize(1);
+
+      Attributes expectedAttrs =
+          Attributes.of(
+              longKey("value_hours"), 1L,
+              longKey("value_minutes"), 0L,
+              booleanKey("is_default"), true);
+      assertThat(snapshot).containsEntry(expectedAttrs, 3L);
+
+      // Second collection should return empty (reset)
+      Map<Attributes, Long> second = supplierCaptor.getValue().get();
+      assertThat(second).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should separate default and custom timeout values into distinct dimension sets")
+    void shouldSeparateDefaultAndCustomTimeoutValues() {
+      // Arrange — 1h 0min (default) vs 2h 0min (custom)
+      collector.recordTimeoutConfigured(1L, 0L, true);
+      collector.recordTimeoutConfigured(2L, 0L, false);
+
+      // Act
+      collector.init();
+
+      // Assert
+      verify(metricRegistry)
+          .registerMultiGauge(eq("safety_timeout_configured"), any(), supplierCaptor.capture());
+      Map<Attributes, Long> snapshot = supplierCaptor.getValue().get();
+      assertThat(snapshot).hasSize(2);
+      assertThat(snapshot.values()).containsExactlyInAnyOrder(1L, 1L);
+    }
+  }
+
+  @Nested
+  @DisplayName("RecordRateLimitConfigured")
+  class RecordRateLimitConfigured {
+
+    @Test
+    @DisplayName("should register multi-gauge with max_attempts, seconds, is_default dimensions")
+    void shouldIncrementCounter_whenRecordRateLimitConfiguredCalled() {
+      // Arrange
+      collector.recordRateLimitConfigured(5L, 60L, false);
+      collector.recordRateLimitConfigured(5L, 60L, false);
+
+      // Act
+      collector.init();
+
+      // Assert
+      verify(metricRegistry)
+          .registerMultiGauge(eq("safety_ratelimit_configured"), any(), supplierCaptor.capture());
+      Map<Attributes, Long> snapshot = supplierCaptor.getValue().get();
+      assertThat(snapshot).hasSize(1);
+
+      Attributes expectedAttrs =
+          Attributes.of(
+              longKey("max_attempts"), 5L,
+              longKey("seconds"), 60L,
+              booleanKey("is_default"), false);
+      assertThat(snapshot).containsEntry(expectedAttrs, 2L);
+
+      // Second collection should return empty (reset)
+      Map<Attributes, Long> second = supplierCaptor.getValue().get();
+      assertThat(second).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("NoEmissionWhenNoChange")
+  class NoEmissionWhenNoChange {
+
+    @Test
+    @DisplayName("should return empty snapshots when no record method called")
+    void shouldNotIncrementAnyCounter_whenNoMethodCalled() {
+      // Arrange
+      collector.init();
+
+      // Assert — timeout gauge
+      verify(metricRegistry)
+          .registerMultiGauge(eq("safety_timeout_configured"), any(), supplierCaptor.capture());
+      assertThat(supplierCaptor.getValue().get()).isEmpty();
+
+      // Assert — ratelimit gauge
+      verify(metricRegistry)
+          .registerMultiGauge(eq("safety_ratelimit_configured"), any(), supplierCaptor.capture());
+      assertThat(supplierCaptor.getValue().get()).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
### Proposed changes

* Added telemetry for chaining simulations' telemetry modifications

### Testing Instructions

1. Create or update a simulation's timeout and rate limit. 
2. Enable, disable, change time.
3. For each, you should see an adequat telemetry

### Related issues

* Closes #5969 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
