### PR TITLE
fix: save events before saving updated action (#4824)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -492,16 +492,20 @@ public class StepService {
     existing.setData(updatedCandidate.getData());
     existing.setInput(updatedCandidate.getInput());
     existing.setOutputParser(updatedCandidate.getOutputParser());
-    Step updated = saveStep(existing);
+
+    // Clear the relationships from the parent entity side to avoid Hibernate collections conflict
+    if (existing.getConditionSteps() != null) {
+      existing.getConditionSteps().clear();
+    }
 
     // Remove all existing conditions (full replace strategy),
     // but preserve conditions referenced by conditionIds so they can be re-linked
     conditionService.deleteAllConditionsByStepId(stepId, stepInput.getConditionIds());
 
     // Recreate conditions from input (same logic as create)
-    stepConditionTemplate(stepInput.getConditions(), stepInput.getWorkflowId(), updated);
-    conditionService.linkExistingConditionsToStep(updated, stepInput.getConditionIds());
-    return updated;
+    stepConditionTemplate(stepInput.getConditions(), stepInput.getWorkflowId(), existing);
+    conditionService.linkExistingConditionsToStep(existing, stepInput.getConditionIds());
+    return saveStep(existing);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -493,14 +493,14 @@ public class StepService {
     existing.setInput(updatedCandidate.getInput());
     existing.setOutputParser(updatedCandidate.getOutputParser());
 
+    // Remove all existing conditions (full replace strategy),
+    // but preserve conditions referenced by conditionIds so they can be re-linked
+    conditionService.deleteAllConditionsByStepId(stepId, stepInput.getConditionIds());
+
     // Clear the relationships from the parent entity side to avoid Hibernate collections conflict
     if (existing.getConditionSteps() != null) {
       existing.getConditionSteps().clear();
     }
-
-    // Remove all existing conditions (full replace strategy),
-    // but preserve conditions referenced by conditionIds so they can be re-linked
-    conditionService.deleteAllConditionsByStepId(stepId, stepInput.getConditionIds());
 
     // Recreate conditions from input (same logic as create)
     stepConditionTemplate(stepInput.getConditions(), stepInput.getWorkflowId(), existing);

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -922,6 +922,8 @@ class StepServiceTest {
       Step existing = new Step();
       Workflow existingWorkflow = new Workflow();
       existing.setWorkflow(existingWorkflow);
+      existing.setConditionSteps(
+          new ArrayList<>(List.of(new ConditionStep(), new ConditionStep())));
 
       Step candidate = new Step();
       candidate.setStepAction(StepActionClass.INJECT_EXECUTION);
@@ -929,6 +931,7 @@ class StepServiceTest {
       candidate.setData("{\"updated\":true}");
       candidate.setInput("{}");
       candidate.setOutputParser("{}");
+      Step saved = new Step();
 
       when(stepInput.getStepAction()).thenReturn(StepActionClass.INJECT_EXECUTION);
       when(stepInput.getConditions()).thenReturn(Collections.emptyList());
@@ -940,15 +943,16 @@ class StepServiceTest {
           .factoryAction(StepActionClass.INJECT_EXECUTION, stepId);
       when(actionStep.create(any(StepsCreateInput.StepInput.class), eq(existingWorkflow)))
           .thenReturn(Optional.of(candidate));
-      when(stepRepository.save(existing)).thenReturn(existing);
+      when(stepRepository.save(existing)).thenReturn(saved);
 
       // Act
       Step updated = stepService.updateStepTemplate(stepId, stepInput);
 
       // Assert
-      assertSame(existing, updated);
-      assertEquals(5, updated.getLimitExecution());
-      assertEquals("{\"updated\":true}", updated.getData());
+      assertSame(saved, updated);
+      assertEquals(5, existing.getLimitExecution());
+      assertEquals("{\"updated\":true}", existing.getData());
+      assertTrue(existing.getConditionSteps().isEmpty());
       verify(conditionService).deleteAllConditionsByStepId(stepId, List.of("cond-x"));
       verify(conditionService).linkExistingConditionsToStep(existing, List.of("cond-x"));
       verify(stepRepository).save(existing);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix error transient when a step is updated

### Testing Instructions

1. Create simulation chaining
2. Create step
3. Create second step with input
4. Try to add event between both steps

### Related issues

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
