### PR TITLE
feat(catalog): add configurable SPLUNK_ES_QUERY field with textarea display (#6244)

### DIFF
--- a/openaev-api/src/main/resources/catalog/catalog-integrators.json
+++ b/openaev-api/src/main/resources/catalog/catalog-integrators.json
@@ -1686,6 +1686,11 @@
                         "description": "Time offset between retry attempts.",
                         "format": "duration",
                         "type": "string"
+                    },
+                    "SPLUNK_ES_QUERY": {
+                        "description": "SPL query template for fetching alerts. Placeholders: {alerts_index} (configured index), {source_ips} (source IP values, quoted for IN operator), {target_ips} (target IP values, quoted for IN operator), {start_date} (inject start date or relative time like -3600s), {end_date} (inject end date or 'now'), {ip_conditions} (legacy: auto-generated IP filters with all CIM field names), {process_conditions} (auto-generated URL path filters), {time_window} (time window in seconds, legacy). The query MUST include '| table _time' for proper alert parsing. Leave empty to use the default query.",
+                        "default": "index={alerts_index} (src_ip IN ({source_ips}) OR src IN ({source_ips}) OR source_ip IN ({source_ips}) OR client_ip IN ({source_ips})) (dst_ip IN ({target_ips}) OR dest IN ({target_ips}) OR dest_ip IN ({target_ips}) OR destination_ip IN ({target_ips}) OR server_ip IN ({target_ips})) {process_conditions} earliest={start_date} latest={end_date} | table _time, src_ip, src, source_ip, client_ip, dst_ip, dest, dest_ip, destination_ip, server_ip, signature, rule_name, event_type, severity, url_path, url, path, query, _raw | sort -_time",
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/openaev-api/src/main/resources/catalog/catalog-integrators.json
+++ b/openaev-api/src/main/resources/catalog/catalog-integrators.json
@@ -1687,7 +1687,7 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "SPLUNK_ES_QUERY": {
+                    "SPLUNK_ES_QUERY_TEMPLATE": {
                         "description": "SPL query template for fetching alerts. Placeholders: {alerts_index} (configured index), {source_ips} (source IP values, quoted for IN operator), {target_ips} (target IP values, quoted for IN operator), {start_date} (inject start date or relative time like -3600s), {end_date} (inject end date or 'now'), {ip_conditions} (legacy: auto-generated IP filters with all CIM field names), {process_conditions} (auto-generated URL path filters), {time_window} (time window in seconds, legacy). The query MUST include '| table _time' for proper alert parsing. Leave empty to use the default query.",
                         "default": "index={alerts_index} (src_ip IN ({source_ips}) OR src IN ({source_ips}) OR source_ip IN ({source_ips}) OR client_ip IN ({source_ips})) (dst_ip IN ({target_ips}) OR dest IN ({target_ips}) OR dest_ip IN ({target_ips}) OR destination_ip IN ({target_ips}) OR server_ip IN ({target_ips})) {process_conditions} earliest={start_date} latest={end_date} | table _time, src_ip, src, source_ip, client_ip, dst_ip, dest, dest_ip, destination_ip, server_ip, signature, rule_name, event_type, severity, url_path, url, path, query, _raw | sort -_time",
                         "type": "string"

--- a/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
+++ b/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
@@ -172,7 +172,12 @@ const ConnectorInstanceForm = ({
       isInMandatoryGroup: false,
       mandatoryGroupContractElementLabels: '',
       key: `connector_instance_configurations.${index}.configuration_value`,
-      type: formatFieldType(definition.connector_configuration_type, definition.connector_configuration_format, !!definition.connector_configuration_enum?.length, definition.connector_configuration_default),
+      type: formatFieldType(
+        definition.connector_configuration_type,
+        definition.connector_configuration_format,
+        !!definition.connector_configuration_enum?.length,
+        definition.connector_configuration_default,
+      ),
       mandatory: required,
       label: formatKeyToLabel(definition.connector_configuration_key || ''), // TODO should be not null
       readOnly: false,

--- a/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
+++ b/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
@@ -145,7 +145,7 @@ const ConnectorInstanceForm = ({
     return 'Create';
   };
 
-  const formatFieldType = (configurationType: CatalogConnectorConfiguration['connector_configuration_type'], configurationFormat: CatalogConnectorConfiguration['connector_configuration_format'], isEnum: boolean): ContractType => {
+  const formatFieldType = (configurationType: CatalogConnectorConfiguration['connector_configuration_type'], configurationFormat: CatalogConnectorConfiguration['connector_configuration_format'], isEnum: boolean, defaultValue?: unknown): ContractType => {
     if (isEnum) {
       return 'choice';
     }
@@ -158,6 +158,9 @@ const ConnectorInstanceForm = ({
     if (configurationType == 'INTEGER') {
       return 'number';
     }
+    if (configurationType == 'STRING' && typeof defaultValue === 'string' && defaultValue.length > 100) {
+      return 'textarea';
+    }
     return 'text';
   };
 
@@ -169,7 +172,7 @@ const ConnectorInstanceForm = ({
       isInMandatoryGroup: false,
       mandatoryGroupContractElementLabels: '',
       key: `connector_instance_configurations.${index}.configuration_value`,
-      type: formatFieldType(definition.connector_configuration_type, definition.connector_configuration_format, !!definition.connector_configuration_enum?.length),
+      type: formatFieldType(definition.connector_configuration_type, definition.connector_configuration_format, !!definition.connector_configuration_enum?.length, definition.connector_configuration_default),
       mandatory: required,
       label: formatKeyToLabel(definition.connector_configuration_key || ''), // TODO should be not null
       readOnly: false,

--- a/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
+++ b/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
@@ -145,7 +145,15 @@ const ConnectorInstanceForm = ({
     return 'Create';
   };
 
-  const formatFieldType = (configurationType: CatalogConnectorConfiguration['connector_configuration_type'], configurationFormat: CatalogConnectorConfiguration['connector_configuration_format'], isEnum: boolean, defaultValue?: unknown): ContractType => {
+  // Threshold above which a STRING field renders as a multiline textarea instead of a single-line input
+  const TEXTAREA_DEFAULT_LENGTH_THRESHOLD = 100;
+
+  const formatFieldType = (
+    configurationType: CatalogConnectorConfiguration['connector_configuration_type'],
+    configurationFormat: CatalogConnectorConfiguration['connector_configuration_format'],
+    isEnum: boolean,
+    defaultValue?: unknown,
+  ): ContractType => {
     if (isEnum) {
       return 'choice';
     }
@@ -158,7 +166,7 @@ const ConnectorInstanceForm = ({
     if (configurationType == 'INTEGER') {
       return 'number';
     }
-    if (configurationType == 'STRING' && typeof defaultValue === 'string' && defaultValue.length > 100) {
+    if (configurationType == 'STRING' && typeof defaultValue === 'string' && defaultValue.length > TEXTAREA_DEFAULT_LENGTH_THRESHOLD) {
       return 'textarea';
     }
     return 'text';


### PR DESCRIPTION
## Summary

Adds a configurable `SPLUNK_ES_QUERY` field to the Splunk ES connector catalog, allowing administrators to view and customize the SPL query template used by the collector.

## Changes

### Backend
- **catalog-integrators.json**: Added `SPLUNK_ES_QUERY` configuration field with description documenting all 8 placeholders and a default SPL query template using Splunk `IN()` syntax

### Frontend
- **ConnectorInstanceForm.tsx**: STRING configuration fields whose default value exceeds a length threshold (100 chars) now render as a multiline textarea instead of a single-line input, making long templates (like SPL queries) readable and editable

## Placeholders

| Placeholder | Description |
|---|---|
| `{alerts_index}` | Splunk index name |
| `{source_ips}` | Source IPs (IN format) |
| `{target_ips}` | Target IPs (IN format) |
| `{process_conditions}` | Process/signature filter |
| `{start_date}` | Query start time |
| `{end_date}` | Query end time |

## Related

- Closes #6244
- Collector-side PR: https://github.com/OpenAEV-Platform/collectors/pull/419