### PR TITLE
fix(dashboard): populate base_security_platforms_side from child agent expectations (#6497)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V5_35__Force_Reindex_Detection_Prevention_Expectations.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V5_35__Force_Reindex_Detection_Prevention_Expectations.java
@@ -1,0 +1,36 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Forces re-indexing of non-agent DETECTION and PREVENTION expectations so that {@code
+ * base_security_platforms_side} is populated from their child agent-level expectations.
+ *
+ * <p>Before this fix, the {@code findForIndexing} SQL only aggregated security-platform IDs from
+ * the expectation's own {@code inject_expectation_results}, which is always empty for non-agent
+ * expectations (asset-level / asset-group-level). As a result, the ES field {@code
+ * base_security_platforms_side} was always an empty set, causing the "Inject Undetected by Security
+ * Platform" dashboard widget to show no data.
+ *
+ * <p>Bumping {@code inject_expectation_updated_at} ensures the next indexing pass picks up all
+ * affected expectations and re-indexes them with the fixed query.
+ *
+ * @see <a href="https://github.com/OpenAEV-Platform/openaev/issues/6497">#6497</a>
+ */
+@Component
+public class V5_35__Force_Reindex_Detection_Prevention_Expectations extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "UPDATE injects_expectations"
+              + " SET inject_expectation_updated_at = now()"
+              + " WHERE agent_id IS NULL"
+              + " AND inject_expectation_type IN ('DETECTION', 'PREVENTION')");
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -54,6 +54,9 @@ class IndexingRegressionTest extends IntegrationTest {
   @Autowired private InjectComposer injectComposer;
   @Autowired private EndpointComposer endpointComposer;
   @Autowired private InjectExpectationComposer injectExpectationComposer;
+  @Autowired private AgentComposer agentComposer;
+  @Autowired private CollectorComposer collectorComposer;
+  @Autowired private SecurityPlatformComposer securityPlatformComposer;
 
   /** A point in time used as the {@code :from} parameter — 1 hour ago. */
   private static final Instant FROM = Instant.now().minus(1, ChronoUnit.HOURS);
@@ -68,6 +71,9 @@ class IndexingRegressionTest extends IntegrationTest {
     injectComposer.reset();
     endpointComposer.reset();
     injectExpectationComposer.reset();
+    agentComposer.reset();
+    collectorComposer.reset();
+    securityPlatformComposer.reset();
   }
 
   // ---------------------------------------------------------------------------
@@ -281,6 +287,76 @@ class IndexingRegressionTest extends IntegrationTest {
 
       // Assert — expectation must appear because its linked inject is recent
       assertThat(results).anyMatch(es -> es.getBase_id().equals(expectation.getId()));
+    }
+
+    @Test
+    @DisplayName(
+        "Asset-level expectation has base_security_platforms_side from child agent expectations")
+    void given_agent_expectation_with_collector_result_should_populate_security_platforms_side() {
+      // Arrange — security platform + collector that identifies it
+      SecurityPlatformComposer.Composer spWrapper =
+          securityPlatformComposer.forSecurityPlatform(
+              SecurityPlatformFixture.createDefault("TestEDR", "EDR"));
+      CollectorComposer.Composer collectorWrapper =
+          collectorComposer
+              .forCollector(CollectorFixture.createDefaultCollector("test-edr-collector"))
+              .withSecurityPlatform(spWrapper)
+              .persist();
+      SecurityPlatform securityPlatform = spWrapper.get();
+
+      // Arrange — endpoint with an attached agent
+      AgentComposer.Composer agentWrapper =
+          agentComposer.forAgent(AgentFixture.createDefaultAgentService());
+      EndpointComposer.Composer endpointWrapper =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint()).withAgent(agentWrapper);
+
+      // Arrange — agent-level expectation with a collector result (sourceId = collector ID)
+      InjectExpectation agentExpectation =
+          InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      agentExpectation.setAgent(agentWrapper.get());
+      agentExpectation.setAsset(endpointWrapper.get());
+      agentExpectation.setResults(
+          List.of(
+              InjectExpectationResult.builder()
+                  .sourceId(collectorWrapper.get().getId())
+                  .result("not_found")
+                  .score(0.0)
+                  .build()));
+      InjectExpectationComposer.Composer agentExpWrapper =
+          injectExpectationComposer.forExpectation(agentExpectation);
+
+      // Arrange — asset-level expectation (agent_id IS NULL) for the same inject
+      InjectExpectation assetExpectation =
+          InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      assetExpectation.setAsset(endpointWrapper.get());
+      InjectExpectationComposer.Composer assetExpWrapper =
+          injectExpectationComposer.forExpectation(assetExpectation);
+
+      // Wire both expectations into one inject inside a scenario
+      InjectComposer.Composer injectWrapper =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withEndpoint(endpointWrapper)
+              .withExpectation(agentExpWrapper)
+              .withExpectation(assetExpWrapper);
+      scenarioComposer
+          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+          .withInject(injectWrapper)
+          .persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<EsInjectExpectation> results = injectExpectationHandler.fetch(FROM, 5000);
+
+      // Assert — the asset-level expectation must carry the security platform ID
+      assertThat(results)
+          .filteredOn(es -> es.getBase_id().equals(assetExpectation.getId()))
+          .singleElement()
+          .satisfies(
+              es ->
+                  assertThat(es.getBase_security_platforms_side())
+                      .contains(securityPlatform.getId()));
     }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -389,6 +389,7 @@ public interface InjectExpectationRepository
           LEFT JOIN collectors c2 ON r2.elem->>'sourceId' = c2.collector_id::text
           WHERE ie2.inject_id = ie.inject_id
             AND ie2.agent_id IS NOT NULL
