### PR TITLE
fix(front): reserve top banner height so the top bar is not glued to it (#6146)

### DIFF
--- a/openaev-front/src/__tests__/public/systembanners/utils.test.ts
+++ b/openaev-front/src/__tests__/public/systembanners/utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeBannerSettings } from '../../../public/components/systembanners/utils';
+import { LICENSE_OPTION_TRIAL, TOP_BANNER_HEIGHT } from '../../../public/components/trialbanners/constants';
+import { type PlatformSettings } from '../../../utils/api-types';
+
+const SYSTEM_BANNER_HEIGHT_PER_MESSAGE = 18;
+const SYSTEM_BANNER_VERTICAL_PADDING = 16;
+// Mirrors DEMO_PLATFORM_URL in utils/Environment (kept private there).
+const DEMO_PLATFORM_URL = 'https://demo.openaev.io';
+
+const buildSettings = (overrides: Partial<PlatformSettings> = {}): PlatformSettings => ({
+  platform_base_url: 'https://app.example.com',
+  ...overrides,
+} as unknown as PlatformSettings);
+
+describe('computeBannerSettings', () => {
+  it('given no banners should reserve no height', () => {
+    const result = computeBannerSettings(buildSettings());
+
+    expect(result.bannerHeightNumber).toBe(0);
+    expect(result.bannerHeight).toBe('0px');
+  });
+
+  it('given a trial license should reserve the top banner height', () => {
+    const result = computeBannerSettings(
+      buildSettings({ platform_license: { license_type: LICENSE_OPTION_TRIAL } as PlatformSettings['platform_license'] }),
+    );
+
+    expect(result.bannerHeightNumber).toBe(TOP_BANNER_HEIGHT);
+    expect(result.bannerHeight).toBe(`${TOP_BANNER_HEIGHT}px`);
+  });
+
+  it('given a demo instance should reserve the top banner height', () => {
+    const result = computeBannerSettings(buildSettings({ platform_base_url: DEMO_PLATFORM_URL }));
+
+    expect(result.bannerHeightNumber).toBe(TOP_BANNER_HEIGHT);
+  });
+
+  it('given system banner messages should reserve per-message height plus padding', () => {
+    const result = computeBannerSettings(
+      buildSettings({
+        platform_banner_by_level: {
+          info: ['a', 'b'],
+          warn: ['c'],
+        } as unknown as PlatformSettings['platform_banner_by_level'],
+      }),
+    );
+
+    expect(result.bannerHeightNumber).toBe((SYSTEM_BANNER_HEIGHT_PER_MESSAGE * 3) + SYSTEM_BANNER_VERTICAL_PADDING);
+  });
+
+  it('given both system messages and a trial license should sum both heights', () => {
+    const result = computeBannerSettings(
+      buildSettings({
+        platform_license: { license_type: LICENSE_OPTION_TRIAL } as PlatformSettings['platform_license'],
+        platform_banner_by_level: { info: ['a'] } as unknown as PlatformSettings['platform_banner_by_level'],
+      }),
+    );
+
+    expect(result.bannerHeightNumber).toBe(
+      SYSTEM_BANNER_HEIGHT_PER_MESSAGE + SYSTEM_BANNER_VERTICAL_PADDING + TOP_BANNER_HEIGHT,
+    );
+  });
+
+  it('given banner levels with only empty messages should reserve no system height', () => {
+    const result = computeBannerSettings(
+      buildSettings({
+        platform_banner_by_level: {
+          info: [],
+          warn: [],
+        } as unknown as PlatformSettings['platform_banner_by_level'],
+      }),
+    );
+
+    expect(result.bannerHeightNumber).toBe(0);
+  });
+});

--- a/openaev-front/src/public/components/systembanners/utils.ts
+++ b/openaev-front/src/public/components/systembanners/utils.ts
@@ -1,8 +1,7 @@
 import { type PlatformSettings } from '../../../utils/api-types';
 import { isDemoInstance } from '../../../utils/Environment';
-import { isNotEmptyField, recordEntries, recordKeys } from '../../../utils/utils';
-import { LICENSE_OPTION_TRIAL } from '../trialbanners/LicenseBanner';
-import { TOP_BANNER_HEIGHT } from '../trialbanners/TopBanner';
+import { recordEntries } from '../../../utils/utils';
+import { LICENSE_OPTION_TRIAL, TOP_BANNER_HEIGHT } from '../trialbanners/constants';
 
 const SYSTEM_BANNER_HEIGHT_PER_MESSAGE = 18;
 // Extra breathing space kept below the system banner messages.
