### PR TITLE
chore(deps): add awssdk2 sts dependency (#6161)

### DIFF
--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -19,6 +19,18 @@
         <amqp-client.version>5.31.0</amqp-client.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.44.10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -114,17 +126,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
-            <version>2.44.10</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.44.10</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
-            <version>2.44.10</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add STS dependency
* Configure bom import as recommended for aligning all sdk parts versions

### Testing Instructions

1. Use AWS EKS pod to deploy openaev
2. Configure opensearch ("es" setting); refer to GH docs
3. Should connect to opensearch authed via STS

### Related issues

* Closes #6161 