### PR TITLE
fix(multitenancy): flaky tests for notification(#4864)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/service/NotificationEvenServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationEvenServiceTest.java
@@ -2,26 +2,21 @@ package io.openaev.service;
 
 import static org.mockito.Mockito.verify;
 
-import io.openaev.IntegrationTest;
 import io.openaev.database.model.NotificationRuleResourceType;
 import io.openaev.notification.handler.ScenarioNotificationEventHandler;
 import io.openaev.notification.model.NotificationEvent;
 import io.openaev.notification.model.NotificationEventType;
-import io.openaev.utilstest.RabbitMQTestListener;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.test.context.TestExecutionListeners;
 
-@SpringBootTest
-@TestExecutionListeners(
-    value = {RabbitMQTestListener.class},
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-public class NotificationEvenServiceTest extends IntegrationTest {
+@ExtendWith(MockitoExtension.class)
+public class NotificationEvenServiceTest {
 
   @Mock private ApplicationEventPublisher appPublisher;
   @Mock private ScenarioNotificationEventHandler scenarioNotificationEventHandler;
@@ -36,7 +31,8 @@ public class NotificationEvenServiceTest extends IntegrationTest {
   }
 
   @Test
-  public void test_handleEvent() {
+  public void given_scenarioNotificationEvent_should_delegateToScenarioHandler() {
+    // -------- Arrange --------
     NotificationEvent notificationEvent =
         NotificationEvent.builder()
             .eventType(NotificationEventType.SIMULATION_COMPLETED)
@@ -44,12 +40,17 @@ public class NotificationEvenServiceTest extends IntegrationTest {
             .timestamp(Instant.now())
             .resourceId("id")
             .build();
+
+    // -------- Act --------
     notificationEventService.handleNotificationEvent(notificationEvent);
+
+    // -------- Assert --------
     verify(scenarioNotificationEventHandler).handle(notificationEvent);
   }
 
   @Test
-  public void test_send_event() {
+  public void given_notificationEvent_should_publishToApplicationEventBus() {
+    // -------- Arrange --------
     NotificationEvent notificationEvent =
         NotificationEvent.builder()
             .eventType(NotificationEventType.SIMULATION_COMPLETED)
@@ -57,7 +58,11 @@ public class NotificationEvenServiceTest extends IntegrationTest {
             .timestamp(Instant.now())
             .resourceId("id")
             .build();
+
+    // -------- Act --------
     notificationEventService.sendNotificationEvent(notificationEvent);
+
+    // -------- Assert --------
     verify(appPublisher).publishEvent(notificationEvent);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/NotificationEventServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationEventServiceTest.java
@@ -16,7 +16,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @ExtendWith(MockitoExtension.class)
-public class NotificationEvenServiceTest {
+public class NotificationEventServiceTest {
 
   @Mock private ApplicationEventPublisher appPublisher;
   @Mock private ScenarioNotificationEventHandler scenarioNotificationEventHandler;

--- a/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
@@ -73,7 +73,8 @@ public class NotificationRuleServiceTest {
     when(notificationRuleRepository.findNotificationRuleByResourceAndTrigger(
             rule.getResourceId(), rule.getTrigger()))
         .thenReturn(List.of(rule));
-    // Use doReturn() to stub unwrap() without invoking it during stubbing (safe if this ever becomes a spy).
+    // Use doReturn() to stub unwrap() without invoking it during stubbing (safe if this ever
+    // becomes a spy).
     doReturn(session).when(entityManager).unwrap(Session.class);
     when(tenantSettingsService.resolveSettingValue(eq("tenant-id"), any(TenantSettingKeys.class)))
         .thenReturn("dark");

--- a/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
@@ -2,10 +2,10 @@ package io.openaev.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.openaev.IntegrationTest;
 import io.openaev.database.model.NotificationRule;
 import io.openaev.database.model.NotificationRuleResourceType;
 import io.openaev.database.model.NotificationRuleTrigger;
@@ -13,40 +13,54 @@ import io.openaev.database.model.NotificationRuleType;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.TenantSettingKeys;
 import io.openaev.database.repository.NotificationRuleRepository;
+import io.openaev.service.scenario.ScenarioService;
 import io.openaev.service.settings.TenantSettingsService;
-import io.openaev.utilstest.RabbitMQTestListener;
 import jakarta.persistence.EntityManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestExecutionListeners;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@SpringBootTest
-@TestExecutionListeners(
-    value = {RabbitMQTestListener.class},
-    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-public class NotificationRuleServiceTest extends IntegrationTest {
+@ExtendWith(MockitoExtension.class)
+public class NotificationRuleServiceTest {
 
   @Mock private EntityManager entityManager;
   @Mock private Session session;
   @Mock private NotificationRuleRepository notificationRuleRepository;
 
+  @Mock private UserService userService;
+  @Mock private ScenarioService scenarioService;
   @Mock private EmailNotificationService emailNotificationService;
 
   @Mock private TenantSettingsService tenantSettingsService;
-
   @Mock private PlatformSettingsService platformSettingsService;
 
-  @InjectMocks private NotificationRuleService notificationRuleService;
+  // Explicit construction ensures the exact mock instances are injected into the final fields,
+  // avoiding the JIT-caching issue that occurs when Mockito falls back to reflection-based
+  // field injection on private-final fields (Lombok @RequiredArgsConstructor) in Java 21.
+  private NotificationRuleService notificationRuleService;
+
+  @BeforeEach
+  void setUp() {
+    notificationRuleService =
+        new NotificationRuleService(
+            entityManager,
+            notificationRuleRepository,
+            userService,
+            scenarioService,
+            emailNotificationService,
+            platformSettingsService,
+            tenantSettingsService);
+  }
 
   @Test
-  public void test_activateNotificationRules() {
+  public void given_notificationRuleWithEmailType_should_sendNotification() {
     // -------- Arrange --------
     Map<String, String> data = new HashMap<>();
     NotificationRule rule = new NotificationRule();
@@ -60,7 +74,9 @@ public class NotificationRuleServiceTest extends IntegrationTest {
     when(notificationRuleRepository.findNotificationRuleByResourceAndTrigger(
             rule.getResourceId(), rule.getTrigger()))
         .thenReturn(List.of(rule));
-    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    // doReturn avoids calling the generic unwrap() method on the mock before the stub is
+    // registered, which prevents a null-return when Mockito cannot infer the generic type <T>.
+    doReturn(session).when(entityManager).unwrap(Session.class);
     when(tenantSettingsService.resolveSettingValue(eq("tenant-id"), any(TenantSettingKeys.class)))
         .thenReturn("dark");
     when(tenantSettingsService.findSetting(eq("tenant-id"), any(String.class)))

--- a/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
@@ -73,8 +73,7 @@ public class NotificationRuleServiceTest {
     when(notificationRuleRepository.findNotificationRuleByResourceAndTrigger(
             rule.getResourceId(), rule.getTrigger()))
         .thenReturn(List.of(rule));
-    // doReturn avoids calling the generic unwrap() method on the mock before the stub is
-    // registered, which prevents a null-return when Mockito cannot infer the generic type <T>.
+    // Use doReturn() to stub unwrap() without invoking it during stubbing (safe if this ever becomes a spy).
     doReturn(session).when(entityManager).unwrap(Session.class);
     when(tenantSettingsService.resolveSettingValue(eq("tenant-id"), any(TenantSettingKeys.class)))
         .thenReturn("dark");

--- a/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
@@ -41,9 +41,8 @@ public class NotificationRuleServiceTest {
   @Mock private TenantSettingsService tenantSettingsService;
   @Mock private PlatformSettingsService platformSettingsService;
 
-  // Explicit construction ensures the exact mock instances are injected into the final fields,
-  // avoiding the JIT-caching issue that occurs when Mockito falls back to reflection-based
-  // field injection on private-final fields (Lombok @RequiredArgsConstructor) in Java 21.
+  // Construct explicitly to ensure deterministic mock injection (and avoid relying on @InjectMocks
+  // behaviour when the test is not running in a Spring context).
   private NotificationRuleService notificationRuleService;
 
   @BeforeEach


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

NotificationRuleServiceTest and NotificationEvenServiceTest mixed @SpringBootTest/extends IntegrationTest with @Mock/@InjectMocks, causing @Mock fields to be unreliably initialized and the wrong EntityManager to reach the service. Fixed by converting both to proper unit tests: drop @SpringBootTest + extends IntegrationTest, add @ExtendWith(MockitoExtension.class), and explicitly construct the service under test in @BeforeEach to guarantee mock injection on final fields.

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
