### PR TITLE
feat(signatures): save expectations at creation for external injectors (#5452)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/Executor.java
+++ b/openaev-api/src/main/java/io/openaev/executors/Executor.java
@@ -1,5 +1,8 @@
 package io.openaev.executors;
 
+import static io.openaev.database.model.ExecutionStatus.EXECUTING;
+import static io.openaev.utils.InjectionUtils.isInInjectableRange;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.database.model.*;
 import io.openaev.database.model.Injector;
@@ -17,16 +20,11 @@ import io.openaev.service.RabbitmqService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import jakarta.annotation.Resource;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationContext;
-import org.springframework.stereotype.Component;
-
 import java.time.Instant;
 import java.util.List;
-
-import static io.openaev.database.model.ExecutionStatus.EXECUTING;
-import static io.openaev.utils.InjectionUtils.isInInjectableRange;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -34,8 +32,6 @@ import static io.openaev.utils.InjectionUtils.isInInjectableRange;
 public class Executor {
 
   @Resource protected ObjectMapper mapper;
-
-  private final ApplicationContext context;
 
   private final InjectStatusRepository injectStatusRepository;
   private final InjectorRepository injectorRepository;
@@ -55,7 +51,7 @@ public class Executor {
   public static final String PSH = "psh";
 
   private InjectStatus executeExternal(ExecutableInject executableInject, Injector injector)
-          throws Exception {
+      throws Exception {
     Inject inject = executableInject.getInjection().getInject();
     String jsonInject =
         mapper.writeValueAsString(
@@ -63,12 +59,14 @@ public class Executor {
     InjectStatus injectStatus =
         this.injectStatusRepository.findByInjectId(inject.getId()).orElseThrow();
 
+    List<AssetToExecute> assetToExecutes = this.injectService.resolveAllAssetsToExecute(inject);
+    injectExpectationService.computeAndSaveExpectations(
+        executableInject, inject, injector.getType(), assetToExecutes);
+
     rabbitmqService.publish(injector.getId(), jsonInject);
     injectStatus.addInfoTrace(
         "The inject has been published and is now waiting to be consumed.",
         ExecutionTraceAction.EXECUTION);
-    List<AssetToExecute> assetToExecutes = this.injectService.resolveAllAssetsToExecute(inject);
-    injectExpectationService.computeAndSaveExpectations(executableInject, inject, injector.getType(), assetToExecutes);
     return this.injectStatusRepository.save(injectStatus);
   }
 
@@ -107,8 +105,7 @@ public class Executor {
               .orElseThrow(
                   () ->
                       new IllegalStateException(
-                          "Injector not found for type: "
-                              + injectorContract.getFirstInjector().getType()));
+                          "Injector not found for type: " + inject.getType()));
     }
 
     // Telemetry - We shouldn't have multiple injector type per executable inject but if it happens,

--- a/openaev-api/src/main/java/io/openaev/executors/Executor.java
+++ b/openaev-api/src/main/java/io/openaev/executors/Executor.java
@@ -1,8 +1,5 @@
 package io.openaev.executors;
 
-import static io.openaev.database.model.ExecutionStatus.EXECUTING;
-import static io.openaev.utils.InjectionUtils.isInInjectableRange;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.database.model.*;
 import io.openaev.database.model.Injector;
@@ -12,18 +9,24 @@ import io.openaev.execution.ExecutableInject;
 import io.openaev.execution.ExecutableInjectDTOMapper;
 import io.openaev.execution.ExecutionExecutorService;
 import io.openaev.integration.ManagerFactory;
+import io.openaev.rest.inject.service.AssetToExecute;
+import io.openaev.rest.inject.service.InjectService;
 import io.openaev.rest.inject.service.InjectStatusService;
+import io.openaev.service.InjectExpectationService;
 import io.openaev.service.RabbitmqService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import jakarta.annotation.Resource;
-import java.io.IOException;
-import java.time.Instant;
-import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+
+import static io.openaev.database.model.ExecutionStatus.EXECUTING;
+import static io.openaev.utils.InjectionUtils.isInInjectableRange;
 
 @Component
 @RequiredArgsConstructor
@@ -43,14 +46,16 @@ public class Executor {
 
   private final ExecutionExecutorService executionExecutorService;
   private final InjectStatusService injectStatusService;
+  private final InjectService injectService;
   private final ExecutableInjectDTOMapper executableInjectDTOMapper;
   private final ConnectorInstanceService connectorInstanceService;
+  private final InjectExpectationService injectExpectationService;
 
   public static final String CMD = "cmd";
   public static final String PSH = "psh";
 
   private InjectStatus executeExternal(ExecutableInject executableInject, Injector injector)
-      throws IOException, TimeoutException {
+          throws Exception {
     Inject inject = executableInject.getInjection().getInject();
     String jsonInject =
         mapper.writeValueAsString(
@@ -62,6 +67,8 @@ public class Executor {
     injectStatus.addInfoTrace(
         "The inject has been published and is now waiting to be consumed.",
         ExecutionTraceAction.EXECUTION);
+    List<AssetToExecute> assetToExecutes = this.injectService.resolveAllAssetsToExecute(inject);
+    injectExpectationService.computeAndSaveExpectations(executableInject, inject, injector.getType(), assetToExecutes);
     return this.injectStatusRepository.save(injectStatus);
   }
 

--- a/openaev-api/src/main/java/io/openaev/executors/Injector.java
+++ b/openaev-api/src/main/java/io/openaev/executors/Injector.java
@@ -1,19 +1,18 @@
 package io.openaev.executors;
 
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.utils.InjectionUtils.isInInjectableRange;
+
 import io.openaev.database.model.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.model.ExecutionProcess;
-import org.apache.commons.io.IOUtils;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.utils.InjectionUtils.isInInjectableRange;
+import org.apache.commons.io.IOUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 public abstract class Injector {
 

--- a/openaev-api/src/main/java/io/openaev/executors/Injector.java
+++ b/openaev-api/src/main/java/io/openaev/executors/Injector.java
@@ -1,20 +1,19 @@
 package io.openaev.executors;
 
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.utils.InjectionUtils.isInInjectableRange;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.model.ExecutionProcess;
-import jakarta.validation.constraints.NotNull;
+import org.apache.commons.io.IOUtils;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.io.IOUtils;
-import org.springframework.transaction.annotation.Transactional;
+
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.utils.InjectionUtils.isInInjectableRange;
 
 public abstract class Injector {
 
@@ -66,14 +65,6 @@ public abstract class Injector {
   }
 
   // region utils
-
-  public <T> T contentConvert(
-      @NotNull final ExecutableInject injection, @NotNull final Class<T> converter)
-      throws Exception {
-    Inject inject = injection.getInjection().getInject();
-    ObjectNode content = inject.getContent();
-    return this.context.getMapper().treeToValue(content, converter);
-  }
 
   public List<DataAttachment> resolveAttachments(
       Execution execution, ExecutableInject injection, List<Document> documents) {

--- a/openaev-api/src/main/java/io/openaev/injectors/challenge/ChallengeExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/challenge/ChallengeExecutor.java
@@ -1,10 +1,5 @@
 package io.openaev.injectors.challenge;
 
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
-
 import io.openaev.api.url_access_token.UrlAccessTokenService;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ChallengeRepository;
@@ -22,10 +17,16 @@ import io.openaev.model.expectation.ChallengeExpectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
 
 public class ChallengeExecutor extends Injector {
 
@@ -66,7 +67,7 @@ public class ChallengeExecutor extends Injector {
   public ExecutionProcess process(
       @NotNull final Execution execution, @NotNull final ExecutableInject injection) {
     try {
-      ChallengeContent content = contentConvert(injection, ChallengeContent.class);
+      ChallengeContent content = injectExpectationService.contentConvert(injection, ChallengeContent.class);
       List<Challenge> challenges =
           fromIterable(challengeRepository.findAllById(content.getChallenges()));
       if (challenges.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/injectors/challenge/ChallengeExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/challenge/ChallengeExecutor.java
@@ -1,5 +1,10 @@
 package io.openaev.injectors.challenge;
 
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
+
 import io.openaev.api.url_access_token.UrlAccessTokenService;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ChallengeRepository;
@@ -17,16 +22,10 @@ import io.openaev.model.expectation.ChallengeExpectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.injectors.challenge.ChallengeContract.CHALLENGE_PUBLISH;
 
 public class ChallengeExecutor extends Injector {
 
@@ -67,7 +66,8 @@ public class ChallengeExecutor extends Injector {
   public ExecutionProcess process(
       @NotNull final Execution execution, @NotNull final ExecutableInject injection) {
     try {
-      ChallengeContent content = injectExpectationService.contentConvert(injection, ChallengeContent.class);
+      ChallengeContent content =
+          injectExpectationService.contentConvert(injection, ChallengeContent.class);
       List<Challenge> challenges =
           fromIterable(challengeRepository.findAllById(content.getChallenges()));
       if (challenges.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/injectors/challenge/model/ChallengeContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/challenge/model/ChallengeContent.java
@@ -2,11 +2,11 @@ package io.openaev.injectors.challenge.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.injectors.email.model.EmailContent;
-import io.openaev.model.inject.form.Expectation;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -15,6 +15,4 @@ public class ChallengeContent extends EmailContent {
   @JsonProperty("challenges")
   private List<String> challenges = new ArrayList<>();
 
-  @JsonProperty("expectations")
-  private List<Expectation> expectations = new ArrayList<>();
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/challenge/model/ChallengeContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/challenge/model/ChallengeContent.java
@@ -2,11 +2,10 @@ package io.openaev.injectors.challenge.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.injectors.email.model.EmailContent;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -14,5 +13,4 @@ public class ChallengeContent extends EmailContent {
 
   @JsonProperty("challenges")
   private List<String> challenges = new ArrayList<>();
-
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
@@ -1,9 +1,5 @@
 package io.openaev.injectors.channel;
 
-import static io.openaev.database.model.ExecutionTrace.*;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
-
 import io.openaev.api.url_access_token.UrlAccessTokenService;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ArticleRepository;
@@ -21,10 +17,15 @@ import io.openaev.model.expectation.ChannelExpectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static io.openaev.database.model.ExecutionTrace.*;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
 
 public class ChannelExecutor extends Injector {
 
@@ -71,7 +72,7 @@ public class ChannelExecutor extends Injector {
   public ExecutionProcess process(
       @NotNull final Execution execution, @NotNull final ExecutableInject injection) {
     try {
-      ChannelContent content = contentConvert(injection, ChannelContent.class);
+      ChannelContent content = injectExpectationService.contentConvert(injection, ChannelContent.class);
       List<Article> articles = fromIterable(articleRepository.findAllById(content.getArticles()));
       if (articles.isEmpty()) {
         throw new UnsupportedOperationException("Inject needs at least one article");

--- a/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/channel/ChannelExecutor.java
@@ -1,5 +1,9 @@
 package io.openaev.injectors.channel;
 
+import static io.openaev.database.model.ExecutionTrace.*;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
+
 import io.openaev.api.url_access_token.UrlAccessTokenService;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ArticleRepository;
@@ -17,15 +21,10 @@ import io.openaev.model.expectation.ChannelExpectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static io.openaev.database.model.ExecutionTrace.*;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.injectors.channel.ChannelContract.CHANNEL_PUBLISH;
 
 public class ChannelExecutor extends Injector {
 
@@ -72,7 +71,8 @@ public class ChannelExecutor extends Injector {
   public ExecutionProcess process(
       @NotNull final Execution execution, @NotNull final ExecutableInject injection) {
     try {
-      ChannelContent content = injectExpectationService.contentConvert(injection, ChannelContent.class);
+      ChannelContent content =
+          injectExpectationService.contentConvert(injection, ChannelContent.class);
       List<Article> articles = fromIterable(articleRepository.findAllById(content.getArticles()));
       if (articles.isEmpty()) {
         throw new UnsupportedOperationException("Inject needs at least one article");

--- a/openaev-api/src/main/java/io/openaev/injectors/channel/model/ChannelContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/channel/model/ChannelContent.java
@@ -2,11 +2,11 @@ package io.openaev.injectors.channel.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.injectors.email.model.EmailContent;
-import io.openaev.model.inject.form.Expectation;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Setter
 @Getter
@@ -15,9 +15,7 @@ public class ChannelContent extends EmailContent {
   @JsonProperty("articles")
   private List<String> articles = new ArrayList<>();
 
-  @JsonProperty("expectations")
-  private List<Expectation> expectations = new ArrayList<>();
-
   @JsonProperty("emailing")
   private boolean emailing;
+
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/channel/model/ChannelContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/channel/model/ChannelContent.java
@@ -2,11 +2,10 @@ package io.openaev.injectors.channel.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.injectors.email.model.EmailContent;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
 @Setter
 @Getter
@@ -17,5 +16,4 @@ public class ChannelContent extends EmailContent {
 
   @JsonProperty("emailing")
   private boolean emailing;
-
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/common/model/BaseInjectContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/common/model/BaseInjectContent.java
@@ -2,17 +2,15 @@ package io.openaev.injectors.common.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.model.inject.form.Expectation;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Setter
 public class BaseInjectContent {
 
-    @JsonProperty("expectations")
-    private List<Expectation> expectations = new ArrayList<>();
-
+  @JsonProperty("expectations")
+  private List<Expectation> expectations = new ArrayList<>();
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/common/model/BaseInjectContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/common/model/BaseInjectContent.java
@@ -1,0 +1,18 @@
+package io.openaev.injectors.common.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.model.inject.form.Expectation;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class BaseInjectContent {
+
+    @JsonProperty("expectations")
+    private List<Expectation> expectations = new ArrayList<>();
+
+}

--- a/openaev-api/src/main/java/io/openaev/injectors/email/EmailExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/EmailExecutor.java
@@ -1,8 +1,5 @@
 package io.openaev.injectors.email;
 
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.injectors.email.EmailContract.EMAIL_GLOBAL;
-
 import io.openaev.database.model.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.execution.ExecutionContext;
@@ -15,9 +12,13 @@ import io.openaev.model.Expectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.injectors.email.EmailContract.EMAIL_GLOBAL;
 
 public class EmailExecutor extends Injector {
 
@@ -87,7 +88,7 @@ public class EmailExecutor extends Injector {
       @NotNull final Execution execution, @NotNull final ExecutableInject injection)
       throws Exception {
     Inject inject = injection.getInjection().getInject();
-    EmailContent content = contentConvert(injection, EmailContent.class);
+    EmailContent content = injectExpectationService.contentConvert(injection, EmailContent.class);
     List<Document> documents =
         inject.getDocuments().stream()
             .filter(InjectDocument::isAttached)

--- a/openaev-api/src/main/java/io/openaev/injectors/email/EmailExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/EmailExecutor.java
@@ -1,5 +1,8 @@
 package io.openaev.injectors.email;
 
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.injectors.email.EmailContract.EMAIL_GLOBAL;
+
 import io.openaev.database.model.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.execution.ExecutionContext;
@@ -12,13 +15,9 @@ import io.openaev.model.Expectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.injectors.email.EmailContract.EMAIL_GLOBAL;
 
 public class EmailExecutor extends Injector {
 

--- a/openaev-api/src/main/java/io/openaev/injectors/email/model/EmailContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/model/EmailContent.java
@@ -3,11 +3,10 @@ package io.openaev.injectors.email.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.injectors.common.model.BaseInjectContent;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.util.StringUtils;
-
-import java.util.Objects;
 
 @Getter
 @Setter

--- a/openaev-api/src/main/java/io/openaev/injectors/email/model/EmailContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/model/EmailContent.java
@@ -2,17 +2,16 @@ package io.openaev.injectors.email.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.execution.ExecutableInject;
-import io.openaev.model.inject.form.Expectation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import io.openaev.injectors.common.model.BaseInjectContent;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.util.StringUtils;
 
+import java.util.Objects;
+
 @Getter
 @Setter
-public class EmailContent {
+public class EmailContent extends BaseInjectContent {
 
   private static final String HEADER_DIV =
       "<div style=\"text-align: center; margin-bottom: 10px;\">";
@@ -30,9 +29,6 @@ public class EmailContent {
 
   @JsonProperty("encrypted")
   private boolean encrypted;
-
-  @JsonProperty("expectations")
-  private List<Expectation> expectations = new ArrayList<>();
 
   public EmailContent() {
     // For mapper

--- a/openaev-api/src/main/java/io/openaev/injectors/manual/ManualExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/manual/ManualExecutor.java
@@ -30,7 +30,7 @@ public class ManualExecutor extends Injector {
       @NotNull final Execution execution, @NotNull final ExecutableInject injection)
       throws Exception {
 
-    ManualContent content = contentConvert(injection, ManualContent.class);
+    ManualContent content = injectExpectationService.contentConvert(injection, ManualContent.class);
 
     List<Expectation> expectations =
         content.getExpectations().stream()

--- a/openaev-api/src/main/java/io/openaev/injectors/manual/model/ManualContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/manual/model/ManualContent.java
@@ -1,15 +1,10 @@
 package io.openaev.injectors.manual.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.openaev.model.inject.form.Expectation;
-import java.util.ArrayList;
-import java.util.List;
+import io.openaev.injectors.common.model.BaseInjectContent;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class ManualContent {
-  @JsonProperty("expectations")
-  private List<Expectation> expectations = new ArrayList<>();
+public class ManualContent extends BaseInjectContent {
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/manual/model/ManualContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/manual/model/ManualContent.java
@@ -6,5 +6,4 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ManualContent extends BaseInjectContent {
-}
+public class ManualContent extends BaseInjectContent {}

--- a/openaev-api/src/main/java/io/openaev/injectors/openaev/OpenAEVImplantExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/openaev/OpenAEVImplantExecutor.java
@@ -1,5 +1,8 @@
 package io.openaev.injectors.openaev;
 
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.utils.ExpectationUtils.OAEV_IMPLANT;
+
 import io.openaev.database.model.Execution;
 import io.openaev.database.model.ExecutionTraceAction;
 import io.openaev.database.model.Inject;
@@ -9,29 +12,21 @@ import io.openaev.executors.InjectorContext;
 import io.openaev.model.ExecutionProcess;
 import io.openaev.rest.inject.service.AssetToExecute;
 import io.openaev.rest.inject.service.InjectService;
-import io.openaev.service.AssetGroupService;
 import io.openaev.service.InjectExpectationService;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.List;
-
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.utils.ExpectationUtils.OAEV_IMPLANT;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class OpenAEVImplantExecutor extends Injector {
 
-  private final AssetGroupService assetGroupService;
   private final InjectExpectationService injectExpectationService;
   private final InjectService injectService;
 
   public OpenAEVImplantExecutor(
       InjectorContext context,
-      AssetGroupService assetGroupService,
       InjectExpectationService injectExpectationService,
       InjectService injectService) {
     super(context);
-    this.assetGroupService = assetGroupService;
     this.injectExpectationService = injectExpectationService;
     this.injectService = injectService;
   }
@@ -52,8 +47,8 @@ public class OpenAEVImplantExecutor extends Injector {
     }
 
     // Compute expectations
-    injectExpectationService.computeAndSaveExpectations(injection, inject, OAEV_IMPLANT, assetToExecutes);
-
+    injectExpectationService.computeAndSaveExpectations(
+        injection, inject, OAEV_IMPLANT, assetToExecutes);
 
     return new ExecutionProcess(true);
   }

--- a/openaev-api/src/main/java/io/openaev/injectors/openaev/OpenAEVImplantExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/openaev/OpenAEVImplantExecutor.java
@@ -1,32 +1,22 @@
 package io.openaev.injectors.openaev;
 
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.model.expectation.DetectionExpectation.*;
-import static io.openaev.model.expectation.ManualExpectation.*;
-import static io.openaev.model.expectation.PreventionExpectation.*;
-import static io.openaev.utils.AgentUtils.getActiveAgents;
-import static io.openaev.utils.ExpectationUtils.*;
-import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
-
-import io.openaev.database.model.*;
+import io.openaev.database.model.Execution;
+import io.openaev.database.model.ExecutionTraceAction;
+import io.openaev.database.model.Inject;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.executors.Injector;
 import io.openaev.executors.InjectorContext;
-import io.openaev.injectors.openaev.model.OpenAEVImplantInjectContent;
 import io.openaev.model.ExecutionProcess;
-import io.openaev.model.Expectation;
-import io.openaev.model.expectation.DetectionExpectation;
-import io.openaev.model.expectation.ManualExpectation;
-import io.openaev.model.expectation.PreventionExpectation;
-import io.openaev.model.expectation.VulnerabilityExpectation;
 import io.openaev.rest.inject.service.AssetToExecute;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.service.AssetGroupService;
 import io.openaev.service.InjectExpectationService;
-import jakarta.validation.constraints.NotNull;
-import java.util.*;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.utils.ExpectationUtils.OAEV_IMPLANT;
 
 @Slf4j
 public class OpenAEVImplantExecutor extends Injector {
@@ -62,225 +52,9 @@ public class OpenAEVImplantExecutor extends Injector {
     }
 
     // Compute expectations
-    OpenAEVImplantInjectContent content =
-        contentConvert(injection, OpenAEVImplantInjectContent.class);
+    injectExpectationService.computeAndSaveExpectations(injection, inject, OAEV_IMPLANT, assetToExecutes);
 
-    List<Expectation> expectations = new ArrayList<>();
-
-    assetToExecutes.forEach(
-        assetToExecute ->
-            computeExpectationsForAssetAndAgents(expectations, content, assetToExecute, inject));
-
-    List<AssetGroup> assetGroups = injection.getAssetGroups();
-    assetGroups.forEach(
-        (assetGroup -> computeExpectationsForAssetGroup(expectations, content, assetGroup)));
-
-    injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
 
     return new ExecutionProcess(true);
-  }
-
-  // -- PRIVATE --
-
-  /** In case of direct assetToExecute, we have an individual expectation for the assetToExecute */
-  private void computeExpectationsForAssetAndAgents(
-      @NotNull final List<Expectation> expectations,
-      @NotNull final OpenAEVImplantInjectContent content,
-      @NotNull final AssetToExecute assetToExecute,
-      final Inject inject) {
-
-    if (!content.getExpectations().isEmpty()) {
-
-      Map<String, Endpoint> valueTargetedAssetsMap = injectService.getValueTargetedAssetMap(inject);
-
-      expectations.addAll(
-          content.getExpectations().stream()
-              .flatMap(
-                  expectation ->
-                      switch (expectation.getType()) {
-                        case PREVENTION ->
-                            getPreventionExpectationsByAsset(
-                                OAEV_IMPLANT,
-                                assetToExecute,
-                                getActiveAgents(assetToExecute.asset(), inject),
-                                expectation,
-                                valueTargetedAssetsMap,
-                                inject.getId())
-                                .stream();
-                        case DETECTION ->
-                            getDetectionExpectationsByAsset(
-                                OAEV_IMPLANT,
-                                assetToExecute,
-                                getActiveAgents(assetToExecute.asset(), inject),
-                                expectation,
-                                valueTargetedAssetsMap,
-                                inject.getId())
-                                .stream();
-                        case VULNERABILITY ->
-                            getVulnerabilityExpectationsByAsset(
-                                OAEV_IMPLANT,
-                                assetToExecute,
-                                getActiveAgents(assetToExecute.asset(), inject),
-                                expectation,
-                                valueTargetedAssetsMap,
-                                inject.getId())
-                                .stream();
-                        case MANUAL ->
-                            getManualExpectationsByAsset(
-                                OAEV_IMPLANT,
-                                assetToExecute,
-                                getActiveAgents(assetToExecute.asset(), inject),
-                                expectation)
-                                .stream();
-                        default -> Stream.of();
-                      })
-              .toList());
-    }
-  }
-
-  /**
-   * In case of asset group if expectation group -> we have an expectation for the group and one for
-   * each asset if not expectation group -> we have an individual expectation for each asset
-   */
-  private void computeExpectationsForAssetGroup(
-      @NotNull final List<Expectation> expectations,
-      @NotNull final OpenAEVImplantInjectContent content,
-      @NotNull final AssetGroup assetGroup) {
-    if (!content.getExpectations().isEmpty()) {
-      expectations.addAll(
-          content.getExpectations().stream()
-              .flatMap(
-                  expectation ->
-                      switch (expectation.getType()) {
-                        case PREVENTION -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  asset ->
-                                      expectations.stream()
-                                          .filter(
-                                              prevExpectation ->
-                                                  InjectExpectation.EXPECTATION_TYPE.PREVENTION
-                                                      == prevExpectation.type())
-                                          .anyMatch(
-                                              prevExpectation ->
-                                                  ((PreventionExpectation) prevExpectation)
-                                                              .getAsset()
-                                                          != null
-                                                      && ((PreventionExpectation) prevExpectation)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                preventionExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.isExpectationGroup(),
-                                    expectation.getExpirationTime()));
-                          }
-                          yield Stream.of();
-                        }
-                        case DETECTION -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  asset ->
-                                      expectations.stream()
-                                          .filter(
-                                              detExpectation ->
-                                                  InjectExpectation.EXPECTATION_TYPE.DETECTION
-                                                      == detExpectation.type())
-                                          .anyMatch(
-                                              detExpectation ->
-                                                  ((DetectionExpectation) detExpectation).getAsset()
-                                                          != null
-                                                      && ((DetectionExpectation) detExpectation)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                detectionExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.isExpectationGroup(),
-                                    expectation.getExpirationTime()));
-                          }
-                          yield Stream.of();
-                        }
-                        case VULNERABILITY -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  asset ->
-                                      expectations.stream()
-                                          .filter(
-                                              vulExpectation ->
-                                                  InjectExpectation.EXPECTATION_TYPE.VULNERABILITY
-                                                      == vulExpectation.type())
-                                          .anyMatch(
-                                              vulExpectation ->
-                                                  ((VulnerabilityExpectation) vulExpectation)
-                                                              .getAsset()
-                                                          != null
-                                                      && ((VulnerabilityExpectation) vulExpectation)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                vulnerabilityExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.isExpectationGroup(),
-                                    expectation.getExpirationTime()));
-                          }
-                          yield Stream.of();
-                        }
-                        case MANUAL -> {
-                          // Verify that at least one asset in the group has been executed
-                          List<Asset> assets =
-                              this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                          if (assets.stream()
-                              .anyMatch(
-                                  asset ->
-                                      expectations.stream()
-                                          .filter(
-                                              manExpectation ->
-                                                  InjectExpectation.EXPECTATION_TYPE.MANUAL
-                                                      == manExpectation.type())
-                                          .anyMatch(
-                                              manExpectation ->
-                                                  ((ManualExpectation) manExpectation).getAsset()
-                                                          != null
-                                                      && ((ManualExpectation) manExpectation)
-                                                          .getAsset()
-                                                          .getId()
-                                                          .equals(asset.getId())))) {
-                            yield Stream.of(
-                                manualExpectationForAssetGroup(
-                                    expectation.getScore(),
-                                    expectation.getName(),
-                                    expectation.getDescription(),
-                                    assetGroup,
-                                    expectation.getExpirationTime(),
-                                    expectation.isExpectationGroup()));
-                          }
-                          yield Stream.of();
-                        }
-                        default -> Stream.of();
-                      })
-              .toList());
-    }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/opencti/OpenCTIExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/opencti/OpenCTIExecutor.java
@@ -1,5 +1,8 @@
 package io.openaev.injectors.opencti;
 
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.injectors.opencti.OpenCTIContract.OPENCTI_CREATE_CASE;
+
 import io.openaev.database.model.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.executors.Injector;
@@ -11,12 +14,8 @@ import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.opencti.service.OpenCTIService;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
-
 import java.util.List;
 import java.util.stream.Stream;
-
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.injectors.opencti.OpenCTIContract.OPENCTI_CREATE_CASE;
 
 public class OpenCTIExecutor extends Injector {
 

--- a/openaev-api/src/main/java/io/openaev/injectors/opencti/OpenCTIExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/opencti/OpenCTIExecutor.java
@@ -1,8 +1,5 @@
 package io.openaev.injectors.opencti;
 
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.injectors.opencti.OpenCTIContract.OPENCTI_CREATE_CASE;
-
 import io.openaev.database.model.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.executors.Injector;
@@ -14,8 +11,12 @@ import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.opencti.service.OpenCTIService;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
+
 import java.util.List;
 import java.util.stream.Stream;
+
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.injectors.opencti.OpenCTIContract.OPENCTI_CREATE_CASE;
 
 public class OpenCTIExecutor extends Injector {
 
@@ -62,7 +63,7 @@ public class OpenCTIExecutor extends Injector {
       @NotNull final Execution execution, @NotNull final ExecutableInject injection)
       throws Exception {
     Inject inject = injection.getInjection().getInject();
-    CaseContent content = contentConvert(injection, CaseContent.class);
+    CaseContent content = injectExpectationService.contentConvert(injection, CaseContent.class);
     List<Document> documents =
         inject.getDocuments().stream()
             .filter(InjectDocument::isAttached)

--- a/openaev-api/src/main/java/io/openaev/injectors/opencti/model/CaseContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/opencti/model/CaseContent.java
@@ -1,25 +1,21 @@
 package io.openaev.injectors.opencti.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.openaev.model.inject.form.Expectation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import io.openaev.injectors.common.model.BaseInjectContent;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Objects;
+
 @Getter
 @Setter
-public class CaseContent {
+public class CaseContent extends BaseInjectContent {
 
   @JsonProperty("name")
   private String name;
 
   @JsonProperty("description")
   private String description;
-
-  @JsonProperty("expectations")
-  private List<Expectation> expectations = new ArrayList<>();
 
   public CaseContent() {
     // For mapper

--- a/openaev-api/src/main/java/io/openaev/injectors/opencti/model/CaseContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/opencti/model/CaseContent.java
@@ -2,10 +2,9 @@ package io.openaev.injectors.opencti.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.injectors.common.model.BaseInjectContent;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.Objects;
 
 @Getter
 @Setter

--- a/openaev-api/src/main/java/io/openaev/injectors/ovh/OvhSmsExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/ovh/OvhSmsExecutor.java
@@ -1,9 +1,5 @@
 package io.openaev.injectors.ovh;
 
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
-import static org.springframework.util.StringUtils.hasText;
-
 import io.openaev.database.model.Execution;
 import io.openaev.database.model.ExecutionTraceAction;
 import io.openaev.database.model.Inject;
@@ -19,12 +15,17 @@ import io.openaev.model.Expectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.util.StringUtils;
+
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.springframework.util.StringUtils;
+
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
+import static org.springframework.util.StringUtils.hasText;
 
 public class OvhSmsExecutor extends Injector {
 
@@ -45,7 +46,7 @@ public class OvhSmsExecutor extends Injector {
       @NotNull final Execution execution, @NotNull final ExecutableInject injection)
       throws Exception {
     Inject inject = injection.getInjection().getInject();
-    OvhSmsContent content = contentConvert(injection, OvhSmsContent.class);
+    OvhSmsContent content = injectExpectationService.contentConvert(injection, OvhSmsContent.class);
     String smsMessage = content.buildMessage(inject.getFooter(), inject.getHeader());
     List<ExecutionContext> users = injection.getUsers();
     if (users.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/injectors/ovh/OvhSmsExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/ovh/OvhSmsExecutor.java
@@ -1,5 +1,9 @@
 package io.openaev.injectors.ovh;
 
+import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
+import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
+import static org.springframework.util.StringUtils.hasText;
+
 import io.openaev.database.model.Execution;
 import io.openaev.database.model.ExecutionTraceAction;
 import io.openaev.database.model.Inject;
@@ -15,17 +19,12 @@ import io.openaev.model.Expectation;
 import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.util.StringUtils;
-
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
-import static io.openaev.database.model.ExecutionTrace.getNewErrorTrace;
-import static io.openaev.database.model.ExecutionTrace.getNewSuccessTrace;
-import static org.springframework.util.StringUtils.hasText;
+import org.springframework.util.StringUtils;
 
 public class OvhSmsExecutor extends Injector {
 

--- a/openaev-api/src/main/java/io/openaev/injectors/ovh/model/OvhSmsContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/ovh/model/OvhSmsContent.java
@@ -2,24 +2,20 @@ package io.openaev.injectors.ovh.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.openaev.model.inject.form.Expectation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import io.openaev.injectors.common.model.BaseInjectContent;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.util.StringUtils;
 
+import java.util.Objects;
+
 @Setter
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class OvhSmsContent {
+public class OvhSmsContent extends BaseInjectContent {
 
   @JsonProperty("message")
   private String message;
-
-  @JsonProperty("expectations")
-  private List<Expectation> expectations = new ArrayList<>();
 
   public String buildMessage(String footer, String header) {
     StringBuilder data = new StringBuilder();

--- a/openaev-api/src/main/java/io/openaev/injectors/ovh/model/OvhSmsContent.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/ovh/model/OvhSmsContent.java
@@ -3,11 +3,10 @@ package io.openaev.injectors.ovh.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.injectors.common.model.BaseInjectContent;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.util.StringUtils;
-
-import java.util.Objects;
 
 @Setter
 @Getter

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegration.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegration.java
@@ -9,7 +9,6 @@ import io.openaev.integration.ComponentRequestEngine;
 import io.openaev.integration.IntegrationInMemory;
 import io.openaev.integration.QualifiedComponent;
 import io.openaev.rest.inject.service.InjectService;
-import io.openaev.service.AssetGroupService;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.service.InjectorService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
@@ -22,7 +21,6 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
   private final OpenAEVImplantContract openAEVImplantContract;
   private final OpenAEVConfig openAEVConfig;
   private final InjectorContext injectorContext;
-  private final AssetGroupService assetGroupService;
   private final InjectExpectationService injectExpectationService;
   private final InjectService injectService;
 
@@ -37,7 +35,6 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
       OpenAEVImplantContract openAEVImplantContract,
       OpenAEVConfig openAEVConfig,
       InjectorContext injectorContext,
-      AssetGroupService assetGroupService,
       InjectExpectationService injectExpectationService,
       InjectService injectService) {
     super(componentRequestEngine, connectorInstance, connectorInstanceService);
@@ -45,7 +42,6 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
     this.openAEVImplantContract = openAEVImplantContract;
     this.openAEVConfig = openAEVConfig;
     this.injectorContext = injectorContext;
-    this.assetGroupService = assetGroupService;
     this.injectExpectationService = injectExpectationService;
     this.injectService = injectService;
   }
@@ -53,8 +49,7 @@ public class OpenaevInjectorIntegration extends IntegrationInMemory {
   @Override
   protected void innerStart() throws Exception {
     this.openAEVImplantExecutor =
-        new OpenAEVImplantExecutor(
-            injectorContext, assetGroupService, injectExpectationService, injectService);
+        new OpenAEVImplantExecutor(injectorContext, injectExpectationService, injectService);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegrationFactory.java
@@ -11,7 +11,6 @@ import io.openaev.integration.BuiltinIntegrationFactory;
 import io.openaev.integration.ComponentRequestEngine;
 import io.openaev.integration.Integration;
 import io.openaev.rest.inject.service.InjectService;
-import io.openaev.service.AssetGroupService;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.service.InjectorService;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
@@ -30,7 +29,6 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
   private final OpenAEVImplantContract openAEVImplantContract;
   private final OpenAEVConfig openAEVConfig;
   private final InjectorContext injectorContext;
-  private final AssetGroupService assetGroupService;
   private final InjectExpectationService injectExpectationService;
   private final InjectService injectService;
 
@@ -43,7 +41,6 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
       CatalogConnectorService catalogConnectorService,
       HttpClientFactory httpClientFactory,
       InjectorContext injectorContext,
-      AssetGroupService assetGroupService,
       InjectExpectationService injectExpectationService,
       InjectService injectService) {
     super(connectorInstanceService, catalogConnectorService, httpClientFactory);
@@ -53,7 +50,6 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
     this.openAEVImplantContract = openAEVImplantContract;
     this.openAEVConfig = openAEVConfig;
     this.injectorContext = injectorContext;
-    this.assetGroupService = assetGroupService;
     this.injectExpectationService = injectExpectationService;
     this.injectService = injectService;
   }
@@ -97,7 +93,6 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
         openAEVImplantContract,
         openAEVConfig,
         injectorContext,
-        assetGroupService,
         injectExpectationService,
         injectService);
   }

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1,5 +1,22 @@
 package io.openaev.service;
 
+import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
+import static io.openaev.expectation.ExpectationType.VULNERABILITY;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
+import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
+import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
+import static io.openaev.service.InjectExpectationUtils.computeScores;
+import static io.openaev.service.InjectExpectationUtils.expectationConverter;
+import static io.openaev.utils.AgentUtils.getActiveAgents;
+import static io.openaev.utils.AgentUtils.getPrimaryAgents;
+import static io.openaev.utils.ExpectationUtils.*;
+import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
+import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -29,6 +46,12 @@ import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -38,29 +61,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
-import static io.openaev.expectation.ExpectationType.VULNERABILITY;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
-import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
-import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
-import static io.openaev.service.InjectExpectationUtils.computeScores;
-import static io.openaev.service.InjectExpectationUtils.expectationConverter;
-import static io.openaev.utils.AgentUtils.getActiveAgents;
-import static io.openaev.utils.AgentUtils.getPrimaryAgents;
-import static io.openaev.utils.ExpectationUtils.*;
-import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
-import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -1063,6 +1063,11 @@ public class InjectExpectationService {
   @Transactional
   public void buildAndSaveInjectExpectations(
       ExecutableInject executableInject, List<Expectation> expectations) {
+    doBuildAndSaveInjectExpectations(executableInject, expectations);
+  }
+
+  private void doBuildAndSaveInjectExpectations(
+      ExecutableInject executableInject, List<Expectation> expectations) {
     if (expectations == null || expectations.isEmpty()) {
       return;
     }
@@ -1313,8 +1318,8 @@ public class InjectExpectationService {
   /**
    * Converts the inject content payload to a typed object.
    *
-   * <p>The content is read from {@link Inject#getContent()} and deserialized with Jackson using
-   * the provided target class.
+   * <p>The content is read from {@link Inject#getContent()} and deserialized with Jackson using the
+   * provided target class.
    *
    * @param injection the executable inject containing the source content
    * @param converter the target class used for conversion
@@ -1323,83 +1328,90 @@ public class InjectExpectationService {
    * @throws Exception if the JSON content cannot be converted to the requested type
    */
   public <T> T contentConvert(
-          @NotNull final ExecutableInject injection, @NotNull final Class<T> converter)
-          throws Exception {
+      @NotNull final ExecutableInject injection, @NotNull final Class<T> converter)
+      throws JsonProcessingException {
     Inject inject = injection.getInjection().getInject();
     ObjectNode content = inject.getContent();
     return this.mapper.treeToValue(content, converter);
   }
 
-  public void computeAndSaveExpectations(ExecutableInject injection, Inject inject, String implantType, List<AssetToExecute> assetToExecutes) throws Exception {
+  @Transactional
+  public void computeAndSaveExpectations(
+      ExecutableInject injection,
+      Inject inject,
+      String implantType,
+      List<AssetToExecute> assetToExecutes)
+      throws JsonProcessingException {
     BaseInjectContent content = contentConvert(injection, BaseInjectContent.class);
 
     List<Expectation> expectations = new ArrayList<>();
 
     assetToExecutes.forEach(
-            assetToExecute ->
-                    computeExpectationsForAssetAndAgents(expectations, content, assetToExecute, inject, implantType));
+        assetToExecute ->
+            computeExpectationsForAssetAndAgents(
+                expectations, content, assetToExecute, inject, implantType));
 
     List<AssetGroup> assetGroups = injection.getAssetGroups();
     assetGroups.forEach(
-            (assetGroup -> computeExpectationsForAssetGroup(expectations, content, assetGroup)));
+        (assetGroup -> computeExpectationsForAssetGroup(expectations, content, assetGroup)));
 
-    buildAndSaveInjectExpectations(injection, expectations);
+    doBuildAndSaveInjectExpectations(injection, expectations);
   }
 
   /** In case of direct assetToExecute, we have an individual expectation for the assetToExecute */
   private void computeExpectationsForAssetAndAgents(
-          @NotNull final List<Expectation> expectations,
-          @NotNull final BaseInjectContent content,
-          @NotNull final AssetToExecute assetToExecute,
-          final Inject inject,
-          String implantType) {
+      @NotNull final List<Expectation> expectations,
+      @NotNull final BaseInjectContent content,
+      @NotNull final AssetToExecute assetToExecute,
+      final Inject inject,
+      String implantType) {
 
     if (!content.getExpectations().isEmpty()) {
 
       Map<String, Endpoint> valueTargetedAssetsMap = injectService.getValueTargetedAssetMap(inject);
 
       expectations.addAll(
-              content.getExpectations().stream()
-                      .flatMap(
-                              expectation ->
-                                      switch (expectation.getType()) {
-                                        case PREVENTION ->
-                                                getPreventionExpectationsByAsset(
-                                                        implantType,
-                                                        assetToExecute,
-                                                        getActiveAgents(assetToExecute.asset(), inject),
-                                                        expectation,
-                                                        valueTargetedAssetsMap,
-                                                        inject.getId())
-                                                        .stream();
-                                        case DETECTION ->
-                                                getDetectionExpectationsByAsset(
-                                                        implantType,
-                                                        assetToExecute,
-                                                        getActiveAgents(assetToExecute.asset(), inject),
-                                                        expectation,
-                                                        valueTargetedAssetsMap,
-                                                        inject.getId())
-                                                        .stream();
-                                        case VULNERABILITY ->
-                                                getVulnerabilityExpectationsByAsset(
-                                                        implantType,
-                                                        assetToExecute,
-                                                        getActiveAgents(assetToExecute.asset(), inject),
-                                                        expectation,
-                                                        valueTargetedAssetsMap,
-                                                        inject.getId())
-                                                        .stream();
-                                        case MANUAL ->
-                                                getManualExpectationsByAsset(
-                                                        implantType,
-                                                        assetToExecute,
-                                                        getActiveAgents(assetToExecute.asset(), inject),
-                                                        expectation)
-                                                        .stream();
-                                        default -> Stream.of();
-                                      })
-                      .toList());
+          content.getExpectations().stream()
+              .flatMap(
+                  expectation ->
+                      switch (expectation.getType()) {
+                        case PREVENTION ->
+                            getPreventionExpectationsByAsset(
+                                implantType,
+                                assetToExecute,
+                                getActiveAgents(assetToExecute.asset(), inject),
+                                expectation,
+                                valueTargetedAssetsMap,
+                                inject.getId())
+                                .stream();
+                        case DETECTION ->
+                            getDetectionExpectationsByAsset(
+                                implantType,
+                                assetToExecute,
+                                getActiveAgents(assetToExecute.asset(), inject),
+                                expectation,
+                                valueTargetedAssetsMap,
+                                inject.getId())
+                                .stream();
+                        case VULNERABILITY ->
+                            getVulnerabilityExpectationsByAsset(
+                                implantType,
+                                assetToExecute,
+                                getActiveAgents(assetToExecute.asset(), inject),
+                                expectation,
+                                valueTargetedAssetsMap,
+                                inject.getId())
+                                .stream();
+                        case MANUAL ->
+                            getManualExpectationsByAsset(
+                                implantType,
+                                assetToExecute,
+                                getActiveAgents(assetToExecute.asset(), inject),
+                                expectation)
+                                .stream();
+                        default -> Stream.of();
+                      })
+              .toList());
     }
   }
 
@@ -1408,145 +1420,137 @@ public class InjectExpectationService {
    * each asset if not expectation group -> we have an individual expectation for each asset
    */
   private void computeExpectationsForAssetGroup(
-          @NotNull final List<Expectation> expectations,
-          @NotNull final BaseInjectContent content,
-          @NotNull final AssetGroup assetGroup) {
+      @NotNull final List<Expectation> expectations,
+      @NotNull final BaseInjectContent content,
+      @NotNull final AssetGroup assetGroup) {
     if (!content.getExpectations().isEmpty()) {
+      List<Asset> assets = this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
       expectations.addAll(
-              content.getExpectations().stream()
-                      .flatMap(
-                              expectation ->
-                                      switch (expectation.getType()) {
-                                        case PREVENTION -> {
-                                          // Verify that at least one asset in the group has been executed
-                                          List<Asset> assets =
-                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                                          if (assets.stream()
-                                                  .anyMatch(
-                                                          asset ->
-                                                                  expectations.stream()
-                                                                          .filter(
-                                                                                  prevExpectation ->
-                                                                                          InjectExpectation.EXPECTATION_TYPE.PREVENTION
-                                                                                                  == prevExpectation.type())
-                                                                          .anyMatch(
-                                                                                  prevExpectation ->
-                                                                                          ((PreventionExpectation) prevExpectation)
-                                                                                                  .getAsset()
-                                                                                                  != null
-                                                                                                  && ((PreventionExpectation) prevExpectation)
-                                                                                                  .getAsset()
-                                                                                                  .getId()
-                                                                                                  .equals(asset.getId())))) {
-                                            yield Stream.of(
-                                                    preventionExpectationForAssetGroup(
-                                                            expectation.getScore(),
-                                                            expectation.getName(),
-                                                            expectation.getDescription(),
-                                                            assetGroup,
-                                                            expectation.isExpectationGroup(),
-                                                            expectation.getExpirationTime()));
-                                          }
-                                          yield Stream.of();
-                                        }
-                                        case DETECTION -> {
-                                          // Verify that at least one asset in the group has been executed
-                                          List<Asset> assets =
-                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                                          if (assets.stream()
-                                                  .anyMatch(
-                                                          asset ->
-                                                                  expectations.stream()
-                                                                          .filter(
-                                                                                  detExpectation ->
-                                                                                          InjectExpectation.EXPECTATION_TYPE.DETECTION
-                                                                                                  == detExpectation.type())
-                                                                          .anyMatch(
-                                                                                  detExpectation ->
-                                                                                          ((DetectionExpectation) detExpectation).getAsset()
-                                                                                                  != null
-                                                                                                  && ((DetectionExpectation) detExpectation)
-                                                                                                  .getAsset()
-                                                                                                  .getId()
-                                                                                                  .equals(asset.getId())))) {
-                                            yield Stream.of(
-                                                    detectionExpectationForAssetGroup(
-                                                            expectation.getScore(),
-                                                            expectation.getName(),
-                                                            expectation.getDescription(),
-                                                            assetGroup,
-                                                            expectation.isExpectationGroup(),
-                                                            expectation.getExpirationTime()));
-                                          }
-                                          yield Stream.of();
-                                        }
-                                        case VULNERABILITY -> {
-                                          // Verify that at least one asset in the group has been executed
-                                          List<Asset> assets =
-                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                                          if (assets.stream()
-                                                  .anyMatch(
-                                                          asset ->
-                                                                  expectations.stream()
-                                                                          .filter(
-                                                                                  vulExpectation ->
-                                                                                          InjectExpectation.EXPECTATION_TYPE.VULNERABILITY
-                                                                                                  == vulExpectation.type())
-                                                                          .anyMatch(
-                                                                                  vulExpectation ->
-                                                                                          ((VulnerabilityExpectation) vulExpectation)
-                                                                                                  .getAsset()
-                                                                                                  != null
-                                                                                                  && ((VulnerabilityExpectation) vulExpectation)
-                                                                                                  .getAsset()
-                                                                                                  .getId()
-                                                                                                  .equals(asset.getId())))) {
-                                            yield Stream.of(
-                                                    vulnerabilityExpectationForAssetGroup(
-                                                            expectation.getScore(),
-                                                            expectation.getName(),
-                                                            expectation.getDescription(),
-                                                            assetGroup,
-                                                            expectation.isExpectationGroup(),
-                                                            expectation.getExpirationTime()));
-                                          }
-                                          yield Stream.of();
-                                        }
-                                        case MANUAL -> {
-                                          // Verify that at least one asset in the group has been executed
-                                          List<Asset> assets =
-                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
-                                          if (assets.stream()
-                                                  .anyMatch(
-                                                          asset ->
-                                                                  expectations.stream()
-                                                                          .filter(
-                                                                                  manExpectation ->
-                                                                                          InjectExpectation.EXPECTATION_TYPE.MANUAL
-                                                                                                  == manExpectation.type())
-                                                                          .anyMatch(
-                                                                                  manExpectation ->
-                                                                                          ((ManualExpectation) manExpectation).getAsset()
-                                                                                                  != null
-                                                                                                  && ((ManualExpectation) manExpectation)
-                                                                                                  .getAsset()
-                                                                                                  .getId()
-                                                                                                  .equals(asset.getId())))) {
-                                            yield Stream.of(
-                                                    manualExpectationForAssetGroup(
-                                                            expectation.getScore(),
-                                                            expectation.getName(),
-                                                            expectation.getDescription(),
-                                                            assetGroup,
-                                                            expectation.getExpirationTime(),
-                                                            expectation.isExpectationGroup()));
-                                          }
-                                          yield Stream.of();
-                                        }
-                                        default -> Stream.of();
-                                      })
-                      .toList());
+          content.getExpectations().stream()
+              .flatMap(
+                  expectation ->
+                      switch (expectation.getType()) {
+                        case PREVENTION -> {
+                          // Verify that at least one asset in the group has been executed
+                          if (assets.stream()
+                              .anyMatch(
+                                  asset ->
+                                      expectations.stream()
+                                          .filter(
+                                              prevExpectation ->
+                                                  InjectExpectation.EXPECTATION_TYPE.PREVENTION
+                                                      == prevExpectation.type())
+                                          .anyMatch(
+                                              prevExpectation ->
+                                                  ((PreventionExpectation) prevExpectation)
+                                                              .getAsset()
+                                                          != null
+                                                      && ((PreventionExpectation) prevExpectation)
+                                                          .getAsset()
+                                                          .getId()
+                                                          .equals(asset.getId())))) {
+                            yield Stream.of(
+                                preventionExpectationForAssetGroup(
+                                    expectation.getScore(),
+                                    expectation.getName(),
+                                    expectation.getDescription(),
+                                    assetGroup,
+                                    expectation.isExpectationGroup(),
+                                    expectation.getExpirationTime()));
+                          }
+                          yield Stream.of();
+                        }
+                        case DETECTION -> {
+                          // Verify that at least one asset in the group has been executed
+                          if (assets.stream()
+                              .anyMatch(
+                                  asset ->
+                                      expectations.stream()
+                                          .filter(
+                                              detExpectation ->
+                                                  InjectExpectation.EXPECTATION_TYPE.DETECTION
+                                                      == detExpectation.type())
+                                          .anyMatch(
+                                              detExpectation ->
+                                                  ((DetectionExpectation) detExpectation).getAsset()
+                                                          != null
+                                                      && ((DetectionExpectation) detExpectation)
+                                                          .getAsset()
+                                                          .getId()
+                                                          .equals(asset.getId())))) {
+                            yield Stream.of(
+                                detectionExpectationForAssetGroup(
+                                    expectation.getScore(),
+                                    expectation.getName(),
+                                    expectation.getDescription(),
+                                    assetGroup,
+                                    expectation.isExpectationGroup(),
+                                    expectation.getExpirationTime()));
+                          }
+                          yield Stream.of();
+                        }
+                        case VULNERABILITY -> {
+                          // Verify that at least one asset in the group has been executed
+                          if (assets.stream()
+                              .anyMatch(
+                                  asset ->
+                                      expectations.stream()
+                                          .filter(
+                                              vulExpectation ->
+                                                  InjectExpectation.EXPECTATION_TYPE.VULNERABILITY
+                                                      == vulExpectation.type())
+                                          .anyMatch(
+                                              vulExpectation ->
+                                                  ((VulnerabilityExpectation) vulExpectation)
+                                                              .getAsset()
+                                                          != null
+                                                      && ((VulnerabilityExpectation) vulExpectation)
+                                                          .getAsset()
+                                                          .getId()
+                                                          .equals(asset.getId())))) {
+                            yield Stream.of(
+                                vulnerabilityExpectationForAssetGroup(
+                                    expectation.getScore(),
+                                    expectation.getName(),
+                                    expectation.getDescription(),
+                                    assetGroup,
+                                    expectation.isExpectationGroup(),
+                                    expectation.getExpirationTime()));
+                          }
+                          yield Stream.of();
+                        }
+                        case MANUAL -> {
+                          // Verify that at least one asset in the group has been executed
+                          if (assets.stream()
+                              .anyMatch(
+                                  asset ->
+                                      expectations.stream()
+                                          .filter(
+                                              manExpectation ->
+                                                  InjectExpectation.EXPECTATION_TYPE.MANUAL
+                                                      == manExpectation.type())
+                                          .anyMatch(
+                                              manExpectation ->
+                                                  ((ManualExpectation) manExpectation).getAsset()
+                                                          != null
+                                                      && ((ManualExpectation) manExpectation)
+                                                          .getAsset()
+                                                          .getId()
+                                                          .equals(asset.getId())))) {
+                            yield Stream.of(
+                                manualExpectationForAssetGroup(
+                                    expectation.getScore(),
+                                    expectation.getName(),
+                                    expectation.getDescription(),
+                                    assetGroup,
+                                    expectation.getExpirationTime(),
+                                    expectation.isExpectationGroup()));
+                          }
+                          yield Stream.of();
+                        }
+                        default -> Stream.of();
+                      })
+              .toList());
     }
   }
-
 }

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1,21 +1,5 @@
 package io.openaev.service;
 
-import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
-import static io.openaev.expectation.ExpectationType.VULNERABILITY;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
-import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
-import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
-import static io.openaev.service.InjectExpectationUtils.computeScores;
-import static io.openaev.service.InjectExpectationUtils.expectationConverter;
-import static io.openaev.utils.AgentUtils.getActiveAgents;
-import static io.openaev.utils.AgentUtils.getPrimaryAgents;
-import static io.openaev.utils.ExpectationUtils.*;
-import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
-import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,12 +30,6 @@ import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -61,6 +39,29 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
+import static io.openaev.expectation.ExpectationType.VULNERABILITY;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
+import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
+import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
+import static io.openaev.service.InjectExpectationUtils.computeScores;
+import static io.openaev.service.InjectExpectationUtils.expectationConverter;
+import static io.openaev.utils.AgentUtils.getActiveAgents;
+import static io.openaev.utils.AgentUtils.getPrimaryAgents;
+import static io.openaev.utils.ExpectationUtils.*;
+import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
+import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -1325,7 +1326,7 @@ public class InjectExpectationService {
    * @param converter the target class used for conversion
    * @return the converted content instance
    * @param <T> the target content type
-   * @throws Exception if the JSON content cannot be converted to the requested type
+   * @throws JsonProcessingException if the JSON content cannot be converted to the requested type
    */
   public <T> T contentConvert(
       @NotNull final ExecutableInject injection, @NotNull final Class<T> converter)
@@ -1335,7 +1336,7 @@ public class InjectExpectationService {
     return this.mapper.treeToValue(content, converter);
   }
 
-  @Transactional
+  @Transactional(rollbackFor = Exception.class)
   public void computeAndSaveExpectations(
       ExecutableInject injection,
       Inject inject,

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1,43 +1,34 @@
 package io.openaev.service;
 
-import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
-import static io.openaev.expectation.ExpectationType.VULNERABILITY;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.service.InjectExpectationUtils.computeScores;
-import static io.openaev.service.InjectExpectationUtils.expectationConverter;
-import static io.openaev.utils.AgentUtils.getPrimaryAgents;
-import static io.openaev.utils.ExpectationUtils.*;
-import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.specification.InjectExpectationSpecification;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.expectation.ExpectationPropertiesConfig;
 import io.openaev.expectation.ExpectationType;
+import io.openaev.injectors.common.model.BaseInjectContent;
 import io.openaev.model.Expectation;
+import io.openaev.model.expectation.DetectionExpectation;
+import io.openaev.model.expectation.ManualExpectation;
+import io.openaev.model.expectation.PreventionExpectation;
+import io.openaev.model.expectation.VulnerabilityExpectation;
 import io.openaev.rest.atomic_testing.form.InjectExpectationAgentOutput;
 import io.openaev.rest.collector.service.CollectorService;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.exercise.form.ExpectationUpdateInput;
 import io.openaev.rest.inject.form.InjectExpectationUpdateInput;
+import io.openaev.rest.inject.service.AssetToExecute;
 import io.openaev.rest.inject.service.ExecutionProcessingContext;
+import io.openaev.rest.inject.service.InjectService;
 import io.openaev.utils.TargetType;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -47,6 +38,29 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
+import static io.openaev.expectation.ExpectationType.VULNERABILITY;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
+import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
+import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
+import static io.openaev.service.InjectExpectationUtils.computeScores;
+import static io.openaev.service.InjectExpectationUtils.expectationConverter;
+import static io.openaev.utils.AgentUtils.getActiveAgents;
+import static io.openaev.utils.AgentUtils.getPrimaryAgents;
+import static io.openaev.utils.ExpectationUtils.*;
+import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
+import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -67,6 +81,8 @@ public class InjectExpectationService {
   private final CollectorService collectorService;
   @Resource private ExpectationPropertiesConfig expectationPropertiesConfig;
   private final SecurityCoverageSendJobService securityCoverageSendJobService;
+  private final AssetGroupService assetGroupService;
+  private final InjectService injectService;
 
   @Resource protected ObjectMapper mapper;
 
@@ -1293,4 +1309,244 @@ public class InjectExpectationService {
                     .isSuccess(injectExpectationResult.getScore() != 0.0)
                     .build()));
   }
+
+  /**
+   * Converts the inject content payload to a typed object.
+   *
+   * <p>The content is read from {@link Inject#getContent()} and deserialized with Jackson using
+   * the provided target class.
+   *
+   * @param injection the executable inject containing the source content
+   * @param converter the target class used for conversion
+   * @return the converted content instance
+   * @param <T> the target content type
+   * @throws Exception if the JSON content cannot be converted to the requested type
+   */
+  public <T> T contentConvert(
+          @NotNull final ExecutableInject injection, @NotNull final Class<T> converter)
+          throws Exception {
+    Inject inject = injection.getInjection().getInject();
+    ObjectNode content = inject.getContent();
+    return this.mapper.treeToValue(content, converter);
+  }
+
+  public void computeAndSaveExpectations(ExecutableInject injection, Inject inject, String implantType, List<AssetToExecute> assetToExecutes) throws Exception {
+    BaseInjectContent content = contentConvert(injection, BaseInjectContent.class);
+
+    List<Expectation> expectations = new ArrayList<>();
+
+    assetToExecutes.forEach(
+            assetToExecute ->
+                    computeExpectationsForAssetAndAgents(expectations, content, assetToExecute, inject, implantType));
+
+    List<AssetGroup> assetGroups = injection.getAssetGroups();
+    assetGroups.forEach(
+            (assetGroup -> computeExpectationsForAssetGroup(expectations, content, assetGroup)));
+
+    buildAndSaveInjectExpectations(injection, expectations);
+  }
+
+  /** In case of direct assetToExecute, we have an individual expectation for the assetToExecute */
+  private void computeExpectationsForAssetAndAgents(
+          @NotNull final List<Expectation> expectations,
+          @NotNull final BaseInjectContent content,
+          @NotNull final AssetToExecute assetToExecute,
+          final Inject inject,
+          String implantType) {
+
+    if (!content.getExpectations().isEmpty()) {
+
+      Map<String, Endpoint> valueTargetedAssetsMap = injectService.getValueTargetedAssetMap(inject);
+
+      expectations.addAll(
+              content.getExpectations().stream()
+                      .flatMap(
+                              expectation ->
+                                      switch (expectation.getType()) {
+                                        case PREVENTION ->
+                                                getPreventionExpectationsByAsset(
+                                                        implantType,
+                                                        assetToExecute,
+                                                        getActiveAgents(assetToExecute.asset(), inject),
+                                                        expectation,
+                                                        valueTargetedAssetsMap,
+                                                        inject.getId())
+                                                        .stream();
+                                        case DETECTION ->
+                                                getDetectionExpectationsByAsset(
+                                                        implantType,
+                                                        assetToExecute,
+                                                        getActiveAgents(assetToExecute.asset(), inject),
+                                                        expectation,
+                                                        valueTargetedAssetsMap,
+                                                        inject.getId())
+                                                        .stream();
+                                        case VULNERABILITY ->
+                                                getVulnerabilityExpectationsByAsset(
+                                                        implantType,
+                                                        assetToExecute,
+                                                        getActiveAgents(assetToExecute.asset(), inject),
+                                                        expectation,
+                                                        valueTargetedAssetsMap,
+                                                        inject.getId())
+                                                        .stream();
+                                        case MANUAL ->
+                                                getManualExpectationsByAsset(
+                                                        implantType,
+                                                        assetToExecute,
+                                                        getActiveAgents(assetToExecute.asset(), inject),
+                                                        expectation)
+                                                        .stream();
+                                        default -> Stream.of();
+                                      })
+                      .toList());
+    }
+  }
+
+  /**
+   * In case of asset group if expectation group -> we have an expectation for the group and one for
+   * each asset if not expectation group -> we have an individual expectation for each asset
+   */
+  private void computeExpectationsForAssetGroup(
+          @NotNull final List<Expectation> expectations,
+          @NotNull final BaseInjectContent content,
+          @NotNull final AssetGroup assetGroup) {
+    if (!content.getExpectations().isEmpty()) {
+      expectations.addAll(
+              content.getExpectations().stream()
+                      .flatMap(
+                              expectation ->
+                                      switch (expectation.getType()) {
+                                        case PREVENTION -> {
+                                          // Verify that at least one asset in the group has been executed
+                                          List<Asset> assets =
+                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
+                                          if (assets.stream()
+                                                  .anyMatch(
+                                                          asset ->
+                                                                  expectations.stream()
+                                                                          .filter(
+                                                                                  prevExpectation ->
+                                                                                          InjectExpectation.EXPECTATION_TYPE.PREVENTION
+                                                                                                  == prevExpectation.type())
+                                                                          .anyMatch(
+                                                                                  prevExpectation ->
+                                                                                          ((PreventionExpectation) prevExpectation)
+                                                                                                  .getAsset()
+                                                                                                  != null
+                                                                                                  && ((PreventionExpectation) prevExpectation)
+                                                                                                  .getAsset()
+                                                                                                  .getId()
+                                                                                                  .equals(asset.getId())))) {
+                                            yield Stream.of(
+                                                    preventionExpectationForAssetGroup(
+                                                            expectation.getScore(),
+                                                            expectation.getName(),
+                                                            expectation.getDescription(),
+                                                            assetGroup,
+                                                            expectation.isExpectationGroup(),
+                                                            expectation.getExpirationTime()));
+                                          }
+                                          yield Stream.of();
+                                        }
+                                        case DETECTION -> {
+                                          // Verify that at least one asset in the group has been executed
+                                          List<Asset> assets =
+                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
+                                          if (assets.stream()
+                                                  .anyMatch(
+                                                          asset ->
+                                                                  expectations.stream()
+                                                                          .filter(
+                                                                                  detExpectation ->
+                                                                                          InjectExpectation.EXPECTATION_TYPE.DETECTION
+                                                                                                  == detExpectation.type())
+                                                                          .anyMatch(
+                                                                                  detExpectation ->
+                                                                                          ((DetectionExpectation) detExpectation).getAsset()
+                                                                                                  != null
+                                                                                                  && ((DetectionExpectation) detExpectation)
+                                                                                                  .getAsset()
+                                                                                                  .getId()
+                                                                                                  .equals(asset.getId())))) {
+                                            yield Stream.of(
+                                                    detectionExpectationForAssetGroup(
+                                                            expectation.getScore(),
+                                                            expectation.getName(),
+                                                            expectation.getDescription(),
+                                                            assetGroup,
+                                                            expectation.isExpectationGroup(),
+                                                            expectation.getExpirationTime()));
+                                          }
+                                          yield Stream.of();
+                                        }
+                                        case VULNERABILITY -> {
+                                          // Verify that at least one asset in the group has been executed
+                                          List<Asset> assets =
+                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
+                                          if (assets.stream()
+                                                  .anyMatch(
+                                                          asset ->
+                                                                  expectations.stream()
+                                                                          .filter(
+                                                                                  vulExpectation ->
+                                                                                          InjectExpectation.EXPECTATION_TYPE.VULNERABILITY
+                                                                                                  == vulExpectation.type())
+                                                                          .anyMatch(
+                                                                                  vulExpectation ->
+                                                                                          ((VulnerabilityExpectation) vulExpectation)
+                                                                                                  .getAsset()
+                                                                                                  != null
+                                                                                                  && ((VulnerabilityExpectation) vulExpectation)
+                                                                                                  .getAsset()
+                                                                                                  .getId()
+                                                                                                  .equals(asset.getId())))) {
+                                            yield Stream.of(
+                                                    vulnerabilityExpectationForAssetGroup(
+                                                            expectation.getScore(),
+                                                            expectation.getName(),
+                                                            expectation.getDescription(),
+                                                            assetGroup,
+                                                            expectation.isExpectationGroup(),
+                                                            expectation.getExpirationTime()));
+                                          }
+                                          yield Stream.of();
+                                        }
+                                        case MANUAL -> {
+                                          // Verify that at least one asset in the group has been executed
+                                          List<Asset> assets =
+                                                  this.assetGroupService.assetsFromAssetGroup(assetGroup.getId());
+                                          if (assets.stream()
+                                                  .anyMatch(
+                                                          asset ->
+                                                                  expectations.stream()
+                                                                          .filter(
+                                                                                  manExpectation ->
+                                                                                          InjectExpectation.EXPECTATION_TYPE.MANUAL
+                                                                                                  == manExpectation.type())
+                                                                          .anyMatch(
+                                                                                  manExpectation ->
+                                                                                          ((ManualExpectation) manExpectation).getAsset()
+                                                                                                  != null
+                                                                                                  && ((ManualExpectation) manExpectation)
+                                                                                                  .getAsset()
+                                                                                                  .getId()
+                                                                                                  .equals(asset.getId())))) {
+                                            yield Stream.of(
+                                                    manualExpectationForAssetGroup(
+                                                            expectation.getScore(),
+                                                            expectation.getName(),
+                                                            expectation.getDescription(),
+                                                            assetGroup,
+                                                            expectation.getExpirationTime(),
+                                                            expectation.isExpectationGroup()));
+                                          }
+                                          yield Stream.of();
+                                        }
+                                        default -> Stream.of();
+                                      })
+                      .toList());
+    }
+  }
+
 }

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1382,7 +1382,7 @@ public class InjectExpectationService {
                                 getActiveAgents(assetToExecute.asset(), inject),
                                 expectation,
                                 valueTargetedAssetsMap,
-                                inject.getId())
+                                inject)
                                 .stream();
                         case DETECTION ->
                             getDetectionExpectationsByAsset(
@@ -1391,7 +1391,7 @@ public class InjectExpectationService {
                                 getActiveAgents(assetToExecute.asset(), inject),
                                 expectation,
                                 valueTargetedAssetsMap,
-                                inject.getId())
+                                inject)
                                 .stream();
                         case VULNERABILITY ->
                             getVulnerabilityExpectationsByAsset(
@@ -1400,14 +1400,15 @@ public class InjectExpectationService {
                                 getActiveAgents(assetToExecute.asset(), inject),
                                 expectation,
                                 valueTargetedAssetsMap,
-                                inject.getId())
+                                inject)
                                 .stream();
                         case MANUAL ->
                             getManualExpectationsByAsset(
                                 implantType,
                                 assetToExecute,
                                 getActiveAgents(assetToExecute.asset(), inject),
-                                expectation)
+                                expectation,
+                                inject)
                                 .stream();
                         default -> Stream.of();
                       })

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1,5 +1,21 @@
 package io.openaev.service;
 
+import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
+import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
+import static io.openaev.expectation.ExpectationType.VULNERABILITY;
+import static io.openaev.helper.StreamHelper.fromIterable;
+import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
+import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
+import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
+import static io.openaev.service.InjectExpectationUtils.computeScores;
+import static io.openaev.service.InjectExpectationUtils.expectationConverter;
+import static io.openaev.utils.AgentUtils.getActiveAgents;
+import static io.openaev.utils.AgentUtils.getPrimaryAgents;
+import static io.openaev.utils.ExpectationUtils.*;
+import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
+import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,6 +46,12 @@ import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -39,29 +61,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static io.openaev.database.model.InjectExpectation.EXPECTATION_TYPE.*;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_END_DATE;
-import static io.openaev.database.model.InjectExpectationSignature.EXPECTATION_SIGNATURE_TYPE_START_DATE;
-import static io.openaev.expectation.ExpectationType.VULNERABILITY;
-import static io.openaev.helper.StreamHelper.fromIterable;
-import static io.openaev.model.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
-import static io.openaev.model.expectation.ManualExpectation.manualExpectationForAssetGroup;
-import static io.openaev.model.expectation.PreventionExpectation.preventionExpectationForAssetGroup;
-import static io.openaev.service.InjectExpectationUtils.computeScores;
-import static io.openaev.service.InjectExpectationUtils.expectationConverter;
-import static io.openaev.utils.AgentUtils.getActiveAgents;
-import static io.openaev.utils.AgentUtils.getPrimaryAgents;
-import static io.openaev.utils.ExpectationUtils.*;
-import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
-import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.*;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
@@ -155,7 +155,8 @@ public class ExpectationUtils {
       final AssetGroup assetGroup,
       final List<Agent> executedAgents,
       final Function<AssetGroup, T> createExpectationForAsset,
-      final BiFunction<Agent, AssetGroup, T> createExpectationForAgent) {
+      final BiFunction<Agent, AssetGroup, T> createExpectationForAgent,
+      final boolean isAgentless) {
     List<T> returnList = new ArrayList<>();
 
     T expectation = createExpectationForAsset.apply(assetGroup);
@@ -164,7 +165,7 @@ public class ExpectationUtils {
             .map(agent -> createExpectationForAgent.apply(agent, assetGroup))
             .toList();
 
-    if (!expectationList.isEmpty()) {
+    if (!expectationList.isEmpty() || isAgentless) {
       returnList.add(expectation);
       returnList.addAll(expectationList);
     }
@@ -176,13 +177,18 @@ public class ExpectationUtils {
       AssetToExecute assetToExecute,
       final List<Agent> executedAgents,
       final Function<AssetGroup, T> createExpectationForAsset,
-      final BiFunction<Agent, AssetGroup, T> createExpectationForAgent) {
+      final BiFunction<Agent, AssetGroup, T> createExpectationForAgent,
+      final boolean isAgentless) {
     List<T> returnList = new ArrayList<>();
 
     if (assetToExecute.isDirectlyLinkedToInject()) {
       returnList.addAll(
           getExpectationForAsset(
-              null, executedAgents, createExpectationForAsset, createExpectationForAgent));
+              null,
+              executedAgents,
+              createExpectationForAsset,
+              createExpectationForAgent,
+              isAgentless));
     }
 
     assetToExecute
@@ -194,7 +200,8 @@ public class ExpectationUtils {
                         assetGroup,
                         executedAgents,
                         createExpectationForAsset,
-                        createExpectationForAgent)));
+                        createExpectationForAgent,
+                        isAgentless)));
 
     return returnList;
   }
@@ -244,7 +251,8 @@ public class ExpectationUtils {
                     OAEV_IMPLANT_CALDERA.equals(implantType)
                         ? agent.getParent().getId()
                         : agent.getId(),
-                    valueTargetedAssetsMap)));
+                    valueTargetedAssetsMap)),
+        isAgentlessAsset(assetToExecute.asset()));
   }
 
   /**
@@ -292,7 +300,8 @@ public class ExpectationUtils {
                     OAEV_IMPLANT_CALDERA.equals(implantType)
                         ? agent.getParent().getId()
                         : agent.getId(),
-                    valueTargetedAssetsMap)));
+                    valueTargetedAssetsMap)),
+        isAgentlessAsset(assetToExecute.asset()));
   }
 
   /**
@@ -328,7 +337,8 @@ public class ExpectationUtils {
                 OAEV_IMPLANT_CALDERA.equals(implantType) ? agent.getParent() : agent,
                 assetToExecute.asset(),
                 assetGroup,
-                expectation.getExpirationTime()));
+                expectation.getExpirationTime()),
+        isAgentlessAsset(assetToExecute.asset()));
   }
 
   /**
@@ -375,7 +385,8 @@ public class ExpectationUtils {
                     OAEV_IMPLANT_CALDERA.equals(implantType)
                         ? agent.getParent().getId()
                         : agent.getId(),
-                    valueTargetedAssetsMap)));
+                    valueTargetedAssetsMap)),
+        isAgentlessAsset(assetToExecute.asset()));
   }
 
   private static List<String> getIpsFromAsset(Asset asset) {
@@ -618,5 +629,15 @@ public class ExpectationUtils {
    */
   public static boolean isAssetGroupExpectation(InjectExpectation e) {
     return e.getAssetGroup() != null && e.getAsset() == null && e.getAgent() == null;
+  }
+
+  /**
+   * Determine if an asset is agentless or not
+   *
+   * @param asset to test
+   * @return true if is agentless, false if not
+   */
+  private static boolean isAgentlessAsset(Asset asset) {
+    return asset instanceof Endpoint endpoint && endpoint.getAgents().isEmpty();
   }
 }

--- a/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
@@ -21,7 +21,6 @@ import io.openaev.model.expectation.PreventionExpectation;
 import io.openaev.model.expectation.VulnerabilityExpectation;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.inject.service.AssetToExecute;
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
@@ -214,7 +213,7 @@ public class ExpectationUtils {
    * @param executedAgents the list of executed agents
    * @param expectation the expectation details
    * @param valueTargetedAssetsMap a map of value targeted assets
-   * @param injectId the ID of the inject
+   * @param inject the inject details
    * @return a list of prevention expectations
    */
   public static List<PreventionExpectation> getPreventionExpectationsByAsset(
@@ -223,7 +222,8 @@ public class ExpectationUtils {
       List<io.openaev.database.model.Agent> executedAgents,
       io.openaev.model.inject.form.Expectation expectation,
       Map<String, Endpoint> valueTargetedAssetsMap,
-      String injectId) {
+      Inject inject) {
+    String injectId = inject != null ? inject.getId() : null;
     return getExpectations(
         assetToExecute,
         executedAgents,
@@ -252,7 +252,7 @@ public class ExpectationUtils {
                         ? agent.getParent().getId()
                         : agent.getId(),
                     valueTargetedAssetsMap)),
-        isAgentlessAsset(assetToExecute.asset()));
+        isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject));
   }
 
   /**
@@ -263,7 +263,7 @@ public class ExpectationUtils {
    * @param executedAgents the list of executed agents
    * @param expectation the expectation details
    * @param valueTargetedAssetsMap a map of value targeted assets
-   * @param injectId the ID of the inject
+   * @param inject the inject details
    * @return a list of detection expectations
    */
   public static List<DetectionExpectation> getDetectionExpectationsByAsset(
@@ -272,7 +272,8 @@ public class ExpectationUtils {
       List<io.openaev.database.model.Agent> executedAgents,
       io.openaev.model.inject.form.Expectation expectation,
       Map<String, Endpoint> valueTargetedAssetsMap,
-      String injectId) {
+      Inject inject) {
+    String injectId = inject != null ? inject.getId() : null;
     return getExpectations(
         assetToExecute,
         executedAgents,
@@ -301,7 +302,7 @@ public class ExpectationUtils {
                         ? agent.getParent().getId()
                         : agent.getId(),
                     valueTargetedAssetsMap)),
-        isAgentlessAsset(assetToExecute.asset()));
+        isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject));
   }
 
   /**
@@ -311,13 +312,15 @@ public class ExpectationUtils {
    * @param assetToExecute the asset to execute the expectation on
    * @param executedAgents the list of executed agents
    * @param expectation the expectation details
+   * @param inject the inject details
    * @return a list of manual expectations
    */
   public static List<ManualExpectation> getManualExpectationsByAsset(
       String implantType,
       AssetToExecute assetToExecute,
       List<io.openaev.database.model.Agent> executedAgents,
-      io.openaev.model.inject.form.Expectation expectation) {
+      io.openaev.model.inject.form.Expectation expectation,
+      Inject inject) {
     return getExpectations(
         assetToExecute,
         executedAgents,
@@ -338,7 +341,7 @@ public class ExpectationUtils {
                 assetToExecute.asset(),
                 assetGroup,
                 expectation.getExpirationTime()),
-        isAgentlessAsset(assetToExecute.asset()));
+        isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject));
   }
 
   /**
@@ -349,6 +352,7 @@ public class ExpectationUtils {
    * @param executedAgents the list of executed agents
    * @param expectation the expectation details
    * @param valueTargetedAssetsMap a map of value targeted assets
+   * @param inject the inject details
    * @return a list of vulnerability expectations
    */
   public static List<VulnerabilityExpectation> getVulnerabilityExpectationsByAsset(
@@ -357,7 +361,8 @@ public class ExpectationUtils {
       List<io.openaev.database.model.Agent> executedAgents,
       io.openaev.model.inject.form.Expectation expectation,
       Map<String, Endpoint> valueTargetedAssetsMap,
-      @Nullable String injectId) {
+      Inject inject) {
+    String injectId = inject != null ? inject.getId() : null;
     return getExpectations(
         assetToExecute,
         executedAgents,
@@ -386,7 +391,7 @@ public class ExpectationUtils {
                         ? agent.getParent().getId()
                         : agent.getId(),
                     valueTargetedAssetsMap)),
-        isAgentlessAsset(assetToExecute.asset()));
+        isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject));
   }
 
   private static List<String> getIpsFromAsset(Asset asset) {
@@ -632,12 +637,17 @@ public class ExpectationUtils {
   }
 
   /**
-   * Determine if an asset is agentless or not
+   * Determine if an asset is agentless and need to have expectations created
    *
    * @param asset to test
-   * @return true if is agentless, false if not
+   * @param inject the inject details
+   * @return true if is agentless and injector payload, false if not
    */
-  private static boolean isAgentlessAsset(Asset asset) {
-    return asset instanceof Endpoint endpoint && endpoint.getAgents().isEmpty();
+  private static boolean isAgentlessAssetExpectationNecessary(Asset asset, Inject inject) {
+    return inject != null
+        && inject.getInjector() != null
+        && !inject.getInjector().isPayloads()
+        && asset instanceof Endpoint endpoint
+        && endpoint.getAgents().isEmpty();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
@@ -43,7 +43,7 @@ class ExpectationUtilsTest extends IntegrationTest {
             List.of(agent),
             ExpectationFixture.createExpectation(),
             new HashMap<>(),
-            inject.getId());
+            inject);
 
     List<DetectionExpectation> detectionExpectations =
         getDetectionExpectationsByAsset(
@@ -52,7 +52,7 @@ class ExpectationUtilsTest extends IntegrationTest {
             List.of(agent),
             ExpectationFixture.createExpectation(),
             new HashMap<>(),
-            inject.getId());
+            inject);
 
     // -- ASSERT --
     InjectExpectationSignature signature =
@@ -190,7 +190,7 @@ class ExpectationUtilsTest extends IntegrationTest {
             List.of(agent),
             ExpectationFixture.createExpectation(),
             targetValues,
-            inject.getId());
+            inject);
 
     List<String> preventionSourceIpv4SignatureValues = new ArrayList<>();
     List<String> preventionSourceIpv6SignatureValues = new ArrayList<>();

--- a/openaev-api/src/test/java/io/openaev/injects/manual/ManualExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/manual/ManualExecutorTest.java
@@ -1,9 +1,5 @@
 package io.openaev.injects.manual;
 
-import static org.mockito.Mockito.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.Execution;
 import io.openaev.database.model.Inject;
@@ -17,13 +13,16 @@ import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.model.inject.form.Expectation;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.utilstest.RabbitMQTestListener;
-import java.time.Instant;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestExecutionListeners;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @TestExecutionListeners(
@@ -33,7 +32,6 @@ public class ManualExecutorTest extends IntegrationTest {
 
   @Mock InjectExpectationService injectExpectationService;
 
-  @Mock ObjectMapper mapper;
   @InjectMocks private InjectorContext injectorContext;
 
   @Test
@@ -53,11 +51,9 @@ public class ManualExecutorTest extends IntegrationTest {
     ExecutableInject executableInject = mock(ExecutableInject.class);
     Injection injection = mock(Injection.class);
     Inject inject = mock(Inject.class);
-    ObjectNode content = mock(ObjectNode.class);
-    when(inject.getContent()).thenReturn(content);
+    when(injectExpectationService.contentConvert(any(), any())).thenReturn(manualContent);
     when(injection.getInject()).thenReturn(inject);
     when(executableInject.getInjection()).thenReturn(injection);
-    when(mapper.treeToValue(content, ManualContent.class)).thenReturn(manualContent);
 
     ManualExecutor executor = new ManualExecutor(injectorContext, injectExpectationService);
     executor.process(execution, executableInject);

--- a/openaev-api/src/test/java/io/openaev/injects/manual/ManualExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/manual/ManualExecutorTest.java
@@ -1,5 +1,7 @@
 package io.openaev.injects.manual;
 
+import static org.mockito.Mockito.*;
+
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.Execution;
 import io.openaev.database.model.Inject;
@@ -13,16 +15,13 @@ import io.openaev.model.expectation.ManualExpectation;
 import io.openaev.model.inject.form.Expectation;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.utilstest.RabbitMQTestListener;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestExecutionListeners;
-
-import java.time.Instant;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @TestExecutionListeners(

--- a/openaev-api/src/test/java/io/openaev/injects/technical_inject/OpenAEVImplantExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/technical_inject/OpenAEVImplantExecutorTest.java
@@ -2,6 +2,7 @@ package io.openaev.injects.technical_inject;
 
 import static io.openaev.collectors.expectations_vulnerability_manager.ExpectationsVulnerabilityManagerCollector.EXPECTATIONS_VULNERABILITY_COLLECTOR_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,8 @@ import jakarta.annotation.Resource;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -180,5 +183,119 @@ public class OpenAEVImplantExecutorTest extends IntegrationTest {
         agentExpectations.stream().flatMap(ie -> ie.getResults().stream()).toList();
     assertTrue(results.stream().allMatch(r -> r.getResult() == null));
     assertTrue(results.stream().allMatch(r -> expectedSourceId.equals(r.getSourceId())));
+  }
+
+  @Test
+  @DisplayName(
+      "Should create prevention expectations for asset group and agents when executing a technical inject")
+  void given_technicalInjectWithPreventionExpectation_should_createAssetGroupAndAgentExpectations()
+      throws Exception {
+    // -- Arrange --
+    Expectation expectation = new Expectation();
+    expectation.setName("prevention");
+    expectation.setType(InjectExpectation.EXPECTATION_TYPE.PREVENTION);
+    expectation.setScore(100.0);
+    expectation.setExpectationGroup(false);
+
+    openaevInjectorIntegrationFactory.registerConnectorForTenant(TenantContext.getCurrentTenant());
+    io.openaev.executors.Injector openAEVImplantExecutor =
+        new OpenAEVImplantExecutor(injectorContext, injectExpectationService, injectService);
+
+    Inject inject = createTechnicalInjectHelper(List.of(expectation));
+    Injection injection = mock(Injection.class);
+    when(injection.getInject()).thenReturn(inject);
+    ExecutableInject executableInject =
+        new ExecutableInject(
+            false,
+            false,
+            injection,
+            List.of(),
+            inject.getAssets(),
+            inject.getAssetGroups(),
+            List.of());
+    Execution execution = new Execution(executableInject.isRuntime());
+
+    // -- Act --
+    openAEVImplantExecutor.process(execution, executableInject);
+
+    // -- Assert --
+    List<InjectExpectation> expectations =
+        injectExpectationRepository.findAllByInjectId(inject.getId());
+    assertEquals(4, expectations.size());
+
+    List<InjectExpectation> assetGroupExpectations =
+        expectations.stream()
+            .filter(
+                ie -> ie.getAgent() == null && ie.getAsset() == null && ie.getAssetGroup() != null)
+            .toList();
+    assertEquals(1, assetGroupExpectations.size());
+
+    List<InjectExpectation> agentExpectations =
+        expectations.stream()
+            .filter(
+                ie -> ie.getAgent() != null && ie.getAsset() != null && ie.getAssetGroup() != null)
+            .toList();
+    assertEquals(2, agentExpectations.size());
+
+    List<InjectExpectationResult> results =
+        agentExpectations.stream().flatMap(ie -> ie.getResults().stream()).toList();
+    assertFalse(results.isEmpty());
+    assertTrue(results.stream().allMatch(r -> r.getResult() == null));
+    assertTrue(results.stream().allMatch(r -> CollectorsUtils.CROWDSTRIKE.equals(r.getSourceId())));
+  }
+
+  @Test
+  @DisplayName(
+      "Should create manual expectations without collector results for agent-level expectations")
+  void
+      given_technicalInjectWithManualExpectation_should_createAssetGroupExpectationWithoutCollectorResults()
+          throws Exception {
+    // -- Arrange --
+    Expectation expectation = new Expectation();
+    expectation.setName("manual");
+    expectation.setType(InjectExpectation.EXPECTATION_TYPE.MANUAL);
+    expectation.setScore(100.0);
+    expectation.setExpectationGroup(false);
+
+    openaevInjectorIntegrationFactory.registerConnectorForTenant(TenantContext.getCurrentTenant());
+    io.openaev.executors.Injector openAEVImplantExecutor =
+        new OpenAEVImplantExecutor(injectorContext, injectExpectationService, injectService);
+
+    Inject inject = createTechnicalInjectHelper(List.of(expectation));
+    Injection injection = mock(Injection.class);
+    when(injection.getInject()).thenReturn(inject);
+    ExecutableInject executableInject =
+        new ExecutableInject(
+            false,
+            false,
+            injection,
+            List.of(),
+            inject.getAssets(),
+            inject.getAssetGroups(),
+            List.of());
+    Execution execution = new Execution(executableInject.isRuntime());
+
+    // -- Act --
+    openAEVImplantExecutor.process(execution, executableInject);
+
+    // -- Assert --
+    List<InjectExpectation> expectations =
+        injectExpectationRepository.findAllByInjectId(inject.getId());
+    assertEquals(4, expectations.size());
+
+    List<InjectExpectation> assetGroupExpectations =
+        expectations.stream()
+            .filter(
+                ie -> ie.getAgent() == null && ie.getAsset() == null && ie.getAssetGroup() != null)
+            .toList();
+    assertEquals(1, assetGroupExpectations.size());
+
+    List<InjectExpectation> agentExpectations =
+        expectations.stream()
+            .filter(
+                ie -> ie.getAgent() != null && ie.getAsset() != null && ie.getAssetGroup() != null)
+            .toList();
+    assertEquals(2, agentExpectations.size());
+    assertTrue(agentExpectations.stream().allMatch(ie -> ie.getResults().isEmpty()));
   }
 }

--- a/openaev-api/src/test/java/io/openaev/injects/technical_inject/OpenAEVImplantExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/technical_inject/OpenAEVImplantExecutorTest.java
@@ -42,7 +42,6 @@ public class OpenAEVImplantExecutorTest extends IntegrationTest {
   @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
   @Autowired private InjectExpectationRepository injectExpectationRepository;
   @Autowired private InjectorContext injectorContext;
-  @Autowired private io.openaev.service.AssetGroupService assetGroupService;
   @Autowired private io.openaev.service.InjectExpectationService injectExpectationService;
   @Autowired private io.openaev.rest.inject.service.InjectService injectService;
 
@@ -130,8 +129,7 @@ public class OpenAEVImplantExecutorTest extends IntegrationTest {
 
     openaevInjectorIntegrationFactory.registerConnectorForTenant(TenantContext.getCurrentTenant());
     io.openaev.executors.Injector openAEVImplantExecutor =
-        new OpenAEVImplantExecutor(
-            injectorContext, assetGroupService, injectExpectationService, injectService);
+        new OpenAEVImplantExecutor(injectorContext, injectExpectationService, injectService);
 
     Inject inject = createTechnicalInjectHelper(List.of(expectation));
     Injection injection = mock(Injection.class);

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -3,6 +3,7 @@ package io.openaev.service;
 import static io.openaev.utils.fixtures.InjectExpectationFixture.createVulnerabilityInjectExpectation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -12,12 +13,22 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.InjectExpectationRepository;
+import io.openaev.execution.ExecutableInject;
+import io.openaev.injectors.common.model.BaseInjectContent;
+import io.openaev.model.expectation.DetectionExpectation;
+import io.openaev.model.expectation.ManualExpectation;
+import io.openaev.model.expectation.PreventionExpectation;
+import io.openaev.model.expectation.VulnerabilityExpectation;
+import io.openaev.rest.collector.service.CollectorService;
 import io.openaev.rest.inject.form.InjectExecutionAction;
 import io.openaev.rest.inject.form.InjectExecutionInput;
 import io.openaev.rest.inject.form.InjectExpectationUpdateInput;
+import io.openaev.rest.inject.service.AssetToExecute;
 import io.openaev.rest.inject.service.ExecutionProcessingContext;
+import io.openaev.rest.inject.service.InjectService;
 import io.openaev.utils.ExpectationUtils;
 import io.openaev.utils.fixtures.*;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +48,10 @@ class InjectExpectationServiceTest {
   static final Long EXPIRATION_TIME_SIX_HOURS = 21600L;
 
   @Mock private InjectExpectationRepository injectExpectationRepository;
+  @Mock private CollectorService collectorService;
+  @Mock private SecurityCoverageSendJobService securityCoverageSendJobService;
+  @Mock private AssetGroupService assetGroupService;
+  @Mock private InjectService injectService;
   @Spy @InjectMocks private InjectExpectationService injectExpectationService;
   @Spy private ObjectMapper mapper = new ObjectMapper();
 
@@ -92,6 +107,345 @@ class InjectExpectationServiceTest {
       MockedStatic<ExpectationUtils> mocked) {
     mocked.verify(
         () -> ExpectationUtils.setResultExpectationVulnerable(any(), any(), any()), times(1));
+  }
+
+  private static io.openaev.model.inject.form.Expectation createFormExpectation(
+      InjectExpectation.EXPECTATION_TYPE type) {
+    io.openaev.model.inject.form.Expectation expectation =
+        ExpectationFixture.createExpectation(type, "test-" + type.name().toLowerCase());
+    expectation.setExpectationGroup(false);
+    return expectation;
+  }
+
+  private void invokeComputeExpectationsForAssetAndAgents(
+      List<io.openaev.model.Expectation> expectations,
+      BaseInjectContent content,
+      AssetToExecute assetToExecute,
+      Inject currentInject,
+      String implantType)
+      throws Exception {
+    Method method =
+        InjectExpectationService.class.getDeclaredMethod(
+            "computeExpectationsForAssetAndAgents",
+            List.class,
+            BaseInjectContent.class,
+            AssetToExecute.class,
+            Inject.class,
+            String.class);
+    method.setAccessible(true);
+    method.invoke(
+        injectExpectationService,
+        expectations,
+        content,
+        assetToExecute,
+        currentInject,
+        implantType);
+  }
+
+  private void invokeComputeExpectationsForAssetGroup(
+      List<io.openaev.model.Expectation> expectations,
+      BaseInjectContent content,
+      AssetGroup assetGroup)
+      throws Exception {
+    Method method =
+        InjectExpectationService.class.getDeclaredMethod(
+            "computeExpectationsForAssetGroup",
+            List.class,
+            BaseInjectContent.class,
+            AssetGroup.class);
+    method.setAccessible(true);
+    method.invoke(injectExpectationService, expectations, content, assetGroup);
+  }
+
+  @Test
+  @DisplayName("Should return early when build input expectations are null or empty")
+  void given_nullOrEmptyExpectations_should_notSaveAnyInjectExpectation() {
+    // Arrange
+    ExecutableInject executableInject = mock(ExecutableInject.class);
+
+    // Act
+    injectExpectationService.buildAndSaveInjectExpectations(executableInject, null);
+    injectExpectationService.buildAndSaveInjectExpectations(executableInject, List.of());
+
+    // Assert
+    verify(injectExpectationRepository, never()).saveAll(any());
+  }
+
+  @Test
+  @DisplayName(
+      "Should map zero score to unsuccessful collector result when validating asset result")
+  void given_zeroScoreResult_should_setIsSuccessToFalseInCollectorUpdate() {
+    // Arrange
+    InjectExpectation expectation =
+        InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
+    InjectExpectationResult result = new InjectExpectationResult();
+    result.setSourceId("collector-id");
+    result.setResult("detected");
+    result.setScore(0.0);
+
+    ArgumentCaptor<InjectExpectationUpdateInput> captor =
+        ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
+    doReturn(expectation)
+        .when(injectExpectationService)
+        .updateInjectExpectation(eq(expectation.getId()), any(InjectExpectationUpdateInput.class));
+
+    // Act
+    injectExpectationService.validateResultForAsset(List.of(expectation), result);
+
+    // Assert
+    verify(injectExpectationService)
+        .updateInjectExpectation(eq(expectation.getId()), captor.capture());
+    assertEquals(Boolean.FALSE, captor.getValue().getIsSuccess());
+  }
+
+  @Test
+  @DisplayName(
+      "Should map positive score to successful collector result when validating asset result")
+  void given_positiveScoreResult_should_setIsSuccessToTrueInCollectorUpdate() {
+    // Arrange
+    InjectExpectation expectation =
+        InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
+    InjectExpectationResult result = new InjectExpectationResult();
+    result.setSourceId("collector-id");
+    result.setResult("detected");
+    result.setScore(42.0);
+
+    ArgumentCaptor<InjectExpectationUpdateInput> captor =
+        ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
+    doReturn(expectation)
+        .when(injectExpectationService)
+        .updateInjectExpectation(eq(expectation.getId()), any(InjectExpectationUpdateInput.class));
+
+    // Act
+    injectExpectationService.validateResultForAsset(List.of(expectation), result);
+
+    // Assert
+    verify(injectExpectationService)
+        .updateInjectExpectation(eq(expectation.getId()), captor.capture());
+    assertEquals(Boolean.TRUE, captor.getValue().getIsSuccess());
+  }
+
+  @Test
+  @DisplayName(
+      "Should skip asset and agent expectation computation when content expectations are empty")
+  void given_emptyContentExpectations_should_notComputeAssetAndAgentExpectations()
+      throws Exception {
+    // Arrange
+    BaseInjectContent content = new BaseInjectContent();
+    List<io.openaev.model.Expectation> expectations = new ArrayList<>();
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    endpoint.setId("asset-id");
+
+    // Act
+    invokeComputeExpectationsForAssetAndAgents(
+        expectations, content, new AssetToExecute(endpoint), inject, "implant");
+
+    // Assert
+    assertTrue(expectations.isEmpty());
+    verifyNoInteractions(injectService);
+  }
+
+  @Test
+  @DisplayName("Should ignore unsupported expectation type for asset and agent computation")
+  void given_unsupportedExpectationType_should_notCreateAssetAndAgentExpectations()
+      throws Exception {
+    // Arrange
+    BaseInjectContent content = new BaseInjectContent();
+    content.setExpectations(
+        List.of(createFormExpectation(InjectExpectation.EXPECTATION_TYPE.ARTICLE)));
+    List<io.openaev.model.Expectation> expectations = new ArrayList<>();
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    endpoint.setId("asset-id");
+    inject.setId("inject-id");
+    when(injectService.getValueTargetedAssetMap(inject)).thenReturn(Map.of());
+
+    // Act
+    invokeComputeExpectationsForAssetAndAgents(
+        expectations, content, new AssetToExecute(endpoint), inject, "implant");
+
+    // Assert
+    assertTrue(expectations.isEmpty());
+    verify(injectService).getValueTargetedAssetMap(inject);
+  }
+
+  @Test
+  @DisplayName(
+      "Should skip asset group expectation computation when content expectations are empty")
+  void given_emptyContentExpectations_should_notComputeAssetGroupExpectations() throws Exception {
+    // Arrange
+    BaseInjectContent content = new BaseInjectContent();
+    List<io.openaev.model.Expectation> expectations = new ArrayList<>();
+    AssetGroup assetGroup = AssetGroupFixture.createDefaultAssetGroup("ag");
+    assetGroup.setId("ag-id");
+
+    // Act
+    invokeComputeExpectationsForAssetGroup(expectations, content, assetGroup);
+
+    // Assert
+    assertTrue(expectations.isEmpty());
+    verifyNoInteractions(assetGroupService);
+  }
+
+  @Test
+  @DisplayName(
+      "Should execute false branches and default branch for asset group expectation matching when no asset matches")
+  void
+      given_nonMatchingAssetExpectations_should_notCreateAssetGroupExpectationAndCoverFalseBranches()
+          throws Exception {
+    // Arrange
+    BaseInjectContent content = new BaseInjectContent();
+    content.setExpectations(
+        List.of(
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.PREVENTION),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.DETECTION),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.VULNERABILITY),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.MANUAL),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.ARTICLE)));
+
+    Asset matchingAsset = AssetFixture.createDefaultAsset("matching");
+    matchingAsset.setId("asset-matching-id");
+    Asset nonMatchingAsset = AssetFixture.createDefaultAsset("other");
+    nonMatchingAsset.setId("asset-other-id");
+
+    AssetGroup assetGroup = AssetGroupFixture.createDefaultAssetGroup("ag");
+    assetGroup.setId("ag-id");
+    when(assetGroupService.assetsFromAssetGroup(assetGroup.getId()))
+        .thenReturn(List.of(matchingAsset));
+
+    PreventionExpectation preventionWithNullAsset =
+        PreventionExpectation.preventionExpectationForAsset(
+            100.0, "p-null", "desc", matchingAsset, assetGroup, 60L);
+    preventionWithNullAsset.setAsset(null);
+    PreventionExpectation preventionWithNonMatchingAsset =
+        PreventionExpectation.preventionExpectationForAsset(
+            100.0, "p-other", "desc", nonMatchingAsset, assetGroup, 60L);
+
+    DetectionExpectation detectionWithNullAsset =
+        DetectionExpectation.detectionExpectationForAsset(
+            100.0, "d-null", "desc", matchingAsset, assetGroup, 60L);
+    detectionWithNullAsset.setAsset(null);
+    DetectionExpectation detectionWithNonMatchingAsset =
+        DetectionExpectation.detectionExpectationForAsset(
+            100.0, "d-other", "desc", nonMatchingAsset, assetGroup, 60L);
+
+    VulnerabilityExpectation vulnerabilityWithNullAsset = new VulnerabilityExpectation();
+    vulnerabilityWithNullAsset.setName("v-null");
+    vulnerabilityWithNullAsset.setScore(100.0);
+    vulnerabilityWithNullAsset.setAsset(null);
+    VulnerabilityExpectation vulnerabilityWithNonMatchingAsset = new VulnerabilityExpectation();
+    vulnerabilityWithNonMatchingAsset.setName("v-other");
+    vulnerabilityWithNonMatchingAsset.setScore(100.0);
+    vulnerabilityWithNonMatchingAsset.setAsset(nonMatchingAsset);
+
+    ManualExpectation manualWithNullAsset =
+        ManualExpectation.manualExpectationForAsset(
+            100.0, "m-null", "desc", matchingAsset, assetGroup, 60L);
+    manualWithNullAsset.setAsset(null);
+    ManualExpectation manualWithNonMatchingAsset =
+        ManualExpectation.manualExpectationForAsset(
+            100.0, "m-other", "desc", nonMatchingAsset, assetGroup, 60L);
+
+    List<io.openaev.model.Expectation> expectations =
+        new ArrayList<>(
+            List.of(
+                preventionWithNullAsset,
+                preventionWithNonMatchingAsset,
+                detectionWithNullAsset,
+                detectionWithNonMatchingAsset,
+                vulnerabilityWithNullAsset,
+                vulnerabilityWithNonMatchingAsset,
+                manualWithNullAsset,
+                manualWithNonMatchingAsset));
+    int initialSize = expectations.size();
+
+    // Act
+    invokeComputeExpectationsForAssetGroup(expectations, content, assetGroup);
+
+    // Assert
+    assertEquals(initialSize, expectations.size());
+    verify(assetGroupService).assetsFromAssetGroup(assetGroup.getId());
+  }
+
+  @Test
+  @DisplayName(
+      "Should execute all supported switch branches for asset and agent expectation computation")
+  void given_supportedExpectationTypes_should_computeAssetAndAgentExpectationsAcrossAllCases()
+      throws Exception {
+    // Arrange
+    BaseInjectContent content = new BaseInjectContent();
+    content.setExpectations(
+        List.of(
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.PREVENTION),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.DETECTION),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.VULNERABILITY),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.MANUAL)));
+
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    endpoint.setId("asset-id");
+    endpoint.setAgents(List.of());
+    inject.setId("inject-id");
+
+    when(injectService.getValueTargetedAssetMap(inject)).thenReturn(Map.of());
+    List<io.openaev.model.Expectation> expectations = new ArrayList<>();
+
+    // Act
+    invokeComputeExpectationsForAssetAndAgents(
+        expectations, content, new AssetToExecute(endpoint), inject, "implant");
+
+    // Assert
+    assertNotNull(expectations);
+    verify(injectService).getValueTargetedAssetMap(inject);
+  }
+
+  @Test
+  @DisplayName(
+      "Should create one asset group expectation per supported type when at least one asset matches")
+  void given_matchingAssetExpectations_should_createAssetGroupExpectationsForAllSupportedTypes()
+      throws Exception {
+    // Arrange
+    BaseInjectContent content = new BaseInjectContent();
+    content.setExpectations(
+        List.of(
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.PREVENTION),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.DETECTION),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.VULNERABILITY),
+            createFormExpectation(InjectExpectation.EXPECTATION_TYPE.MANUAL)));
+
+    Asset matchingAsset = AssetFixture.createDefaultAsset("matching");
+    matchingAsset.setId("asset-matching-id");
+    AssetGroup assetGroup = AssetGroupFixture.createDefaultAssetGroup("ag-match");
+    assetGroup.setId("ag-match-id");
+    when(assetGroupService.assetsFromAssetGroup(assetGroup.getId()))
+        .thenReturn(List.of(matchingAsset));
+
+    PreventionExpectation preventionMatching =
+        PreventionExpectation.preventionExpectationForAsset(
+            100.0, "p", "desc", matchingAsset, assetGroup, 60L);
+    DetectionExpectation detectionMatching =
+        DetectionExpectation.detectionExpectationForAsset(
+            100.0, "d", "desc", matchingAsset, assetGroup, 60L);
+    VulnerabilityExpectation vulnerabilityMatching = new VulnerabilityExpectation();
+    vulnerabilityMatching.setName("v");
+    vulnerabilityMatching.setDescription("desc");
+    vulnerabilityMatching.setScore(100.0);
+    vulnerabilityMatching.setAsset(matchingAsset);
+    vulnerabilityMatching.setAssetGroup(assetGroup);
+    vulnerabilityMatching.setExpirationTime(60L);
+    ManualExpectation manualMatching =
+        ManualExpectation.manualExpectationForAsset(
+            100.0, "m", "desc", matchingAsset, assetGroup, 60L);
+
+    List<io.openaev.model.Expectation> expectations =
+        new ArrayList<>(
+            List.of(preventionMatching, detectionMatching, vulnerabilityMatching, manualMatching));
+    int initialSize = expectations.size();
+
+    // Act
+    invokeComputeExpectationsForAssetGroup(expectations, content, assetGroup);
+
+    // Assert
+    assertEquals(initialSize + 4, expectations.size());
+    verify(assetGroupService).assetsFromAssetGroup(assetGroup.getId());
   }
 
   @Test


### PR DESCRIPTION
### Proposed changes

* Add signatures creation at inject execution start for external injectors

### Testing Instructions

1. Start an inject from an external injector (nuclei, nmap, etc)
2. once the inject is in pending, you should have the expectations created on it

### Related issues

* Closes #5452 
