### PR TITLE
fix(audit_log): audit log does not capture password change event (#6189)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -69,22 +69,11 @@ public class AccessControlAuditLogAspect {
     Action action = null;
     boolean isActive = false;
     boolean isActionActive = false;
-    boolean isActiveOnSkipRBAC = false;
 
     try {
       action = accessControl.actionPerformed();
       isActive = auditLogger.isAuditLoggingEnabled();
       isActionActive = auditLogger.isAuditLoggingValid(action);
-
-      // If skipRBAC is active but there is a resourceType and actionPerformed
-      // defined, we will still log the event. This will be applicable when the
-      // user changes a password, or an agent token...
-      isActiveOnSkipRBAC =
-          accessControl.skipRBAC()
-              && accessControl.resourceType() != null
-              && accessControl.resourceType() != ResourceType.SKIP_RBAC
-              && action != null
-              && action != Action.SKIP_RBAC;
     } catch (Exception e) {
       log.warn(LOG_ERROR_MSG, e);
     }
@@ -106,7 +95,7 @@ public class AccessControlAuditLogAspect {
 
             logAccessControlEvent(
                 joinPoint, accessControl, eventScope, eventStatus, errorNode, snapshots);
-          } else if (isActionActive || isActiveOnSkipRBAC) {
+          } else if (isActionActive) {
             // Capture snapshots on the servlet thread before any async handoff.
             snapshots = captureEntitySnapshots();
             String eventScope = LogUtils.getEventScope(action);
@@ -124,18 +113,16 @@ public class AccessControlAuditLogAspect {
       throw ex;
     }
 
-    if (isActive) {
+    if (isActive && isActionActive) {
       try {
-        if (isActionActive || isActiveOnSkipRBAC) {
-          // Capture snapshots on the servlet thread before any async handoff.
-          snapshots = captureEntitySnapshots();
-          String eventScope = LogUtils.getEventScope(action);
-          String eventStatus = LogUtils.getEventStatus(EventStatus.SUCCESS);
-          JsonNode resultNode = getOutputNode(result);
+        // Capture snapshots on the servlet thread before any async handoff.
+        snapshots = captureEntitySnapshots();
+        String eventScope = LogUtils.getEventScope(action);
+        String eventStatus = LogUtils.getEventStatus(EventStatus.SUCCESS);
+        JsonNode resultNode = getOutputNode(result);
 
-          logAccessControlEvent(
-              joinPoint, accessControl, eventScope, eventStatus, resultNode, snapshots);
-        }
+        logAccessControlEvent(
+            joinPoint, accessControl, eventScope, eventStatus, resultNode, snapshots);
       } catch (Exception ex) {
         log.warn(LOG_ERROR_MSG, ex);
       }

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -69,11 +69,22 @@ public class AccessControlAuditLogAspect {
     Action action = null;
     boolean isActive = false;
     boolean isActionActive = false;
+    boolean isActiveOnSkipRBAC = false;
 
     try {
       action = accessControl.actionPerformed();
       isActive = auditLogger.isAuditLoggingEnabled();
       isActionActive = auditLogger.isAuditLoggingValid(action);
+
+      // If skipRBAC is active but there is a resourceType and actionPerformed
+      // defined, we will still log the event. This will be applicable when the
+      // user changes a password, or an agent token...
+      isActiveOnSkipRBAC =
+          accessControl.skipRBAC()
+              && accessControl.resourceType() != null
+              && accessControl.resourceType() != ResourceType.SKIP_RBAC
+              && action != null
+              && action != Action.SKIP_RBAC;
     } catch (Exception e) {
       log.warn(LOG_ERROR_MSG, e);
     }
@@ -95,7 +106,7 @@ public class AccessControlAuditLogAspect {
 
             logAccessControlEvent(
                 joinPoint, accessControl, eventScope, eventStatus, errorNode, snapshots);
-          } else if (isActionActive) {
+          } else if (isActionActive || isActiveOnSkipRBAC) {
             // Capture snapshots on the servlet thread before any async handoff.
             snapshots = captureEntitySnapshots();
             String eventScope = LogUtils.getEventScope(action);
@@ -113,16 +124,18 @@ public class AccessControlAuditLogAspect {
       throw ex;
     }
 
-    if (isActive && isActionActive) {
+    if (isActive) {
       try {
-        // Capture snapshots on the servlet thread before any async handoff.
-        snapshots = captureEntitySnapshots();
-        String eventScope = LogUtils.getEventScope(action);
-        String eventStatus = LogUtils.getEventStatus(EventStatus.SUCCESS);
-        JsonNode resultNode = getOutputNode(result);
+        if (isActionActive || isActiveOnSkipRBAC) {
+          // Capture snapshots on the servlet thread before any async handoff.
+          snapshots = captureEntitySnapshots();
+          String eventScope = LogUtils.getEventScope(action);
+          String eventStatus = LogUtils.getEventStatus(EventStatus.SUCCESS);
+          JsonNode resultNode = getOutputNode(result);
 
-        logAccessControlEvent(
-            joinPoint, accessControl, eventScope, eventStatus, resultNode, snapshots);
+          logAccessControlEvent(
+              joinPoint, accessControl, eventScope, eventStatus, resultNode, snapshots);
+        }
       } catch (Exception ex) {
         log.warn(LOG_ERROR_MSG, ex);
       }

--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -9,6 +9,8 @@ import io.openaev.aop.AccessControl;
 import io.openaev.api.tenants.TenantMapper;
 import io.openaev.api.tenants.TenantOutput;
 import io.openaev.config.SessionManager;
+import io.openaev.database.model.Action;
+import io.openaev.database.model.ResourceType;
 import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.OrganizationRepository;
@@ -67,7 +69,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PutMapping(ME_URI + "/profile")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User updateProfile(@Valid @RequestBody UpdateProfileInput input) {
     User user =
         userRepository
@@ -82,7 +84,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PutMapping(ME_URI + "/information")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User updateInformation(@Valid @RequestBody UpdateUserInfoInput input) {
     User user =
         userRepository
@@ -95,7 +97,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PutMapping(ME_URI + "/password")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User updatePassword(@Valid @RequestBody UpdateMePasswordInput input)
       throws InputValidationException {
     User user =

--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -69,6 +69,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PutMapping(ME_URI + "/profile")
+  // Adding actionPerformed in the AccessControl annotation allows this endpoint to be audit logged.
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User updateProfile(@Valid @RequestBody UpdateProfileInput input) {
     User user =
@@ -84,6 +85,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PutMapping(ME_URI + "/information")
+  // Adding actionPerformed in the AccessControl annotation allows this endpoint to be audit logged.
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User updateInformation(@Valid @RequestBody UpdateUserInfoInput input) {
     User user =
@@ -97,6 +99,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PutMapping(ME_URI + "/password")
+  // Adding actionPerformed in the AccessControl annotation allows this endpoint to be audit logged.
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User updatePassword(@Valid @RequestBody UpdateMePasswordInput input)
       throws InputValidationException {

--- a/openaev-api/src/main/java/io/openaev/rest/user/UserApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/UserApi.java
@@ -114,6 +114,7 @@ public class UserApi extends RestBehavior {
         @ApiResponse(responseCode = "400", description = "The user was not found")
       })
   @PostMapping("/api/reset")
+  // Adding actionPerformed in the AccessControl annotation allows this endpoint to be audit logged.
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public ResponseEntity<?> passwordReset(@Valid @RequestBody ResetUserInput input) {
     // async execution; check method annotation
@@ -132,6 +133,7 @@ public class UserApi extends RestBehavior {
             content = @Content(schema = @Schema(implementation = User.class))),
       })
   @PostMapping("/api/reset/{token}")
+  // Adding actionPerformed in the AccessControl annotation allows this endpoint to be audit logged.
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User changePasswordReset(
       @PathVariable @Schema(description = "Token generated during reset") String token,
@@ -151,7 +153,7 @@ public class UserApi extends RestBehavior {
             content = @Content(schema = @Schema(implementation = Boolean.class))),
       })
   @GetMapping("/api/reset/{token}")
-  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
+  @AccessControl(skipRBAC = true)
   public boolean validatePasswordResetToken(
       @PathVariable @Schema(description = "Token generated during reset") String token) {
     return userService.getResetToken(token);

--- a/openaev-api/src/main/java/io/openaev/rest/user/UserApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/UserApi.java
@@ -114,7 +114,7 @@ public class UserApi extends RestBehavior {
         @ApiResponse(responseCode = "400", description = "The user was not found")
       })
   @PostMapping("/api/reset")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public ResponseEntity<?> passwordReset(@Valid @RequestBody ResetUserInput input) {
     // async execution; check method annotation
     userService.requestPasswordReset(input);
@@ -132,7 +132,7 @@ public class UserApi extends RestBehavior {
             content = @Content(schema = @Schema(implementation = User.class))),
       })
   @PostMapping("/api/reset/{token}")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public User changePasswordReset(
       @PathVariable @Schema(description = "Token generated during reset") String token,
       @Valid @RequestBody ChangePasswordInput input)
@@ -151,7 +151,7 @@ public class UserApi extends RestBehavior {
             content = @Content(schema = @Schema(implementation = Boolean.class))),
       })
   @GetMapping("/api/reset/{token}")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   public boolean validatePasswordResetToken(
       @PathVariable @Schema(description = "Token generated during reset") String token) {
     return userService.getResetToken(token);

--- a/openaev-api/src/main/java/io/openaev/service/LogService.java
+++ b/openaev-api/src/main/java/io/openaev/service/LogService.java
@@ -178,10 +178,14 @@ public class LogService {
 
       // Enrich with entity-level diffs captured by @AuditDiffTracked listeners.
       if (entityDiffsNode != null && !entityDiffsNode.isEmpty()) {
+        entityDiffsNode = ObjectRedactionUtils.redact(entityDiffsNode, resourceType);
         ctx.put("entity_diffs", toContextValue(entityDiffsNode));
       }
 
-      doc.getRequestMetadata().setSignature(signatureNode);
+      if (signatureNode != null) {
+        signatureNode = ObjectRedactionUtils.redact(signatureNode, resourceType);
+        doc.getRequestMetadata().setSignature(signatureNode);
+      }
 
       ctx.put("message", message);
       doc.setContextData(ctx);

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.config.AuditLogProperties;
@@ -13,10 +14,12 @@ import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.database.model.ResourceType;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.engine.model.log.LogEvent;
+import io.openaev.helper.CryptoHelper;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.utils.HttpReqRespUtils;
 import io.openaev.utils.log.dispatcher.AuditLogTransportDispatcherUtils;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
 import java.util.logging.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -291,5 +294,411 @@ class LogServiceTest {
     // Assert
     assertThat(result).isTrue();
     verify(auditLogTransportDispatcherUtils).dispatch(any(LogEvent.class), any());
+  }
+
+  @Nested
+  @DisplayName("logRequestEvent — redaction of entity_diffs and signature")
+  class LogRequestEventRedaction {
+
+    private static final String REDACTED = "*** Redacted ***";
+
+    @BeforeEach
+    void enableAudit() {
+      when(previewFeatureService.isFeatureEnabled(any())).thenReturn(true);
+      when(auditLogTransportDispatcherUtils.dispatch(any(LogEvent.class), any())).thenReturn(true);
+    }
+
+    // -- entity_diffs: sensitive field redaction --
+
+    @Test
+    @DisplayName("given_entityDiffsWithPasswordField_should_redactValue")
+    void given_entityDiffsWithPasswordField_should_redactValue() {
+      // Arrange
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("user_password", "plaintext-secret");
+      entityDiffs.put("role_name", "admin");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-1",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r1");
+
+      // Assert
+      Map<String, Object> diffs = captureEntityDiffs();
+      assertThat(diffs)
+          .containsEntry("user_password", REDACTED)
+          .containsEntry("role_name", "admin");
+    }
+
+    @Test
+    @DisplayName("given_entityDiffsWithSecretField_should_redactValue")
+    void given_entityDiffsWithSecretField_should_redactValue() {
+      // Arrange
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("client_secret", "s3cr3t!");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-2",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r2");
+
+      // Assert
+      assertThat(captureEntityDiffs()).containsEntry("client_secret", REDACTED);
+    }
+
+    @Test
+    @DisplayName("given_entityDiffsWithCredentialField_should_redactValue")
+    void given_entityDiffsWithCredentialField_should_redactValue() {
+      // Arrange
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("api_credential", "cred-xyz");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-3",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r3");
+
+      // Assert
+      assertThat(captureEntityDiffs()).containsEntry("api_credential", REDACTED);
+    }
+
+    @Test
+    @DisplayName("given_entityDiffsWithTokenField_should_hashValue")
+    void given_entityDiffsWithTokenField_should_hashValue() {
+      // Arrange – token fields are hashed, not blanket-redacted
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("user_token", "abc-secret-token");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-4",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r4");
+
+      // Assert
+      assertThat(captureEntityDiffs())
+          .containsEntry("user_token", CryptoHelper.hashWithSHA256("abc-secret-token"));
+    }
+
+    @Test
+    @DisplayName("given_entityDiffsWithApiKeyField_should_hashValue")
+    void given_entityDiffsWithApiKeyField_should_hashValue() {
+      // Arrange
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("api_key", "key-123-abc");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-5",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r5");
+
+      // Assert
+      assertThat(captureEntityDiffs())
+          .containsEntry("api_key", CryptoHelper.hashWithSHA256("key-123-abc"));
+    }
+
+    // -- entity_diffs: PII removal (USER resource type only) --
+
+    @Test
+    @DisplayName("given_entityDiffsWithPIIFields_and_userResourceType_should_removePIIKeys")
+    void given_entityDiffsWithPIIFields_and_userResourceType_should_removePIIKeys() {
+      // Arrange
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("user_email", "alice@example.com");
+      entityDiffs.put("user_firstname", "Alice");
+      entityDiffs.put("user_lastname", "Smith");
+      entityDiffs.put("role_name", "analyst"); // non-PII — must survive
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER,
+          "user-1",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r6");
+
+      // Assert
+      Map<String, Object> diffs = captureEntityDiffs();
+      assertThat(diffs)
+          .doesNotContainKey("user_email")
+          .doesNotContainKey("user_firstname")
+          .doesNotContainKey("user_lastname")
+          .containsEntry("role_name", "analyst");
+    }
+
+    @Test
+    @DisplayName("given_entityDiffsWithPIIFields_and_nonUserResourceType_should_keepPIIKeys")
+    void given_entityDiffsWithPIIFields_and_nonUserResourceType_should_keepPIIKeys() {
+      // Arrange – same payload but for a GROUP resource: PII removal must NOT apply
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("user_email", "alice@example.com");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "group-1",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r7");
+
+      // Assert
+      assertThat(captureEntityDiffs()).containsKey("user_email");
+    }
+
+    // -- entity_diffs: non-sensitive fields pass through unchanged --
+
+    @Test
+    @DisplayName("given_entityDiffsWithNonSensitiveFields_should_passThroughUnchanged")
+    void given_entityDiffsWithNonSensitiveFields_should_passThroughUnchanged() {
+      // Arrange
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.put("entity_type", "Role");
+      entityDiffs.put("operation", "update");
+      entityDiffs.put("role_description", "platform admin");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-8",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r8");
+
+      // Assert
+      assertThat(captureEntityDiffs())
+          .containsEntry("entity_type", "Role")
+          .containsEntry("operation", "update")
+          .containsEntry("role_description", "platform admin");
+    }
+
+    // -- entity_diffs: nested sensitive fields --
+
+    @Test
+    @DisplayName("given_entityDiffsWithNestedPasswordField_should_redactNestedValue")
+    void given_entityDiffsWithNestedPasswordField_should_redactNestedValue() {
+      // Arrange – diff entry with a nested "before" snapshot that contains a password key
+      ObjectNode beforeSnapshot = objectMapper.createObjectNode();
+      beforeSnapshot.put("user_password", "old-hash");
+      beforeSnapshot.put("user_name", "bob");
+
+      ObjectNode entityDiffs = objectMapper.createObjectNode();
+      entityDiffs.set("before", beforeSnapshot);
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-9",
+          null,
+          null,
+          null,
+          entityDiffs,
+          Level.WARNING,
+          "uuid-r9");
+
+      // Assert
+      @SuppressWarnings("unchecked")
+      Map<String, Object> before = (Map<String, Object>) captureEntityDiffs().get("before");
+      assertThat(before).containsEntry("user_password", REDACTED).containsEntry("user_name", "bob");
+    }
+
+    // -- signature: sensitive field redaction --
+
+    @Test
+    @DisplayName("given_signatureWithPasswordField_should_redactPasswordValue")
+    void given_signatureWithPasswordField_should_redactPasswordValue() {
+      // Arrange
+      ObjectNode signature = objectMapper.createObjectNode();
+      signature.put("user_password", "plaintext");
+      signature.put("algo", "sha256");
+
+      // Act
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-10",
+          null,
+          null,
+          signature,
+          null,
+          Level.WARNING,
+          "uuid-r10");
+
+      // Assert
+      JsonNode sig = captureSignature();
+      assertThat(sig.get("user_password").asText()).isEqualTo(REDACTED);
+      assertThat(sig.get("algo").asText()).isEqualTo("sha256");
+    }
+
+    @Test
+    @DisplayName("given_signatureWithTokenField_should_hashTokenValue")
+    void given_signatureWithTokenField_should_hashTokenValue() {
+      // Arrange
+      ObjectNode signature = objectMapper.createObjectNode();
+      signature.put("api_token", "tok-xyz-789");
+
+      // Act
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-11",
+          null,
+          null,
+          signature,
+          null,
+          Level.WARNING,
+          "uuid-r11");
+
+      // Assert
+      assertThat(captureSignature().get("api_token").asText())
+          .isEqualTo(CryptoHelper.hashWithSHA256("tok-xyz-789"));
+    }
+
+    @Test
+    @DisplayName("given_signatureWithSecretField_should_redactSecretValue")
+    void given_signatureWithSecretField_should_redactSecretValue() {
+      // Arrange
+      ObjectNode signature = objectMapper.createObjectNode();
+      signature.put("client_secret", "very-secret");
+
+      // Act
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-12",
+          null,
+          null,
+          signature,
+          null,
+          Level.WARNING,
+          "uuid-r12");
+
+      // Assert
+      assertThat(captureSignature().get("client_secret").asText()).isEqualTo(REDACTED);
+    }
+
+    @Test
+    @DisplayName("given_nullSignature_should_notSetSignatureOnRequestMetadata")
+    void given_nullSignature_should_notSetSignatureOnRequestMetadata() {
+      // Act – no signatureNode passed
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.USER_GROUP,
+          "id-13",
+          null,
+          null,
+          null,
+          null,
+          Level.WARNING,
+          "uuid-r13");
+
+      // Assert
+      assertThat(captureEvent().getRequestMetadata().getSignature()).isNull();
+    }
+
+    @Test
+    @DisplayName("given_signatureWithPIIFields_and_userResourceType_should_removePIIKeys")
+    void given_signatureWithPIIFields_and_userResourceType_should_removePIIKeys() {
+      // Arrange
+      ObjectNode signature = objectMapper.createObjectNode();
+      signature.put("user_email", "bob@example.com");
+      signature.put("user_phone", "+1-555-0100");
+      signature.put("method_name", "updateProfile");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.USER,
+          "user-2",
+          null,
+          null,
+          signature,
+          null,
+          Level.WARNING,
+          "uuid-r14");
+
+      // Assert
+      JsonNode sig = captureSignature();
+      assertThat(sig.has("user_email")).isFalse();
+      assertThat(sig.has("user_phone")).isFalse();
+      assertThat(sig.get("method_name").asText()).isEqualTo("updateProfile");
+    }
+
+    // -- helpers --
+
+    private LogEvent captureEvent() {
+      ArgumentCaptor<LogEvent> captor = ArgumentCaptor.forClass(LogEvent.class);
+      verify(auditLogTransportDispatcherUtils, atLeastOnce()).dispatch(captor.capture(), any());
+      return captor.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> captureEntityDiffs() {
+      return (Map<String, Object>) captureEvent().getContextData().get("entity_diffs");
+    }
+
+    private JsonNode captureSignature() {
+      return captureEvent().getRequestMetadata().getSignature();
+    }
   }
 }


### PR DESCRIPTION
### Description
When a user changes their password in OpenAEV, the action is not recorded in the audit log. This means there is no traceable record of password change events, which is a security and compliance gap particularly critical for enterprise customers operating in regulated environments (e.g. financial services, government).

### Proposed changes

* This issue occurs because the corresponding API method has skipRBAC enabled and there is no actionPerformed.
* The AccessControlAuditLogAspect already logs events that have skipRBAC equal to true and also actionPerformed attribute.
* Therefore, we only need to add the actionPerformed attribute to the change password method, as follows:
[@accesscontrol](https://github.com/accesscontrol)(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
While resourceType is optional, it’s beneficial to include it, so we are adding it as well.
* We will also need to redact the logged sensitive data.

### Testing Instructions

1. Log in to OpenAEV as any user
2. Navigate to Profile
3. Change the user password and confirm the change
4. Go to your console and check this logged event.

### Related issues

* #6189

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
