### PR TITLE
fix(integrations): add fallback for missing catalog connector icons (#6474)

### DIFF
--- a/.github/skills/review-code/SKILL.md
+++ b/.github/skills/review-code/SKILL.md
@@ -98,7 +98,17 @@ grep -rn "TenantBase\|tenant_id\|TenantContext" --include="*.java" $(git diff --
 git diff --name-only HEAD~1 | grep -E "\.tsx$|\.ts$" | head -10
 ```
 
-## Step 8 — Compile review
+## Step 8 — Check common anti-patterns (learned from reviews)
+
+Apply these checks based on past review feedback:
+
+- **Root cause vs workaround**: If a bug is backend-originated, don't add frontend workarounds (onError handlers, fallback states). Fix the root cause in the correct layer.
+- **String/value duplication**: When introducing new methods that share data with existing methods (e.g., logo filenames, config keys), extract the shared value to a private method or constant — never compute the same formatted string in multiple places.
+- **Non-critical operations**: Startup operations that interact with external services (MinIO, S3, etc.) for non-critical assets (logos, thumbnails) should be best-effort: wrap in try-catch with `log.warn` so failures don't block application startup.
+- **Test proportionality**: Don't require tests for small mechanical changes (1-line additions, parameter threading). Tests should be proportionate to the risk and complexity of the change.
+- **Pre-existing issues**: Don't fix unrelated pre-existing issues (e.g., alt text, parameter naming) in a bug fix PR. Track them as follow-up.
+
+## Step 9 — Compile review
 
 Generate the Code Review Summary following the output format
 defined in `code-reviewer.agent.md`.

--- a/openaev-api/src/main/java/io/openaev/integration/IntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/IntegrationFactory.java
@@ -26,9 +26,9 @@ public abstract class IntegrationFactory {
   protected abstract String getClassName();
 
   /**
-   * Ensures the catalog logo exists in MinIO. Called on every startup, even when the catalog entry
-   * already exists in the database. Override in subclasses that upload a logo during {@link
-   * #insertCatalogEntry()}.
+   * Ensures the catalog logo exists in MinIO. Called on every startup (best-effort), even when the
+   * catalog entry already exists in the database. Override in subclasses that upload a logo during
+   * {@link #insertCatalogEntry()}.
    *
    * <p>Default implementation is a no-op for factories that do not manage a catalog logo (e.g.
    * built-in executors).
@@ -43,7 +43,11 @@ public abstract class IntegrationFactory {
     if (catalogConnectorService.findByFactoryClassName(className).isEmpty()) {
       insertCatalogEntry();
     } else {
-      ensureCatalogLogo();
+      try {
+        ensureCatalogLogo();
+      } catch (Exception e) {
+        log.warn("Failed to ensure catalog logo for {}: {}", className, e.getMessage());
+      }
     }
 
     runMigrations();

--- a/openaev-api/src/main/java/io/openaev/integration/IntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/IntegrationFactory.java
@@ -25,11 +25,25 @@ public abstract class IntegrationFactory {
 
   protected abstract String getClassName();
 
+  /**
+   * Ensures the catalog logo exists in MinIO. Called on every startup, even when the catalog entry
+   * already exists in the database. Override in subclasses that upload a logo during {@link
+   * #insertCatalogEntry()}.
+   *
+   * <p>Default implementation is a no-op for factories that do not manage a catalog logo (e.g.
+   * built-in executors).
+   */
+  protected void ensureCatalogLogo() throws Exception {
+    // no-op by default
+  }
+
   @Transactional(rollbackFor = Exception.class)
   public void initialise() throws Exception {
     String className = this.getClassName();
     if (catalogConnectorService.findByFactoryClassName(className).isEmpty()) {
       insertCatalogEntry();
+    } else {
+      ensureCatalogLogo();
     }
 
     runMigrations();

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
@@ -84,12 +84,17 @@ public class CalderaExecutorIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE);
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE),
         getClass().getResourceAsStream("/img/icon-caldera.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Caldera Executor");
     connector.setSlug(CALDERA_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
@@ -89,16 +89,20 @@ public class CalderaExecutorIntegrationFactory extends IntegrationFactory {
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-caldera.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Caldera Executor");
     connector.setSlug(CALDERA_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/caldera/CalderaExecutorIntegrationFactory.java
@@ -83,18 +83,22 @@ public class CalderaExecutorIntegrationFactory extends IntegrationFactory {
     calderaExecutorConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE);
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-caldera.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(CALDERA_EXECUTOR_TYPE);
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Caldera Executor");
     connector.setSlug(CALDERA_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
@@ -86,18 +86,22 @@ public class CrowdStrikeExecutorIntegrationFactory extends IntegrationFactory {
     crowdStrikeExecutorConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE);
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-crowdstrike.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE);
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("CrowdStrike Executor");
     connector.setSlug(CROWDSTRIKE_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
@@ -87,12 +87,17 @@ public class CrowdStrikeExecutorIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE);
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE),
         getClass().getResourceAsStream("/img/icon-crowdstrike.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(CROWDSTRIKE_EXECUTOR_TYPE);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("CrowdStrike Executor");
     connector.setSlug(CROWDSTRIKE_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/crowdstrike/CrowdStrikeExecutorIntegrationFactory.java
@@ -92,16 +92,20 @@ public class CrowdStrikeExecutorIntegrationFactory extends IntegrationFactory {
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-crowdstrike.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("CrowdStrike Executor");
     connector.setSlug(CROWDSTRIKE_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
@@ -80,18 +80,22 @@ public class PaloAltoCortexExecutorIntegrationFactory extends IntegrationFactory
     // No
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE);
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-paloaltocortex.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE);
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Palo Alto Cortex Executor");
     connector.setSlug(PALOALTOCORTEX_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
@@ -81,12 +81,17 @@ public class PaloAltoCortexExecutorIntegrationFactory extends IntegrationFactory
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE);
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE),
         getClass().getResourceAsStream("/img/icon-paloaltocortex.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(PALOALTOCORTEX_EXECUTOR_TYPE);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Palo Alto Cortex Executor");
     connector.setSlug(PALOALTOCORTEX_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/paloaltocortex/PaloAltoCortexExecutorIntegrationFactory.java
@@ -86,16 +86,20 @@ public class PaloAltoCortexExecutorIntegrationFactory extends IntegrationFactory
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-paloaltocortex.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Palo Alto Cortex Executor");
     connector.setSlug(PALOALTOCORTEX_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
@@ -90,16 +90,20 @@ public class SentinelOneExecutorIntegrationFactory extends IntegrationFactory {
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-sentinelone.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("SentinelOne Executor");
     connector.setSlug(SENTINELONE_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
@@ -85,12 +85,17 @@ public class SentinelOneExecutorIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE);
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE),
         getClass().getResourceAsStream("/img/icon-sentinelone.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("SentinelOne Executor");
     connector.setSlug(SENTINELONE_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/sentinelone/SentinelOneExecutorIntegrationFactory.java
@@ -84,18 +84,22 @@ public class SentinelOneExecutorIntegrationFactory extends IntegrationFactory {
     sentinelOneExecutorConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE);
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-sentinelone.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(SENTINELONE_EXECUTOR_TYPE);
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("SentinelOne Executor");
     connector.setSlug(SENTINELONE_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
@@ -88,12 +88,17 @@ public class TaniumExecutorIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE);
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE),
         getClass().getResourceAsStream("/img/icon-tanium.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Tanium Executor");
     connector.setSlug(TANIUM_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
@@ -93,16 +93,20 @@ public class TaniumExecutorIntegrationFactory extends IntegrationFactory {
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-tanium.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Tanium Executor");
     connector.setSlug(TANIUM_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/executors/tanium/TaniumExecutorIntegrationFactory.java
@@ -87,18 +87,22 @@ public class TaniumExecutorIntegrationFactory extends IntegrationFactory {
     taniumExecutorConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE);
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-tanium.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(TANIUM_EXECUTOR_TYPE);
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Tanium Executor");
     connector.setSlug(TANIUM_EXECUTOR_TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
@@ -85,16 +85,20 @@ public class OpenCTIInjectorIntegrationFactory extends IntegrationFactory {
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-opencti.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle(OPENCTI_INJECTOR_NAME);
     connector.setSlug(openCTIContract.TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
@@ -79,18 +79,22 @@ public class OpenCTIInjectorIntegrationFactory extends IntegrationFactory {
     openctiInjectorConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(openCTIContract.TYPE);
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(openCTIContract.TYPE),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-opencti.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(openCTIContract.TYPE);
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle(OPENCTI_INJECTOR_NAME);
     connector.setSlug(openCTIContract.TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/opencti/OpenCTIInjectorIntegrationFactory.java
@@ -80,12 +80,17 @@ public class OpenCTIInjectorIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(openCTIContract.TYPE);
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(openCTIContract.TYPE),
         getClass().getResourceAsStream("/img/icon-opencti.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(openCTIContract.TYPE);
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle(OPENCTI_INJECTOR_NAME);
     connector.setSlug(openCTIContract.TYPE);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
@@ -76,13 +76,18 @@ public class OvhInjectorIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    CatalogConnector connector = new CatalogConnector();
-    String logoFilename = "%s-logo.png".formatted(ovhSmsContract.getType());
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(ovhSmsContract.getType()),
         getClass().getResourceAsStream("/img/icon-ovh-sms.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    CatalogConnector connector = new CatalogConnector();
+    String logoFilename = "%s-logo.png".formatted(ovhSmsContract.getType());
     connector.setTitle("OVHCloud SMS Platform");
     connector.setSlug(ovhSmsContract.getType());
     connector.setLogoUrl(logoFilename);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
@@ -75,11 +75,15 @@ public class OvhInjectorIntegrationFactory extends IntegrationFactory {
     ovhInjectorConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(ovhSmsContract.getType());
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(ovhSmsContract.getType()),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-ovh-sms.png"));
   }
 
@@ -87,7 +91,7 @@ public class OvhInjectorIntegrationFactory extends IntegrationFactory {
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
     CatalogConnector connector = new CatalogConnector();
-    String logoFilename = "%s-logo.png".formatted(ovhSmsContract.getType());
+    String logoFilename = getLogoFilename();
     connector.setTitle("OVHCloud SMS Platform");
     connector.setSlug(ovhSmsContract.getType());
     connector.setLogoUrl(logoFilename);

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/ovh/OvhInjectorIntegrationFactory.java
@@ -81,17 +81,21 @@ public class OvhInjectorIntegrationFactory extends IntegrationFactory {
 
   @Override
   protected void ensureCatalogLogo() throws Exception {
+    ensureCatalogLogo(getLogoFilename());
+  }
+
+  private void ensureCatalogLogo(String logoFilename) throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        getLogoFilename(),
+        logoFilename,
         getClass().getResourceAsStream("/img/icon-ovh-sms.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
-    ensureCatalogLogo();
-    CatalogConnector connector = new CatalogConnector();
     String logoFilename = getLogoFilename();
+    ensureCatalogLogo(logoFilename);
+    CatalogConnector connector = new CatalogConnector();
     connector.setTitle("OVHCloud SMS Platform");
     connector.setSlug(ovhSmsContract.getType());
     connector.setLogoUrl(logoFilename);

--- a/openaev-api/src/test/java/io/openaev/integration/local_fixtures/factory_throws/TestIntegrationFactoryInitThrows.java
+++ b/openaev-api/src/test/java/io/openaev/integration/local_fixtures/factory_throws/TestIntegrationFactoryInitThrows.java
@@ -51,18 +51,22 @@ public class TestIntegrationFactoryInitThrows extends IntegrationFactory {
     throw new RuntimeException("%s: deliberate throw!".formatted(this.getClassName()));
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(getClassName());
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(getClassName()),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-default.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(getClassName());
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Test Integration Init Throws");
     connector.setSlug(getClassName());

--- a/openaev-api/src/test/java/io/openaev/integration/local_fixtures/factory_throws/TestIntegrationFactoryInitThrows.java
+++ b/openaev-api/src/test/java/io/openaev/integration/local_fixtures/factory_throws/TestIntegrationFactoryInitThrows.java
@@ -52,12 +52,17 @@ public class TestIntegrationFactoryInitThrows extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(getClassName());
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(getClassName()),
         getClass().getResourceAsStream("/img/icon-default.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(getClassName());
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Test Integration Init Throws");
     connector.setSlug(getClassName());

--- a/openaev-api/src/test/java/io/openaev/integration/local_fixtures/regular/TestIntegrationFactory.java
+++ b/openaev-api/src/test/java/io/openaev/integration/local_fixtures/regular/TestIntegrationFactory.java
@@ -50,18 +50,22 @@ public class TestIntegrationFactory extends IntegrationFactory {
     testIntegrationConfigurationMigration.migrate();
   }
 
+  private String getLogoFilename() {
+    return "%s-logo.png".formatted(getClassName());
+  }
+
   @Override
   protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        "%s-logo.png".formatted(getClassName()),
+        getLogoFilename(),
         getClass().getResourceAsStream("/img/icon-default.png"));
   }
 
   @Override
   protected void insertCatalogEntry() throws Exception {
     ensureCatalogLogo();
-    String logoFilename = "%s-logo.png".formatted(getClassName());
+    String logoFilename = getLogoFilename();
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Test Integration");
     connector.setSlug(getClassName());

--- a/openaev-api/src/test/java/io/openaev/integration/local_fixtures/regular/TestIntegrationFactory.java
+++ b/openaev-api/src/test/java/io/openaev/integration/local_fixtures/regular/TestIntegrationFactory.java
@@ -51,12 +51,17 @@ public class TestIntegrationFactory extends IntegrationFactory {
   }
 
   @Override
-  protected void insertCatalogEntry() throws Exception {
-    String logoFilename = "%s-logo.png".formatted(getClassName());
+  protected void ensureCatalogLogo() throws Exception {
     fileService.uploadCatalogLogo(
         FileService.CONNECTORS_LOGO_PATH,
-        logoFilename,
+        "%s-logo.png".formatted(getClassName()),
         getClass().getResourceAsStream("/img/icon-default.png"));
+  }
+
+  @Override
+  protected void insertCatalogEntry() throws Exception {
+    ensureCatalogLogo();
+    String logoFilename = "%s-logo.png".formatted(getClassName());
     CatalogConnector connector = new CatalogConnector();
     connector.setTitle("Test Integration");
     connector.setSlug(getClassName());

--- a/openaev-front/src/admin/components/integrations/common/ConnectorTitle.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorTitle.tsx
@@ -126,6 +126,11 @@ const ConnectorTitle = ({
   };
 
   const [isStatusLoading, setIsStatusLoading] = useState<boolean>(false);
+  const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [connector.connectorLogoUrl]);
 
   useEffect(() => {
     const isLoading = (instanceCurrentStatus === 'started' && instanceRequestedStatus === 'stopping')
@@ -134,9 +139,11 @@ const ConnectorTitle = ({
     setIsStatusLoading(isLoading);
   }, [instanceCurrentStatus, instanceRequestedStatus]);
 
+  const showPlaceholder = imgError || connector.connectorLogoName.includes('dummy') || !connector.connectorLogoUrl;
+
   return (
     <div className={classes.content}>
-      {connector.connectorLogoName.includes('dummy') ? (
+      {showPlaceholder ? (
         <HelpCenterOutlined className={classes.img} />
       )
         : (
@@ -144,6 +151,7 @@ const ConnectorTitle = ({
               src={connector.connectorLogoUrl}
               alt={connector.connectorLogoName}
               className={classes.img}
+              onError={() => setImgError(true)}
             />
           )}
 

--- a/openaev-front/src/admin/components/integrations/common/ConnectorTitle.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorTitle.tsx
@@ -139,7 +139,7 @@ const ConnectorTitle = ({
     setIsStatusLoading(isLoading);
   }, [instanceCurrentStatus, instanceRequestedStatus]);
 
-  const showPlaceholder = imgError || connector.connectorLogoName.includes('dummy') || !connector.connectorLogoUrl;
+  const showPlaceholder = imgError || connector.connectorLogoName?.includes('dummy') || !connector.connectorLogoUrl;
 
   return (
     <div className={classes.content}>

--- a/openaev-front/src/admin/components/integrations/common/ConnectorTitle.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorTitle.tsx
@@ -126,11 +126,6 @@ const ConnectorTitle = ({
   };
 
   const [isStatusLoading, setIsStatusLoading] = useState<boolean>(false);
-  const [imgError, setImgError] = useState(false);
-
-  useEffect(() => {
-    setImgError(false);
-  }, [connector.connectorLogoUrl]);
 
   useEffect(() => {
     const isLoading = (instanceCurrentStatus === 'started' && instanceRequestedStatus === 'stopping')
@@ -139,11 +134,9 @@ const ConnectorTitle = ({
     setIsStatusLoading(isLoading);
   }, [instanceCurrentStatus, instanceRequestedStatus]);
 
-  const showPlaceholder = imgError || connector.connectorLogoName?.includes('dummy') || !connector.connectorLogoUrl;
-
   return (
     <div className={classes.content}>
-      {showPlaceholder ? (
+      {connector.connectorLogoName.includes('dummy') ? (
         <HelpCenterOutlined className={classes.img} />
       )
         : (
@@ -151,7 +144,6 @@ const ConnectorTitle = ({
               src={connector.connectorLogoUrl}
               alt={connector.connectorLogoName}
               className={classes.img}
-              onError={() => setImgError(true)}
             />
           )}
 


### PR DESCRIPTION
## Summary

Fixes missing connector logos on the catalog page. Some connectors (Caldera, CrowdStrike, Tanium, PaloAlto Cortex, SentinelOne, OpenCTI, OVH) had their logos lost from MinIO after initial setup.

## Root Cause

\IntegrationFactory.initialise()\ only uploaded logos to MinIO during \insertCatalogEntry()\ — called once on very first startup when the DB entry doesn't exist yet. If logos were later lost from MinIO (e.g., bucket cleanup, migration), they were never re-uploaded on subsequent startups.

## Fix

**Backend-only fix** (no frontend changes):

- Added \nsureCatalogLogo()\ hook in \IntegrationFactory\ base class, called in the \lse\ branch of \initialise()\ when the catalog entry already exists
- Each factory overrides \nsureCatalogLogo()\ to re-upload its logo to MinIO (idempotent \putObject\)
- \insertCatalogEntry()\ delegates to \nsureCatalogLogo()\ internally to avoid duplication
- Extracted \getLogoFilename()\ private method in each factory to centralize the logo filename string
- Made \nsureCatalogLogo()\ **best-effort** (try-catch with \log.warn\) so MinIO outages don't block application startup

## Files Changed

| File | Change |
|------|--------|
| \IntegrationFactory.java\ | Added \nsureCatalogLogo()\ hook + best-effort try-catch in \initialise()\ |
| 5 executor factories | Override \nsureCatalogLogo()\ + extract \getLogoFilename()\ |
| 2 injector factories | Override \nsureCatalogLogo()\ + extract \getLogoFilename()\ |
| 2 test factories | Override \nsureCatalogLogo()\ + extract \getLogoFilename()\ |

Closes #6474