### PR TITLE
fix(inject): improve warn logs for requeueCallbacks (#6487)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
@@ -220,8 +220,15 @@ public class BatchingInjectStatusService {
         callbacksToRequeue.poll();
       } catch (Exception e) {
         log.warn(
-            "Unable to requeue inject execution callback {}, keeping it in memory for retry",
-            callback,
+            "Unable to requeue inject execution callback injectId="
+                + callback.getInjectId()
+                + " agentId="
+                + callback.getAgentId()
+                + " retryCount="
+                + callback.getRetryCount()
+                + " message="
+                + callback.getInjectExecutionInput().getMessage()
+                + " , keeping it in memory for retry",
             e);
         break;
       }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
@@ -219,7 +219,10 @@ public class BatchingInjectStatusService {
         injectTraceQueueService.publish(callback);
         callbacksToRequeue.poll();
       } catch (Exception e) {
-        log.warn("Unable to requeue inject execution callback, keeping it in memory for retry", e);
+        log.warn(
+            "Unable to requeue inject execution callback {}, keeping it in memory for retry",
+            callback,
+            e);
         break;
       }
     }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/BatchingInjectStatusService.java
@@ -227,7 +227,17 @@ public class BatchingInjectStatusService {
                 + " retryCount="
                 + callback.getRetryCount()
                 + " message="
-                + callback.getInjectExecutionInput().getMessage()
+                + (callback.getInjectExecutionInput() != null
+                    ? callback.getInjectExecutionInput().getMessage()
+                    : null)
+                + " outputStructured="
+                + (callback.getInjectExecutionInput() != null
+                    ? callback.getInjectExecutionInput().getOutputStructured()
+                    : null)
+                + " outputRaw="
+                + (callback.getInjectExecutionInput() != null
+                    ? callback.getInjectExecutionInput().getOutputRaw()
+                    : null)
                 + " , keeping it in memory for retry",
             e);
         break;


### PR DESCRIPTION
## Proposed changes

- Add a warning log in the inject callback path to improve observability when callback behavior is unexpected.
- Keep the change minimal and scoped to the existing inject flow (single-file update, no functional redesign).

## Why

Debugging callback-related issues in inject can be difficult when failures or unexpected states are silent.
This PR adds explicit warning-level logging so operators and developers can quickly identify and triage these situations.

## Testing Instructions

Trigger the inject flow with a callback scenario (including a case that should emit the warning).
Verify the warning log is emitted with the expected context.
Run the standard checks/test suite to confirm no regressions.

## Related issues
N/A (no linked issue yet)

## Further comments
This is a small observability-focused change intended to make callback diagnostics easier without changing the broader inject behavior.
