### PR TITLE
test(audit_log): e2e testing for login and logout successfully with audit (#6092)

### DIFF
--- a/openaev-front/tests_e2e/tests/aop/audit_log/login-audit.spec.ts
+++ b/openaev-front/tests_e2e/tests/aop/audit_log/login-audit.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from '@playwright/test';
+
+import { test } from '../../../fixtures/baseFixtures';
+import LoginPage from '../../../model/login.page';
+import appUrl, { tenantUrl } from '../../../utils/url';
+
+test.describe('Authentication flow', () => {
+  test.use({
+    storageState: {
+      cookies: [],
+      origins: [],
+    },
+  });
+
+  test('should login and logout successfully', async ({ page }) => {
+    // -- ARRANGE --
+    const loginPage = new LoginPage(page);
+    const username = process.env.E2E_USERNAME ?? 'admin@openaev.io';
+    const password = process.env.E2E_PASSWORD ?? 'admin';
+
+    await page.goto(appUrl());
+    await expect(loginPage.getLoginPage()).toBeVisible();
+
+    // -- ACT --
+    await loginPage.getLoginInput().fill(username);
+    await loginPage.getPasswordInput().fill(password);
+    await loginPage.getSignInButton().click();
+
+    // Ensure we are on an admin page where the top bar account menu is rendered.
+    await page.goto(tenantUrl('/admin'));
+    await expect(page).toHaveURL(/\/admin(?!\/login)/);
+
+    // Trigger CsrfFilter once to ensure XSRF-TOKEN cookie exists, then logout with matching header.
+    await page.evaluate(async () => {
+      await fetch('/api/scenarios/search', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      }).catch(() => {});
+
+      const tokenCookie = document.cookie
+        .split('; ')
+        .find(cookie => cookie.startsWith('XSRF-TOKEN='));
+      const token = tokenCookie ? decodeURIComponent(tokenCookie.split('=')[1]) : '';
+
+      await fetch('/logout', {
+        method: 'POST',
+        credentials: 'include',
+        headers: token ? { 'X-XSRF-TOKEN': token } : {},
+      });
+    });
+    await page.goto(appUrl());
+
+    // -- ASSERT --
+    await expect(loginPage.getSignInButton()).toBeVisible();
+  });
+});

--- a/openaev-front/tests_e2e/tests/aop/audit_log/login-audit.spec.ts
+++ b/openaev-front/tests_e2e/tests/aop/audit_log/login-audit.spec.ts
@@ -15,7 +15,7 @@ test.describe('Authentication flow', () => {
   test('should login and logout successfully', async ({ page }) => {
     test.info().annotations.push({
       type: 'manual',
-      description: 'Verify backend-api console contains audit log entries for login and logout (console transport enabled).',
+      description: 'Please verify if backend-api console contains audit log entries for login and logout (console transport enabled).',
     });
 
     // -- ARRANGE --

--- a/openaev-front/tests_e2e/tests/aop/audit_log/login-audit.spec.ts
+++ b/openaev-front/tests_e2e/tests/aop/audit_log/login-audit.spec.ts
@@ -13,6 +13,11 @@ test.describe('Authentication flow', () => {
   });
 
   test('should login and logout successfully', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'manual',
+      description: 'Verify backend-api console contains audit log entries for login and logout (console transport enabled).',
+    });
+
     // -- ARRANGE --
     const loginPage = new LoginPage(page);
     const username = process.env.E2E_USERNAME ?? 'admin@openaev.io';
@@ -26,7 +31,7 @@ test.describe('Authentication flow', () => {
     await loginPage.getPasswordInput().fill(password);
     await loginPage.getSignInButton().click();
 
-    // Ensure we are on an admin page where the top bar account menu is rendered.
+    // Ensure we are on an admin page (the URL assertion below prevents /admin/login redirects)
     await page.goto(tenantUrl('/admin'));
     await expect(page).toHaveURL(/\/admin(?!\/login)/);
 


### PR DESCRIPTION
## Description

End-to-end integration test covering the frontend login:

1. With Playwright
2. Execute a login action
3. Then logout
4. Check **manually** if login action was logged in the backend-api's console (console transport must be active)
Note: Because we don't have yet the audit-log search API, we need to perform this **check manually.**

### Proposed changes

Create a test file to comply with the requirements in the related issue and above description.

### Testing Instructions

1. Run one of the following commands: 
`yarn test:e2e tests_e2e/tests/aop/audit_log/login-audit.spec.ts --project="Google Chrome" --no-deps`
 or
 `yarn playwright test tests_e2e/tests/aop/audit_log/login-audit.spec.ts --project="Google Chrome" --no-deps`
 or
 `npx playwright test tests_e2e/tests/aop/audit_log/login-audit.spec.ts --project="Google Chrome" --no-deps`

### Related issues

* #6092

## Definition of Done

- [x] was login and logout actions logged into console

