### PR TITLE
test(notification): pass mocks instead of nulls for unused collaborators (#6188)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/NotificationRuleServiceTest.java
@@ -12,6 +12,7 @@ import io.openaev.database.model.NotificationRuleType;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.TenantSettingKeys;
 import io.openaev.database.repository.NotificationRuleRepository;
+import io.openaev.service.scenario.ScenarioService;
 import io.openaev.service.settings.TenantSettingsService;
 import jakarta.persistence.EntityManager;
 import java.util.HashMap;
@@ -42,6 +43,10 @@ public class NotificationRuleServiceTest {
   @Mock private Session session;
   @Mock private NotificationRuleRepository notificationRuleRepository;
 
+  @Mock private UserService userService;
+
+  @Mock private ScenarioService scenarioService;
+
   @Mock private EmailNotificationService emailNotificationService;
 
   @Mock private TenantSettingsService tenantSettingsService;
@@ -56,8 +61,8 @@ public class NotificationRuleServiceTest {
         new NotificationRuleService(
             entityManager,
             notificationRuleRepository,
-            null,
-            null,
+            userService,
+            scenarioService,
             emailNotificationService,
             platformSettingsService,
             tenantSettingsService);


### PR DESCRIPTION
Related to #6188 (follow-up to #6190, which was merged while this last review fix was in flight).

## Summary

Copilot review follow-up on the NotificationRuleServiceTest conversion from #6190: constructing NotificationRuleService with null UserService/ScenarioService made the unit test brittle to future refactors that start using those collaborators. Provide mocks for all constructor parameters instead.

## Test plan

- [x] mvn test -Dtest=NotificationRuleServiceTest green locally
- [x] mvn spotless:check green locally
