### PR TITLE
test(audit_log): backend e2e testing for document CRUD (#5496)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLogTestHelper.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLogTestHelper.java
@@ -1,0 +1,118 @@
+package io.openaev.aop.audit_log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.FileAppender;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared test utilities for audit-log integration tests.
+ *
+ * <p>Provides helpers for wiring a Logback {@link FileAppender} to the {@code AUDIT_LOG} logger and
+ * asserting on log file content, so individual test classes avoid duplicating this boilerplate.
+ */
+public final class AuditLogTestHelper {
+
+  private AuditLogTestHelper() {}
+
+  /**
+   * Registers a {@link FileAppender} on the {@code AUDIT_LOG} logger that writes to {@code
+   * logFile}. Idempotent: no-op if an appender with {@code appenderName} already exists.
+   *
+   * <p>Call from {@code @BeforeAll}.
+   */
+  public static void setupFileAppender(Path logFile, String appenderName) throws Exception {
+    Files.createDirectories(logFile.getParent());
+    Files.deleteIfExists(logFile);
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
+
+    if (auditLog.getAppender(appenderName) == null) {
+      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+      encoder.setContext(context);
+      encoder.setPattern("%msg%n");
+      encoder.start();
+
+      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
+      appender.setName(appenderName);
+      appender.setContext(context);
+      appender.setFile(logFile.toString());
+      appender.setAppend(true);
+      appender.setEncoder(encoder);
+      appender.start();
+
+      auditLog.addAppender(appender);
+      auditLog.setAdditive(false);
+    }
+  }
+
+  /**
+   * Stops and detaches the named appender from the {@code AUDIT_LOG} logger.
+   *
+   * <p>Call from {@code @AfterAll}.
+   */
+  public static void teardownFileAppender(String appenderName) {
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
+    var appender = auditLog.getAppender(appenderName);
+    if (appender != null) {
+      appender.stop();
+      auditLog.detachAppender(appenderName);
+    }
+  }
+
+  /**
+   * Asserts that new content was appended to {@code logFile} after {@code sizeBefore} and that it
+   * contains every {@code expectedSnippets}. Waits up to 10 seconds for async flush.
+   *
+   * @return the new content appended after {@code sizeBefore}
+   */
+  public static String assertAuditLogContainsNewContent(
+      Path logFile, long sizeBefore, String... expectedSnippets) {
+    final String[] captured = new String[1];
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertThat(logFile).exists();
+              long sizeAfter = Files.size(logFile);
+              assertThat(sizeAfter).isGreaterThan(sizeBefore);
+
+              String fullContent = Files.readString(logFile, StandardCharsets.UTF_8);
+              String newContent =
+                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+
+              for (String expectedSnippet : expectedSnippets) {
+                assertThat(newContent).contains(expectedSnippet);
+              }
+              captured[0] = newContent;
+            });
+
+    return captured[0];
+  }
+
+  /**
+   * Asserts that no new content matching {@code unexpectedSnippet} was written to {@code logFile}
+   * after {@code sizeBefore}. Should be called after {@link #assertAuditLogContainsNewContent} has
+   * already confirmed the expected event was flushed, so any spurious sibling event is already
+   * present.
+   */
+  public static void assertAuditLogDoesNotContainNewContent(
+      Path logFile, long sizeBefore, String unexpectedSnippet) throws Exception {
+    if (!Files.exists(logFile)) {
+      return;
+    }
+    String fullContent = Files.readString(logFile, StandardCharsets.UTF_8);
+    String newContent = fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+    assertThat(newContent).doesNotContain(unexpectedSnippet);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
@@ -1,5 +1,7 @@
 package io.openaev.aop.audit_log;
 
+import static io.openaev.aop.audit_log.AuditLogTestHelper.setupFileAppender;
+import static io.openaev.aop.audit_log.AuditLogTestHelper.teardownFileAppender;
 import static io.openaev.rest.document.DocumentApi.DOCUMENT_API;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,9 +12,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.core.FileAppender;
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.Capability;
@@ -28,8 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,13 +35,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockPart;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -56,13 +50,9 @@ import org.springframework.transaction.annotation.Transactional;
     properties = {
       "openaev.audit-logs.transports=file",
       "openaev.audit-logs.halt-on-failure=false",
-      "AUDIT_LOG_DIR=target/test-audit-logger"
+      "AUDIT_LOG_DIR=target/test-audit-log-doc"
     })
 class AuditLoggerDocumentTest extends IntegrationTest {
-
-  static {
-    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-log-doc");
-  }
 
   private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-log-doc/audit.log");
   private static final String TEST_APPENDER_NAME = "AUDIT_LOG_DOCUMENT_E2E_TEST_APPENDER";
@@ -73,48 +63,14 @@ class AuditLoggerDocumentTest extends IntegrationTest {
   @MockitoBean private EnterpriseEditionService enterpriseEditionService;
   @MockitoBean private PreviewFeatureService previewFeatureService;
 
-  @DynamicPropertySource
-  static void registerProperties(DynamicPropertyRegistry registry) {
-    registry.add("openaev.audit-logs.transports", () -> "file");
-    registry.add("openaev.audit-logs.halt-on-failure", () -> "false");
-  }
-
   @BeforeAll
   void setupAuditFileAppender() throws Exception {
-    Files.createDirectories(AUDIT_LOG_FILE.getParent());
-    Files.deleteIfExists(AUDIT_LOG_FILE);
-
-    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
-
-    if (auditLog.getAppender(TEST_APPENDER_NAME) == null) {
-      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
-      encoder.setContext(context);
-      encoder.setPattern("%msg%n");
-      encoder.start();
-
-      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
-      appender.setName(TEST_APPENDER_NAME);
-      appender.setContext(context);
-      appender.setFile(AUDIT_LOG_FILE.toString());
-      appender.setAppend(true);
-      appender.setEncoder(encoder);
-      appender.start();
-
-      auditLog.addAppender(appender);
-      auditLog.setAdditive(false);
-    }
+    setupFileAppender(AUDIT_LOG_FILE, TEST_APPENDER_NAME);
   }
 
   @AfterAll
   void teardownAuditFileAppender() {
-    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
-    var appender = auditLog.getAppender(TEST_APPENDER_NAME);
-    if (appender != null) {
-      appender.stop();
-      auditLog.detachAppender(TEST_APPENDER_NAME);
-    }
+    teardownFileAppender(TEST_APPENDER_NAME);
   }
 
   @BeforeEach
@@ -285,26 +241,7 @@ class AuditLoggerDocumentTest extends IntegrationTest {
   }
 
   private String assertAuditLogContainsNewContent(long sizeBefore, String... expectedSnippets) {
-    final String[] captured = new String[1];
-
-    Awaitility.await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              assertThat(Files.exists(AUDIT_LOG_FILE)).isTrue();
-              long sizeAfter = Files.size(AUDIT_LOG_FILE);
-              assertThat(sizeAfter).isGreaterThan(sizeBefore);
-
-              String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
-              String newContent =
-                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
-
-              for (String expectedSnippet : expectedSnippets) {
-                assertThat(newContent).contains(expectedSnippet);
-              }
-              captured[0] = newContent;
-            });
-
-    return captured[0];
+    return AuditLogTestHelper.assertAuditLogContainsNewContent(
+        AUDIT_LOG_FILE, sizeBefore, expectedSnippets);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
@@ -110,7 +110,9 @@ class AuditLoggerDocumentTest extends IntegrationTest {
   void teardownAuditFileAppender() {
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
     ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
-    if (auditLog.getAppender(TEST_APPENDER_NAME) != null) {
+    var appender = auditLog.getAppender(TEST_APPENDER_NAME);
+    if (appender != null) {
+      appender.stop();
       auditLog.detachAppender(TEST_APPENDER_NAME);
     }
   }

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
@@ -61,7 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 class AuditLoggerDocumentTest extends IntegrationTest {
 
   static {
-    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-logger");
+    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-log-doc");
   }
 
   private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-log-doc/audit.log");

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
@@ -92,7 +92,7 @@ class AuditLoggerDocumentTest extends IntegrationTest {
 
     @Test
     @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS})
-    void given_newDocumentUpload_should_logUpdateScopeForCurrentContract() throws Exception {
+    void given_newDocumentUpload_should_logUpdateScope() throws Exception {
       // Arrange
       String fileName = "audit-create-" + UUID.randomUUID() + ".txt";
       String content = "create-content-" + UUID.randomUUID();
@@ -114,7 +114,7 @@ class AuditLoggerDocumentTest extends IntegrationTest {
 
     @Test
     @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS})
-    void given_documentMetadataUpdate_should_logChangedInputField() throws Exception {
+    void given_documentMetadataUpdate_should_notLogChangedInputField() throws Exception {
       // Arrange
       String fileName = "audit-update-" + UUID.randomUUID() + ".txt";
       String oldDescription = "Initial description";
@@ -147,15 +147,15 @@ class AuditLoggerDocumentTest extends IntegrationTest {
               "\"url\" : \"http://localhost/api/documents/" + documentId + "\"",
               "\"input\" : {",
               "\"document_description\" : \"" + newDescription + "\"");
-      assertThat(newContent).doesNotContain("\"old_value\"");
-      assertThat(newContent).doesNotContain("\"new_value\"");
-      assertThat(newContent).contains("\"message\" : \"updates Document `" + documentId + "`\"");
+      assertThat(newContent)
+          .doesNotContain("\"old_value\"")
+          .doesNotContain("\"new_value\"")
+          .contains("\"message\" : \"updates Document `" + documentId + "`\"");
     }
 
     @Test
     @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS, Capability.DELETE_DOCUMENTS})
-    void given_documentDeletion_should_logEntityTypeAndDocumentIdInMessageForCurrentContract()
-        throws Exception {
+    void given_documentDeletion_should_logEntityTypeAndDocumentIdInMessage() throws Exception {
       // Arrange
       String fileName = "audit-delete-" + UUID.randomUUID() + ".txt";
       String uploadResponse =
@@ -179,7 +179,7 @@ class AuditLoggerDocumentTest extends IntegrationTest {
 
     @Test
     @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS})
-    void given_noOpDocumentUpdate_should_stillLogUpdateEventForCurrentContract() throws Exception {
+    void given_noOpDocumentUpdate_should_stillLogUpdateEvent() throws Exception {
       // Arrange
       String fileName = "audit-noop-" + UUID.randomUUID() + ".txt";
       String description = "No-op description";

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerDocumentTest.java
@@ -58,7 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
       "openaev.audit-logs.halt-on-failure=false",
       "AUDIT_LOG_DIR=target/test-audit-logger"
     })
-class DocumentAuditLogE2eTest extends IntegrationTest {
+class AuditLoggerDocumentTest extends IntegrationTest {
 
   static {
     System.setProperty("AUDIT_LOG_DIR", "target/test-audit-logger");

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerTest.java
@@ -1,5 +1,7 @@
 package io.openaev.aop.audit_log;
 
+import static io.openaev.aop.audit_log.AuditLogTestHelper.setupFileAppender;
+import static io.openaev.aop.audit_log.AuditLogTestHelper.teardownFileAppender;
 import static io.openaev.rest.team.TeamApi.TEAM_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,9 +11,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.core.FileAppender;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.Team;
@@ -27,13 +26,10 @@ import io.openaev.utils.fixtures.TeamFixture;
 import io.openaev.utils.fixtures.UserFixture;
 import io.openaev.utils.fixtures.composers.UserComposer;
 import io.openaev.utils.mockUser.WithMockUser;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,11 +38,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -62,10 +55,6 @@ import org.springframework.transaction.annotation.Transactional;
     })
 class AuditLoggerTest extends IntegrationTest {
 
-  static {
-    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-logger");
-  }
-
   private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-logger/audit.log");
   private static final String TEST_APPENDER_NAME = "AUDIT_LOG_TEST_APPENDER";
 
@@ -78,46 +67,14 @@ class AuditLoggerTest extends IntegrationTest {
   @MockitoBean private EnterpriseEditionService enterpriseEditionService;
   @MockitoBean private PreviewFeatureService previewFeatureService;
 
-  @DynamicPropertySource
-  static void registerProperties(DynamicPropertyRegistry registry) {
-    registry.add("openaev.audit-logs.transports", () -> "file");
-    registry.add("openaev.audit-logs.halt-on-failure", () -> "false");
-  }
-
   @BeforeAll
   void setupAuditFileAppender() throws Exception {
-    Files.createDirectories(AUDIT_LOG_FILE.getParent());
-    Files.deleteIfExists(AUDIT_LOG_FILE);
-
-    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
-
-    if (auditLogger.getAppender(TEST_APPENDER_NAME) == null) {
-      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
-      encoder.setContext(context);
-      encoder.setPattern("%msg%n");
-      encoder.start();
-
-      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
-      appender.setName(TEST_APPENDER_NAME);
-      appender.setContext(context);
-      appender.setFile(AUDIT_LOG_FILE.toString());
-      appender.setAppend(true);
-      appender.setEncoder(encoder);
-      appender.start();
-
-      auditLogger.addAppender(appender);
-      auditLogger.setAdditive(false);
-    }
+    setupFileAppender(AUDIT_LOG_FILE, TEST_APPENDER_NAME);
   }
 
   @AfterAll
   void teardownAuditFileAppender() {
-    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
-    if (auditLogger.getAppender(TEST_APPENDER_NAME) != null) {
-      auditLogger.detachAppender(TEST_APPENDER_NAME);
-    }
+    teardownFileAppender(TEST_APPENDER_NAME);
   }
 
   @BeforeEach
@@ -269,22 +226,8 @@ class AuditLoggerTest extends IntegrationTest {
   }
 
   private void assertAuditLogContainsNewContent(long sizeBefore, String... expectedSnippets) {
-    Awaitility.await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              assertThat(Files.exists(AUDIT_LOG_FILE)).isTrue();
-              long sizeAfter = Files.size(AUDIT_LOG_FILE);
-              assertThat(sizeAfter).isGreaterThan(sizeBefore);
-
-              String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
-              String newContent =
-                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
-
-              for (String expectedSnippet : expectedSnippets) {
-                assertThat(newContent).contains(expectedSnippet);
-              }
-            });
+    AuditLogTestHelper.assertAuditLogContainsNewContent(
+        AUDIT_LOG_FILE, sizeBefore, expectedSnippets);
   }
 
   /**
@@ -295,11 +238,7 @@ class AuditLoggerTest extends IntegrationTest {
    */
   private void assertAuditLogDoesNotContainNewContent(long sizeBefore, String unexpectedSnippet)
       throws Exception {
-    if (!Files.exists(AUDIT_LOG_FILE)) {
-      return;
-    }
-    String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
-    String newContent = fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
-    assertThat(newContent).doesNotContain(unexpectedSnippet);
+    AuditLogTestHelper.assertAuditLogDoesNotContainNewContent(
+        AUDIT_LOG_FILE, sizeBefore, unexpectedSnippet);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/DocumentAuditLogE2eTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/DocumentAuditLogE2eTest.java
@@ -196,7 +196,8 @@ class DocumentAuditLogE2eTest extends IntegrationTest {
 
     @Test
     @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS, Capability.DELETE_DOCUMENTS})
-    void given_documentDeletion_should_logEntityTypeAndDocumentNameInMessage() throws Exception {
+    void given_documentDeletion_should_logEntityTypeAndDocumentIdInMessageForCurrentContract()
+        throws Exception {
       // Arrange
       String fileName = "audit-delete-" + UUID.randomUUID() + ".txt";
       String uploadResponse =

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/DocumentAuditLogE2eTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/DocumentAuditLogE2eTest.java
@@ -64,7 +64,7 @@ class DocumentAuditLogE2eTest extends IntegrationTest {
     System.setProperty("AUDIT_LOG_DIR", "target/test-audit-logger");
   }
 
-  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-logger/audit.log");
+  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-log-doc/audit.log");
   private static final String TEST_APPENDER_NAME = "AUDIT_LOG_DOCUMENT_E2E_TEST_APPENDER";
 
   @Autowired private MockMvc mvc;

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/DocumentAuditLogE2eTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/DocumentAuditLogE2eTest.java
@@ -1,0 +1,307 @@
+package io.openaev.aop.audit_log;
+
+import static io.openaev.rest.document.DocumentApi.DOCUMENT_API;
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.FileAppender;
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Capability;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.rest.document.form.DocumentCreateInput;
+import io.openaev.rest.document.form.DocumentUpdateInput;
+import io.openaev.rest.settings.PreviewFeature;
+import io.openaev.service.PreviewFeatureService;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(PER_CLASS)
+@Transactional
+@TestPropertySource(
+    properties = {
+      "openaev.audit-logs.transports=file",
+      "openaev.audit-logs.halt-on-failure=false",
+      "AUDIT_LOG_DIR=target/test-audit-logger"
+    })
+class DocumentAuditLogE2eTest extends IntegrationTest {
+
+  static {
+    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-logger");
+  }
+
+  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-logger/audit.log");
+  private static final String TEST_APPENDER_NAME = "AUDIT_LOG_DOCUMENT_E2E_TEST_APPENDER";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private AuditLogger auditLogger;
+
+  @MockitoBean private EnterpriseEditionService enterpriseEditionService;
+  @MockitoBean private PreviewFeatureService previewFeatureService;
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("openaev.audit-logs.transports", () -> "file");
+    registry.add("openaev.audit-logs.halt-on-failure", () -> "false");
+  }
+
+  @BeforeAll
+  void setupAuditFileAppender() throws Exception {
+    Files.createDirectories(AUDIT_LOG_FILE.getParent());
+    Files.deleteIfExists(AUDIT_LOG_FILE);
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
+
+    if (auditLog.getAppender(TEST_APPENDER_NAME) == null) {
+      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+      encoder.setContext(context);
+      encoder.setPattern("%msg%n");
+      encoder.start();
+
+      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
+      appender.setName(TEST_APPENDER_NAME);
+      appender.setContext(context);
+      appender.setFile(AUDIT_LOG_FILE.toString());
+      appender.setAppend(true);
+      appender.setEncoder(encoder);
+      appender.start();
+
+      auditLog.addAppender(appender);
+      auditLog.setAdditive(false);
+    }
+  }
+
+  @AfterAll
+  void teardownAuditFileAppender() {
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLog = context.getLogger("AUDIT_LOG");
+    if (auditLog.getAppender(TEST_APPENDER_NAME) != null) {
+      auditLog.detachAppender(TEST_APPENDER_NAME);
+    }
+  }
+
+  @BeforeEach
+  void setupTest() throws Exception {
+    Mockito.when(enterpriseEditionService.isLicenseActive(Mockito.any())).thenReturn(true);
+    Mockito.when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+    assertThat(auditLogger.isAuditLoggingEnabled()).isTrue();
+    Files.writeString(
+        AUDIT_LOG_FILE,
+        "",
+        StandardCharsets.UTF_8,
+        java.nio.file.StandardOpenOption.CREATE,
+        java.nio.file.StandardOpenOption.TRUNCATE_EXISTING);
+  }
+
+  @Nested
+  @DisplayName("Document lifecycle")
+  class DocumentLifecycleAudit {
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS})
+    void given_newDocumentUpload_should_logUpdateScopeForCurrentContract() throws Exception {
+      // Arrange
+      String fileName = "audit-create-" + UUID.randomUUID() + ".txt";
+      String content = "create-content-" + UUID.randomUUID();
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      uploadDocument(fileName, "Create description", content);
+
+      // Assert
+      String newContent =
+          assertAuditLogContainsNewContent(
+              sizeBefore,
+              "\"event_scope\" : \"update\"",
+              "\"method\" : \"POST\"",
+              "\"url\" : \"http://localhost/api/documents\"",
+              "\"entity_type\" : \"Document\"");
+      assertThat(newContent).contains("\"message\" : \"updates Document\"");
+    }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS})
+    void given_documentMetadataUpdate_should_logChangedInputField() throws Exception {
+      // Arrange
+      String fileName = "audit-update-" + UUID.randomUUID() + ".txt";
+      String oldDescription = "Initial description";
+      String newDescription = "Updated description";
+      String uploadResponse =
+          uploadDocument(fileName, oldDescription, "update-content-" + UUID.randomUUID());
+      String documentId = JsonPath.read(uploadResponse, "$.document_id");
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      DocumentUpdateInput updateInput = new DocumentUpdateInput();
+      updateInput.setDescription(newDescription);
+      updateInput.setTagIds(List.of());
+      updateInput.setExerciseIds(List.of());
+      updateInput.setScenarioIds(List.of());
+
+      // Act
+      mvc.perform(
+              put(DOCUMENT_API + "/{documentId}", documentId)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(updateInput))
+                  .with(csrf()))
+          .andExpect(status().isOk());
+
+      // Assert
+      String newContent =
+          assertAuditLogContainsNewContent(
+              sizeBefore,
+              "\"event_scope\" : \"update\"",
+              "\"method\" : \"PUT\"",
+              "\"url\" : \"http://localhost/api/documents/" + documentId + "\"",
+              "\"input\" : {",
+              "\"document_description\" : \"" + newDescription + "\"");
+      assertThat(newContent).doesNotContain("\"old_value\"");
+      assertThat(newContent).doesNotContain("\"new_value\"");
+      assertThat(newContent).contains("\"message\" : \"updates Document `" + documentId + "`\"");
+    }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS, Capability.DELETE_DOCUMENTS})
+    void given_documentDeletion_should_logEntityTypeAndDocumentNameInMessage() throws Exception {
+      // Arrange
+      String fileName = "audit-delete-" + UUID.randomUUID() + ".txt";
+      String uploadResponse =
+          uploadDocument(fileName, "Delete description", "delete-content-" + UUID.randomUUID());
+      String documentId = JsonPath.read(uploadResponse, "$.document_id");
+      String documentName = JsonPath.read(uploadResponse, "$.document_name");
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      mvc.perform(delete(DOCUMENT_API + "/{documentId}", documentId).with(csrf()))
+          .andExpect(status().isOk());
+
+      // Assert
+      assertAuditLogContainsNewContent(
+          sizeBefore,
+          "\"event_scope\" : \"delete\"",
+          "\"entity_type\" : \"Document\"",
+          "\"message\" : \"deletes Document `" + documentId + "`\"");
+      assertThat(documentName).isNotBlank();
+    }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_DOCUMENTS})
+    void given_noOpDocumentUpdate_should_stillLogUpdateEventForCurrentContract() throws Exception {
+      // Arrange
+      String fileName = "audit-noop-" + UUID.randomUUID() + ".txt";
+      String description = "No-op description";
+      String uploadResponse =
+          uploadDocument(fileName, description, "noop-content-" + UUID.randomUUID());
+      String documentId = JsonPath.read(uploadResponse, "$.document_id");
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      DocumentUpdateInput updateInput = new DocumentUpdateInput();
+      updateInput.setDescription(description);
+      updateInput.setTagIds(List.of());
+      updateInput.setExerciseIds(List.of());
+      updateInput.setScenarioIds(List.of());
+
+      // Act
+      mvc.perform(
+              put(DOCUMENT_API + "/{documentId}", documentId)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(updateInput))
+                  .with(csrf()))
+          .andExpect(status().isOk());
+
+      // Assert
+      assertAuditLogContainsNewContent(
+          sizeBefore,
+          "\"event_scope\" : \"update\"",
+          "\"method\" : \"PUT\"",
+          "\"url\" : \"http://localhost/api/documents/" + documentId + "\"",
+          "\"document_description\" : \"" + description + "\"");
+    }
+
+    private String uploadDocument(String fileName, String description, String content)
+        throws Exception {
+      DocumentCreateInput input = new DocumentCreateInput();
+      input.setDescription(description);
+
+      MockPart inputPart =
+          new MockPart("input", asJsonString(input).getBytes(StandardCharsets.UTF_8));
+      inputPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+      MockMultipartFile filePart =
+          new MockMultipartFile(
+              "file",
+              fileName,
+              MediaType.TEXT_PLAIN_VALUE,
+              content.getBytes(StandardCharsets.UTF_8));
+
+      return mvc.perform(
+              multipart(DOCUMENT_API)
+                  .part(inputPart)
+                  .file(filePart)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().isOk())
+          .andReturn()
+          .getResponse()
+          .getContentAsString();
+    }
+  }
+
+  private String assertAuditLogContainsNewContent(long sizeBefore, String... expectedSnippets) {
+    final String[] captured = new String[1];
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertThat(Files.exists(AUDIT_LOG_FILE)).isTrue();
+              long sizeAfter = Files.size(AUDIT_LOG_FILE);
+              assertThat(sizeAfter).isGreaterThan(sizeBefore);
+
+              String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
+              String newContent =
+                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+
+              for (String expectedSnippet : expectedSnippets) {
+                assertThat(newContent).contains(expectedSnippet);
+              }
+              captured[0] = newContent;
+            });
+
+    return captured[0];
+  }
+}


### PR DESCRIPTION
## Description

End-to-end integration test covering Document CRUD lifecycle:

1. Upload a new document (`POST /api/documents`)
2. Update document metadata (`PUT /api/documents/{id}`)
3. Delete the document

### Proposed changes

Create a test class to comply with the requirements in the related issue and above description.

### Testing Instructions

1. Run: 
`mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.aop.audit_log.AuditLoggerDocumentTest -Dsurefire.failIfNoSpecifiedTests=false test`

### Related issues

* #5496

## Definition of Done

- [ ] Upload produces `event_scope="create"` (NOT `"update"`)
- [ ] Update shows diff (`input` + `old_value` with only changed fields)
- [ ] Delete shows `entity_type="Document"` + document name in `message`
- [ ] No-op update (same data) produces NO audit event (semantic diff)
- [ ] Uses OpenAEV's test patterns
