### PR TITLE
feat(audit-log): populate session_id and prevent unexpected expired (#6079)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
@@ -19,6 +19,7 @@ import io.openaev.service.user_events.UserEventService;
 import io.openaev.utils.log.LogUtils;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -129,6 +130,13 @@ public class AppSecurityConfig {
                     // invalidates the session and clears cookies
                     .addLogoutHandler(
                         (request, response, authentication) -> {
+                          // Mark session as explicitly logged out BEFORE invalidation,
+                          // so sessionDestroyed does not emit a spurious session_expired event.
+                          HttpSession session = request.getSession(false);
+                          if (session != null) {
+                            session.setAttribute(SessionManager.EXPLICIT_LOGOUT, Boolean.TRUE);
+                          }
+
                           auditLogger.ifPresent(
                               logger -> {
                                 ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder

--- a/openaev-api/src/main/java/io/openaev/config/ThreadPoolTaskLoggerConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/ThreadPoolTaskLoggerConfig.java
@@ -104,24 +104,23 @@ public class ThreadPoolTaskLoggerConfig {
 
   public static ThreadRequestContextHolder.RequestContextData buildThreadRequestContextHolder(
       HttpServletRequest request, Authentication authentication) {
-    // GET REQUEST HEADERS AND IP, REQUEST URI and BODY (PARENT THREAD)
     Map<String, String> headers;
-    String remoteAddress, method, url;
+    String remoteAddress, method, url, sessionId;
 
     if (request != null) {
       headers = HttpReqRespUtils.extractHeaders(request);
       remoteAddress = request.getRemoteAddr();
       method = request.getMethod();
-
       url = request.getRequestURL().toString();
+      var session = request.getSession(false);
+      sessionId = session != null ? session.getId() : null;
     } else {
       headers = null;
-      remoteAddress = method = url = null;
+      remoteAddress = method = url = sessionId = null;
     }
 
-    // STORE HEADERS AND REMOTE ADDRESS
     return new ThreadRequestContextHolder.RequestContextData(
-        headers, remoteAddress, method, url, authentication);
+        headers, remoteAddress, method, url, sessionId, authentication);
   }
 
   public static class ThreadRequestContextHolder {
@@ -131,6 +130,7 @@ public class ThreadPoolTaskLoggerConfig {
         String remoteAddress,
         String method,
         String url,
+        String sessionId,
         Authentication authentication) {}
 
     private static final ThreadLocal<Map<String, Object>> CONTEXT = new ThreadLocal<>();

--- a/openaev-api/src/main/java/io/openaev/service/LogService.java
+++ b/openaev-api/src/main/java/io/openaev/service/LogService.java
@@ -358,13 +358,13 @@ public class LogService {
     // HTTP request headers
     HttpServletRequest request = HttpReqRespUtils.getCurrentRequest();
 
-    // Session ID for correlation
-    if (request != null) {
-      var session = request.getSession(false);
-      if (session != null) {
-        meta.setSessionId(session.getId());
-        hasData = true;
-      }
+    // Session ID for correlation — always comes from RequestContextData captured on servlet thread,
+    // since populateUserMetadata runs on the async taskLoggerExecutor thread.
+    ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData rcd =
+        ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.getRequestContextData();
+    if (rcd != null && rcd.sessionId() != null) {
+      meta.setSessionId(rcd.sessionId());
+      hasData = true;
     }
 
     Map<String, String> headers = HttpReqRespUtils.extractHeaders(request);

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerTest.java
@@ -1,0 +1,305 @@
+package io.openaev.aop.audit_log;
+
+import static io.openaev.rest.team.TeamApi.TEAM_URI;
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.FileAppender;
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Capability;
+import io.openaev.database.model.Team;
+import io.openaev.database.model.User;
+import io.openaev.database.repository.TeamRepository;
+import io.openaev.database.repository.UserRepository;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.rest.settings.PreviewFeature;
+import io.openaev.rest.team.form.TeamUpdateInput;
+import io.openaev.rest.user.form.login.LoginUserInput;
+import io.openaev.service.PreviewFeatureService;
+import io.openaev.utils.fixtures.TeamFixture;
+import io.openaev.utils.fixtures.UserFixture;
+import io.openaev.utils.fixtures.composers.UserComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(PER_CLASS)
+@Transactional
+@TestPropertySource(
+    properties = {
+      "openaev.audit-logs.transports=file",
+      "openaev.audit-logs.halt-on-failure=false",
+      "AUDIT_LOG_DIR=target/test-audit-logger"
+    })
+class AuditLoggerTest extends IntegrationTest {
+
+  static {
+    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-logger");
+  }
+
+  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-logger/audit.log");
+  private static final String TEST_APPENDER_NAME = "AUDIT_LOG_TEST_APPENDER";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private UserRepository userRepository;
+  @Autowired private UserComposer userComposer;
+  @Autowired private TeamRepository teamRepository;
+  @Autowired private AuditLogger auditLogger;
+
+  @MockitoBean private EnterpriseEditionService enterpriseEditionService;
+  @MockitoBean private PreviewFeatureService previewFeatureService;
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("openaev.audit-logs.transports", () -> "file");
+    registry.add("openaev.audit-logs.halt-on-failure", () -> "false");
+  }
+
+  @BeforeAll
+  void setupAuditFileAppender() throws Exception {
+    Files.createDirectories(AUDIT_LOG_FILE.getParent());
+    Files.deleteIfExists(AUDIT_LOG_FILE);
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
+
+    if (auditLogger.getAppender(TEST_APPENDER_NAME) == null) {
+      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+      encoder.setContext(context);
+      encoder.setPattern("%msg%n");
+      encoder.start();
+
+      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
+      appender.setName(TEST_APPENDER_NAME);
+      appender.setContext(context);
+      appender.setFile(AUDIT_LOG_FILE.toString());
+      appender.setAppend(true);
+      appender.setEncoder(encoder);
+      appender.start();
+
+      auditLogger.addAppender(appender);
+      auditLogger.setAdditive(false);
+    }
+  }
+
+  @AfterAll
+  void teardownAuditFileAppender() {
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
+    if (auditLogger.getAppender(TEST_APPENDER_NAME) != null) {
+      auditLogger.detachAppender(TEST_APPENDER_NAME);
+    }
+  }
+
+  @BeforeEach
+  void enableAuditFeatureFlags() {
+    Mockito.when(enterpriseEditionService.isLicenseActive(Mockito.any())).thenReturn(true);
+    Mockito.when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+    assertThat(auditLogger.isAuditLoggingEnabled()).isTrue();
+  }
+
+  @Nested
+  @DisplayName("Login endpoint")
+  class LoginEndpoint {
+
+    @Test
+    @DisplayName("Given login request should create audit file and log login event")
+    void given_loginRequest_should_createAuditFileAndLogLoginEvent() throws Exception {
+      // Arrange
+      ensureLoginUserExists();
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+      LoginUserInput loginUserInput = UserFixture.getLoginUserInput();
+
+      // Act
+      mvc.perform(
+              post("/api/login")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(loginUserInput))
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      // Assert
+      assertAuditLogContainsNewContent(
+          sizeBefore,
+          "\"event_scope\" : \"login\"",
+          "\"message\" : \"login from provider `local`\"");
+    }
+  }
+
+  @Nested
+  @DisplayName("Logout endpoint")
+  class LogoutEndpoint {
+
+    @Test
+    @WithMockUser(isAdmin = true)
+    @DisplayName("Given security logout request should append logout audit event")
+    void given_securityLogoutRequest_should_appendLogoutAuditEvent() throws Exception {
+      // Arrange
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      mvc.perform(post("/logout").accept(MediaType.APPLICATION_JSON).with(csrf()))
+          .andExpect(status().is3xxRedirection());
+
+      // Assert
+      assertAuditLogContainsNewContent(
+          sizeBefore, "\"event_scope\" : \"logout\"", "\"message\" : \"logout\"");
+    }
+
+    @Test
+    @WithMockUser(isAdmin = true)
+    @DisplayName(
+        "Given explicit logout should log logout event and not produce spurious session_expired")
+    void given_explicitLogout_should_logLogoutEvent_and_not_logSessionExpired() throws Exception {
+      // Arrange
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      mvc.perform(post("/logout").accept(MediaType.APPLICATION_JSON).with(csrf()))
+          .andExpect(status().is3xxRedirection());
+
+      // Assert — logout trace must be present (proves the event was emitted)
+      assertAuditLogContainsNewContent(
+          sizeBefore, "\"event_scope\" : \"logout\"", "\"message\" : \"logout\"");
+
+      // Assert — no spurious session_expired must appear alongside the logout
+      assertAuditLogDoesNotContainNewContent(sizeBefore, "session_expired");
+    }
+  }
+
+  @Nested
+  @DisplayName("Update endpoint")
+  class UpdateEndpoint {
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_TEAMS_AND_PLAYERS})
+    @DisplayName("Given team update should append mutation update audit event")
+    void given_teamUpdate_should_appendMutationUpdateAuditEvent() throws Exception {
+      // Arrange
+      Team team = teamRepository.saveAndFlush(TeamFixture.getDefaultTeam());
+      TeamUpdateInput updateInput = new TeamUpdateInput();
+      String updatedName = "AuditLoggerTest-" + UUID.randomUUID();
+      updateInput.setName(updatedName);
+      updateInput.setDescription("Updated by audit logger test");
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      mvc.perform(
+              put(TEAM_URI + "/{teamId}", team.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(updateInput))
+                  .with(csrf()))
+          .andExpect(status().isOk());
+
+      // Assert
+      assertAuditLogContainsNewContent(
+          sizeBefore,
+          "\"event_scope\" : \"update\"",
+          "\"event_type\" : \"mutation\"",
+          "\"entity_type\" : \"Team\"");
+    }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_TEAMS_AND_PLAYERS})
+    @DisplayName("Given authenticated request should populate session_id in audit log")
+    void given_authenticatedRequest_should_populateSessionIdInAuditLog() throws Exception {
+      // Arrange
+      Team team = teamRepository.saveAndFlush(TeamFixture.getDefaultTeam());
+      TeamUpdateInput updateInput = new TeamUpdateInput();
+      updateInput.setName("SessionIdTest-" + UUID.randomUUID());
+      updateInput.setDescription("Session ID verification test");
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      mvc.perform(
+              put(TEAM_URI + "/{teamId}", team.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(updateInput))
+                  .with(csrf()))
+          .andExpect(status().isOk());
+
+      // Assert — session_id must be present and non-null in the emitted trace
+      assertAuditLogContainsNewContent(sizeBefore, "\"session_id\" :");
+    }
+  }
+
+  private void ensureLoginUserExists() {
+    User user =
+        userRepository
+            .findByEmailIgnoreCase(UserFixture.EMAIL)
+            .orElseGet(
+                () -> {
+                  User created = UserFixture.getUser("Test", "User", UserFixture.EMAIL);
+                  created.setPassword(UserFixture.ENCODED_PASSWORD);
+                  return userComposer.forUser(created).persist().get();
+                });
+
+    // Keep a valid known password in case another test changed it.
+    user.setPassword(UserFixture.ENCODED_PASSWORD);
+    userRepository.saveAndFlush(user);
+  }
+
+  private void assertAuditLogContainsNewContent(long sizeBefore, String... expectedSnippets) {
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertThat(Files.exists(AUDIT_LOG_FILE)).isTrue();
+              long sizeAfter = Files.size(AUDIT_LOG_FILE);
+              assertThat(sizeAfter).isGreaterThan(sizeBefore);
+
+              String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
+              String newContent =
+                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+
+              for (String expectedSnippet : expectedSnippets) {
+                assertThat(newContent).contains(expectedSnippet);
+              }
+            });
+  }
+
+  /**
+   * Asserts that no new content matching {@code unexpectedSnippet} was written to the audit log
+   * after position {@code sizeBefore}. Called after {@link #assertAuditLogContainsNewContent} has
+   * already confirmed that the expected event was flushed, so any spurious sibling event would
+   * already be present at this point.
+   */
+  private void assertAuditLogDoesNotContainNewContent(long sizeBefore, String unexpectedSnippet)
+      throws Exception {
+    if (!Files.exists(AUDIT_LOG_FILE)) {
+      return;
+    }
+    String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
+    String newContent = fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+    assertThat(newContent).doesNotContain(unexpectedSnippet);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerUnitTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerUnitTest.java
@@ -1,0 +1,171 @@
+package io.openaev.aop.audit_log;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.ResourceType;
+import io.openaev.service.LogService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuditLogger unit tests")
+class AuditLoggerUnitTest {
+
+  @Mock private LogService logService;
+
+  @Spy @InjectMocks private AuditLogger auditLogger;
+
+  @BeforeEach
+  void setUp() {
+    // Never actually call System.exit in tests
+    lenient().doNothing().when(auditLogger).prepareLogFailure();
+    doReturn(true).when(logService).isEnabled();
+  }
+
+  @Nested
+  @DisplayName("logAuthEvent - prepareLogFailure")
+  class LogAuthEventFailure {
+
+    @Test
+    @DisplayName("given_logServiceThrows_should_triggerPrepareLogFailure")
+    void given_logServiceThrows_should_triggerPrepareLogFailure() {
+      // Arrange
+      when(logService.logAuthEvent(
+              "login", "error", "local", null, java.util.logging.Level.WARNING, "log-1"))
+          .thenThrow(new RuntimeException("transport failure"));
+
+      // Act
+      auditLogger.logAuthEvent("login", "error", "local", null, "log-1").join();
+
+      // Assert
+      verify(auditLogger).prepareLogFailure();
+    }
+
+    @Test
+    @DisplayName("given_logServiceReturnsFalse_should_triggerPrepareLogFailure")
+    void given_logServiceReturnsFalse_should_triggerPrepareLogFailure() {
+      // Arrange
+      when(logService.logAuthEvent(
+              "login", "error", "local", null, java.util.logging.Level.WARNING, "log-2"))
+          .thenReturn(false);
+
+      // Act
+      auditLogger.logAuthEvent("login", "error", "local", null, "log-2").join();
+
+      // Assert
+      verify(auditLogger).prepareLogFailure();
+    }
+
+    @Test
+    @DisplayName("given_logServiceReturnsTrue_should_notTriggerPrepareLogFailure")
+    void given_logServiceReturnsTrue_should_notTriggerPrepareLogFailure() {
+      // Arrange
+      when(logService.logAuthEvent(
+              "login", "success", "local", null, java.util.logging.Level.WARNING, "log-3"))
+          .thenReturn(true);
+
+      // Act
+      auditLogger.logAuthEvent("login", "success", "local", null, "log-3").join();
+
+      // Assert
+      verify(auditLogger, never()).prepareLogFailure();
+    }
+  }
+
+  @Nested
+  @DisplayName("logAccessControlEvent - prepareLogFailure")
+  class LogAccessControlEventFailure {
+
+    @Test
+    @DisplayName("given_logServiceThrows_should_triggerPrepareLogFailure")
+    void given_logServiceThrows_should_triggerPrepareLogFailure() {
+      // Arrange
+      when(logService.logRequestEvent(
+              "update",
+              "error",
+              ResourceType.TEAM,
+              "team-1",
+              null,
+              null,
+              null,
+              null,
+              java.util.logging.Level.WARNING,
+              "log-4"))
+          .thenThrow(new RuntimeException("transport failure"));
+
+      // Act
+      auditLogger
+          .logAccessControlEvent(
+              "update", "error", ResourceType.TEAM, "team-1", null, null, null, null, "log-4")
+          .join();
+
+      // Assert
+      verify(auditLogger).prepareLogFailure();
+    }
+
+    @Test
+    @DisplayName("given_logServiceReturnsFalse_should_triggerPrepareLogFailure")
+    void given_logServiceReturnsFalse_should_triggerPrepareLogFailure() {
+      // Arrange
+      when(logService.logRequestEvent(
+              "update",
+              "error",
+              ResourceType.TEAM,
+              "team-2",
+              null,
+              null,
+              null,
+              null,
+              java.util.logging.Level.WARNING,
+              "log-5"))
+          .thenReturn(false);
+
+      // Act
+      auditLogger
+          .logAccessControlEvent(
+              "update", "error", ResourceType.TEAM, "team-2", null, null, null, null, "log-5")
+          .join();
+
+      // Assert
+      verify(auditLogger).prepareLogFailure();
+    }
+
+    @Test
+    @DisplayName("given_logServiceReturnsTrue_should_notTriggerPrepareLogFailure")
+    void given_logServiceReturnsTrue_should_notTriggerPrepareLogFailure() {
+      // Arrange
+      when(logService.logRequestEvent(
+              "update",
+              "success",
+              ResourceType.TEAM,
+              "team-3",
+              null,
+              null,
+              null,
+              null,
+              java.util.logging.Level.WARNING,
+              "log-6"))
+          .thenReturn(true);
+
+      // Act
+      auditLogger
+          .logAccessControlEvent(
+              "update", "success", ResourceType.TEAM, "team-3", null, null, null, null, "log-6")
+          .join();
+
+      // Assert
+      verify(auditLogger, never()).prepareLogFailure();
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.config.AuditLogProperties;
+import io.openaev.config.ThreadPoolTaskLoggerConfig;
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.database.model.ResourceType;
 import io.openaev.ee.EnterpriseEditionService;
@@ -200,6 +201,64 @@ class LogServiceTest {
       // -- VERIFY --
       assertFalse(result);
       verify(auditLogTransportDispatcherUtils).dispatch(any(LogEvent.class), any());
+    }
+  }
+
+  @Nested
+  @DisplayName("logAuthEvent")
+  class LogAuthEvent {
+
+    @Test
+    @DisplayName("given_activeSession_should_populateSessionIdInUserMetadata")
+    void given_activeSession_should_populateSessionIdInUserMetadata() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any())).thenReturn(true);
+
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.setRequestContextData(
+          new ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData(
+              null, null, "GET", "/api/logout", "session-xyz", null));
+
+      // -- EXECUTE --
+      boolean result;
+      try {
+        result = logService.logAuthEvent("logout", "success", "local", null, null, null);
+      } finally {
+        ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.clear();
+      }
+
+      // -- VERIFY --
+      assertTrue(result);
+
+      ArgumentCaptor<LogEvent> captor = ArgumentCaptor.forClass(LogEvent.class);
+      verify(auditLogTransportDispatcherUtils).dispatch(captor.capture(), any());
+      LogEvent event = captor.getValue();
+      assertNotNull(event.getUserMetadata());
+      assertEquals("session-xyz", event.getUserMetadata().getSessionId());
+    }
+
+    @Test
+    @DisplayName("given_noActiveSession_should_notSetSessionIdInUserMetadata")
+    void given_noActiveSession_should_notSetSessionIdInUserMetadata() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any())).thenReturn(true);
+
+      // No ThreadRequestContextHolder set — simulates no active HTTP session
+
+      // -- EXECUTE --
+      boolean result = logService.logAuthEvent("logout", "success", "local", null, null, null);
+
+      // -- VERIFY --
+      assertTrue(result);
+
+      ArgumentCaptor<LogEvent> captor = ArgumentCaptor.forClass(LogEvent.class);
+      verify(auditLogTransportDispatcherUtils).dispatch(captor.capture(), any());
+      LogEvent event = captor.getValue();
+      // UserMetadata may be null or sessionId must be null — no session to correlate
+      if (event.getUserMetadata() != null) {
+        assertNull(event.getUserMetadata().getSessionId());
+      }
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
@@ -209,20 +209,20 @@ class LogServiceTest {
   class LogAuthEvent {
 
     @Test
-    @DisplayName("given_activeSession_should_populateSessionIdInUserMetadata")
-    void given_activeSession_should_populateSessionIdInUserMetadata() {
+    @DisplayName("given_loginRequestContext_should_populateSessionIdInUserMetadata")
+    void given_loginRequestContext_should_populateSessionIdInUserMetadata() {
       // -- PREPARE --
       when(previewFeatureService.isFeatureEnabled(any())).thenReturn(true);
       when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any())).thenReturn(true);
 
       ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.setRequestContextData(
           new ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData(
-              null, null, "GET", "/api/logout", "session-xyz", null));
+              null, null, "POST", "/api/login", "session-xyz", null));
 
       // -- EXECUTE --
       boolean result;
       try {
-        result = logService.logAuthEvent("logout", "success", "local", null, null, null);
+        result = logService.logAuthEvent("login", "success", "local", null, null, null);
       } finally {
         ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.clear();
       }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Correctly populate session_id
* Prevent unexpected expired session when explicit logout

### Testing Instructions

1. Logout
2. Check there are no session expired message and that the session_id is populated

### Related issues

* Closes #6079 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

