### PR TITLE
fix: centralize drawer content spacing (#3278)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/scenario_assistant/SelectTTPsDrawer.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/scenario_assistant/SelectTTPsDrawer.tsx
@@ -66,10 +66,8 @@ const SelectTTPsDrawer = ({ open, onClose, initialSelectedTTPIds, onUpdateAttack
       handleClose={onClose}
       title={t('ATT&CK Matrix')}
       variant="full"
-      containerStyle={{
-        padding: 0,
-        maxHeight: '100%',
-      }}
+      disableContainerPadding
+      containerMaxHeight="100%"
     >
       <>
         <MitreFilter

--- a/openaev-front/src/admin/components/simulations/simulation/ExercisePopover.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/ExercisePopover.tsx
@@ -209,7 +209,7 @@ const ExercisePopover: FunctionComponent<ExercisePopoverProps> = ({
       />
       <Drawer
         open={openReports}
-        containerStyle={{ padding: '0px' }}
+        disableContainerPadding
         handleClose={handleCloseReports}
         title={t('Reports')}
       >

--- a/openaev-front/src/components/common/Drawer.tsx
+++ b/openaev-front/src/components/common/Drawer.tsx
@@ -155,7 +155,7 @@ const Drawer: FunctionComponent<DrawerProps> = ({
       </div>
       <div style={{
         ...(disableContainerPadding ? {} : { padding: '10px 20px 20px 20px' }),
-        ...(containerMaxHeight ? { maxHeight: containerMaxHeight } : {}),
+        ...(containerMaxHeight !== undefined && containerMaxHeight !== null ? { maxHeight: containerMaxHeight } : {}),
         ...containerStyle,
       }}
       >

--- a/openaev-front/src/components/common/Drawer.tsx
+++ b/openaev-front/src/components/common/Drawer.tsx
@@ -58,6 +58,8 @@ interface DrawerProps {
   PaperProps?: PaperProps;
   disableEnforceFocus?: boolean;
   containerStyle?: CSSProperties;
+  disableContainerPadding?: boolean;
+  containerMaxHeight?: CSSProperties['maxHeight'];
 }
 
 const Drawer: FunctionComponent<DrawerProps> = ({
@@ -71,6 +73,8 @@ const Drawer: FunctionComponent<DrawerProps> = ({
   PaperProps = undefined,
   disableEnforceFocus = false,
   containerStyle = {},
+  disableContainerPadding = false,
+  containerMaxHeight,
 }) => {
   const theme = useTheme();
   const { settings } = useAuth();
@@ -150,7 +154,8 @@ const Drawer: FunctionComponent<DrawerProps> = ({
         </div>
       </div>
       <div style={{
-        padding: '10px 20px 20px 20px',
+        ...(disableContainerPadding ? {} : { padding: '10px 20px 20px 20px' }),
+        ...(containerMaxHeight ? { maxHeight: containerMaxHeight } : {}),
         ...containerStyle,
       }}
       >

--- a/openaev-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
+++ b/openaev-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
@@ -195,10 +195,8 @@ const PaginationComponentV2 = <T extends object>({
                 handleClose={() => setOpenMitreFilter(false)}
                 title={t('ATT&CK Matrix')}
                 variant="full"
-                containerStyle={{
-                  padding: 0,
-                  maxHeight: '100%',
-                }}
+                disableContainerPadding
+                containerMaxHeight="100%"
               >
                 <MitreFilter
                   className={classes.TTPMitreContainer}


### PR DESCRIPTION
## Related issue
- Fixes #3278

## What changed
- Added explicit Drawer API props to control spacing semantics: `disableContainerPadding` and `containerMaxHeight`.
- Moved hardcoded per-call spacing (`padding: 0`, `maxHeight: '100%'`) into Drawer prop usage for ATT&CK drawers.
- Replaced inline `containerStyle` overrides in:
  - `SelectTTPsDrawer`
  - `PaginationComponentV2`
  - `ExercisePopover`

## Why
This keeps spacing defaults in `Drawer` and reduces duplicated inline overrides across usage sites.

## Validation
- `npm run check-ts` (attempted) could not run: `tsc` is not available in this environment (`sh: tsc: command not found`).
- `npm run check` script is not defined in `openaev-front/package.json` (attempted and received missing script error).
