### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.4 for completion-notice fix (#6242)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -39,7 +39,7 @@
     "@ckeditor/ckeditor5-react": "11.1.2",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
-    "@filigran/chatbot": "3.7.3",
+    "@filigran/chatbot": "3.7.4",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",
     "@hello-pangea/dnd": "18.0.1",

--- a/openaev-front/yarn.lock
+++ b/openaev-front/yarn.lock
@@ -1668,15 +1668,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.7.3":
-  version: 3.7.3
-  resolution: "@filigran/chatbot@npm:3.7.3"
+"@filigran/chatbot@npm:3.7.4":
+  version: 3.7.4
+  resolution: "@filigran/chatbot@npm:3.7.4"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/dca158e21a31d5a95eed6dda2502e6a345d1d289525da77c8c118419e7b979199650973fef484fedc1c111113c07ece5092924e5377e1de87104e37dc0839bc6
+  checksum: 10c0/b29ceb727765ccd8c06eb7f482cf54eff8dcfb1b669bdbfe96ced0222a47decbd58e82bb80cbcedf29206e64c4ccc6e7dee80ef025dd182d6f5cfa497b174b9a
   languageName: node
   linkType: hard
 
@@ -9860,7 +9860,7 @@ __metadata:
     "@emotion/styled": "npm:11.14.1"
     "@eslint/js": "npm:9.39.4"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.7.3"
+    "@filigran/chatbot": "npm:3.7.4"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"
     "@hello-pangea/dnd": "npm:18.0.1"


### PR DESCRIPTION
## Summary

Closes #6242.

Bump `@filigran/chatbot` 3.7.3 -> 3.7.4 in `openaev-front`.

3.7.4 is a patch release that fixes the "Ask Ariane" chat firing a turn-completion notification while the chat panel is already visible. The completion notice (document-title flash / browser notification / host toast) should only fire when the user is away or looking elsewhere; 3.7.4 suppresses it when the panel is on screen.

This is a dependency-only bump: the chat public API (`ChatPanel`, `ChatMode`) is unchanged, so no OpenAEV code changes are required.

Upstream fix: FiligranHQ/filigran-ui#332.

## Changes

- `openaev-front`: bump `@filigran/chatbot` 3.7.3 -> 3.7.4 and regenerate `yarn.lock`.

## Test plan

- [x] `yarn install --mode=update-lockfile` regenerates `yarn.lock` against the published 3.7.4 (the only changed entry is `@filigran/chatbot`).
- [ ] CI `yarn install --immutable` succeeds against the published 3.7.4.
- [ ] Ask Ariane no longer raises a completion notification when the chat panel is open and visible.
