### PR TITLE
fix(atomic-testing): display error after relaunch atomic testing (#6148)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/common/injects/UpdateInject.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/common/injects/UpdateInject.test.tsx
@@ -10,7 +10,7 @@ const { mockDispatch, mockCannot } = vi.hoisted(() => ({
   mockCannot: vi.fn(() => false),
 }));
 
-let currentInject: any;
+let currentInject: Record<string, unknown> | undefined;
 
 vi.mock('../../../../../actions/Inject', () => ({ fetchInject: vi.fn(() => ({ type: 'FETCH_INJECT' })) }));
 
@@ -32,9 +32,9 @@ vi.mock('../../../../../utils/hooks/useDataLoader', async () => {
 });
 
 vi.mock('../../../../../components/i18n', async (importOriginal) => {
-  const original = await importOriginal<typeof import('../../../../../components/i18n')>();
+  const original = await importOriginal();
   return {
-    ...original,
+    ...(original as Record<string, unknown>),
     useFormatter: () => ({ t: (value: string) => value }),
   };
 });

--- a/openaev-front/src/__tests__/admin/components/common/injects/UpdateInject.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/common/injects/UpdateInject.test.tsx
@@ -1,0 +1,161 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { createContext, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import UpdateInject from '../../../../../admin/components/common/injects/UpdateInject';
+
+const { mockDispatch, mockCannot } = vi.hoisted(() => ({
+  mockDispatch: vi.fn(() => Promise.resolve()),
+  mockCannot: vi.fn(() => false),
+}));
+
+let currentInject: any;
+
+vi.mock('../../../../../actions/Inject', () => ({ fetchInject: vi.fn(() => ({ type: 'FETCH_INJECT' })) }));
+
+vi.mock('../../../../../actions/injects/inject-action', () => ({ fetchDocumentsPayloadByInject: vi.fn(() => Promise.resolve([])) }));
+
+vi.mock('../../../../../store', () => ({ useHelper: vi.fn((selector: (helper: { getInject: () => unknown }) => unknown) => selector({ getInject: () => currentInject })) }));
+
+vi.mock('../../../../../utils/hooks', () => ({ useAppDispatch: () => mockDispatch }));
+
+vi.mock('../../../../../utils/hooks/useDataLoader', async () => {
+  const React = await import('react');
+  return {
+    default: (loader: () => Promise<void> | void) => {
+      React.useEffect(() => {
+        void loader();
+      }, []);
+    },
+  };
+});
+
+vi.mock('../../../../../components/i18n', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../../../components/i18n')>();
+  return {
+    ...original,
+    useFormatter: () => ({ t: (value: string) => value }),
+  };
+});
+
+vi.mock('../../../../../components/common/Drawer', () => ({
+  default: ({ open, children, title }: {
+    open: boolean;
+    children: ReactNode;
+    title: string;
+  }) => (open
+    ? (
+        <div data-testid="drawer">
+          <h1>{title}</h1>
+          {children}
+        </div>
+      )
+    : null),
+}));
+
+vi.mock('../../../../../admin/components/common/injects/form/InjectForm', () => ({ default: () => <div data-testid="inject-form" /> }));
+
+vi.mock('../../../../../admin/components/payloads/PayloadComponent', () => ({ default: () => <div data-testid="payload-component" /> }));
+
+vi.mock('../../../../../admin/components/common/injects/UpdateInjectLogicalChains', () => ({ default: () => <div data-testid="logical-chains" /> }));
+
+vi.mock('../../../../../admin/components/common/injects/InjectCardComponent', () => ({ default: ({ title }: { title: string }) => <div data-testid="inject-card">{title}</div> }));
+
+vi.mock('../../../../../admin/components/common/injects/InjectIcon', () => ({ default: () => <div data-testid="inject-icon" /> }));
+
+vi.mock('../../../../../components/PlatformIcon', () => ({ default: () => <div data-testid="platform-icon" /> }));
+
+vi.mock('../../../../../admin/components/common/Context', () => {
+  const PermissionsContext = createContext({
+    permissions: {
+      canAccess: true,
+      canManage: true,
+      canLaunch: true,
+      canDelete: true,
+      readOnly: false,
+      isRunning: false,
+    },
+    inherited_context: 'NONE',
+  });
+
+  return { PermissionsContext };
+});
+
+vi.mock('../../../../../utils/permissions/permissionsContext', () => {
+  const AbilityContext = createContext({ cannot: mockCannot });
+  return { AbilityContext };
+});
+
+const theme = createTheme();
+
+const renderUpdateInject = () => render(
+  <ThemeProvider theme={theme}>
+    <UpdateInject
+      open
+      handleClose={() => {}}
+      onUpdateInject={() => Promise.resolve()}
+      massUpdateInject={() => Promise.resolve()}
+      injectId="inject-1"
+      isAtomic
+      injects={[]}
+      articlesFromExerciseOrScenario={[]}
+      uriVariable=""
+      variablesFromExerciseOrScenario={[]}
+    />
+  </ThemeProvider>,
+);
+
+describe('UpdateInject', () => {
+  beforeEach(() => {
+    currentInject = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('does not render guarded panels when loading ends but inject is undefined', async () => {
+    // Arrange
+    currentInject = undefined;
+
+    // Act
+    renderUpdateInject();
+
+    // Assert
+    await waitFor(() => expect(mockDispatch).toHaveBeenCalled());
+    expect(screen.getByTestId('drawer')).toBeDefined();
+    expect(screen.queryByTestId('inject-form')).toBeNull();
+    expect(screen.queryByTestId('payload-component')).toBeNull();
+    expect(screen.queryByTestId('logical-chains')).toBeNull();
+  });
+
+  it('renders InjectForm when inject is available after loading', async () => {
+    // Arrange
+    currentInject = {
+      inject_id: 'inject-1',
+      inject_enabled: true,
+      inject_title: 'Inject title',
+      inject_injector: 'injector-1',
+      inject_attack_patterns: [],
+      inject_kill_chain_phases: [],
+      inject_injector_contract: {
+        convertedContent: {
+          contract_id: 'contract-1',
+          fields: [],
+          variables: [],
+        },
+        injector_contract_injector_names: { 'injector-1': 'Injector One' },
+        injector_contract_platforms: [],
+        injector_contract_needs_executor: false,
+      },
+    };
+
+    // Act
+    renderUpdateInject();
+
+    // Assert
+    await waitFor(() => expect(screen.getByTestId('inject-form')).toBeDefined());
+  });
+});

--- a/openaev-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openaev-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -193,7 +193,7 @@ const UpdateInject: React.FC<Props> = ({
         {/* Inject details */}
         <TabPanel value="Inject details" keepMounted className={classes.tabPanel}>
           {injectFormContent}
-          {!isInjectLoading && (
+          {!isInjectLoading && inject && (
             <InjectForm
               handleClose={handleClose}
               disabled={
@@ -219,7 +219,7 @@ const UpdateInject: React.FC<Props> = ({
         {/* Action info */}
         {contractPayload && !isAtomic && (
           <TabPanel value="Action info" keepMounted className={classes.tabPanel}>
-            {!isInjectLoading && (
+            {!isInjectLoading && inject && (
               <PayloadComponent
                 documentsMap={documentsMap}
                 selectedPayload={contractPayload}
@@ -234,7 +234,7 @@ const UpdateInject: React.FC<Props> = ({
         {/* Logical chains */}
         <TabPanel value="Logical chains" keepMounted className={classes.tabPanel}>
           {injectFormContent}
-          {!isInjectLoading && !isAtomic && (
+          {!isInjectLoading && inject && !isAtomic && (
             <UpdateInjectLogicalChains
               inject={inject}
               handleClose={handleClose}


### PR DESCRIPTION
quick fix on the refresh after submitting a atomic test relaunch


### Testing Instructions

1. go to an existant atomic test and relaunch
before: 
<img width="705" height="399" alt="image" src="https://github.com/user-attachments/assets/f6479335-3515-444b-8691-54b869c8b88d" />

expected ouput: 
update atomic test display his overview

### Related issues

* Closes #6148 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
