### PR TITLE
fix(icon): address review comments on image endpoints and file service (#4864)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
@@ -86,7 +86,7 @@ public class CalderaExecutorIntegrationFactory extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE);
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-caldera.png"));

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
@@ -89,7 +89,7 @@ public class CrowdStrikeExecutorIntegrationFactory extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE);
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-crowdstrike.png"));

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/openaev/OpenAEVExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/openaev/OpenAEVExecutorIntegrationFactory.java
@@ -9,7 +9,6 @@ import io.openaev.executors.ExecutorService;
 import io.openaev.integration.BuiltinIntegrationFactory;
 import io.openaev.integration.ComponentRequestEngine;
 import io.openaev.integration.Integration;
-import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.account.ServiceAccountPrivilegeService;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
@@ -76,23 +75,19 @@ public class OpenAEVExecutorIntegrationFactory extends BuiltinIntegrationFactory
 
   @Override
   public void registerConnectorForTenant(String tenantId) throws Exception {
-    try {
-      executorService.executor(OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_ID);
-    } catch (ElementNotFoundException e) {
-      executorService.register(
-          OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_ID,
-          OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_TYPE,
-          OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_NAME,
-          OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_DOCUMENTATION_LINK,
-          OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_BACKGROUND_COLOR,
-          getClass().getResourceAsStream("/img/icon-openaev.png"),
-          getClass().getResourceAsStream("/img/banner-openaev.png"),
-          new String[] {
-            Endpoint.PLATFORM_TYPE.Windows.name(),
-            Endpoint.PLATFORM_TYPE.Linux.name(),
-            Endpoint.PLATFORM_TYPE.MacOS.name()
-          },
-          false);
-    }
+    executorService.register(
+        OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_ID,
+        OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_TYPE,
+        OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_NAME,
+        OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_DOCUMENTATION_LINK,
+        OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_BACKGROUND_COLOR,
+        getClass().getResourceAsStream("/img/icon-openaev.png"),
+        getClass().getResourceAsStream("/img/banner-openaev.png"),
+        new String[] {
+          Endpoint.PLATFORM_TYPE.Windows.name(),
+          Endpoint.PLATFORM_TYPE.Linux.name(),
+          Endpoint.PLATFORM_TYPE.MacOS.name()
+        },
+        false);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
@@ -83,7 +83,7 @@ public class PaloAltoCortexExecutorIntegrationFactory extends IntegrationFactory
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE);
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-paloaltocortex.png"));

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
@@ -87,7 +87,7 @@ public class SentinelOneExecutorIntegrationFactory extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE);
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-sentinelone.png"));

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
@@ -90,7 +90,7 @@ public class TaniumExecutorIntegrationFactory extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE);
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-tanium.png"));

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
@@ -82,7 +82,7 @@ public class OpenCTIInjectorIntegrationFactory extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(openCTIContract.TYPE);
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-opencti.png"));

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
@@ -79,7 +79,7 @@ public class OvhInjectorIntegrationFactory extends IntegrationFactory {
   protected void insertCatalogEntry() throws Exception {
     CatalogConnector connector = new CatalogConnector();
     String logoFilename = "%s-logo.png".formatted(ovhSmsContract.getType());
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-ovh-sms.png"));

--- a/openaev-api/src/main/java/io/openaev/rest/catalog_connector/CatalogConnectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/catalog_connector/CatalogConnectorApi.java
@@ -1,7 +1,5 @@
 package io.openaev.rest.catalog_connector;
 
-import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
-
 import io.openaev.aop.AccessControl;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.CatalogConnectorConfiguration;
@@ -28,28 +26,20 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CatalogConnectorApi extends RestBehavior {
   public static final String CATALOG_CONNECTOR_URI = "/api/catalog-connector";
-  private static final String TENANT_CATALOG_CONNECTOR_URI = TENANT_PREFIX + "/catalog-connector";
-  private static final String IMAGES_URI = "/api/images";
-  private static final String TENANT_IMAGES_URI = TENANT_PREFIX + "/images";
   private static final String CATALOG_CONNECTOR_LOGO_URI =
-      IMAGES_URI + "/catalog/connectors/logos/{fileName}";
-  private static final String TENANT_CATALOG_CONNECTOR_LOGO_URI =
-      TENANT_IMAGES_URI + "/catalog/connectors/logos/{fileName}";
+      "/api/images/catalog/connectors/logos/{fileName}";
 
   private final CatalogConnectorService catalogConnectorService;
   private final FileService fileService;
 
-  @GetMapping({CATALOG_CONNECTOR_URI, TENANT_CATALOG_CONNECTOR_URI})
+  @GetMapping(CATALOG_CONNECTOR_URI)
   @Transactional
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.CATALOG)
   public List<CatalogConnectorOutput> getCatalogConnectors() {
     return this.catalogConnectorService.getCatalogConnectors();
   }
 
-  @GetMapping({
-    CATALOG_CONNECTOR_URI + "/{catalogConnectorId}",
-    TENANT_CATALOG_CONNECTOR_URI + "/{catalogConnectorId}"
-  })
+  @GetMapping(CATALOG_CONNECTOR_URI + "/{catalogConnectorId}")
   @Transactional
   @AccessControl(
       resourceId = "#catalogConnectorId",
@@ -59,13 +49,11 @@ public class CatalogConnectorApi extends RestBehavior {
     return this.catalogConnectorService.catalogConnectorOutput(catalogConnectorId);
   }
 
-  @GetMapping(
-      value = {CATALOG_CONNECTOR_LOGO_URI, TENANT_CATALOG_CONNECTOR_LOGO_URI},
-      produces = MediaType.IMAGE_PNG_VALUE)
+  @GetMapping(value = CATALOG_CONNECTOR_LOGO_URI, produces = MediaType.IMAGE_PNG_VALUE)
   @Transactional
   @AccessControl(skipRBAC = true)
   public ResponseEntity<byte[]> getCatalogLogo(@PathVariable String fileName) throws IOException {
-    Optional<InputStream> fileStream = fileService.getCatalogConnectorImage(fileName, false);
+    Optional<InputStream> fileStream = fileService.getCatalogConnectorImage(fileName);
 
     if (fileStream.isPresent()) {
       byte[] bytes = IOUtils.toByteArray(fileStream.get());
@@ -75,10 +63,7 @@ public class CatalogConnectorApi extends RestBehavior {
     return ResponseEntity.notFound().build();
   }
 
-  @GetMapping({
-    CATALOG_CONNECTOR_URI + "/{catalogConnectorId}/configurations",
-    TENANT_CATALOG_CONNECTOR_URI + "/{catalogConnectorId}/configurations"
-  })
+  @GetMapping(CATALOG_CONNECTOR_URI + "/{catalogConnectorId}/configurations")
   @Transactional
   @AccessControl(
       resourceId = "#catalogConnectorId",

--- a/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
@@ -124,6 +124,7 @@ public class CollectorApi extends RestBehavior {
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   @Operation(summary = "Get collector image by type")
+  @Transactional
   public ResponseEntity<byte[]> getCollectorImage(@PathVariable String collectorType)
       throws IOException {
     Optional<InputStream> fileStream = fileService.getCollectorImage(collectorType);
@@ -145,6 +146,7 @@ public class CollectorApi extends RestBehavior {
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   @Operation(summary = "Get collector image by collector id")
+  @Transactional
   public ResponseEntity<byte[]> getCollectorImageById(@PathVariable String collectorId)
       throws IOException {
     Optional<Collector> collector = collectorRepository.findById(collectorId);

--- a/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
@@ -23,11 +23,16 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.IOUtils;
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -107,6 +112,27 @@ public class CollectorApi extends RestBehavior {
   @Transactional
   public ConnectorIds getCollectorRelatedIds(@PathVariable String collectorId) {
     return collectorService.getCollectorRelationsId(collectorId);
+  }
+
+  // -- IMAGE --
+
+  @GetMapping(
+      value = {
+        COLLECTOR_URI + "/{collectorType}/image",
+        TENANT_COLLECTOR_URI + "/{collectorType}/image"
+      },
+      produces = MediaType.IMAGE_PNG_VALUE)
+  @AccessControl(skipRBAC = true)
+  @Operation(summary = "Get collector image by id")
+  public ResponseEntity<byte[]> getCollectorImage(@PathVariable String collectorType)
+      throws IOException {
+    Optional<InputStream> fileStream = fileService.getCollectorImage(collectorType);
+    if (fileStream.isPresent()) {
+      return ResponseEntity.ok()
+          .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
+          .body(IOUtils.toByteArray(fileStream.get()));
+    }
+    return ResponseEntity.notFound().build();
   }
 
   @PutMapping({COLLECTOR_URI + "/{collectorId}", TENANT_COLLECTOR_URI + "/{collectorId}"})

--- a/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
@@ -123,14 +123,41 @@ public class CollectorApi extends RestBehavior {
       },
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
-  @Operation(summary = "Get collector image by id")
+  @Operation(summary = "Get collector image by type")
   public ResponseEntity<byte[]> getCollectorImage(@PathVariable String collectorType)
       throws IOException {
     Optional<InputStream> fileStream = fileService.getCollectorImage(collectorType);
     if (fileStream.isPresent()) {
-      return ResponseEntity.ok()
-          .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
-          .body(IOUtils.toByteArray(fileStream.get()));
+      try (InputStream is = fileStream.get()) {
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
+            .body(IOUtils.toByteArray(is));
+      }
+    }
+    return ResponseEntity.notFound().build();
+  }
+
+  @GetMapping(
+      value = {
+        COLLECTOR_URI + "/id/{collectorId}/image",
+        TENANT_COLLECTOR_URI + "/id/{collectorId}/image"
+      },
+      produces = MediaType.IMAGE_PNG_VALUE)
+  @AccessControl(skipRBAC = true)
+  @Operation(summary = "Get collector image by collector id")
+  public ResponseEntity<byte[]> getCollectorImageById(@PathVariable String collectorId)
+      throws IOException {
+    Optional<Collector> collector = collectorRepository.findById(collectorId);
+    if (collector.isEmpty()) {
+      return ResponseEntity.notFound().build();
+    }
+    Optional<InputStream> fileStream = fileService.getCollectorImage(collector.get().getType());
+    if (fileStream.isPresent()) {
+      try (InputStream is = fileStream.get()) {
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
+            .body(IOUtils.toByteArray(is));
+      }
     }
     return ResponseEntity.notFound().build();
   }

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -60,10 +60,6 @@ public class DocumentApi extends RestBehavior {
   private static final String TENANT_DOCUMENT_API = TENANT_PREFIX + "/documents";
   private static final String IMAGES_API = "/api/images";
   private static final String TENANT_IMAGES_API = TENANT_PREFIX + "/images";
-  private static final String INJECTOR_IMAGES_API = IMAGES_API + "/injectors";
-  private static final String TENANT_INJECTOR_IMAGES_API = TENANT_IMAGES_API + "/injectors";
-  private static final String COLLECTOR_IMAGES_API = IMAGES_API + "/collectors";
-  private static final String TENANT_COLLECTOR_IMAGES_API = TENANT_IMAGES_API + "/collectors";
   private static final String SECURITY_PLATFORM_IMAGES_API = IMAGES_API + "/security_platforms";
   private static final String TENANT_SECURITY_PLATFORM_IMAGES_API =
       TENANT_IMAGES_API + "/security_platforms";
@@ -80,7 +76,6 @@ public class DocumentApi extends RestBehavior {
   private final ExerciseRepository exerciseRepository;
   private final ScenarioRepository scenarioRepository;
   private final UserRepository userRepository;
-  private final InjectorRepository injectorRepository;
   private final CollectorRepository collectorRepository;
   private final SecurityPlatformRepository securityPlatformRepository;
 
@@ -311,72 +306,21 @@ public class DocumentApi extends RestBehavior {
         .body(new InputStreamResource(in));
   }
 
-  @GetMapping(
-      value = {
-        INJECTOR_IMAGES_API + "/id/{injectorId}",
-        TENANT_INJECTOR_IMAGES_API + "/id/{injectorId}"
-      },
-      produces = MediaType.IMAGE_PNG_VALUE)
-  @Transactional
-  @AccessControl(skipRBAC = true)
-  public @ResponseBody ResponseEntity<InputStreamResource> getInjectorImageFromId(
-      @PathVariable String injectorId) {
-    Injector injector =
-        this.injectorRepository
-            .findByIdAndTenantId(injectorId, TenantContext.getCurrentTenant())
-            .orElseThrow(() -> new ElementNotFoundException("Injector not found"));
-
-    return fileService
-        .getInjectorImage(injector.getType(), injector.isExternal())
-        .map(
-            inputStream ->
-                ResponseEntity.ok()
-                    .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
-                    .body(new InputStreamResource(inputStream)))
-        .orElse(null);
-  }
-
-  public ResponseEntity<InputStreamResource> downloadCollectorImage(
-      @PathVariable String collectorType) {
-    Collector collector =
-        this.collectorRepository
-            .findByTypeAndTenantId(collectorType, TenantContext.getCurrentTenant())
-            .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
-
-    InputStream in =
+  public void downloadCollectorImage(
+      @PathVariable String collectorType, HttpServletResponse response) throws IOException {
+    response.addHeader(
+        HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + collectorType + ".png");
+    response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE);
+    response.setStatus(HttpServletResponse.SC_OK);
+    try (InputStream fileStream =
         fileService
-            .getCollectorImage(collectorType, collector.isExternal())
+            .getCollectorImage(collectorType)
             .orElseThrow(() -> new ElementNotFoundException("File not found"));
 
     return ResponseEntity.ok()
         .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + collectorType + ".png")
         .contentType(MediaType.IMAGE_PNG)
         .body(new InputStreamResource(in));
-  }
-
-  @GetMapping(
-      value = {
-        COLLECTOR_IMAGES_API + "/id/{collectorId}",
-        TENANT_COLLECTOR_IMAGES_API + "/id/{collectorId}"
-      },
-      produces = MediaType.IMAGE_PNG_VALUE)
-  @Transactional
-  @AccessControl(skipRBAC = true)
-  public @ResponseBody ResponseEntity<InputStreamResource> getCollectorImageFromId(
-      @PathVariable String collectorId) {
-    Collector collector =
-        this.collectorRepository
-            .findById(collectorId)
-            .orElseThrow(() -> new ElementNotFoundException("Collector not found"));
-    Optional<InputStream> fileStream =
-        fileService.getCollectorImage(collector.getType(), collector.isExternal());
-    return fileStream
-        .map(
-            inputStream ->
-                ResponseEntity.ok()
-                    .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
-                    .body(new InputStreamResource(inputStream)))
-        .orElse(null);
   }
 
   @GetMapping(
@@ -441,7 +385,7 @@ public class DocumentApi extends RestBehavior {
   public @ResponseBody ResponseEntity<InputStreamResource> getExecutorIconImage(
       @PathVariable String executorId) {
     return fileService
-        .getExecutorIconImage(executorId, false)
+        .getExecutorIconImage(executorId)
         .map(
             inputStream ->
                 ResponseEntity.ok()
@@ -461,7 +405,7 @@ public class DocumentApi extends RestBehavior {
   public @ResponseBody ResponseEntity<InputStreamResource> getExecutorBannerImage(
       @PathVariable String executorId) {
     return fileService
-        .getExecutorBannerImage(executorId, false)
+        .getExecutorBannerImage(executorId)
         .map(
             inputStream ->
                 ResponseEntity.ok()

--- a/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/document/DocumentApi.java
@@ -306,13 +306,9 @@ public class DocumentApi extends RestBehavior {
         .body(new InputStreamResource(in));
   }
 
-  public void downloadCollectorImage(
-      @PathVariable String collectorType, HttpServletResponse response) throws IOException {
-    response.addHeader(
-        HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + collectorType + ".png");
-    response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE);
-    response.setStatus(HttpServletResponse.SC_OK);
-    try (InputStream fileStream =
+  public ResponseEntity<InputStreamResource> downloadCollectorImage(
+      @PathVariable String collectorType) {
+    InputStream in =
         fileService
             .getCollectorImage(collectorType)
             .orElseThrow(() -> new ElementNotFoundException("File not found"));

--- a/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
@@ -21,6 +21,7 @@ import io.openaev.rest.injector.form.InjectorCreateInput;
 import io.openaev.rest.injector.form.InjectorOutput;
 import io.openaev.rest.injector.form.InjectorUpdateInput;
 import io.openaev.rest.injector.response.InjectorRegistration;
+import io.openaev.service.FileService;
 import io.openaev.service.InjectorService;
 import io.openaev.utils.AgentUtils;
 import io.openaev.utils.FilterUtilsJpa;
@@ -35,11 +36,14 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -59,6 +63,7 @@ public class InjectorApi extends RestBehavior {
   private final InjectorContractRepository injectorContractRepository;
   private final InjectStatusService injectStatusService;
   private final InjectorService injectorService;
+  private final FileService fileService;
 
   @Value("${info.app.version:unknown}")
   String version;
@@ -166,6 +171,27 @@ public class InjectorApi extends RestBehavior {
   @Transactional
   public ConnectorIds getInjectorRelatedIds(@PathVariable String injectorId) {
     return injectorService.getInjectorRelationsId(injectorId);
+  }
+
+  // -- IMAGE --
+
+  @GetMapping(
+      value = {
+        INJECT0R_URI + "/{injectorType}/image",
+        TENANT_INJECTOR_URI + "/{injectorType}/image"
+      },
+      produces = MediaType.IMAGE_PNG_VALUE)
+  @AccessControl(skipRBAC = true)
+  @Operation(summary = "Get injector image by id")
+  public ResponseEntity<byte[]> getInjectorImage(@PathVariable String injectorType)
+      throws IOException {
+    Optional<InputStream> fileStream = fileService.getInjectorImage(injectorType);
+    if (fileStream.isPresent()) {
+      return ResponseEntity.ok()
+          .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
+          .body(IOUtils.toByteArray(fileStream.get()));
+    }
+    return ResponseEntity.notFound().build();
   }
 
   @PostMapping(

--- a/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
@@ -182,14 +182,16 @@ public class InjectorApi extends RestBehavior {
       },
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
-  @Operation(summary = "Get injector image by id")
+  @Operation(summary = "Get injector image by type")
   public ResponseEntity<byte[]> getInjectorImage(@PathVariable String injectorType)
       throws IOException {
     Optional<InputStream> fileStream = fileService.getInjectorImage(injectorType);
     if (fileStream.isPresent()) {
-      return ResponseEntity.ok()
-          .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
-          .body(IOUtils.toByteArray(fileStream.get()));
+      try (InputStream is = fileStream.get()) {
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES))
+            .body(IOUtils.toByteArray(is));
+      }
     }
     return ResponseEntity.notFound().build();
   }

--- a/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
@@ -183,6 +183,7 @@ public class InjectorApi extends RestBehavior {
       produces = MediaType.IMAGE_PNG_VALUE)
   @AccessControl(skipRBAC = true)
   @Operation(summary = "Get injector image by type")
+  @Transactional
   public ResponseEntity<byte[]> getInjectorImage(@PathVariable String injectorType)
       throws IOException {
     Optional<InputStream> fileStream = fileService.getInjectorImage(injectorType);

--- a/openaev-api/src/main/java/io/openaev/service/catalog_connectors/CatalogConnectorIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/catalog_connectors/CatalogConnectorIngestionService.java
@@ -297,7 +297,7 @@ public class CatalogConnectorIngestionService {
 
       String fileName = connectorSlug + "-logo.png";
 
-      fileService.uploadStream(FileService.CONNECTORS_LOGO_PATH, fileName, dataStream);
+      fileService.uploadCatalogLogo(FileService.CONNECTORS_LOGO_PATH, fileName, dataStream);
 
       return fileName;
     } catch (Exception e) {

--- a/openaev-api/src/main/resources/catalog/catalog-integrators.json
+++ b/openaev-api/src/main/resources/catalog/catalog-integrators.json
@@ -71,11 +71,6 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "crowdstrike/img/icon-crowdstrike.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
-                    },
                     "COLLECTOR_PLATFORM": {
                         "default": "EDR",
                         "description": "Platform type for the collector (e.g., EDR, SIEM, etc.).",
@@ -182,11 +177,6 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "microsoft_entra/img/icon-microsoft-entra.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
-                    },
                     "COLLECTOR_MICROSOFT_ENTRA_TENANT_ID": {
                         "description": "Azure Active Directory tenant ID for Microsoft Entra.",
                         "type": "string"
@@ -284,11 +274,6 @@
                         "default": "PT1H",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "microsoft_intune/img/icon-microsoft-intune.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "COLLECTOR_MICROSOFT_INTUNE_TENANT_ID": {
@@ -395,11 +380,6 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "microsoft_defender/img/icon-microsoft-defender.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
-                    },
                     "COLLECTOR_PLATFORM": {
                         "default": "EDR",
                         "description": "Platform type for the collector (e.g., EDR, SIEM, etc.).",
@@ -495,11 +475,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "microsoft_azure/img/icon-microsoft-azure.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "COLLECTOR_MICROSOFT_AZURE_TENANT_ID": {
@@ -604,11 +579,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "microsoft_sentinel/img/icon-microsoft-sentinel.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "COLLECTOR_PLATFORM": {
@@ -729,11 +699,6 @@
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
                         "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "atomic_red_team/img/icon-atomic-red-team.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
                     }
                 },
                 "required": [
@@ -810,11 +775,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "tanium_threat_response/img/icon-tanium.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "COLLECTOR_PLATFORM": {
@@ -921,11 +881,6 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "nvd_nist_cve/img/icon-nist.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
-                    },
                     "NVDNISTCVE_API_KEY": {
                         "default": "",
                         "description": "The NVD API key.",
@@ -1019,11 +974,6 @@
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
                         "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "mitre_attack/img/icon-mitre-attack.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
                     }
                 },
                 "required": [
@@ -1109,11 +1059,6 @@
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
                         "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "openaev/img/icon-openaev.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
                     }
                 },
                 "required": [
@@ -1191,11 +1136,6 @@
                         "default": "PT1H",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "google_workspace/img/icon-google-workspace.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "COLLECTOR_GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON": {
@@ -1299,11 +1239,6 @@
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
                         "type": "string"
-                    },
-                    "INJECTOR_ICON_FILEPATH": {
-                        "default": "nmap/img/nmap.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
                     }
                 },
                 "required": [
@@ -1380,11 +1315,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "INJECTOR_ICON_FILEPATH": {
-                        "default": "nuclei/img/nuclei.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "INJECTOR_EXTERNAL_CONTRACTS_MAINTENANCE_SCHEDULE_SECONDS": {
@@ -1468,11 +1398,6 @@
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
                         "type": "string"
-                    },
-                    "INJECTOR_ICON_FILEPATH": {
-                        "default": "http-query/img/icon-http.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
                     }
                 },
                 "required": [
@@ -1549,11 +1474,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "INJECTOR_ICON_FILEPATH": {
-                        "default": "aws/img/icon-aws.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     }
                 },
@@ -1637,11 +1557,6 @@
                         "default": "PT2M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "src/img/sentinelone-logo.png",
-                        "description": "Path to the icon file of the collector.",
                         "type": "string"
                     },
                     "SENTINELONE_BASE_URL": {
@@ -1757,11 +1672,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "src/img/splunk-logo.png",
-                        "description": "Path to the icon file of the collector.",
                         "type": "string"
                     },
                     "SPLUNK_ES_BASE_URL": {
@@ -1885,11 +1795,6 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "aws_resources/img/icon-aws-resources.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
-                    },
                     "COLLECTOR_AWS_ACCESS_KEY_ID": {
                         "description": "AWS Access Key ID",
                         "type": "string"
@@ -1989,11 +1894,6 @@
                         "default": "PT1M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "INJECTOR_ICON_FILEPATH": {
-                        "default": "shodan/img/icon-shodan.png",
-                        "description": "Path to the icon file",
                         "type": "string"
                     },
                     "SHODAN_BASE_URL": {
@@ -2103,11 +2003,6 @@
                         "format": "duration",
                         "type": "string"
                     },
-                    "INJECTOR_ICON_FILEPATH": {
-                        "default": "teams/img/icon-teams.png",
-                        "description": "Path to the icon file",
-                        "type": "string"
-                    },
                     "INJECTOR_TYPE": {
                         "default": "openaev_teams",
                         "description": "Type of the injector.",
@@ -2194,11 +2089,6 @@
                         "default": "PT2M",
                         "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
                         "format": "duration",
-                        "type": "string"
-                    },
-                    "COLLECTOR_ICON_FILEPATH": {
-                        "default": "src/img/palo-alto-cortex-xdr-logo.png",
-                        "description": "Path to the icon file of the collector.",
                         "type": "string"
                     },
                     "PALO_ALTO_CORTEX_XDR_FQDN": {

--- a/openaev-api/src/test/java/io/openaev/integration/local_fixtures/factory_throws/TestIntegrationFactoryInitThrows.java
+++ b/openaev-api/src/test/java/io/openaev/integration/local_fixtures/factory_throws/TestIntegrationFactoryInitThrows.java
@@ -54,7 +54,7 @@ public class TestIntegrationFactoryInitThrows extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(getClassName());
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-default.png"));

--- a/openaev-api/src/test/java/io/openaev/integration/local_fixtures/regular/TestIntegrationFactory.java
+++ b/openaev-api/src/test/java/io/openaev/integration/local_fixtures/regular/TestIntegrationFactory.java
@@ -53,7 +53,7 @@ public class TestIntegrationFactory extends IntegrationFactory {
   @Override
   protected void insertCatalogEntry() throws Exception {
     String logoFilename = "%s-logo.png".formatted(getClassName());
-    fileService.uploadStream(
+    fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
         logoFilename,
         getClass().getResourceAsStream("/img/icon-default.png"));

--- a/openaev-api/src/test/java/io/openaev/rest/CatalogConnectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/CatalogConnectorApiTest.java
@@ -9,13 +9,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openaev.IntegrationTest;
-import io.openaev.context.TenantContext;
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.CatalogConnector;
 import io.openaev.database.model.CatalogConnectorConfiguration;
-import io.openaev.database.model.Tenant;
 import io.openaev.service.FileService;
-import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.ConnectorInstanceFixture;
 import io.openaev.utils.fixtures.composers.CatalogConnectorComposer;
 import io.openaev.utils.fixtures.composers.CatalogConnectorConfigurationComposer;
@@ -41,7 +38,6 @@ public class CatalogConnectorApiTest extends IntegrationTest {
   @Autowired private CatalogConnectorComposer catalogConnectorComposer;
   @Autowired private ConnectorInstanceComposer connectorInstanceComposer;
   @Autowired private CatalogConnectorConfigurationComposer catalogConfigurationComposer;
-  @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
   @Autowired private FileService fileService;
 
   @Test
@@ -138,25 +134,15 @@ public class CatalogConnectorApiTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("Given non-default tenant should retrieve catalog logo from default tenant storage")
-  void given_nonDefaultTenant_should_retrieveCatalogLogoFromDefaultTenantStorage()
-      throws Exception {
+  @DisplayName(
+      "Given catalog logo uploaded to platform storage should be retrievable without tenant context")
+  void given_catalogLogoUploadedToPlatformStorage_should_beRetrievable() throws Exception {
     // Arrange
-    String fileName = "tenant-fallback-logo.png";
-    TenantContext.setCurrentTenant(Tenant.DEFAULT_TENANT_UUID);
-    try {
-      fileService.uploadStream(
-          FileService.CONNECTORS_LOGO_PATH,
-          fileName,
-          new ByteArrayInputStream(new byte[] {1, 2, 3}));
-    } finally {
-      TenantContext.clearCurrentTenant();
-    }
-    Tenant tenant = tenantIsolationTestHelper.createTenantWithCurrentUser("logo-fallback");
+    String fileName = "platform-logo.png";
+    fileService.uploadCatalogLogo(
+        FileService.CONNECTORS_LOGO_PATH, fileName, new ByteArrayInputStream(new byte[] {1, 2, 3}));
 
     // Act / Assert
-    mvc.perform(
-            get("/api/tenants/" + tenant.getId() + "/images/catalog/connectors/logos/" + fileName))
-        .andExpect(status().isOk());
+    mvc.perform(get("/api/images/catalog/connectors/logos/" + fileName)).andExpect(status().isOk());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/CollectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/CollectorApiTest.java
@@ -20,6 +20,7 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.CollectorRepository;
 import io.openaev.rest.collector.form.CollectorCreateInput;
+import io.openaev.service.FileService;
 import io.openaev.utils.fixtures.CollectorFixture;
 import io.openaev.utils.fixtures.SecurityPlatformFixture;
 import io.openaev.utils.fixtures.composers.*;
@@ -43,6 +44,7 @@ public class CollectorApiTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
 
   @Autowired private CollectorRepository collectorRepository;
+  @Autowired private FileService fileService;
 
   @Autowired private CatalogConnectorComposer catalogConnectorComposer;
   @Autowired private CollectorComposer collectorComposer;
@@ -413,6 +415,53 @@ public class CollectorApiTest extends IntegrationTest {
           collectorRepository.findByIdAndTenantId(input.getId(), TenantContext.getCurrentTenant());
       assertThat(persisted).isPresent();
       assertThat(persisted.get().getSecurityPlatform()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("Collector image")
+  class CollectorImage {
+    @Test
+    @DisplayName("Given existing collector image should return image by type")
+    void given_existingCollectorImage_should_returnImageByType() throws Exception {
+      // -- Arrange --
+      String collectorType = "test-collector-type";
+      fileService.uploadStream(
+          FileService.COLLECTORS_IMAGES_BASE_PATH,
+          collectorType + FileService.EXT_PNG,
+          new java.io.ByteArrayInputStream(new byte[] {1, 2, 3}));
+
+      // -- Act / Assert --
+      mvc.perform(get(COLLECTOR_URI + "/" + collectorType + "/image")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Given existing collector image should return image by id")
+    void given_existingCollectorImage_should_returnImageById() throws Exception {
+      // -- Arrange --
+      Collector collector = getCollector("test-collector-by-id");
+      fileService.uploadStream(
+          FileService.COLLECTORS_IMAGES_BASE_PATH,
+          collector.getType() + FileService.EXT_PNG,
+          new java.io.ByteArrayInputStream(new byte[] {1, 2, 3}));
+
+      // -- Act / Assert --
+      mvc.perform(get(COLLECTOR_URI + "/id/" + collector.getId() + "/image"))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Given missing collector image should return 404")
+    void given_missingCollectorImage_should_return404() throws Exception {
+      // -- Act / Assert --
+      mvc.perform(get(COLLECTOR_URI + "/nonexistent-type/image")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Given unknown collector id should return 404")
+    void given_unknownCollectorId_should_return404() throws Exception {
+      // -- Act / Assert --
+      mvc.perform(get(COLLECTOR_URI + "/id/nonexistent-id/image")).andExpect(status().isNotFound());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/InjectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/InjectorApiTest.java
@@ -26,6 +26,7 @@ import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
 import io.openaev.rest.injector.form.InjectorCreateInput;
 import io.openaev.rest.injector_contract.form.InjectorContractInput;
+import io.openaev.service.FileService;
 import io.openaev.utils.AgentUtils;
 import io.openaev.utils.HashUtils;
 import io.openaev.utils.TenantIsolationTestHelper;
@@ -65,6 +66,7 @@ public class InjectorApiTest extends IntegrationTest {
   @Autowired private InjectRepository injectRepository;
   @Autowired private EntityManager em;
   @Autowired private TenantIsolationTestHelper tenantHelper;
+  @Autowired private FileService fileService;
 
   @Autowired private InjectComposer injectComposer;
   @Autowired private EndpointComposer endpointComposer;
@@ -640,6 +642,31 @@ public class InjectorApiTest extends IntegrationTest {
       assertThat(reloadedInject.getInjector().getTenant().getId())
           .as("Injector should belong to tenant A")
           .isEqualTo(tenantA);
+    }
+  }
+
+  @Nested
+  @DisplayName("Injector image")
+  class InjectorImage {
+    @Test
+    @DisplayName("Given existing injector image should return image")
+    void given_existingInjectorImage_should_returnImage() throws Exception {
+      // -- Arrange --
+      String injectorType = "test-injector-type";
+      fileService.uploadStream(
+          FileService.INJECTORS_IMAGES_BASE_PATH,
+          injectorType + FileService.EXT_PNG,
+          new java.io.ByteArrayInputStream(new byte[] {1, 2, 3}));
+
+      // -- Act / Assert --
+      mvc.perform(get(INJECT0R_URI + "/" + injectorType + "/image")).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Given missing injector image should return 404")
+    void given_missingInjectorImage_should_return404() throws Exception {
+      // -- Act / Assert --
+      mvc.perform(get(INJECT0R_URI + "/nonexistent-type/image")).andExpect(status().isNotFound());
     }
   }
 }

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTestingRemediations.tsx
@@ -223,7 +223,7 @@ const AtomicTestingRemediations = () => {
                         label={(
                           <Box display="flex" alignItems="center">
                             <img
-                              src={buildTenantApiPath(`/api/images/collectors/id/${tab.collector_id}`)}
+                              src={buildTenantApiPath(`/api/collectors/${tab.collector_type}/image`)}
                               alt={tab.collector_type}
                               style={{
                                 width: 20,

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -51,7 +51,7 @@ const InjectExpectationResultList = ({
       return (
         <img
           src={expectationResult.sourceType === 'collector'
-            ? buildTenantApiPath(`/api/images/collectors/id/${expectationResult.sourceId}`)
+            ? buildTenantApiPath(`/api/collectors/${expectationResult.sourceId}/image`)
             : buildTenantApiPath(`/api/images/security_platforms/id/${expectationResult.sourceId}/${theme.palette.mode}`)}
           alt={expectationResult.sourceId}
           style={{

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -51,7 +51,7 @@ const InjectExpectationResultList = ({
       return (
         <img
           src={expectationResult.sourceType === 'collector'
-            ? buildTenantApiPath(`/api/collectors/${expectationResult.sourceId}/image`)
+            ? buildTenantApiPath(`/api/collectors/id/${expectationResult.sourceId}/image`)
             : buildTenantApiPath(`/api/images/security_platforms/id/${expectationResult.sourceId}/${theme.palette.mode}`)}
           alt={expectationResult.sourceId}
           style={{

--- a/openaev-front/src/admin/components/common/collectors/CollectorIcon.tsx
+++ b/openaev-front/src/admin/components/common/collectors/CollectorIcon.tsx
@@ -1,0 +1,22 @@
+import { type CSSProperties } from 'react';
+
+import { buildTenantApiPath } from '../../../../utils/url-helper';
+
+interface Props {
+  type: string;
+  style: CSSProperties;
+  onClick?: () => void;
+}
+
+const CollectorIcon = ({ type, style, onClick }: Props) => {
+  return (
+    <img
+      src={buildTenantApiPath(`/api/collectors/${type}/image`)}
+      onClick={onClick}
+      alt={type}
+      style={style}
+    />
+  );
+};
+
+export default CollectorIcon;

--- a/openaev-front/src/admin/components/common/injectors/InjectorIcon.tsx
+++ b/openaev-front/src/admin/components/common/injectors/InjectorIcon.tsx
@@ -1,0 +1,22 @@
+import { type CSSProperties } from 'react';
+
+import { buildTenantApiPath } from '../../../../utils/url-helper';
+
+interface Props {
+  type: string;
+  style: CSSProperties;
+  onClick?: () => void;
+}
+
+const InjectorIcon = ({ type, style, onClick }: Props) => {
+  return (
+    <img
+      src={buildTenantApiPath(`/api/injectors/${type}/image`)}
+      onClick={onClick}
+      alt={type}
+      style={style}
+    />
+  );
+};
+
+export default InjectorIcon;

--- a/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
+++ b/openaev-front/src/admin/components/common/injects/InjectIcon.tsx
@@ -3,13 +3,10 @@ import { useTheme } from '@mui/material/styles';
 import { ApplicationCogOutline, Console, FileImportOutline, LanConnect } from 'mdi-material-ui';
 import { type FunctionComponent } from 'react';
 
-import { type CollectorHelper } from '../../../../actions/collectors/collector-helper';
-import { type InjectorHelper } from '../../../../actions/injectors/injector-helper';
 import CustomTooltip from '../../../../components/CustomTooltip';
 import { useFormatter } from '../../../../components/i18n';
-import { useHelper } from '../../../../store';
-import { type Collector, type Injector } from '../../../../utils/api-types';
-import { buildTenantApiPath } from '../../../../utils/url-helper';
+import CollectorIcon from '../collectors/CollectorIcon';
+import InjectorIcon from '../injectors/InjectorIcon';
 
 interface Props {
   type: string | undefined;
@@ -37,18 +34,6 @@ const InjectIcon: FunctionComponent<Props> = ({
   const theme = useTheme();
   const fontSize = size || 'medium';
 
-  const { injectors } = useHelper((helper: InjectorHelper) => ({ injectors: helper.getInjectorsIncludingPending() }));
-
-  const { collectors } = useHelper((helper: CollectorHelper) => ({ collectors: helper.getCollectorsIncludingPending() }));
-
-  const resolvedInjectorId = (injectors as Injector[])?.find(
-    (inj: Injector) => inj.injector_type === type,
-  )?.injector_id;
-
-  const resolvedCollectorId = (collectors as Collector[])?.find(
-    (c: Collector) => c.collector_type === type,
-  )?.collector_id;
-
   const iconSelector = (type: string, isPayload: boolean, variant: string, fontSize: string, done: boolean, disabled: boolean) => {
     const style = {
       marginTop: variant === 'list' ? theme.spacing(0.5) : 0,
@@ -66,14 +51,7 @@ const InjectIcon: FunctionComponent<Props> = ({
     }
     if (isPayload) {
       if (type.startsWith('openaev_')) {
-        return (
-          <img
-            onClick={onClick}
-            src={resolvedCollectorId ? buildTenantApiPath(`/api/images/collectors/id/${resolvedCollectorId}`) : undefined}
-            alt={type}
-            style={style}
-          />
-        );
+        return (<CollectorIcon type={type} style={style} onClick={onClick} />);
       }
       switch (type) {
         case 'Command':
@@ -90,14 +68,7 @@ const InjectIcon: FunctionComponent<Props> = ({
           return <HelpOutlineOutlined color="primary" onClick={onClick} style={style} />;
       }
     }
-    return (
-      <img
-        src={resolvedInjectorId ? buildTenantApiPath(`/api/images/injectors/id/${resolvedInjectorId}`) : undefined}
-        onClick={onClick}
-        alt={type}
-        style={style}
-      />
-    );
+    return (<InjectorIcon type={type} style={style} onClick={onClick} />);
   };
 
   return (

--- a/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
+++ b/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
@@ -5,7 +5,6 @@ import { useOutletContext } from 'react-router';
 
 import { useFormatter } from '../../../../components/i18n';
 import { type CatalogConnectorOutput } from '../../../../utils/api-types';
-import { buildTenantApiPath } from '../../../../utils/url-helper';
 import ConnectorCard from '../common/ConnectorCard';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import CatalogFilters from './CatalogFilters';

--- a/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
+++ b/openaev-front/src/admin/components/integrations/catalog_connectors/Catalog.tsx
@@ -49,7 +49,7 @@ const Catalog = () => {
                   connectorName: connector.catalog_connector_title,
                   connectorType: connector.catalog_connector_type,
                   connectorLogoName: `connector-logo-${connector.catalog_connector_id}`,
-                  connectorLogoUrl: buildTenantApiPath(`/api/images/catalog/connectors/logos/${connector.catalog_connector_logo_url}`),
+                  connectorLogoUrl: `/api/images/catalog/connectors/logos/${connector.catalog_connector_logo_url}`,
                   connectorDescription: connector.catalog_connector_short_description,
                   isExternal: connector.catalog_connector_manager_supported,
                   isVerified: true,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorContext.ts
@@ -56,7 +56,7 @@ export const injectorConfig: ConnectorContextType<InjectorOutput> = {
     list: '/admin/integrations/injectors',
     detail: (id: string) => `/admin/integrations/injectors/${id}`,
   },
-  logoUrl: (injectorId: string) => buildTenantApiPath(`/api/images/injectors/id/${injectorId}`),
+  logoUrl: (type: string) => buildTenantApiPath(`/api/injectors/${type}/image`),
   normalizeSingle: data => ({
     id: data?.injector_id,
     name: data?.injector_name,
@@ -77,7 +77,7 @@ export const collectorConfig: ConnectorContextType<CollectorOutput & Collector> 
     fetchSingle: (id: string) => fetchCollector(id),
     getRelatedIds: (id: string) => fetchCollectorRelatedIds(id),
   },
-  logoUrl: (injectorId: string) => buildTenantApiPath(`/api/images/collectors/id/${injectorId}`),
+  logoUrl: (type: string) => buildTenantApiPath(`/api/collectors/${type}/image`),
   normalizeSingle: data => ({
     id: data?.collector_id,
     name: data?.collector_name,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorDetails.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorDetails.tsx
@@ -5,7 +5,6 @@ import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { buildTenantApiPath } from '../../../../utils/url-helper';
 import { type CatalogContextType } from '../catalog_connectors/CatalogLayout';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import ConnectorCatalogInfo from './ConnectorCatalogInfo';
@@ -34,7 +33,7 @@ const ConnectorDetails = () => {
           connectorName: catalogConnector.catalog_connector_title,
           connectorType: catalogConnector.catalog_connector_type,
           connectorLogoName: `connector-logo-${catalogConnector.catalog_connector_id}`,
-          connectorLogoUrl: buildTenantApiPath(`/api/images/catalog/connectors/logos/${catalogConnector.catalog_connector_logo_url}`),
+          connectorLogoUrl: `/api/images/catalog/connectors/logos/${catalogConnector.catalog_connector_logo_url}`,
           connectorDescription: catalogConnector.catalog_connector_short_description,
           isExternal: catalogConnector.catalog_connector_manager_supported,
           isVerified: true,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorList.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorList.tsx
@@ -22,7 +22,6 @@ import type {
 import { useAppDispatch } from '../../../../utils/hooks';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import useSearchAndFilter from '../../../../utils/SortingFiltering';
-import { buildTenantApiPath } from '../../../../utils/url-helper';
 import ConnectorCard from '../common/ConnectorCard';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import { ConnectorContext, type ConnectorOutput } from './ConnectorContext';
@@ -105,8 +104,6 @@ const ConnectorList = () => {
       <div className="clearfix" />
       <Grid container={true} spacing={3} style={{ marginTop: theme.spacing(2) }}>
         {sortedConnectors.map((connector: ConnectorOutput) => {
-          // Executors store images by type (not UUID); injectors/collectors use UUID.
-          const logoKey = connectorType === 'executor' ? (connector.type ?? '') : (connector.id ?? '');
           return (
             <Grid key={connector.id} size={{ xs: 4 }}>
               <ConnectorCard
@@ -114,7 +111,7 @@ const ConnectorList = () => {
                   connectorName: connector.name,
                   connectorType: connectorType.toUpperCase() as CatalogConnector['catalog_connector_type'],
                   connectorLogoName: connector.type,
-                  connectorLogoUrl: connector?.isExisting ? logoUrl(logoKey) : (connector.catalog?.catalog_connector_logo_url && buildTenantApiPath(`/api/images/catalog/connectors/logos/${connector.catalog?.catalog_connector_logo_url}`)),
+                  connectorLogoUrl: connector?.isExisting ? logoUrl(connector.type) : (connector.catalog?.catalog_connector_logo_url && `/api/images/catalog/connectors/logos/${connector.catalog?.catalog_connector_logo_url}`),
                   connectorDescription: connector.catalog?.catalog_connector_short_description,
                   lastUpdatedAt: connector.updatedAt,
                   isVerified: connector.isVerified,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -8,7 +8,6 @@ import { useFormatter } from '../../../../components/i18n';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
-import { buildTenantApiPath } from '../../../../utils/url-helper';
 import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnectorInstanceDrawer';
 import ConnectorAlerts from './ConnectorAlerts';
 import ConnectorCatalogInfo from './ConnectorCatalogInfo';
@@ -23,11 +22,8 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
   const { connector, instance, catalogConnector, isXtmComposerUp, refreshConnector } = useOutletContext<ConnectorContextLayoutType>();
   const { isValidated: isEnterpriseEdition } = useEnterpriseEdition();
   const ability = useContext(AbilityContext);
-  const { logoUrl, connectorType } = useContext(ConnectorContext);
+  const { logoUrl } = useContext(ConnectorContext);
   const createInstanceDrawer = useDialog();
-
-  // Executors store images by type (not UUID); injectors/collectors use UUID.
-  const connectorLogoKey = connectorType === 'executor' ? (connector?.type ?? '') : (connector?.id ?? '');
 
   const onCloseCreateInstanceDrawer = () => {
     createInstanceDrawer.handleClose();
@@ -65,10 +61,9 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
           connectorName: connector?.name || catalogConnector?.catalog_connector_title,
           connectorType: catalogConnector?.catalog_connector_type,
           connectorLogoName: connector?.type || catalogConnector?.catalog_connector_slug,
-          // Executors store images by type (not UUID); injectors/collectors use UUID.
           connectorLogoUrl: instance
-            ? buildTenantApiPath(`/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}`)
-            : logoUrl(connectorLogoKey),
+            ? `/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}`
+            : logoUrl(connector?.type),
           connectorDescription: catalogConnector?.catalog_connector_description,
           isExternal: catalogConnector?.catalog_connector_manager_supported,
           isVerified: instance != null,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -63,7 +63,7 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
           connectorLogoName: connector?.type || catalogConnector?.catalog_connector_slug,
           connectorLogoUrl: instance
             ? `/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}`
-            : logoUrl(connector?.type),
+            : connector?.type ? logoUrl(connector.type) : undefined,
           connectorDescription: catalogConnector?.catalog_connector_description,
           isExternal: catalogConnector?.catalog_connector_manager_supported,
           isVerified: instance != null,

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -48,6 +48,11 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
 
   const { currentTab, handleChangeTab } = useTabs(tabEntries[0].key);
 
+  const legacyConnectorLogoUrl = connector?.type ? logoUrl(connector.type) : undefined;
+  const connectorLogoUrl = instance
+    ? `/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}`
+    : legacyConnectorLogoUrl;
+
   return (
     <>
       <ConnectorAlerts
@@ -61,9 +66,7 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
           connectorName: connector?.name || catalogConnector?.catalog_connector_title,
           connectorType: catalogConnector?.catalog_connector_type,
           connectorLogoName: connector?.type || catalogConnector?.catalog_connector_slug,
-          connectorLogoUrl: instance
-            ? `/api/images/catalog/connectors/logos/${catalogConnector?.catalog_connector_logo_url}`
-            : connector?.type ? logoUrl(connector.type) : undefined,
+          connectorLogoUrl,
           connectorDescription: catalogConnector?.catalog_connector_description,
           isExternal: catalogConnector?.catalog_connector_manager_supported,
           isVerified: instance != null,

--- a/openaev-front/src/admin/components/threat_arsenal/form/RemediationFormTabs.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/form/RemediationFormTabs.tsx
@@ -87,7 +87,7 @@ const RemediationFormTabs = ({ actionId }: RemediationFormTabsProps) => {
                         label={(
                           <Box display="flex" alignItems="center">
                             <img
-                              src={buildTenantApiPath(`/api/images/collectors/id/${tab.collector_id}`)}
+                              src={buildTenantApiPath(`/api/collectors/${tab.collector_type}/image`)}
                               alt={tab.collector_type}
                               style={{
                                 width: 20,

--- a/openaev-front/src/root.tsx
+++ b/openaev-front/src/root.tsx
@@ -4,9 +4,7 @@ import { lazy, Suspense, useEffect, useMemo } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 
 import { fetchMe, fetchPlatformParameters } from './actions/Application';
-import { fetchCollectors } from './actions/Collector';
 import { type LoggedHelper } from './actions/helper';
-import { fetchInjectors } from './actions/injectors/injector-action';
 import fetchPublicPlatformParameters from './actions/settings/platform-settings-action';
 import { fetchTenantSettings } from './actions/settings/tenant-settings-action';
 import EnterpriseEditionAgreementDialog from './admin/components/common/entreprise_edition/EnterpriseEditionAgreementDialog';
@@ -65,13 +63,6 @@ const Root = () => {
     if (logged && me) {
       dispatch(fetchPlatformParameters());
       dispatch(fetchTenantSettings());
-      // Only fetch tenant-scoped data once the URL contains a valid tenant segment.
-      // Without this guard, buildTenantApiPath() falls back to DEFAULT_TENANT_UUID
-      // and populates the store with IDs from the wrong tenant.
-      if (extractTenantFromUrl()) {
-        dispatch(fetchInjectors());
-        dispatch(fetchCollectors());
-      }
     } else if (logged === null) {
       dispatch(fetchPublicPlatformParameters());
     }

--- a/openaev-front/src/utils/url-helper.ts
+++ b/openaev-front/src/utils/url-helper.ts
@@ -154,6 +154,7 @@ const TENANT_EXEMPT_PREFIXES = [
   '/api/xtm-composer',
   '/api/schemas',
   '/api/engine',
+  '/api/catalog-connector',
 ];
 
 /**

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -79,6 +79,23 @@ public class FileService {
   }
 
   /**
+   * Uploads a catalog asset (e.g. connector logo) to the platform-level MinIO path, shared across
+   * all tenants. Use this instead of {@link #uploadStream} for catalog logos written by {@code
+   * insertCatalogEntry()} or the catalog ingestion service.
+   *
+   * @param path the directory path within the platform space
+   * @param name the filename
+   * @param data the input stream containing the file data
+   * @return the full platform path of the uploaded file
+   * @throws Exception if the upload fails
+   */
+  public String uploadCatalogLogo(String path, String name, InputStream data) throws Exception {
+    String file = path.endsWith("/") ? path + name : path + "/" + name;
+    minioService.uploadStreamInPlatformPath(file, name, data);
+    return file;
+  }
+
+  /**
    * Deletes a file from MinIO.
    *
    * @param name the file path/name to delete
@@ -136,36 +153,30 @@ public class FileService {
    * Retrieves an injector's image file.
    *
    * @param injectType the injector type identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
-   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getInjectorImage(String injectType, boolean isExternal) {
-    return getPlatformImage(INJECTORS_IMAGES_BASE_PATH + injectType + EXT_PNG, isExternal);
+  public Optional<InputStream> getInjectorImage(String injectType) {
+    return getPlatformImage(INJECTORS_IMAGES_BASE_PATH + injectType + EXT_PNG);
   }
 
   /**
    * Retrieves a collector's image file.
    *
    * @param collectorId the collector identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
-   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getCollectorImage(String collectorId, boolean isExternal) {
-    return getPlatformImage(COLLECTORS_IMAGES_BASE_PATH + collectorId + EXT_PNG, isExternal);
+  public Optional<InputStream> getCollectorImage(String collectorId) {
+    return getPlatformImage(COLLECTORS_IMAGES_BASE_PATH + collectorId + EXT_PNG);
   }
 
   /**
    * Retrieves an executor's icon image file.
    *
    * @param executorId the executor identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
-   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getExecutorIconImage(String executorId, boolean isExternal) {
-    return getPlatformImage(EXECUTORS_IMAGES_ICONS_BASE_PATH + executorId + EXT_PNG, isExternal);
+  public Optional<InputStream> getExecutorIconImage(String executorId) {
+    return getPlatformImage(EXECUTORS_IMAGES_ICONS_BASE_PATH + executorId + EXT_PNG);
   }
 
   /**
@@ -176,20 +187,34 @@ public class FileService {
    *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getExecutorBannerImage(String executorId, boolean isExternal) {
-    return getPlatformImage(EXECUTORS_IMAGES_BANNERS_BASE_PATH + executorId + EXT_PNG, isExternal);
+  public Optional<InputStream> getExecutorBannerImage(String executorId) {
+    return getPlatformImage(EXECUTORS_IMAGES_BANNERS_BASE_PATH + executorId + EXT_PNG);
   }
 
   /**
-   * Retrieves a catalog connector's logo image file.
+   * Retrieves a catalog connector's logo image file from the platform-level MinIO path.
+   *
+   * <p>Falls back to the legacy tenant-scoped paths for instances deployed before the migration to
+   * platform-level storage:
+   *
+   * <ul>
+   *   <li>{@code platform/connectors/logos/{fileName}} — current path (bucket root)
+   *   <li>{@code {DEFAULT_TENANT_UUID}/platform/connectors/logos/{fileName}} — legacy path
+   * </ul>
    *
    * @param fileName the logo filename
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
-   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
-  public Optional<InputStream> getCatalogConnectorImage(String fileName, boolean isExternal) {
-    return getPlatformImage(CONNECTORS_LOGO_PATH + fileName, isExternal);
+  public Optional<InputStream> getCatalogConnectorImage(String fileName) {
+    Optional<InputStream> platform =
+        minioService.getFilePathInPlatform(CONNECTORS_LOGO_PATH + fileName);
+    if (platform.isPresent()) {
+      return platform;
+    }
+    // Fallback: legacy path before platform storage migration
+    // (files were stored as {DEFAULT_TENANT_UUID}/platform/connectors/logos/{fileName})
+    return minioService.getFilePathForTenant(
+        Tenant.DEFAULT_TENANT_UUID, "platform" + CONNECTORS_LOGO_PATH + fileName);
   }
 
   /**
@@ -197,17 +222,14 @@ public class FileService {
    * should fall back to specific tenant if isExternal is true.
    *
    * @param filePath to retrieve
-   * @param isExternal indicates if the file is a built-in asset (false) or from an external asset
-   *     (true)
    * @return finded file
    */
-  private Optional<InputStream> getPlatformImage(String filePath, boolean isExternal) {
+  private Optional<InputStream> getPlatformImage(String filePath) {
     Optional<InputStream> tenantFile = getFilePath(filePath);
     if (tenantFile.isPresent()) {
       return tenantFile;
     }
-    return minioService.getFilePathForTenant(
-        isExternal ? TenantContext.getCurrentTenant() : Tenant.DEFAULT_TENANT_UUID, filePath);
+    return minioService.getFilePathForTenant(TenantContext.getCurrentTenant(), filePath);
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -86,7 +86,7 @@ public class FileService {
    * @param path the directory path within the platform space
    * @param name the filename
    * @param data the input stream containing the file data
-   * @return the full platform path of the uploaded file
+   * @return the object key within the platform namespace (without the "platform/" prefix)
    * @throws Exception if the upload fails
    */
   public String uploadCatalogLogo(String path, String name, InputStream data) throws Exception {

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -1,6 +1,5 @@
 package io.openaev.service;
 
-import io.openaev.context.TenantContext;
 import io.openaev.database.model.Document;
 import io.openaev.database.model.Tenant;
 import java.io.InputStream;
@@ -183,8 +182,6 @@ public class FileService {
    * Retrieves an executor's banner image file.
    *
    * @param executorId the executor identifier
-   * @param isExternal indicates if the file is a built-in asset (false) or a tenant-specific file
-   *     (true)
    * @return an Optional containing the image input stream, or empty if not found
    */
   public Optional<InputStream> getExecutorBannerImage(String executorId) {
@@ -213,26 +210,29 @@ public class FileService {
     }
     // Fallback: legacy paths before platform storage migration
     Optional<InputStream> legacyDefaultTenant =
-        minioService.getFilePathForTenant(Tenant.DEFAULT_TENANT_UUID, CONNECTORS_LOGO_PATH + fileName);
+        minioService.getFilePathForTenant(
+            Tenant.DEFAULT_TENANT_UUID, CONNECTORS_LOGO_PATH + fileName);
     if (legacyDefaultTenant.isPresent()) {
       return legacyDefaultTenant;
     }
     return minioService.getFilePathForTenant(
         Tenant.DEFAULT_TENANT_UUID, "platform" + CONNECTORS_LOGO_PATH + fileName);
+  }
 
   /**
-   * Platform assets are written once under the default tenant during startup for built in assets
-   * should fall back to specific tenant if isExternal is true.
+   * Retrieves a platform image, checking the current tenant path first (for externally registered
+   * integrations) then falling back to the default tenant (for built-in platform assets uploaded at
+   * startup).
    *
-   * @param filePath to retrieve
-   * @return finded file
+   * @param filePath the file path to retrieve
+   * @return an Optional containing the image input stream, or empty if not found
    */
   private Optional<InputStream> getPlatformImage(String filePath) {
     Optional<InputStream> tenantFile = getFilePath(filePath);
     if (tenantFile.isPresent()) {
       return tenantFile;
     }
-    return minioService.getFilePathForTenant(TenantContext.getCurrentTenant(), filePath);
+    return minioService.getFilePathForTenant(Tenant.DEFAULT_TENANT_UUID, filePath);
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/service/FileService.java
+++ b/openaev-model/src/main/java/io/openaev/service/FileService.java
@@ -211,11 +211,14 @@ public class FileService {
     if (platform.isPresent()) {
       return platform;
     }
-    // Fallback: legacy path before platform storage migration
-    // (files were stored as {DEFAULT_TENANT_UUID}/platform/connectors/logos/{fileName})
+    // Fallback: legacy paths before platform storage migration
+    Optional<InputStream> legacyDefaultTenant =
+        minioService.getFilePathForTenant(Tenant.DEFAULT_TENANT_UUID, CONNECTORS_LOGO_PATH + fileName);
+    if (legacyDefaultTenant.isPresent()) {
+      return legacyDefaultTenant;
+    }
     return minioService.getFilePathForTenant(
         Tenant.DEFAULT_TENANT_UUID, "platform" + CONNECTORS_LOGO_PATH + fileName);
-  }
 
   /**
    * Platform assets are written once under the default tenant during startup for built in assets

--- a/openaev-model/src/main/java/io/openaev/service/MinioService.java
+++ b/openaev-model/src/main/java/io/openaev/service/MinioService.java
@@ -79,6 +79,27 @@ public class MinioService implements DependenciesManager {
     return getTenantPath(fileName);
   }
 
+  /**
+   * Uploads a stream to the platform-level path (no tenant prefix). Use for assets that are shared
+   * across all tenants, such as catalog connector logos.
+   *
+   * @param fileName the file path/name within the platform space
+   * @param name the original filename stored as metadata
+   * @param data the input stream containing the file data
+   * @return the full platform path of the uploaded file
+   */
+  public String uploadStreamInPlatformPath(String fileName, String name, InputStream data)
+      throws Exception {
+    minioClient.putObject(
+        PutObjectArgs.builder()
+            .bucket(bucket())
+            .object(getPlatformPath(fileName))
+            .userMetadata(Map.of("filename", name))
+            .stream(data, data.available(), -1)
+            .build());
+    return getPlatformPath(fileName);
+  }
+
   // -- READ --
 
   public Optional<InputStream> getFilePathInTenant(String name) {
@@ -106,6 +127,26 @@ public class MinioService implements DependenciesManager {
       return Optional.of(streamResource.getInputStream());
     } catch (Exception e) {
       log.info("Error during file access", e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Retrieves a file from the platform-level path (no tenant prefix). Use for assets shared across
+   * all tenants, such as catalog connector logos.
+   *
+   * @param name the file path/name within the platform space
+   * @return an Optional containing the input stream, or empty if not found
+   */
+  public Optional<InputStream> getFilePathInPlatform(String name) {
+    try {
+      GetObjectResponse objectStream =
+          minioClient.getObject(
+              GetObjectArgs.builder().bucket(bucket()).object(getPlatformPath(name)).build());
+      InputStreamResource streamResource = new InputStreamResource(objectStream);
+      return Optional.of(streamResource.getInputStream());
+    } catch (Exception e) {
+      log.info("Platform file not found: {}", name);
       return Optional.empty();
     }
   }
@@ -270,5 +311,16 @@ public class MinioService implements DependenciesManager {
       return tenantId + objectName;
     }
     return tenantId + "/" + objectName;
+  }
+
+  /**
+   * Returns the platform-level path, prefixed with "platform/" to avoid collisions with
+   * tenant-scoped paths (which use a UUID prefix).
+   */
+  private String getPlatformPath(String objectName) {
+    if (objectName.startsWith("/")) {
+      return "platform" + objectName;
+    }
+    return "platform/" + objectName;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/service/MinioService.java
+++ b/openaev-model/src/main/java/io/openaev/service/MinioService.java
@@ -74,7 +74,7 @@ public class MinioService implements DependenciesManager {
             .bucket(bucket())
             .object(getTenantPath(fileName))
             .userMetadata(Map.of("filename", name))
-            .stream(data, data.available(), -1)
+            .stream(data, -1, 10 * 1024 * 1024)
             .build());
     return getTenantPath(fileName);
   }
@@ -95,7 +95,7 @@ public class MinioService implements DependenciesManager {
             .bucket(bucket())
             .object(getPlatformPath(fileName))
             .userMetadata(Map.of("filename", name))
-            .stream(data, data.available(), -1)
+            .stream(data, -1, 10 * 1024 * 1024)
             .build());
     return getPlatformPath(fileName);
   }


### PR DESCRIPTION
Several bugs introduced in the icon management rework: a compile error from a missing brace, a duplicate MinIO lookup, unreliable stream sizing, and a frontend URL mismatch between collector UUID and collector type.

### Backend

- **`FileService.getCatalogConnectorImage()`**: Added missing closing `}` — method body was swallowing the `getPlatformImage` private method, causing a compile failure.
- **`FileService.getPlatformImage()`**: Fallback was calling `getFilePathForTenant(currentTenant, ...)` — identical to the first call. Fixed to fall back to `DEFAULT_TENANT_UUID` for built-in platform assets.
- **`FileService.getExecutorBannerImage()`**: Removed stale `@param isExternal` from Javadoc.
- **`MinioService`**: Replaced `data.available()` (unreliable — may return 0) with `size=-1, partSize=10MB` in both `uploadStreamInTenantPath` and `uploadStreamInPlatformPath`.
- **`InjectorApi` / `CollectorApi`**: Fixed `@Operation(summary)` from "by id" → "by type"; wrapped `InputStream` in `try-with-resources` to prevent connection leak.
- **`CollectorApi`**: Added `GET /api/collectors/id/{collectorId}/image` (+ tenant variant) — resolves image by UUID→type lookup, replacing the removed `getCollectorImageFromId` in `DocumentApi`.

### Frontend

- **`InjectExpectationResultList.tsx`**: `expectationResult.sourceId` is a collector UUID (set via `collector.getId()` in `ExpectationResultBuilder`), not a type. Switched to the new `/api/collectors/id/{id}/image` endpoint.
- **`ConnectorPage.tsx`**: `logoUrl(connector?.type)` could produce `/api/injectors/undefined/image`. Guarded to only call `logoUrl` when `connector.type` is defined.

### Tests

- **`CatalogConnectorApiTest`**: Updated to upload via `uploadCatalogLogo()` (platform path) and assert against the non-tenant-scoped route `/api/images/catalog/connectors/logos/`.
- **`InjectorApiTest`** / **`CollectorApiTest`**: Added `@Nested` image test groups covering 200 (existing image) and 404 (missing image/unknown id) for the new endpoints.