### PR TITLE
fix(engine): fix ES indexing cursor skipping expectations with same timestamp (#6490)

### DIFF
--- a/.github/instructions/performance.instructions.md
+++ b/.github/instructions/performance.instructions.md
@@ -106,5 +106,6 @@ Repositories that are used with `ReferenceResolver` must expose a `countByIdIn(S
 - ❌ Iterating a list to call `repository.findById()` in a loop — use `ReferenceResolver` or `findAllById()` instead
 - ❌ Opening a transaction for read-only operations without `readOnly = true`
 - ❌ Returning JPA entities with LAZY collections from `@RestController` (triggers proxy outside session)
+- ❌ Duplicate native `@Query` methods that differ only by an optional parameter — merge into one method using SQL null-guards (e.g. `OR (:lastId IS NOT NULL AND ...)`) to avoid maintaining two copies of large query blocks
 - ❌ Performing MinIO / S3 / file I/O inside `@Transactional` — split into DB method + separate best-effort upload method called after the transaction commits
 

--- a/openaev-api/src/main/java/io/openaev/migration/V5_35__Add_indexing_last_id.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_35__Add_indexing_last_id.java
@@ -1,0 +1,18 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V5_35__Add_indexing_last_id extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "ALTER TABLE indexing_status ADD COLUMN IF NOT EXISTS indexing_last_id TEXT NULL");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V5_35__Add_indexing_last_id.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_35__Add_indexing_last_id.java
@@ -16,8 +16,8 @@ public class V5_35__Add_indexing_last_id extends BaseJavaMigration {
       // Force a one-time full reindex for expectations so that any rows that were previously
       // skipped (same-timestamp batch overflow before this fix) are picked up on next cycle.
       statement.execute(
-          "UPDATE indexing_status SET indexing_last_id = NULL, indexing_last = '1970-01-01 00:00:00'"
-              + " WHERE indexing_type = 'expectation-inject'");
+          "UPDATE indexing_status SET indexing_last_id = NULL, indexing_status_indexing_date = '1970-01-01 00:00:00'"
+              + " WHERE indexing_status_type = 'expectation-inject'");
     }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/migration/V5_35__Add_indexing_last_id.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_35__Add_indexing_last_id.java
@@ -13,6 +13,11 @@ public class V5_35__Add_indexing_last_id extends BaseJavaMigration {
     try (Statement statement = context.getConnection().createStatement()) {
       statement.execute(
           "ALTER TABLE indexing_status ADD COLUMN IF NOT EXISTS indexing_last_id TEXT NULL");
+      // Force a one-time full reindex for expectations so that any rows that were previously
+      // skipped (same-timestamp batch overflow before this fix) are picked up on next cycle.
+      statement.execute(
+          "UPDATE indexing_status SET indexing_last_id = NULL, indexing_last = '1970-01-01 00:00:00'"
+              + " WHERE indexing_type = 'expectation-inject'");
     }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260630122959088__Add_inject_expectation_signatures_initialized.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260630122959088__Add_inject_expectation_signatures_initialized.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class V6_20260630122959088__Add_inject_expectation_signatures_initialized
     extends BaseJavaMigration {
-
   @Override
   public void migrate(Context context) throws Exception {
     try (Statement statement = context.getConnection().createStatement()) {

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -25,6 +25,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestExecutionListeners;
@@ -804,6 +805,72 @@ class IndexingRegressionTest extends IntegrationTest {
       Endpoint endpoint = endpointWrapper.get();
       String expectedBaseId = endpoint.getId() + "_" + exercise.getId();
       assertThat(results).anyMatch(es -> es.getBase_id().equals(expectedBaseId));
+    }
+
+    @Test
+    @DisplayName(
+        "Compound cursor: all expectations sharing the same timestamp are returned across"
+            + " batches")
+    void compound_cursor_returns_all_expectations_at_same_timestamp() {
+      // Arrange — 3 expectations in the same inject, all forced to identical updated_at
+      // (simulates bulkComputeTechnicalExpectations saving many rows in a single saveAll())
+      Instant sharedTimestamp = FROM.plus(30, ChronoUnit.MINUTES);
+
+      InjectExpectation exp1 = InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      InjectExpectation exp2 = InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      InjectExpectation exp3 = InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+
+      scenarioComposer
+          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+          .withInject(
+              injectComposer
+                  .forInject(InjectFixture.getDefaultInject())
+                  .withExpectation(
+                      injectExpectationComposer
+                          .forExpectation(exp1)
+                          .withEndpoint(
+                              endpointComposer.forEndpoint(EndpointFixture.createEndpoint())))
+                  .withExpectation(
+                      injectExpectationComposer
+                          .forExpectation(exp2)
+                          .withEndpoint(
+                              endpointComposer.forEndpoint(EndpointFixture.createEndpoint())))
+                  .withExpectation(
+                      injectExpectationComposer
+                          .forExpectation(exp3)
+                          .withEndpoint(
+                              endpointComposer.forEndpoint(EndpointFixture.createEndpoint()))))
+          .persist();
+      entityManager.flush();
+
+      // Force all 3 expectations to the exact same timestamp
+      for (InjectExpectation exp : List.of(exp1, exp2, exp3)) {
+        entityManager
+            .createNativeQuery(
+                "UPDATE injects_expectations SET inject_expectation_updated_at = :ts"
+                    + " WHERE inject_expectation_id = :id")
+            .setParameter("ts", sharedTimestamp)
+            .setParameter("id", exp.getId())
+            .executeUpdate();
+      }
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — first batch (limit=2): returns 2 expectations ordered by (updated_at, id)
+      List<EsInjectExpectation> batch1 = injectExpectationHandler.fetch(FROM, 2);
+      assertThat(batch1).hasSize(2);
+
+      // Act — compound cursor continues from last item of batch1; must return the 3rd
+      String lastId = batch1.getLast().getBase_id();
+      List<EsInjectExpectation> batch2 = injectExpectationHandler.fetch(FROM, lastId, 2);
+
+      // Assert — all 3 expectations are covered across both batches (none skipped)
+      List<String> allReturnedIds =
+          Stream.concat(batch1.stream(), batch2.stream())
+              .map(EsInjectExpectation::getBase_id)
+              .toList();
+      assertThat(allReturnedIds)
+          .containsExactlyInAnyOrder(exp1.getId(), exp2.getId(), exp3.getId());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -94,51 +94,51 @@ class IndexingRegressionTest extends IntegrationTest {
 
   private void pushScenarioToPast(String scenarioId) {
     entityManager
-        .createNativeQuery("UPDATE scenarios SET scenario_updated_at = :ts WHERE scenario_id = :id")
-        .setParameter("ts", PAST)
-        .setParameter("id", scenarioId)
+        .createNativeQuery("UPDATE scenarios SET scenario_updated_at = ?1 WHERE scenario_id = ?2")
+        .setParameter(1, PAST)
+        .setParameter(2, scenarioId)
         .executeUpdate();
   }
 
   private void pushExerciseToPast(String exerciseId) {
     entityManager
-        .createNativeQuery("UPDATE exercises SET exercise_updated_at = :ts WHERE exercise_id = :id")
-        .setParameter("ts", PAST)
-        .setParameter("id", exerciseId)
+        .createNativeQuery("UPDATE exercises SET exercise_updated_at = ?1 WHERE exercise_id = ?2")
+        .setParameter(1, PAST)
+        .setParameter(2, exerciseId)
         .executeUpdate();
   }
 
   private void pushEndpointToPast(String assetId) {
     entityManager
-        .createNativeQuery("UPDATE assets SET asset_updated_at = :ts WHERE asset_id = :id")
-        .setParameter("ts", PAST)
-        .setParameter("id", assetId)
+        .createNativeQuery("UPDATE assets SET asset_updated_at = ?1 WHERE asset_id = ?2")
+        .setParameter(1, PAST)
+        .setParameter(2, assetId)
         .executeUpdate();
   }
 
   private void pushInjectToPast(String injectId) {
     entityManager
-        .createNativeQuery("UPDATE injects SET inject_updated_at = :ts WHERE inject_id = :id")
-        .setParameter("ts", PAST)
-        .setParameter("id", injectId)
+        .createNativeQuery("UPDATE injects SET inject_updated_at = ?1 WHERE inject_id = ?2")
+        .setParameter(1, PAST)
+        .setParameter(2, injectId)
         .executeUpdate();
   }
 
   private void pushExpectationToPast(String expectationId) {
     entityManager
         .createNativeQuery(
-            "UPDATE injects_expectations SET inject_expectation_updated_at = :ts"
-                + " WHERE inject_expectation_id = :id")
-        .setParameter("ts", PAST)
-        .setParameter("id", expectationId)
+            "UPDATE injects_expectations SET inject_expectation_updated_at = ?1"
+                + " WHERE inject_expectation_id = ?2")
+        .setParameter(1, PAST)
+        .setParameter(2, expectationId)
         .executeUpdate();
   }
 
   private void touchInject(String injectId) {
     entityManager
-        .createNativeQuery("UPDATE injects SET inject_updated_at = :ts WHERE inject_id = :id")
-        .setParameter("ts", Instant.now())
-        .setParameter("id", injectId)
+        .createNativeQuery("UPDATE injects SET inject_updated_at = ?1 WHERE inject_id = ?2")
+        .setParameter(1, Instant.now())
+        .setParameter(2, injectId)
         .executeUpdate();
   }
 
@@ -234,15 +234,15 @@ class IndexingRegressionTest extends IntegrationTest {
       List<?> injectIds =
           entityManager
               .createNativeQuery(
-                  "SELECT inject_id FROM injects WHERE inject_scenario = :sid ORDER BY inject_id")
-              .setParameter("sid", scenarioWrapper.get().getId())
+                  "SELECT inject_id FROM injects WHERE inject_scenario = ?1 ORDER BY inject_id")
+              .setParameter(1, scenarioWrapper.get().getId())
               .getResultList();
       Instant base = FROM.plusSeconds(1);
       for (int i = 0; i < injectIds.size(); i++) {
         entityManager
-            .createNativeQuery("UPDATE injects SET inject_updated_at = :ts WHERE inject_id = :id")
-            .setParameter("ts", base.plusSeconds(i))
-            .setParameter("id", injectIds.get(i).toString())
+            .createNativeQuery("UPDATE injects SET inject_updated_at = ?1 WHERE inject_id = ?2")
+            .setParameter(1, base.plusSeconds(i))
+            .setParameter(2, injectIds.get(i).toString())
             .executeUpdate();
         expectedIds.add(injectIds.get(i).toString());
       }
@@ -283,7 +283,6 @@ class IndexingRegressionTest extends IntegrationTest {
     @Test
     @DisplayName("Scenario appears when only its linked inject was updated after :from")
     void scenario_reindexed_when_linked_inject_updated() {
-      // Arrange — create a scenario with an inject
       InjectComposer.Composer injectWrapper =
           injectComposer.forInject(InjectFixture.getDefaultInject());
       Scenario scenario =
@@ -294,16 +293,12 @@ class IndexingRegressionTest extends IntegrationTest {
               .get();
       entityManager.flush();
 
-      // Push the scenario's own updated_at into the past
       pushScenarioToPast(scenario.getId());
-      // The inject's updated_at stays at now() — recent
       entityManager.flush();
       entityManager.clear();
 
-      // Act
       List<EsScenario> results = scenarioHandler.fetch(FROM, 5000);
 
-      // Assert — scenario must appear because its inject is recent
       assertThat(results).anyMatch(es -> es.getBase_id().equals(scenario.getId()));
     }
 
@@ -325,27 +320,25 @@ class IndexingRegressionTest extends IntegrationTest {
       }
       entityManager.flush();
 
-      // Assign distinct timestamps on scenarios AND their injects so GREATEST is deterministic
       int i = 0;
       for (String id : expectedIds) {
         Instant ts = FROM.plusSeconds(++i);
         entityManager
             .createNativeQuery(
-                "UPDATE scenarios SET scenario_updated_at = :ts WHERE scenario_id = :id")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE scenarios SET scenario_updated_at = ?1 WHERE scenario_id = ?2")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
         entityManager
             .createNativeQuery(
-                "UPDATE injects SET inject_updated_at = :ts WHERE inject_scenario = :id")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE injects SET inject_updated_at = ?1 WHERE inject_scenario = ?2")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
       }
       entityManager.flush();
       entityManager.clear();
 
-      // Simulate cursor loop
       Set<String> collectedIds = new HashSet<>();
       Instant cursor = FROM;
       int iterations = 0;
@@ -376,7 +369,6 @@ class IndexingRegressionTest extends IntegrationTest {
     @Test
     @DisplayName("Exercise appears when only its linked inject was updated after :from")
     void exercise_reindexed_when_linked_inject_updated() {
-      // Arrange — create an exercise with an inject
       InjectComposer.Composer injectWrapper =
           injectComposer.forInject(InjectFixture.getDefaultInject());
       Exercise exercise =
@@ -387,15 +379,12 @@ class IndexingRegressionTest extends IntegrationTest {
               .get();
       entityManager.flush();
 
-      // Push the exercise's own updated_at into the past
       pushExerciseToPast(exercise.getId());
       entityManager.flush();
       entityManager.clear();
 
-      // Act
       List<EsSimulation> results = simulationHandler.fetch(FROM, 5000);
 
-      // Assert — exercise must appear because its inject is recent
       assertThat(results).anyMatch(es -> es.getBase_id().equals(exercise.getId()));
     }
 
@@ -417,21 +406,20 @@ class IndexingRegressionTest extends IntegrationTest {
       }
       entityManager.flush();
 
-      // Set distinct timestamps on exercises AND their injects so GREATEST is deterministic
       int i = 0;
       for (String id : expectedIds) {
         Instant ts = FROM.plusSeconds(++i);
         entityManager
             .createNativeQuery(
-                "UPDATE exercises SET exercise_updated_at = :ts WHERE exercise_id = :id")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE exercises SET exercise_updated_at = ?1 WHERE exercise_id = ?2")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
         entityManager
             .createNativeQuery(
-                "UPDATE injects SET inject_updated_at = :ts WHERE inject_exercise = :id")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE injects SET inject_updated_at = ?1 WHERE inject_exercise = ?2")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
       }
       entityManager.flush();
@@ -467,7 +455,6 @@ class IndexingRegressionTest extends IntegrationTest {
     @Test
     @DisplayName("Endpoint appears when only its linked inject was updated after :from")
     void endpoint_reindexed_when_linked_inject_updated() {
-      // Arrange — create an endpoint linked to an inject via a scenario
       EndpointComposer.Composer endpointWrapper =
           endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
       InjectComposer.Composer injectWrapper =
@@ -481,19 +468,14 @@ class IndexingRegressionTest extends IntegrationTest {
       Endpoint endpoint = endpointWrapper.get();
       Inject inject = injectWrapper.get();
 
-      // Push the endpoint's own updated_at into the past
       pushEndpointToPast(endpoint.getId());
-      // Also push the inject so the only "recent" change must come from touching it
       pushInjectToPast(inject.getId());
-      // Now touch the inject so it becomes recent again
       touchInject(inject.getId());
       entityManager.flush();
       entityManager.clear();
 
-      // Act
       List<EsEndpoint> results = endpointHandler.fetch(FROM, 5000);
 
-      // Assert — endpoint must appear because its linked inject is recent
       assertThat(results).anyMatch(es -> es.getBase_id().equals(endpoint.getId()));
     }
 
@@ -517,21 +499,20 @@ class IndexingRegressionTest extends IntegrationTest {
       }
       entityManager.flush();
 
-      // Set distinct timestamps on endpoints AND their injects so GREATEST is deterministic
       int i = 0;
       for (String id : expectedIds) {
         Instant ts = FROM.plusSeconds(++i);
         entityManager
-            .createNativeQuery("UPDATE assets SET asset_updated_at = :ts WHERE asset_id = :id")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+            .createNativeQuery("UPDATE assets SET asset_updated_at = ?1 WHERE asset_id = ?2")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
         entityManager
             .createNativeQuery(
-                "UPDATE injects SET inject_updated_at = :ts WHERE inject_id IN"
-                    + " (SELECT inject_id FROM injects_assets WHERE asset_id = :id)")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE injects SET inject_updated_at = ?1 WHERE inject_id IN"
+                    + " (SELECT inject_id FROM injects_assets WHERE asset_id = ?2)")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
       }
       entityManager.flush();
@@ -567,7 +548,6 @@ class IndexingRegressionTest extends IntegrationTest {
     @Test
     @DisplayName("Expectation appears when only its linked inject was updated after :from")
     void expectation_reindexed_when_linked_inject_updated() {
-      // Arrange — create an inject with an expectation inside a scenario
       EndpointComposer.Composer endpointWrapper =
           endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
       BaseInjectExpectation expectation =
@@ -586,18 +566,14 @@ class IndexingRegressionTest extends IntegrationTest {
 
       Inject inject = injectWrapper.get();
 
-      // Push the expectation's own updated_at into the past
       pushExpectationToPast(expectation.getId());
-      // Also push the inject then touch it so the inject is the only recent change
       pushInjectToPast(inject.getId());
       touchInject(inject.getId());
       entityManager.flush();
       entityManager.clear();
 
-      // Act — the handler filters out agent-level expectations, so we pass null/large limit
       List<EsInjectExpectation> results = injectExpectationHandler.fetch(FROM, 5000);
 
-      // Assert — expectation must appear because its linked inject is recent
       assertThat(results).anyMatch(es -> es.getBase_id().equals(expectation.getId()));
     }
 
@@ -606,7 +582,6 @@ class IndexingRegressionTest extends IntegrationTest {
         "Agentless expectation keeps security platforms side from agent-level expectation results")
     void
         given_agentless_expectation_should_index_security_platforms_from_agent_expectation_results() {
-      // Arrange
       SecurityPlatformComposer.Composer securityPlatform =
           securityPlatformComposer
               .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR test", "EDR"))
@@ -662,10 +637,8 @@ class IndexingRegressionTest extends IntegrationTest {
       entityManager.flush();
       entityManager.clear();
 
-      // Act
       List<EsInjectExpectation> results = injectExpectationHandler.fetch(FROM, 5000);
 
-      // Assert
       assertThat(results)
           .filteredOn(es -> es.getBase_id().equals(agentlessExpectation.getId()))
           .singleElement()
@@ -728,23 +701,22 @@ class IndexingRegressionTest extends IntegrationTest {
       }
       entityManager.flush();
 
-      // Set distinct timestamps on expectations AND their injects so GREATEST is deterministic
       int i = 0;
       for (String id : expectedIds) {
         Instant ts = FROM.plusSeconds(++i);
         entityManager
             .createNativeQuery(
-                "UPDATE injects_expectations SET inject_expectation_updated_at = :ts"
-                    + " WHERE inject_expectation_id = :id")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE injects_expectations SET inject_expectation_updated_at = ?1"
+                    + " WHERE inject_expectation_id = ?2")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
         entityManager
             .createNativeQuery(
-                "UPDATE injects SET inject_updated_at = :ts WHERE inject_id = "
-                    + "(SELECT inject_id FROM injects_expectations WHERE inject_expectation_id = :id)")
-            .setParameter("ts", ts)
-            .setParameter("id", id)
+                "UPDATE injects SET inject_updated_at = ?1 WHERE inject_id = "
+                    + "(SELECT inject_id FROM injects_expectations WHERE inject_expectation_id = ?2)")
+            .setParameter(1, ts)
+            .setParameter(2, id)
             .executeUpdate();
       }
       entityManager.flush();
@@ -767,6 +739,92 @@ class IndexingRegressionTest extends IntegrationTest {
 
       assertThat(collectedIds).containsExactlyInAnyOrderElementsOf(expectedIds);
     }
+
+    @Test
+    @DisplayName(
+        "Compound cursor: all expectations sharing the same timestamp are returned across"
+            + " batches")
+    void compound_cursor_returns_all_expectations_at_same_timestamp() {
+      // Arrange — 3 expectations in the same inject, all forced to identical updated_at
+      // (simulates bulkComputeTechnicalExpectations saving many rows in a single saveAll())
+      Instant sharedTimestamp = FROM.plus(30, ChronoUnit.MINUTES);
+
+      // Use composer wrappers: .get().getId() is the established pattern that guarantees
+      // the JPA-assigned ID after persist+flush, regardless of @GeneratedValue strategy.
+      InjectExpectationComposer.Composer exp1Composer =
+          injectExpectationComposer
+              .forExpectation(InjectExpectationFixture.createDefaultDetectionInjectExpectation())
+              .withEndpoint(endpointComposer.forEndpoint(EndpointFixture.createEndpoint()));
+      InjectExpectationComposer.Composer exp2Composer =
+          injectExpectationComposer
+              .forExpectation(InjectExpectationFixture.createDefaultDetectionInjectExpectation())
+              .withEndpoint(endpointComposer.forEndpoint(EndpointFixture.createEndpoint()));
+      InjectExpectationComposer.Composer exp3Composer =
+          injectExpectationComposer
+              .forExpectation(InjectExpectationFixture.createDefaultDetectionInjectExpectation())
+              .withEndpoint(endpointComposer.forEndpoint(EndpointFixture.createEndpoint()));
+
+      scenarioComposer
+          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+          .withInject(
+              injectComposer
+                  .forInject(InjectFixture.getDefaultInject())
+                  .withExpectation(exp1Composer)
+                  .withExpectation(exp2Composer)
+                  .withExpectation(exp3Composer))
+          .persist();
+      entityManager.flush();
+
+      String id1 = exp1Composer.get().getId();
+      String id2 = exp2Composer.get().getId();
+      String id3 = exp3Composer.get().getId();
+
+      // Force all 3 expectations AND their inject to sharedTimestamp so that
+      // GREATEST(raw_expectation, inject_updated_at, contract_updated_at) = sharedTimestamp.
+      // Without aligning the inject, GREATEST = NOW() (inject was just created), and the
+      // compound cursor fetch(NOW(), lastId, …) finds nothing at that exact timestamp → exp3 skip.
+      for (String expId : List.of(id1, id2, id3)) {
+        entityManager
+            .createNativeQuery(
+                "UPDATE injects_expectations SET inject_expectation_updated_at = ?1"
+                    + " WHERE inject_expectation_id = ?2")
+            .setParameter(1, sharedTimestamp)
+            .setParameter(2, expId)
+            .executeUpdate();
+      }
+      entityManager
+          .createNativeQuery(
+              "UPDATE injects SET inject_updated_at = ?1 WHERE inject_id IN"
+                  + " (SELECT inject_id FROM injects_expectations WHERE inject_expectation_id = ?2)")
+          .setParameter(1, sharedTimestamp)
+          .setParameter(2, id1)
+          .executeUpdate();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act — batch1: cursor starts 1 ms before sharedTimestamp so only the 3 seeded
+      // expectations are in scope (pre-existing data is at older timestamps).
+      List<EsInjectExpectation> batch1 =
+          injectExpectationHandler.fetch(sharedTimestamp.minusMillis(1), 2);
+      assertThat(batch1)
+          .as("first batch must return exactly 2 of the 3 same-timestamp expectations")
+          .hasSize(2);
+
+      // Act — batch2: compound cursor advances past the last item of batch1.
+      String lastId = batch1.getLast().getBase_id();
+      Instant lastUpdatedAt = batch1.getLast().getBase_updated_at();
+      List<EsInjectExpectation> batch2 = injectExpectationHandler.fetch(lastUpdatedAt, lastId, 2);
+
+      // Assert — all 3 IDs appear across both batches with no duplicates.
+      // Filter to targetIds: batch2 may include other expectations newer than sharedTimestamp.
+      Set<String> targetIds = Set.of(id1, id2, id3);
+      List<String> relevantIds =
+          Stream.concat(batch1.stream(), batch2.stream())
+              .map(EsInjectExpectation::getBase_id)
+              .filter(targetIds::contains)
+              .toList();
+      assertThat(relevantIds).containsExactlyInAnyOrder(id1, id2, id3);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -780,7 +838,6 @@ class IndexingRegressionTest extends IntegrationTest {
     @Test
     @DisplayName("VulnerableEndpoint appears when its exercise was updated after :from")
     void vulnerable_endpoint_reindexed_when_exercise_updated() {
-      // Arrange — endpoint with a CVE finding from an inject in an exercise
       EndpointComposer.Composer endpointWrapper =
           endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
       FindingComposer.Composer findingWrapper =
@@ -798,81 +855,11 @@ class IndexingRegressionTest extends IntegrationTest {
       entityManager.flush();
       entityManager.clear();
 
-      // Act
       List<EsVulnerableEndpoint> results = vulnerableEndpointHandler.fetch(FROM, 5000);
 
-      // Assert — the endpoint+exercise combo must appear
       Endpoint endpoint = endpointWrapper.get();
       String expectedBaseId = endpoint.getId() + "_" + exercise.getId();
       assertThat(results).anyMatch(es -> es.getBase_id().equals(expectedBaseId));
-    }
-
-    @Test
-    @DisplayName(
-        "Compound cursor: all expectations sharing the same timestamp are returned across"
-            + " batches")
-    void compound_cursor_returns_all_expectations_at_same_timestamp() {
-      // Arrange — 3 expectations in the same inject, all forced to identical updated_at
-      // (simulates bulkComputeTechnicalExpectations saving many rows in a single saveAll())
-      Instant sharedTimestamp = FROM.plus(30, ChronoUnit.MINUTES);
-
-      InjectExpectation exp1 = InjectExpectationFixture.createDefaultDetectionInjectExpectation();
-      InjectExpectation exp2 = InjectExpectationFixture.createDefaultDetectionInjectExpectation();
-      InjectExpectation exp3 = InjectExpectationFixture.createDefaultDetectionInjectExpectation();
-
-      scenarioComposer
-          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
-          .withInject(
-              injectComposer
-                  .forInject(InjectFixture.getDefaultInject())
-                  .withExpectation(
-                      injectExpectationComposer
-                          .forExpectation(exp1)
-                          .withEndpoint(
-                              endpointComposer.forEndpoint(EndpointFixture.createEndpoint())))
-                  .withExpectation(
-                      injectExpectationComposer
-                          .forExpectation(exp2)
-                          .withEndpoint(
-                              endpointComposer.forEndpoint(EndpointFixture.createEndpoint())))
-                  .withExpectation(
-                      injectExpectationComposer
-                          .forExpectation(exp3)
-                          .withEndpoint(
-                              endpointComposer.forEndpoint(EndpointFixture.createEndpoint()))))
-          .persist();
-      entityManager.flush();
-
-      // Force all 3 expectations to the exact same timestamp
-      for (InjectExpectation exp : List.of(exp1, exp2, exp3)) {
-        entityManager
-            .createNativeQuery(
-                "UPDATE injects_expectations SET inject_expectation_updated_at = :ts"
-                    + " WHERE inject_expectation_id = :id")
-            .setParameter("ts", sharedTimestamp)
-            .setParameter("id", exp.getId())
-            .executeUpdate();
-      }
-      entityManager.flush();
-      entityManager.clear();
-
-      // Act — first batch (limit=2): returns 2 expectations ordered by (updated_at, id)
-      List<EsInjectExpectation> batch1 = injectExpectationHandler.fetch(FROM, 2);
-      assertThat(batch1).hasSize(2);
-
-      // Act — compound cursor: from = updated_at of last item (simulates lastIndexing after full
-      // batch), lastId = id of last item. Must return the 3rd expectation only.
-      String lastId = batch1.getLast().getBase_id();
-      Instant lastUpdatedAt = batch1.getLast().getBase_updated_at();
-      List<EsInjectExpectation> batch2 = injectExpectationHandler.fetch(lastUpdatedAt, lastId, 2);
-
-      // Assert — all 3 expectations are covered across both batches (none skipped)
-      List<String> allReturnedIds =
-          Stream.concat(batch1.stream(), batch2.stream())
-              .map(EsInjectExpectation::getBase_id)
-              .toList();
-      assertThat(allReturnedIds)
-          .containsExactlyInAnyOrder(exp1.getId(), exp2.getId(), exp3.getId());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -860,9 +860,11 @@ class IndexingRegressionTest extends IntegrationTest {
       List<EsInjectExpectation> batch1 = injectExpectationHandler.fetch(FROM, 2);
       assertThat(batch1).hasSize(2);
 
-      // Act — compound cursor continues from last item of batch1; must return the 3rd
+      // Act — compound cursor: from = updated_at of last item (simulates lastIndexing after full
+      // batch), lastId = id of last item. Must return the 3rd expectation only.
       String lastId = batch1.getLast().getBase_id();
-      List<EsInjectExpectation> batch2 = injectExpectationHandler.fetch(FROM, lastId, 2);
+      Instant lastUpdatedAt = batch1.getLast().getBase_updated_at();
+      List<EsInjectExpectation> batch2 = injectExpectationHandler.fetch(lastUpdatedAt, lastId, 2);
 
       // Assert — all 3 expectations are covered across both batches (none skipped)
       List<String> allReturnedIds =

--- a/openaev-model/src/main/java/io/openaev/database/model/IndexingStatus.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/IndexingStatus.java
@@ -23,4 +23,10 @@ public class IndexingStatus {
   @Column(name = "indexing_status_indexing_date")
   @JsonProperty("indexing_status_indexing_date")
   private Instant lastIndexing;
+
+  /** Last processed entity ID within the current indexing timestamp window (compound cursor). */
+  @Getter
+  @Column(name = "indexing_last_id")
+  @JsonProperty("indexing_last_id")
+  private String lastId;
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -438,6 +438,85 @@ public interface InjectExpectationRepository
   List<RawInjectExpectationIndexing> findForIndexing(
       @Param("from") Instant from, @Param("limit") int limit);
 
+  @Query(
+      value =
+          """
+    WITH changed_expectations AS (
+        SELECT ie.inject_expectation_id FROM injects_expectations ie
+          WHERE ie.inject_expectation_updated_at > :from
+          OR (ie.inject_expectation_updated_at = :from AND ie.inject_expectation_id > :lastId)
+        UNION
+        SELECT ie.inject_expectation_id FROM injects_expectations ie
+          JOIN injects i ON i.inject_id = ie.inject_id
+          WHERE i.inject_updated_at > :from
+          OR (i.inject_updated_at = :from AND ie.inject_expectation_id > :lastId)
+        UNION
+        SELECT ie.inject_expectation_id FROM injects_expectations ie
+          JOIN injects i ON i.inject_id = ie.inject_id
+          JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
+          WHERE ic.injector_contract_updated_at > :from
+          OR (ic.injector_contract_updated_at = :from AND ie.inject_expectation_id > :lastId)
+    ),
+    inject_expectation_data AS (
+      SELECT
+      ie.inject_expectation_id,
+      ie.inject_expectation_name,
+      ie.inject_expectation_description,
+      ie.inject_expectation_type,
+      ie.inject_expectation_results,
+      ie.inject_expectation_score,
+      ie.inject_expectation_expected_score,
+      ie.inject_expiration_time,
+      ie.inject_expectation_group,
+      ie.inject_expectation_created_at,
+      GREATEST(ie.inject_expectation_updated_at, max(i.inject_updated_at), max(ic.injector_contract_updated_at)) as inject_expectation_updated_at,
+      ie.exercise_id,
+      ie.inject_id,
+      ie.user_id,
+      ie.team_id,
+      ie.agent_id,
+      ie.asset_id,
+      ie.asset_group_id,
+      i.tenant_id,
+      i.inject_title as inject_title,
+      MAX(ins.tracking_sent_date) AS tracking_sent_date,
+      array_agg(DISTINCT ap.attack_pattern_id) FILTER ( WHERE ap.attack_pattern_id IS NOT NULL ) AS attack_pattern_ids,
+      array_agg(DISTINCT ic_d.domain_id) FILTER (WHERE ic_d.domain_id IS NOT NULL ) AS domain_ids,
+      MAX(se.scenario_id) AS scenario_id,
+      array_agg(DISTINCT c.collector_security_platform) FILTER ( WHERE c.collector_security_platform IS NOT NULL ) ||
+      array_agg(DISTINCT a.asset_id) FILTER ( WHERE a.asset_id IS NOT NULL ) AS security_platform_ids
+    FROM injects_expectations ie
+    JOIN changed_expectations ce ON ie.inject_expectation_id = ce.inject_expectation_id
+    LEFT JOIN exercises ex ON ex.exercise_id = ie.exercise_id
+    LEFT JOIN injects i ON i.inject_id = ie.inject_id
+    LEFT JOIN injects_statuses ins ON ins.status_inject = i.inject_id
+    LEFT JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
+    LEFT JOIN injectors_contracts_attack_patterns ic_ap ON ic_ap.injector_contract_id = ic.injector_contract_id
+    LEFT JOIN attack_patterns ap ON ap.attack_pattern_id = ic_ap.attack_pattern_id
+    LEFT JOIN injectors_contracts_domains ic_d ON ic_d.injector_contract_id = ic.injector_contract_id
+    LEFT JOIN users u ON u.user_id = ie.user_id
+    LEFT JOIN teams t ON t.team_id = ie.team_id
+    LEFT JOIN assets asset ON asset.asset_id = ie.asset_id
+    LEFT JOIN asset_groups ag ON ag.asset_group_id = ie.asset_group_id
+    LEFT JOIN scenarios_exercises se ON se.exercise_id = ie.exercise_id
+    LEFT JOIN LATERAL jsonb_array_elements(ie.inject_expectation_results::jsonb) AS r(elem) ON true
+    LEFT JOIN collectors c ON r.elem->>'sourceId' = c.collector_id::text
+    LEFT JOIN assets a ON r.elem->>'sourceId' = a.asset_id::text
+    GROUP BY
+      ie.inject_expectation_id,
+      ic.injector_contract_id,
+      i.inject_title,
+        i.tenant_id
+    )
+    SELECT * FROM inject_expectation_data ied
+    WHERE ied.agent_id IS NULL
+    ORDER BY ied.inject_expectation_updated_at ASC, ied.inject_expectation_id ASC
+    LIMIT :limit
+    """,
+      nativeQuery = true)
+  List<RawInjectExpectationIndexing> findForIndexingAfter(
+      @Param("from") Instant from, @Param("lastId") String lastId, @Param("limit") int limit);
+
   /**
    * Retrieves a set of distinct inject IDs associated with the specified inject expectation IDs.
    *

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -438,24 +438,33 @@ public interface InjectExpectationRepository
   List<RawInjectExpectationIndexing> findForIndexing(
       @Param("from") Instant from, @Param("limit") int limit);
 
+  /**
+   * Fetches inject expectations updated after {@code from}, using a compound keyset cursor when
+   * {@code lastId} is non-null to avoid skipping items that share the same {@code updated_at}
+   * timestamp across batch boundaries.
+   *
+   * <p>When {@code lastId} is {@code null} the query degrades to a simple {@code > :from} cursor
+   * (first-batch behaviour). When non-null it additionally returns rows at exactly {@code from}
+   * whose ID is strictly greater than {@code lastId}.
+   */
   @Query(
       value =
           """
     WITH changed_expectations AS (
-        SELECT ie.inject_expectation_id FROM injects_expectations ie
-          WHERE ie.inject_expectation_updated_at > :from
-          OR (ie.inject_expectation_updated_at = :from AND ie.inject_expectation_id > :lastId)
-        UNION
-        SELECT ie.inject_expectation_id FROM injects_expectations ie
-          JOIN injects i ON i.inject_id = ie.inject_id
-          WHERE i.inject_updated_at > :from
-          OR (i.inject_updated_at = :from AND ie.inject_expectation_id > :lastId)
-        UNION
-        SELECT ie.inject_expectation_id FROM injects_expectations ie
-          JOIN injects i ON i.inject_id = ie.inject_id
-          JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
-          WHERE ic.injector_contract_updated_at > :from
-          OR (ic.injector_contract_updated_at = :from AND ie.inject_expectation_id > :lastId)
+      SELECT ie.inject_expectation_id FROM injects_expectations ie
+        WHERE ie.inject_expectation_updated_at > :from
+        OR (:lastId IS NOT NULL AND ie.inject_expectation_updated_at = :from AND ie.inject_expectation_id > :lastId)
+      UNION
+      SELECT ie.inject_expectation_id FROM injects_expectations ie
+        JOIN injects i ON i.inject_id = ie.inject_id
+        WHERE i.inject_updated_at > :from
+        OR (:lastId IS NOT NULL AND i.inject_updated_at = :from AND ie.inject_expectation_id > :lastId)
+      UNION
+      SELECT ie.inject_expectation_id FROM injects_expectations ie
+        JOIN injects i ON i.inject_id = ie.inject_id
+        JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
+        WHERE ic.injector_contract_updated_at > :from
+        OR (:lastId IS NOT NULL AND ic.injector_contract_updated_at = :from AND ie.inject_expectation_id > :lastId)
     ),
     inject_expectation_data AS (
       SELECT
@@ -506,7 +515,7 @@ public interface InjectExpectationRepository
       ie.inject_expectation_id,
       ic.injector_contract_id,
       i.inject_title,
-        i.tenant_id
+      i.tenant_id
     )
     SELECT * FROM inject_expectation_data ied
     WHERE ied.agent_id IS NULL

--- a/openaev-model/src/main/java/io/openaev/engine/Handler.java
+++ b/openaev-model/src/main/java/io/openaev/engine/Handler.java
@@ -21,4 +21,25 @@ public interface Handler<T extends EsBase> {
    * @return list data to index
    */
   List<T> fetch(Instant from, int limit);
+
+  /**
+   * Variant of {@link #fetch(Instant, int)} using a compound keyset cursor (timestamp + last entity
+   * ID) to avoid missing items that share the same {@code updated_at} timestamp when the previous
+   * batch was full.
+   *
+   * <p>The default implementation ignores {@code lastId} and falls back to the basic cursor,
+   * providing backward-compatible behaviour for handlers that do not need compound pagination.
+   * Override in handlers where the same-millisecond duplicate issue is observable (e.g.
+   * InjectExpectationHandler).
+   *
+   * @param from lower-bound timestamp (exclusive unless lastId is provided)
+   * @param lastId ID of the last successfully indexed entity at {@code from}; when non-null the
+   *     query returns items at {@code from} with ID strictly greater than this value, plus all
+   *     items strictly after {@code from}
+   * @param limit maximum number of records to fetch per batch
+   * @return list data to index
+   */
+  default List<T> fetch(Instant from, String lastId, int limit) {
+    return fetch(from, limit);
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/engine/model/injectexpectation/InjectExpectationHandler.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/injectexpectation/InjectExpectationHandler.java
@@ -25,7 +25,7 @@ public class InjectExpectationHandler implements Handler<EsInjectExpectation> {
   @Override
   public List<EsInjectExpectation> fetch(Instant from, int limit) {
     Instant queryFrom = from != null ? from : Instant.ofEpochMilli(0);
-    return this.injectExpectationRepository.findForIndexing(queryFrom, limit).stream()
+    return this.injectExpectationRepository.findForIndexingAfter(queryFrom, null, limit).stream()
         .map(this::map)
         .toList();
   }

--- a/openaev-model/src/main/java/io/openaev/engine/model/injectexpectation/InjectExpectationHandler.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/injectexpectation/InjectExpectationHandler.java
@@ -25,114 +25,112 @@ public class InjectExpectationHandler implements Handler<EsInjectExpectation> {
   @Override
   public List<EsInjectExpectation> fetch(Instant from, int limit) {
     Instant queryFrom = from != null ? from : Instant.ofEpochMilli(0);
-    List<RawInjectExpectationIndexing> forIndexing =
-        this.injectExpectationRepository.findForIndexing(queryFrom, limit);
-    return forIndexing.stream()
-        .map(
-            injectExpectation -> {
-              EsInjectExpectation esInjectExpectation = new EsInjectExpectation();
-              // Base
-              esInjectExpectation.setBase_id(injectExpectation.getInject_expectation_id());
-              esInjectExpectation.setBase_representative(
-                  injectExpectation.getInject_expectation_name());
-              esInjectExpectation.setBase_created_at(
-                  injectExpectation.getInject_expectation_created_at());
-              esInjectExpectation.setBase_updated_at(
-                  injectExpectation.getInject_expectation_updated_at());
-              esInjectExpectation.setBase_restrictions(
-                  buildRestrictions(
-                      injectExpectation.getExercise_id(), injectExpectation.getInject_id()));
-              esInjectExpectation.setBase_tenant_side(injectExpectation.getTenant_id());
-              // Specific
-              esInjectExpectation.setInject_expectation_name(
-                  injectExpectation.getInject_expectation_name());
-              esInjectExpectation.setInject_expectation_description(
-                  injectExpectation.getInject_expectation_description());
-              esInjectExpectation.setInject_expectation_type(
-                  injectExpectation.getInject_expectation_type());
-              esInjectExpectation.setInject_expectation_results(
-                  injectExpectation.getInject_expectation_results());
-              esInjectExpectation.setInject_title(injectExpectation.getInject_title());
-              esInjectExpectation.setExecution_date(injectExpectation.getTracking_sent_date());
-
-              esInjectExpectation.setInject_expectation_score(
-                  injectExpectation.getInject_expectation_score());
-              esInjectExpectation.setInject_expectation_expected_score(
-                  injectExpectation.getInject_expectation_expected_score());
-              esInjectExpectation.setInject_expectation_expiration_time(
-                  injectExpectation.getInject_expiration_time());
-              esInjectExpectation.setInject_expectation_group(
-                  injectExpectation.getInject_expectation_group());
-              // Dependencies (see base_dependencies in EsBase)
-              List<String> dependencies = new ArrayList<>();
-              if (hasText(injectExpectation.getExercise_id())) {
-                dependencies.add(injectExpectation.getExercise_id());
-                esInjectExpectation.setBase_simulation_side(injectExpectation.getExercise_id());
-              } else {
-                esInjectExpectation.setBase_simulation_side(null);
-              }
-              if (hasText(injectExpectation.getScenario_id())) {
-                dependencies.add(injectExpectation.getScenario_id());
-                esInjectExpectation.setBase_scenario_side(injectExpectation.getScenario_id());
-              } else {
-                esInjectExpectation.setBase_scenario_side(null);
-              }
-              if (hasText(injectExpectation.getInject_id())) {
-                dependencies.add(injectExpectation.getInject_id());
-                esInjectExpectation.setBase_inject_side(injectExpectation.getInject_id());
-              } else {
-                esInjectExpectation.setBase_inject_side(null);
-              }
-              if (hasText(injectExpectation.getUser_id())) {
-                dependencies.add(injectExpectation.getUser_id());
-                esInjectExpectation.setBase_user_side(injectExpectation.getUser_id());
-              } else {
-                esInjectExpectation.setBase_user_side(null);
-              }
-              if (hasText(injectExpectation.getTeam_id())) {
-                dependencies.add(injectExpectation.getTeam_id());
-                esInjectExpectation.setBase_team_side(injectExpectation.getTeam_id());
-              } else {
-                esInjectExpectation.setBase_team_side(null);
-              }
-              if (hasText(injectExpectation.getAsset_id())) {
-                dependencies.add(injectExpectation.getAsset_id());
-                esInjectExpectation.setBase_asset_side(injectExpectation.getAsset_id());
-              } else {
-                esInjectExpectation.setBase_asset_side(null);
-              }
-              if (hasText(injectExpectation.getAsset_group_id())) {
-                dependencies.add(injectExpectation.getAsset_group_id());
-                esInjectExpectation.setBase_asset_group_side(injectExpectation.getAsset_group_id());
-              } else {
-                esInjectExpectation.setBase_asset_group_side(null);
-              }
-              if (!isEmpty(injectExpectation.getAttack_pattern_ids())) {
-                esInjectExpectation.setBase_attack_patterns_side(
-                    injectExpectation.getAttack_pattern_ids());
-              } else {
-                esInjectExpectation.setBase_attack_patterns_side(Set.of());
-              }
-              if (!isEmpty(injectExpectation.getDomain_ids())) {
-                esInjectExpectation.setBase_security_domains_side(
-                    injectExpectation.getDomain_ids());
-              } else {
-                esInjectExpectation.setBase_security_domains_side(Set.of());
-              }
-              if (!isEmpty(injectExpectation.getSecurity_platform_ids())) {
-                esInjectExpectation.setBase_security_platforms_side(
-                    injectExpectation.getSecurity_platform_ids());
-              } else {
-                esInjectExpectation.setBase_security_platforms_side(Set.of());
-              }
-              esInjectExpectation.setInject_expectation_status(
-                  valueOf(
-                      computeStatus(
-                          injectExpectation.getInject_expectation_score(),
-                          injectExpectation.getInject_expectation_expected_score())));
-              esInjectExpectation.setBase_dependencies(dependencies);
-              return esInjectExpectation;
-            })
+    return this.injectExpectationRepository.findForIndexing(queryFrom, limit).stream()
+        .map(this::map)
         .toList();
+  }
+
+  @Override
+  public List<EsInjectExpectation> fetch(Instant from, String lastId, int limit) {
+    Instant queryFrom = from != null ? from : Instant.ofEpochMilli(0);
+    return this.injectExpectationRepository.findForIndexingAfter(queryFrom, lastId, limit).stream()
+        .map(this::map)
+        .toList();
+  }
+
+  private EsInjectExpectation map(RawInjectExpectationIndexing injectExpectation) {
+    EsInjectExpectation esInjectExpectation = new EsInjectExpectation();
+    // Base
+    esInjectExpectation.setBase_id(injectExpectation.getInject_expectation_id());
+    esInjectExpectation.setBase_representative(injectExpectation.getInject_expectation_name());
+    esInjectExpectation.setBase_created_at(injectExpectation.getInject_expectation_created_at());
+    esInjectExpectation.setBase_updated_at(injectExpectation.getInject_expectation_updated_at());
+    esInjectExpectation.setBase_restrictions(
+        buildRestrictions(injectExpectation.getExercise_id(), injectExpectation.getInject_id()));
+    esInjectExpectation.setBase_tenant_side(injectExpectation.getTenant_id());
+    // Specific
+    esInjectExpectation.setInject_expectation_name(injectExpectation.getInject_expectation_name());
+    esInjectExpectation.setInject_expectation_description(
+        injectExpectation.getInject_expectation_description());
+    esInjectExpectation.setInject_expectation_type(injectExpectation.getInject_expectation_type());
+    esInjectExpectation.setInject_expectation_results(
+        injectExpectation.getInject_expectation_results());
+    esInjectExpectation.setInject_title(injectExpectation.getInject_title());
+    esInjectExpectation.setExecution_date(injectExpectation.getTracking_sent_date());
+    esInjectExpectation.setInject_expectation_score(
+        injectExpectation.getInject_expectation_score());
+    esInjectExpectation.setInject_expectation_expected_score(
+        injectExpectation.getInject_expectation_expected_score());
+    esInjectExpectation.setInject_expectation_expiration_time(
+        injectExpectation.getInject_expiration_time());
+    esInjectExpectation.setInject_expectation_group(
+        injectExpectation.getInject_expectation_group());
+    // Dependencies (see base_dependencies in EsBase)
+    List<String> dependencies = new ArrayList<>();
+    if (hasText(injectExpectation.getExercise_id())) {
+      dependencies.add(injectExpectation.getExercise_id());
+      esInjectExpectation.setBase_simulation_side(injectExpectation.getExercise_id());
+    } else {
+      esInjectExpectation.setBase_simulation_side(null);
+    }
+    if (hasText(injectExpectation.getScenario_id())) {
+      dependencies.add(injectExpectation.getScenario_id());
+      esInjectExpectation.setBase_scenario_side(injectExpectation.getScenario_id());
+    } else {
+      esInjectExpectation.setBase_scenario_side(null);
+    }
+    if (hasText(injectExpectation.getInject_id())) {
+      dependencies.add(injectExpectation.getInject_id());
+      esInjectExpectation.setBase_inject_side(injectExpectation.getInject_id());
+    } else {
+      esInjectExpectation.setBase_inject_side(null);
+    }
+    if (hasText(injectExpectation.getUser_id())) {
+      dependencies.add(injectExpectation.getUser_id());
+      esInjectExpectation.setBase_user_side(injectExpectation.getUser_id());
+    } else {
+      esInjectExpectation.setBase_user_side(null);
+    }
+    if (hasText(injectExpectation.getTeam_id())) {
+      dependencies.add(injectExpectation.getTeam_id());
+      esInjectExpectation.setBase_team_side(injectExpectation.getTeam_id());
+    } else {
+      esInjectExpectation.setBase_team_side(null);
+    }
+    if (hasText(injectExpectation.getAsset_id())) {
+      dependencies.add(injectExpectation.getAsset_id());
+      esInjectExpectation.setBase_asset_side(injectExpectation.getAsset_id());
+    } else {
+      esInjectExpectation.setBase_asset_side(null);
+    }
+    if (hasText(injectExpectation.getAsset_group_id())) {
+      dependencies.add(injectExpectation.getAsset_group_id());
+      esInjectExpectation.setBase_asset_group_side(injectExpectation.getAsset_group_id());
+    } else {
+      esInjectExpectation.setBase_asset_group_side(null);
+    }
+    if (!isEmpty(injectExpectation.getAttack_pattern_ids())) {
+      esInjectExpectation.setBase_attack_patterns_side(injectExpectation.getAttack_pattern_ids());
+    } else {
+      esInjectExpectation.setBase_attack_patterns_side(Set.of());
+    }
+    if (!isEmpty(injectExpectation.getDomain_ids())) {
+      esInjectExpectation.setBase_security_domains_side(injectExpectation.getDomain_ids());
+    } else {
+      esInjectExpectation.setBase_security_domains_side(Set.of());
+    }
+    if (!isEmpty(injectExpectation.getSecurity_platform_ids())) {
+      esInjectExpectation.setBase_security_platforms_side(
+          injectExpectation.getSecurity_platform_ids());
+    } else {
+      esInjectExpectation.setBase_security_platforms_side(Set.of());
+    }
+    esInjectExpectation.setInject_expectation_status(
+        valueOf(
+            computeStatus(
+                injectExpectation.getInject_expectation_score(),
+                injectExpectation.getInject_expectation_expected_score())));
+    esInjectExpectation.setBase_dependencies(dependencies);
+    return esInjectExpectation;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -342,8 +342,9 @@ public class ElasticService implements EngineService {
                   Instant fetchInstant =
                       indexingStatus.map(IndexingStatus::getLastIndexing).orElse(null);
                   long fetchStart = System.currentTimeMillis();
+                  String lastId = indexingStatus.map(IndexingStatus::getLastId).orElse(null);
                   List<? extends EsBase> results =
-                      handler.fetch(fetchInstant, engineConfig.getIndexingBatchSize());
+                      handler.fetch(fetchInstant, lastId, engineConfig.getIndexingBatchSize());
                   long fetchMs = System.currentTimeMillis() - fetchStart;
                   if (fetchMs > 1000) {
                     log.warn(
@@ -376,14 +377,23 @@ public class ElasticService implements EngineService {
                         }
                       } else {
                         // Update the status for the next round
+                        EsBase lastResult = results.getLast();
+                        // When the batch is full, more items may share the same timestamp;
+                        // track lastId so the compound cursor skips already-processed ones.
+                        String nextLastId =
+                            results.size() == engineConfig.getIndexingBatchSize()
+                                ? lastResult.getBase_id()
+                                : null;
                         if (indexingStatus.isPresent()) {
                           IndexingStatus status = indexingStatus.get();
-                          status.setLastIndexing(results.getLast().getBase_updated_at());
+                          status.setLastIndexing(lastResult.getBase_updated_at());
+                          status.setLastId(nextLastId);
                           return status;
                         } else {
                           IndexingStatus status = new IndexingStatus();
                           status.setType(model.getName());
-                          status.setLastIndexing(results.getLast().getBase_updated_at());
+                          status.setLastIndexing(lastResult.getBase_updated_at());
+                          status.setLastId(nextLastId);
                           return status;
                         }
                       }

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -409,8 +409,9 @@ public class OpenSearchService implements EngineService {
                   Instant fetchInstant =
                       indexingStatus.map(IndexingStatus::getLastIndexing).orElse(null);
                   long fetchStart = System.currentTimeMillis();
+                  String lastId = indexingStatus.map(IndexingStatus::getLastId).orElse(null);
                   List<? extends EsBase> results =
-                      handler.fetch(fetchInstant, engineConfig.getIndexingBatchSize());
+                      handler.fetch(fetchInstant, lastId, engineConfig.getIndexingBatchSize());
                   long fetchMs = System.currentTimeMillis() - fetchStart;
                   if (fetchMs > 1000) {
                     log.warn(
@@ -443,14 +444,23 @@ public class OpenSearchService implements EngineService {
                         }
                       } else {
                         // Update the status for the next round
+                        EsBase lastResult = results.getLast();
+                        // When the batch is full, more items may share the same timestamp;
+                        // track lastId so the compound cursor skips already-processed ones.
+                        String nextLastId =
+                            results.size() == engineConfig.getIndexingBatchSize()
+                                ? lastResult.getBase_id()
+                                : null;
                         if (indexingStatus.isPresent()) {
                           IndexingStatus status = indexingStatus.get();
-                          status.setLastIndexing(results.getLast().getBase_updated_at());
+                          status.setLastIndexing(lastResult.getBase_updated_at());
+                          status.setLastId(nextLastId);
                           return status;
                         } else {
                           IndexingStatus status = new IndexingStatus();
                           status.setType(model.getName());
-                          status.setLastIndexing(results.getLast().getBase_updated_at());
+                          status.setLastIndexing(lastResult.getBase_updated_at());
+                          status.setLastId(nextLastId);
                           return status;
                         }
                       }


### PR DESCRIPTION
## Problem

The custom dashboard shows **100% detected** for some injects. Clicking opens a drawer with `inject_expectation_status = SUCCESS` from Elasticsearch. Clicking an inject navigates to the inject detail page which shows **100% not detected** — inconsistent data between ES and DB.

Fixes #6490

## Root Cause

`findForIndexing` uses a strict `>` comparison on `updated_at`:

```sql
WHERE inject_expectation_updated_at > :from
ORDER BY inject_expectation_updated_at ASC
LIMIT 500
```

When `bulkComputeTechnicalExpectations` expires hundreds of expectations in one `saveAll()` call, Hibernate's `@UpdateTimestamp` assigns the **same millisecond** to all of them. If there are >500 with the same timestamp, the cursor advances to `T`, then `updated_at > T` permanently skips the rest.

## Fix: Compound keyset cursor

Add a secondary `inject_expectation_id` cursor so the query can resume within a timestamp:

```sql
WHERE (inject_expectation_updated_at > :from)
   OR (inject_expectation_updated_at = :from AND inject_expectation_id > :lastId)
ORDER BY inject_expectation_updated_at ASC, inject_expectation_id ASC
```

### Changes

| File | Change |
|---|---|
| `V5_35__Add_indexing_last_id.java` | Migration: add `indexing_last_id TEXT NULL` to `indexing_status` |
| `IndexingStatus.java` | Add `lastId` field for compound cursor |
| `InjectExpectationRepository.java` | Add `findForIndexingAfter(from, lastId, limit)` query |
| `Handler.java` | Add default `fetch(from, lastId, limit)` method (backward-compatible) |
| `InjectExpectationHandler.java` | Override compound-cursor fetch + extract shared `map()` helper |
| `OpenSearchService.java` | Track `lastId` in `bulkProcessing`, pass to handler |
| `ElasticService.java` | Same as OpenSearch |

### Cursor logic

- Full batch returned (size == 500): save `lastId = lastItem.id`, keep same `lastIndexing`
- Partial batch (size < 500): clear `lastId = null`, advance `lastIndexing` as before