### PR TITLE
chore(front): bump @filigran/chatbot to 3.5.2 (#6155)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.4.0",
+    "@filigran/chatbot": "3.5.1",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@filigran/chatbot@npm:3.4.0"
+"@filigran/chatbot@npm:3.5.1":
+  version: 3.5.1
+  resolution: "@filigran/chatbot@npm:3.5.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/8c329c7060a258944d862758ceffeacec532e1cd1b9afbcd483053f3fe1e664307a1ad49f07f11d434468611201901aa1ad6a5014dfbaf720fb3ac2c6b7d9e2f
+  checksum: 10c0/64f0c69bcecf6f1e0bf4bee2ed842a4cd89da4332113327025614433120fb917850417f404b278feab4251a4a11646864a1cce0ee78d2f0c97f70b35f72a9de2
   languageName: node
   linkType: hard
 
@@ -9851,7 +9851,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.4.0"
+    "@filigran/chatbot": "npm:3.5.1"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
Follow-up to #6155 / #6156 - bump @filigran/chatbot from 3.4.0 to 3.5.1.

3.5.0 + 3.5.1 settle the reasoning display on the standard AI-chat UX (pairs with XTM-One-Platform/xtm-one#1560):

- The status bubble and the reasoning window disappear together the moment the final answer starts flowing - reasoning never renders inside the answer area and vice versa.
- Cursor-style top dissolve on the capped-height reasoning window (soft fade at the top only - text reads as scrolling up and dissolving), scroll pin with detach/re-pin.
- Handles the new stream_retract event from the XTM One agent loop hold-back window.
- Proper spacing between the status bubble and the reasoning window.

Releases: https://github.com/FiligranHQ/filigran-ui/releases (chatbot v3.5.0, v3.5.1 - FiligranHQ/filigran-ui#313, FiligranHQ/filigran-ui#314)