### PR TITLE
test(audit_log): relocating ObjectDiffUtils inside of the object folder and create some test units (#5480)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -79,7 +79,6 @@ public class AccessControlAuditLogAspect {
     }
 
     Object result = null;
-    Map<String, EntityDiffContext.EntitySnapshot> snapshots = null;
 
     try {
       result = joinPoint.proceed();
@@ -87,24 +86,18 @@ public class AccessControlAuditLogAspect {
       if (isActive) {
         try {
           if (isRbacDeniedException(ex)) {
-            // Capture snapshots on the servlet thread before any async handoff.
-            snapshots = captureEntitySnapshots();
             String eventScope = LogUtils.getEventScope(Action.UNAUTHORIZED);
             String eventStatus = LogUtils.getEventStatus(EventStatus.ERROR);
             JsonNode errorNode = buildErrorNode(null, ex);
 
-            logAccessControlEvent(
-                joinPoint, accessControl, eventScope, eventStatus, errorNode, snapshots);
+            logAccessControlEvent(joinPoint, accessControl, eventScope, eventStatus, errorNode);
           } else if (isActionActive) {
-            // Capture snapshots on the servlet thread before any async handoff.
-            snapshots = captureEntitySnapshots();
             String eventScope = LogUtils.getEventScope(action);
             String eventStatus = LogUtils.getEventStatus(EventStatus.ERROR);
             JsonNode resultNode = getOutputNode(result);
             JsonNode errorNode = buildErrorNode(resultNode, ex);
 
-            logAccessControlEvent(
-                joinPoint, accessControl, eventScope, eventStatus, errorNode, snapshots);
+            logAccessControlEvent(joinPoint, accessControl, eventScope, eventStatus, errorNode);
           }
         } catch (Exception e) {
           log.warn(LOG_ERROR_MSG, e);
@@ -115,14 +108,11 @@ public class AccessControlAuditLogAspect {
 
     if (isActive && isActionActive) {
       try {
-        // Capture snapshots on the servlet thread before any async handoff.
-        snapshots = captureEntitySnapshots();
         String eventScope = LogUtils.getEventScope(action);
         String eventStatus = LogUtils.getEventStatus(EventStatus.SUCCESS);
         JsonNode resultNode = getOutputNode(result);
 
-        logAccessControlEvent(
-            joinPoint, accessControl, eventScope, eventStatus, resultNode, snapshots);
+        logAccessControlEvent(joinPoint, accessControl, eventScope, eventStatus, resultNode);
       } catch (Exception ex) {
         log.warn(LOG_ERROR_MSG, ex);
       }
@@ -136,14 +126,16 @@ public class AccessControlAuditLogAspect {
       AccessControl accessControl,
       String eventScope,
       String eventStatus,
-      JsonNode outputNode,
-      Map<String, EntityDiffContext.EntitySnapshot> snapshots) {
+      JsonNode outputNode) {
     try {
       String logUUID = UUID.randomUUID().toString();
       ResourceType resourceType = accessControl.resourceType();
       String resourceId = resolveResourceId(joinPoint, accessControl);
       JsonNode inputNode = getInputNode(joinPoint, eventScope);
       JsonNode signatureNode = getMethodSignature(joinPoint, inputNode);
+
+      // Capture snapshots on the servlet thread before any async handoff.
+      Map<String, EntityDiffContext.EntitySnapshot> snapshots = captureEntitySnapshots();
 
       BiConsumer<Boolean, Throwable> logCompletion =
           (success, throwable) -> {

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AuditLogger.java
@@ -10,7 +10,7 @@ import io.openaev.database.audit.EntityDiffContext;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.service.LogService;
-import io.openaev.utils.ObjectDiffUtils;
+import io.openaev.utils.object.ObjectDiffUtils;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectDiffUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectDiffUtils.java
@@ -1,4 +1,4 @@
-package io.openaev.utils;
+package io.openaev.utils.object;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectDiffUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectDiffUtils.java
@@ -96,15 +96,5 @@ public class ObjectDiffUtils {
   public record FieldChange(
       String field,
       @JsonProperty("old_value") Object oldValue,
-      @JsonProperty("new_value") Object newValue) {
-
-    /**
-     * Returns a human-readable summary of the change, e.g. {@code "old value Alice -> new value
-     * Bob"}.
-     */
-    @JsonProperty("change")
-    public String change() {
-      return "old value " + oldValue + " -> new value " + newValue;
-    }
-  }
+      @JsonProperty("new_value") Object newValue) {}
 }

--- a/openaev-api/src/main/java/io/openaev/utils/object/ObjectDiffUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/object/ObjectDiffUtils.java
@@ -96,5 +96,15 @@ public class ObjectDiffUtils {
   public record FieldChange(
       String field,
       @JsonProperty("old_value") Object oldValue,
-      @JsonProperty("new_value") Object newValue) {}
+      @JsonProperty("new_value") Object newValue) {
+
+    /**
+     * Returns a human-readable summary of the change, e.g. {@code "old value Alice -> new value
+     * Bob"}.
+     */
+    @JsonProperty("change")
+    public String change() {
+      return "old value " + oldValue + " -> new value " + newValue;
+    }
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/utils/object/ObjectDiffUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/object/ObjectDiffUtilsTest.java
@@ -62,6 +62,10 @@ class ObjectDiffUtilsTest {
       assertThat(entry.get("operation").asText()).isEqualTo("UPDATE");
       assertThat(entry.get("changes").isArray()).isTrue();
       assertThat(entry.get("changes").size()).isEqualTo(1);
+
+      JsonNode firstChange = entry.get("changes").get(0);
+      assertThat(firstChange.get("old_value").asText()).isEqualTo("Alice");
+      assertThat(firstChange.get("new_value").asText()).isEqualTo("Bob");
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/utils/object/ObjectDiffUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/object/ObjectDiffUtilsTest.java
@@ -12,10 +12,7 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class ObjectDiffUtilsTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -103,7 +100,7 @@ class ObjectDiffUtilsTest {
 
       // -- ASSERT --
       assertThat(result).isNotNull();
-      assertThat(result.get(0).get("changes").size()).isEqualTo(0);
+      assertThat(result.get(0).get("changes").size()).isZero();
     }
   }
 
@@ -132,9 +129,9 @@ class ObjectDiffUtilsTest {
       List<ObjectDiffUtils.FieldChange> changes = ObjectDiffUtils.computeFieldChanges(null, after);
 
       // -- ASSERT --
-      assertThat(changes).hasSize(2);
-      assertThat(changes).allSatisfy(c -> assertThat(c.oldValue()).isNull());
       assertThat(changes)
+          .hasSize(2)
+          .allSatisfy(c -> assertThat(c.oldValue()).isNull())
           .extracting(ObjectDiffUtils.FieldChange::field)
           .containsExactlyInAnyOrder("name", "age");
     }
@@ -149,9 +146,9 @@ class ObjectDiffUtilsTest {
       List<ObjectDiffUtils.FieldChange> changes = ObjectDiffUtils.computeFieldChanges(before, null);
 
       // -- ASSERT --
-      assertThat(changes).hasSize(2);
-      assertThat(changes).allSatisfy(c -> assertThat(c.newValue()).isNull());
       assertThat(changes)
+          .hasSize(2)
+          .allSatisfy(c -> assertThat(c.newValue()).isNull())
           .extracting(ObjectDiffUtils.FieldChange::field)
           .containsExactlyInAnyOrder("name", "age");
     }
@@ -179,7 +176,7 @@ class ObjectDiffUtilsTest {
 
       // -- ASSERT --
       assertThat(changes).hasSize(1);
-      ObjectDiffUtils.FieldChange change = changes.get(0);
+      ObjectDiffUtils.FieldChange change = changes.getFirst();
       assertThat(change.field()).isEqualTo("name");
       assertThat(change.oldValue()).isEqualTo("Alice");
       assertThat(change.newValue()).isEqualTo("Bob");
@@ -200,9 +197,9 @@ class ObjectDiffUtilsTest {
 
       // -- ASSERT --
       assertThat(changes).hasSize(1);
-      assertThat(changes.get(0).field()).isEqualTo("email");
-      assertThat(changes.get(0).oldValue()).isNull();
-      assertThat(changes.get(0).newValue()).isEqualTo("alice@example.com");
+      assertThat(changes.getFirst().field()).isEqualTo("email");
+      assertThat(changes.getFirst().oldValue()).isNull();
+      assertThat(changes.getFirst().newValue()).isEqualTo("alice@example.com");
     }
 
     @Test
@@ -220,9 +217,9 @@ class ObjectDiffUtilsTest {
 
       // -- ASSERT --
       assertThat(changes).hasSize(1);
-      assertThat(changes.get(0).field()).isEqualTo("email");
-      assertThat(changes.get(0).oldValue()).isEqualTo("alice@example.com");
-      assertThat(changes.get(0).newValue()).isNull();
+      assertThat(changes.getFirst().field()).isEqualTo("email");
+      assertThat(changes.getFirst().oldValue()).isEqualTo("alice@example.com");
+      assertThat(changes.getFirst().newValue()).isNull();
     }
 
     @Test
@@ -255,7 +252,7 @@ class ObjectDiffUtilsTest {
 
       // -- ASSERT --
       assertThat(changes).hasSize(1);
-      assertThat(changes.get(0).field()).isEqualTo("roles");
+      assertThat(changes.getFirst().field()).isEqualTo("roles");
     }
   }
 
@@ -300,7 +297,7 @@ class ObjectDiffUtilsTest {
       String norm2 = ObjectDiffUtils.normalizeForComparison(list2);
 
       // -- ASSERT --
-      assertThat(norm1).isEqualTo(norm2).isEqualTo("apple,banana,cherry");
+      assertThat(norm1).isEqualTo(norm2);
     }
 
     @Test
@@ -320,32 +317,18 @@ class ObjectDiffUtilsTest {
     }
 
     @Test
-    @DisplayName("Should normalize a map to key=value pairs sorted by key")
-    void given_mapValue_should_returnKeyValuePairsSortedByKey() {
-      // -- ARRANGE --
-      Map<String, Object> map = new LinkedHashMap<>();
-      map.put("z", "last");
-      map.put("a", "first");
-      map.put("m", "middle");
-
-      // -- ACT --
-      String result = ObjectDiffUtils.normalizeForComparison(map);
-
-      // -- ASSERT --
-      assertThat(result).isEqualTo("a=first|m=middle|z=last");
-    }
-
-    @Test
     @DisplayName(
         "Should return the same normalized string for maps with same entries in different insertion order")
     void given_mapsWithDifferentInsertionOrder_should_returnSameNormalizedString() {
       // -- ARRANGE --
       Map<String, Object> map1 = new LinkedHashMap<>();
-      map1.put("b", "2");
-      map1.put("a", "1");
+      map1.put("z", "last");
+      map1.put("a", "first");
+      map1.put("m", "middle");
       Map<String, Object> map2 = new LinkedHashMap<>();
-      map2.put("a", "1");
-      map2.put("b", "2");
+      map2.put("a", "first");
+      map2.put("m", "middle");
+      map2.put("z", "last");
 
       // -- ACT --
       String norm1 = ObjectDiffUtils.normalizeForComparison(map1);
@@ -356,34 +339,42 @@ class ObjectDiffUtilsTest {
     }
 
     @Test
-    @DisplayName("Should handle nested map values recursively")
-    void given_mapWithNestedMapValue_should_normalizeRecursively() {
+    @DisplayName(
+        "Should return the same normalized string for nested maps with same entries in different insertion order")
+    void given_nestedMapsWithDifferentInsertionOrder_should_returnSameNormalizedString() {
       // -- ARRANGE --
-      Map<String, Object> inner = new LinkedHashMap<>();
-      inner.put("x", "10");
-      inner.put("y", "20");
-      Map<String, Object> outer = new LinkedHashMap<>();
-      outer.put("nested", inner);
+      Map<String, Object> inner1 = new LinkedHashMap<>();
+      inner1.put("y", "20");
+      inner1.put("x", "10");
+      Map<String, Object> outer1 = new LinkedHashMap<>();
+      outer1.put("nested", inner1);
+
+      Map<String, Object> inner2 = new LinkedHashMap<>();
+      inner2.put("x", "10");
+      inner2.put("y", "20");
+      Map<String, Object> outer2 = new LinkedHashMap<>();
+      outer2.put("nested", inner2);
 
       // -- ACT --
-      String result = ObjectDiffUtils.normalizeForComparison(outer);
+      String norm1 = ObjectDiffUtils.normalizeForComparison(outer1);
+      String norm2 = ObjectDiffUtils.normalizeForComparison(outer2);
 
       // -- ASSERT --
-      assertThat(result).isEqualTo("nested=x=10|y=20");
+      assertThat(norm1).isEqualTo(norm2);
     }
 
     @Test
     @DisplayName("Should handle an empty collection")
     void given_emptyCollection_should_returnEmptyString() {
       // -- ACT & ASSERT --
-      assertThat(ObjectDiffUtils.normalizeForComparison(List.of())).isEqualTo("");
+      assertThat(ObjectDiffUtils.normalizeForComparison(List.of())).isEmpty();
     }
 
     @Test
     @DisplayName("Should handle an empty map")
     void given_emptyMap_should_returnEmptyString() {
       // -- ACT & ASSERT --
-      assertThat(ObjectDiffUtils.normalizeForComparison(Map.of())).isEqualTo("");
+      assertThat(ObjectDiffUtils.normalizeForComparison(Map.of())).isEmpty();
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/utils/object/ObjectDiffUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/object/ObjectDiffUtilsTest.java
@@ -1,0 +1,389 @@
+package io.openaev.utils.object;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.database.audit.EntityDiffContext;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ObjectDiffUtilsTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  // ---------------------------------------------------------------------------
+  // computeEntityDiffsNode
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("computeEntityDiffsNode")
+  class ComputeEntityDiffsNode {
+
+    @Test
+    @DisplayName("Should return null when snapshots map is null")
+    void given_nullSnapshots_should_returnNull() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.computeEntityDiffsNode(null, objectMapper)).isNull();
+    }
+
+    @Test
+    @DisplayName("Should return null when snapshots map is empty")
+    void given_emptySnapshots_should_returnNull() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.computeEntityDiffsNode(Map.of(), objectMapper)).isNull();
+    }
+
+    @Test
+    @DisplayName("Should return a JSON array with one entry for a single snapshot")
+    void given_singleSnapshot_should_returnJsonArrayWithOneEntry() {
+      // -- ARRANGE --
+      var snapshot =
+          new EntityDiffContext.EntitySnapshot(
+              "User", "UPDATE", Map.of("name", "Alice"), Map.of("name", "Bob"));
+      Map<String, EntityDiffContext.EntitySnapshot> snapshots = Map.of("user-1", snapshot);
+
+      // -- ACT --
+      JsonNode result = ObjectDiffUtils.computeEntityDiffsNode(snapshots, objectMapper);
+
+      // -- ASSERT --
+      assertThat(result).isNotNull();
+      assertThat(result.isArray()).isTrue();
+      assertThat(result.size()).isEqualTo(1);
+
+      JsonNode entry = result.get(0);
+      assertThat(entry.get("id").asText()).isEqualTo("user-1");
+      assertThat(entry.get("entity_type").asText()).isEqualTo("User");
+      assertThat(entry.get("operation").asText()).isEqualTo("UPDATE");
+      assertThat(entry.get("changes").isArray()).isTrue();
+      assertThat(entry.get("changes").size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Should return a JSON array with multiple entries for multiple snapshots")
+    void given_multipleSnapshots_should_returnJsonArrayWithMultipleEntries() {
+      // -- ARRANGE --
+      Map<String, EntityDiffContext.EntitySnapshot> snapshots = new LinkedHashMap<>();
+      snapshots.put(
+          "user-1",
+          new EntityDiffContext.EntitySnapshot(
+              "User", "UPDATE", Map.of("name", "Alice"), Map.of("name", "Bob")));
+      snapshots.put(
+          "org-1",
+          new EntityDiffContext.EntitySnapshot(
+              "Organization", "DELETE", Map.of("orgName", "Acme"), null));
+
+      // -- ACT --
+      JsonNode result = ObjectDiffUtils.computeEntityDiffsNode(snapshots, objectMapper);
+
+      // -- ASSERT --
+      assertThat(result).isNotNull();
+      assertThat(result.isArray()).isTrue();
+      assertThat(result.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Should include an empty changes array when before equals after")
+    void given_unchangedSnapshot_should_returnEmptyChangesArray() {
+      // -- ARRANGE --
+      Map<String, Object> state = Map.of("name", "Alice", "age", 30);
+      var snapshot = new EntityDiffContext.EntitySnapshot("User", "UPDATE", state, state);
+      Map<String, EntityDiffContext.EntitySnapshot> snapshots = Map.of("user-1", snapshot);
+
+      // -- ACT --
+      JsonNode result = ObjectDiffUtils.computeEntityDiffsNode(snapshots, objectMapper);
+
+      // -- ASSERT --
+      assertThat(result).isNotNull();
+      assertThat(result.get(0).get("changes").size()).isEqualTo(0);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // computeFieldChanges
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("computeFieldChanges")
+  class ComputeFieldChanges {
+
+    @Test
+    @DisplayName("Should return empty list when both before and after are null")
+    void given_bothNull_should_returnEmptyList() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.computeFieldChanges(null, null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should return all after fields as additions when before is null")
+    void given_beforeNull_should_returnAllAfterFieldsAsAdditions() {
+      // -- ARRANGE --
+      Map<String, Object> after = Map.of("name", "Alice", "age", 30);
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes = ObjectDiffUtils.computeFieldChanges(null, after);
+
+      // -- ASSERT --
+      assertThat(changes).hasSize(2);
+      assertThat(changes).allSatisfy(c -> assertThat(c.oldValue()).isNull());
+      assertThat(changes)
+          .extracting(ObjectDiffUtils.FieldChange::field)
+          .containsExactlyInAnyOrder("name", "age");
+    }
+
+    @Test
+    @DisplayName("Should return all before fields as removals when after is null")
+    void given_afterNull_should_returnAllBeforeFieldsAsRemovals() {
+      // -- ARRANGE --
+      Map<String, Object> before = Map.of("name", "Alice", "age", 30);
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes = ObjectDiffUtils.computeFieldChanges(before, null);
+
+      // -- ASSERT --
+      assertThat(changes).hasSize(2);
+      assertThat(changes).allSatisfy(c -> assertThat(c.newValue()).isNull());
+      assertThat(changes)
+          .extracting(ObjectDiffUtils.FieldChange::field)
+          .containsExactlyInAnyOrder("name", "age");
+    }
+
+    @Test
+    @DisplayName("Should return empty list when before and after are identical")
+    void given_identicalMaps_should_returnEmptyList() {
+      // -- ARRANGE --
+      Map<String, Object> state = Map.of("name", "Alice", "age", 30);
+
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.computeFieldChanges(state, state)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should detect a modified field")
+    void given_modifiedField_should_returnOneChange() {
+      // -- ARRANGE --
+      Map<String, Object> before = Map.of("name", "Alice");
+      Map<String, Object> after = Map.of("name", "Bob");
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes =
+          ObjectDiffUtils.computeFieldChanges(before, after);
+
+      // -- ASSERT --
+      assertThat(changes).hasSize(1);
+      ObjectDiffUtils.FieldChange change = changes.get(0);
+      assertThat(change.field()).isEqualTo("name");
+      assertThat(change.oldValue()).isEqualTo("Alice");
+      assertThat(change.newValue()).isEqualTo("Bob");
+    }
+
+    @Test
+    @DisplayName("Should detect a newly added field")
+    void given_newFieldInAfter_should_includeAdditionChange() {
+      // -- ARRANGE --
+      Map<String, Object> before = Map.of("name", "Alice");
+      Map<String, Object> after = new LinkedHashMap<>();
+      after.put("name", "Alice");
+      after.put("email", "alice@example.com");
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes =
+          ObjectDiffUtils.computeFieldChanges(before, after);
+
+      // -- ASSERT --
+      assertThat(changes).hasSize(1);
+      assertThat(changes.get(0).field()).isEqualTo("email");
+      assertThat(changes.get(0).oldValue()).isNull();
+      assertThat(changes.get(0).newValue()).isEqualTo("alice@example.com");
+    }
+
+    @Test
+    @DisplayName("Should detect a removed field")
+    void given_fieldRemovedInAfter_should_includeRemovalChange() {
+      // -- ARRANGE --
+      Map<String, Object> before = new LinkedHashMap<>();
+      before.put("name", "Alice");
+      before.put("email", "alice@example.com");
+      Map<String, Object> after = Map.of("name", "Alice");
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes =
+          ObjectDiffUtils.computeFieldChanges(before, after);
+
+      // -- ASSERT --
+      assertThat(changes).hasSize(1);
+      assertThat(changes.get(0).field()).isEqualTo("email");
+      assertThat(changes.get(0).oldValue()).isEqualTo("alice@example.com");
+      assertThat(changes.get(0).newValue()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should not report a change when collection fields differ only in order")
+    void given_collectionFieldsWithDifferentOrder_should_notReportChange() {
+      // -- ARRANGE --
+      Map<String, Object> before = new LinkedHashMap<>();
+      before.put("roles", new ArrayList<>(List.of("ADMIN", "USER")));
+      Map<String, Object> after = new LinkedHashMap<>();
+      after.put("roles", new ArrayList<>(List.of("USER", "ADMIN")));
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes =
+          ObjectDiffUtils.computeFieldChanges(before, after);
+
+      // -- ASSERT --
+      assertThat(changes).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should report a change when collection fields have different elements")
+    void given_collectionFieldsWithDifferentElements_should_reportChange() {
+      // -- ARRANGE --
+      Map<String, Object> before = Map.of("roles", List.of("ADMIN"));
+      Map<String, Object> after = Map.of("roles", List.of("USER"));
+
+      // -- ACT --
+      List<ObjectDiffUtils.FieldChange> changes =
+          ObjectDiffUtils.computeFieldChanges(before, after);
+
+      // -- ASSERT --
+      assertThat(changes).hasSize(1);
+      assertThat(changes.get(0).field()).isEqualTo("roles");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // normalizeForComparison
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("normalizeForComparison")
+  class NormalizeForComparison {
+
+    @Test
+    @DisplayName("Should return null when value is null")
+    void given_nullValue_should_returnNull() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.normalizeForComparison(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("Should return toString representation for a plain string value")
+    void given_plainStringValue_should_returnSameString() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.normalizeForComparison("hello")).isEqualTo("hello");
+    }
+
+    @Test
+    @DisplayName("Should return toString representation for a numeric value")
+    void given_numericValue_should_returnStringRepresentation() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.normalizeForComparison(42)).isEqualTo("42");
+    }
+
+    @Test
+    @DisplayName("Should return the same normalized string for collections differing only in order")
+    void given_collectionsWithDifferentOrder_should_returnSameNormalizedString() {
+      // -- ARRANGE --
+      List<String> list1 = List.of("banana", "apple", "cherry");
+      List<String> list2 = List.of("cherry", "banana", "apple");
+
+      // -- ACT --
+      String norm1 = ObjectDiffUtils.normalizeForComparison(list1);
+      String norm2 = ObjectDiffUtils.normalizeForComparison(list2);
+
+      // -- ASSERT --
+      assertThat(norm1).isEqualTo(norm2).isEqualTo("apple,banana,cherry");
+    }
+
+    @Test
+    @DisplayName(
+        "Should return different normalized strings for collections with different elements")
+    void given_collectionsWithDifferentElements_should_returnDifferentNormalizedStrings() {
+      // -- ARRANGE --
+      List<String> list1 = List.of("apple", "banana");
+      List<String> list2 = List.of("apple", "mango");
+
+      // -- ACT --
+      String norm1 = ObjectDiffUtils.normalizeForComparison(list1);
+      String norm2 = ObjectDiffUtils.normalizeForComparison(list2);
+
+      // -- ASSERT --
+      assertThat(norm1).isNotEqualTo(norm2);
+    }
+
+    @Test
+    @DisplayName("Should normalize a map to key=value pairs sorted by key")
+    void given_mapValue_should_returnKeyValuePairsSortedByKey() {
+      // -- ARRANGE --
+      Map<String, Object> map = new LinkedHashMap<>();
+      map.put("z", "last");
+      map.put("a", "first");
+      map.put("m", "middle");
+
+      // -- ACT --
+      String result = ObjectDiffUtils.normalizeForComparison(map);
+
+      // -- ASSERT --
+      assertThat(result).isEqualTo("a=first|m=middle|z=last");
+    }
+
+    @Test
+    @DisplayName(
+        "Should return the same normalized string for maps with same entries in different insertion order")
+    void given_mapsWithDifferentInsertionOrder_should_returnSameNormalizedString() {
+      // -- ARRANGE --
+      Map<String, Object> map1 = new LinkedHashMap<>();
+      map1.put("b", "2");
+      map1.put("a", "1");
+      Map<String, Object> map2 = new LinkedHashMap<>();
+      map2.put("a", "1");
+      map2.put("b", "2");
+
+      // -- ACT --
+      String norm1 = ObjectDiffUtils.normalizeForComparison(map1);
+      String norm2 = ObjectDiffUtils.normalizeForComparison(map2);
+
+      // -- ASSERT --
+      assertThat(norm1).isEqualTo(norm2);
+    }
+
+    @Test
+    @DisplayName("Should handle nested map values recursively")
+    void given_mapWithNestedMapValue_should_normalizeRecursively() {
+      // -- ARRANGE --
+      Map<String, Object> inner = new LinkedHashMap<>();
+      inner.put("x", "10");
+      inner.put("y", "20");
+      Map<String, Object> outer = new LinkedHashMap<>();
+      outer.put("nested", inner);
+
+      // -- ACT --
+      String result = ObjectDiffUtils.normalizeForComparison(outer);
+
+      // -- ASSERT --
+      assertThat(result).isEqualTo("nested=x=10|y=20");
+    }
+
+    @Test
+    @DisplayName("Should handle an empty collection")
+    void given_emptyCollection_should_returnEmptyString() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.normalizeForComparison(List.of())).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("Should handle an empty map")
+    void given_emptyMap_should_returnEmptyString() {
+      // -- ACT & ASSERT --
+      assertThat(ObjectDiffUtils.normalizeForComparison(Map.of())).isEqualTo("");
+    }
+  }
+}


### PR DESCRIPTION
### Description

ObjectDiffUtils class is in the wrong folder.

### Proposed changes

* Move ObjectDiffUtils file to utils/object/ folder.
* Also create the correspondent test units class.

### Testing Instructions

Run the following cmds:
- mvn -U -pl openaev-api -am -Dspring.profiles.active=dev -Dtest=io.openaev.utils.object.ObjectDiffUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test

### Related issues

* Closes #5480

### Checklis

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
