### PR TITLE
test(audit_log): e2e testing for test the audit logging in the backend api (#6093)

### DIFF
--- a/openaev-front/tests_e2e/tests/scenario/scenario-teams.spec.ts
+++ b/openaev-front/tests_e2e/tests/scenario/scenario-teams.spec.ts
@@ -22,7 +22,6 @@ test.describe('Scenario - Teams management', () => {
         }
       `;
       document.head.appendChild(style);
-
     });
 
     // First admin load can force a one-time Getting Started redirect in clean contexts.
@@ -33,12 +32,11 @@ test.describe('Scenario - Teams management', () => {
     });
 
     // Retry once because tenant initialization can still race with the first navigation.
-    for (let attempt = 0; attempt < 2; attempt += 1) {
+    await page.goto(scenarioDefinitionPath);
+    await page.waitForLoadState('domcontentloaded');
+    if (!await scenarioPage.definitionTab.isVisible()) {
       await page.goto(scenarioDefinitionPath);
       await page.waitForLoadState('domcontentloaded');
-      if (await scenarioPage.definitionTab.isVisible()) {
-        break;
-      }
     }
 
     await expect(scenarioPage.definitionTab).toBeVisible();

--- a/openaev-front/tests_e2e/tests/scenario/scenario-teams.spec.ts
+++ b/openaev-front/tests_e2e/tests/scenario/scenario-teams.spec.ts
@@ -12,6 +12,7 @@ test.describe('Scenario - Teams management', () => {
   test.beforeEach(async ({ page, emptyScenario }) => {
     updateTeamDialog = new UpdateTeamDialog(page);
     scenarioPage = new ScenarioPage(page);
+    const scenarioDefinitionPath = tenantUrl(`/admin/scenarios/${emptyScenario.scenario_id}/definition`);
     await page.addInitScript(() => {
       const style = document.createElement('style');
       style.innerHTML = `
@@ -21,10 +22,26 @@ test.describe('Scenario - Teams management', () => {
         }
       `;
       document.head.appendChild(style);
+
     });
-    await page.goto(tenantUrl(`/admin/scenarios/${emptyScenario.scenario_id}/definition`));
-    await page.waitForLoadState('domcontentloaded');
-    await scenarioPage.definitionTab.waitFor({ state: 'visible' });
+
+    // First admin load can force a one-time Getting Started redirect in clean contexts.
+    await page.goto(tenantUrl('/admin'));
+    await page.evaluate(() => {
+      // Disable that redirect so this spec stays on scenario routes.
+      localStorage.setItem('go-to-getting-started', 'false');
+    });
+
+    // Retry once because tenant initialization can still race with the first navigation.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await page.goto(scenarioDefinitionPath);
+      await page.waitForLoadState('domcontentloaded');
+      if (await scenarioPage.definitionTab.isVisible()) {
+        break;
+      }
+    }
+
+    await expect(scenarioPage.definitionTab).toBeVisible();
   });
 
   test.describe('Team CRUD Operations in scenario', () => {

--- a/openaev-front/tests_e2e/tests/scenario/scenario-teams.spec.ts
+++ b/openaev-front/tests_e2e/tests/scenario/scenario-teams.spec.ts
@@ -24,12 +24,12 @@ test.describe('Scenario - Teams management', () => {
       document.head.appendChild(style);
     });
 
-    // First admin load can force a one-time Getting Started redirect in clean contexts.
-    await page.goto(tenantUrl('/admin'));
-    await page.evaluate(() => {
+    await page.addInitScript(() => {
       // Disable that redirect so this spec stays on scenario routes.
       localStorage.setItem('go-to-getting-started', 'false');
     });
+    // First admin load can force a one-time Getting Started redirect in clean contexts.
+    await page.goto(tenantUrl('/admin'));
 
     // Retry once because tenant initialization can still race with the first navigation.
     await page.goto(scenarioDefinitionPath);


### PR DESCRIPTION
## Description

End-to-end integration test covering the frontend atomic-testing creation:

1. With Playwright
2. add an existing team to scenario
3. remove it from scenario context
4. create a new contextual team from the scenario screen
5. delete that contextual team
6. create players
7. create a team containing those players
8. add that team to the scenario and verify presence
9. Check if creation action was logged in the backend-api's console (console transport must be active)Note: Because we don't have yet the audit-log search API, we need to perform this check manually.

### Proposed changes

Use the test file scenario/scenario-teams.spec.ts to comply with the requirements in the related issue and above description.

### Testing Instructions

1. Run one of the following commands: 
`yarn test:e2e tests_e2e/tests/scenario/scenario-teams.spec.ts --project="Google Chrome" --no-deps`
 or
 `yarn playwright test tests_e2e/tests/scenario/scenario-teams.spec.ts --project="Google Chrome" --no-deps`
 or
 `npx playwright test tests_e2e/tests/scenario/scenario-teams.spec.ts --project="Google Chrome" --no-deps`

### Related issues

* #6093

## Definition of Done

- [x] was creation, removal and update actions logged into console


