### PR TITLE
fix(player): reinforce checks on player identity (#6279)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/UrlAccessControlAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/UrlAccessControlAspect.java
@@ -104,7 +104,7 @@ public class UrlAccessControlAspect {
     if (!urlAccessControl.userId().isEmpty()) {
       String paramName = stripSpelPrefix(urlAccessControl.userId());
       for (int i = 0; i < parameterNames.length; i++) {
-        if (paramName.equals(parameterNames[i]) && shouldExecuteInjection(args[i])) {
+        if (paramName.equals(parameterNames[i])) {
           Object[] newArgs = Arrays.copyOf(args, args.length);
           newArgs[i] = Optional.of(token.getUser().getId());
           return joinPoint.proceed(newArgs);
@@ -153,27 +153,5 @@ public class UrlAccessControlAspect {
    */
   private static String stripSpelPrefix(String spelExpression) {
     return spelExpression.startsWith("#") ? spelExpression.substring(1) : spelExpression;
-  }
-
-  /**
-   * Check if the given object is null, or a string "null"
-   *
-   * @param arg object to check
-   * @return check value
-   */
-  private static boolean shouldExecuteInjection(Object arg) {
-    if (arg == null) {
-      return true;
-    }
-    if (arg instanceof Optional<?> opt) {
-      return opt.isEmpty()
-          || opt.filter(String.class::isInstance)
-              .map(String.class::cast)
-              .map(String::trim)
-              .filter(
-                  value -> "null".equalsIgnoreCase(value) || "undefined".equalsIgnoreCase(value))
-              .isPresent();
-    }
-    return false;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/challenge/SimulationChallengeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/challenge/SimulationChallengeApi.java
@@ -144,7 +144,7 @@ public class SimulationChallengeApi extends RestBehavior {
     TENANT_PREFIX + "/player/simulations/{simulationId}/challenges"
   })
   @AccessControl(skipRBAC = true)
-  @UrlAccessControl(userId = "#userId")
+  @UrlAccessControl(exerciseId = "#simulationId", userId = "#userId")
   public SimulationChallengesReader playerChallenges(
       @PathVariable String simulationId, @RequestParam Optional<String> userId) {
     final User user = impersonateUser(userRepository, userId);

--- a/openaev-api/src/main/java/io/openaev/rest/challenge/SimulationChallengeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/challenge/SimulationChallengeApi.java
@@ -1,6 +1,5 @@
 package io.openaev.rest.challenge;
 
-import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
 import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
@@ -86,9 +85,6 @@ public class SimulationChallengeApi extends RestBehavior {
     validateUUID(challengeId);
 
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
     return challengeService.validateChallenge(exerciseId, challengeId, input, user);
   }
 
@@ -107,7 +103,7 @@ public class SimulationChallengeApi extends RestBehavior {
     if (exerciseOpt.isPresent()) {
       if (!exerciseOpt.get().isUserHasAccess(user)
           && !exerciseOpt.get().getUsers().contains(user)) {
-        throw new UnsupportedOperationException("The given player is not in this exercise");
+        throw new AuthenticationError("The given player is not in this exercise");
       }
       return exerciseService.getExercisePlayerDocuments(exerciseOpt.get());
     } else {

--- a/openaev-api/src/main/java/io/openaev/rest/challenge/SimulationChallengeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/challenge/SimulationChallengeApi.java
@@ -25,6 +25,7 @@ import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.exception.InputValidationException;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.rest.helper.RestBehavior;
+import io.openaev.security.error.AuthenticationError;
 import io.openaev.service.ChallengeService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -80,7 +81,7 @@ public class SimulationChallengeApi extends RestBehavior {
       @PathVariable String challengeId,
       @Valid @RequestBody ChallengeTryInput input,
       @RequestParam Optional<String> userId)
-      throws InputValidationException {
+      throws InputValidationException, AuthenticationError {
     validateUUID(exerciseId);
     validateUUID(challengeId);
 
@@ -95,16 +96,14 @@ public class SimulationChallengeApi extends RestBehavior {
     "/api/player/simulations/{simulationId}/documents",
     TENANT_PREFIX + "/player/simulations/{simulationId}/documents"
   })
-  @UrlAccessControl(userId = "#userId")
+  @UrlAccessControl(exerciseId = "#simulationId", userId = "#userId")
   @AccessControl(skipRBAC = true)
   public List<Document> playerDocuments(
-      @PathVariable String simulationId, @RequestParam Optional<String> userId) {
+      @PathVariable String simulationId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     Optional<Exercise> exerciseOpt =
         this.exerciseRepository.findByIdAndTenantId(simulationId, TenantContext.getCurrentTenant());
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
     if (exerciseOpt.isPresent()) {
       if (!exerciseOpt.get().isUserHasAccess(user)
           && !exerciseOpt.get().getUsers().contains(user)) {
@@ -146,11 +145,9 @@ public class SimulationChallengeApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(exerciseId = "#simulationId", userId = "#userId")
   public SimulationChallengesReader playerChallenges(
-      @PathVariable String simulationId, @RequestParam Optional<String> userId) {
+      @PathVariable String simulationId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
     return challengeService.playerChallenges(simulationId, user);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
@@ -1,6 +1,5 @@
 package io.openaev.rest.channel;
 
-import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
 import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.rest.channel.ChannelHelper.enrichArticleWithVirtualPublication;
 import static io.openaev.rest.exercise.ExerciseApi.TENANT_EXERCISE_URI;
@@ -173,9 +172,6 @@ public class ChannelApi extends RestBehavior {
       @RequestParam Optional<String> userId)
       throws AuthenticationError {
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
     return channelService.validateArticles(exerciseId, channelId, user);
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/channel/ChannelApi.java
@@ -18,6 +18,7 @@ import io.openaev.rest.channel.response.ChannelReader;
 import io.openaev.rest.document.DocumentService;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.helper.RestBehavior;
+import io.openaev.security.error.AuthenticationError;
 import io.openaev.service.ChannelService;
 import io.openaev.service.scenario.ScenarioService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -169,7 +170,8 @@ public class ChannelApi extends RestBehavior {
   public ChannelReader playerArticles(
       @PathVariable String exerciseId,
       @PathVariable String channelId,
-      @RequestParam Optional<String> userId) {
+      @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     final User user = impersonateUser(userRepository, userId);
     if (user.getId().equals(ANONYMOUS)) {
       throw new UnsupportedOperationException("User must be logged or dynamic player is required");

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -1,6 +1,5 @@
 package io.openaev.rest.document;
 
-import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
 import static io.openaev.config.SessionHelper.currentUser;
 import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.helper.StreamHelper.fromIterable;
@@ -558,20 +557,17 @@ public class DocumentApi extends RestBehavior {
             exerciseOrScenarioId, TenantContext.getCurrentTenant());
 
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
 
     if (exerciseOpt.isPresent()) {
       if (!exerciseOpt.get().isUserHasAccess(user)
           && !exerciseOpt.get().getUsers().contains(user)) {
-        throw new UnsupportedOperationException("The given player is not in this exercise");
+        throw new AuthenticationError("The given player is not in this exercise");
       }
       return getExercisePlayerDocuments(exerciseOpt.get());
     } else if (scenarioOpt.isPresent()) {
       if (!scenarioOpt.get().isUserHasAccess(user)
           && !scenarioOpt.get().getUsers().contains(user)) {
-        throw new UnsupportedOperationException("The given player is not in this exercise");
+        throw new AuthenticationError("The given player is not in this exercise");
       }
       return getScenarioPlayerDocuments(scenarioOpt.get());
     } else {
@@ -599,15 +595,12 @@ public class DocumentApi extends RestBehavior {
             exerciseOrScenarioId, TenantContext.getCurrentTenant());
 
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
 
     Document document = null;
     if (exerciseOpt.isPresent()) {
       if (!exerciseOpt.get().isUserHasAccess(user)
           && !exerciseOpt.get().getUsers().contains(user)) {
-        throw new UnsupportedOperationException("The given player is not in this exercise");
+        throw new AuthenticationError("The given player is not in this exercise");
       }
       document =
           getExercisePlayerDocuments(exerciseOpt.get()).stream()
@@ -617,7 +610,7 @@ public class DocumentApi extends RestBehavior {
     } else if (scenarioOpt.isPresent()) {
       if (!scenarioOpt.get().isUserHasAccess(user)
           && !scenarioOpt.get().getUsers().contains(user)) {
-        throw new UnsupportedOperationException("The given player is not in this exercise");
+        throw new AuthenticationError("The given player is not in this exercise");
       }
       document =
           getScenarioPlayerDocuments(scenarioOpt.get()).stream()

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -23,6 +23,7 @@ import io.openaev.rest.document.form.DocumentUpdateInput;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.inject.service.InjectService;
+import io.openaev.security.error.AuthenticationError;
 import io.openaev.service.ChannelService;
 import io.openaev.service.FileService;
 import io.openaev.utils.pagination.SearchPaginationInput;
@@ -547,7 +548,8 @@ public class DocumentApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(userId = "#userId")
   public List<Document> playerDocuments(
-      @PathVariable String exerciseOrScenarioId, @RequestParam Optional<String> userId) {
+      @PathVariable String exerciseOrScenarioId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     Optional<Exercise> exerciseOpt =
         this.exerciseRepository.findByIdAndTenantId(
             exerciseOrScenarioId, TenantContext.getCurrentTenant());
@@ -588,7 +590,7 @@ public class DocumentApi extends RestBehavior {
       @PathVariable String documentId,
       @RequestParam Optional<String> userId,
       HttpServletResponse response)
-      throws IOException {
+      throws IOException, AuthenticationError {
     Optional<Exercise> exerciseOpt =
         this.exerciseRepository.findByIdAndTenantId(
             exerciseOrScenarioId, TenantContext.getCurrentTenant());

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/ExercisePlayerApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/ExercisePlayerApi.java
@@ -11,6 +11,7 @@ import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.exercise.response.PublicExercise;
 import io.openaev.rest.helper.RestBehavior;
+import io.openaev.security.error.AuthenticationError;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,7 +33,8 @@ public class ExercisePlayerApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(exerciseId = "#exerciseId", userId = "#userId")
   public PublicExercise playerExercise(
-      @PathVariable String exerciseId, @RequestParam Optional<String> userId) {
+      @PathVariable String exerciseId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     impersonateUser(this.userRepository, userId);
     Exercise exercise =
         this.exerciseRepository

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -11,6 +11,7 @@ import io.openaev.aop.lock.LockAcquisitionException;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.exception.*;
+import io.openaev.security.error.AuthenticationError;
 import io.openaev.stix.parsing.ParsingException;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -321,12 +322,29 @@ public class RestBehavior {
     return new ResponseEntity<>(new ErrorMessage(errorMessage), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  @ExceptionHandler(AuthenticationError.class)
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(schema = @Schema(implementation = ResponseEntity.class)))
+      })
+  ResponseEntity<ErrorMessage> handleAuthenticationError(AuthenticationError ex) {
+    String errorMessage =
+        ex.getMessage() != null && !ex.getMessage().isEmpty()
+            ? ex.getMessage()
+            : HttpStatus.UNAUTHORIZED.getReasonPhrase();
+    return new ResponseEntity<>(new ErrorMessage(errorMessage), HttpStatus.UNAUTHORIZED);
+  }
+
   // --- Open channel access
-  public User impersonateUser(UserRepository userRepository, Optional<String> userId) {
+  public User impersonateUser(UserRepository userRepository, Optional<String> userId)
+      throws AuthenticationError {
     if (ANONYMOUS.equals(currentUser().getId())) {
       if (userId.isEmpty()) {
-        throw new UnsupportedOperationException(
-            "User must be logged or dynamic player is required");
+        throw new AuthenticationError("User must be logged or dynamic player is required");
       }
       return userRepository
           .findById(userId.get())

--- a/openaev-api/src/main/java/io/openaev/rest/lessons/ExerciseLessonsApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/lessons/ExerciseLessonsApi.java
@@ -15,6 +15,7 @@ import io.openaev.database.specification.LessonsQuestionSpecification;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.lessons.form.*;
+import io.openaev.security.error.AuthenticationError;
 import io.openaev.service.MailingService;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -393,7 +394,8 @@ public class ExerciseLessonsApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(exerciseId = "#exerciseId", userId = "#userId")
   public List<LessonsCategory> playerLessonsCategories(
-      @PathVariable String exerciseId, @RequestParam Optional<String> userId) {
+      @PathVariable String exerciseId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     impersonateUser(userRepository, userId); // Protection for ?
     return lessonsCategoryRepository
         .findAll(LessonsCategorySpecification.fromExercise(exerciseId))
@@ -416,7 +418,8 @@ public class ExerciseLessonsApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(exerciseId = "#exerciseId", userId = "#userId")
   public List<LessonsQuestion> playerLessonsQuestions(
-      @PathVariable String exerciseId, @RequestParam Optional<String> userId) {
+      @PathVariable String exerciseId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     impersonateUser(userRepository, userId); // Protection for ?
     return lessonsCategoryRepository
         .findAll(LessonsCategorySpecification.fromExercise(exerciseId))
@@ -436,7 +439,8 @@ public class ExerciseLessonsApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(exerciseId = "#exerciseId", userId = "#userId")
   public List<LessonsAnswer> playerLessonsAnswers(
-      @PathVariable String exerciseId, @RequestParam Optional<String> userId) {
+      @PathVariable String exerciseId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     impersonateUser(userRepository, userId); // Protection for ?
     return lessonsCategoryRepository
         .findAll(LessonsCategorySpecification.fromExercise(exerciseId))
@@ -470,7 +474,8 @@ public class ExerciseLessonsApi extends RestBehavior {
       @PathVariable String exerciseId,
       @PathVariable String lessonsQuestionId,
       @Valid @RequestBody LessonsAnswerCreateInput input,
-      @RequestParam Optional<String> userId) {
+      @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     User user = impersonateUser(userRepository, userId);
     LessonsQuestion lessonsQuestion =
         lessonsQuestionRepository

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
@@ -14,6 +14,7 @@ import io.openaev.rest.challenge.response.ScenarioChallengesReader;
 import io.openaev.rest.document.DocumentService;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.helper.RestBehavior;
+import io.openaev.security.error.AuthenticationError;
 import io.openaev.service.ChallengeService;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +44,8 @@ public class ScenarioChallengesApi extends RestBehavior {
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(userId = "#userId")
   public List<Document> playerDocuments(
-      @PathVariable String scenarioId, @RequestParam Optional<String> userId) {
+      @PathVariable String scenarioId, @RequestParam Optional<String> userId)
+      throws AuthenticationError {
     Optional<Scenario> scenarioOpt =
         this.scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant());
     final User user = impersonateUser(userRepository, userId);

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
@@ -1,6 +1,5 @@
 package io.openaev.rest.scenario;
 
-import static io.openaev.config.OpenAEVAnonymous.ANONYMOUS;
 import static io.openaev.helper.StreamHelper.fromIterable;
 
 import io.openaev.aop.AccessControl;
@@ -49,13 +48,10 @@ public class ScenarioChallengesApi extends RestBehavior {
     Optional<Scenario> scenarioOpt =
         this.scenarioRepository.findByIdAndTenantId(scenarioId, TenantContext.getCurrentTenant());
     final User user = impersonateUser(userRepository, userId);
-    if (user.getId().equals(ANONYMOUS)) {
-      throw new UnsupportedOperationException("User must be logged or dynamic player is required");
-    }
     if (scenarioOpt.isPresent()) {
       if (!scenarioOpt.get().isUserHasAccess(user)
           && !scenarioOpt.get().getUsers().contains(user)) {
-        throw new UnsupportedOperationException("The given player is not in this exercise");
+        throw new AuthenticationError("The given player is not in this exercise");
       }
       return getScenarioPlayerDocuments(scenarioOpt.get());
     } else {

--- a/openaev-api/src/test/java/io/openaev/rest/PlayerApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlayerApiTest.java
@@ -1,36 +1,43 @@
 package io.openaev.rest;
 
+import static io.openaev.api.url_access_token.UrlAccessTokenApi.URL_ACCESS_COOKIE_NAME;
 import static io.openaev.config.AppConfig.EMAIL_FORMAT;
 import static io.openaev.rest.user.PlayerApi.PLAYER_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static io.openaev.utils.fixtures.PlayerFixture.PLAYER_FIXTURE_FIRSTNAME;
+import static io.openaev.utils.fixtures.UrlAccessTokenFixture.DEFAULT_RAW_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.database.model.Exercise;
 import io.openaev.database.model.Organization;
 import io.openaev.database.model.Tag;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.OrganizationRepository;
 import io.openaev.database.repository.TagRepository;
 import io.openaev.database.repository.UserRepository;
+import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.rest.user.form.player.PlayerInput;
-import io.openaev.utils.fixtures.OrganizationFixture;
-import io.openaev.utils.fixtures.PlayerFixture;
-import io.openaev.utils.fixtures.TagFixture;
+import io.openaev.service.PreviewFeatureService;
+import io.openaev.utils.fixtures.*;
+import io.openaev.utils.fixtures.composers.*;
 import io.openaev.utils.mockUser.WithMockUser;
+import jakarta.persistence.EntityManager;
+import jakarta.servlet.http.Cookie;
+import java.text.MessageFormat;
 import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +53,337 @@ class PlayerApiTest extends IntegrationTest {
   @Autowired private OrganizationRepository organizationRepository;
   @Autowired private TagRepository tagRepository;
   @Autowired private UserRepository userRepository;
+  @MockitoBean private PreviewFeatureService mockPreviewFeatureService;
+
+  @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private LessonsCategoryComposer lessonsCategoryComposer;
+  @Autowired private LessonsQuestionsComposer lessonsQuestionsComposer;
+  @Autowired private UserComposer userComposer;
+  @Autowired private UrlAccessTokenComposer urlAccessTokenComposer;
+  @Autowired private LessonsAnswersComposer lessonsAnswersComposer;
+
+  @Autowired private EntityManager entityManager;
+
+  @Nested
+  @DisplayName("Player Lessons API")
+  class PlayerLessonsApi {
+    @BeforeEach
+    void before() {
+      when(mockPreviewFeatureService.isFeatureEnabled(PreviewFeature.URL_ACCESS_TOKEN))
+          .thenReturn(true);
+
+      exerciseComposer.reset();
+      lessonsCategoryComposer.reset();
+      lessonsQuestionsComposer.reset();
+      userComposer.reset();
+      urlAccessTokenComposer.reset();
+      lessonsAnswersComposer.reset();
+    }
+
+    private record PlayerApiObjectWrappers(
+        ExerciseComposer.Composer simulationWrapper, UserComposer.Composer userWrapper) {}
+
+    private PlayerApiObjectWrappers getExerciseWrapper() {
+      UserComposer.Composer userWrapper =
+          userComposer.forUser(UserFixture.getUserWithDefaultEmail());
+      ExerciseComposer.Composer simulationWrapper =
+          exerciseComposer
+              .forExercise(ExerciseFixture.createDefaultExercise())
+              .withLessonCategory(
+                  lessonsCategoryComposer
+                      .forLessonsCategory(LessonsCategoryFixture.createDefaultLessonsCategory())
+                      .withLessonsQuestion(
+                          lessonsQuestionsComposer
+                              .forLessonsQuestion(
+                                  LessonsQuestionFixture.createDefaultLessonsQuestion())
+                              .withAnswer(
+                                  lessonsAnswersComposer
+                                      .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
+                                      .withUser(userWrapper))))
+              .persist();
+      return new PlayerApiObjectWrappers(simulationWrapper, userWrapper);
+    }
+
+    @Nested
+    @DisplayName("Lessons Questions API")
+    class LessonsQuestionsApi {
+      private final String urlMask = "/api/player/lessons/exercise/{0}/lessons_questions";
+
+      private String getUrl(String simulationId) {
+        return MessageFormat.format(urlMask, simulationId);
+      }
+
+      private String getUrl(String simulationId, String userId) {
+        return MessageFormat.format(
+            "{0}?userId={1}", MessageFormat.format(urlMask, simulationId), userId);
+      }
+
+      @Nested
+      @DisplayName("With no URL access control cookie")
+      class WithNoUrlAccessControlCookie {
+        @Test
+        @DisplayName("Given no specific userId on the query string, throw Unauthorised")
+        public void given_noSpecificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(wrappers.simulationWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, throw Unauthorised")
+        public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.userWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+      }
+
+      @Nested
+      @DisplayName("With invalid URL access control cookie")
+      class WithInvalidUrlAccessControlCookie {
+        @Test
+        @DisplayName("Given no specific userId on the query string, throw Unauthorised")
+        public void given_noSpecificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(wrappers.simulationWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, throw Unauthorised")
+        public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.userWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+      }
+
+      @Nested
+      @DisplayName("With valid URL access control cookie")
+      class WithValidUrlAccessControlCookie {
+
+        private UrlAccessTokenComposer.Composer createUrlAccessToken(
+            Exercise simulation, User user, String url) {
+          return urlAccessTokenComposer.forToken(
+              UrlAccessTokenFixture.createValidToken(simulation, user, url));
+        }
+
+        @Test
+        @DisplayName("Given no specific userId on the query string, 200 OK")
+        public void given_noSpecificUserIdOnTheQueryString_200OK() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          createUrlAccessToken(
+                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(url)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, 200 OK")
+        public void given_specificUserIdOnTheQueryString_200OK() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          createUrlAccessToken(
+                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(url)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("Lessons Answers API")
+    class LessonsAnswersApi {
+      private final String urlMask = "/api/player/lessons/exercise/{0}/lessons_answers";
+
+      private String getUrl(String simulationId) {
+        return MessageFormat.format(urlMask, simulationId);
+      }
+
+      private String getUrl(String simulationId, String userId) {
+        return MessageFormat.format(
+            "{0}?userId={1}", MessageFormat.format(urlMask, simulationId), userId);
+      }
+
+      @Nested
+      @DisplayName("With no URL access control cookie")
+      class WithNoUrlAccessControlCookie {
+        @Test
+        @DisplayName("Given no specific userId on the query string, throw Unauthorised")
+        public void given_noSpecificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(wrappers.simulationWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, throw Unauthorised")
+        public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          UserComposer.Composer userWrapper =
+              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(wrappers.simulationWrapper().get().getId(), userWrapper.get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+      }
+
+      @Nested
+      @DisplayName("With invalid URL access control cookie")
+      class WithInvalidUrlAccessControlCookie {
+        @Test
+        @DisplayName("Given no specific userId on the query string, throw Unauthorised")
+        public void given_noSpecificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(wrappers.simulationWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, throw Unauthorised")
+        public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          UserComposer.Composer userWrapper =
+              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(getUrl(wrappers.simulationWrapper().get().getId(), userWrapper.get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+      }
+
+      @Nested
+      @DisplayName("With valid URL access control cookie")
+      class WithValidUrlAccessControlCookie {
+
+        private UrlAccessTokenComposer.Composer createUrlAccessToken(
+            Exercise simulation, User user, String url) {
+          return urlAccessTokenComposer.forToken(
+              UrlAccessTokenFixture.createValidToken(simulation, user, url));
+        }
+
+        @Test
+        @DisplayName("Given no specific userId on the query string, 200 OK")
+        public void given_noSpecificUserIdOnTheQueryString_200OK() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          createUrlAccessToken(
+                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(url)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, 200 OK")
+        public void given_specificUserIdOnTheQueryString_200OK() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          createUrlAccessToken(
+                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  get(url)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk());
+        }
+      }
+    }
+  }
 
   @DisplayName("Given valid player input, should create a player successfully")
   @Test

--- a/openaev-api/src/test/java/io/openaev/rest/PlayerApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlayerApiTest.java
@@ -6,6 +6,7 @@ import static io.openaev.rest.user.PlayerApi.PLAYER_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static io.openaev.utils.fixtures.PlayerFixture.PLAYER_FIXTURE_FIRSTNAME;
 import static io.openaev.utils.fixtures.UrlAccessTokenFixture.DEFAULT_RAW_TOKEN;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -81,10 +82,14 @@ class PlayerApiTest extends IntegrationTest {
     }
 
     private record PlayerApiObjectWrappers(
-        ExerciseComposer.Composer simulationWrapper, UserComposer.Composer userWrapper) {}
+        ExerciseComposer.Composer simulationWrapper,
+        UserComposer.Composer userWrapper,
+        UserComposer.Composer otherUserWrapper) {}
 
     private PlayerApiObjectWrappers getExerciseWrapper() {
       UserComposer.Composer userWrapper =
+          userComposer.forUser(UserFixture.getUserWithDefaultEmail());
+      UserComposer.Composer otherUserWrapper =
           userComposer.forUser(UserFixture.getUserWithDefaultEmail());
       ExerciseComposer.Composer simulationWrapper =
           exerciseComposer
@@ -99,9 +104,13 @@ class PlayerApiTest extends IntegrationTest {
                               .withAnswer(
                                   lessonsAnswersComposer
                                       .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
-                                      .withUser(userWrapper))))
+                                      .withUser(userWrapper))
+                              .withAnswer(
+                                  lessonsAnswersComposer
+                                      .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
+                                      .withUser(otherUserWrapper))))
               .persist();
-      return new PlayerApiObjectWrappers(simulationWrapper, userWrapper);
+      return new PlayerApiObjectWrappers(simulationWrapper, userWrapper, otherUserWrapper);
     }
 
     @Nested
@@ -226,7 +235,9 @@ class PlayerApiTest extends IntegrationTest {
         @DisplayName("Given specific userId on the query string, 200 OK")
         public void given_specificUserIdOnTheQueryString_200OK() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
-          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          String url =
+              getUrl(
+                  wrappers.simulationWrapper().get().getId(), wrappers.userWrapper().get().getId());
           createUrlAccessToken(
                   wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
               .persist();
@@ -280,13 +291,13 @@ class PlayerApiTest extends IntegrationTest {
         @DisplayName("Given specific userId on the query string, throw Unauthorised")
         public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
-          UserComposer.Composer userWrapper =
-              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
           entityManager.flush();
           entityManager.clear();
 
           mvc.perform(
-                  get(getUrl(wrappers.simulationWrapper().get().getId(), userWrapper.get().getId()))
+                  get(getUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.userWrapper().get().getId()))
                       .contentType(MediaType.APPLICATION_JSON)
                       .accept(MediaType.APPLICATION_JSON)
                       .with(csrf()))
@@ -317,13 +328,13 @@ class PlayerApiTest extends IntegrationTest {
         @DisplayName("Given specific userId on the query string, throw Unauthorised")
         public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
-          UserComposer.Composer userWrapper =
-              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
           entityManager.flush();
           entityManager.clear();
 
           mvc.perform(
-                  get(getUrl(wrappers.simulationWrapper().get().getId(), userWrapper.get().getId()))
+                  get(getUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.userWrapper().get().getId()))
                       .contentType(MediaType.APPLICATION_JSON)
                       .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
                       .accept(MediaType.APPLICATION_JSON)
@@ -343,43 +354,247 @@ class PlayerApiTest extends IntegrationTest {
         }
 
         @Test
-        @DisplayName("Given no specific userId on the query string, 200 OK")
+        @DisplayName(
+            "Given user A has no answers, pass User A cookie and no id query string, then empty response")
         public void given_noSpecificUserIdOnTheQueryString_200OK() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
           String url = getUrl(wrappers.simulationWrapper().get().getId());
-          createUrlAccessToken(
-                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+          // create extra user
+          UserComposer.Composer extraUserWrapper =
+              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
+          createUrlAccessToken(wrappers.simulationWrapper().get(), extraUserWrapper.get(), url)
               .persist();
           entityManager.flush();
           entityManager.clear();
 
-          mvc.perform(
-                  get(url)
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
-                      .accept(MediaType.APPLICATION_JSON)
-                      .with(csrf()))
-              .andExpect(status().isOk());
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString).isEqualTo("[]");
         }
 
         @Test
-        @DisplayName("Given specific userId on the query string, 200 OK")
-        public void given_specificUserIdOnTheQueryString_200OK() throws Exception {
+        @DisplayName(
+            "Given user A has answers, pass User A cookie and no id query string, then all answers in response belong to user A")
+        public void given_noSpecificUserIdOnTheQueryStringButExistingAnswers_200OK()
+            throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
           String url = getUrl(wrappers.simulationWrapper().get().getId());
-          createUrlAccessToken(
-                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+          UrlAccessTokenComposer.Composer tokenWrapper =
+              createUrlAccessToken(
+                      wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+                  .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString)
+              .isArray()
+              .allSatisfy(
+                  node -> {
+                    assertThatJson(node)
+                        .node("lessons_answer_user")
+                        .isEqualTo(tokenWrapper.get().getUser().getId());
+                  });
+        }
+
+        @Test
+        @DisplayName(
+            "Given user A has no answers, pass User A cookie and User A id query string, then empty response")
+        public void given_specificOtherUserIdOnTheQueryString_200OK() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          // create extra user
+          UserComposer.Composer extraUserWrapper =
+              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
+          String url =
+              getUrl(wrappers.simulationWrapper().get().getId(), extraUserWrapper.get().getId());
+          createUrlAccessToken(wrappers.simulationWrapper().get(), extraUserWrapper.get(), url)
               .persist();
           entityManager.flush();
           entityManager.clear();
 
-          mvc.perform(
-                  get(url)
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
-                      .accept(MediaType.APPLICATION_JSON)
-                      .with(csrf()))
-              .andExpect(status().isOk());
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString).isEqualTo("[]");
+        }
+
+        @Test
+        @DisplayName(
+            "Given user A has no answers, user B has answers, pass User A cookie and User B id query string, then empty response")
+        public void given_specificSameUserIdOnTheQueryString_200OK() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          // create extra user
+          UserComposer.Composer extraUserWrapper =
+              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
+          String url =
+              getUrl(
+                  wrappers.simulationWrapper().get().getId(), wrappers.userWrapper().get().getId());
+          createUrlAccessToken(wrappers.simulationWrapper().get(), extraUserWrapper.get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString).isEqualTo("[]");
+        }
+
+        @Test
+        @DisplayName(
+            "Given user A has answers, pass User A cookie and User A id query string, then all answers in response belong to user A")
+        public void given_specificSameUserIdOnTheQueryStringAndCorrespondingCookie_200OK()
+            throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url =
+              getUrl(
+                  wrappers.simulationWrapper().get().getId(), wrappers.userWrapper().get().getId());
+          UrlAccessTokenComposer.Composer tokenWrapper =
+              createUrlAccessToken(
+                      wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+                  .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString)
+              .isArray()
+              .allSatisfy(
+                  node -> {
+                    assertThatJson(node)
+                        .node("lessons_answer_user")
+                        .isEqualTo(tokenWrapper.get().getUser().getId());
+                  });
+        }
+
+        @Test
+        @DisplayName(
+            "Given user A has answers, user B has no answers, pass User A cookie and User B id query string, then all answers in response belong to user A")
+        public void given_specificOtherUserIdOnTheQueryStringAndDifferentUserCookie_200OK()
+            throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          // create extra user
+          UserComposer.Composer extraUserWrapper =
+              userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
+          String url =
+              getUrl(wrappers.simulationWrapper().get().getId(), extraUserWrapper.get().getId());
+          UrlAccessTokenComposer.Composer tokenWrapper =
+              createUrlAccessToken(
+                      wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+                  .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString)
+              .isArray()
+              .allSatisfy(
+                  node -> {
+                    assertThatJson(node)
+                        .node("lessons_answer_user")
+                        .isEqualTo(tokenWrapper.get().getUser().getId());
+                  });
+        }
+
+        @Test
+        @DisplayName(
+            "Given user A has answers, user B also has answers, pass User A cookie and User B id query string, then all answers in response belong to user A")
+        public void
+            given_specificOtherUserIdOnTheQueryStringAndDifferentUserCookieWithAnswers_200OK()
+                throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url =
+              getUrl(
+                  wrappers.simulationWrapper().get().getId(),
+                  wrappers.otherUserWrapper().get().getId());
+          UrlAccessTokenComposer.Composer tokenWrapper =
+              createUrlAccessToken(
+                      wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+                  .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      get(url)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString)
+              .isArray()
+              .allSatisfy(
+                  node -> {
+                    assertThatJson(node)
+                        .node("lessons_answer_user")
+                        .isEqualTo(tokenWrapper.get().getUser().getId());
+                  });
         }
       }
     }

--- a/openaev-api/src/test/java/io/openaev/rest/PlayerApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/PlayerApiTest.java
@@ -84,33 +84,38 @@ class PlayerApiTest extends IntegrationTest {
     private record PlayerApiObjectWrappers(
         ExerciseComposer.Composer simulationWrapper,
         UserComposer.Composer userWrapper,
-        UserComposer.Composer otherUserWrapper) {}
+        UserComposer.Composer otherUserWrapper,
+        LessonsCategoryComposer.Composer categoryWrapper,
+        LessonsQuestionsComposer.Composer questionWrapper) {}
 
     private PlayerApiObjectWrappers getExerciseWrapper() {
       UserComposer.Composer userWrapper =
           userComposer.forUser(UserFixture.getUserWithDefaultEmail());
       UserComposer.Composer otherUserWrapper =
           userComposer.forUser(UserFixture.getUserWithDefaultEmail());
+      LessonsCategoryComposer.Composer categoryWrapper =
+          lessonsCategoryComposer.forLessonsCategory(
+              LessonsCategoryFixture.createDefaultLessonsCategory());
+      LessonsQuestionsComposer.Composer questionWrapper =
+          lessonsQuestionsComposer.forLessonsQuestion(
+              LessonsQuestionFixture.createDefaultLessonsQuestion());
       ExerciseComposer.Composer simulationWrapper =
           exerciseComposer
               .forExercise(ExerciseFixture.createDefaultExercise())
               .withLessonCategory(
-                  lessonsCategoryComposer
-                      .forLessonsCategory(LessonsCategoryFixture.createDefaultLessonsCategory())
-                      .withLessonsQuestion(
-                          lessonsQuestionsComposer
-                              .forLessonsQuestion(
-                                  LessonsQuestionFixture.createDefaultLessonsQuestion())
-                              .withAnswer(
-                                  lessonsAnswersComposer
-                                      .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
-                                      .withUser(userWrapper))
-                              .withAnswer(
-                                  lessonsAnswersComposer
-                                      .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
-                                      .withUser(otherUserWrapper))))
+                  categoryWrapper.withLessonsQuestion(
+                      questionWrapper
+                          .withAnswer(
+                              lessonsAnswersComposer
+                                  .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
+                                  .withUser(userWrapper))
+                          .withAnswer(
+                              lessonsAnswersComposer
+                                  .forLessonsAnswer(LessonsAnswerFixture.createLessonsAnswer())
+                                  .withUser(otherUserWrapper))))
               .persist();
-      return new PlayerApiObjectWrappers(simulationWrapper, userWrapper, otherUserWrapper);
+      return new PlayerApiObjectWrappers(
+          simulationWrapper, userWrapper, otherUserWrapper, categoryWrapper, questionWrapper);
     }
 
     @Nested
@@ -258,29 +263,43 @@ class PlayerApiTest extends IntegrationTest {
     @Nested
     @DisplayName("Lessons Answers API")
     class LessonsAnswersApi {
-      private final String urlMask = "/api/player/lessons/exercise/{0}/lessons_answers";
+      private final String getAnswersUrlMask = "/api/player/lessons/exercise/{0}/lessons_answers";
 
-      private String getUrl(String simulationId) {
-        return MessageFormat.format(urlMask, simulationId);
+      private String getAnswersUrl(String simulationId) {
+        return MessageFormat.format(getAnswersUrlMask, simulationId);
       }
 
-      private String getUrl(String simulationId, String userId) {
+      private String getAnswersUrl(String simulationId, String userId) {
         return MessageFormat.format(
-            "{0}?userId={1}", MessageFormat.format(urlMask, simulationId), userId);
+            "{0}?userId={1}", MessageFormat.format(getAnswersUrlMask, simulationId), userId);
+      }
+
+      private final String postAnswersUrlMask =
+          "/api/player/lessons/exercise/{0}/lessons_categories/{1}/lessons_questions/{2}/lessons_answers";
+
+      private String postAnswersUrl(String simulationId, String categoryId, String questionId) {
+        return MessageFormat.format(postAnswersUrlMask, simulationId, categoryId, questionId);
+      }
+
+      private String postAnswersUrl(
+          String simulationId, String categoryId, String questionId, String userId) {
+        return MessageFormat.format(
+            "{0}?userId={1}",
+            MessageFormat.format(postAnswersUrlMask, simulationId, categoryId, questionId), userId);
       }
 
       @Nested
       @DisplayName("With no URL access control cookie")
       class WithNoUrlAccessControlCookie {
         @Test
-        @DisplayName("Given no specific userId on the query string, throw Unauthorised")
+        @DisplayName("Given no specific userId on the query string, get answers throw Unauthorised")
         public void given_noSpecificUserIdOnTheQueryString_throw401() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
           entityManager.flush();
           entityManager.clear();
 
           mvc.perform(
-                  get(getUrl(wrappers.simulationWrapper().get().getId()))
+                  get(getAnswersUrl(wrappers.simulationWrapper().get().getId()))
                       .contentType(MediaType.APPLICATION_JSON)
                       .accept(MediaType.APPLICATION_JSON)
                       .with(csrf()))
@@ -288,16 +307,70 @@ class PlayerApiTest extends IntegrationTest {
         }
 
         @Test
-        @DisplayName("Given specific userId on the query string, throw Unauthorised")
+        @DisplayName("Given specific userId on the query string, get answers throw Unauthorised")
         public void given_specificUserIdOnTheQueryString_throw401() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
           entityManager.flush();
           entityManager.clear();
 
           mvc.perform(
-                  get(getUrl(
+                  get(getAnswersUrl(
                           wrappers.simulationWrapper().get().getId(),
                           wrappers.userWrapper().get().getId()))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName(
+            "Given no specific userId on the query string, post answers throw Unauthorised")
+        public void given_noSpecificUserIdOnTheQueryString_postAnswersThrow401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  post(postAnswersUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.categoryWrapper().get().getId(),
+                          wrappers.questionWrapper().get().getId()))
+                      .content(
+                          """
+                          {
+                            "lessons_answer_score":80,
+                            "lessons_answer_positive":"test",
+                            "lessons_answer_negative":"test"
+                          }
+                          """)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, post answers throw Unauthorised")
+        public void given_specificUserIdOnTheQueryString_postAnswersThrow401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  post(postAnswersUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.categoryWrapper().get().getId(),
+                          wrappers.questionWrapper().get().getId(),
+                          wrappers.userWrapper().get().getId()))
+                      .content(
+                          """
+                          {
+                            "lessons_answer_score":80,
+                            "lessons_answer_positive":"test",
+                            "lessons_answer_negative":"test"
+                          }
+                          """)
                       .contentType(MediaType.APPLICATION_JSON)
                       .accept(MediaType.APPLICATION_JSON)
                       .with(csrf()))
@@ -316,7 +389,7 @@ class PlayerApiTest extends IntegrationTest {
           entityManager.clear();
 
           mvc.perform(
-                  get(getUrl(wrappers.simulationWrapper().get().getId()))
+                  get(getAnswersUrl(wrappers.simulationWrapper().get().getId()))
                       .contentType(MediaType.APPLICATION_JSON)
                       .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
                       .accept(MediaType.APPLICATION_JSON)
@@ -332,11 +405,65 @@ class PlayerApiTest extends IntegrationTest {
           entityManager.clear();
 
           mvc.perform(
-                  get(getUrl(
+                  get(getAnswersUrl(
                           wrappers.simulationWrapper().get().getId(),
                           wrappers.userWrapper().get().getId()))
                       .contentType(MediaType.APPLICATION_JSON)
                       .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, "bad cookie"))
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName(
+            "Given no specific userId on the query string, post answers throw Unauthorised")
+        public void given_noSpecificUserIdOnTheQueryString_postAnswersThrow401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  post(postAnswersUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.categoryWrapper().get().getId(),
+                          wrappers.questionWrapper().get().getId()))
+                      .content(
+                          """
+                          {
+                            "lessons_answer_score":80,
+                            "lessons_answer_positive":"test",
+                            "lessons_answer_negative":"test"
+                          }
+                          """)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("Given specific userId on the query string, post answers throw Unauthorised")
+        public void given_specificUserIdOnTheQueryString_postAnswersThrow401() throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          entityManager.flush();
+          entityManager.clear();
+
+          mvc.perform(
+                  post(postAnswersUrl(
+                          wrappers.simulationWrapper().get().getId(),
+                          wrappers.categoryWrapper().get().getId(),
+                          wrappers.questionWrapper().get().getId(),
+                          wrappers.userWrapper().get().getId()))
+                      .content(
+                          """
+                          {
+                            "lessons_answer_score":80,
+                            "lessons_answer_positive":"test",
+                            "lessons_answer_negative":"test"
+                          }
+                          """)
+                      .contentType(MediaType.APPLICATION_JSON)
                       .accept(MediaType.APPLICATION_JSON)
                       .with(csrf()))
               .andExpect(status().isUnauthorized());
@@ -355,10 +482,96 @@ class PlayerApiTest extends IntegrationTest {
 
         @Test
         @DisplayName(
+            "Given valid User A cookie and no id query string, then answer attributed to User A")
+        public void
+            given_validUserACookieAndNoSpecificUserIdOnTheQueryString_answerAttributedUserA()
+                throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url =
+              postAnswersUrl(
+                  wrappers.simulationWrapper().get().getId(),
+                  wrappers.categoryWrapper().get().getId(),
+                  wrappers.questionWrapper().get().getId());
+          createUrlAccessToken(
+                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      post(url)
+                          .content(
+                              """
+                              {
+                                "lessons_answer_score":80,
+                                "lessons_answer_positive":"test",
+                                "lessons_answer_negative":"test"
+                              }
+                              """)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString)
+              .node("lessons_answer_user")
+              .isEqualTo(wrappers.userWrapper().get().getId());
+        }
+
+        @Test
+        @DisplayName(
+            "Given valid User A cookie and specified User B id query string, then answer attributed to User A")
+        public void given_validUserACookieAndSpecificUserIdOnTheQueryString_answerAttributedUserA()
+            throws Exception {
+          PlayerApiObjectWrappers wrappers = getExerciseWrapper();
+          String url =
+              postAnswersUrl(
+                  wrappers.simulationWrapper().get().getId(),
+                  wrappers.categoryWrapper().get().getId(),
+                  wrappers.questionWrapper().get().getId(),
+                  wrappers.otherUserWrapper().get().getId());
+          createUrlAccessToken(
+                  wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
+              .persist();
+          entityManager.flush();
+          entityManager.clear();
+
+          String responseString =
+              mvc.perform(
+                      post(url)
+                          .content(
+                              """
+                              {
+                                "lessons_answer_score":80,
+                                "lessons_answer_positive":"test",
+                                "lessons_answer_negative":"test"
+                              }
+                              """)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .cookie(new Cookie(URL_ACCESS_COOKIE_NAME, DEFAULT_RAW_TOKEN))
+                          .accept(MediaType.APPLICATION_JSON)
+                          .with(csrf()))
+                  .andExpect(status().isOk())
+                  .andReturn()
+                  .getResponse()
+                  .getContentAsString();
+
+          assertThatJson(responseString)
+              .node("lessons_answer_user")
+              .isEqualTo(wrappers.userWrapper().get().getId());
+        }
+
+        @Test
+        @DisplayName(
             "Given user A has no answers, pass User A cookie and no id query string, then empty response")
         public void given_noSpecificUserIdOnTheQueryString_200OK() throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
-          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          String url = getAnswersUrl(wrappers.simulationWrapper().get().getId());
           // create extra user
           UserComposer.Composer extraUserWrapper =
               userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
@@ -388,7 +601,7 @@ class PlayerApiTest extends IntegrationTest {
         public void given_noSpecificUserIdOnTheQueryStringButExistingAnswers_200OK()
             throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
-          String url = getUrl(wrappers.simulationWrapper().get().getId());
+          String url = getAnswersUrl(wrappers.simulationWrapper().get().getId());
           UrlAccessTokenComposer.Composer tokenWrapper =
               createUrlAccessToken(
                       wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
@@ -427,7 +640,8 @@ class PlayerApiTest extends IntegrationTest {
           UserComposer.Composer extraUserWrapper =
               userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
           String url =
-              getUrl(wrappers.simulationWrapper().get().getId(), extraUserWrapper.get().getId());
+              getAnswersUrl(
+                  wrappers.simulationWrapper().get().getId(), extraUserWrapper.get().getId());
           createUrlAccessToken(wrappers.simulationWrapper().get(), extraUserWrapper.get(), url)
               .persist();
           entityManager.flush();
@@ -457,7 +671,7 @@ class PlayerApiTest extends IntegrationTest {
           UserComposer.Composer extraUserWrapper =
               userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
           String url =
-              getUrl(
+              getAnswersUrl(
                   wrappers.simulationWrapper().get().getId(), wrappers.userWrapper().get().getId());
           createUrlAccessToken(wrappers.simulationWrapper().get(), extraUserWrapper.get(), url)
               .persist();
@@ -486,7 +700,7 @@ class PlayerApiTest extends IntegrationTest {
             throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
           String url =
-              getUrl(
+              getAnswersUrl(
                   wrappers.simulationWrapper().get().getId(), wrappers.userWrapper().get().getId());
           UrlAccessTokenComposer.Composer tokenWrapper =
               createUrlAccessToken(
@@ -527,7 +741,8 @@ class PlayerApiTest extends IntegrationTest {
           UserComposer.Composer extraUserWrapper =
               userComposer.forUser(UserFixture.getUserWithDefaultEmail()).persist();
           String url =
-              getUrl(wrappers.simulationWrapper().get().getId(), extraUserWrapper.get().getId());
+              getAnswersUrl(
+                  wrappers.simulationWrapper().get().getId(), extraUserWrapper.get().getId());
           UrlAccessTokenComposer.Composer tokenWrapper =
               createUrlAccessToken(
                       wrappers.simulationWrapper().get(), wrappers.userWrapper().get(), url)
@@ -565,7 +780,7 @@ class PlayerApiTest extends IntegrationTest {
                 throws Exception {
           PlayerApiObjectWrappers wrappers = getExerciseWrapper();
           String url =
-              getUrl(
+              getAnswersUrl(
                   wrappers.simulationWrapper().get().getId(),
                   wrappers.otherUserWrapper().get().getId());
           UrlAccessTokenComposer.Composer tokenWrapper =

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/UrlAccessTokenFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/UrlAccessTokenFixture.java
@@ -27,7 +27,6 @@ public class UrlAccessTokenFixture {
    */
   public static UrlAccessToken createValidToken(Exercise exercise, User user, String url) {
     UrlAccessToken token = new UrlAccessToken();
-    token.setId(UUID.randomUUID().toString());
     token.setTokenHash(hashToken(DEFAULT_RAW_TOKEN));
     token.setUrl(url);
     token.setExercise(exercise);
@@ -45,7 +44,6 @@ public class UrlAccessTokenFixture {
    */
   public static UrlAccessToken createExpiredToken(Exercise exercise, User user) {
     UrlAccessToken token = new UrlAccessToken();
-    token.setId(UUID.randomUUID().toString());
     token.setTokenHash(hashToken("expired-token-" + UUID.randomUUID()));
     token.setUrl(DEFAULT_TARGET_URL);
     token.setExercise(exercise);

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/composers/ExerciseComposer.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/composers/ExerciseComposer.java
@@ -79,6 +79,7 @@ public class ExerciseComposer extends ComposerBase<Exercise> {
       this.categoryComposers.add(categoryComposer);
       List<LessonsCategory> tempCategories = this.exercise.getLessonsCategories();
       tempCategories.add(categoryComposer.get());
+      categoryComposer.get().setExercise(this.exercise);
       this.exercise.setLessonsCategories(tempCategories);
       return this;
     }

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/composers/LessonsAnswersComposer.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/composers/LessonsAnswersComposer.java
@@ -1,0 +1,52 @@
+package io.openaev.utils.fixtures.composers;
+
+import io.openaev.database.model.LessonsAnswer;
+import io.openaev.database.repository.LessonsAnswerRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LessonsAnswersComposer extends ComposerBase<LessonsAnswer> {
+
+  @Autowired private LessonsAnswerRepository lessonsAnswerRepository;
+
+  public class Composer extends InnerComposerBase<LessonsAnswer> {
+    private final LessonsAnswer lessonAnswer;
+    private Optional<UserComposer.Composer> userComposer = Optional.empty();
+
+    public Composer(LessonsAnswer lessonAnswer) {
+      this.lessonAnswer = lessonAnswer;
+    }
+
+    public Composer withUser(UserComposer.Composer userWrapper) {
+      userComposer = Optional.of(userWrapper);
+      this.lessonAnswer.setUser(userWrapper.get());
+      return this;
+    }
+
+    @Override
+    public Composer persist() {
+      userComposer.ifPresent(UserComposer.Composer::persist);
+      lessonsAnswerRepository.save(lessonAnswer);
+      return this;
+    }
+
+    @Override
+    public Composer delete() {
+      userComposer.ifPresent(UserComposer.Composer::delete);
+      lessonsAnswerRepository.delete(lessonAnswer);
+      return this;
+    }
+
+    @Override
+    public LessonsAnswer get() {
+      return this.lessonAnswer;
+    }
+  }
+
+  public Composer forLessonsAnswer(LessonsAnswer lessonsAnswer) {
+    generatedItems.add(lessonsAnswer);
+    return new Composer(lessonsAnswer);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/composers/LessonsQuestionsComposer.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/composers/LessonsQuestionsComposer.java
@@ -1,7 +1,10 @@
 package io.openaev.utils.fixtures.composers;
 
+import io.openaev.database.model.LessonsAnswer;
 import io.openaev.database.model.LessonsQuestion;
 import io.openaev.database.repository.LessonsQuestionRepository;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +15,7 @@ public class LessonsQuestionsComposer extends ComposerBase<LessonsQuestion> {
 
   public class Composer extends InnerComposerBase<LessonsQuestion> {
     private final LessonsQuestion lessonsQuestion;
+    private final List<LessonsAnswersComposer.Composer> lessonsAnswerComposers = new ArrayList<>();
 
     public Composer(LessonsQuestion lessonsQuestion) {
       this.lessonsQuestion = lessonsQuestion;
@@ -22,14 +26,25 @@ public class LessonsQuestionsComposer extends ComposerBase<LessonsQuestion> {
       return this;
     }
 
+    public Composer withAnswer(LessonsAnswersComposer.Composer lessonsAnswerWrapper) {
+      lessonsAnswerComposers.add(lessonsAnswerWrapper);
+      List<LessonsAnswer> tempAnswers = this.lessonsQuestion.getAnswers();
+      tempAnswers.add(lessonsAnswerWrapper.get());
+      lessonsAnswerWrapper.get().setQuestion(this.lessonsQuestion);
+      this.lessonsQuestion.setAnswers(tempAnswers);
+      return this;
+    }
+
     @Override
     public Composer persist() {
+      lessonsAnswerComposers.forEach(LessonsAnswersComposer.Composer::persist);
       lessonsQuestionRepository.save(lessonsQuestion);
       return this;
     }
 
     @Override
     public Composer delete() {
+      lessonsAnswerComposers.forEach(LessonsAnswersComposer.Composer::delete);
       lessonsQuestionRepository.delete(lessonsQuestion);
       return this;
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Better checks on player identity

### Testing Instructions

1. Create two users
2. Enroll them in simulation
3. Send end of simulation questionnaire
4. Open questionnaire as User A
5. Change userId parameter in URL with that of User B for submitting answers
6. Change userId parameter in URL with that of User B for fetching answers

### Related issues

* Closes #6279 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
