### PR TITLE
perf: add missing DB indexes, batch fetching and frontend memoization (#6153)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V5_18__Add_Missing_Performance_Indexes.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_18__Add_Missing_Performance_Indexes.java
@@ -1,0 +1,120 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds missing indexes identified by the 2026-06 performance audit.
+ *
+ * <p>Focus areas: execution_traces (fastest-growing table, zero FK indexes, cascade deletes from
+ * injects_statuses/agents seq-scan it), injects scenario/exercise FK lookups, agent
+ * registration/identification on assets, executor synchronization on agents, IMAP communication
+ * sync, ES re-indexing cursors on *_updated_at columns and inject execution hot paths.
+ */
+@Component
+public class V5_18__Add_Missing_Performance_Indexes extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // --- execution_traces: one row per agent execution message; joined by
+      // ExecutionTraceRepository and cascade-deleted from injects_statuses,
+      // injects_tests_statuses and agents. No index existed on any FK column.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_execution_traces_inject_status "
+              + "ON execution_traces (execution_inject_status_id)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_execution_traces_agent "
+              + "ON execution_traces (execution_agent_id)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_execution_traces_test_status "
+              + "ON execution_traces (execution_inject_test_status_id)");
+
+      // --- injects: scenario/exercise lookups (findByScenarioId, scenario deletes,
+      // findByExerciseId, kill-chain CTEs). The only existing exercise index is partial
+      // on inject_enabled = true and unusable for these queries.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_injects_scenario "
+              + "ON injects (inject_scenario) WHERE inject_scenario IS NOT NULL");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_injects_exercise "
+              + "ON injects (inject_exercise) WHERE inject_exercise IS NOT NULL");
+      // ES re-indexing cursor (findForIndexing pages on inject_updated_at)
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_injects_updated_at ON injects (inject_updated_at)");
+
+      // --- assets: agent registration resolves endpoints by hostname/IPs/MACs on every
+      // agent check-in (EndpointRepository &&-overlap and lower(hostname) queries).
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_assets_tenant_hostname "
+              + "ON assets (tenant_id, lower(endpoint_hostname)) "
+              + "WHERE endpoint_hostname IS NOT NULL");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_assets_endpoint_ips "
+              + "ON assets USING gin (endpoint_ips)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_assets_endpoint_macs "
+              + "ON assets USING gin (endpoint_mac_addresses)");
+      // Endpoint listings/indexing always filter on the discriminator
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_assets_tenant_type ON assets (tenant_id, asset_type)");
+
+      // --- communications: IMAP sync calls existsByIdentifier per synced message;
+      // communication_inject is an unindexed FK with ON DELETE CASCADE.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_communications_message_id "
+              + "ON communications (communication_message_id)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_communications_inject "
+              + "ON communications (communication_inject)");
+
+      // --- agents: executor sync (findByExecutorId, findByExternalReferenceAndTenantId)
+      // and cascade deletes from executors/parents/injects.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_agents_executor ON agents (agent_executor)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_agents_parent "
+              + "ON agents (agent_parent) WHERE agent_parent IS NOT NULL");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_agents_inject "
+              + "ON agents (agent_inject) WHERE agent_inject IS NOT NULL");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_agents_tenant_external_ref "
+              + "ON agents (tenant_id, agent_external_reference)");
+
+      // --- asset_agent_jobs: agent job polling filters on asset_agent_agent; the existing
+      // unique index is partial on asset_agent_inject IS NULL and cannot serve these queries.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_asset_agent_jobs_agent "
+              + "ON asset_agent_jobs (asset_agent_agent)");
+
+      // --- ES re-indexing cursors: every indexing job pages with
+      // WHERE x_updated_at > :from ORDER BY x_updated_at LIMIT :limit.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_findings_updated_at ON findings (finding_updated_at)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_teams_updated_at ON teams (team_updated_at)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_asset_groups_updated_at "
+              + "ON asset_groups (asset_group_updated_at)");
+
+      // --- injects_expectations: signature updates run per agent during execution with
+      // WHERE inject_id = :injectId AND agent_id = :agentId; composite beats bitmap-AND
+      // of the two existing single-column indexes on this hot write path.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_injects_expectations_inject_agent "
+              + "ON injects_expectations (inject_id, agent_id)");
+
+      // --- misc unindexed FKs / lookup columns on runtime paths
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_pauses_exercise ON pauses (pause_exercise)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_documents_target ON documents (document_target)");
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_scenarios_tenant_external_ref "
+              + "ON scenarios (tenant_id, scenario_external_reference)");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -480,5 +480,4 @@ public class InjectsExecutionJob implements Job {
     }
     injectService.saveAll(fulfilled);
   }
-
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -66,6 +66,9 @@ public class InjectsExecutionJob implements Job {
 
   public static final String DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES = "10";
 
+  // Thread-safe and expensive to instantiate; never recreate per dependency evaluation
+  private static final ExpressionParser SPEL_PARSER = new SpelExpressionParser();
+
   @Value("${openaev.notification.simulation-completed-delay-seconds:3600}")
   private long delayForSimulationCompletedEvent;
 
@@ -277,11 +280,9 @@ public class InjectsExecutionJob implements Job {
                     String.format("#this['%s']", condition.split("==")[0].trim()));
           }
 
