### PR TITLE
fix(multi_tenancy): converting imapService with tenant scope (#160)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/email/service/ImapService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/service/ImapService.java
@@ -207,61 +207,66 @@ public class ImapService extends ExternalServiceBase {
     for (Message message : messages) {
       MimeMessage mimeMessage = (MimeMessage) message;
       String messageID = mimeMessage.getMessageID();
-      boolean messageAlreadyAvailable = communicationRepository.existsByIdentifier(messageID);
-      if (!messageAlreadyAvailable) {
-        String content = getTextFromMessage(message);
-        String contentHtml = getHtmlFromMessage(message);
-        Inject inject = injectResolver(content, contentHtml);
-        List<String> participants = computeParticipants(message);
-        List<User> users = userRepository.findAllByEmailInIgnoreCase(participants);
-        if (inject != null && !users.isEmpty()) {
-          String subject = message.getSubject();
-          String from = String.valueOf(Arrays.stream(message.getFrom()).toList().get(0));
-          String to = String.valueOf(Arrays.stream(message.getAllRecipients()).toList());
-          Date receivedDate = message.getReceivedDate();
-          Date sentDate = message.getSentDate();
-          // Save messaging
-          Communication communication = new Communication();
-          communication.setReceivedAt(receivedDate.toInstant());
-          communication.setSentAt(sentDate.toInstant());
-          communication.setSubject(subject);
-          communication.setContent(content);
-          communication.setContentHtml(contentHtml);
-          communication.setIdentifier(messageID);
-          communication.setUsers(users);
-          communication.setInject(inject);
-          communication.setAnimation(isSent);
-          communication.setFrom(from);
-          communication.setTo(to);
-          try {
-            // Save the communication
-            Communication comm = communicationRepository.save(communication);
-            // Update inject for real time
-            inject.setUpdatedAt(now());
-            injectRepository.save(inject);
-            // Upload attachments in communication
-            final MimeMessageParser mimeParser = new MimeMessageParser(mimeMessage).parse();
-            final List<DataSource> attachmentList = mimeParser.getAttachmentList();
-            final List<String> uploads = new ArrayList<>();
-            String exerciseId = null;
-            if (inject.getExercise() != null) {
-              exerciseId = inject.getExercise().getId();
+      String content = getTextFromMessage(message);
+      String contentHtml = getHtmlFromMessage(message);
+      Inject inject = injectResolver(content, contentHtml);
+      if (inject != null) {
+        String tenantId = inject.getTenant().getId();
+        boolean messageAlreadyAvailable =
+            communicationRepository.existsByIdentifierAndInjectTenantId(messageID, tenantId);
+        if (!messageAlreadyAvailable) {
+          List<String> participants = computeParticipants(message);
+          List<User> users =
+              userRepository.findAllByEmailInIgnoreCaseAndTenantId(participants, tenantId);
+          if (!users.isEmpty()) {
+            String subject = message.getSubject();
+            String from = String.valueOf(Arrays.stream(message.getFrom()).toList().get(0));
+            String to = String.valueOf(Arrays.stream(message.getAllRecipients()).toList());
+            Date receivedDate = message.getReceivedDate();
+            Date sentDate = message.getSentDate();
+            // Save messaging
+            Communication communication = new Communication();
+            communication.setReceivedAt(receivedDate.toInstant());
+            communication.setSentAt(sentDate.toInstant());
+            communication.setSubject(subject);
+            communication.setContent(content);
+            communication.setContentHtml(contentHtml);
+            communication.setIdentifier(messageID);
+            communication.setUsers(users);
+            communication.setInject(inject);
+            communication.setAnimation(isSent);
+            communication.setFrom(from);
+            communication.setTo(to);
+            try {
+              // Save the communication
+              Communication comm = communicationRepository.save(communication);
+              // Update inject for real time
+              inject.setUpdatedAt(now());
+              injectRepository.save(inject);
+              // Upload attachments in communication
+              final MimeMessageParser mimeParser = new MimeMessageParser(mimeMessage).parse();
+              final List<DataSource> attachmentList = mimeParser.getAttachmentList();
+              final List<String> uploads = new ArrayList<>();
+              String exerciseId = null;
+              if (inject.getExercise() != null) {
+                exerciseId = inject.getExercise().getId();
+              }
+              for (DataSource dataSource : attachmentList) {
+                final String fileName = dataSource.getName();
+                String path =
+                    exerciseId != null
+                        ? "/" + exerciseId + "/communications/" + comm.getId()
+                        : "/communications/" + comm.getId();
+                String uploadName =
+                    fileService.uploadStream(path, fileName, dataSource.getInputStream());
+                uploads.add(uploadName);
+              }
+              // Add attachment in the communication
+              comm.setAttachments(uploads.toArray(String[]::new));
+              communicationRepository.save(comm);
+            } catch (Exception e) {
+              log.error(e.getMessage(), e);
             }
-            for (DataSource dataSource : attachmentList) {
-              final String fileName = dataSource.getName();
-              String path =
-                  exerciseId != null
-                      ? "/" + exerciseId + "/communications/" + comm.getId()
-                      : "/communications/" + comm.getId();
-              String uploadName =
-                  fileService.uploadStream(path, fileName, dataSource.getInputStream());
-              uploads.add(uploadName);
-            }
-            // Add attachment in the communication
-            comm.setAttachments(uploads.toArray(String[]::new));
-            communicationRepository.save(comm);
-          } catch (Exception e) {
-            log.error(e.getMessage(), e);
           }
         }
       }

--- a/openaev-api/src/test/java/io/openaev/injectors/email/service/ImapServiceTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/email/service/ImapServiceTenantScopeTest.java
@@ -1,0 +1,104 @@
+package io.openaev.injectors.email.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.Communication;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.CommunicationRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.database.repository.SettingRepository;
+import io.openaev.database.repository.UserRepository;
+import io.openaev.service.FileService;
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+class ImapServiceTenantScopeTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private InjectRepository injectRepository;
+  @Mock private CommunicationRepository communicationRepository;
+  @Mock private FileService fileService;
+  @Mock private Environment env;
+  @Mock private SettingRepository settingRepository;
+
+  @InjectMocks private ImapService imapService;
+
+  @BeforeEach
+  void beforeEach() {
+    ReflectionTestUtils.setField(imapService, "username", "mailbox@openaev.test");
+  }
+
+  @Nested
+  @DisplayName("Tenant-scoped parsing")
+  class TenantScopedParsing {
+
+    @Test
+    @DisplayName("given_messageAlreadyAvailableInInjectTenant_should_notCreateCommunication")
+    void given_messageAlreadyAvailableInInjectTenant_should_notCreateCommunication()
+        throws Exception {
+      // Arrange
+      String tenantId = "tenant-a";
+      String injectId = "inject-a";
+      String messageId = "message-a";
+
+      Inject inject = new Inject();
+      inject.setId(injectId);
+      inject.setTenant(new Tenant(tenantId));
+
+      when(injectRepository.findById(injectId)).thenReturn(java.util.Optional.of(inject));
+      when(communicationRepository.existsByIdentifierAndInjectTenantId(messageId, tenantId))
+          .thenReturn(true);
+
+      Message[] messages =
+          new Message[] {
+            buildMessage(messageId, "[inject_id=" + injectId + "]")
+          };
+
+      // Act
+      ReflectionTestUtils.invokeMethod(imapService, "parseMessages", messages, false);
+
+      // Assert
+      verify(communicationRepository).existsByIdentifierAndInjectTenantId(messageId, tenantId);
+      verify(userRepository, never())
+          .findAllByEmailInIgnoreCaseAndTenantId(anyList(), anyString());
+      verify(communicationRepository, never()).save(any(Communication.class));
+    }
+  }
+
+  private MimeMessage buildMessage(String messageId, String body) throws Exception {
+    String participantEmail = "participant@acme.test";
+    Session session = Session.getInstance(new Properties());
+    MimeMessage message = new MimeMessage(session);
+    message.setFrom(new InternetAddress(participantEmail));
+    message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(participantEmail));
+    message.setText(body);
+
+    MimeMessage spy = org.mockito.Mockito.spy(message);
+    doReturn(messageId).when(spy).getMessageID();
+    return spy;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/injectors/email/service/ImapServiceTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/email/service/ImapServiceTenantScopeTest.java
@@ -3,8 +3,11 @@ package io.openaev.injectors.email.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,22 +23,22 @@ import jakarta.mail.Message;
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import java.util.Date;
+import java.util.List;
 import java.util.Properties;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-@TestInstance(Lifecycle.PER_CLASS)
 class ImapServiceTenantScopeTest {
 
   @Mock private UserRepository userRepository;
@@ -45,10 +48,18 @@ class ImapServiceTenantScopeTest {
   @Mock private Environment env;
   @Mock private SettingRepository settingRepository;
 
-  @InjectMocks private ImapService imapService;
+  private ImapService imapService;
 
   @BeforeEach
   void beforeEach() {
+    imapService =
+        new ImapService(
+            userRepository,
+            injectRepository,
+            communicationRepository,
+            fileService,
+            env,
+            settingRepository);
     ReflectionTestUtils.setField(imapService, "username", "mailbox@openaev.test");
   }
 
@@ -73,19 +84,142 @@ class ImapServiceTenantScopeTest {
       when(communicationRepository.existsByIdentifierAndInjectTenantId(messageId, tenantId))
           .thenReturn(true);
 
-      Message[] messages =
-          new Message[] {
-            buildMessage(messageId, "[inject_id=" + injectId + "]")
-          };
+      Message[] messages = new Message[] {buildMessage(messageId, "[inject_id=" + injectId + "]")};
 
       // Act
       ReflectionTestUtils.invokeMethod(imapService, "parseMessages", messages, false);
 
       // Assert
       verify(communicationRepository).existsByIdentifierAndInjectTenantId(messageId, tenantId);
-      verify(userRepository, never())
-          .findAllByEmailInIgnoreCaseAndTenantId(anyList(), anyString());
+      verify(userRepository, never()).findAllByEmailInIgnoreCaseAndTenantId(anyList(), anyString());
       verify(communicationRepository, never()).save(any(Communication.class));
+    }
+
+    @Test
+    @DisplayName("given_messageForInject_should_lookupAndPersistUsersOnlyInInjectTenant")
+    void given_messageForInject_should_lookupAndPersistUsersOnlyInInjectTenant() throws Exception {
+      // Arrange
+      String tenantId = "tenant-a";
+      String injectId = "inject-a";
+      String messageId = "message-b";
+
+      Inject inject = new Inject();
+      inject.setId(injectId);
+      inject.setTenant(new Tenant(tenantId));
+
+      when(injectRepository.findById(anyString())).thenReturn(java.util.Optional.of(inject));
+      when(communicationRepository.existsByIdentifierAndInjectTenantId(messageId, tenantId))
+          .thenReturn(false);
+      when(userRepository.findAllByEmailInIgnoreCaseAndTenantId(anyList(), eq(tenantId)))
+          .thenReturn(java.util.List.of());
+
+      Message[] messages = new Message[] {buildMessage(messageId, "[inject_id=" + injectId + "]")};
+
+      // Act
+      ReflectionTestUtils.invokeMethod(imapService, "parseMessages", messages, false);
+
+      // Assert
+      verify(communicationRepository).existsByIdentifierAndInjectTenantId(messageId, tenantId);
+      verify(userRepository).findAllByEmailInIgnoreCaseAndTenantId(anyList(), eq(tenantId));
+      verify(communicationRepository, never()).save(any(Communication.class));
+    }
+
+    @Test
+    @DisplayName("given_twoInjectsFromDifferentTenantsWithSameEmail_should_linkOnlyTenantUser")
+    void given_twoInjectsFromDifferentTenantsWithSameEmail_should_linkOnlyTenantUser()
+        throws Exception {
+      // Arrange
+      String tenantA = "tenant-a";
+      String tenantB = "tenant-b";
+      String injectIdA = "inject-a";
+      String injectIdB = "inject-b";
+      String messageIdA = "message-a";
+      String messageIdB = "message-b";
+
+      Inject injectA = new Inject();
+      injectA.setId(injectIdA);
+      injectA.setTenant(new Tenant(tenantA));
+
+      Inject injectB = new Inject();
+      injectB.setId(injectIdB);
+      injectB.setTenant(new Tenant(tenantB));
+
+      io.openaev.database.model.User userA = new io.openaev.database.model.User();
+      userA.setId("user-a");
+      userA.setEmail("participant@acme.test");
+
+      io.openaev.database.model.User userB = new io.openaev.database.model.User();
+      userB.setId("user-b");
+      userB.setEmail("participant@acme.test");
+
+      when(injectRepository.findById(anyString()))
+          .thenAnswer(
+              invocation -> {
+                String injectId = invocation.getArgument(0);
+                if (injectId != null && injectId.contains(injectIdA)) {
+                  return java.util.Optional.of(injectA);
+                }
+                if (injectId != null && injectId.contains(injectIdB)) {
+                  return java.util.Optional.of(injectB);
+                }
+                return java.util.Optional.empty();
+              });
+      when(communicationRepository.existsByIdentifierAndInjectTenantId(anyString(), anyString()))
+          .thenReturn(false);
+      when(userRepository.findAllByEmailInIgnoreCaseAndTenantId(anyList(), anyString()))
+          .thenAnswer(
+              invocation -> {
+                String tenantId = invocation.getArgument(1);
+                if (tenantA.equals(tenantId)) {
+                  return java.util.List.of(userA);
+                }
+                if (tenantB.equals(tenantId)) {
+                  return java.util.List.of(userB);
+                }
+                return java.util.List.of();
+              });
+      when(communicationRepository.save(any(Communication.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      Message[] messages =
+          new Message[] {
+            buildMessage(messageIdA, "[inject_id=" + injectIdA + "]"),
+            buildMessage(messageIdB, "[inject_id=" + injectIdB + "]")
+          };
+
+      // Act
+      ReflectionTestUtils.invokeMethod(imapService, "parseMessages", messages, false);
+
+      // Assert
+      verify(userRepository, times(1))
+          .findAllByEmailInIgnoreCaseAndTenantId(anyList(), eq(tenantA));
+      verify(userRepository, times(1))
+          .findAllByEmailInIgnoreCaseAndTenantId(anyList(), eq(tenantB));
+
+      ArgumentCaptor<Communication> communicationCaptor =
+          ArgumentCaptor.forClass(Communication.class);
+      verify(communicationRepository, times(4)).save(communicationCaptor.capture());
+      List<Communication> savedCommunications = communicationCaptor.getAllValues();
+
+      List<Communication> tenantACommunications =
+          savedCommunications.stream().filter(c -> messageIdA.equals(c.getIdentifier())).toList();
+      List<Communication> tenantBCommunications =
+          savedCommunications.stream().filter(c -> messageIdB.equals(c.getIdentifier())).toList();
+
+      Assertions.assertFalse(tenantACommunications.isEmpty());
+      Assertions.assertFalse(tenantBCommunications.isEmpty());
+      Assertions.assertTrue(
+          tenantACommunications.stream()
+              .allMatch(
+                  c ->
+                      c.getUsers().size() == 1
+                          && "user-a".equals(c.getUsers().getFirst().getId())));
+      Assertions.assertTrue(
+          tenantBCommunications.stream()
+              .allMatch(
+                  c ->
+                      c.getUsers().size() == 1
+                          && "user-b".equals(c.getUsers().getFirst().getId())));
     }
   }
 
@@ -96,9 +230,12 @@ class ImapServiceTenantScopeTest {
     message.setFrom(new InternetAddress(participantEmail));
     message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(participantEmail));
     message.setText(body);
+    message.setSentDate(new Date());
 
     MimeMessage spy = org.mockito.Mockito.spy(message);
     doReturn(messageId).when(spy).getMessageID();
+    lenient().doReturn(new Date()).when(spy).getSentDate();
+    lenient().doReturn(new Date()).when(spy).getReceivedDate();
     return spy;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/CommunicationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/CommunicationRepository.java
@@ -17,5 +17,5 @@ public interface CommunicationRepository
 
   List<Communication> findByInjectId(@NotNull String injectId);
 
-  boolean existsByIdentifier(String identifier);
+  boolean existsByIdentifierAndInjectTenantId(String identifier, String tenantId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/UserRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/UserRepository.java
@@ -27,7 +27,10 @@ public interface UserRepository
 
   Optional<User> findByEmailIgnoreCase(String email);
 
-  List<User> findAllByEmailInIgnoreCase(List<String> emails);
+  @Query(
+      "SELECT DISTINCT u FROM User u JOIN u.tenants t WHERE LOWER(u.email) IN :emails AND t.id = :tenantId")
+  List<User> findAllByEmailInIgnoreCaseAndTenantId(
+      @Param("emails") List<String> emails, @Param("tenantId") String tenantId);
 
   @Override
   @Query(

--- a/openaev-model/src/main/java/io/openaev/database/repository/UserRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/UserRepository.java
@@ -7,6 +7,7 @@ import io.openaev.database.raw.RawUserAuthFlat;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Page;
@@ -29,8 +30,17 @@ public interface UserRepository
 
   @Query(
       "SELECT DISTINCT u FROM User u JOIN u.tenants t WHERE LOWER(u.email) IN :emails AND t.id = :tenantId")
-  List<User> findAllByEmailInIgnoreCaseAndTenantId(
+  List<User> findAllByEmailInAndTenantIdNormalized(
       @Param("emails") List<String> emails, @Param("tenantId") String tenantId);
+
+  default List<User> findAllByEmailInIgnoreCaseAndTenantId(List<String> emails, String tenantId) {
+    if (emails == null || emails.isEmpty()) {
+      return List.of();
+    }
+    List<String> normalizedEmails =
+        emails.stream().map(email -> email.toLowerCase(Locale.ROOT)).toList();
+    return findAllByEmailInAndTenantIdNormalized(normalizedEmails, tenantId);
+  }
 
   @Override
   @Query(


### PR DESCRIPTION
### Description

Imap Service is not tenant-scoped

### Proposed changes

* When ImapService is parsing the messages, is not checking the tenant id, getting the wrong users for that communication.
* Change the parseMessages method to filter participants by tenant.

### Testing Instructions

**Pre-conditions:**
- 2 tenants configured on the platform
- IMAP enabled and connected to a shared mailbox
- 1 inject created in Tenant A (note its UUID from the URL)
- A user with the same email existing in both tenants

**Steps:**
1. Log in as **Tenant A** → grab the inject UUID from the URL
2. Send an email to the shared IMAP mailbox with `[inject_id=<inject-uuid-from-tenant-A>]` in the body, using a participant email that exists in both tenants
3. Wait ~10 seconds for `ImapService` to process it
4. Log in as **Tenant B** → check Communications

**Expected:** Tenant B cannot see Tenant A's communication
**Actual:** Communication is visible across tenants and/or users from Tenant B are linked to Tenant A's inject

### Related issues

* [#160](https://github.com/OpenAEV-Platform/filigran-private/issues/160)

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

