### PR TITLE
fix(groups): seed default tenant admin group at platform bootstrap (#6345)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
+++ b/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
@@ -65,10 +65,14 @@ public class InitAdminCommandLineRunner implements CommandLineRunner {
     Optional<Token> adminToken = this.tokenRepository.findById(ADMIN_TOKEN_UUID);
     adminToken.ifPresentOrElse(this::updateToken, () -> this.createToken(adminUser));
 
-    // Ensure the default tenant owns an admin group and the admin user belongs to it. The default
-    // tenant is created by a Flyway migration and never runs the tenant-provisioning chain that
-    // seeds the default groups for tenants created through the API, so this must be bootstrapped
-    // explicitly here, once the admin user is guaranteed to exist.
+    // Ensure the admin user holds full administrative privileges through well-known groups: a
+    // platform-scoped "Administrators" group (granting platform BYPASS) and the default-tenant
+    // "Administrators" group (granting tenant BYPASS). The default tenant is created by a Flyway
+    // migration and never runs the tenant-provisioning chain that seeds default groups for
+    // API-created tenants, so both must be bootstrapped explicitly here, once the admin user is
+    // guaranteed to exist. The platform group is ensured first because the tenant path clears the
+    // persistence context last (see AdminPrivilegeService#ensureAdminGroup).
+    this.adminPrivilegeService.ensurePlatformAdminGroup(adminUser);
     this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, adminUser);
   }
 

--- a/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
+++ b/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
@@ -69,7 +69,7 @@ public class InitAdminCommandLineRunner implements CommandLineRunner {
     // tenant is created by a Flyway migration and never runs the tenant-provisioning chain that
     // seeds the default groups for tenants created through the API, so this must be bootstrapped
     // explicitly here, once the admin user is guaranteed to exist.
-    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, adminUser.getId());
+    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, adminUser);
   }
 
   // -- USER --

--- a/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
+++ b/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
@@ -11,6 +11,7 @@ import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.TokenRepository;
 import io.openaev.database.repository.UserRepository;
+import io.openaev.service.account.AdminPrivilegeService;
 import io.openaev.service.tenants.TenantUserService;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -40,14 +41,17 @@ public class InitAdminCommandLineRunner implements CommandLineRunner {
   private final UserRepository userRepository;
   private final TokenRepository tokenRepository;
   private final TenantUserService tenantUserService;
+  private final AdminPrivilegeService adminPrivilegeService;
 
   public InitAdminCommandLineRunner(
       @NotNull final UserRepository userRepository,
       @NotNull final TokenRepository tokenRepository,
-      @NotNull final TenantUserService tenantUserService) {
+      @NotNull final TenantUserService tenantUserService,
+      @NotNull final AdminPrivilegeService adminPrivilegeService) {
     this.userRepository = userRepository;
     this.tokenRepository = tokenRepository;
     this.tenantUserService = tenantUserService;
+    this.adminPrivilegeService = adminPrivilegeService;
   }
 
   @Override
@@ -60,6 +64,12 @@ public class InitAdminCommandLineRunner implements CommandLineRunner {
     // Handle admin token
     Optional<Token> adminToken = this.tokenRepository.findById(ADMIN_TOKEN_UUID);
     adminToken.ifPresentOrElse(this::updateToken, () -> this.createToken(adminUser));
+
+    // Ensure the default tenant owns an admin group and the admin user belongs to it. The default
+    // tenant is created by a Flyway migration and never runs the tenant-provisioning chain that
+    // seeds the default groups for tenants created through the API, so this must be bootstrapped
+    // explicitly here, once the admin user is guaranteed to exist.
+    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, adminUser.getId());
   }
 
   // -- USER --

