### PR TITLE
fix(security-coverage): use integer value instead of double (#6202)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/stix/CoverageResult.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/CoverageResult.java
@@ -8,9 +8,9 @@ import lombok.Setter;
 public class CoverageResult {
   private String name;
 
-  private double score;
+  private int score;
 
-  public CoverageResult(String name, double successRate) {
+  public CoverageResult(String name, int successRate) {
     this.name = name;
     this.score = successRate;
   }

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -752,7 +752,8 @@ public class SecurityCoverageService {
     for (InjectExpectationResultUtils.ExpectationResultsByType result : coverageResults) {
       CoverageResult cov =
           new CoverageResult(
-              result.type().name(), (int) Math.round(result.getSuccessRate() * 100)); // force percentage points
+              result.type().name(),
+              (int) Math.round(result.getSuccessRate() * 100)); // force percentage points
       coverageValues.add(new Complex<>(cov));
     }
     return new io.openaev.stix.types.List<>(coverageValues);

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -752,7 +752,7 @@ public class SecurityCoverageService {
     for (InjectExpectationResultUtils.ExpectationResultsByType result : coverageResults) {
       CoverageResult cov =
           new CoverageResult(
-              result.type().name(), result.getSuccessRate() * 100); // force percentage points
+              result.type().name(), (int) Math.round(result.getSuccessRate() * 100)); // force percentage points
       coverageValues.add(new Complex<>(cov));
     }
     return new io.openaev.stix.types.List<>(coverageValues);

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -171,7 +171,11 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
             injects.stream().map(Inject::getId).collect(Collectors.toSet()));
     return toList(
         results.stream()
-            .map(r -> new Complex<>(new CoverageResult(r.type().name(), (int) Math.round(r.getSuccessRate() * 100))))
+            .map(
+                r ->
+                    new Complex<>(
+                        new CoverageResult(
+                            r.type().name(), (int) Math.round(r.getSuccessRate() * 100))))
             .toList());
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -171,7 +171,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
             injects.stream().map(Inject::getId).collect(Collectors.toSet()));
     return toList(
         results.stream()
-            .map(r -> new Complex<>(new CoverageResult(r.type().name(), r.getSuccessRate() * 100)))
+            .map(r -> new Complex<>(new CoverageResult(r.type().name(), (int) Math.round(r.getSuccessRate() * 100))))
             .toList());
   }
 
@@ -320,8 +320,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                             .getId()
                                             .getValue()
                                             .contains(securityPlatformWrapper.get().getId())
-                                        ? 100.0
-                                        : 0.0)),
+                                        ? 100
+                                        : 0)),
                             new Complex<>(
                                 new CoverageResult(
                                     "DETECTION",
@@ -329,8 +329,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                             .getId()
                                             .getValue()
                                             .contains(securityPlatformWrapper.get().getId())
-                                        ? 100.0
-                                        : 0.0))))));
+                                        ? 100
+                                        : 0))))));
         assertThatJson(actualSro.toStix(mapper))
             .whenIgnoringPaths(CommonProperties.ID.toString())
             .isEqualTo(expectedSro.toStix(mapper));
@@ -362,8 +362,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                     ExtendedProperties.COVERAGE.toString(),
                     toList(
                         List.of(
-                            new Complex<>(new CoverageResult("PREVENTION", 100.0)),
-                            new Complex<>(new CoverageResult("DETECTION", 100.0))))));
+                            new Complex<>(new CoverageResult("PREVENTION", 100)),
+                            new Complex<>(new CoverageResult("DETECTION", 100))))));
         assertThatJson(actualSro.toStix(mapper))
             .whenIgnoringPaths(CommonProperties.ID.toString())
             .isEqualTo(expectedSro.toStix(mapper));
@@ -434,7 +434,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                       ExtendedProperties.COVERED.toString(),
                       new io.openaev.stix.types.Boolean(true),
                       ExtendedProperties.COVERAGE.toString(),
-                      toList(List.of(new Complex<>(new CoverageResult("VULNERABILITY", 100.0))))));
+                      toList(List.of(new Complex<>(new CoverageResult("VULNERABILITY", 100))))));
           assertThatJson(actualSro.toStix(mapper))
               .whenIgnoringPaths(CommonProperties.ID.toString())
               .isEqualTo(expectedSro.toStix(mapper));
@@ -716,8 +716,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                           .getId()
                                           .getValue()
                                           .contains(securityPlatformWrapper.get().getId())
-                                      ? 50.0
-                                      : 0.0)),
+                                      ? 50
+                                      : 0)),
                           new Complex<>(
                               new CoverageResult(
                                   "DETECTION",
@@ -725,8 +725,8 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                                           .getId()
                                           .getValue()
                                           .contains(securityPlatformWrapper.get().getId())
-                                      ? 50.0
-                                      : 0.0))))));
+                                      ? 50
+                                      : 0))))));
       assertThatJson(actualSro.toStix(mapper))
           .whenIgnoringPaths(CommonProperties.ID.toString())
           .isEqualTo(expectedSro.toStix(mapper));
@@ -764,11 +764,11 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
                           new Complex<>(
                               new CoverageResult(
                                   "PREVENTION",
-                                  stixRef.getExternalRefs().contains("T1234") ? 100.0 : 0.0)),
+                                  stixRef.getExternalRefs().contains("T1234") ? 100 : 0)),
                           new Complex<>(
                               new CoverageResult(
                                   "DETECTION",
-                                  stixRef.getExternalRefs().contains("T1234") ? 100.0 : 0.0))))));
+                                  stixRef.getExternalRefs().contains("T1234") ? 100 : 0))))));
       assertThatJson(actualSro.toStix(mapper))
           .whenIgnoringPaths(CommonProperties.ID.toString())
           .isEqualTo(expectedSro.toStix(mapper));


### PR DESCRIPTION
### Proposed changes

* Change coverage score type from double to integer

### Testing Instructions

1. Create and run a scenario from OCTI
2. Everything should work as usual, and send coverage score should be integer type

### Related issues

* Closes #6202 