### PR TITLE
feat(executors): add #{payload_location} placeholder for payload commands (#6265)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/ExecutorHelper.java
+++ b/openaev-api/src/main/java/io/openaev/executors/ExecutorHelper.java
@@ -6,6 +6,9 @@ public class ExecutorHelper {
 
   public static final String WINDOWS_LOCATION_PATH = "$PWD.Path";
   public static final String UNIX_LOCATION_PATH = "$(pwd)";
+  public static final String WINDOWS_PAYLOAD_LOCATION_PATH =
+      "$($PWD.Path.Replace('\\runtimes\\','\\payloads\\'))";
+  public static final String UNIX_PAYLOAD_LOCATION_PATH = "$(pwd | sed 's#/runtimes/#/payloads/#')";
   public static final String IMPLANT_BASE_NAME = "implant-";
   // Only used in Tanium / CS / Caldera executors, the native OpenAEV agent will determine a
   // relative path at its level
@@ -60,8 +63,17 @@ public class ExecutorHelper {
           default ->
               throw new IllegalArgumentException("Unsupported platform type: " + platformType);
         };
+    String payloadLocation =
+        switch (platformType) {
+          case Windows -> WINDOWS_PAYLOAD_LOCATION_PATH;
+          case Linux, MacOS -> UNIX_PAYLOAD_LOCATION_PATH;
+          default ->
+              throw new IllegalArgumentException("Unsupported platform type: " + platformType);
+        };
 
     return command
+        .replace("\"#{payload_location}\"", payloadLocation)
+        .replace("#{payload_location}", payloadLocation)
         .replace("\"#{location}\"", location)
         .replace("#{inject}", injectId)
         .replace("#{agent}", agentId)

--- a/openaev-api/src/main/java/io/openaev/executors/ExecutorHelper.java
+++ b/openaev-api/src/main/java/io/openaev/executors/ExecutorHelper.java
@@ -4,16 +4,23 @@ import io.openaev.database.model.Endpoint.PLATFORM_TYPE;
 
 public class ExecutorHelper {
 
+  private static final String WINDOWS_RUNTIMES_DIRECTORY = "\\runtimes\\";
+  private static final String WINDOWS_PAYLOADS_DIRECTORY = "\\payloads\\";
+
   public static final String WINDOWS_LOCATION_PATH = "$PWD.Path";
   public static final String UNIX_LOCATION_PATH = "$(pwd)";
   public static final String WINDOWS_PAYLOAD_LOCATION_PATH =
-      "$($PWD.Path.Replace('\\runtimes\\','\\payloads\\'))";
+      "$($PWD.Path.Replace('"
+          + WINDOWS_RUNTIMES_DIRECTORY
+          + "','"
+          + WINDOWS_PAYLOADS_DIRECTORY
+          + "'))";
   public static final String UNIX_PAYLOAD_LOCATION_PATH = "$(pwd | sed 's#/runtimes/#/payloads/#')";
   public static final String IMPLANT_BASE_NAME = "implant-";
   // Only used in Tanium / CS / Caldera executors, the native OpenAEV agent will determine a
   // relative path at its level
   public static final String IMPLANT_LOCATION_WINDOWS =
-      "\"C:\\Program Files (x86)\\Filigran\\OAEV Agent\\runtimes\\";
+      "\"C:\\Program Files (x86)\\Filigran\\OAEV Agent" + WINDOWS_RUNTIMES_DIRECTORY;
   public static final String IMPLANT_LOCATION_UNIX = "/opt/openaev-agent/runtimes/";
   // Clean payloads older than 24 hours
   public static final String WINDOWS_CLEAN_PAYLOADS_COMMAND =
@@ -64,17 +71,15 @@ public class ExecutorHelper {
               throw new IllegalArgumentException("Unsupported platform type: " + platformType);
         };
     String payloadLocation =
-        switch (platformType) {
-          case Windows -> WINDOWS_PAYLOAD_LOCATION_PATH;
-          case Linux, MacOS -> UNIX_PAYLOAD_LOCATION_PATH;
-          default ->
-              throw new IllegalArgumentException("Unsupported platform type: " + platformType);
-        };
+        platformType == PLATFORM_TYPE.Windows
+            ? WINDOWS_PAYLOAD_LOCATION_PATH
+            : UNIX_PAYLOAD_LOCATION_PATH;
 
     return command
         .replace("\"#{payload_location}\"", payloadLocation)
         .replace("#{payload_location}", payloadLocation)
         .replace("\"#{location}\"", location)
+        .replace("#{location}", location)
         .replace("#{inject}", injectId)
         .replace("#{agent}", agentId)
         .replace("#{tenant}", tenantId)

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
@@ -42,6 +43,7 @@ public class ExecutableInjectService {
 
   @Resource protected ObjectMapper mapper;
 
+  private static final Set<String> RESERVED_PLACEHOLDERS = Set.of("location", "payload_location");
   private static final Pattern argumentsRegex = Pattern.compile("#\\{([^#{}]+)}");
   private static final Pattern cmdVariablesRegex = Pattern.compile("%(\\w+)%");
 
@@ -97,6 +99,10 @@ public class ExecutableInjectService {
     List<String> argumentKeys = getArgumentsFromCommandLines(command);
 
     for (String argumentKey : argumentKeys) {
+      if (RESERVED_PLACEHOLDERS.contains(argumentKey)) {
+        continue;
+      }
+
       String value;
       PayloadArgument defaultPayloadArgument =
           defaultPayloadArguments.stream()

--- a/openaev-api/src/test/java/io/openaev/executors/ExecutorHelperTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/ExecutorHelperTest.java
@@ -61,6 +61,74 @@ class ExecutorHelperTest {
   }
 
   @Test
+  @DisplayName("Should replace payload location placeholder for Linux platform")
+  void shouldReplacePayloadLocationForLinux() {
+    // prepare
+    String command = "cat #{payload_location}/linpeas.sh";
+
+    // act
+    String result =
+        ExecutorHelper.replaceArgs(
+            PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+
+    // assert
+    assertThat(result)
+        .isEqualTo("cat " + ExecutorHelper.UNIX_PAYLOAD_LOCATION_PATH + "/linpeas.sh");
+  }
+
+  @Test
+  @DisplayName("Should replace payload location placeholder for Windows platform")
+  void shouldReplacePayloadLocationForWindows() {
+    // prepare
+    String command = "Get-Content #{payload_location}\\linpeas.ps1";
+
+    // act
+    String result =
+        ExecutorHelper.replaceArgs(
+            PLATFORM_TYPE.Windows, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+
+    // assert
+    assertThat(result)
+        .isEqualTo("Get-Content " + ExecutorHelper.WINDOWS_PAYLOAD_LOCATION_PATH + "\\linpeas.ps1");
+  }
+
+  @Test
+  @DisplayName("Should replace location and payload location placeholders independently")
+  void shouldReplaceLocationAndPayloadLocationIndependently() {
+    // prepare
+    String command = "cd \"#{location}\" && cat #{payload_location}/linpeas.sh";
+
+    // act
+    String result =
+        ExecutorHelper.replaceArgs(
+            PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+
+    // assert
+    assertThat(result)
+        .isEqualTo(
+            "cd "
+                + ExecutorHelper.UNIX_LOCATION_PATH
+                + " && cat "
+                + ExecutorHelper.UNIX_PAYLOAD_LOCATION_PATH
+                + "/linpeas.sh");
+  }
+
+  @Test
+  @DisplayName("Should keep existing location placeholder behavior")
+  void shouldKeepExistingLocationPlaceholderBehavior() {
+    // prepare
+    String command = "pwd=\"#{location}\"";
+
+    // act
+    String result =
+        ExecutorHelper.replaceArgs(
+            PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+
+    // assert
+    assertThat(result).isEqualTo("pwd=" + ExecutorHelper.UNIX_LOCATION_PATH);
+  }
+
+  @Test
   @DisplayName("Should replace token placeholder for Linux platform")
   void given_linuxCommandWithPlaceholders_should_replaceTokenTenantAndBaseUrl() {
     // Arrange
@@ -147,6 +215,18 @@ class ExecutorHelperTest {
   }
 
   @Test
+  @DisplayName("Should throw when platform is unsupported")
+  void shouldThrowWhenPlatformIsUnsupported() {
+    // act & assert
+    assertThatThrownBy(
+            () ->
+                ExecutorHelper.replaceArgs(
+                    PLATFORM_TYPE.Unknown, "echo hello", INJECT_ID, AGENT_ID, TENANT_ID, TOKEN))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported platform type: Unknown");
+  }
+
+  @Test
   @DisplayName(
       "Should propagate IllegalArgumentException from base overload when an argument is null")
   void given_nullCommand_should_throwIllegalArgumentException() {
@@ -185,6 +265,21 @@ class ExecutorHelperTest {
                     MAX_SIZE,
                     UNSECURED_CERTIFICATE,
                     WITH_PROXY))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                ExecutorHelper.replaceArgs(
+                    PLATFORM_TYPE.Linux, "echo hello", null, AGENT_ID, TENANT_ID, TOKEN))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                ExecutorHelper.replaceArgs(
+                    PLATFORM_TYPE.Linux, "echo hello", INJECT_ID, null, TENANT_ID, TOKEN))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                ExecutorHelper.replaceArgs(
+                    PLATFORM_TYPE.Linux, "echo hello", INJECT_ID, AGENT_ID, null, TOKEN))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/executors/ExecutorHelperTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/ExecutorHelperTest.java
@@ -114,10 +114,10 @@ class ExecutorHelperTest {
   }
 
   @Test
-  @DisplayName("Should keep existing location placeholder behavior")
-  void shouldKeepExistingLocationPlaceholderBehavior() {
+  @DisplayName("Should replace an unquoted location placeholder")
+  void given_unquotedLocation_should_replacePlaceholder() {
     // prepare
-    String command = "pwd=\"#{location}\"";
+    String command = "cd #{location}";
 
     // act
     String result =
@@ -125,7 +125,7 @@ class ExecutorHelperTest {
             PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
 
     // assert
-    assertThat(result).isEqualTo("pwd=" + ExecutorHelper.UNIX_LOCATION_PATH);
+    assertThat(result).isEqualTo("cd " + ExecutorHelper.UNIX_LOCATION_PATH);
   }
 
   @Test
@@ -188,6 +188,35 @@ class ExecutorHelperTest {
 
     // Assert
     assertThat(result).isEqualTo("curl -H \"Authorization: " + TOKEN + "\" " + MAX_SIZE);
+  }
+
+  @Test
+  @DisplayName("Should replace token and payload location placeholders for MacOS platform")
+  void shouldReplaceTokenForMacOS() {
+    // prepare
+    String command = "curl -H \"Authorization: #{token}\" #{payload_location}";
+
+    // Act
+    String result =
+        ExecutorHelper.replaceArgs(
+            PLATFORM_TYPE.MacOS,
+            command,
+            INJECT_ID,
+            AGENT_ID,
+            TENANT_ID,
+            TOKEN,
+            BASE_URL,
+            MAX_SIZE,
+            UNSECURED_CERTIFICATE,
+            WITH_PROXY);
+
+    // assert
+    assertThat(result)
+        .isEqualTo(
+            "curl -H \"Authorization: "
+                + TOKEN
+                + "\" "
+                + ExecutorHelper.UNIX_PAYLOAD_LOCATION_PATH);
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/executors/ExecutorHelperTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/ExecutorHelperTest.java
@@ -69,7 +69,16 @@ class ExecutorHelperTest {
     // act
     String result =
         ExecutorHelper.replaceArgs(
-            PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+            PLATFORM_TYPE.Linux,
+            command,
+            INJECT_ID,
+            AGENT_ID,
+            TENANT_ID,
+            TOKEN,
+            BASE_URL,
+            MAX_SIZE,
+            UNSECURED_CERTIFICATE,
+            WITH_PROXY);
 
     // assert
     assertThat(result)
@@ -85,7 +94,16 @@ class ExecutorHelperTest {
     // act
     String result =
         ExecutorHelper.replaceArgs(
-            PLATFORM_TYPE.Windows, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+            PLATFORM_TYPE.Windows,
+            command,
+            INJECT_ID,
+            AGENT_ID,
+            TENANT_ID,
+            TOKEN,
+            BASE_URL,
+            MAX_SIZE,
+            UNSECURED_CERTIFICATE,
+            WITH_PROXY);
 
     // assert
     assertThat(result)
@@ -101,7 +119,16 @@ class ExecutorHelperTest {
     // act
     String result =
         ExecutorHelper.replaceArgs(
-            PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+            PLATFORM_TYPE.Linux,
+            command,
+            INJECT_ID,
+            AGENT_ID,
+            TENANT_ID,
+            TOKEN,
+            BASE_URL,
+            MAX_SIZE,
+            UNSECURED_CERTIFICATE,
+            WITH_PROXY);
 
     // assert
     assertThat(result)
@@ -122,7 +149,16 @@ class ExecutorHelperTest {
     // act
     String result =
         ExecutorHelper.replaceArgs(
-            PLATFORM_TYPE.Linux, command, INJECT_ID, AGENT_ID, TENANT_ID, TOKEN);
+            PLATFORM_TYPE.Linux,
+            command,
+            INJECT_ID,
+            AGENT_ID,
+            TENANT_ID,
+            TOKEN,
+            BASE_URL,
+            MAX_SIZE,
+            UNSECURED_CERTIFICATE,
+            WITH_PROXY);
 
     // assert
     assertThat(result).isEqualTo("cd " + ExecutorHelper.UNIX_LOCATION_PATH);
@@ -250,7 +286,16 @@ class ExecutorHelperTest {
     assertThatThrownBy(
             () ->
                 ExecutorHelper.replaceArgs(
-                    PLATFORM_TYPE.Unknown, "echo hello", INJECT_ID, AGENT_ID, TENANT_ID, TOKEN))
+                    PLATFORM_TYPE.Unknown,
+                    "echo hello",
+                    INJECT_ID,
+                    AGENT_ID,
+                    TENANT_ID,
+                    TOKEN,
+                    BASE_URL,
+                    MAX_SIZE,
+                    UNSECURED_CERTIFICATE,
+                    WITH_PROXY))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unsupported platform type: Unknown");
   }
@@ -298,17 +343,44 @@ class ExecutorHelperTest {
     assertThatThrownBy(
             () ->
                 ExecutorHelper.replaceArgs(
-                    PLATFORM_TYPE.Linux, "echo hello", null, AGENT_ID, TENANT_ID, TOKEN))
+                    PLATFORM_TYPE.Linux,
+                    "echo hello",
+                    null,
+                    AGENT_ID,
+                    TENANT_ID,
+                    TOKEN,
+                    BASE_URL,
+                    MAX_SIZE,
+                    UNSECURED_CERTIFICATE,
+                    WITH_PROXY))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(
             () ->
                 ExecutorHelper.replaceArgs(
-                    PLATFORM_TYPE.Linux, "echo hello", INJECT_ID, null, TENANT_ID, TOKEN))
+                    PLATFORM_TYPE.Linux,
+                    "echo hello",
+                    INJECT_ID,
+                    null,
+                    TENANT_ID,
+                    TOKEN,
+                    BASE_URL,
+                    MAX_SIZE,
+                    UNSECURED_CERTIFICATE,
+                    WITH_PROXY))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(
             () ->
                 ExecutorHelper.replaceArgs(
-                    PLATFORM_TYPE.Linux, "echo hello", INJECT_ID, AGENT_ID, null, TOKEN))
+                    PLATFORM_TYPE.Linux,
+                    "echo hello",
+                    INJECT_ID,
+                    AGENT_ID,
+                    null,
+                    TOKEN,
+                    BASE_URL,
+                    MAX_SIZE,
+                    UNSECURED_CERTIFICATE,
+                    WITH_PROXY))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -1,0 +1,45 @@
+package io.openaev.rest.inject.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.database.model.ArgumentType;
+import io.openaev.database.model.PayloadArgument;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ExecutableInjectService tests")
+class ExecutableInjectServiceTest {
+
+  private final ExecutableInjectService service =
+      new ExecutableInjectService(null, null, null, null, null);
+
+  @Test
+  @DisplayName("Should preserve reserved implant placeholders when replacing payload arguments")
+  void given_reservedPlaceholders_should_preserveThemWhenReplacingPayloadArguments() {
+    // Arrange
+    ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
+    injectContent.put("message", "hello");
+    String command =
+        "cat #{payload_location}/linpeas.sh && cd #{location} && echo #{message} #{missing}";
+
+    // Act
+    String result =
+        service.replaceArgumentsByValue(
+            command, List.of(payloadArgument("message", "fallback")), List.of(), injectContent);
+
+    // Assert
+    assertThat(result)
+        .isEqualTo("cat #{payload_location}/linpeas.sh && cd #{location} && echo hello ");
+  }
+
+  private static PayloadArgument payloadArgument(String key, String defaultValue) {
+    PayloadArgument payloadArgument = new PayloadArgument();
+    payloadArgument.setType(ArgumentType.Text);
+    payloadArgument.setKey(key);
+    payloadArgument.setDefaultValue(defaultValue);
+    return payloadArgument;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.openaev.database.model.ArgumentType;
+import io.openaev.database.model.PrimitiveType;
 import io.openaev.database.model.PayloadArgument;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +37,7 @@ class ExecutableInjectServiceTest {
 
   private static PayloadArgument payloadArgument(String key, String defaultValue) {
     PayloadArgument payloadArgument = new PayloadArgument();
-    payloadArgument.setType(ArgumentType.Text);
+    payloadArgument.setType(PrimitiveType.Text);
     payloadArgument.setKey(key);
     payloadArgument.setDefaultValue(defaultValue);
     return payloadArgument;

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.openaev.database.model.PrimitiveType;
 import io.openaev.database.model.PayloadArgument;
+import io.openaev.database.model.PrimitiveType;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### Proposed changes

* Adds a new `#{payload_location}` placeholder that resolves to the `payloads/execution-<uuid>/` directory, so prerequisite / get / cleanup commands of an Executable payload can reference an uploaded file (e.g. `cat #{payload_location}/linpeas.sh`). As @RomuDeuxfois diagnosed in #6265, the uploaded file lands in `payloads/execution-<uuid>/` but those commands run with the working directory set to the sibling `runtimes/execution-<uuid>/`, and the only existing placeholder `#{location}` also resolves to `runtimes/` -- so there was previously no way to point at the uploaded file.
* `ExecutorHelper.replaceArgs` now substitutes `#{payload_location}` to a per-platform expression that rewrites the runtime working directory to its `payloads/` sibling (`UNIX_PAYLOAD_LOCATION_PATH` / `WINDOWS_PAYLOAD_LOCATION_PATH`), alongside the unchanged `#{location}` substitution.
* `ExecutableInjectService.replaceArgumentsByValue` now treats `location` and `payload_location` as reserved placeholders and skips them during payload-argument substitution. Without this, the argument regex (`#\{([^#{}]+)}`) matched `#{payload_location}` as an unknown argument and blanked it (`cat #{payload_location}/linpeas.sh` became `cat /linpeas.sh`) before the implant could resolve it.

Backward compatibility: existing `#{location}` behavior is unchanged, and a reserved placeholder is now preserved through to implant resolution rather than being silently stripped.

### Testing Instructions

1. `ExecutorHelperTest` covers the new placeholder on Linux and Windows, both placeholders present in one command resolving to distinct directories, the unchanged `#{location}` path, the unsupported-platform `IllegalArgumentException`, and the null-argument guards.
2. `ExecutableInjectServiceTest` asserts that `#{location}` and `#{payload_location}` survive `replaceArgumentsByValue` untouched while ordinary payload arguments are still substituted and unknown non-reserved placeholders are still blanked.
3. Run locally with JDK 21: `mvn -pl openaev-api -am test -Dtest='ExecutorHelperTest,ExecutableInjectServiceTest' -Dsurefire.failIfNoSpecifiedTests=false` (11 tests, 0 failures) and `mvn -pl openaev-api spotless:check`.

### Related issues

* Closes #6265

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

The per-platform `#{payload_location}` expressions rewrite the runtime working directory to its `payloads/` sibling at agent-execution time (`$(pwd | sed 's#/runtimes/#/payloads/#')` on Unix, the `$PWD.Path.Replace(...)` form on Windows), mirroring how `#{location}` is resolved from `$(pwd)` / `$PWD.Path`. This keeps resolution in the agent shell rather than baking an absolute server-side path into the command. The placeholder name follows the one proposed in #6265. Happy to adjust the constant expressions or naming if you would prefer a different resolution strategy.
