### PR TITLE
chore(cicd): param by default enable all feature flag on feature branch (#0000)

### DIFF
--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       openaev_config:
         type: string
-        default: '{ "SPRING_PROFILES_ACTIVE": "ci" }'
+        default: '{ "SPRING_PROFILES_ACTIVE": "ci", "OPENAEV_ENABLED-DEV-FEATURES": "*" }'
         required: false
 
 permissions:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Enable all feature flagds by default when requesting a Feature branch. User can also override the `*` to specify the specific feature but at least the syntax for the env variable is proposed here (i keep forgettingit)