### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.3 for waiting mini-game autoscroll (#6240)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.7.2",
+    "@filigran/chatbot": "3.7.3",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.7.2":
-  version: 3.7.2
-  resolution: "@filigran/chatbot@npm:3.7.2"
+"@filigran/chatbot@npm:3.7.3":
+  version: 3.7.3
+  resolution: "@filigran/chatbot@npm:3.7.3"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/4c014714631627623acac2d6671708e32bb0db21bf4e372f1c1456c7f0d7b58adee679765b93162747f95f9b10ba52d5e0e4bf7ce45207a0bab798a5aeec56de
+  checksum: 10c0/dca158e21a31d5a95eed6dda2502e6a345d1d289525da77c8c118419e7b979199650973fef484fedc1c111113c07ece5092924e5377e1de87104e37dc0839bc6
   languageName: node
   linkType: hard
 
@@ -9860,7 +9860,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.7.2"
+    "@filigran/chatbot": "npm:3.7.3"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

Bumps `@filigran/chatbot` from 3.7.2 to 3.7.3 in `openaev-front`.

3.7.3 brings the waiting mini-game auto-scroll fix (FiligranHQ/filigran-ui#330): when the waiting mini-game appears at the bottom of the chat while the user is following the conversation, it now scrolls into view automatically instead of sitting under the fold. Users who scrolled up to read history are left untouched.

Parity with OpenCTI and XTM One, which track the same `@filigran/chatbot` release.

## Changes

- `openaev-front/package.json`: `@filigran/chatbot` 3.7.2 -> 3.7.3
- `openaev-front/yarn.lock`: updated to resolve `@filigran/chatbot@npm:3.7.3`

Closes #6240
