### PR TITLE
[frontend] fix(dashboard): stop widgets reloading on data drawer open/close (#6107)

### DIFF
--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
@@ -211,6 +211,7 @@ const CustomDashboardWrapper = ({
     fetchEntities,
     fetchEntitiesRuntime,
     fetchCount,
+    fetchAverage,
     fetchSeries,
     fetchAttackPaths,
     handleOpenWidgetDataDrawer,

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
@@ -1,6 +1,6 @@
 import type { AxiosResponse } from 'axios';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { useLocalStorage, useReadLocalStorage } from 'usehooks-ts';
 
 import Loader from '../../../../components/Loader';
@@ -86,25 +86,28 @@ const CustomDashboardWrapper = ({
     };
   }, []);
 
-  const [, setSearchParams] = useSearchParams();
+  // Drive the drawer through navigate() rather than useSearchParams(): the
+  // latter would subscribe this provider to every URL change, so opening or
+  // closing the drawer would re-render the whole dashboard subtree (re-running
+  // the parameter-init effect and re-fetching every widget). WidgetDataDrawer
+  // reads useSearchParams() on its own, so only it needs to react to the URL.
+  const navigate = useNavigate();
 
-  const handleOpenWidgetDataDrawer = (conf: WidgetDataDrawerConf) => {
-    setSearchParams((prevParams) => {
-      const newParams = new URLSearchParams(prevParams);
-      newParams.set('widget_id', conf.widgetId);
-      newParams.set('series_index', (conf.series_index ?? '').toString());
-      if (conf.filter_values_map) {
-        Object.entries(conf.filter_values_map).forEach(([key, value]) => {
-          newParams.set(key, (value ?? []).join(','));
-        });
-      }
-      return newParams;
-    }, { replace: true });
-  };
+  const handleOpenWidgetDataDrawer = useCallback((conf: WidgetDataDrawerConf) => {
+    const newParams = new URLSearchParams(window.location.search);
+    newParams.set('widget_id', conf.widgetId);
+    newParams.set('series_index', (conf.series_index ?? '').toString());
+    if (conf.filter_values_map) {
+      Object.entries(conf.filter_values_map).forEach(([key, value]) => {
+        newParams.set(key, (value ?? []).join(','));
+      });
+    }
+    navigate({ search: `?${newParams.toString()}` }, { replace: true });
+  }, [navigate]);
 
-  const handleCloseWidgetDataDrawer = () => {
-    setSearchParams(new URLSearchParams(), { replace: true });
-  };
+  const handleCloseWidgetDataDrawer = useCallback(() => {
+    navigate({ search: '' }, { replace: true });
+  }, [navigate]);
 
   const setDataReadyWithDelay = () => {
     const elapsed = Date.now() - loadingStartTime.current;
@@ -210,6 +213,8 @@ const CustomDashboardWrapper = ({
     fetchCount,
     fetchSeries,
     fetchAttackPaths,
+    handleOpenWidgetDataDrawer,
+    handleCloseWidgetDataDrawer,
   ]);
 
   if (loading) {


### PR DESCRIPTION
## Summary

Closes #6107

On custom dashboards (including Home), clicking a chart element correctly opens the right-hand widget data drawer — but every open **and** every close re-fetched and re-rendered all the other widgets (they flashed back to their loading spinners). This made the drawer interaction reload the whole dashboard and generated unnecessary API calls, undermining the performance work from #5210.

## Root cause

The drawer's open/close state lives in the URL search params. `CustomDashboardWrapper` — the component that owns the dashboard data, the parameter-initialization effect and the `CustomDashboardContext` provider consumed by every widget — called `useSearchParams()` only to obtain the setter for `openWidgetDataDrawer` / `closeWidgetDataDrawer`. `useSearchParams()` subscribes the component to location changes, so each drawer open/close re-rendered the whole provider subtree, re-ran the parameter-init effect, and handed every `WidgetWrapper` a fresh `customDashboardParameters` reference. Each widget's `fetchWidgetData` callback depends on that reference, so all widgets re-fetched on every drawer toggle.

## Fix

Drive the drawer from `CustomDashboardWrapper` with `useNavigate()` (which does **not** subscribe the component to location changes) and expose the open/close handlers as stable `useCallback`s included in the context value. `WidgetDataDrawer` already reads `useSearchParams()` on its own, so it remains the only component that re-renders when the drawer URL changes — the widget tree keeps its already-fetched data.

- Replace `useSearchParams()` with `useNavigate()` in `CustomDashboardWrapper`.
- `handleOpenWidgetDataDrawer` / `handleCloseWidgetDataDrawer` are now `useCallback`s (stable) and are listed in the `contextValue` dependency array (they were previously inline and omitted from the deps).
- Also add the previously-missing `fetchAverage` to the `contextValue` `useMemo` deps so the context can no longer expose a stale `fetchAverage` reference when the configuration changes. This dep was already absent before this PR; the front-end ESLint config does not enable `react-hooks/exhaustive-deps`, so the linter did not surface it.

## Test plan

- Open a custom dashboard with several widgets (Home works); let all widgets finish loading.
- Click a chart element (bar / point / donut slice) to open the "Display list" drawer → the drawer opens and loads its data; the other widgets do **not** reload.
- Close the drawer → the other widgets do **not** reload.
- Paginate / change filters inside the drawer → only the drawer content updates.
- Confirm chart drill-down, fullscreen, and dashboard parameter changes still work; parameter changes still refresh widget data as expected.

## Verification

- `yarn check-ts` and `yarn lint --max-warnings 0` pass locally on the changed file.