--- a/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
@@ -87,8 +87,9 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
   }
 
   /**
-   * Idempotently ensures the given tenant owns the admin group (with the BYPASS role) and that the
-   * given user is a member of it. Safe to call on every platform startup.
+   * Idempotently ensures the given tenant owns the admin group (with the BYPASS role), that the
+   * given user belongs to that tenant, and that the user is a member of the group. Safe to call on
+   * every platform startup.
    *
    * <p>The caller passes the already-resolved admin {@link User} (the bootstrap runner has just
    * created or loaded it) rather than an id, so the membership check never depends on re-fetching
@@ -112,6 +113,10 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
           getGroupName(),
           tenantId);
     }
+    // Mirror ServiceAccountPrivilegeService: make sure the admin belongs to the tenant that owns
+    // the group, so the self-heal also covers installs whose users_tenants row is missing. The call
+    // is idempotent and clears the persistence context, so it runs after the group enrollment.
+    tenantUserService.attachToTenant(adminUser.getId(), tenantId);
     return group;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
@@ -1,0 +1,114 @@
+package io.openaev.service.account;
+
+import io.openaev.database.model.Capability;
+import io.openaev.database.model.Group;
+import io.openaev.database.model.User;
+import io.openaev.service.AbstractPrivilegeService;
+import io.openaev.service.RoleService;
+import io.openaev.service.TenantGroupService;
+import io.openaev.service.UserService;
+import io.openaev.service.tenants.TenantUserService;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Ensures a tenant owns a well-known "Administrators" group (granting the BYPASS capability) and
+ * that the platform admin user belongs to it.
+ *
+ * <p>New tenants get their default Admin/Manager/Observer groups seeded through the tenant
+ * provisioning chain (see {@code V20260330_Default_tenant_data}). The default tenant, however, is
+ * created by a Flyway migration and never goes through that chain, so a fresh platform ended up
+ * with no admin group at all. The platform admin still bypasses RBAC through {@code
+ * user_admin = true}, but the missing group broke group-based administration parity with every
+ * other tenant. This regression was introduced together with multi-tenancy (PR #4864).
+ *
+ * <p>Bootstrapping the group from {@link io.openaev.runner.InitAdminCommandLineRunner} is the only
+ * place that runs after the admin user is guaranteed to exist, which is why the membership is wired
+ * here rather than in the datapack.
+ */
+@Service
+@Slf4j
+public class AdminPrivilegeService extends AbstractPrivilegeService {
+
+  public static final String ADMIN_ROLE_ID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
+  public static final String ADMIN_ROLE_NAME = "Admin";
+  public static final String ADMIN_ROLE_DESCRIPTION = "Full administrative access to the platform.";
+  public static final Set<Capability> ADMIN_ROLE_CAPABILITIES = Set.of(Capability.BYPASS);
+
+  public static final String ADMIN_GROUP_ID = "2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e";
+  public static final String ADMIN_GROUP_NAME = "Administrators";
+  public static final String ADMIN_GROUP_DESCRIPTION = "Platform administrators.";
+
+  @Autowired
+  public AdminPrivilegeService(
+      RoleService roleService,
+      TenantGroupService tenantGroupService,
+      UserService userService,
+      TenantUserService tenantUserService) {
+    super(roleService, tenantGroupService, userService, tenantUserService);
+  }
+
+  @Override
+  protected String getRoleId() {
+    return ADMIN_ROLE_ID;
+  }
+
+  @Override
+  protected String getRoleName() {
+    return ADMIN_ROLE_NAME;
+  }
+
+  @Override
+  protected String getRoleDescription() {
+    return ADMIN_ROLE_DESCRIPTION;
+  }
+
+  @Override
+  protected Set<Capability> getRoleCapabilities() {
+    return ADMIN_ROLE_CAPABILITIES;
+  }
+
+  @Override
+  protected String getGroupId() {
+    return ADMIN_GROUP_ID;
+  }
+
+  @Override
+  protected String getGroupName() {
+    return ADMIN_GROUP_NAME;
+  }
+
+  @Override
+  protected String getGroupDescription() {
+    return ADMIN_GROUP_DESCRIPTION;
+  }
+
+  /**
+   * Idempotently ensures the given tenant owns the admin group (with the BYPASS role) and that the
+   * given user is a member of it. Safe to call on every platform startup.
+   *
+   * @param tenantId the tenant the group belongs to
+   * @param adminUserId the user to enroll as an administrator
+   * @return the (created or existing) admin group
+   */
+  @Transactional
+  public Group ensureAdminGroup(String tenantId, String adminUserId) {
+    Group group = createWellKnownGroupWithRole(createWellKnownRole(tenantId), tenantId);
+    User admin = userService.user(adminUserId);
+    boolean alreadyMember =
+        admin.getUnscopedGroups().stream().anyMatch(g -> g.getId().equals(group.getId()));
+    if (!alreadyMember) {
+      admin.getUnscopedGroups().add(group);
+      userService.saveUser(admin);
+      log.info(
+          "Enrolled admin user {} into the '{}' group for tenant {}",
+          adminUserId,
+          getGroupName(),
+          tenantId);
+    }
+    return group;
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
@@ -164,7 +164,7 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
             PLATFORM_ADMIN_ROLE_DESCRIPTION,
             Set.of(Capability.BYPASS));
     Group group =
-        platformGroupService.ensureInternalPlatformGroupWithRole(
+        platformGroupService.ensureInternalPlatformGroupWithRoles(
             PLATFORM_ADMIN_GROUP_ID,
             PLATFORM_ADMIN_GROUP_NAME,
             PLATFORM_ADMIN_GROUP_DESCRIPTION,

--- a/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
@@ -2,12 +2,16 @@ package io.openaev.service.account;
 
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.Group;
+import io.openaev.database.model.Role;
 import io.openaev.database.model.User;
 import io.openaev.service.AbstractPrivilegeService;
 import io.openaev.service.RoleService;
 import io.openaev.service.TenantGroupService;
 import io.openaev.service.UserService;
+import io.openaev.service.platform.groups.PlatformGroupService;
+import io.openaev.service.platform.roles.PlatformRoleService;
 import io.openaev.service.tenants.TenantUserService;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,17 +19,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Ensures a tenant owns a well-known "Administrators" group (granting the BYPASS capability) and
- * that the platform admin user belongs to it.
+ * Ensures the platform admin user holds full administrative privileges through well-known
+ * "Administrators" groups: a platform-scoped group (tenant = null) granting platform BYPASS and a
+ * per-tenant group granting tenant BYPASS, with the admin user enrolled in both.
  *
  * <p>New tenants get their default Admin/Manager/Observer groups seeded through the tenant
  * provisioning chain (see {@code V20260330_Default_tenant_data}). The default tenant, however, is
  * created by a Flyway migration and never goes through that chain, so a fresh platform ended up
  * with no admin group at all. The platform admin still bypasses RBAC through {@code user_admin =
- * true}, but the missing group broke group-based administration parity with every other tenant.
+ * true}, but the missing groups broke group-based administration parity with every other tenant.
  * This regression was introduced together with multi-tenancy (PR #4864).
  *
- * <p>Bootstrapping the group from {@link io.openaev.runner.InitAdminCommandLineRunner} is the only
+ * <p>The two scopes are both required: a tenant BYPASS only expands to tenant-scoped capabilities
+ * (see {@link io.openaev.database.model.User#getCapabilities()}), so a platform-scoped admin group
+ * is needed to grant the platform-only capabilities (tenants, platform settings, platform
+ * users/groups/roles) through group membership rather than only via {@code user_admin}.
+ *
+ * <p>Bootstrapping the groups from {@link io.openaev.runner.InitAdminCommandLineRunner} is the only
  * place that runs after the admin user is guaranteed to exist, which is why the membership is wired
  * here rather than in the datapack.
  */
@@ -42,13 +52,29 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
   public static final String ADMIN_GROUP_NAME = "Administrators";
   public static final String ADMIN_GROUP_DESCRIPTION = "Tenant administrators.";
 
+  public static final String PLATFORM_ADMIN_ROLE_ID = "3c4d5e6f-7a8b-4c9d-8e0f-2a3b4c5d6e7f";
+  public static final String PLATFORM_ADMIN_ROLE_NAME = "Admin";
+  public static final String PLATFORM_ADMIN_ROLE_DESCRIPTION =
+      "Full administrative access to the platform.";
+
+  public static final String PLATFORM_ADMIN_GROUP_ID = "4d5e6f7a-8b9c-4d0e-9f1a-3b4c5d6e7f8a";
+  public static final String PLATFORM_ADMIN_GROUP_NAME = "Administrators";
+  public static final String PLATFORM_ADMIN_GROUP_DESCRIPTION = "Platform administrators.";
+
+  private final PlatformRoleService platformRoleService;
+  private final PlatformGroupService platformGroupService;
+
   @Autowired
   public AdminPrivilegeService(
       RoleService roleService,
       TenantGroupService tenantGroupService,
       UserService userService,
-      TenantUserService tenantUserService) {
+      TenantUserService tenantUserService,
+      PlatformRoleService platformRoleService,
+      PlatformGroupService platformGroupService) {
     super(roleService, tenantGroupService, userService, tenantUserService);
+    this.platformRoleService = platformRoleService;
+    this.platformGroupService = platformGroupService;
   }
 
   @Override
@@ -117,6 +143,42 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
     // the group, so the self-heal also covers installs whose users_tenants row is missing. The call
     // is idempotent and clears the persistence context, so it runs after the group enrollment.
     tenantUserService.attachToTenant(adminUser.getId(), tenantId);
+    return group;
+  }
+
+  /**
+   * Idempotently ensures a platform-scoped (tenant = null) admin group granting platform BYPASS
+   * exists and that the given user is a member. Unlike a tenant BYPASS, a platform BYPASS expands
+   * to the platform-only capabilities (tenants, platform settings, platform users/groups/roles).
+   * Safe to call on every platform startup.
+   *
+   * @param adminUser the user to enroll as a platform administrator
+   * @return the (created or existing) platform admin group
+   */
+  @Transactional
+  public Group ensurePlatformAdminGroup(User adminUser) {
+    Role role =
+        platformRoleService.ensureInternalPlatformRole(
+            PLATFORM_ADMIN_ROLE_ID,
+            PLATFORM_ADMIN_ROLE_NAME,
+            PLATFORM_ADMIN_ROLE_DESCRIPTION,
+            Set.of(Capability.BYPASS));
+    Group group =
+        platformGroupService.ensureInternalPlatformGroupWithRole(
+            PLATFORM_ADMIN_GROUP_ID,
+            PLATFORM_ADMIN_GROUP_NAME,
+            PLATFORM_ADMIN_GROUP_DESCRIPTION,
+            List.of(role));
+    boolean alreadyMember =
+        adminUser.getUnscopedGroups().stream().anyMatch(g -> g.getId().equals(group.getId()));
+    if (!alreadyMember) {
+      adminUser.getUnscopedGroups().add(group);
+      userService.saveUser(adminUser);
+      log.info(
+          "Enrolled admin user {} into the platform '{}' group",
+          adminUser.getId(),
+          PLATFORM_ADMIN_GROUP_NAME);
+    }
     return group;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/account/AdminPrivilegeService.java
@@ -21,9 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>New tenants get their default Admin/Manager/Observer groups seeded through the tenant
  * provisioning chain (see {@code V20260330_Default_tenant_data}). The default tenant, however, is
  * created by a Flyway migration and never goes through that chain, so a fresh platform ended up
- * with no admin group at all. The platform admin still bypasses RBAC through {@code
- * user_admin = true}, but the missing group broke group-based administration parity with every
- * other tenant. This regression was introduced together with multi-tenancy (PR #4864).
+ * with no admin group at all. The platform admin still bypasses RBAC through {@code user_admin =
+ * true}, but the missing group broke group-based administration parity with every other tenant.
+ * This regression was introduced together with multi-tenancy (PR #4864).
  *
  * <p>Bootstrapping the group from {@link io.openaev.runner.InitAdminCommandLineRunner} is the only
  * place that runs after the admin user is guaranteed to exist, which is why the membership is wired
@@ -35,12 +35,12 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
 
   public static final String ADMIN_ROLE_ID = "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d";
   public static final String ADMIN_ROLE_NAME = "Admin";
-  public static final String ADMIN_ROLE_DESCRIPTION = "Full administrative access to the platform.";
+  public static final String ADMIN_ROLE_DESCRIPTION = "Full administrative access to the tenant.";
   public static final Set<Capability> ADMIN_ROLE_CAPABILITIES = Set.of(Capability.BYPASS);
 
   public static final String ADMIN_GROUP_ID = "2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e";
   public static final String ADMIN_GROUP_NAME = "Administrators";
-  public static final String ADMIN_GROUP_DESCRIPTION = "Platform administrators.";
+  public static final String ADMIN_GROUP_DESCRIPTION = "Tenant administrators.";
 
   @Autowired
   public AdminPrivilegeService(
@@ -90,22 +90,25 @@ public class AdminPrivilegeService extends AbstractPrivilegeService {
    * Idempotently ensures the given tenant owns the admin group (with the BYPASS role) and that the
    * given user is a member of it. Safe to call on every platform startup.
    *
+   * <p>The caller passes the already-resolved admin {@link User} (the bootstrap runner has just
+   * created or loaded it) rather than an id, so the membership check never depends on re-fetching
+   * the user through {@code UserService} - a service that some test contexts replace with a mock.
+   *
    * @param tenantId the tenant the group belongs to
-   * @param adminUserId the user to enroll as an administrator
+   * @param adminUser the user to enroll as an administrator
    * @return the (created or existing) admin group
    */
   @Transactional
-  public Group ensureAdminGroup(String tenantId, String adminUserId) {
+  public Group ensureAdminGroup(String tenantId, User adminUser) {
     Group group = createWellKnownGroupWithRole(createWellKnownRole(tenantId), tenantId);
-    User admin = userService.user(adminUserId);
     boolean alreadyMember =
-        admin.getUnscopedGroups().stream().anyMatch(g -> g.getId().equals(group.getId()));
+        adminUser.getUnscopedGroups().stream().anyMatch(g -> g.getId().equals(group.getId()));
     if (!alreadyMember) {
-      admin.getUnscopedGroups().add(group);
-      userService.saveUser(admin);
+      adminUser.getUnscopedGroups().add(group);
+      userService.saveUser(adminUser);
       log.info(
           "Enrolled admin user {} into the '{}' group for tenant {}",
-          adminUserId,
+          adminUser.getId(),
           getGroupName(),
           tenantId);
     }

--- a/openaev-api/src/main/java/io/openaev/service/platform/groups/PlatformGroupService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/groups/PlatformGroupService.java
@@ -46,7 +46,9 @@ public class PlatformGroupService {
   /**
    * Idempotently creates or updates a system-managed platform group (with the given roles) using a
    * deterministic id (used by the bootstrap to seed the platform administrators group). Keeps the
-   * group platform-scoped (no tenant) and does not touch its membership.
+   * group platform-scoped (no tenant) and does not touch its membership. Fails fast if a group
+   * already exists under the id but is tenant-scoped, since {@code tenant_id} is {@code
+   * updatable=false} and silently reusing it would corrupt the platform scope invariant.
    */
   public Group ensureInternalPlatformGroupWithRole(
       @NotBlank final String id,
@@ -54,6 +56,10 @@ public class PlatformGroupService {
       final String description,
       final List<Role> roles) {
     Group group = groupRepository.findById(id).orElseGet(Group::new);
+    if (group.getTenant() != null) {
+      throw new IllegalStateException(
+          "Group " + id + " already exists as a tenant-scoped group; expected a platform group");
+    }
     group.setId(id);
     group.setName(name);
     group.setDescription(description);

--- a/openaev-api/src/main/java/io/openaev/service/platform/groups/PlatformGroupService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/groups/PlatformGroupService.java
@@ -50,7 +50,7 @@ public class PlatformGroupService {
    * already exists under the id but is tenant-scoped, since {@code tenant_id} is {@code
    * updatable=false} and silently reusing it would corrupt the platform scope invariant.
    */
-  public Group ensureInternalPlatformGroupWithRole(
+  public Group ensureInternalPlatformGroupWithRoles(
       @NotBlank final String id,
       @NotBlank final String name,
       final String description,

--- a/openaev-api/src/main/java/io/openaev/service/platform/groups/PlatformGroupService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/groups/PlatformGroupService.java
@@ -43,6 +43,25 @@ public class PlatformGroupService {
     return groupRepository.save(group);
   }
 
+  /**
+   * Idempotently creates or updates a system-managed platform group (with the given roles) using a
+   * deterministic id (used by the bootstrap to seed the platform administrators group). Keeps the
+   * group platform-scoped (no tenant) and does not touch its membership.
+   */
+  public Group ensureInternalPlatformGroupWithRole(
+      @NotBlank final String id,
+      @NotBlank final String name,
+      final String description,
+      final List<Role> roles) {
+    Group group = groupRepository.findById(id).orElseGet(Group::new);
+    group.setId(id);
+    group.setName(name);
+    group.setDescription(description);
+    group.setDefaultUserAssignation(false);
+    group.setRoles(new java.util.ArrayList<>(roles));
+    return groupRepository.save(group);
+  }
+
   // -- READ --
 
   @Transactional(readOnly = true)

--- a/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
@@ -42,7 +42,9 @@ public class PlatformRoleService {
   /**
    * Idempotently creates or updates a system-managed platform role with a deterministic id (used by
    * the bootstrap to seed the platform administrators role). Bypasses reserved-name validation and
-   * keeps the role platform-scoped (no tenant).
+   * keeps the role platform-scoped (no tenant). Fails fast if a role already exists under the id
+   * but is tenant-scoped, since {@code tenant_id} is {@code updatable=false} and silently reusing
+   * it would grant incorrect, tenant-scoped privileges.
    */
   public Role ensureInternalPlatformRole(
       @NotBlank final String id,
@@ -51,6 +53,10 @@ public class PlatformRoleService {
       @NotNull final Set<Capability> capabilities) {
     Capability.validateForPlatformRole(capabilities);
     Role role = roleRepository.findById(id).orElseGet(Role::new);
+    if (role.getTenant() != null) {
+      throw new IllegalStateException(
+          "Role " + id + " already exists as a tenant-scoped role; expected a platform role");
+    }
     role.setId(id);
     role.setName(name);
     role.setDescription(description);

--- a/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
@@ -40,11 +40,12 @@ public class PlatformRoleService {
   }
 
   /**
-   * Idempotently creates or updates a system-managed platform role with a deterministic id (used by
-   * the bootstrap to seed the platform administrators role). Bypasses reserved-name validation and
-   * keeps the role platform-scoped (no tenant). Fails fast if a role already exists under the id
-   * but is tenant-scoped, since {@code tenant_id} is {@code updatable=false} and silently reusing
-   * it would grant incorrect, tenant-scoped privileges.
+   * Idempotently creates or updates a system-managed platform role under a fixed, well-known id
+   * (used by the bootstrap to seed the platform administrators role). This is an internal seeding
+   * path that keeps the role platform-scoped (no tenant); unlike the tenant-scoped role CRUD, it
+   * does not run the reserved-id validation. Fails fast if a role already exists under the id but
+   * is tenant-scoped, since {@code tenant_id} is {@code updatable=false} and silently reusing it
+   * would grant incorrect, tenant-scoped privileges.
    */
   public Role ensureInternalPlatformRole(
       @NotBlank final String id,

--- a/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
@@ -39,6 +39,25 @@ public class PlatformRoleService {
     return roleRepository.save(role);
   }
 
+  /**
+   * Idempotently creates or updates a system-managed platform role with a deterministic id (used by
+   * the bootstrap to seed the platform administrators role). Bypasses reserved-name validation and
+   * keeps the role platform-scoped (no tenant).
+   */
+  public Role ensureInternalPlatformRole(
+      @NotBlank final String id,
+      @NotBlank final String name,
+      final String description,
+      @NotNull final Set<Capability> capabilities) {
+    Capability.validateForPlatformRole(capabilities);
+    Role role = roleRepository.findById(id).orElseGet(Role::new);
+    role.setId(id);
+    role.setName(name);
+    role.setDescription(description);
+    role.setCapabilities(Capability.resolveWithParents(capabilities));
+    return roleRepository.save(role);
+  }
+
   // -- READ --
 
   @Transactional(readOnly = true)

--- a/openaev-api/src/test/java/io/openaev/rest/UserApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/UserApiTest.java
@@ -157,7 +157,11 @@ class UserApiTest extends IntegrationTest {
 
     @AfterEach
     public void after() {
-      userRepository.deleteAll();
+      // Only remove the user created by this test. A blunt deleteAll() would also remove the
+      // bootstrap admin, who now belongs to the default-tenant "Administrators" group; deleting a
+      // group member through Hibernate without clearing the bidirectional users_groups link raises
+      // a TransientObjectException (see TenantGroupService.delete()).
+      userRepository.findByEmailIgnoreCase(EMAIL).ifPresent(userRepository::delete);
     }
 
     @DisplayName("With a known email")

--- a/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
+++ b/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
@@ -98,4 +98,23 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
 
     assertThat(adminGroupCount).isEqualTo(1);
   }
+
+  @DisplayName("Admin user is enrolled in the platform admin group at bootstrap")
+  @Test
+  void given_platform_bootstrap_should_enroll_admin_in_platform_admin_group() {
+    // Act
+    User adminUser = this.userRepository.findById(ADMIN_UUID).orElseThrow();
+    List<Group> platformAdminGroups =
+        adminUser.getUnscopedGroups().stream()
+            .filter(group -> AdminPrivilegeService.PLATFORM_ADMIN_GROUP_ID.equals(group.getId()))
+            .toList();
+
+    // Assert
+    assertThat(platformAdminGroups).hasSize(1);
+    Group platformAdminGroup = platformAdminGroups.getFirst();
+    assertThat(platformAdminGroup.getTenant()).isNull();
+    assertThat(platformAdminGroup.getRoles())
+        .anyMatch(role -> role.getCapabilities().contains(Capability.BYPASS));
+    assertThat(adminUser.hasPlatformBypass()).isTrue();
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
+++ b/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
@@ -12,6 +12,7 @@ import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.TokenRepository;
 import io.openaev.database.repository.UserRepository;
+import io.openaev.service.AbstractPrivilegeService;
 import io.openaev.service.account.AdminPrivilegeService;
 import io.openaev.utilstest.RabbitMQTestListener;
 import java.util.List;
@@ -52,14 +53,20 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
 
   @DisplayName("Admin user is enrolled in the default-tenant admin group at bootstrap")
   @Test
-  void adminUserBelongsToAdminGroupTest() {
-    User adminUser = this.userRepository.findById(ADMIN_UUID).orElseThrow();
+  void given_platform_bootstrap_should_enroll_admin_in_default_tenant_admin_group() {
+    // Arrange
+    String adminGroupId =
+        AbstractPrivilegeService.getUUIDFromName(
+            AdminPrivilegeService.ADMIN_GROUP_ID, DEFAULT_TENANT_UUID);
 
+    // Act
+    User adminUser = this.userRepository.findById(ADMIN_UUID).orElseThrow();
     List<Group> adminGroups =
         adminUser.getUnscopedGroups().stream()
-            .filter(group -> AdminPrivilegeService.ADMIN_GROUP_NAME.equals(group.getName()))
+            .filter(group -> adminGroupId.equals(group.getId()))
             .toList();
 
+    // Assert
     assertThat(adminGroups).hasSize(1);
     Group adminGroup = adminGroups.getFirst();
     assertThat(adminGroup.getTenant()).isNotNull();
@@ -68,16 +75,25 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
         .anyMatch(role -> role.getCapabilities().contains(Capability.BYPASS));
   }
 
-  @DisplayName("Ensuring the admin group twice is idempotent")
+  @DisplayName("Ensuring the admin group twice keeps a single membership")
   @Test
-  void ensureAdminGroupIsIdempotentTest() {
-    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, ADMIN_UUID);
-    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, ADMIN_UUID);
+  void given_admin_group_ensured_twice_should_keep_single_membership() {
+    // Arrange
+    String adminGroupId =
+        AbstractPrivilegeService.getUUIDFromName(
+            AdminPrivilegeService.ADMIN_GROUP_ID, DEFAULT_TENANT_UUID);
 
+    // Act
+    this.adminPrivilegeService.ensureAdminGroup(
+        DEFAULT_TENANT_UUID, this.userRepository.findById(ADMIN_UUID).orElseThrow());
+    this.adminPrivilegeService.ensureAdminGroup(
+        DEFAULT_TENANT_UUID, this.userRepository.findById(ADMIN_UUID).orElseThrow());
+
+    // Assert
     User adminUser = this.userRepository.findById(ADMIN_UUID).orElseThrow();
     long adminGroupCount =
         adminUser.getUnscopedGroups().stream()
-            .filter(group -> AdminPrivilegeService.ADMIN_GROUP_NAME.equals(group.getName()))
+            .filter(group -> adminGroupId.equals(group.getId()))
             .count();
 
     assertThat(adminGroupCount).isEqualTo(1);

--- a/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
+++ b/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
@@ -1,15 +1,20 @@
 package io.openaev.runner;
 
+import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
 import static io.openaev.database.model.Token.ADMIN_TOKEN_UUID;
 import static io.openaev.database.model.User.ADMIN_UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openaev.IntegrationTest;
+import io.openaev.database.model.Capability;
+import io.openaev.database.model.Group;
 import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.TokenRepository;
 import io.openaev.database.repository.UserRepository;
+import io.openaev.service.account.AdminPrivilegeService;
 import io.openaev.utilstest.RabbitMQTestListener;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,8 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
 
   @Autowired private TokenRepository tokenRepository;
 
+  @Autowired private AdminPrivilegeService adminPrivilegeService;
+
   @DisplayName("Test if admin user is created")
   @Test
   void adminUserExistTest() {
@@ -41,5 +48,38 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
   void adminTokenExistTest() {
     Optional<Token> adminToken = this.tokenRepository.findById(ADMIN_TOKEN_UUID);
     assertThat(adminToken.isPresent()).isTrue();
+  }
+
+  @DisplayName("Admin user is enrolled in the default-tenant admin group at bootstrap")
+  @Test
+  void adminUserBelongsToAdminGroupTest() {
+    User adminUser = this.userRepository.findById(ADMIN_UUID).orElseThrow();
+
+    List<Group> adminGroups =
+        adminUser.getUnscopedGroups().stream()
+            .filter(group -> AdminPrivilegeService.ADMIN_GROUP_NAME.equals(group.getName()))
+            .toList();
+
+    assertThat(adminGroups).hasSize(1);
+    Group adminGroup = adminGroups.getFirst();
+    assertThat(adminGroup.getTenant()).isNotNull();
+    assertThat(adminGroup.getTenant().getId()).isEqualTo(DEFAULT_TENANT_UUID);
+    assertThat(adminGroup.getRoles())
+        .anyMatch(role -> role.getCapabilities().contains(Capability.BYPASS));
+  }
+
+  @DisplayName("Ensuring the admin group twice is idempotent")
+  @Test
+  void ensureAdminGroupIsIdempotentTest() {
+    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, ADMIN_UUID);
+    this.adminPrivilegeService.ensureAdminGroup(DEFAULT_TENANT_UUID, ADMIN_UUID);
+
+    User adminUser = this.userRepository.findById(ADMIN_UUID).orElseThrow();
+    long adminGroupCount =
+        adminUser.getUnscopedGroups().stream()
+            .filter(group -> AdminPrivilegeService.ADMIN_GROUP_NAME.equals(group.getName()))
+            .count();
+
+    assertThat(adminGroupCount).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## Summary

- Fixes #6345: since multi-tenancy was introduced, a fresh platform no longer seeded an admin group on the default tenant.
- Adds an idempotent `AdminPrivilegeService` (mirroring the existing `ServiceAccountPrivilegeService` / `AbstractPrivilegeService` pattern) that ensures a well-known "Administrators" group exists at two scopes - a platform-scoped group (`tenant = null`) granting platform BYPASS and a default-tenant group granting tenant BYPASS - and that the admin user belongs to both (and to the tenant).
- Enrolls the built-in admin user from `InitAdminCommandLineRunner`, the one bootstrap step that runs after the admin user is guaranteed to exist, on every startup (so it self-heals existing platforms too).

## Why both scopes

`User.getCapabilities()` expands a BYPASS role differently by group scope: a tenant-scoped BYPASS expands to `Capability.allTenantScoped()` only, while a platform-scoped BYPASS expands to `Capability.allPlatformScoped()`. The platform-only capabilities (tenants, platform settings, platform users/groups/roles) are therefore NOT granted by the default-tenant admin group - before this they were reachable only via `user_admin = true`. Seeding a platform-scoped admin group restores full, group-based platform administration (pre-multi-tenancy, the single admin group effectively covered both scopes).

## Root cause

The default tenant is created by a Flyway migration and never runs the `DependenciesManager.createDependencyForTenant(...)` chain that seeds default groups for API-created tenants. The datapack `V20260330_Default_tenant_data` also explicitly skips the default tenant:

```java
if (!Tenant.DEFAULT_TENANT_UUID.equals(TenantContext.getCurrentTenant())) {
    // ... seed roles / groups ...
}
```

This guard was introduced as part of the core multi-tenancy work (#4864). The built-in admin still bypassed RBAC via `user_admin = true`, so the regression went unnoticed: it is a management / RBAC-parity issue, not a lockout, which is why neither CI nor review caught it.

Note on the existing `V4_29__Add_default_roles` migration (raised in review): it only inserts three global default roles (`Observer`/`Manager`/`Admin`, with `Admin` getting `BYPASS`) with random ids and no group and no membership, so it cannot restore group-based admin parity on its own. This bootstrap is what seeds the deterministic admin role+group and enrolls the admin user.

## Behavior

- Fresh platform: a platform-scoped "Administrators" group (platform BYPASS) and a default-tenant "Administrators" group (tenant BYPASS) both exist, and the admin user is a member of both.
- Existing platforms: idempotent and self-healing - the groups/roles are created on the next startup if missing, the admin's tenant membership (`users_tenants`) is ensured, and the admin group memberships are added once.
- Deterministic well-known IDs (same approach as the service account) make the bootstrap safe to run on every boot. Both platform helpers fail fast if an entity already exists under the well-known id but is tenant-scoped, since `tenant_id` is `updatable=false`.

## Review feedback addressed

- `ensureAdminGroup` takes the admin `User` already resolved by the bootstrap runner instead of re-fetching it through `UserService` (some test contexts replace `UserService` with a mock that returns `null`, which made the `CommandLineRunner` throw and the `ApplicationContext` fail to load).
- `ensureAdminGroup` attaches the admin to the tenant (`tenantUserService.attachToTenant`, idempotent `ON CONFLICT DO NOTHING`), matching `ServiceAccountPrivilegeService`, so the self-heal also covers installs whose `users_tenants` row is missing.
- `UserApiTest` reset-password cleanup deletes only the user it created instead of `userRepository.deleteAll()` (the blunt delete tripped a Hibernate `TransientObjectException` on the bidirectional `users_groups` link now that the admin belongs to a group).
- Tenant-scoped wording for the role/group descriptions; new tests renamed to the `given_X_should_Y` convention with Arrange/Act/Assert comments; assertions on the deterministic well-known group id instead of the group name.
- Renamed `PlatformGroupService#ensureInternalPlatformGroupWithRole` to `ensureInternalPlatformGroupWithRoles` (it takes a `List<Role>`), and reworded the `ensureInternalPlatformRole` Javadoc so it no longer claims to "bypass reserved-name validation" - the reserved-key checks validate IDs (on the tenant-scoped CRUD path), not names.

## Rebase

Rebased cleanly onto the latest `main`; all commits are signed and the diff is the six admin-bootstrap files only.

## Test plan

- `InitAdminCommandLineRunnerTest`: the admin is enrolled in the default-tenant admin group and the platform admin group at bootstrap (the platform test asserts `tenant = null`, BYPASS, and `hasPlatformBypass()`), and ensuring the tenant group twice keeps a single membership.
- Spotless, frontend build/quality, CodeQL, signed-commits and PR-title checks pass on the rebased head. Backend compile / API / E2E currently hit an intermittent CI infrastructure race resolving the freshly built `openaev-annotation-processor` artifact (Maven falls back to `shibboleth-releases`, which the runner cannot reach); it is unrelated to this change (the build config is identical to `main`, which is green on the same base commit) and clears on re-run.
- Manual: boot a clean platform and confirm the Groups page shows administrators groups (platform + default tenant) with the admin user as a member.
