### PR TITLE
test(audit_log): e2e testing for test the audit logging (#5480)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AccessControlAuditLogAspectTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AccessControlAuditLogAspectTest.java
@@ -112,23 +112,17 @@ class AccessControlAuditLogAspectTest extends IntegrationTest {
 
     @Test
     @WithMockUser
-    void given_missingCapabilityWithAutomatedUserAgent_should_logUnauthorizedEvent()
-        throws Exception {
+    void given_missingCapabilityWithInactiveAction_should_logUnauthorizedEvent() throws Exception {
       // Arrange
+      doReturn(false).when(auditLogger).isAuditLoggingValid(any());
+
       ArgumentCaptor<String> eventScopeCaptor = ArgumentCaptor.forClass(String.class);
       ArgumentCaptor<String> eventStatusCaptor = ArgumentCaptor.forClass(String.class);
       ArgumentCaptor<ResourceType> resourceTypeCaptor = ArgumentCaptor.forClass(ResourceType.class);
       ArgumentCaptor<String> resourceIdCaptor = ArgumentCaptor.forClass(String.class);
-      ArgumentCaptor<JsonNode> inputCaptor = ArgumentCaptor.forClass(JsonNode.class);
-      ArgumentCaptor<JsonNode> outputCaptor = ArgumentCaptor.forClass(JsonNode.class);
-      ArgumentCaptor<JsonNode> signatureCaptor = ArgumentCaptor.forClass(JsonNode.class);
-      ArgumentCaptor<String> logUuidCaptor = ArgumentCaptor.forClass(String.class);
 
       // Act
-      mvc.perform(
-              delete(TEAM_URI + "/{teamId}", PROTECTED_TEAM_ID)
-                  .with(csrf())
-                  .header("User-Agent", "openaev-agent/x.x.x"))
+      mvc.perform(delete(TEAM_URI + "/{teamId}", PROTECTED_TEAM_ID).with(csrf()))
           .andExpect(status().isForbidden());
 
       // Assert
@@ -138,22 +132,16 @@ class AccessControlAuditLogAspectTest extends IntegrationTest {
               eventStatusCaptor.capture(),
               resourceTypeCaptor.capture(),
               resourceIdCaptor.capture(),
-              inputCaptor.capture(),
-              outputCaptor.capture(),
-              signatureCaptor.capture(),
               any(),
-              logUuidCaptor.capture());
+              any(),
+              any(),
+              any(),
+              anyString());
 
       assertThat(eventScopeCaptor.getValue()).isEqualTo("unauthorized");
       assertThat(eventStatusCaptor.getValue()).isEqualTo("error");
       assertThat(resourceTypeCaptor.getValue()).isEqualTo(ResourceType.TEAM);
       assertThat(resourceIdCaptor.getValue()).isEqualTo(PROTECTED_TEAM_ID);
-      assertThat(inputCaptor.getValue()).isNull();
-      assertThat(outputCaptor.getValue()).isNotNull();
-      assertThat(outputCaptor.getValue().path("exception_type").asText())
-          .contains("AccessControlAspect$");
-      assertThat(signatureCaptor.getValue()).isNotNull();
-      assertThat(logUuidCaptor.getValue()).isNotBlank();
     }
   }
 
@@ -190,6 +178,31 @@ class AccessControlAuditLogAspectTest extends IntegrationTest {
     void given_successfulRead_should_notLogEvent() throws Exception {
       // Arrange / Act
       mvc.perform(get(TEAM_URI)).andExpect(status().isOk());
+
+      // Assert
+      verify(auditLogger, after(1000).never())
+          .logAccessControlEvent(
+              anyString(),
+              anyString(),
+              any(),
+              anyString(),
+              any(),
+              any(),
+              any(),
+              any(),
+              anyString());
+    }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.ACCESS_TEAMS_AND_PLAYERS})
+    void given_successfulSearch_should_notLogEvent() throws Exception {
+      // Arrange / Act
+      mvc.perform(
+              post(TEAM_URI + "/search")
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{}"))
+          .andExpect(status().isOk());
 
       // Assert
       verify(auditLogger, after(1000).never())
@@ -285,6 +298,35 @@ class AccessControlAuditLogAspectTest extends IntegrationTest {
       assertThat(eventStatusCaptor.getValue()).isEqualTo("success");
       assertThat(resourceTypeCaptor.getValue()).isEqualTo(ResourceType.TEAM);
       assertThat(resourceIdCaptor.getValue()).isEqualTo(team.getId());
+    }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.DELETE_TEAMS_AND_PLAYERS})
+    void given_successfulDelete_should_logDeleteEventWithNullInput() throws Exception {
+      // Arrange
+      Team team = teamRepository.save(TeamFixture.getDefaultTeam());
+      entityManager.flush();
+
+      ArgumentCaptor<JsonNode> inputCaptor = ArgumentCaptor.forClass(JsonNode.class);
+
+      // Act
+      mvc.perform(delete(TEAM_URI + "/{teamId}", team.getId()).with(csrf()))
+          .andExpect(status().isOk());
+
+      // Assert
+      verify(auditLogger, timeout(1000))
+          .logAccessControlEvent(
+              anyString(),
+              anyString(),
+              any(),
+              anyString(),
+              inputCaptor.capture(),
+              any(),
+              any(),
+              any(),
+              anyString());
+
+      assertThat(inputCaptor.getValue()).isNull();
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -16,11 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.collectors.expectations_expiration_manager.ExpectationsExpirationManagerCollector;
-import io.openaev.context.TenantContext;
 import io.openaev.engine.model.log.LogEvent;
 import io.openaev.injectors.email.service.ImapService;
-import io.openaev.integration.impl.injectors.email.EmailInjectorIntegrationFactory;
-import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.rest.atomic_testing.AtomicTestingApi;
 import io.openaev.rest.atomic_testing.form.AtomicTestingInput;
 import io.openaev.rest.payload.form.PayloadCreateInput;
@@ -63,8 +60,6 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
   @Autowired private DomainComposer domainComposer;
   @Autowired private EndpointComposer endpointComposer;
-  @Autowired private EmailInjectorIntegrationFactory emailInjectorIntegrationFactory;
-  @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
 
   @MockitoBean private ImapService imapService;
 
@@ -97,13 +92,6 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
     @WithMockUser(isAdmin = true)
     // Verifies end-to-end audit logging for payload + atomic testing lifecycle actions.
     void given_payloadAndAtomicTestingLifecycle_should_logExpectedAuditEvents() throws Exception {
-      // Arrange
-      // Register built-in injector under the active mock user context for deterministic tenant
-      // scope.
-      emailInjectorIntegrationFactory.registerConnectorForTenant(TenantContext.getCurrentTenant());
-      openaevInjectorIntegrationFactory.registerConnectorForTenant(
-          TenantContext.getCurrentTenant());
-
       // Use unique labels to avoid collisions with existing data in integration environments.
       String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
       String payloadName = "audit-payload-" + uniqueSuffix;

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/PayloadAtomicTestingAuditLogLifecycleTest.java
@@ -16,8 +16,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.collectors.expectations_expiration_manager.ExpectationsExpirationManagerCollector;
+import io.openaev.context.TenantContext;
 import io.openaev.engine.model.log.LogEvent;
 import io.openaev.injectors.email.service.ImapService;
+import io.openaev.integration.impl.injectors.email.EmailInjectorIntegrationFactory;
+import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.rest.atomic_testing.AtomicTestingApi;
 import io.openaev.rest.atomic_testing.form.AtomicTestingInput;
 import io.openaev.rest.payload.form.PayloadCreateInput;
@@ -60,6 +63,8 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
   @Autowired private DomainComposer domainComposer;
   @Autowired private EndpointComposer endpointComposer;
+  @Autowired private EmailInjectorIntegrationFactory emailInjectorIntegrationFactory;
+  @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
 
   @MockitoBean private ImapService imapService;
 
@@ -92,6 +97,13 @@ class PayloadAtomicTestingAuditLogLifecycleTest extends IntegrationTest {
     @WithMockUser(isAdmin = true)
     // Verifies end-to-end audit logging for payload + atomic testing lifecycle actions.
     void given_payloadAndAtomicTestingLifecycle_should_logExpectedAuditEvents() throws Exception {
+      // Arrange
+      // Register built-in injector under the active mock user context for deterministic tenant
+      // scope.
+      emailInjectorIntegrationFactory.registerConnectorForTenant(TenantContext.getCurrentTenant());
+      openaevInjectorIntegrationFactory.registerConnectorForTenant(
+          TenantContext.getCurrentTenant());
+
       // Use unique labels to avoid collisions with existing data in integration environments.
       String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
       String payloadName = "audit-payload-" + uniqueSuffix;

--- a/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
@@ -167,4 +167,110 @@ public class AppSecurityConfigTest extends IntegrationTest {
                 .with(csrf()))
         .andExpect(status().isOk());
   }
+
+  @Test
+  @DisplayName("given no credentials and no csrf, should return HTTP 403")
+  void given_noCredentialsAndNoCsrf_should_returnForbidden() throws Exception {
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI).contentType(MediaType.APPLICATION_JSON).content(SEARCH_BODY))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("given invalid auth cookie and valid csrf, should return HTTP 401")
+  void given_invalidAuthCookieAndValidCsrf_should_returnUnauthorized() throws Exception {
+    Cookie authCookie = new Cookie(AUTH_COOKIE_NAME, "invalid-token");
+    Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .cookie(authCookie, csrfCookie)
+                .header(CSRF_HEADER_NAME, "test-csrf-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY)
+                .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("given valid auth cookie and missing csrf header, should return HTTP 403")
+  void given_validAuthCookieAndMissingCsrfHeader_should_returnForbidden() throws Exception {
+    Cookie authCookie = new Cookie(AUTH_COOKIE_NAME, adminToken);
+    Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .cookie(authCookie, csrfCookie)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("given valid auth cookie and missing csrf cookie, should return HTTP 403")
+  void given_validAuthCookieAndMissingCsrfCookie_should_returnForbidden() throws Exception {
+    Cookie authCookie = new Cookie(AUTH_COOKIE_NAME, adminToken);
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .cookie(authCookie)
+                .header(CSRF_HEADER_NAME, "test-csrf-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("given valid bearer and invalid auth cookie, should return HTTP 200")
+  void given_validBearerAndInvalidAuthCookie_should_returnOk() throws Exception {
+    Cookie authCookie = new Cookie(AUTH_COOKIE_NAME, "invalid-token");
+    Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                .cookie(authCookie, csrfCookie)
+                .header(CSRF_HEADER_NAME, "test-csrf-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY)
+                .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("given valid jsessionid and missing csrf header, should return HTTP 403")
+  void given_validJsessionIdAndMissingCsrfHeader_should_returnForbidden() throws Exception {
+    MockHttpSession session = new MockHttpSession();
+    Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .session(session)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                .cookie(csrfCookie)
+                .header(CSRF_HEADER_NAME, "test-csrf-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY)
+                .with(csrf()))
+        .andExpect(status().isOk());
+
+    String sessionId = Objects.requireNonNull(session.getId());
+    Cookie jsessionCookie = new Cookie("JSESSIONID", sessionId);
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .session(session)
+                .cookie(jsessionCookie)
+                .cookie(new Cookie(CSRF_COOKIE_NAME, "test-csrf-token"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY))
+        .andExpect(status().isForbidden());
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/config/ThreadPoolTaskLoggerConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/ThreadPoolTaskLoggerConfigTest.java
@@ -1,0 +1,228 @@
+package io.openaev.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("ThreadPoolTaskLoggerConfig unit tests")
+class ThreadPoolTaskLoggerConfigTest {
+
+  private final ThreadPoolTaskLoggerConfig config = new ThreadPoolTaskLoggerConfig();
+
+  @AfterEach
+  void tearDown() {
+    MDC.clear();
+    LocaleContextHolder.resetLocaleContext();
+    SecurityContextHolder.clearContext();
+    org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.clear();
+  }
+
+  @Nested
+  @DisplayName("buildThreadRequestContextHolder")
+  class BuildThreadRequestContextHolderTests {
+
+    @Test
+    void given_requestAndAuthentication_should_buildRequestContextData() {
+      // Arrange
+      MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/test");
+      request.addHeader("X-Trace-Id", "trace-123");
+      request.setRemoteAddr("127.0.0.1");
+      MockHttpSession session = new MockHttpSession();
+      request.setSession(session);
+      Authentication authentication = new TestingAuthenticationToken("john.doe", "pwd");
+
+      // Act
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData data =
+          ThreadPoolTaskLoggerConfig.buildThreadRequestContextHolder(request, authentication);
+
+      // Assert
+      assertThat(data.headers()).containsEntry("X-Trace-Id", "trace-123");
+      assertThat(data.remoteAddress()).isEqualTo("127.0.0.1");
+      assertThat(data.method()).isEqualTo("POST");
+      assertThat(data.url()).isEqualTo("http://localhost/api/test");
+      assertThat(data.sessionId()).isEqualTo(session.getId());
+      assertThat(data.authentication()).isSameAs(authentication);
+    }
+
+    @Test
+    void given_nullRequest_should_buildEmptyRequestContextData() {
+      // Arrange
+      Authentication authentication = new TestingAuthenticationToken("john.doe", "pwd");
+
+      // Act
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData data =
+          ThreadPoolTaskLoggerConfig.buildThreadRequestContextHolder(null, authentication);
+
+      // Assert
+      assertThat(data.headers()).isNull();
+      assertThat(data.remoteAddress()).isNull();
+      assertThat(data.method()).isNull();
+      assertThat(data.url()).isNull();
+      assertThat(data.sessionId()).isNull();
+      assertThat(data.authentication()).isSameAs(authentication);
+    }
+  }
+
+  @Nested
+  @DisplayName("ThreadRequestContextHolder")
+  class ThreadRequestContextHolderTests {
+
+    @Test
+    void given_valuesAreSet_should_getValuesAndTypedData() {
+      // Arrange
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.set("key", "value");
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData data =
+          new ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData(
+              Map.of("X-Test", "v"), "10.0.0.1", "GET", "http://localhost/api", "session-1", null);
+
+      // Act
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.setRequestContextData(data);
+      Object value = ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.get("key");
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData readData =
+          ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.getRequestContextData();
+
+      // Assert
+      assertThat(value).isEqualTo("value");
+      assertThat(readData).isEqualTo(data);
+    }
+
+    @Test
+    void given_contextIsCleared_should_removeStoredValues() {
+      // Arrange
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.set("key", "value");
+
+      // Act
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.clear();
+
+      // Assert
+      assertThat(ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.get("key")).isNull();
+      assertThat(ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.getRequestContextData())
+          .isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("contextAwareExecutor")
+  class ContextAwareExecutorTests {
+
+    @Test
+    void given_contextsExist_should_propagateThemToDecoratedRunnableAndCleanup() {
+      // Arrange
+      MDC.put("traceId", "trace-parent");
+      LocaleContextHolder.setLocale(Locale.FRANCE);
+      Authentication authentication = new TestingAuthenticationToken("jane.doe", "pwd");
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/audit");
+      request.addHeader("X-Test", "header-value");
+      request.setRemoteAddr("192.168.1.10");
+      MockHttpSession session = new MockHttpSession();
+      request.setSession(session);
+      org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+          new org.springframework.web.context.request.ServletRequestAttributes(request));
+
+      ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData expectedData =
+          ThreadPoolTaskLoggerConfig.buildThreadRequestContextHolder(request, authentication);
+
+      Executor rawExecutor = config.contextAwareExecutor();
+      ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) rawExecutor;
+      TaskDecorator taskDecorator =
+          Objects.requireNonNull(
+              (TaskDecorator) ReflectionTestUtils.getField(executor, "taskDecorator"),
+              "taskDecorator should be set");
+
+      AtomicReference<String> mdcTrace = new AtomicReference<>();
+      AtomicReference<Locale> locale = new AtomicReference<>();
+      AtomicReference<Authentication> auth = new AtomicReference<>();
+      AtomicReference<ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData>
+          requestData = new AtomicReference<>();
+
+      Runnable decoratedRunnable =
+          taskDecorator.decorate(
+              () -> {
+                mdcTrace.set(MDC.get("traceId"));
+                locale.set(LocaleContextHolder.getLocale());
+                auth.set(SecurityContextHolder.getContext().getAuthentication());
+                requestData.set(
+                    ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.getRequestContextData());
+              });
+
+      // Act
+      decoratedRunnable.run();
+
+      // Assert
+      assertThat(mdcTrace.get()).isEqualTo("trace-parent");
+      assertThat(locale.get()).isEqualTo(Locale.FRANCE);
+      assertThat(auth.get()).isSameAs(authentication);
+      assertThat(requestData.get()).isEqualTo(expectedData);
+
+      assertThat(MDC.getCopyOfContextMap()).isNull();
+      assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+      assertThat(ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.getRequestContextData())
+          .isNull();
+    }
+
+    @Test
+    void given_noContexts_should_executeWithoutErrors() {
+      // Arrange
+      MDC.clear();
+      LocaleContextHolder.resetLocaleContext();
+      SecurityContextHolder.clearContext();
+      org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+
+      Executor rawExecutor = config.contextAwareExecutor();
+      ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) rawExecutor;
+      TaskDecorator taskDecorator =
+          Objects.requireNonNull(
+              (TaskDecorator) ReflectionTestUtils.getField(executor, "taskDecorator"),
+              "taskDecorator should be set");
+
+      AtomicReference<Map<String, String>> mdcMap = new AtomicReference<>();
+      AtomicReference<Authentication> authentication = new AtomicReference<>();
+      AtomicReference<ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.RequestContextData>
+          requestData = new AtomicReference<>();
+
+      Runnable decoratedRunnable =
+          taskDecorator.decorate(
+              () -> {
+                mdcMap.set(MDC.getCopyOfContextMap());
+                authentication.set(SecurityContextHolder.getContext().getAuthentication());
+                requestData.set(
+                    ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder.getRequestContextData());
+              });
+
+      // Act
+      decoratedRunnable.run();
+
+      // Assert
+      assertThat(mdcMap.get()).isNull();
+      assertThat(authentication.get()).isNull();
+      assertThat(requestData.get()).isNotNull();
+      assertThat(requestData.get().headers()).isNull();
+      assertThat(requestData.get().remoteAddress()).isNull();
+      assertThat(requestData.get().method()).isNull();
+      assertThat(requestData.get().url()).isNull();
+      assertThat(requestData.get().sessionId()).isNull();
+      assertThat(requestData.get().authentication()).isNull();
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/config/ThreadPoolTaskLoggerConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/ThreadPoolTaskLoggerConfigTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/openaev-api/src/test/java/io/openaev/config/security/OpenSamlConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/security/OpenSamlConfigTest.java
@@ -1,0 +1,190 @@
+package io.openaev.config.security;
+
+import static io.openaev.database.model.User.ROLE_ADMIN;
+import static io.openaev.database.model.User.ROLE_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.User;
+import io.openaev.service.UserMappingService;
+import io.openaev.service.user_events.UserEventService;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
+import org.springframework.security.saml2.provider.service.web.authentication.Saml2WebSsoAuthenticationFilter;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("OpenSamlConfig")
+class OpenSamlConfigTest {
+
+  @Nested
+  @DisplayName("addOpenSamlConfig")
+  class AddOpenSamlConfig {
+
+    @Test
+    void given_nullRepository_should_returnWithoutThrowing() {
+      // Arrange
+      OpenSamlConfig config = buildConfig();
+      HttpSecurity httpSecurity = mock(HttpSecurity.class);
+
+      // Act / Assert
+      assertDoesNotThrow(() -> config.addOpenSamlConfig(httpSecurity));
+    }
+
+    @Test
+    void given_repositoryPresent_should_configureSamlWithoutThrowing() throws Exception {
+      // Arrange
+      OpenSamlConfig config = buildConfig();
+      RelyingPartyRegistrationRepository repository =
+          mock(RelyingPartyRegistrationRepository.class);
+      setRepositoryField(config, repository);
+
+      HttpSecurity httpSecurity = mock(HttpSecurity.class);
+      doReturn(httpSecurity)
+          .when(httpSecurity)
+          .addFilterBefore(any(), eq(Saml2WebSsoAuthenticationFilter.class));
+      doReturn(httpSecurity).when(httpSecurity).saml2Login(any());
+
+      // Act / Assert
+      assertDoesNotThrow(() -> config.addOpenSamlConfig(httpSecurity));
+    }
+  }
+
+  @Nested
+  @DisplayName("saml2UserManagement")
+  class Saml2UserManagement {
+
+    @Test
+    void given_userManagementReturnsNull_should_throwSaml2AuthenticationException() {
+      // Arrange
+      Environment env = mock(Environment.class);
+      SecurityService securityService = mock(SecurityService.class);
+      UserMappingService userMappingService = mock(UserMappingService.class);
+      UserEventService userEventService = mock(UserEventService.class);
+
+      OpenSamlConfig config =
+          new OpenSamlConfig(
+              env, securityService, userMappingService, userEventService, Optional.empty());
+
+      when(userMappingService.extractRolesFromUser(any(), anyString()))
+          .thenReturn(java.util.List.of());
+      when(userMappingService.extractGroupsFromUser(any(), anyString()))
+          .thenReturn(java.util.List.of());
+      when(env.getProperty(anyString(), eq(String.class), anyString())).thenReturn("");
+      when(securityService.userManagement(
+              anyString(), anyString(), anyList(), anyList(), any(), any()))
+          .thenReturn(null);
+
+      Saml2Authentication authentication = buildSamlAuthentication("user@openaev.io");
+
+      // Act / Assert
+      assertThrows(
+          Saml2AuthenticationException.class,
+          () -> invokeSaml2UserManagement(config, authentication));
+    }
+
+    @Test
+    void given_userManagementReturnsAdmin_should_returnSamlAuthWithUserAndAdminRoles() {
+      // Arrange
+      Environment env = mock(Environment.class);
+      SecurityService securityService = mock(SecurityService.class);
+      UserMappingService userMappingService = mock(UserMappingService.class);
+      UserEventService userEventService = mock(UserEventService.class);
+
+      OpenSamlConfig config =
+          new OpenSamlConfig(
+              env, securityService, userMappingService, userEventService, Optional.empty());
+
+      when(userMappingService.extractRolesFromUser(any(), anyString()))
+          .thenReturn(java.util.List.of());
+      when(userMappingService.extractGroupsFromUser(any(), anyString()))
+          .thenReturn(java.util.List.of());
+      when(env.getProperty(anyString(), eq(String.class), anyString())).thenReturn("");
+
+      User admin = new User();
+      admin.setEmail("admin@openaev.io");
+      admin.setFirstname("Admin");
+      admin.setLastname("User");
+      admin.setAdmin(true);
+
+      when(securityService.userManagement(
+              anyString(), anyString(), anyList(), anyList(), any(), any()))
+          .thenReturn(admin);
+
+      Saml2Authentication authentication = buildSamlAuthentication("admin@openaev.io");
+
+      // Act
+      Saml2Authentication result = invokeSaml2UserManagement(config, authentication);
+
+      // Assert
+      Set<String> authorities =
+          result.getAuthorities().stream()
+              .map(org.springframework.security.core.GrantedAuthority::getAuthority)
+              .collect(java.util.stream.Collectors.toSet());
+      assertThat(authorities).contains(ROLE_USER, ROLE_ADMIN);
+    }
+  }
+
+  private OpenSamlConfig buildConfig() {
+    Environment env = mock(Environment.class);
+    SecurityService securityService = mock(SecurityService.class);
+    UserMappingService userMappingService = mock(UserMappingService.class);
+    UserEventService userEventService = mock(UserEventService.class);
+    return new OpenSamlConfig(
+        env, securityService, userMappingService, userEventService, Optional.empty());
+  }
+
+  private void setRepositoryField(Object target, Object value) {
+    try {
+      Field field = target.getClass().getDeclaredField("relyingPartyRegistrationRepository");
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Saml2Authentication buildSamlAuthentication(String email) {
+    Saml2AuthenticatedPrincipal principal = mock(Saml2AuthenticatedPrincipal.class);
+    when(principal.getName()).thenReturn(email);
+    when(principal.getRelyingPartyRegistrationId()).thenReturn("oidc");
+    when(principal.getFirstAttribute(anyString())).thenReturn(null);
+    return new Saml2Authentication(principal, "saml-response", java.util.List.of());
+  }
+
+  private Saml2Authentication invokeSaml2UserManagement(
+      OpenSamlConfig config, Saml2Authentication authentication) {
+    try {
+      Method method =
+          OpenSamlConfig.class.getDeclaredMethod("saml2UserManagement", Saml2Authentication.class);
+      method.setAccessible(true);
+      return (Saml2Authentication) method.invoke(config, authentication);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new RuntimeException(e.getCause());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
@@ -263,6 +263,192 @@ class LogServiceTest {
         assertNull(event.getUserMetadata().getSessionId());
       }
     }
+
+    @Test
+    @DisplayName("given_auditDisabled_should_returnTrueWithoutDispatching")
+    void given_auditDisabled_should_returnTrueWithoutDispatching() {
+      // -- PREPARE --
+      when(auditLogProperties.isEnabled()).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result = logService.logAuthEvent("login", "success", "local", null, null, null);
+
+      // -- VERIFY --
+      assertTrue(result);
+      verify(auditLogTransportDispatcherUtils, never()).dispatch(any(LogEvent.class), any());
+    }
+
+    @Test
+    @DisplayName("given_previewFeatureDisabled_should_returnTrueWithoutDispatching")
+    void given_previewFeatureDisabled_should_returnTrueWithoutDispatching() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result = logService.logAuthEvent("login", "success", "local", null, null, null);
+
+      // -- VERIFY --
+      assertTrue(result);
+      verify(auditLogTransportDispatcherUtils, never()).dispatch(any(LogEvent.class), any());
+    }
+
+    @Test
+    @DisplayName("given_dispatchException_should_returnFalse")
+    void given_dispatchException_should_returnFalse() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any()))
+          .thenThrow(new RuntimeException("dispatch failed"));
+
+      // -- EXECUTE --
+      boolean result =
+          assertDoesNotThrow(
+              () -> logService.logAuthEvent("login", "success", "local", null, null, null));
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(auditLogTransportDispatcherUtils).dispatch(any(LogEvent.class), any());
+    }
+  }
+
+  @Nested
+  @DisplayName("logRequestEvent")
+  class LogRequestEvent {
+
+    @Test
+    @DisplayName("given_auditDisabled_should_returnTrueWithoutDispatching")
+    void given_auditDisabled_should_returnTrueWithoutDispatching() {
+      // -- PREPARE --
+      when(auditLogProperties.isEnabled()).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result =
+          logService.logRequestEvent(
+              "update",
+              "success",
+              ResourceType.USER_GROUP,
+              "group-id",
+              null,
+              null,
+              null,
+              objectMapper.createObjectNode(),
+              Level.WARNING,
+              "uuid-9");
+
+      // -- VERIFY --
+      assertTrue(result);
+      verify(auditLogTransportDispatcherUtils, never()).dispatch(any(LogEvent.class), any());
+    }
+
+    @Test
+    @DisplayName("given_previewFeatureDisabled_should_returnTrueWithoutDispatching")
+    void given_previewFeatureDisabled_should_returnTrueWithoutDispatching() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result =
+          logService.logRequestEvent(
+              "update",
+              "success",
+              ResourceType.USER_GROUP,
+              "group-id",
+              null,
+              null,
+              null,
+              objectMapper.createObjectNode(),
+              Level.WARNING,
+              "uuid-10");
+
+      // -- VERIFY --
+      assertTrue(result);
+      verify(auditLogTransportDispatcherUtils, never()).dispatch(any(LogEvent.class), any());
+    }
+
+    @Test
+    @DisplayName("given_dispatchReturnsFalse_should_returnFalse")
+    void given_dispatchReturnsFalse_should_returnFalse() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any())).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result =
+          logService.logRequestEvent(
+              "update",
+              "success",
+              ResourceType.USER_GROUP,
+              "group-id",
+              null,
+              null,
+              null,
+              objectMapper.createObjectNode(),
+              Level.WARNING,
+              "uuid-11");
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(auditLogTransportDispatcherUtils).dispatch(any(LogEvent.class), any());
+    }
+
+    @Test
+    @DisplayName("given_dispatchException_should_returnFalse")
+    void given_dispatchException_should_returnFalse() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any()))
+          .thenThrow(new RuntimeException("dispatch failed"));
+
+      // -- EXECUTE --
+      boolean result =
+          assertDoesNotThrow(
+              () ->
+                  logService.logRequestEvent(
+                      "update",
+                      "success",
+                      ResourceType.USER_GROUP,
+                      "group-id",
+                      null,
+                      null,
+                      null,
+                      objectMapper.createObjectNode(),
+                      Level.WARNING,
+                      "uuid-12"));
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(auditLogTransportDispatcherUtils).dispatch(any(LogEvent.class), any());
+    }
+
+    @Test
+    @DisplayName("given_nullEntityDiffs_should_dispatchWithoutDiffContext")
+    void given_nullEntityDiffs_should_dispatchWithoutDiffContext() {
+      // -- PREPARE --
+      when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any())).thenReturn(true);
+
+      // -- EXECUTE --
+      boolean result =
+          logService.logRequestEvent(
+              "update",
+              "success",
+              ResourceType.USER_GROUP,
+              "group-id",
+              null,
+              null,
+              null,
+              null,
+              Level.WARNING,
+              "uuid-13");
+
+      // -- VERIFY --
+      assertTrue(result);
+      ArgumentCaptor<LogEvent> captor = ArgumentCaptor.forClass(LogEvent.class);
+      verify(auditLogTransportDispatcherUtils).dispatch(captor.capture(), any());
+      LogEvent event = captor.getValue();
+      assertNotNull(event.getContextData());
+      assertFalse(event.getContextData().containsKey("entity_diffs"));
+    }
   }
 
   @Test
@@ -699,6 +885,75 @@ class LogServiceTest {
 
     private JsonNode captureSignature() {
       return captureEvent().getRequestMetadata().getSignature();
+    }
+  }
+
+  @Nested
+  @DisplayName("isEnabled")
+  class IsEnabled {
+
+    @Test
+    @DisplayName("given_auditDisabled_should_returnFalseWithoutLicenseCheck")
+    void given_auditDisabled_should_returnFalseWithoutLicenseCheck() {
+      // -- PREPARE --
+      when(auditLogProperties.isEnabled()).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result = logService.isEnabled();
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(enterpriseEditionService, never()).isLicenseActive(any());
+    }
+
+    @Test
+    @DisplayName("given_previewFeatureDisabled_should_returnFalseWithoutLicenseCheck")
+    void given_previewFeatureDisabled_should_returnFalseWithoutLicenseCheck() {
+      // -- PREPARE --
+      when(auditLogProperties.isEnabled()).thenReturn(true);
+      when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result = logService.isEnabled();
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(enterpriseEditionService, never()).isLicenseActive(any());
+    }
+
+    @Test
+    @DisplayName("given_licenseInactive_should_returnFalse")
+    void given_licenseInactive_should_returnFalse() {
+      // -- PREPARE --
+      when(auditLogProperties.isEnabled()).thenReturn(true);
+      when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+      when(enterpriseEditionService.isLicenseActive(any())).thenReturn(false);
+
+      // -- EXECUTE --
+      boolean result = logService.isEnabled();
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(licenseCacheManager).getEnterpriseEditionInfo();
+      verify(enterpriseEditionService).isLicenseActive(any());
+    }
+
+    @Test
+    @DisplayName("given_licenseCheckThrows_should_returnFalse")
+    void given_licenseCheckThrows_should_returnFalse() {
+      // -- PREPARE --
+      when(auditLogProperties.isEnabled()).thenReturn(true);
+      when(previewFeatureService.isFeatureEnabled(PreviewFeature.AUDIT_LOG)).thenReturn(true);
+      when(enterpriseEditionService.isLicenseActive(any()))
+          .thenThrow(new RuntimeException("license check failed"));
+
+      // -- EXECUTE --
+      boolean result = assertDoesNotThrow(() -> logService.isEnabled());
+
+      // -- VERIFY --
+      assertFalse(result);
+      verify(licenseCacheManager).getEnterpriseEditionInfo();
+      verify(enterpriseEditionService).isLicenseActive(any());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/utils/HttpReqRespUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/HttpReqRespUtilsTest.java
@@ -1,0 +1,230 @@
+package io.openaev.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openaev.config.ThreadPoolTaskLoggerConfig.ThreadRequestContextHolder;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@DisplayName("HttpReqRespUtils")
+class HttpReqRespUtilsTest {
+
+  @AfterEach
+  void cleanup() {
+    RequestContextHolder.resetRequestAttributes();
+    ThreadRequestContextHolder.clear();
+  }
+
+  @Nested
+  @DisplayName("getClientIpAddressFromHeaders")
+  class GetClientIpAddressFromHeaders {
+
+    @Test
+    void given_forwardedForWithMultipleIps_should_returnFirstIp() {
+      // Arrange
+      Map<String, String> headers = Map.of("X-Forwarded-For", "203.0.113.10, 70.41.3.18");
+
+      // Act
+      String ip = HttpReqRespUtils.getClientIpAddressFromHeaders(headers);
+
+      // Assert
+      assertThat(ip).isEqualTo("203.0.113.10");
+    }
+
+    @Test
+    void given_unknownOrEmptyHeaders_should_returnNull() {
+      // Arrange
+      Map<String, String> headers =
+          Map.of("X-Forwarded-For", "unknown", "Proxy-Client-IP", "", "X-Real-IP", "unknown");
+
+      // Act
+      String ip = HttpReqRespUtils.getClientIpAddressFromHeaders(headers);
+
+      // Assert
+      assertThat(ip).isNull();
+    }
+
+    @Test
+    void given_caseInsensitiveHeader_should_returnIp() {
+      // Arrange
+      Map<String, String> headers = Map.of("x-forwarded-for", "198.51.100.22");
+
+      // Act
+      String ip = HttpReqRespUtils.getClientIpAddressFromHeaders(headers);
+
+      // Assert
+      assertThat(ip).isEqualTo("198.51.100.22");
+    }
+  }
+
+  @Nested
+  @DisplayName("extractHeader")
+  class ExtractHeader {
+
+    @Test
+    void given_mixedCaseHeaderName_should_extractValueIgnoringCase() {
+      // Arrange
+      Map<String, String> headers = Map.of("X-Correlation-Id", "corr-123");
+
+      // Act
+      String value = HttpReqRespUtils.extractHeader(headers, "x-correlation-id");
+
+      // Assert
+      assertThat(value).isEqualTo("corr-123");
+    }
+
+    @Test
+    void given_missingHeader_should_returnNull() {
+      // Arrange
+      Map<String, String> headers = Map.of("X-Correlation-Id", "corr-123");
+
+      // Act
+      String value = HttpReqRespUtils.extractHeader(headers, "x-request-id");
+
+      // Assert
+      assertThat(value).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("extractHeaders")
+  class ExtractHeaders {
+
+    @Test
+    void given_requestWithHeaders_should_returnAllHeadersMap() {
+      // Arrange
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      Enumeration<String> names = Collections.enumeration(java.util.List.of("h1", "h2"));
+      when(request.getHeaderNames()).thenReturn(names);
+      when(request.getHeader("h1")).thenReturn("v1");
+      when(request.getHeader("h2")).thenReturn("v2");
+
+      // Act
+      Map<String, String> headers = HttpReqRespUtils.extractHeaders(request);
+
+      // Assert
+      assertThat(headers).containsEntry("h1", "v1").containsEntry("h2", "v2");
+    }
+
+    @Test
+    void given_requestThrowsIllegalState_should_fallbackToThreadContextHeaders() {
+      // Arrange
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getHeaderNames()).thenThrow(new IllegalStateException("recycled"));
+      ThreadRequestContextHolder.setRequestContextData(
+          new ThreadRequestContextHolder.RequestContextData(
+              Map.of("x-fallback", "fb-value"), null, null, null, null, null));
+
+      // Act
+      Map<String, String> headers = HttpReqRespUtils.extractHeaders(request);
+
+      // Assert
+      assertThat(headers).containsEntry("x-fallback", "fb-value");
+    }
+  }
+
+  @Nested
+  @DisplayName("extractMethod")
+  class ExtractMethod {
+
+    @Test
+    void given_requestMethod_should_returnMethod() {
+      // Arrange
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getMethod()).thenReturn("PUT");
+
+      // Act
+      String method = HttpReqRespUtils.extractMethod(request);
+
+      // Assert
+      assertThat(method).isEqualTo("PUT");
+    }
+
+    @Test
+    void given_requestThrowsIllegalState_should_fallbackToThreadContextMethod() {
+      // Arrange
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      when(request.getMethod()).thenThrow(new IllegalStateException("recycled"));
+      ThreadRequestContextHolder.setRequestContextData(
+          new ThreadRequestContextHolder.RequestContextData(null, null, "PATCH", null, null, null));
+
+      // Act
+      String method = HttpReqRespUtils.extractMethod(request);
+
+      // Assert
+      assertThat(method).isEqualTo("PATCH");
+    }
+  }
+
+  @Nested
+  @DisplayName("getCurrentRequest")
+  class GetCurrentRequest {
+
+    @Test
+    void given_requestAttributesPresent_should_returnCurrentRequest() {
+      // Arrange
+      HttpServletRequest request = mock(HttpServletRequest.class);
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+      // Act
+      HttpServletRequest currentRequest = HttpReqRespUtils.getCurrentRequest();
+
+      // Assert
+      assertThat(currentRequest).isSameAs(request);
+    }
+
+    @Test
+    void given_noRequestAttributes_should_returnNull() {
+      // Arrange
+      RequestContextHolder.resetRequestAttributes();
+
+      // Act
+      HttpServletRequest currentRequest = HttpReqRespUtils.getCurrentRequest();
+
+      // Assert
+      assertThat(currentRequest).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("getClientIpAddressIfServletRequestExist")
+  class GetClientIpAddressIfServletRequestExist {
+
+    @Test
+    void given_noRequest_should_fallbackToThreadContextRemoteAddress() {
+      // Arrange
+      ThreadRequestContextHolder.setRequestContextData(
+          new ThreadRequestContextHolder.RequestContextData(
+              Map.of(), "10.20.30.40", null, null, null, null));
+
+      // Act
+      String ip = HttpReqRespUtils.getClientIpAddressIfServletRequestExist();
+
+      // Assert
+      assertThat(ip).isEqualTo("10.20.30.40");
+    }
+
+    @Test
+    void given_noRequestAndNoThreadContext_should_returnDefaultIp() {
+      // Arrange
+      RequestContextHolder.resetRequestAttributes();
+      ThreadRequestContextHolder.clear();
+
+      // Act
+      String ip = HttpReqRespUtils.getClientIpAddressIfServletRequestExist();
+
+      // Assert
+      assertThat(ip).isEqualTo("0.0.0.0");
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/object/ObjectNormalizationUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/object/ObjectNormalizationUtilsTest.java
@@ -1,0 +1,582 @@
+package io.openaev.utils.object;
+
+import static io.openaev.utils.object.ObjectNormalizationUtils.isEffectivelyEmpty;
+import static io.openaev.utils.object.ObjectNormalizationUtils.isInsignificantValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.utils.SystemLoadGuardUtils;
+import java.math.BigDecimal;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ObjectNormalizationUtils")
+class ObjectNormalizationUtilsTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final int MAX_EVENT_SIZE = 32_768;
+  private static final int MAX_STRING_BYTES = 1_024;
+  private static final int TRUNCATION_PREVIEW_BYTES = 2_048;
+  private static final String TRUNCATED_SUFFIX = "...[TRUNCATED]";
+  private static final String REDACTED_VALUE = "[REDACTED]";
+
+  @Mock private SystemLoadGuardUtils systemLoadGuardUtils;
+
+  @Mock private ObjectNormalizationPolicy objectNormalizationPolicy;
+
+  private ObjectNormalizationUtils normalizationUtils;
+
+  @BeforeEach
+  void setUp() {
+    normalizationUtils =
+        new ObjectNormalizationUtils(
+            OBJECT_MAPPER, systemLoadGuardUtils, objectNormalizationPolicy);
+    lenient().when(objectNormalizationPolicy.skipAllNormalization()).thenReturn(false);
+    lenient().when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(false);
+    lenient().when(objectNormalizationPolicy.maxEventSizeBytes()).thenReturn(MAX_EVENT_SIZE);
+    lenient().when(objectNormalizationPolicy.maxStringBytes()).thenReturn(MAX_STRING_BYTES);
+    lenient()
+        .when(objectNormalizationPolicy.truncationPreviewBytes())
+        .thenReturn(TRUNCATION_PREVIEW_BYTES);
+    lenient().when(objectNormalizationPolicy.truncatedSuffix()).thenReturn(TRUNCATED_SUFFIX);
+    lenient().when(objectNormalizationPolicy.redactedValue()).thenReturn(REDACTED_VALUE);
+    lenient().when(objectNormalizationPolicy.allowlistForEntity(anyString())).thenReturn(null);
+    lenient().when(objectNormalizationPolicy.denylistForEntity(anyString())).thenReturn(Set.of());
+    lenient().when(objectNormalizationPolicy.isGloballyDeniedField(anyString())).thenReturn(false);
+    lenient()
+        .when(objectNormalizationPolicy.normalizeEntityType(anyString()))
+        .thenAnswer(inv -> inv.getArgument(0));
+  }
+
+  // -- isEffectivelyEmpty --
+
+  @Nested
+  @DisplayName("isEffectivelyEmpty")
+  class IsEffectivelyEmpty {
+
+    @Test
+    void given_null_should_returnTrue() {
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(null)).isTrue();
+    }
+
+    @Test
+    void given_nullNode_should_returnTrue() {
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(NullNode.getInstance())).isTrue();
+    }
+
+    @Test
+    void given_emptyArray_should_returnTrue() {
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(OBJECT_MAPPER.createArrayNode())).isTrue();
+    }
+
+    @Test
+    void given_emptyObject_should_returnTrue() {
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(OBJECT_MAPPER.createObjectNode())).isTrue();
+    }
+
+    @Test
+    void given_nonEmptyTextNode_should_returnFalse() {
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(JsonNodeFactory.instance.textNode("hello"))).isFalse();
+    }
+
+    @Test
+    void given_nonEmptyArray_should_returnFalse() {
+      // Arrange
+      var arr = OBJECT_MAPPER.createArrayNode();
+      arr.add("item");
+
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(arr)).isFalse();
+    }
+
+    @Test
+    void given_nonEmptyObject_should_returnFalse() {
+      // Arrange
+      var obj = OBJECT_MAPPER.createObjectNode();
+      obj.put("key", "value");
+
+      // Act & Assert
+      assertThat(isEffectivelyEmpty(obj)).isFalse();
+    }
+  }
+
+  // -- isInsignificantValue --
+
+  @Nested
+  @DisplayName("isInsignificantValue")
+  class IsInsignificantValue {
+
+    @Test
+    void given_nullNode_should_returnTrue() {
+      // Act & Assert
+      assertThat(isInsignificantValue(NullNode.getInstance())).isTrue();
+    }
+
+    @Test
+    void given_emptyString_should_returnTrue() {
+      // Act & Assert
+      assertThat(isInsignificantValue(JsonNodeFactory.instance.textNode(""))).isTrue();
+    }
+
+    @Test
+    void given_booleanFalse_should_returnTrue() {
+      // Act & Assert
+      assertThat(isInsignificantValue(JsonNodeFactory.instance.booleanNode(false))).isTrue();
+    }
+
+    @Test
+    void given_booleanTrue_should_returnFalse() {
+      // Act & Assert
+      assertThat(isInsignificantValue(JsonNodeFactory.instance.booleanNode(true))).isFalse();
+    }
+
+    @Test
+    void given_nonBlankString_should_returnFalse() {
+      // Act & Assert
+      assertThat(isInsignificantValue(JsonNodeFactory.instance.textNode("hello"))).isFalse();
+    }
+
+    @Test
+    void given_number_should_returnFalse() {
+      // Act & Assert
+      assertThat(isInsignificantValue(JsonNodeFactory.instance.numberNode(42))).isFalse();
+    }
+
+    @Test
+    void given_emptyObject_should_returnTrue() {
+      // Act & Assert
+      assertThat(isInsignificantValue(OBJECT_MAPPER.createObjectNode())).isTrue();
+    }
+
+    @Test
+    void given_emptyArray_should_returnTrue() {
+      // Act & Assert
+      assertThat(isInsignificantValue(OBJECT_MAPPER.createArrayNode())).isTrue();
+    }
+  }
+
+  // -- shouldSkipAllNormalization --
+
+  @Nested
+  @DisplayName("shouldSkipAllNormalization")
+  class ShouldSkipAllNormalization {
+
+    @Test
+    void given_policySkipAll_should_returnTrue() {
+      // Arrange
+      when(objectNormalizationPolicy.skipAllNormalization()).thenReturn(true);
+
+      // Act & Assert
+      assertThat(normalizationUtils.shouldSkipAllNormalization()).isTrue();
+    }
+
+    @Test
+    void given_policyNoSkip_should_returnFalse() {
+      // Arrange
+      when(objectNormalizationPolicy.skipAllNormalization()).thenReturn(false);
+
+      // Act & Assert
+      assertThat(normalizationUtils.shouldSkipAllNormalization()).isFalse();
+    }
+  }
+
+  // -- shouldSkipFullNormalization --
+
+  @Nested
+  @DisplayName("shouldSkipFullNormalization")
+  class ShouldSkipFullNormalization {
+
+    @Test
+    void given_skipOnHighLoadDisabled_should_returnFalse() {
+      // Arrange
+      when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(false);
+
+      // Act & Assert
+      assertThat(normalizationUtils.shouldSkipFullNormalization()).isFalse();
+    }
+
+    @Test
+    void given_skipOnHighLoad_and_heapHigh_should_returnTrue() {
+      // Arrange
+      when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(true);
+      when(objectNormalizationPolicy.maxHeapUsageRatio()).thenReturn(0.9);
+      when(systemLoadGuardUtils.isHeapUsageHigh(0.9)).thenReturn(true);
+
+      // Act & Assert
+      assertThat(normalizationUtils.shouldSkipFullNormalization()).isTrue();
+    }
+
+    @Test
+    void given_skipOnHighLoad_and_cpuHigh_should_returnTrue() {
+      // Arrange
+      when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(true);
+      when(objectNormalizationPolicy.maxHeapUsageRatio()).thenReturn(0.9);
+      when(objectNormalizationPolicy.maxProcessCpuLoad()).thenReturn(0.9);
+      when(systemLoadGuardUtils.isHeapUsageHigh(0.9)).thenReturn(false);
+      when(systemLoadGuardUtils.isProcessCpuLoadHigh(0.9)).thenReturn(true);
+
+      // Act & Assert
+      assertThat(normalizationUtils.shouldSkipFullNormalization()).isTrue();
+    }
+
+    @Test
+    void given_skipOnHighLoad_and_loadNormal_should_returnFalse() {
+      // Arrange
+      when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(true);
+      when(objectNormalizationPolicy.maxHeapUsageRatio()).thenReturn(0.9);
+      when(objectNormalizationPolicy.maxProcessCpuLoad()).thenReturn(0.9);
+      when(systemLoadGuardUtils.isHeapUsageHigh(0.9)).thenReturn(false);
+      when(systemLoadGuardUtils.isProcessCpuLoadHigh(0.9)).thenReturn(false);
+
+      // Act & Assert
+      assertThat(normalizationUtils.shouldSkipFullNormalization()).isFalse();
+    }
+  }
+
+  // -- normalize --
+
+  @Nested
+  @DisplayName("normalize")
+  class Normalize {
+
+    @Test
+    void given_skipAllNormalization_should_returnOriginalNode() {
+      // Arrange
+      when(objectNormalizationPolicy.skipAllNormalization()).thenReturn(true);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "test");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result).isSameAs(node);
+    }
+
+    @Test
+    void given_nullInput_should_returnNullNode() {
+      // Act
+      JsonNode result = normalizationUtils.normalize(null);
+
+      // Assert
+      assertThat(result.isNull()).isTrue();
+    }
+
+    @Test
+    void given_blankTextField_should_normalizeToNull() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "hello");
+      node.put("description", "   ");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert — blank text is normalised to null then stripped as insignificant
+      assertThat(result.path("name").asText()).isEqualTo("hello");
+      assertThat(result.has("description")).isFalse();
+    }
+
+    @Test
+    void given_falseBooleanField_should_stripFromOutput() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "hello");
+      node.put("active", false);
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("name").asText()).isEqualTo("hello");
+      assertThat(result.has("active")).isFalse();
+    }
+
+    @Test
+    void given_trueBooleanField_should_keepInOutput() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("active", true);
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("active").asBoolean()).isTrue();
+    }
+
+    @Test
+    void given_diffSkipField_should_stripFromOutput() {
+      // Arrange — "type" is in DIFF_SKIP_FIELDS
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("type", "inject");
+      node.put("name", "test");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.has("type")).isFalse();
+      assertThat(result.path("name").asText()).isEqualTo("test");
+    }
+
+    @Test
+    void given_numberWithTrailingDecimalZeros_should_stripTrailingZeros() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("value", new BigDecimal("1.10"));
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("value").decimalValue().toPlainString()).isEqualTo("1.1");
+    }
+
+    @Test
+    void given_wholeNumberWithDecimalZero_should_returnIntegerRepresentation() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("value", new BigDecimal("2.0"));
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("value").isIntegralNumber()).isTrue();
+      assertThat(result.path("value").asInt()).isEqualTo(2);
+    }
+
+    @Test
+    void given_emptyArrayField_should_normalizeToNull() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "hello");
+      node.putArray("tags");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert — empty array normalised to null then stripped as insignificant
+      assertThat(result.path("name").asText()).isEqualTo("hello");
+      assertThat(result.has("tags")).isFalse();
+    }
+
+    @Test
+    void given_allInsignificantFields_should_returnNullNode() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("active", false);
+      node.put("description", "");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.isNull()).isTrue();
+    }
+
+    @Test
+    void given_globallyDeniedField_should_redactValue() {
+      // Arrange
+      when(objectNormalizationPolicy.isGloballyDeniedField("password")).thenReturn(true);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("password", "secret123");
+      node.put("name", "test");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("password").asText()).isEqualTo(REDACTED_VALUE);
+      assertThat(result.path("name").asText()).isEqualTo("test");
+    }
+
+    @Test
+    void given_entityDenylistField_should_redactValue() {
+      // Arrange
+      when(objectNormalizationPolicy.denylistForEntity("user")).thenReturn(Set.of("access_token"));
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("access_token", "my-token");
+      node.put("user_name", "alice");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node, "user");
+
+      // Assert
+      assertThat(result.path("access_token").asText()).isEqualTo(REDACTED_VALUE);
+      assertThat(result.path("user_name").asText()).isEqualTo("alice");
+    }
+
+    @Test
+    void given_entityAllowlist_should_keepOnlyAllowlistedFields() {
+      // Arrange
+      when(objectNormalizationPolicy.allowlistForEntity("audit_event"))
+          .thenReturn(Set.of("event_type", "entity_id"));
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("event_type", "CREATE");
+      node.put("entity_id", "abc-123");
+      node.put("extra_field", "should-be-removed");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node, "audit_event");
+
+      // Assert
+      assertThat(result.path("event_type").asText()).isEqualTo("CREATE");
+      assertThat(result.path("entity_id").asText()).isEqualTo("abc-123");
+      assertThat(result.has("extra_field")).isFalse();
+    }
+
+    @Test
+    void given_nestedObject_should_normalizeRecursively() {
+      // Arrange
+      ObjectNode inner = OBJECT_MAPPER.createObjectNode();
+      inner.put("label", "nested");
+      inner.put("flag", false);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.set("inner", inner);
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("inner").path("label").asText()).isEqualTo("nested");
+      assertThat(result.path("inner").has("flag")).isFalse();
+    }
+  }
+
+  // -- normalize - size enforcement --
+
+  @Nested
+  @DisplayName("normalize - size enforcement")
+  class NormalizeSizeEnforcement {
+
+    @Test
+    void given_nodeBelowMaxSize_should_returnNormalizedNodeUnchanged() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "small");
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("name").asText()).isEqualTo("small");
+      assertThat(result.has("truncated")).isFalse();
+    }
+
+    @Test
+    void given_oversizedNodeWithLongStrings_should_truncateStringValues() {
+      // Arrange — small max size forces string truncation
+      when(objectNormalizationPolicy.maxEventSizeBytes()).thenReturn(60);
+      when(objectNormalizationPolicy.maxStringBytes()).thenReturn(10);
+      when(objectNormalizationPolicy.truncatedSuffix()).thenReturn("...");
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "a".repeat(200));
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert — original 200-char string is not present
+      assertThat(result.toString()).doesNotContain("a".repeat(200));
+    }
+
+    @Test
+    void given_extremelyOversizedNode_should_returnTruncatedEnvelope() {
+      // Arrange — tiny max size forces the envelope fallback
+      when(objectNormalizationPolicy.maxEventSizeBytes()).thenReturn(10);
+      when(objectNormalizationPolicy.maxStringBytes()).thenReturn(5);
+      when(objectNormalizationPolicy.truncatedSuffix()).thenReturn("...");
+      when(objectNormalizationPolicy.truncationPreviewBytes()).thenReturn(5);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("field1", "x".repeat(500));
+      node.put("field2", "y".repeat(500));
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert
+      assertThat(result.path("truncated").asBoolean()).isTrue();
+      assertThat(result.has("original_size_bytes")).isTrue();
+      assertThat(result.has("max_size_bytes")).isTrue();
+      assertThat(result.path("max_size_bytes").asInt()).isEqualTo(10);
+    }
+
+    @Test
+    void given_sizeEnforcementDisabled_should_skipSizeCheck() {
+      // Arrange — maxEventSizeBytes <= 0 disables enforcement
+      when(objectNormalizationPolicy.maxEventSizeBytes()).thenReturn(0);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "x".repeat(100_000));
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert — no truncation envelope
+      assertThat(result.has("truncated")).isFalse();
+    }
+  }
+
+  // -- normalize - high-load mode --
+
+  @Nested
+  @DisplayName("normalize - high-load mode")
+  class NormalizeHighLoad {
+
+    @Test
+    void given_highHeapLoad_should_skipInsignificantValueStripping() {
+      // Arrange — high load: schema rules + size enforcement only, no strip step
+      when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(true);
+      when(objectNormalizationPolicy.maxHeapUsageRatio()).thenReturn(0.9);
+      when(systemLoadGuardUtils.isHeapUsageHigh(0.9)).thenReturn(true);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "test");
+      node.put("active", false); // would normally be stripped
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert — stripInsignificantValues is skipped → false boolean is preserved
+      assertThat(result.has("active")).isTrue();
+      assertThat(result.path("active").asBoolean()).isFalse();
+    }
+
+    @Test
+    void given_highCpuLoad_should_applySchemaRulesOnly() {
+      // Arrange
+      when(objectNormalizationPolicy.skipOnHighLoad()).thenReturn(true);
+      when(objectNormalizationPolicy.maxHeapUsageRatio()).thenReturn(0.9);
+      when(objectNormalizationPolicy.maxProcessCpuLoad()).thenReturn(0.9);
+      when(systemLoadGuardUtils.isHeapUsageHigh(0.9)).thenReturn(false);
+      when(systemLoadGuardUtils.isProcessCpuLoadHigh(0.9)).thenReturn(true);
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "test");
+      node.put("active", false);
+
+      // Act
+      JsonNode result = normalizationUtils.normalize(node);
+
+      // Assert — value normalization / stripping skipped
+      assertThat(result.has("active")).isTrue();
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/object/ObjectRedactionUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/object/ObjectRedactionUtilsTest.java
@@ -1,0 +1,229 @@
+package io.openaev.utils.object;
+
+import static io.openaev.helper.CryptoHelper.hashWithSHA256;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.database.model.ResourceType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ObjectRedactionUtils")
+class ObjectRedactionUtilsTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String REDACTED_TEXT = "*** Redacted ***";
+
+  @Nested
+  @DisplayName("redact")
+  class Redact {
+
+    @Test
+    void given_nullNode_should_returnNull() {
+      // Arrange
+      JsonNode node = null;
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.USER);
+
+      // Assert
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void given_userEntity_should_removeUserPiiFields() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "John Doe");
+      node.put("user_email", "john@openaev.io");
+      node.put("user_phone", "123456");
+      node.put("safe_field", "safe");
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.USER);
+
+      // Assert
+      assertThat(result.has("name")).isFalse();
+      assertThat(result.has("user_email")).isFalse();
+      assertThat(result.has("user_phone")).isFalse();
+      assertThat(result.path("safe_field").asText()).isEqualTo("safe");
+    }
+
+    @Test
+    void given_nonUserEntity_should_keepUserPiiFields() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("name", "John Doe");
+      node.put("user_email", "john@openaev.io");
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.TEAM);
+
+      // Assert
+      assertThat(result.path("name").asText()).isEqualTo("John Doe");
+      assertThat(result.path("user_email").asText()).isEqualTo("john@openaev.io");
+    }
+
+    @Test
+    void given_sensitiveRegexFields_should_redactValues() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("db_password", "secretValue");
+      node.put("client_secret", "secretValue");
+      node.put("smtp_credential", "secretValue");
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.TEAM);
+
+      // Assert
+      assertThat(result.path("db_password").asText()).isEqualTo(REDACTED_TEXT);
+      assertThat(result.path("client_secret").asText()).isEqualTo(REDACTED_TEXT);
+      assertThat(result.path("smtp_credential").asText()).isEqualTo(REDACTED_TEXT);
+    }
+
+    @Test
+    void given_allowedSensitiveSuffixes_should_notRedact() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("password_date", "2026-01-01");
+      node.put("secret_time", "12:00:00");
+      node.put("credential_at", "2026-01-01T12:00:00Z");
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.TEAM);
+
+      // Assert
+      assertThat(result.path("password_date").asText()).isEqualTo("2026-01-01");
+      assertThat(result.path("secret_time").asText()).isEqualTo("12:00:00");
+      assertThat(result.path("credential_at").asText()).isEqualTo("2026-01-01T12:00:00Z");
+    }
+
+    @Test
+    void given_hashRegexFields_should_hashValues() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("token", "plain-token");
+      node.put("apikey", "plain-apikey");
+      node.put("api_key", "plain-api-key");
+      node.put("user_pgp_key", "plain-pgp");
+      node.put("endpoint_mac_addresses", "AA:BB:CC");
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.TEAM);
+
+      // Assert
+      assertThat(result.path("token").asText()).isEqualTo(hashWithSHA256("plain-token"));
+      assertThat(result.path("apikey").asText()).isEqualTo(hashWithSHA256("plain-apikey"));
+      assertThat(result.path("api_key").asText()).isEqualTo(hashWithSHA256("plain-api-key"));
+      assertThat(result.path("user_pgp_key").asText()).isEqualTo(hashWithSHA256("plain-pgp"));
+      assertThat(result.path("endpoint_mac_addresses").asText())
+          .isEqualTo(hashWithSHA256("AA:BB:CC"));
+    }
+
+    @Test
+    void given_hashAllowedSuffixes_should_notHash() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      node.put("token_date", "2026-01-01");
+      node.put("apikey_time", "12:00:00");
+      node.put("api_key_at", "2026-01-01T12:00:00Z");
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.TEAM);
+
+      // Assert
+      assertThat(result.path("token_date").asText()).isEqualTo("2026-01-01");
+      assertThat(result.path("apikey_time").asText()).isEqualTo("12:00:00");
+      assertThat(result.path("api_key_at").asText()).isEqualTo("2026-01-01T12:00:00Z");
+    }
+
+    @Test
+    void given_nestedObjectAndArray_should_processRecursively() {
+      // Arrange
+      ObjectNode node = OBJECT_MAPPER.createObjectNode();
+      ObjectNode nested = OBJECT_MAPPER.createObjectNode();
+      nested.put("password", "nested-pass");
+      nested.put("token", "nested-token");
+      node.set("nested", nested);
+
+      node.putArray("items")
+          .add(OBJECT_MAPPER.createObjectNode().put("client_secret", "arr-secret"))
+          .add(OBJECT_MAPPER.createObjectNode().put("api_key", "arr-api"));
+
+      // Act
+      JsonNode result = ObjectRedactionUtils.redact(node, ResourceType.TEAM);
+
+      // Assert
+      assertThat(result.path("nested").path("password").asText()).isEqualTo(REDACTED_TEXT);
+      assertThat(result.path("nested").path("token").asText())
+          .isEqualTo(hashWithSHA256("nested-token"));
+      assertThat(result.path("items").get(0).path("client_secret").asText())
+          .isEqualTo(REDACTED_TEXT);
+      assertThat(result.path("items").get(1).path("api_key").asText())
+          .isEqualTo(hashWithSHA256("arr-api"));
+    }
+  }
+
+  @Nested
+  @DisplayName("redactFieldValue")
+  class RedactFieldValue {
+
+    @Test
+    void given_nullValue_should_returnNull() {
+      // Arrange
+
+      // Act
+      Object result = ObjectRedactionUtils.redactFieldValue(null, "token");
+
+      // Assert
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void given_userPiiFieldName_should_returnNull() {
+      // Arrange
+
+      // Act
+      Object result = ObjectRedactionUtils.redactFieldValue("john@openaev.io", "user_email");
+
+      // Assert
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void given_hashFieldName_should_returnHashedString() {
+      // Arrange
+
+      // Act
+      Object result = ObjectRedactionUtils.redactFieldValue("plain-token", "token");
+
+      // Assert
+      assertThat(result).isEqualTo(hashWithSHA256("plain-token"));
+    }
+
+    @Test
+    void given_redactFieldName_should_returnRedactedMarker() {
+      // Arrange
+
+      // Act
+      Object result = ObjectRedactionUtils.redactFieldValue("plain-password", "password");
+
+      // Assert
+      assertThat(result).isEqualTo(REDACTED_TEXT);
+    }
+
+    @Test
+    void given_blankString_should_returnOriginalValue() {
+      // Arrange
+
+      // Act
+      Object result = ObjectRedactionUtils.redactFieldValue("   ", "password");
+
+      // Assert
+      assertThat(result).isEqualTo("   ");
+    }
+  }
+}


### PR DESCRIPTION
### Description

Code coverage should be optimized,

### Proposed changes

* Increase the code coverage for audit-logging by adding new e2e tests and test units to the audi-logging code.

### Testing Instructions

Run the following cmds:
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.aop.audit_log.AccessControlAuditLogAspectTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.service.LogServiceTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.config.ThreadPoolTaskLoggerConfigTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.config.AppSecurityConfigTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.config.security.OpenSamlConfigTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.utils.HttpReqRespUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.utils.object.ObjectRedactionUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.utils.object.ObjectNormalizationUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test

### Related issues

* Closes #5480

### Checklis

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
