### PR TITLE
chore(front): bump @filigran/chatbot to 3.5.2 (#6155)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.5.1",
+    "@filigran/chatbot": "3.5.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.5.1":
-  version: 3.5.1
-  resolution: "@filigran/chatbot@npm:3.5.1"
+"@filigran/chatbot@npm:3.5.2":
+  version: 3.5.2
+  resolution: "@filigran/chatbot@npm:3.5.2"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/64f0c69bcecf6f1e0bf4bee2ed842a4cd89da4332113327025614433120fb917850417f404b278feab4251a4a11646864a1cce0ee78d2f0c97f70b35f72a9de2
+  checksum: 10c0/54eb2d82a33c3e93bb697dbe26b7550fc65a0322aa624cc467c35935062f186bd1534648602466ebc82002487a94f65c3160e08ab0b488302c924bcb8fdf0acb
   languageName: node
   linkType: hard
 
@@ -9851,7 +9851,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.5.1"
+    "@filigran/chatbot": "npm:3.5.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
Follow-up to #6155 / #6158 - bump @filigran/chatbot from 3.5.1 to 3.5.2.

3.5.2 adds the -webkit-mask-image twin so the reasoning window top dissolve also renders on Safari/WebKit (mirrors the Copilot review finding on XTM-One-Platform/xtm-one#1560).

Release: https://github.com/FiligranHQ/filigran-ui/releases (chatbot v3.5.2 - FiligranHQ/filigran-ui#315)