+            AND (ie.asset_id IS NULL OR ie2.asset_id = ie.asset_id)
       ) AS security_platform_ids
     FROM injects_expectations ie
     JOIN changed_expectations ce ON ie.inject_expectation_id = ce.inject_expectation_id

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -380,7 +380,16 @@ public interface InjectExpectationRepository
       array_agg(DISTINCT ic_d.domain_id) FILTER (WHERE ic_d.domain_id IS NOT NULL ) AS domain_ids,
       MAX(se.scenario_id) AS scenario_id,
       array_agg(DISTINCT c.collector_security_platform) FILTER ( WHERE c.collector_security_platform IS NOT NULL ) ||
-      array_agg(DISTINCT a.asset_id) FILTER ( WHERE a.asset_id IS NOT NULL ) AS security_platform_ids
+      array_agg(DISTINCT a.asset_id) FILTER ( WHERE a.asset_id IS NOT NULL ) ||
+      (
+          SELECT array_agg(DISTINCT c2.collector_security_platform)
+                 FILTER (WHERE c2.collector_security_platform IS NOT NULL)
+          FROM injects_expectations ie2
+          LEFT JOIN LATERAL jsonb_array_elements(ie2.inject_expectation_results::jsonb) AS r2(elem) ON true
+          LEFT JOIN collectors c2 ON r2.elem->>'sourceId' = c2.collector_id::text
+          WHERE ie2.inject_id = ie.inject_id
+            AND ie2.agent_id IS NOT NULL
+      ) AS security_platform_ids
     FROM injects_expectations ie
     JOIN changed_expectations ce ON ie.inject_expectation_id = ce.inject_expectation_id
     LEFT JOIN exercises ex ON ex.exercise_id = ie.exercise_id


### PR DESCRIPTION
## Summary

Fixes #6497

The **'Inject Undetected by Security Platform'** default widget was always showing **no data** when grouped by security platform, even without filters.

## Root Cause

\InjectExpectationRepository.findForIndexing\ computes \security_platform_ids\ by joining the row's own \inject_expectation_results\ with the \collectors\ table. However:

- The query only indexes **non-agent expectations** (\WHERE agent_id IS NULL\)
- Non-agent expectations **never have results populated** — results are only set when \getAgent() != null\ in \InjectExpectationService.setupDefaultExpectationResults()\

→ \security_platform_ids\ is always NULL → \ase_security_platforms_side = Set.of()\ in ES → **no terms buckets → no data**

Breakdown by simulation worked because \ase_simulation_side\ is derived from \xercise_id\ (a direct column), not from \inject_expectation_results\.

## Fix

### 1. SQL fix (\InjectExpectationRepository.java\)
Added a correlated subquery to aggregate security platform IDs from **child agent-level expectations** sharing the same \inject_id\:

\\\sql
|| (
    SELECT array_agg(DISTINCT c2.collector_security_platform)
           FILTER (WHERE c2.collector_security_platform IS NOT NULL)
    FROM injects_expectations ie2
    LEFT JOIN LATERAL jsonb_array_elements(ie2.inject_expectation_results::jsonb) AS r2(elem) ON true
    LEFT JOIN collectors c2 ON r2.elem->>'sourceId' = c2.collector_id::text
    WHERE ie2.inject_id = ie.inject_id
      AND ie2.agent_id IS NOT NULL
)
\\\

The correlated subquery is efficient thanks to the existing composite index \idx_injects_expectations_inject_agent\ on \(inject_id, agent_id)\.

### 2. Migration (\V5_35__Force_Reindex_Detection_Prevention_Expectations.java\)
Bumps \inject_expectation_updated_at\ for all existing non-agent DETECTION/PREVENTION expectations so the next indexing pass re-indexes them with the fixed query.

### 3. Regression test (\IndexingRegressionTest.java\)
Added \given_agent_expectation_with_collector_result_should_populate_security_platforms_side\ — creates an agent-level expectation with a collector result, asserts that the parent asset-level expectation gets \ase_security_platforms_side\ populated.

## Checklist
- [x] Spotless passes
- [x] Regression test added