### PR TITLE
test(audit_log): e2e testing for admin role management with capabilities (#5497)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerRoleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerRoleTest.java
@@ -58,7 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
       "AUDIT_LOG_DIR=target/test-audit-role-audit"
     })
 @DisplayName("Role audit logging integration tests")
-class RoleAuditLogIntegrationTest extends IntegrationTest {
+class AuditLoggerRoleTest extends IntegrationTest {
 
   static {
     System.setProperty("AUDIT_LOG_DIR", "target/test-audit-log-role");

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerRoleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerRoleTest.java
@@ -9,9 +9,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.core.FileAppender;
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.Capability;
@@ -20,17 +17,13 @@ import io.openaev.rest.role.form.RoleInput;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.PreviewFeatureService;
 import io.openaev.utils.mockUser.WithMockUser;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,11 +32,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -55,14 +45,10 @@ import org.springframework.transaction.annotation.Transactional;
     properties = {
       "openaev.audit-logs.transports=file",
       "openaev.audit-logs.halt-on-failure=false",
-      "AUDIT_LOG_DIR=target/test-audit-role-audit"
+      "AUDIT_LOG_DIR=target/test-audit-log-role"
     })
 @DisplayName("Role audit logging integration tests")
 class AuditLoggerRoleTest extends IntegrationTest {
-
-  static {
-    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-log-role");
-  }
 
   private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-log-role/audit.log");
   private static final String TEST_APPENDER_NAME = "AUDIT_ROLE_LOG_TEST_APPENDER";
@@ -72,46 +58,14 @@ class AuditLoggerRoleTest extends IntegrationTest {
   @MockitoBean private EnterpriseEditionService enterpriseEditionService;
   @MockitoBean private PreviewFeatureService previewFeatureService;
 
-  @DynamicPropertySource
-  static void registerProperties(DynamicPropertyRegistry registry) {
-    registry.add("openaev.audit-logs.transports", () -> "file");
-    registry.add("openaev.audit-logs.halt-on-failure", () -> "false");
-  }
-
   @BeforeAll
   void setupAuditFileAppender() throws Exception {
-    Files.createDirectories(AUDIT_LOG_FILE.getParent());
-    Files.deleteIfExists(AUDIT_LOG_FILE);
-
-    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
-
-    if (auditLogger.getAppender(TEST_APPENDER_NAME) == null) {
-      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
-      encoder.setContext(context);
-      encoder.setPattern("%msg%n");
-      encoder.start();
-
-      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
-      appender.setName(TEST_APPENDER_NAME);
-      appender.setContext(context);
-      appender.setFile(AUDIT_LOG_FILE.toString());
-      appender.setAppend(true);
-      appender.setEncoder(encoder);
-      appender.start();
-
-      auditLogger.addAppender(appender);
-      auditLogger.setAdditive(false);
-    }
+    AuditLogTestHelper.setupFileAppender(AUDIT_LOG_FILE, TEST_APPENDER_NAME);
   }
 
   @AfterAll
   void teardownAuditFileAppender() {
-    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
-    if (auditLogger.getAppender(TEST_APPENDER_NAME) != null) {
-      auditLogger.detachAppender(TEST_APPENDER_NAME);
-    }
+    AuditLogTestHelper.teardownFileAppender(TEST_APPENDER_NAME);
   }
 
   @BeforeEach
@@ -243,24 +197,6 @@ class AuditLoggerRoleTest extends IntegrationTest {
   }
 
   private String readNewAuditLogContent(long sizeBefore) {
-    AtomicReference<String> newContentRef = new AtomicReference<>();
-
-    Awaitility.await()
-        .atMost(10, TimeUnit.SECONDS)
-        .untilAsserted(
-            () -> {
-              assertThat(Files.exists(AUDIT_LOG_FILE)).isTrue();
-              long sizeAfter = Files.size(AUDIT_LOG_FILE);
-              assertThat(sizeAfter).isGreaterThan(sizeBefore);
-
-              byte[] bytes = Files.readAllBytes(AUDIT_LOG_FILE);
-              int start = (int) Math.min(sizeBefore, bytes.length);
-
-              String newContent =
-                  new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8);
-              newContentRef.set(newContent);
-            });
-
-    return newContentRef.get();
+    return AuditLogTestHelper.assertAuditLogContainsNewContent(AUDIT_LOG_FILE, sizeBefore);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/RoleAuditLogIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/RoleAuditLogIntegrationTest.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -221,11 +223,23 @@ class RoleAuditLogIntegrationTest extends IntegrationTest {
 
       // Validate add/remove behavior across sequential updates.
       assertThat(firstUpdateLog).contains("ACCESS_ASSESSMENT");
-      assertThat(secondUpdateLog).doesNotContain("MANAGE_PAYLOADS");
+      String secondUpdateInputCapabilities = extractInputCapabilitiesBlock(secondUpdateLog);
+      assertThat(secondUpdateInputCapabilities).doesNotContain("ACCESS_ASSESSMENT");
+      assertThat(secondUpdateInputCapabilities).contains("MANAGE_ASSESSMENT");
 
-      assertThat(secondUpdateLog).doesNotContain("\"old_value\" : [ 0");
-      assertThat(secondUpdateLog).doesNotContain("\"new_value\" : [ 0");
+      assertThat(secondUpdateLog).doesNotContainPattern("\\\"old_value\\\"\\s*:\\s*\\[\\s*\\d");
+      assertThat(secondUpdateLog).doesNotContainPattern("\\\"new_value\\\"\\s*:\\s*\\[\\s*\\d");
     }
+  }
+
+  private String extractInputCapabilitiesBlock(String logEntry) {
+    Pattern inputCapabilitiesPattern =
+        Pattern.compile(
+            "\\\"input\\\"\\s*:\\s*\\{.*?\\\"role_capabilities\\\"\\s*:\\s*\\[(.*?)\\]",
+            Pattern.DOTALL);
+    Matcher matcher = inputCapabilitiesPattern.matcher(logEntry);
+    assertThat(matcher.find()).isTrue();
+    return matcher.group(1);
   }
 
   private String readNewAuditLogContent(long sizeBefore) {
@@ -239,9 +253,11 @@ class RoleAuditLogIntegrationTest extends IntegrationTest {
               long sizeAfter = Files.size(AUDIT_LOG_FILE);
               assertThat(sizeAfter).isGreaterThan(sizeBefore);
 
-              String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
+              byte[] bytes = Files.readAllBytes(AUDIT_LOG_FILE);
+              int start = (int) Math.min(sizeBefore, bytes.length);
+
               String newContent =
-                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+                  new String(bytes, start, bytes.length - start, StandardCharsets.UTF_8);
               newContentRef.set(newContent);
             });
 

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/RoleAuditLogIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/RoleAuditLogIntegrationTest.java
@@ -1,0 +1,250 @@
+package io.openaev.aop.audit_log;
+
+import static io.openaev.rest.role.TenantRoleApi.ROLE_URI;
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.FileAppender;
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Capability;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.rest.role.form.RoleInput;
+import io.openaev.rest.settings.PreviewFeature;
+import io.openaev.service.PreviewFeatureService;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(PER_CLASS)
+@Transactional
+@TestPropertySource(
+    properties = {
+      "openaev.audit-logs.transports=file",
+      "openaev.audit-logs.halt-on-failure=false",
+      "AUDIT_LOG_DIR=target/test-audit-role-audit"
+    })
+@DisplayName("Role audit logging integration tests")
+class RoleAuditLogIntegrationTest extends IntegrationTest {
+
+  static {
+    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-role-audit");
+  }
+
+  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-role-audit/audit.log");
+  private static final String TEST_APPENDER_NAME = "AUDIT_ROLE_LOG_TEST_APPENDER";
+
+  @Autowired private MockMvc mvc;
+
+  @MockitoBean private EnterpriseEditionService enterpriseEditionService;
+  @MockitoBean private PreviewFeatureService previewFeatureService;
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("openaev.audit-logs.transports", () -> "file");
+    registry.add("openaev.audit-logs.halt-on-failure", () -> "false");
+  }
+
+  @BeforeAll
+  void setupAuditFileAppender() throws Exception {
+    Files.createDirectories(AUDIT_LOG_FILE.getParent());
+    Files.deleteIfExists(AUDIT_LOG_FILE);
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
+
+    if (auditLogger.getAppender(TEST_APPENDER_NAME) == null) {
+      PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+      encoder.setContext(context);
+      encoder.setPattern("%msg%n");
+      encoder.start();
+
+      FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> appender = new FileAppender<>();
+      appender.setName(TEST_APPENDER_NAME);
+      appender.setContext(context);
+      appender.setFile(AUDIT_LOG_FILE.toString());
+      appender.setAppend(true);
+      appender.setEncoder(encoder);
+      appender.start();
+
+      auditLogger.addAppender(appender);
+      auditLogger.setAdditive(false);
+    }
+  }
+
+  @AfterAll
+  void teardownAuditFileAppender() {
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    ch.qos.logback.classic.Logger auditLogger = context.getLogger("AUDIT_LOG");
+    if (auditLogger.getAppender(TEST_APPENDER_NAME) != null) {
+      auditLogger.detachAppender(TEST_APPENDER_NAME);
+    }
+  }
+
+  @BeforeEach
+  void enableAuditFeatureFlags() {
+    Mockito.when(enterpriseEditionService.isLicenseActive(Mockito.any())).thenReturn(true);
+    Mockito.when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+  }
+
+  @Nested
+  @DisplayName("Admin role management")
+  class AdminRoleManagement {
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_SETTINGS})
+    void given_roleCapabilityLifecycle_should_logAdministrationEventsWithReadableCapabilityDiff()
+        throws Exception {
+      // -- ARRANGE --
+      String roleName = "audit-role-" + UUID.randomUUID();
+      RoleInput createInput =
+          RoleInput.builder()
+              .name(roleName)
+              .description("role for audit integration test")
+              .capabilities(Set.of(Capability.ACCESS_ASSESSMENT))
+              .build();
+
+      // -- ACT --
+      long createSizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+      String createResponse =
+          mvc.perform(
+                  post(ROLE_URI)
+                      .content(asJsonString(createInput))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -- ASSERT --
+      String createLog = readNewAuditLogContent(createSizeBefore);
+      assertThat(createLog).contains("\"event_scope\" : \"create\"");
+      assertThat(createLog).contains("\"event_access\" : \"administration\"");
+      assertThat(createLog).contains("\"input\" : {");
+      assertThat(createLog).contains("\"role_name\" : \"" + roleName + "\"");
+
+      // -- ARRANGE --
+      String roleId = JsonPath.read(createResponse, "$.role_id");
+      RoleInput assignCapabilitiesInput =
+          RoleInput.builder()
+              .name(roleName)
+              .description("role for audit integration test")
+              .capabilities(Set.of(Capability.ACCESS_ASSESSMENT, Capability.MANAGE_ASSETS))
+              .build();
+
+      // -- ACT --
+      long firstUpdateSizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+      mvc.perform(
+              put(ROLE_URI + "/" + roleId)
+                  .content(asJsonString(assignCapabilitiesInput))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      // -- ASSERT --
+      String firstUpdateLog = readNewAuditLogContent(firstUpdateSizeBefore);
+      assertThat(firstUpdateLog).contains("\"event_scope\" : \"update\"");
+      assertThat(firstUpdateLog).contains("\"event_access\" : \"administration\"");
+      assertThat(firstUpdateLog).contains("\"role_capabilities\"");
+      assertThat(firstUpdateLog).contains("ACCESS_ASSESSMENT");
+      assertThat(firstUpdateLog).contains("MANAGE_ASSETS");
+
+      // Validate human-readable capability names are logged (not ordinals).
+      assertThat(firstUpdateLog)
+          .doesNotContainPattern("\\\"role_capabilities\\\"\\s*:\\s*\\[\\s*\\d");
+      assertThat(firstUpdateLog).contains("ACCESS_ASSESSMENT");
+      assertThat(firstUpdateLog).contains("MANAGE_ASSETS");
+
+      // -- ARRANGE --
+      RoleInput updateCapabilitiesInput =
+          RoleInput.builder()
+              .name(roleName)
+              .description("role for audit integration test")
+              .capabilities(Set.of(Capability.MANAGE_ASSESSMENT, Capability.MANAGE_ASSETS))
+              .build();
+
+      // -- ACT --
+      long secondUpdateSizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+      mvc.perform(
+              put(ROLE_URI + "/" + roleId)
+                  .content(asJsonString(updateCapabilitiesInput))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful());
+
+      // -- ASSERT --
+      String secondUpdateLog = readNewAuditLogContent(secondUpdateSizeBefore);
+      assertThat(secondUpdateLog).contains("\"event_scope\" : \"update\"");
+      assertThat(secondUpdateLog).contains("\"event_access\" : \"administration\"");
+      assertThat(secondUpdateLog).contains("\"role_capabilities\"");
+      assertThat(secondUpdateLog).contains("MANAGE_ASSESSMENT");
+      assertThat(secondUpdateLog).contains("MANAGE_ASSETS");
+
+      // Validate human-readable capability names are logged (not ordinals).
+      assertThat(secondUpdateLog)
+          .doesNotContainPattern("\\\"role_capabilities\\\"\\s*:\\s*\\[\\s*\\d");
+
+      // Validate add/remove behavior across sequential updates.
+      assertThat(firstUpdateLog).contains("ACCESS_ASSESSMENT");
+      assertThat(secondUpdateLog).doesNotContain("MANAGE_PAYLOADS");
+
+      assertThat(secondUpdateLog).doesNotContain("\"old_value\" : [ 0");
+      assertThat(secondUpdateLog).doesNotContain("\"new_value\" : [ 0");
+    }
+  }
+
+  private String readNewAuditLogContent(long sizeBefore) {
+    AtomicReference<String> newContentRef = new AtomicReference<>();
+
+    Awaitility.await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              assertThat(Files.exists(AUDIT_LOG_FILE)).isTrue();
+              long sizeAfter = Files.size(AUDIT_LOG_FILE);
+              assertThat(sizeAfter).isGreaterThan(sizeBefore);
+
+              String fullContent = Files.readString(AUDIT_LOG_FILE, StandardCharsets.UTF_8);
+              String newContent =
+                  fullContent.substring((int) Math.min(sizeBefore, fullContent.length()));
+              newContentRef.set(newContent);
+            });
+
+    return newContentRef.get();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/RoleAuditLogIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/RoleAuditLogIntegrationTest.java
@@ -61,10 +61,10 @@ import org.springframework.transaction.annotation.Transactional;
 class RoleAuditLogIntegrationTest extends IntegrationTest {
 
   static {
-    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-role-audit");
+    System.setProperty("AUDIT_LOG_DIR", "target/test-audit-log-role");
   }
 
-  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-role-audit/audit.log");
+  private static final Path AUDIT_LOG_FILE = Paths.get("target/test-audit-log-role/audit.log");
   private static final String TEST_APPENDER_NAME = "AUDIT_ROLE_LOG_TEST_APPENDER";
 
   @Autowired private MockMvc mvc;


### PR DESCRIPTION
## Description

End-to-end integration test covering admin role management with capabilities:

1. Create a new role
2. Assign capabilities to the role (e.g. `ACCESS_ASSESSMENT`, `MANAGE_PAYLOADS`)
3. Update role capabilities (add/remove)


### Proposed changes

Create a test class to comply with the requirements in the related issue and above description.

### Testing Instructions

1. Run: 
`mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.aop.audit_log.AuditLoggerRoleTest -Dsurefire.failIfNoSpecifiedTests=false test`

### Related issues

* #5497

## Definition of Done

- [x] `event_access="administration"` for all events (admin resource type)
- [x] Create event `input` includes `role_name`
- [x] Update event `input`/`old_value` show capability names (not enum ordinals)
- [x] Capability names are human-readable (e.g. `"MANAGE_ASSESSMENT"`)
- [x] Adding/removing capabilities shows correct diff
- [x] Uses OpenAEV's test patterns
