### PR TITLE
fix(auth): unblock bearer-token API clients on cookie replay and in CE (#6343)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
@@ -2,6 +2,7 @@ package io.openaev.config;
 
 import static io.openaev.config.security.SecurityService.REGISTRATION_ID;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
 import static org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +20,7 @@ import io.openaev.service.user_events.UserEventService;
 import io.openaev.utils.log.LogUtils;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +35,8 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.context.DeferredSecurityContext;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -49,6 +53,10 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.HttpRequestResponseHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
@@ -86,7 +94,11 @@ public class AppSecurityConfig {
                     .ignoringRequestMatchers("/api/health", "/api/login", "/actuator/**")
                     .ignoringRequestMatchers(bearerWithoutCookiesMatcher()))
         .formLogin(AbstractHttpConfigurer::disable)
-        .securityContext(securityContext -> securityContext.requireExplicitSave(false))
+        .securityContext(
+            securityContext ->
+                securityContext
+                    .requireExplicitSave(false)
+                    .securityContextRepository(bearerAwareSecurityContextRepository()))
         .authorizeHttpRequests(
             rq ->
                 rq.requestMatchers("/api/health")
@@ -301,12 +313,74 @@ public class AppSecurityConfig {
     };
   }
 
+  /**
+   * Skip CSRF only for a bearer request that sends no cookies.
+   *
+   * <p>A pure API client authenticates statelessly with a bearer token and sends no cookies.
+   *
+   * <p>Bearer auth is stateless (bearerAwareSecurityContextRepository) so no session cookie is set.
+   *
+   * <p>So a standard client keeps passing on every call, not just the first (the #6343 regression).
+   *
+   * <p>A request that also sends cookies keeps full CSRF protection (no bearer bypass).
+   */
   private RequestMatcher bearerWithoutCookiesMatcher() {
     return request -> {
       String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-      boolean hasBearer = authorization != null && authorization.startsWith("Bearer ");
+      boolean hasBearer = startsWithIgnoreCase(authorization, "Bearer ");
       boolean hasCookies = request.getCookies() != null && request.getCookies().length > 0;
       return hasBearer && !hasCookies;
     };
+  }
+
+  /**
+   * Persists the security context in the HTTP session for browser / cookie auth.
+   *
+   * <p>Authorization-header (bearer) requests stay stateless - no session is read or created.
+   *
+   * <p>So a pure API client never receives a JSESSIONID to replay (#6343); SSO sessions are intact.
+   */
+  private SecurityContextRepository bearerAwareSecurityContextRepository() {
+    return new BearerAwareSecurityContextRepository();
+  }
+
+  /** See {@link #bearerAwareSecurityContextRepository()}. */
+  private static final class BearerAwareSecurityContextRepository
+      implements SecurityContextRepository {
+
+    private final HttpSessionSecurityContextRepository sessionRepository =
+        new HttpSessionSecurityContextRepository();
+    private final RequestAttributeSecurityContextRepository statelessRepository =
+        new RequestAttributeSecurityContextRepository();
+
+    private SecurityContextRepository delegate(HttpServletRequest request) {
+      String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+      if (startsWithIgnoreCase(authorization, "Bearer ")) {
+        return statelessRepository;
+      }
+      return sessionRepository;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public SecurityContext loadContext(HttpRequestResponseHolder requestResponseHolder) {
+      return delegate(requestResponseHolder.getRequest()).loadContext(requestResponseHolder);
+    }
+
+    @Override
+    public DeferredSecurityContext loadDeferredContext(HttpServletRequest request) {
+      return delegate(request).loadDeferredContext(request);
+    }
+
+    @Override
+    public boolean containsContext(HttpServletRequest request) {
+      return delegate(request).containsContext(request);
+    }
+
+    @Override
+    public void saveContext(
+        SecurityContext context, HttpServletRequest request, HttpServletResponse response) {
+      delegate(request).saveContext(context, request, response);
+    }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppSecurityConfig.java
@@ -71,6 +71,7 @@ public class AppSecurityConfig {
   private static final String TENANT_AGENT_URI = "/api/tenants/*/agent/**";
   private static final String TENANT_IMPLANT_URI = "/api/tenants/*/implant/**";
   private static final String TENANT_PLAYER_URI = "/api/tenants/*/player/**";
+  private static final String BEARER_PREFIX = "Bearer ";
 
   private final OpenAEVConfig openAEVConfig;
   private final OpenSamlConfig openSamlConfig;
@@ -326,11 +327,17 @@ public class AppSecurityConfig {
    */
   private RequestMatcher bearerWithoutCookiesMatcher() {
     return request -> {
-      String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-      boolean hasBearer = startsWithIgnoreCase(authorization, "Bearer ");
       boolean hasCookies = request.getCookies() != null && request.getCookies().length > 0;
-      return hasBearer && !hasCookies;
+      return hasBearerToken(request) && !hasCookies;
     };
+  }
+
+  /**
+   * Whether the request carries a bearer token. Single-sourced so the CSRF-skip rule and the
+   * stateless-context rule can never disagree on what counts as a bearer request.
+   */
+  private static boolean hasBearerToken(HttpServletRequest request) {
+    return startsWithIgnoreCase(request.getHeader(HttpHeaders.AUTHORIZATION), BEARER_PREFIX);
   }
 
   /**
@@ -354,11 +361,7 @@ public class AppSecurityConfig {
         new RequestAttributeSecurityContextRepository();
 
     private SecurityContextRepository delegate(HttpServletRequest request) {
-      String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-      if (startsWithIgnoreCase(authorization, "Bearer ")) {
-        return statelessRepository;
-      }
-      return sessionRepository;
+      return hasBearerToken(request) ? statelessRepository : sessionRepository;
     }
 
     @Override

--- a/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
@@ -136,35 +136,33 @@ public class AppSecurityConfigTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("given valid jsessionid and csrf without bearer token, should return HTTP 200")
-  void given_validJsessionIdAndCsrfWithoutBearerToken_should_returnOk() throws Exception {
+  @DisplayName("bearer auth is stateless: replaying its session cookie alone is unauthorized")
+  void given_replayedBearerSessionWithoutToken_should_returnUnauthorized() throws Exception {
+    // A bearer call succeeds but must NOT establish a reusable server-side session: token auth is
+    // stateless, so no JSESSIONID is persisted for the client to replay (the #6343 root cause).
     MockHttpSession session = new MockHttpSession();
-    Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
     mockMvc
         .perform(
             post(SCENARIO_SEARCH_URI)
                 .session(session)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
-                .cookie(csrfCookie)
-                .header(CSRF_HEADER_NAME, "test-csrf-token")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(SEARCH_BODY)
-                .with(csrf()))
+                .content(SEARCH_BODY))
         .andExpect(status().isOk());
 
-    String sessionId = Objects.requireNonNull(session.getId());
-    Cookie jsessionCookie = new Cookie("JSESSIONID", sessionId);
+    // Replaying only the JSESSIONID from that bearer call (no bearer token) is not authenticated.
+    Cookie jsessionCookie = new Cookie("JSESSIONID", Objects.requireNonNull(session.getId()));
+    Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
 
     mockMvc
         .perform(
             post(SCENARIO_SEARCH_URI)
                 .session(session)
-                .cookie(jsessionCookie)
-                .cookie(new Cookie(CSRF_COOKIE_NAME, "test-csrf-token"))
+                .cookie(jsessionCookie, csrfCookie)
                 .header(CSRF_HEADER_NAME, "test-csrf-token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(SEARCH_BODY)
                 .with(csrf()))
-        .andExpect(status().isOk());
+        .andExpect(status().isUnauthorized());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
@@ -1,6 +1,7 @@
 package io.openaev.config;
 
 import static io.openaev.rest.scenario.ScenarioApi.SCENARIO_URI;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 @TestInstance(Lifecycle.PER_CLASS)
@@ -164,5 +166,26 @@ public class AppSecurityConfigTest extends IntegrationTest {
                 .content(SEARCH_BODY)
                 .with(csrf()))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("given pure bearer request, should not create session nor issue JSESSIONID")
+  void given_pureBearerRequest_should_notCreateSessionNorIssueJsessionId() throws Exception {
+    // The #6343 root cause: a pure bearer (stateless) call must neither establish a server-side
+    // session nor emit a JSESSIONID for the client to replay - otherwise CSRF re-engages on the
+    // next call and standards-compliant clients (Postman, httpx, requests) get 403 from the second
+    // request onwards. No session is injected here so the absence is actually asserted.
+    MvcResult result =
+        mockMvc
+            .perform(
+                post(SCENARIO_SEARCH_URI)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(SEARCH_BODY))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertThat(result.getResponse().getCookie("JSESSIONID")).isNull();
+    assertThat(result.getRequest().getSession(false)).isNull();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
@@ -138,10 +138,10 @@ public class AppSecurityConfigTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("bearer auth is stateless: replaying its session cookie alone is unauthorized")
+  @DisplayName("a bearer call's session is not reusable to authenticate without the bearer token")
   void given_replayedBearerSessionWithoutToken_should_returnUnauthorized() throws Exception {
-    // A bearer call succeeds but must NOT establish a reusable server-side session: token auth is
-    // stateless, so no JSESSIONID is persisted for the client to replay (the #6343 root cause).
+    // A bearer call may run with a session present, but token auth is stateless: its
+    // SecurityContext is never persisted to that session (the #6343 root cause).
     MockHttpSession session = new MockHttpSession();
     mockMvc
         .perform(
@@ -152,7 +152,8 @@ public class AppSecurityConfigTest extends IntegrationTest {
                 .content(SEARCH_BODY))
         .andExpect(status().isOk());
 
-    // Replaying only the JSESSIONID from that bearer call (no bearer token) is not authenticated.
+    // Replaying that same server-side session (via .session(...); the JSESSIONID cookie below is
+    // redundant in MockMvc) with a valid CSRF token but no bearer token stays unauthenticated.
     Cookie jsessionCookie = new Cookie("JSESSIONID", Objects.requireNonNull(session.getId()));
     Cookie csrfCookie = new Cookie(CSRF_COOKIE_NAME, "test-csrf-token");
 

--- a/openaev-api/src/test/java/io/openaev/service/PermissionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/PermissionServiceTest.java
@@ -192,6 +192,18 @@ public class PermissionServiceTest extends IntegrationTest {
   }
 
   @Test
+  public void test_hasPermission_search_payload_WHEN_has_tenant_bypass_capa() {
+    // Regression for #6331 / #6332: a CE admin's authority is a default-tenant BYPASS group, so a
+    // tenant BYPASS must cover /api/payloads/** like every other tenant resource. ACCESS_PAYLOADS
+    // previously had an empty capability scope, leaving payloads unreachable via BYPASS (403).
+    User user = getUser(USER_ID, false);
+    user.setGroups(List.of(getGroup(Capability.BYPASS)));
+    assertTrue(
+        permissionService.hasPermission(
+            user, Optional.empty(), RESOURCE_ID, ResourceType.PAYLOAD, Action.SEARCH));
+  }
+
+  @Test
   public void test_hasPermission_write_WHEN_has_read_capa() {
     User user = getUser(USER_ID, false);
     user.setGroups(List.of(getGroup(Capability.ACCESS_CHANNELS)));

--- a/openaev-model/src/main/java/io/openaev/database/model/Capability.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Capability.java
@@ -113,15 +113,14 @@ public enum Capability {
       pair(ResourceType.ASSET, Action.DELETE),
       pair(ResourceType.ASSET_GROUP, Action.DELETE)),
 
-  // Payloads -- PAYLOAD CAPABILITIES ARE DEPRECATED
+  // Payloads -- PAYLOAD CAPABILITIES ARE DEPRECATED.
+  // Tenant-scoped (Payload is a TenantBase) so a tenant BYPASS covers /api/payloads/**; an empty
+  // scope previously made ACCESS_PAYLOADS unreachable via BYPASS (issues #6331 / #6332).
   @Deprecated(
       since = "Remove after closing https://github.com/OpenAEV-Platform/client-python/issues/211")
   ACCESS_PAYLOADS(
       null,
       CapabilityGroup.THREAT_ARSENALS,
-      // Payload is a TenantBase (tenant-scoped) resource, like every sibling in this group. The
-      // tenant scope lets a tenant BYPASS cover payload access; an empty scope made ACCESS_PAYLOADS
-      // unreachable via BYPASS, so even a CE admin was denied /api/payloads/** (issues #6331/#6332).
       EnumSet.of(CapabilityScope.TENANT),
       pair(ResourceType.PAYLOAD, Action.READ),
       pair(ResourceType.PAYLOAD, Action.SEARCH)),

--- a/openaev-model/src/main/java/io/openaev/database/model/Capability.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Capability.java
@@ -119,7 +119,10 @@ public enum Capability {
   ACCESS_PAYLOADS(
       null,
       CapabilityGroup.THREAT_ARSENALS,
-      Set.of(),
+      // Payload is a TenantBase (tenant-scoped) resource, like every sibling in this group. The
+      // tenant scope lets a tenant BYPASS cover payload access; an empty scope made ACCESS_PAYLOADS
+      // unreachable via BYPASS, so even a CE admin was denied /api/payloads/** (issues #6331/#6332).
+      EnumSet.of(CapabilityScope.TENANT),
       pair(ResourceType.PAYLOAD, Action.READ),
       pair(ResourceType.PAYLOAD, Action.SEARCH)),
   @Deprecated(

--- a/openaev-model/src/main/java/io/openaev/database/model/User.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/User.java
@@ -398,13 +398,17 @@ public class User implements Base {
   }
 
   /**
-   * Returns only groups visible in the current tenant context: groups belonging to the current
+   * Returns the groups visible in the current tenant context: groups belonging to the current
    * tenant plus platform-level groups (tenant IS NULL).
+   *
+   * <p>A request without an explicit tenant context - token/bearer API clients (Postman, httpx, the
+   * integrations) and Community Edition, where multi-tenancy is disabled - still operates on the
+   * default tenant. {@link TenantContext#getCurrentTenant()} falls back to the default tenant when
+   * none is set, so such requests resolve default-tenant groups plus platform groups. Without this,
+   * {@code getCapabilities()} was empty for those requests and {@code AccessControlAspect} denied
+   * them with 403 (issues #6331 / #6332).
    */
   private List<Group> scopedGroups() {
-    if (!TenantContext.hasCurrentTenant()) {
-      return platformGroups();
-    }
     String currentTenant = TenantContext.getCurrentTenant();
     return getUnscopedGroups().stream()
         .filter(


### PR DESCRIPTION
## Summary

Bearer-token authenticated REST calls (Postman, httpx / requests, and the platform integrations) worked on the first call but returned `403 Forbidden` on every subsequent call, and integrations were denied with "access denied / insufficient permissions". Both are fixed, without weakening CSRF.

Fixes #6343. Resolves #6331 and #6332.

## Root cause (deep-dive)

1. Cookie generation on token auth. `requireExplicitSave(false)` persisted the `SecurityContext` of every token-authenticated request to an `HttpSession`, so even a stateless bearer API call received a `JSESSIONID`. Standards-compliant clients store and replay it, which re-enabled CSRF (skipped only for a bearer request with no cookies) and 403-ed every call after the first.
2. Capability resolution. Since #6039, `User.scopedGroups()` returned only platform groups (`tenant IS NULL`) when there was no tenant context. Token / bearer clients and Community Edition operate without an explicit tenant, so the admin's default-tenant groups were dropped, `getCapabilities()` was empty, and `AccessControlAspect` denied with 403.
3. Payloads-only residual 403. After the capability fallback, one endpoint still denied a CE admin: `POST /api/payloads/search`. The deprecated `ACCESS_PAYLOADS` capability was declared with an empty `CapabilityScope` set, so it was excluded from `allTenantScoped()` / `allPlatformScoped()` and from BYPASS scope-matching - making it unreachable via BYPASS, unlike every other (scoped) resource capability.

## Changes

* `AppSecurityConfig`: Authorization-header (bearer) auth is now STATELESS. A dedicated `SecurityContextRepository` stores the context in the `HttpSession` for browser / cookie auth, but never reads or creates a session for bearer requests - so a pure API client receives no `JSESSIONID` to replay and keeps working on every call. The original `bearer && no-cookies` CSRF rule is kept intact (no weakening); the bearer check is locale-independent.
* `AppSecurityConfig`: the bearer-token detection is single-sourced in a `hasBearerToken(...)` helper shared by the CSRF-skip matcher and the stateless `SecurityContextRepository`, so the two rules cannot diverge on what counts as a bearer request.
* `User.scopedGroups()`: a request without an explicit tenant context resolves default-tenant + platform groups via the default-tenant fallback, instead of platform-only.
* `Capability.ACCESS_PAYLOADS`: scoped to `TENANT` (was an empty scope set). `Payload` is a `TenantBase` resource like its siblings, so a tenant BYPASS now covers `/api/payloads/**`, fixing the last CE-admin 403. `MANAGE_PAYLOADS` / `DELETE_PAYLOADS` inherit the scope.

## Security (addressing @antoinemzs review)

CSRF is NOT weakened. CSRF is skipped only for a bearer request that sends no cookies - the stateless pure-API case. Any request that mixes a bearer header with cookies keeps full CSRF protection, and browser / session (cookie) auth is unchanged. Because bearer auth no longer issues a session cookie, a standard API client never ends up "mixing" - it simply never receives a cookie to replay. We do not rely on CORS for CSRF protection.

## Note on #6039

The `scopedGroups()` change restores the pre-#6039 behavior for no-tenant contexts (default-tenant + platform groups). In multi-tenant EE, a platform-level (no-tenant) request therefore resolves the caller's own default-tenant capabilities in addition to platform ones. Flagging for the multi-tenancy reviewers.

## Test plan

* Standard Postman / httpx / requests bearer client: first AND repeated `POST /api/**/search` calls return 200 (was 403 on the 2nd call); no `JSESSIONID` is issued.
* `AppSecurityConfigTest` now asserts the stateless guardrail directly: a pure bearer call (no injected session) creates no server-side session and emits no `JSESSIONID` cookie, so the "first call OK, second call 403" regression cannot silently return.
* A request mixing a bearer header with cookies but no CSRF token: rejected (403) - CSRF not bypassed.
* Browser (cookie / session, no bearer header): CSRF still enforced.
* Integrations / admin token: capabilities resolve, no "access denied" 403, including `POST /api/payloads/search`.
* `PermissionServiceTest` regression: a non-admin user with a tenant BYPASS group is allowed to search payloads (would fail with the previous empty scope).
