### PR TITLE
chore(front): bump @filigran/chatbot to 3.4.0 (#6155)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.3.5",
+    "@filigran/chatbot": "3.4.0",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.5":
-  version: 3.3.5
-  resolution: "@filigran/chatbot@npm:3.3.5"
+"@filigran/chatbot@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@filigran/chatbot@npm:3.4.0"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/d11a09a7037311708025bc92282ffbf603008f906cc02e1467ef4c542db811e89c7381eba7b0d9105c1c2c320bd95711668a427617cfdb676379e498c6dadfdc
+  checksum: 10c0/8c329c7060a258944d862758ceffeacec532e1cd1b9afbcd483053f3fe1e664307a1ad49f07f11d434468611201901aa1ad6a5014dfbaf720fb3ac2c6b7d9e2f
   languageName: node
   linkType: hard
 
@@ -9851,7 +9851,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.5"
+    "@filigran/chatbot": "npm:3.4.0"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

Closes #6155

- Bump @filigran/chatbot from 3.3.5 to 3.4.0 in openaev-front (package.json + yarn.lock, lockfile-only update).
- This release brings the Cursor-style reasoning pane to the embedded AI chat: model reasoning (thinking text and pre-tool streamed preambles) renders as smaller, dimmed text inside a capped-height auto-scrolling window with the breathing accent glow, instead of streaming at full size into the answer bubble and then disappearing.
- Release notes: https://github.com/FiligranHQ/filigran-ui/releases/tag/%40filigran%2Fchatbot-v3.4.0 (FiligranHQ/filigran-ui#310, FiligranHQ/filigran-ui#311). Pairs with XTM-One-Platform/xtm-one#1555 which forwards thinking_text events through the platform chat proxy.

## Test plan

- [ ] CI green (front build)
- [ ] Open the AI chat against an XTM One backend that forwards thinking_text and verify reasoning appears in the small dimmed glowing pane while the agent works, then the final answer replaces it cleanly