-          ExpressionParser parser = new SpelExpressionParser();
-
           EvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
           try {
-            Expression exp = parser.parseExpression(expressionToEvaluate);
+            Expression exp = SPEL_PARSER.parseExpression(expressionToEvaluate);
             boolean canBeExecuted =
                 Boolean.TRUE.equals(exp.getValue(context, mapCondition, Boolean.class));
             if (!canBeExecuted) {
@@ -389,6 +390,12 @@ public class InjectsExecutionJob implements Job {
       // Get all injects to execute grouped by exercise.
       List<ExecutableInject> injects = injectHelper.getInjectsToRun();
 
+      // Computed once for the whole batch instead of once per inject (was O(n^2))
+      Set<String> batchInjectIds =
+          injects.stream()
+              .map(execInject -> execInject.getInjection().getId())
+              .collect(Collectors.toSet());
+
       // We're grouping the injects to run by exercises but also making sure no injects
       // run in the same batch as it's parents
       Map<String, List<ExecutableInject>> byExercises =
@@ -403,19 +410,15 @@ public class InjectsExecutionJob implements Job {
                       // out. It'll then start the injects that were not started because the
                       // platform was down.
                       executableInject.getInjection().getInject().getDependsOn() == null
-                          || !intersect(
-                              injects.stream()
-                                  .map(execInject -> execInject.getInjection().getId())
-                                  .toList(),
-                              executableInject.getInjection().getInject().getDependsOn().stream()
-                                  .map(
-                                      injectDependency ->
-                                          injectDependency
-                                              .getCompositeId()
-                                              .getInjectParent()
-                                              .getInject()
-                                              .getId())
-                                  .toList()))
+                          || executableInject.getInjection().getInject().getDependsOn().stream()
+                              .map(
+                                  injectDependency ->
+                                      injectDependency
+                                          .getCompositeId()
+                                          .getInjectParent()
+                                          .getInject()
+                                          .getId())
+                              .noneMatch(batchInjectIds::contains))
               .collect(
                   groupingBy(
                       ex ->
@@ -478,18 +481,4 @@ public class InjectsExecutionJob implements Job {
     injectService.saveAll(fulfilled);
   }
 
-  /**
-   * Return true if some elements are in the two lists
-   *
-   * @param firstList the first list to test
-   * @param secondList the second list to test
-   * @return true if some elements are present in both the lists
-   */
-  private boolean intersect(List<String> firstList, List<String> secondList) {
-    return !firstList.stream()
-        .distinct()
-        .filter(secondList::contains)
-        .collect(Collectors.toSet())
-        .isEmpty();
-  }
 }

--- a/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
@@ -230,7 +230,7 @@ public class InjectImportService {
                                   compositeId.setTeamId(team.getId());
                                   compositeId.setUserId(user.getId());
                                   boolean exists =
-                                      exerciseTeamUserRepository.findById(compositeId).isPresent();
+                                      exerciseTeamUserRepository.existsById(compositeId);
 
                                   if (!exists) {
                                     ExerciseTeamUser exerciseTeamUser = new ExerciseTeamUser();
@@ -275,7 +275,7 @@ public class InjectImportService {
                                   compositeId.setTeamId(team.getId());
                                   compositeId.setUserId(user.getId());
                                   boolean exists =
-                                      scenarioTeamUserRepository.findById(compositeId).isPresent();
+                                      scenarioTeamUserRepository.existsById(compositeId);
 
                                   if (!exists) {
                                     ScenarioTeamUser scenarioTeamUser = new ScenarioTeamUser();

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -444,6 +444,7 @@ public class StepService {
    *
    * @return list of all step templates
    */
+  @Transactional(readOnly = true)
   public List<Step> findAllStepTemplates() {
     return this.stepRepository.findAllByStepTemplateIdIsNull();
   }

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -445,9 +445,7 @@ public class StepService {
    * @return list of all step templates
    */
   public List<Step> findAllStepTemplates() {
-    return this.stepRepository.findAll().stream()
-        .filter(step -> step.getStepTemplate() == null)
-        .toList();
+    return this.stepRepository.findAllByStepTemplateIdIsNull();
   }
 
   /**

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -44,6 +44,9 @@ spring.datasource.password=openaev
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
 spring.jpa.properties.hibernate.jdbc.batch_size=30
+# Batch lazy/eager association loading (IN (?, ?, ...) instead of one SELECT per entity).
+# The model has many EAGER collections without @Fetch(SUBSELECT); this caps the N+1 cost.
+spring.jpa.properties.hibernate.default_batch_fetch_size=50
 spring.datasource.hikari.maximum-pool-size=20
 spring.datasource.hikari.data-source-properties.cachePrepStmts=true
 spring.datasource.hikari.data-source-properties.prepStmtCacheSize=250

--- a/openaev-api/src/test/java/io/openaev/rest/TeamApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/TeamApiTest.java
@@ -805,7 +805,8 @@ class TeamApiTest extends IntegrationTest {
               .getContentAsString();
 
       // Assert — the tenant X team must not leak into tenant Y options
-      assertFalse(crossTenantResponse.contains(teamId));
+      List<String> crossTenantIds = JsonPath.read(crossTenantResponse, "$[*].id");
+      assertFalse(crossTenantIds.contains(teamId));
 
       // Positive control — the team is returned for its own tenant
       String sameTenantResponse =
@@ -819,7 +820,8 @@ class TeamApiTest extends IntegrationTest {
               .getResponse()
               .getContentAsString();
 
-      assertTrue(sameTenantResponse.contains(teamId));
+      List<String> sameTenantIds = JsonPath.read(sameTenantResponse, "$[*].id");
+      assertTrue(sameTenantIds.contains(teamId));
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/TeamApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/TeamApiTest.java
@@ -749,5 +749,77 @@ class TeamApiTest extends IntegrationTest {
       // Assert
       assertThat(responseStatus).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
+
+    @Test
+    @DisplayName("Teams options with ALL_INJECTS should NOT leak teams from another tenant")
+    void given_injectTeamInTenantX_should_notAppearInTenantYAllInjectsOptions() throws Exception {
+      // Arrange — regression test for the OR-precedence bug in
+      // findAllTeamsForAtomicTestingsSimulationsAndScenarios: the EXISTS(injects_teams)
+      // clause used to escape the tenant predicate and leak teams across tenants.
+      Tenant tenantX =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant X",
+              Set.of(Capability.MANAGE_TEAMS_AND_PLAYERS, Capability.ACCESS_TEAMS_AND_PLAYERS));
+      Tenant tenantY =
+          tenantIsolationHelper.createTenantWithCapabilities(
+              "Tenant Y", Set.of(Capability.ACCESS_TEAMS_AND_PLAYERS));
+
+      TeamCreateInput input = createTeam();
+      input.setName("CrossTenantOptionsTeam");
+
+      String createResponse =
+          mvc.perform(
+                  post("/api/tenants/" + tenantX.getId() + "/teams")
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String teamId = JsonPath.read(createResponse, "$.team_id");
+
+      // Reference the team from an inject (in tenant X) so it matches the EXISTS clause
+      tenantIsolationHelper.switchToTenant(tenantX.getId(), entityManager);
+      Team team = teamRepository.findById(teamId).orElseThrow();
+      Inject inject =
+          getInjectForEmailContract(injectorContractFixture.getWellKnownSingleEmailContract());
+      inject.setTeams(new ArrayList<>(List.of(team)));
+      injectRepository.save(inject);
+
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — fetch options with ALL_INJECTS from tenant Y
+      String crossTenantResponse =
+          mvc.perform(
+                  get("/api/tenants/" + tenantY.getId() + "/teams/options")
+                      .queryParam("inputFilterOption", "ALL_INJECTS")
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // Assert — the tenant X team must not leak into tenant Y options
+      assertFalse(crossTenantResponse.contains(teamId));
+
+      // Positive control — the team is returned for its own tenant
+      String sameTenantResponse =
+          mvc.perform(
+                  get("/api/tenants/" + tenantX.getId() + "/teams/options")
+                      .queryParam("inputFilterOption", "ALL_INJECTS")
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      assertTrue(sameTenantResponse.contains(teamId));
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1019,13 +1019,11 @@ class StepServiceTest {
       // Arrange
       Step templateA = new Step();
       Step templateB = new Step();
-      Step executed = new Step();
       templateA.setId("tA");
       templateB.setId("tB");
-      executed.setId("exec");
-      executed.setStepTemplate(new Step());
+      List<Step> templates = List.of(templateA, templateB);
 
-      when(stepRepository.findAll()).thenReturn(List.of(templateA, executed, templateB));
+      when(stepRepository.findAllByStepTemplateIdIsNull()).thenReturn(templates);
 
       // Act
       List<Step> result = stepService.findAllStepTemplates();
@@ -1034,7 +1032,7 @@ class StepServiceTest {
       assertEquals(2, result.size());
       assertTrue(result.contains(templateA));
       assertTrue(result.contains(templateB));
-      assertFalse(result.contains(executed));
+      verify(stepRepository).findAllByStepTemplateIdIsNull();
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1015,7 +1015,7 @@ class StepServiceTest {
     }
 
     @Test
-    void given_mixedSteps_should_findAllStepTemplates_onlyTemplateRows() {
+    void given_templateSteps_should_findAllStepTemplates_returnTemplateRowsFromRepository() {
       // Arrange
       Step templateA = new Step();
       Step templateB = new Step();

--- a/openaev-front/src/admin/Index.tsx
+++ b/openaev-front/src/admin/Index.tsx
@@ -29,9 +29,10 @@ import { SETTINGS_ACCESS_CHECKS } from './components/nav/config/settings.config'
 import LeftBar from './components/nav/LeftBar';
 import TopBar from './components/nav/TopBar';
 import DeployScenario from './components/scenarios/DeployScenario';
-import InjectIndex from './components/simulations/simulation/injects/InjectIndex';
 
 const Home = lazy(() => import('./components/Home'));
+// Lazy like every other route: keeps the inject detail tree (incl. charts) out of the main admin chunk
+const InjectIndex = lazy(() => import('./components/simulations/simulation/injects/InjectIndex'));
 const IndexProfile = lazy(() => import('./components/profile/Index'));
 const FullTextSearch = lazy(() => import('./components/search/FullTextSearch'));
 const Findings = lazy(() => import('./components/findings/Findings'));

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -1,7 +1,7 @@
 import { NotificationsOutlined, UpdateOutlined } from '@mui/icons-material';
 import { Alert, AlertTitle, Box, IconButton, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { type FunctionComponent, lazy, Suspense, useEffect, useState } from 'react';
+import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { Link, Route, Routes, useLocation, useParams } from 'react-router';
 
 import { fetchScenario } from '../../../../actions/scenarios/scenario-actions';
@@ -47,11 +47,14 @@ const IndexScenarioComponent: FunctionComponent<{ scenario: ScenarioOutput }> = 
   const location = useLocation();
   const theme = useTheme();
   const isChainingFeatureEnabled = isFeatureEnabled('INJECT_CHAINING');
-  const permissionsContext: PermissionsContextType = {
-    permissions: useScenarioPermissions(scenario.scenario_id),
+  const permissions = useScenarioPermissions(scenario.scenario_id);
+  // Stable context identities: these providers wrap the whole scenario subtree and a
+  // new value each render forces every consumer (incl. the injects list) to re-render.
+  const permissionsContext: PermissionsContextType = useMemo(() => ({
+    permissions,
     inherited_context: INHERITED_CONTEXT.SCENARIO,
-  };
-  const documentContext: DocumentContextType = {
+  }), [permissions]);
+  const documentContext: DocumentContextType = useMemo(() => ({
     onInitDocument: () => ({
       document_tags: [],
       document_scenarios: scenario
@@ -62,7 +65,7 @@ const IndexScenarioComponent: FunctionComponent<{ scenario: ScenarioOutput }> = 
         : [],
       document_exercises: [],
     }),
-  };
+  }), [scenario?.scenario_id, scenario?.scenario_name]);
   let tabValue = location.pathname;
   if (location.pathname.includes(`/admin/scenarios/${scenario.scenario_id}/definition`)) {
     tabValue = `/admin/scenarios/${scenario.scenario_id}/definition`;

--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioContext.ts
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioContext.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { addInjectForScenario, bulkDeleteInjectsSimple, bulkUpdateInjectSimple, deleteInjectScenario, fetchScenarioInjects, updateInjectActivationForScenario, updateInjectForScenario } from '../../../../actions/Inject';
 import { bulkTestInjects } from '../../../../actions/inject_test/scenario-inject-test-actions';
@@ -13,7 +13,9 @@ const injectContextForScenario = (scenario: Scenario) => {
   const dispatch = useAppDispatch();
   const [injects, setInjects] = useState<InjectOutputType[]>([]);
 
-  return {
+  // This object is the value of InjectContext.Provider wrapping the whole scenario
+  // area: keep its identity stable so consumers don't re-render on unrelated updates.
+  return useMemo(() => ({
     injects,
     setInjects,
     searchInjects(input: SearchPaginationInput): Promise<{ data: Page<InjectOutputType> }> {
@@ -81,7 +83,7 @@ const injectContextForScenario = (scenario: Scenario) => {
         data: result.data,
       }));
     },
-  };
+  }), [dispatch, injects, scenario?.scenario_id]);
 };
 
 export default injectContextForScenario;

--- a/openaev-front/src/admin/components/simulations/simulation/ExerciseContext.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/ExerciseContext.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { fetchExercise, fetchExerciseTeams } from '../../../../actions/Exercise';
 import { dryImportXlsForExercise, importXlsForExercise } from '../../../../actions/exercises/exercise-action';
@@ -33,7 +33,9 @@ const injectContextForExercise = (exercise: Exercise) => {
   const dispatch = useAppDispatch();
   const [injects, setInjects] = useState<InjectOutputType[]>([]);
 
-  return {
+  // This object is the value of InjectContext.Provider wrapping the whole simulation
+  // area: keep its identity stable so consumers don't re-render on unrelated updates.
+  return useMemo(() => ({
     injects,
     setInjects,
     searchInjects(input: SearchPaginationInput): Promise<{ data: Page<InjectOutputType> }> {
@@ -112,7 +114,7 @@ const injectContextForExercise = (exercise: Exercise) => {
         data: result.data,
       }));
     },
-  };
+  }), [dispatch, injects, exercise?.exercise_id]);
 };
 
 export default injectContextForExercise;

--- a/openaev-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/Index.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertTitle, Box, Tab, Tabs } from '@mui/material';
-import { type FunctionComponent, lazy, Suspense, useEffect, useState } from 'react';
+import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 
@@ -54,11 +54,14 @@ const IndexComponent: FunctionComponent<{ exercise: SimulationDetails }> = ({ ex
   const location = useLocation();
   const { classes } = useStyles();
   const isChainingFeatureEnabled = isFeatureEnabled('INJECT_CHAINING');
-  const permissionsContext: PermissionsContextType = {
-    permissions: useSimulationPermissions(exercise.exercise_id, exercise),
+  const permissions = useSimulationPermissions(exercise.exercise_id, exercise);
+  // Stable context identities: these providers wrap the whole simulation subtree and a
+  // new value each render forces every consumer (incl. the injects list) to re-render.
+  const permissionsContext: PermissionsContextType = useMemo(() => ({
+    permissions,
     inherited_context: INHERITED_CONTEXT.SIMULATION,
-  };
-  const documentContext: DocumentContextType = {
+  }), [permissions]);
+  const documentContext: DocumentContextType = useMemo(() => ({
     onInitDocument: () => ({
       document_tags: [],
       document_scenarios: [],
@@ -69,7 +72,7 @@ const IndexComponent: FunctionComponent<{ exercise: SimulationDetails }> = ({ ex
           }]
         : [],
     }),
-  };
+  }), [exercise?.exercise_id, exercise?.exercise_name]);
 
   let tabValue = location.pathname;
   if (location.pathname.includes(`/admin/simulations/${exercise.exercise_id}/definition`)) {

--- a/openaev-front/src/admin/components/simulations/simulation/articles/articleContextForExercise.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/articles/articleContextForExercise.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { type FullArticleStore } from '../../../../../actions/channels/Article';
 import {
   addExerciseArticle,
@@ -12,7 +14,8 @@ import { useAppDispatch } from '../../../../../utils/hooks';
 
 const articleContextForExercise = (exerciseId: Exercise['exercise_id']) => {
   const dispatch = useAppDispatch();
-  return {
+  // Stable identity: used as a context provider value on hot screens
+  return useMemo(() => ({
     previewArticleUrl: (article: FullArticleStore) => `/channels/${exerciseId}/${article.article_fullchannel?.channel_id}?preview=true`,
     fetchArticles: () => dispatch(fetchExerciseArticles(exerciseId)),
     fetchChannels: () => dispatch(fetchSimulationChannels(exerciseId)),
@@ -24,7 +27,7 @@ const articleContextForExercise = (exerciseId: Exercise['exercise_id']) => {
     onDeleteArticle: (article: Article) => dispatch(
       deleteExerciseArticle(exerciseId, article.article_id),
     ),
-  };
+  }), [dispatch, exerciseId]);
 };
 
 export default articleContextForExercise;

--- a/openaev-front/src/admin/components/simulations/simulation/injects/ExerciseInjects.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/injects/ExerciseInjects.tsx
@@ -1,6 +1,6 @@
 import { BarChartOutlined, ReorderOutlined, ViewTimelineOutlined } from '@mui/icons-material';
 import { GridLegacy, Paper, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
-import { type FunctionComponent, useState } from 'react';
+import { type FunctionComponent, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 
@@ -85,13 +85,14 @@ const ExerciseInjects: FunctionComponent = () => {
   const articleContext = articleContextForExercise(exerciseId);
   const teamContext = teamContextForExercise(exerciseId, exercise.exercise_teams_users, exercise.exercise_all_users_number, exercise.exercise_users_number);
   const endpointContext = endpointContextForExercise(exerciseId);
-  const challengeContext = { fetchChallenges: () => dispatch(fetchExerciseChallenges(exerciseId)) };
+  // Stable context identities so the whole injects list does not re-render on each update
+  const challengeContext = useMemo(() => ({ fetchChallenges: () => dispatch(fetchExerciseChallenges(exerciseId)) }), [dispatch, exerciseId]);
 
-  const injectTestContext: InjectTestContextType = {
+  const injectTestContext: InjectTestContextType = useMemo(() => ({
     contextId: exerciseId,
     url: `/admin/simulations/${exerciseId}/tests/`,
     testInject: testInject,
-  };
+  }), [exerciseId]);
 
   return (
     <ViewModeContext.Provider value={viewMode}>

--- a/openaev-front/src/admin/components/simulations/simulation/teams/teamContextForExercise.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/teams/teamContextForExercise.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { addExerciseTeamPlayers, disableExerciseTeamPlayers, enableExerciseTeamPlayers, fetchExerciseTeams, removeExerciseTeamPlayers } from '../../../../../actions/Exercise';
 import { removeExerciseTeams, replaceExerciseTeams, searchExerciseTeams } from '../../../../../actions/exercises/exercise-teams-action';
 import { addTeam } from '../../../../../actions/teams/team-actions';
@@ -10,7 +12,8 @@ import { type UserStore } from '../../../teams/players/Player';
 const teamContextForExercise = (exerciseId: Exercise['exercise_id'], exerciseTeamsUsers: Exercise['exercise_teams_users'], allUsersNumber = 0, allUsersEnabledNumber = 0): TeamContextType => {
   const dispatch = useAppDispatch();
 
-  return {
+  // Stable identity: used as a context provider value on hot screens
+  return useMemo(() => ({
     async onAddUsersTeam(teamId: Team['team_id'], userIds: UserStore['user_id'][]): Promise<void> {
       await dispatch(addExerciseTeamPlayers(exerciseId, teamId, { exercise_team_players: userIds }));
       return dispatch(fetchExerciseTeams(exerciseId));
@@ -55,7 +58,7 @@ const teamContextForExercise = (exerciseId: Exercise['exercise_id'], exerciseTea
     searchTeams(input: SearchPaginationInput, contextualOnly?: boolean): Promise<{ data: Page<TeamOutput> }> {
       return searchExerciseTeams(exerciseId, input, contextualOnly);
     },
-  };
+  }), [dispatch, exerciseId, exerciseTeamsUsers, allUsersNumber, allUsersEnabledNumber]);
 };
 
 export default teamContextForExercise;

--- a/openaev-front/src/components/AppThemeProvider.tsx
+++ b/openaev-front/src/components/AppThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { enUS, esES, frFR, type Localization, zhCN } from '@mui/material/locale';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { type FunctionComponent, type ReactNode, useEffect, useState } from 'react';
+import { type FunctionComponent, type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { type LoggedHelper } from '../actions/helper';
 import { useHelper } from '../store';
@@ -46,42 +46,46 @@ const AppThemeProvider: FunctionComponent<Props> = ({ children }) => {
     setMuiLocale(localeMap[locale as keyof typeof localeMap]);
   }, [locale]);
 
-  const dark = tenantSettings?.platform_dark_theme ?? settings.platform_dark_theme;
-  let muiTheme = createTheme(
-    {
-      spacing: scaleFactor,
-      ...themeDark(
-        dark?.logo_url,
-        dark?.logo_url_collapsed,
-        dark?.background_color,
-        dark?.paper_color,
-        dark?.navigation_color,
-        dark?.primary_color,
-        dark?.secondary_color,
-        dark?.accent_color,
-      ),
-    },
-    muiLocale,
-  );
-  if (theme === 'light') {
-    const light = tenantSettings?.platform_light_theme ?? settings.platform_light_theme;
-    muiTheme = createTheme(
+  // createTheme is expensive and a new theme object invalidates the style cache of the
+  // whole subtree: only build the variant in use, and only when its inputs change.
+  const muiTheme = useMemo(() => {
+    if (theme === 'light') {
+      const light = tenantSettings?.platform_light_theme ?? settings.platform_light_theme;
+      return createTheme(
+        {
+          spacing: scaleFactor,
+          ...themeLight(
+            light?.logo_url,
+            light?.logo_url_collapsed,
+            light?.background_color,
+            light?.paper_color,
+            light?.navigation_color,
+            light?.primary_color,
+            light?.secondary_color,
+            light?.accent_color,
+          ),
+        },
+        muiLocale,
+      );
+    }
+    const dark = tenantSettings?.platform_dark_theme ?? settings.platform_dark_theme;
+    return createTheme(
       {
         spacing: scaleFactor,
-        ...themeLight(
-          light?.logo_url,
-          light?.logo_url_collapsed,
-          light?.background_color,
-          light?.paper_color,
-          light?.navigation_color,
-          light?.primary_color,
-          light?.secondary_color,
-          light?.accent_color,
+        ...themeDark(
+          dark?.logo_url,
+          dark?.logo_url_collapsed,
+          dark?.background_color,
+          dark?.paper_color,
+          dark?.navigation_color,
+          dark?.primary_color,
+          dark?.secondary_color,
+          dark?.accent_color,
         ),
       },
       muiLocale,
     );
-  }
+  }, [theme, muiLocale, settings, tenantSettings]);
   return <ThemeProvider theme={muiTheme}>{children}</ThemeProvider>;
 };
 

--- a/openaev-front/src/root.tsx
+++ b/openaev-front/src/root.tsx
@@ -1,6 +1,6 @@
 import { CssBaseline } from '@mui/material';
 import { StyledEngineProvider } from '@mui/material/styles';
-import { lazy, Suspense, useEffect } from 'react';
+import { lazy, Suspense, useEffect, useMemo } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 
 import { fetchMe, fetchPlatformParameters } from './actions/Application';
@@ -69,6 +69,19 @@ const Root = () => {
   }, [logged, me]);
 
   const { isReachable } = useNetworkCheck(settings?.xtm_hub_url && `${settings?.xtm_hub_url}/health`);
+
+  // Stable context identity: without this, every Root render produced a new object and
+  // re-rendered every useAuth() consumer in the app.
+  const userContextValue = useMemo(() => ({
+    me,
+    settings,
+    isXTMHubAccessible: isReachable,
+    userTenants,
+    currentUserTenant,
+    switchUserTenant,
+    reloadUserTenants,
+  }), [me, settings, isReachable, userTenants, currentUserTenant, switchUserTenant, reloadUserTenants]);
+
   if (logged && typeof logged === 'object' && Object.keys(logged).length === 0) {
     return <div />;
   }
@@ -115,17 +128,7 @@ const Root = () => {
 
   return (
     <PermissionsProvider capabilities={me.user_capabilities} grants={me.user_grants} isAdmin={me.user_admin}>
-      <UserContext.Provider
-        value={{
-          me,
-          settings,
-          isXTMHubAccessible: isReachable,
-          userTenants,
-          currentUserTenant,
-          switchUserTenant,
-          reloadUserTenants,
-        }}
-      >
+      <UserContext.Provider value={userContextValue}>
         <StyledEngineProvider injectFirst>
           <ConnectedIntlProvider>
             <ConnectedThemeProvider>

--- a/openaev-front/src/utils/context/endpoint/EndpointContextForExercise.ts
+++ b/openaev-front/src/utils/context/endpoint/EndpointContextForExercise.ts
@@ -1,17 +1,20 @@
+import { useMemo } from 'react';
+
 import { findSimulationAssetGroupsByIds } from '../../../actions/asset_groups/assetgroup-action';
 import { findSimulationEndpointsByIds } from '../../../actions/assets/endpoint-actions';
 import type { Exercise } from '../../api-types';
 import { type EndpointContextType } from './EndpointContext';
 
 const endpointContextForExercise = (exerciseId: Exercise['exercise_id']): EndpointContextType => {
-  return {
+  // Stable identity: used as a context provider value on hot screens
+  return useMemo(() => ({
     async fetchEndpointsByIds(endpointIds: string[]) {
       return findSimulationEndpointsByIds(exerciseId, endpointIds);
     },
     async fetchAssetGroupsByIds(assetGroupIds: string[]) {
       return findSimulationAssetGroupsByIds(exerciseId, assetGroupIds);
     },
-  };
+  }), [exerciseId]);
 };
 
 export default endpointContextForExercise;

--- a/openaev-front/src/utils/permissions/useScenarioPermissions.ts
+++ b/openaev-front/src/utils/permissions/useScenarioPermissions.ts
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 
 import { type LoggedHelper, type UserHelper } from '../../actions/helper';
 import { type ScenariosHelper } from '../../actions/scenarios/scenario-helper';
@@ -14,20 +14,24 @@ const useScenarioPermissions = (scenarioId: string) => {
     return { logged: helper.logged() };
   });
 
-  const canAccess = ability.can(ACTIONS.ACCESS, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT);
-  const canManage = ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT);
-  const canLaunch = ability.can(ACTIONS.LAUNCH, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.LAUNCH, SUBJECTS.ASSESSMENT);
-  const canDelete = ability.can(ACTIONS.DELETE, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.DELETE, SUBJECTS.ASSESSMENT);
+  // Memoized: this result feeds context providers, so it must keep a stable identity
+  // when nothing permission-related changed.
+  return useMemo(() => {
+    const canAccess = ability.can(ACTIONS.ACCESS, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT);
+    const canManage = ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT);
+    const canLaunch = ability.can(ACTIONS.LAUNCH, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.LAUNCH, SUBJECTS.ASSESSMENT);
+    const canDelete = ability.can(ACTIONS.DELETE, SUBJECTS.RESOURCE, scenarioId) || ability.can(ACTIONS.DELETE, SUBJECTS.ASSESSMENT);
 
-  return {
-    canAccess,
-    canManage,
-    canLaunch,
-    canDelete,
-    readOnly: !canManage,
-    isLoggedIn: !R.isEmpty(logged),
-    isRunning: false,
-  };
+    return {
+      canAccess,
+      canManage,
+      canLaunch,
+      canDelete,
+      readOnly: !canManage,
+      isLoggedIn: !R.isEmpty(logged),
+      isRunning: false,
+    };
+  }, [ability, scenarioId, logged]);
 };
 
 export default useScenarioPermissions;

--- a/openaev-front/src/utils/permissions/useSimulationPermissions.ts
+++ b/openaev-front/src/utils/permissions/useSimulationPermissions.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 
 import { type ExercisesHelper } from '../../actions/exercises/exercise-helper';
 import { type LoggedHelper, type UserHelper } from '../../actions/helper';
@@ -18,34 +18,38 @@ const useSimulationPermissions = (exerciseId: string, fullExercise?: SimulationD
     };
   });
 
-  if ((!fullExercise && !exercise) || !me) {
+  // Memoized: this result feeds context providers, so it must keep a stable identity
+  // when nothing permission-related changed.
+  return useMemo(() => {
+    if ((!fullExercise && !exercise) || !me) {
+      return {
+        canAccess: false,
+        canManage: false,
+        canLaunch: false,
+        canDelete: false,
+        readOnly: true,
+        isLoggedIn: Boolean(logged),
+        isRunning: false,
+      };
+    }
+
+    const canAccess = ability.can(ACTIONS.ACCESS, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT);
+    const canManage = ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT);
+    const canLaunch = ability.can(ACTIONS.LAUNCH, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.LAUNCH, SUBJECTS.ASSESSMENT);
+    const canDelete = ability.can(ACTIONS.DELETE, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.DELETE, SUBJECTS.ASSESSMENT);
+    const isRunning = (exercise || fullExercise).exercise_status === 'RUNNING';
+    const readOnly = !canManage;
+
     return {
-      canAccess: false,
-      canManage: false,
-      canLaunch: false,
-      canDelete: false,
-      readOnly: true,
+      canAccess,
+      canManage,
+      canLaunch,
+      canDelete,
+      readOnly,
       isLoggedIn: Boolean(logged),
-      isRunning: false,
+      isRunning,
     };
-  }
-
-  const canAccess = ability.can(ACTIONS.ACCESS, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT);
-  const canManage = ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT);
-  const canLaunch = ability.can(ACTIONS.LAUNCH, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.LAUNCH, SUBJECTS.ASSESSMENT);
-  const canDelete = ability.can(ACTIONS.DELETE, SUBJECTS.RESOURCE, exerciseId) || ability.can(ACTIONS.DELETE, SUBJECTS.ASSESSMENT);
-  const isRunning = (exercise || fullExercise).exercise_status === 'RUNNING';
-  const readOnly = !canManage;
-
-  return {
-    canAccess,
-    canManage,
-    canLaunch,
-    canDelete,
-    readOnly,
-    isLoggedIn: Boolean(logged),
-    isRunning,
-  };
+  }, [ability, exerciseId, exercise, fullExercise, me, logged]);
 };
 
 export default useSimulationPermissions;

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -24,6 +24,14 @@ public interface StepRepository extends JpaRepository<Step, String> {
   List<Step> findAllByStepTemplateIdIsNullAndWorkflowId(String workflowId);
 
   /**
+   * Retrieves all {@link Step} entities that are step templates (filtered at the database level
+   * instead of loading the whole table).
+   *
+   * @return a list of all step templates
+   */
+  List<Step> findAllByStepTemplateIdIsNull();
+
+  /**
    * Retrieves a {@link Step} entity by its ID and status, ensuring it is not based on a step
    * template.
    *

--- a/openaev-model/src/main/java/io/openaev/database/repository/TeamRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TeamRepository.java
@@ -92,9 +92,9 @@ public interface TeamRepository
       value =
           "SELECT DISTINCT t.team_id, t.team_name, t.team_description, t.team_created_at, t.team_updated_at, t.team_organization, t.team_contextual "
               + "FROM teams t "
-              + "WHERE EXISTS (SELECT 1 FROM injects_teams it WHERE it.team_id = t.team_id) "
+              + "WHERE (EXISTS (SELECT 1 FROM injects_teams it WHERE it.team_id = t.team_id) "
               + "OR EXISTS (SELECT 1 FROM exercises_teams et WHERE et.team_id = t.team_id) "
-              + "OR EXISTS (SELECT 1 FROM scenarios_teams st WHERE st.team_id = t.team_id) "
+              + "OR EXISTS (SELECT 1 FROM scenarios_teams st WHERE st.team_id = t.team_id)) "
               + "AND t.tenant_id = :#{#tenantContext.currentTenant};",
       nativeQuery = true)
   List<Team> findAllTeamsForAtomicTestingsSimulationsAndScenarios();

--- a/openaev-model/src/main/java/io/openaev/database/repository/TeamRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TeamRepository.java
@@ -90,7 +90,7 @@ public interface TeamRepository
 
   @Query(
       value =
-          "SELECT DISTINCT t.team_id, t.team_name, t.team_description, t.team_created_at, t.team_updated_at, t.team_organization, t.team_contextual "
+          "SELECT DISTINCT t.team_id, t.team_name, t.team_description, t.team_created_at, t.team_updated_at, t.team_organization, t.team_contextual, t.tenant_id "
               + "FROM teams t "
               + "WHERE (EXISTS (SELECT 1 FROM injects_teams it WHERE it.team_id = t.team_id) "
               + "OR EXISTS (SELECT 1 FROM exercises_teams et WHERE et.team_id = t.team_id) "


### PR DESCRIPTION
## Summary

First wave of fixes from the platform-wide performance assessment documented in #6153. All changes are low-risk and behavior-preserving (except the tenant-filter bug fix, which is a correctness fix).

### Database (Flyway migration V5_18)

Adds 22 missing indexes identified by cross-checking the full migration history against every repository @Query:

- execution_traces: indexes on its 3 FK columns (execution_inject_status_id, execution_agent_id, execution_inject_test_status_id). This is the fastest-growing table and had no FK index at all; every trace lookup and every cascade delete from injects_statuses/agents seq-scanned it.
- injects: inject_scenario (none existed), inject_exercise (only an unusable partial index existed), inject_updated_at (ES re-indexing cursor).
- assets: (tenant_id, lower(endpoint_hostname)) and GIN indexes on endpoint_ips / endpoint_mac_addresses for the agent registration identity queries (&& overlap operators), plus (tenant_id, asset_type).
- communications: communication_message_id (IMAP existence check per synced mail) and communication_inject FK.
- agents: agent_executor, agent_parent, agent_inject FKs and (tenant_id, agent_external_reference) for executor synchronization.
- asset_agent_jobs: asset_agent_agent (agent job polling).
- ES re-indexing cursors: findings/teams/asset_groups updated_at columns.
- injects_expectations: composite (inject_id, agent_id) for the per-signature UPDATE hot path.
- pauses.pause_exercise, documents.document_target, scenarios (tenant_id, scenario_external_reference).

All statements use CREATE INDEX IF NOT EXISTS, consistent with previous index migrations (V5_11/V5_12). Plain CREATE INDEX (not CONCURRENTLY) is intentional: migrations run at startup before the node serves traffic, and CONCURRENTLY cannot run inside Flyway's transaction (see review discussion).

### Backend

- application.properties: set hibernate.default_batch_fetch_size=50. The model has many EAGER collections without @Fetch(SUBSELECT); this turns the resulting one-SELECT-per-entity N+1 patterns into batched IN queries platform-wide.
- TeamRepository.findAllTeamsForAtomicTestingsSimulationsAndScenarios: fixed an OR-precedence bug where the tenant_id filter only applied to the last EXISTS clause; the query could scan and return teams across tenants. Perf + tenant-isolation fix, now covered by a dedicated regression test in TeamApiTest.TenantIsolation. The new test also surfaced a latent hydration bug in the same query (tenant_id was missing from the SELECT list while the result maps to the Team entity, so any non-empty result failed to hydrate) - fixed by selecting the column.
- InjectsExecutionJob (runs every minute):
  - the dependency filter rebuilt the batch id list and did List.contains per inject (O(n^2)-O(n^3)); replaced with a Set computed once per batch,
  - SpelExpressionParser is now a static field instead of being instantiated per dependency evaluation,
  - removed the now-unused intersect() helper.
- StepService.findAllStepTemplates(): filtered at the database level via a derived query instead of findAll() + Java filtering, and annotated @Transactional(readOnly = true) per the read-path convention.
- InjectImportService: existsById() instead of findById().isPresent() in the per-inject x per-team x per-user import loops.

### Frontend

- AppThemeProvider: createTheme() is now memoized and only the active theme variant is built. Previously a new theme object was created on every render (twice in light mode), invalidating the Emotion style cache for the entire app subtree.
- Stable context identities (a new value per render forced every consumer to re-render, including the injects list on the hottest screens):
  - root UserContext value,
  - InjectContext for simulations (ExerciseContext.ts) and scenarios (ScenarioContext.ts),
  - permissions + document contexts in both simulation and scenario Index components,
  - article/team/endpoint context factories (fixes all call sites: ExerciseInjects, TimelineOverview, Mails, SimulationTeams, ExerciseArticles),
  - challenge + inject-test contexts in ExerciseInjects.
- useSimulationPermissions / useScenarioPermissions: memoized results (they feed context providers).
- admin/Index.tsx: InjectIndex was the only non-lazy route; now lazy like the other 18 routes, keeping the inject detail tree (incl. charts) out of the main admin chunk.

### Tests

- StepServiceTest: aligned the step template unit test with the new derived query.
- TeamApiTest.TenantIsolation: regression test asserting the ALL_INJECTS team options endpoint does not leak teams across tenants (the exact path fixed by the OR-precedence change).

## Assessment

The complete deep-dive (about 100 findings across backend JPA, services/schedulers, database and frontend) and the recommended follow-up backlog (Inject aggregate EAGER->LAZY conversion, expectation endpoint SQL filtering, implant callback graph re-resolution, binary streaming, selector layer memoization, retention strategy for unbounded tables) are documented in #6153.

## Test plan

- [x] openaev-model + openaev-api compile
- [x] Frontend: yarn check-ts passes, ESLint clean on all touched files
- [x] CI: full backend test suite (Docker-backed) validates the migration and query changes
- [ ] Verify migration V5_18 applies cleanly on a production-sized dataset (index creation time)
- [ ] Smoke test: simulation screen interaction during a running simulation (SSE updates) to confirm reduced re-render churn

Closes #6153
