### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.1 for shared waiting experience (#6234)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.7.0",
+    "@filigran/chatbot": "3.7.1",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.6.1",
+    "@filigran/chatbot": "3.7.0",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
@@ -10,6 +10,7 @@ import { useLocation } from 'react-router';
 
 import { useFormatter } from '../../../components/i18n';
 import { api } from '../../../network';
+import { MESSAGING$ } from '../../../utils/Environment';
 import useAuth from '../../../utils/hooks/useAuth';
 import installChatbotCsrf from './installChatbotCsrf';
 
@@ -182,6 +183,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
       onWidthChange={onWidthChange}
       onResizeStart={onResizeStart}
       onResizeEnd={onResizeEnd}
+      onTaskComplete={(_title, body) => MESSAGING$.notifySuccess(body)}
     />,
     container,
   );

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@filigran/chatbot@npm:3.6.1"
+"@filigran/chatbot@npm:3.7.1":
+  version: 3.7.1
+  resolution: "@filigran/chatbot@npm:3.7.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/420ca59e54fe3a175d439ce1436bcd1c12d479ae0f9622539a4bb2827c9026fbc437088302b50c217af40e410d367b17c90965cb67ac6bc1301647d9443cf476
+  checksum: 10c0/b603d2d550dd5c7511764fd25b832990d545237fd0c3e057293c1ac70b3a17b32979e98e0301b8b4e8670c341f9ab6715726afb2f3bf0deb6bcaca71151de12f
   languageName: node
   linkType: hard
 
@@ -9860,7 +9860,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.6.1"
+    "@filigran/chatbot": "npm:3.7.1"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

Closes #6234.

Adopt the new shared chat waiting experience from `@filigran/chatbot` 3.7.1 in the "Ask Ariane" panel, so the loading/thinking state is identical across XTM One, OpenCTI and OpenAEV (all three render the same `ChatPanel`).

3.7.1 adds, on by default:
- dynamic rotating status messages during longer waits;
- an optional Space Invader mini-game that shoots the message letters away one by one (toggle on the panel, persisted per browser; skipped under `prefers-reduced-motion`, where messages still rotate as plain text);
- a completion notification when a long turn finishes and the user is not watching the chat: document-title flash + browser notification (when granted) when away (tab hidden / another window), and a host toast when in-app but looking elsewhere.

Upstream feature: FiligranHQ/filigran-ui#326. Companion: XTM-One-Platform/xtm-one#1626.

## Changes

- `openaev-front`: bump `@filigran/chatbot` 3.6.1 -> 3.7.1.
- `AskArianePanel`: wire `onTaskComplete` to `MESSAGING$.notifySuccess` so the user gets an in-app toast when an agent reply lands while they are working elsewhere in OpenAEV.

## Test plan

- [x] `yarn install --immutable` succeeds (lockfile regenerated against the published 3.7.1).
- [ ] Open Ask Ariane, send a message: the dynamic waiting messages + Space Invader appear during the wait and disappear when the answer streams.
- [ ] Send a message, click into the main app while the panel stays open -> a success toast appears when the reply lands.
- [ ] Send a message, switch to another tab/window -> document title flashes (and a browser notification fires if permission was granted).
