### PR TITLE
chore: align issue templates across repositories (#6116)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,8 +2,9 @@
 name: Bug report
 about: Create a bug report to help us improve OpenAEV
 title: 'fix: '
-labels: bug, needs triage
+labels: needs triage, bug
 assignees: ''
+type: bug
 
 ---
 
@@ -13,28 +14,25 @@ assignees: ''
 
 ## Environment
 
-1. OS (where OpenAEV server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenAEV version: { e.g. OpenAEV 1.0.2 }
-3. OpenAEV client: { e.g. frontend or python }
-4. Other environment details:
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
-## Reproducible Steps
+## Reproducible steps
 
 Steps to create the smallest reproducible scenario:
 1. { e.g. Run ... }
 2. { e.g. Click ... }
 3. { e.g. Error ... }
 
-## Expected Output
+## Expected output
 
 <!-- Please describe what you expected to happen. -->
 
-## Actual Output
+## Actual output
 
 <!-- Please describe what actually happened. -->
 
 ## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
-
-## Screenshots (optional)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/OpenAEV-Platform/openaev/security/policy
+    about: Please review our security policy and report vulnerabilities privately and responsibly.
+  - name: Filigran community Slack
+    url: https://community.filigran.io
+    about: Ask questions and chat with the Filigran community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,36 +1,29 @@
 ---
 name: Feature request
-about: Ask for a new feature to be implemented in OpenAEV
+about: Suggest a new feature or capability for OpenAEV
 title: 'feat: '
-labels: feature, needs triage
+labels: needs triage, feature
 assignees: ''
+type: feature
 
 ---
 
-## Context
-
-<!-- 
-- Why is this solution needed?
-- What value or benefits will the end-users gain from this change?
-- Is this change a technical improvement? just for internal use, or does it impact users as well?
--->
-
 ## Use case
 
-<!-- Please describe the use case for which you need a solution -->
+<!-- Please describe the use case for which you need a solution. -->
 
-## Current Workaround
+## Current workaround
 
-<!-- Please describe how you currently solve or work around this problem, given OpenAEV's limitation. -->
+<!-- Please describe how you currently solve or work around this problem. -->
 
-## Proposed Solution
+## Proposed solution
 
-<!-- Please describe the solution you would like OpenAEV to provide, to solve the problem above. -->
+<!-- Please describe the solution you would like to be provided. -->
 
-## Additional Information
+## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
 
 ## If the feature request is approved, would you be willing to submit a PR?
 
-Yes / No (Help can be provided if you need assistance submitting a PR)
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question concerning OpenAEV
+about: Ask a question about OpenAEV
 title: ''
 labels: needs triage, question
 assignees: ''
@@ -9,9 +9,9 @@ assignees: ''
 
 ## Prerequisites
 
-- [ ] I read the [Deployment and Setup](https://docs.openaev.io/latest/deployment/overview) section of the OpenAEV documentation as well as the [Troubleshooting](https://docs.openaev.io/latest/deployment/troubleshooting) page and didn't find anything relevant to my problem.
-- [ ] I went through old GitHub issues and couldn't find anything relevant
-- [ ] I googled the issue and didn't find anything relevant
+- [ ] I read the documentation and didn't find anything relevant to my problem.
+- [ ] I went through old GitHub issues and couldn't find anything relevant.
+- [ ] I searched the web and didn't find anything relevant.
 
 ## Description
 
@@ -19,17 +19,9 @@ assignees: ''
 
 ## Environment
 
-1. OS (where OpenAEV server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenAEV version: { e.g. OpenAEV 1.0.2 }
-3. OpenAEV client: { e.g. frontend or python }
-4. Other environment details:
-
-## Reproducible Steps
-
-Steps to create the smallest reproducible scenario:
-1. { e.g. Run ... }
-2. { e.g. Click ... }
-3. { e.g. Error ... }
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #6116