### PR TITLE
fix(audit_log): token renewal is not getting logged (#6164)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -113,6 +113,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PostMapping(ME_URI + "/token/refresh")
+  // Adding actionPerformed in the AccessControl annotation allows this endpoint to be audit logged.
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   @Transactional(rollbackOn = Exception.class)
   public Token renewToken(@Valid @RequestBody RenewTokenInput input) {

--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -9,6 +9,8 @@ import io.openaev.aop.AccessControl;
 import io.openaev.api.tenants.TenantMapper;
 import io.openaev.api.tenants.TenantOutput;
 import io.openaev.config.SessionManager;
+import io.openaev.database.model.Action;
+import io.openaev.database.model.ResourceType;
 import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.OrganizationRepository;
@@ -111,7 +113,7 @@ public class MeApi extends RestBehavior {
   }
 
   @PostMapping(ME_URI + "/token/refresh")
-  @AccessControl(skipRBAC = true)
+  @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   @Transactional(rollbackOn = Exception.class)
   public Token renewToken(@Valid @RequestBody RenewTokenInput input) {
     User user =


### PR DESCRIPTION
### Description

As a Platform Admin, I want to see audit logs for token renewal, So that I can monitor credential activity, investigate incidents, and meet compliance/traceability requirements.

### Proposed changes

* This issue occurs because the corresponding API method has skipRBAC enabled and there is no actionPerformed.
* The AccessControlAuditLogAspect already logs events that have skipRBAC equal to true and also actionPerformed attribute.
* Therefore, we only need to add the actionPerformed attribute to the renew token method, as follows:
[@accesscontrol](https://github.com/accesscontrol)(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
While resourceType is optional, it’s beneficial to include it, so we are adding it as well.

### Testing Instructions

1. Log in to OpenAEV as any user
2. Navigate to Profile
3. Renew token and confirm the change
4. Go to your console and check this logged event.

### Related issues

* #6164

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
