### PR TITLE
chore(front): bump @filigran/chatbot to 3.6.1 (#6155)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.6.0",
+    "@filigran/chatbot": "3.6.1",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.6.0":
-  version: 3.6.0
-  resolution: "@filigran/chatbot@npm:3.6.0"
+"@filigran/chatbot@npm:3.6.1":
+  version: 3.6.1
+  resolution: "@filigran/chatbot@npm:3.6.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/50715d5ce0a1ef1dddf8477054d9ade23c73ebcbd8ab9cbf6992e3cd83090268339ed4abf11963851bc6a8959590168eb4bf0d39f8ae9867da3c4885f852d4da
+  checksum: 10c0/420ca59e54fe3a175d439ce1436bcd1c12d479ae0f9622539a4bb2827c9026fbc437088302b50c217af40e410d367b17c90965cb67ac6bc1301647d9443cf476
   languageName: node
   linkType: hard
 
@@ -9851,7 +9851,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.6.0"
+    "@filigran/chatbot": "npm:3.6.1"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

- Bump @filigran/chatbot from 3.6.0 to 3.6.1 (published today, follow-up patch to the v3.6.x line)
- Only package.json and yarn.lock are touched

## Verification

- yarn install: only @filigran/chatbot changed in the lockfile
- yarn check-ts: passes
- yarn build: succeeds (pre-existing chunk-size warnings only)

Related issue: #6155
