### PR TITLE
feat(telemetry): make telemetry always-on, gated solely by connectivity probe (#6114)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
@@ -64,9 +64,9 @@ public class OpenTelemetryConfig {
     // below is the only gate, mirroring OpenCTI and XTM One. Air-gapped or
     // egress-blocked installs self-disable when the collector is unreachable.
     String endpoint = getOTELEndpoint();
-    log.info("Telemetry - using endpoint: " + endpoint);
-    log.info("Telemetry - Using collect interval: " + collectInterval);
-    log.info("Telemetry - Using export interval: " + exportInterval);
+    log.info("Telemetry - Using endpoint: {}", endpoint);
+    log.info("Telemetry - Using collect interval: {}", collectInterval);
+    log.info("Telemetry - Using export interval: {}", exportInterval);
 
     if (!isEndpointReachable(endpoint)) {
       log.warn("OTLP endpoint not reachable. Falling back to noop OpenTelemetry.");

--- a/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
@@ -59,18 +58,13 @@ public class OpenTelemetryConfig {
   private static final DateTimeFormatter CREATION_DATE_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.n]");
 
-  @Value("${openbas.telemetry.enabled:${openaev.telemetry.enabled:true}}")
-  private boolean telemetryEnabled;
-
   @Bean
   public OpenTelemetry openTelemetry() {
-    if (!telemetryEnabled) {
-      log.info("OpenTelemetry is disabled via 'openaev.telemetry.enabled=false'. Skipping init.");
-      return OpenTelemetry.noop();
-    }
-
+    // Telemetry is always on (no user-facing opt-out): the connectivity probe
+    // below is the only gate, mirroring OpenCTI and XTM One. Air-gapped or
+    // egress-blocked installs self-disable when the collector is unreachable.
     String endpoint = getOTELEndpoint();
-    log.info("Telemetry enabled - using endpoint: " + endpoint);
+    log.info("Telemetry - using endpoint: " + endpoint);
     log.info("Telemetry - Using collect interval: " + collectInterval);
     log.info("Telemetry - Using export interval: " + exportInterval);
 


### PR DESCRIPTION
## Summary

Makes OpenAEV's anonymous usage telemetry **always-on, gated solely by the connectivity probe** — consistent with the other Filigran products.

`OpenTelemetryConfig` previously had a user-facing opt-out flag (`openaev.telemetry.enabled` / `openbas.telemetry.enabled`, default `true`) that short-circuited init to `OpenTelemetry.noop()`, *in addition* to the startup connectivity probe. This diverged from:

- **OpenCTI** — telemetry manager `enabledByConfig: true` (hardcoded); the OTLP exporter is activated/deactivated only by the startup connectivity probe.
- **XTM One** — telemetry always initialises and self-disables only when the collector is unreachable or under the test runner (XTM-One-Platform/xtm-one#1380, reconciled acceptance criteria in XTM-One-Platform/xtm-one#1379).

This PR removes the opt-out flag and its init short-circuit, keeping the connectivity probe (`isEndpointReachable`) as the **only** gate. Air-gapped / egress-blocked installs still self-disable cleanly (the probe falls back to `OpenTelemetry.noop()`).

Closes #6114.

## Changes

- `openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java`: drop the `telemetryEnabled` `@Value` field + the `if (!telemetryEnabled) return noop()` short-circuit (and the now-unused `@Value` import); keep the connectivity probe as the sole gate.
- Switch the telemetry-init log statements to parameterized SLF4J logging (`{}` placeholders) to match the style already used in `isEndpointReachable`, and normalise their casing to `Using`.

## Notes

- No change to **what** is collected (anonymous aggregate counts only) or to the export/collect cadence.
- No change to the test profile: `@Profile("test")` still uses `NoOpOpenTelemetryConfig`, and the 3-arg constructor is unchanged.
- The in-repo `README.md` only links to the external telemetry documentation; the user-facing opt-out flag is not documented in this repository. The hosted docs (docs.openaev.io) may still reference the removed flag and should be updated separately.

## Test plan

- [x] `mvn spotless:check` (formatting) — validated in CI.
- [x] `mvn clean install -DskipTests -Pdev` (compiles) — validated in CI.
- [x] Backend tests pass (the `test` profile uses the no-op telemetry config, so behaviour is unchanged under test).
- [ ] Manual: start with a reachable collector → telemetry initialises; start with an unreachable collector → probe fails, telemetry self-disables, startup unaffected.