@@ -11,11 +10,6 @@ export type BannerMessage = Record<'debug' | 'info' | 'warn' | 'error' | 'fatal'
 // eslint-disable-next-line import/prefer-default-export
 export const computeBannerSettings = (settings: PlatformSettings) => {
   const bannerByLevel = settings.platform_banner_by_level;
-  const isSystemBannerActivated = bannerByLevel !== undefined
-    && isNotEmptyField(recordKeys(bannerByLevel));
-  // Trial / demo / license banner displayed at the very top of the platform.
-  const isTopBannerActivated = settings.platform_license?.license_type === LICENSE_OPTION_TRIAL
-    || isDemoInstance(settings);
 
   let numberOfElements = 0;
   if (bannerByLevel !== undefined) {
@@ -23,6 +17,14 @@ export const computeBannerSettings = (settings: PlatformSettings) => {
       numberOfElements += bannerLevel[1].length;
     }
   }
+
+  // The system banner is only rendered when it actually has messages (see
+  // SystemBanners), so reserve its height only then to avoid an unexplained
+  // offset when banner levels exist but carry no messages.
+  const isSystemBannerActivated = numberOfElements > 0;
+  // Trial / demo / license banner displayed at the very top of the platform.
+  const isTopBannerActivated = settings.platform_license?.license_type === LICENSE_OPTION_TRIAL
+    || isDemoInstance(settings);
 
   // Reserve the actual height of each displayed banner so the top bar (logo,
   // search) is never glued to / hidden behind them. The top banner has a fixed

--- a/openaev-front/src/public/components/systembanners/utils.ts
+++ b/openaev-front/src/public/components/systembanners/utils.ts
@@ -2,24 +2,37 @@ import { type PlatformSettings } from '../../../utils/api-types';
 import { isDemoInstance } from '../../../utils/Environment';
 import { isNotEmptyField, recordEntries, recordKeys } from '../../../utils/utils';
 import { LICENSE_OPTION_TRIAL } from '../trialbanners/LicenseBanner';
+import { TOP_BANNER_HEIGHT } from '../trialbanners/TopBanner';
 
 const SYSTEM_BANNER_HEIGHT_PER_MESSAGE = 18;
+// Extra breathing space kept below the system banner messages.
+const SYSTEM_BANNER_VERTICAL_PADDING = 16;
 export type BannerMessage = Record<'debug' | 'info' | 'warn' | 'error' | 'fatal', string[]>;
 // eslint-disable-next-line import/prefer-default-export
 export const computeBannerSettings = (settings: PlatformSettings) => {
   const bannerByLevel = settings.platform_banner_by_level;
-  const isBannerActivated = (bannerByLevel !== undefined
-    && isNotEmptyField(recordKeys(bannerByLevel)))
-  || settings.platform_license?.license_type === LICENSE_OPTION_TRIAL
-  || isDemoInstance(settings);
+  const isSystemBannerActivated = bannerByLevel !== undefined
+    && isNotEmptyField(recordKeys(bannerByLevel));
+  // Trial / demo / license banner displayed at the very top of the platform.
+  const isTopBannerActivated = settings.platform_license?.license_type === LICENSE_OPTION_TRIAL
+    || isDemoInstance(settings);
+
   let numberOfElements = 0;
-  if (settings.platform_banner_by_level !== undefined) {
-    for (const bannerLevel of recordEntries(settings.platform_banner_by_level)) {
+  if (bannerByLevel !== undefined) {
+    for (const bannerLevel of recordEntries(bannerByLevel)) {
       numberOfElements += bannerLevel[1].length;
     }
   }
-  const bannerHeight = isBannerActivated ? `${(SYSTEM_BANNER_HEIGHT_PER_MESSAGE * numberOfElements) + 16}px` : '0';
-  const bannerHeightNumber = isBannerActivated ? (SYSTEM_BANNER_HEIGHT_PER_MESSAGE * numberOfElements) + 16 : 0;
+
+  // Reserve the actual height of each displayed banner so the top bar (logo,
+  // search) is never glued to / hidden behind them. The top banner has a fixed
+  // height (TOP_BANNER_HEIGHT), the system banner grows with its messages.
+  const systemBannerHeight = isSystemBannerActivated
+    ? (SYSTEM_BANNER_HEIGHT_PER_MESSAGE * numberOfElements) + SYSTEM_BANNER_VERTICAL_PADDING
+    : 0;
+  const topBannerHeight = isTopBannerActivated ? TOP_BANNER_HEIGHT : 0;
+  const bannerHeightNumber = systemBannerHeight + topBannerHeight;
+  const bannerHeight = `${bannerHeightNumber}px`;
   return {
     bannerByLevel,
     bannerHeight,

--- a/openaev-front/src/public/components/trialbanners/LicenseBanner.tsx
+++ b/openaev-front/src/public/components/trialbanners/LicenseBanner.tsx
@@ -15,9 +15,9 @@ import { simplePostCall } from '../../../utils/Action';
 import { type License, type PlatformSettings } from '../../../utils/api-types';
 import { daysBetweenDates } from '../../../utils/Time';
 import { zodImplement } from '../../../utils/Zod';
+import { LICENSE_OPTION_TRIAL } from './constants';
 import TopBanner, { type TopBannerColor } from './TopBanner';
 
-export const LICENSE_OPTION_TRIAL = 'trial';
 const TRIAL_YELLOW_DAYS = 8;
 const TRIAL_GREEN_DAYS = 22;
 interface ContactUsInput { message: string }

--- a/openaev-front/src/public/components/trialbanners/TopBanner.tsx
+++ b/openaev-front/src/public/components/trialbanners/TopBanner.tsx
@@ -8,9 +8,7 @@ import type React from 'react';
 import type { LoggedHelper } from '../../../actions/helper';
 import { useHelper } from '../../../store';
 import { isNotEmptyField } from '../../../utils/utils';
-
-export const TOP_BANNER_HEIGHT = 30;
-export const SYSTEM_BANNER_HEIGHT = 20;
+import { SYSTEM_BANNER_HEIGHT, TOP_BANNER_HEIGHT } from './constants';
 
 const TOPBANNER_COLORS = {
   gradient_blue: {

--- a/openaev-front/src/public/components/trialbanners/constants.ts
+++ b/openaev-front/src/public/components/trialbanners/constants.ts
@@ -1,0 +1,6 @@
+// Shared, framework-agnostic constants for the platform banners. Kept out of the
+// React component modules so pure layout utilities (e.g. computeBannerSettings)
+// can reuse them without importing MUI/React and risking circular dependencies.
+export const TOP_BANNER_HEIGHT = 30;
+export const SYSTEM_BANNER_HEIGHT = 20;
+export const LICENSE_OPTION_TRIAL = 'trial';


### PR DESCRIPTION
## Summary

- On demo/trial instances, the top bar (logo + search + right-side icons) was glued to the top banner, with no space below it, and looked slightly hidden.
- Root cause: `computeBannerSettings` only reserved a fixed `16px` base for the trial/demo/license top banner, while that banner (`TopBanner`) is actually `TOP_BANNER_HEIGHT = 30px` tall. The reserved space was therefore smaller than the banner, so the top bar sat flush against it.
- Fix: reserve the real banner heights - `TOP_BANNER_HEIGHT` for the top banner and the per-message height (plus the existing padding) for the system banner - summing them when both are displayed. This matches OpenCTI, which keeps a clean gap below the same banner.

System-banner-only spacing is unchanged. The reserved height flows through every consumer of `computeBannerSettings` (top bar toolbar, left menu, drawers, admin layout margins), so the whole layout stays consistent and the top bar gets a small breathing space below the banner.

## Review follow-ups

- Reserve the system banner height only when it actually has messages (`numberOfElements > 0`), matching the render condition in `SystemBanners`, so banner levels that exist but carry only empty message arrays no longer add an unexplained top offset.
- Extract `TOP_BANNER_HEIGHT`, `SYSTEM_BANNER_HEIGHT` and `LICENSE_OPTION_TRIAL` into a framework-agnostic `trialbanners/constants.ts`. `computeBannerSettings` now imports only from that module, removing its coupling to the React/MUI component modules (`TopBanner`, `LicenseBanner`) and the associated circular-dependency risk.
- Add unit tests for `computeBannerSettings` covering the gating fix and the top/system banner height branches.

## Test plan

- [x] `yarn check-ts` passes (done locally)
- [x] `yarn lint` passes, including `import/no-cycle`, no new import cycle (done locally)
- [x] `yarn vitest run` for the new `computeBannerSettings` tests passes (done locally)
- [ ] On a demo / trial-license instance, verify there is a small space between the top banner and the top bar (logo + search), consistent with OpenCTI
- [ ] On a normal instance (no banner), the top bar layout is unchanged
- [ ] With a system banner configured, spacing is unchanged

Closes #6146
