### PR TITLE
fix(core-ci): restore mvn cache first (#0000)

### DIFF
--- a/.github/actions/backend-package/action.yml
+++ b/.github/actions/backend-package/action.yml
@@ -17,6 +17,12 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set up Java 21
+      uses: actions/setup-java@v5
+      with:
+        java-version: "21"
+        distribution: temurin
+        cache: maven
     - name: Download frontend build artifact
       uses: actions/download-artifact@v8
       with:
@@ -33,12 +39,6 @@ runs:
       with:
         name: release-assets
         path: openaev-api/src/main/resources
-    - name: Set up Java 21
-      uses: actions/setup-java@v5
-      with:
-        java-version: "21"
-        distribution: temurin
-        cache: maven
     - name: Verify downloaded artifacts
       run: |
         # Verify frontend build


### PR DESCRIPTION
## Root cause: 
In backend-package/action.yml, the Download compiled Maven artifacts step placed freshly compiled JARs (including the new findAllByTenantIdAndCatalogConnectorClassName method) into ~/.m2. But the subsequent Set up Java 21 step with cache: maven restored an older Maven cache on top, overwriting those JARs with a stale version of openaev-model that didn't have the new method. When mvn -pl openaev-api package then recompiled only openaev-api using the stale openaev-model, the compilation failed.

## Fix: 
Move Set up Java 21 to the first step, so the cache is restored first, and the fresh downloaded artifacts overwrite it — not the reverse.

## Why it wasn't caught until Backend Package (glibc):
The CI workflow is split into two jobs:
1.Backend Compile — runs mvn install across ALL modules together. openaev-model and openaev-api compile in tandem → ✅ succeeds.
2.Backend Package (glibc) — downloads the pre-compiled openaev-model JAR from the artifact, restores the Maven cache (which overwrites that fresh JAR with the old version from cache), then compiles only openaev-api in isolation against the stale model → ❌ cannot find symbol.

## Why it wasn't surfaced before today:
This is the first time since the CI split (3ab11e586, April 27) that a method was removed from a repository interface in openaev-model and the call site in openaev-api was updated simultaneously. All previous repository changes only added new methods — those don't cause "cannot find symbol" errors (unused old methods just stay in the cache JAR harmlessly).