### PR TITLE
fix(inject): allow user to update atomic testing with assessment capability (#5784)

### DIFF
--- a/openaev-front/src/admin/components/common/injects/UpdateInject.tsx
+++ b/openaev-front/src/admin/components/common/injects/UpdateInject.tsx
@@ -201,7 +201,8 @@ const UpdateInject: React.FC<Props> = ({
                 || !injectorContractContent
                 || permissions.readOnly
                 || (inherited_context === INHERITED_CONTEXT.NONE
-                  && ability.cannot(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId))
+                  && ability.cannot(ACTIONS.MANAGE, SUBJECTS.RESOURCE, injectId)
+                  && ability.cannot(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT))
               }
               isAtomic={isAtomic}
               defaultInject={inject}


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Allow a user assigned to a role with the Assessment capability to update an existing atomic testing. 

### Testing Instructions
As an Admin:

- Navigate to Settings → Security → Roles
- Create a new role with the following capabilities enabled for Assessment:
    - Access
    - Manage
    - Delete
    - Launch
- Navigate to Settings → Security → Groups
- Create a new group and assign the role created above to it
- Add a user to this group — ensure this user belongs only to this group

As the user in the newly created group:

- Navigate to Atomic Testing
- Open an existing atomic testing
- Attempt to edit it
- Observe that the inject form can be modified 

### Related issues

* Closes #5784 
