### PR TITLE
[backend] fix(telemetry): point OTLP exporter at telemetry.oaev.* endpoints

### DIFF
--- a/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
@@ -109,10 +109,10 @@ public class OpenTelemetryConfig {
 
   // -- PRIVATE --
   private String getOTELEndpoint() {
-    String endpoint = "https://telemetry.obas.filigran.io/v1/metrics";
+    String endpoint = "https://telemetry.oaev.filigran.io/v1/metrics";
     if (Arrays.asList(environment.getActiveProfiles()).contains("dev")
         || Arrays.asList(environment.getActiveProfiles()).contains("ci")) {
-      endpoint = "https://telemetry.obas.staging.filigran.io/v1/metrics";
+      endpoint = "https://telemetry.oaev.staging.filigran.io/v1/metrics";
     }
     return endpoint;
   }


### PR DESCRIPTION
## Summary

Point the usage-telemetry OTLP exporter at the canonical **`telemetry.oaev.*`** hostnames following the OpenBAS → OpenAEV rename.

In `OpenTelemetryConfig.getOTELEndpoint()`:
- prod: `telemetry.obas.filigran.io` → **`telemetry.oaev.filigran.io`**
- dev/ci: `telemetry.obas.staging.filigran.io` → **`telemetry.oaev.staging.filigran.io`**

Closes #6104.

## Why it's safe / non-breaking
- The telemetry collector already serves both `telemetry.oaev.*` and `telemetry.obas.*` on the same ingress (shared SAN cert) on **prod and staging**, so old builds keep working and this just moves to the canonical name. (Infra: FiligranHQ/platform#2750.)
- The S3 landing prefix was migrated `metrics_obas → metrics_oaev` on both buckets, and the ingestion DAG reads `metrics_oaev`.

## Scope
- One-file, two-line change. No behavior change beyond the destination hostname.
- The unused test-only `telemetry.oaev.endpoint` property in `src/test/resources/application.properties` already used the `oaev` name and is left as-is.

## Test plan
- [ ] On a `dev`/`ci` profile run, confirm the exporter targets `telemetry.oaev.staging.filigran.io` and the startup reachability probe passes (HTTP 200).
- [ ] Confirm metrics land in the `metrics_oaev` prefix of the staging telemetry bucket.
