### PR TITLE
fix(export): include inject-attached documents in scenario export (#6509)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -138,6 +138,37 @@ public class V1_DataImporter implements Importer {
           return null;
         }
       }
+      // For payload injects, remap Document-type argument values so the inject references the
+      // newly uploaded document UUID rather than the original export UUID.
+      default -> {
+        try {
+          Optional<InjectorContract> contractOpt = injectorContractRepository.findById(contract);
+          if (contractOpt.isEmpty() || contractOpt.get().getPayload() == null) {
+            break;
+          }
+          List<String> docArgKeys =
+              contractOpt.get().getPayload().getArguments().stream()
+                  .filter(arg -> ArgumentType.Document == arg.getType())
+                  .map(PayloadArgument::getKey)
+                  .toList();
+          if (docArgKeys.isEmpty()) {
+            break;
+          }
+          ObjectNode contentNode = (ObjectNode) mapper.readTree(content);
+          for (String key : docArgKeys) {
+            JsonNode valueNode = contentNode.get(key);
+            if (valueNode != null && valueNode.isTextual()) {
+              Base newBase = baseIds.get(valueNode.asText());
+              if (newBase != null) {
+                contentNode.put(key, newBase.getId());
+              }
+            }
+          }
+          content = mapper.writeValueAsString(contentNode);
+        } catch (Exception e) {
+          // Error rewriting content, keep original
+        }
+      }
     }
     return content;
   }

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -548,8 +548,7 @@ public class ScenarioService {
                 scenario.getDocuments().stream(),
                 scenario.getInjects().stream()
                     .flatMap(
-                        inject ->
-                            inject.getDocuments().stream().map(InjectDocument::getDocument)),
+                        inject -> inject.getDocuments().stream().map(InjectDocument::getDocument)),
                 scenario.getInjects().stream()
                     .flatMap(
                         inject -> {
@@ -567,8 +566,7 @@ public class ScenarioService {
 
     scenarioFileExport.setDocuments(documentExports);
     objectMapper.addMixIn(Document.class, Mixins.Document.class);
-    scenarioTags.addAll(
-        documentExports.stream().flatMap(doc -> doc.getTags().stream()).toList());
+    scenarioTags.addAll(documentExports.stream().flatMap(doc -> doc.getTags().stream()).toList());
     List<String> documentIds =
         new ArrayList<>(documentExports.stream().map(Document::getId).toList());
 

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.context.TenantContext;
@@ -542,7 +543,11 @@ public class ScenarioService {
       objectMapper.addMixIn(Variable.class, VariableMixin.class);
     }
 
-    // Add Documents — collect from scenario, inject direct attachments, and inject payload files
+    // Add Documents — collect from:
+    // 1. documents directly attached to the scenario
+    // 2. documents directly attached to injects (InjectDocument)
+    // 3. payload's attached document (e.g., FileDrop)
+    // 4. documents referenced by Document-type payload arguments in inject content
     List<Document> documentExports =
         Stream.of(
                 scenario.getDocuments().stream(),
@@ -559,6 +564,20 @@ public class ScenarioService {
                           return pl.getAttachedDocument().isPresent()
                               ? Stream.of(pl.getAttachedDocument().get())
                               : Stream.of();
+                        }),
+                scenario.getInjects().stream()
+                    .flatMap(
+                        inject -> {
+                          if (inject.getPayload().isEmpty() || inject.getContent() == null) {
+                            return Stream.of();
+                          }
+                          ObjectNode content = inject.getContent();
+                          return inject.getPayload().get().getArguments().stream()
+                              .filter(arg -> ArgumentType.Document == arg.getType())
+                              .map(arg -> content.path(arg.getKey()))
+                              .filter(node -> node.isTextual() && hasText(node.asText()))
+                              .map(node -> documentRepository.findById(node.asText()))
+                              .flatMap(Optional::stream);
                         }))
             .flatMap(s -> s)
             .distinct()

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -542,27 +542,33 @@ public class ScenarioService {
       objectMapper.addMixIn(Variable.class, VariableMixin.class);
     }
 
-    // Add Documents
-    List<Document> documentExports = new ArrayList<>();
-    documentExports.addAll(scenario.getDocuments());
-    documentExports.addAll(
-        scenario.getInjects().stream()
-            .flatMap(
-                inject -> {
-                  if (inject.getPayload().isEmpty()) {
-                    return Stream.of();
-                  }
-                  Payload pl = inject.getPayload().get();
-                  return pl.getAttachedDocument().isPresent()
-                      ? Stream.of(pl.getAttachedDocument().get())
-                      : Stream.of();
-                })
-            .toList());
+    // Add Documents — collect from scenario, inject direct attachments, and inject payload files
+    List<Document> documentExports =
+        Stream.of(
+                scenario.getDocuments().stream(),
+                scenario.getInjects().stream()
+                    .flatMap(
+                        inject ->
+                            inject.getDocuments().stream().map(InjectDocument::getDocument)),
+                scenario.getInjects().stream()
+                    .flatMap(
+                        inject -> {
+                          if (inject.getPayload().isEmpty()) {
+                            return Stream.of();
+                          }
+                          Payload pl = inject.getPayload().get();
+                          return pl.getAttachedDocument().isPresent()
+                              ? Stream.of(pl.getAttachedDocument().get())
+                              : Stream.of();
+                        }))
+            .flatMap(s -> s)
+            .distinct()
+            .collect(Collectors.toCollection(ArrayList::new));
 
     scenarioFileExport.setDocuments(documentExports);
     objectMapper.addMixIn(Document.class, Mixins.Document.class);
     scenarioTags.addAll(
-        scenario.getDocuments().stream().flatMap(doc -> doc.getTags().stream()).toList());
+        documentExports.stream().flatMap(doc -> doc.getTags().stream()).toList());
     List<String> documentIds =
         new ArrayList<>(documentExports.stream().map(Document::getId).toList());
 

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioExportTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioExportTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import net.javacrumbs.jsonunit.core.Option;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,7 @@ public class ScenarioExportTest extends IntegrationTest {
   @Autowired private PayloadComposer payloadComposer;
   @Autowired private DomainComposer domainComposer;
   @Autowired private TagComposer tagComposer;
+  @Autowired private DocumentComposer documentComposer;
   @Autowired private InjectorFixture injectorFixture;
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper mapper;
@@ -49,62 +51,124 @@ public class ScenarioExportTest extends IntegrationTest {
     injectorContractComposer.reset();
     payloadComposer.reset();
     tagComposer.reset();
+    documentComposer.reset();
   }
 
   private String getJsonExportFromZip(byte[] zipBytes, String entryName) throws IOException {
     return ZipUtils.getZipEntry(zipBytes, "%s.json".formatted(entryName), ZipUtils::streamToString);
   }
 
-  @Test
-  @WithMockUser(isAdmin = true)
-  @DisplayName("When payloads have tags, scenario export has these tags")
-  public void WhenPayloadsHaveTags_ScenarioExportHasTheseTags() throws Exception {
+  @Nested
+  @DisplayName("Scenario document export")
+  class ScenarioDocumentExport {
 
-    ObjectMapper objectMapper = mapper.copy();
-    Scenario scenario =
-        scenarioComposer
-            .forScenario(ScenarioFixture.createDefaultCrisisScenario())
-            .withTag(tagComposer.forTag(TagFixture.getTagWithText("scenario tag")))
-            .withInject(
-                injectComposer
-                    .forInject(InjectFixture.getDefaultInject())
-                    .withTag(tagComposer.forTag(TagFixture.getTagWithText("inject tag")))
-                    .withInjectorContract(
-                        injectorContractComposer
-                            .forInjectorContract(
-                                InjectorContractFixture.createDefaultInjectorContract())
-                            .withInjector(injectorFixture.getWellKnownOaevImplantInjector())
-                            .withDomain(domainComposer.forDomain(DomainFixture.getRandomDomain()))
-                            .withTag(
-                                tagComposer.forTag(
-                                    TagFixture.getTagWithText("this is a payload tag")))
-                            .withPayload(
-                                payloadComposer.forPayload(PayloadFixture.createDefaultCommand()))))
-            .persist()
-            .get();
+    @Test
+    @WithMockUser(isAdmin = true)
+    @DisplayName(
+        "given_injectWithDirectDocument_should_includeDocumentInScenarioDocuments")
+    public void given_injectWithDirectDocument_should_includeDocumentInScenarioDocuments()
+        throws Exception {
+      // Arrange
+      DocumentComposer.Composer docComposer =
+          documentComposer.forDocument(DocumentFixture.getDocumentJpeg());
 
-    manager.flush();
-    manager.clear();
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .withInject(
+                  injectComposer
+                      .forInject(InjectFixture.getDefaultInject())
+                      .withDocument(docComposer))
+              .persist()
+              .get();
 
-    byte[] response =
-        mvc.perform(
-                get(SCENARIO_URI + "/" + scenario.getId() + "/export")
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse()
-            .getContentAsByteArray();
+      manager.flush();
+      manager.clear();
 
-    String actualJson = getJsonExportFromZip(response, scenario.getName());
+      // Act
+      byte[] response =
+          mvc.perform(
+                  get(SCENARIO_URI + "/" + scenario.getId() + "/export")
+                      .accept(MediaType.APPLICATION_JSON))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsByteArray();
 
-    objectMapper.addMixIn(Base.class, Mixins.Base.class);
-    objectMapper.addMixIn(Tag.class, Mixins.Tag.class);
-    String tagsJson = objectMapper.writeValueAsString(tagComposer.generatedItems.stream().toList());
+      String actualJson = getJsonExportFromZip(response, scenario.getName());
 
-    assertThatJson(actualJson)
-        .when(Option.IGNORING_ARRAY_ORDER)
-        .node("scenario_tags")
-        .isArray()
-        .isEqualTo(tagsJson);
+      // Assert — inject-attached document must appear in scenario_documents
+      assertThatJson(actualJson)
+          .when(Option.IGNORING_ARRAY_ORDER)
+          .node("scenario_documents")
+          .isArray()
+          .isNotEmpty();
+
+      assertThatJson(actualJson)
+          .when(Option.IGNORING_ARRAY_ORDER)
+          .node("scenario_documents[0].document_id")
+          .isEqualTo(docComposer.get().getId());
+    }
+  }
+
+  @Nested
+  @DisplayName("Scenario tag export")
+  class ScenarioTagExport {
+
+    @Test
+    @WithMockUser(isAdmin = true)
+    @DisplayName("When payloads have tags, scenario export has these tags")
+    public void WhenPayloadsHaveTags_ScenarioExportHasTheseTags() throws Exception {
+
+      ObjectMapper objectMapper = mapper.copy();
+      Scenario scenario =
+          scenarioComposer
+              .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("scenario tag")))
+              .withInject(
+                  injectComposer
+                      .forInject(InjectFixture.getDefaultInject())
+                      .withTag(tagComposer.forTag(TagFixture.getTagWithText("inject tag")))
+                      .withInjectorContract(
+                          injectorContractComposer
+                              .forInjectorContract(
+                                  InjectorContractFixture.createDefaultInjectorContract())
+                              .withInjector(injectorFixture.getWellKnownOaevImplantInjector())
+                              .withDomain(
+                                  domainComposer.forDomain(DomainFixture.getRandomDomain()))
+                              .withTag(
+                                  tagComposer.forTag(
+                                      TagFixture.getTagWithText("this is a payload tag")))
+                              .withPayload(
+                                  payloadComposer.forPayload(
+                                      PayloadFixture.createDefaultCommand()))))
+              .persist()
+              .get();
+
+      manager.flush();
+      manager.clear();
+
+      byte[] response =
+          mvc.perform(
+                  get(SCENARIO_URI + "/" + scenario.getId() + "/export")
+                      .accept(MediaType.APPLICATION_JSON))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsByteArray();
+
+      String actualJson = getJsonExportFromZip(response, scenario.getName());
+
+      objectMapper.addMixIn(Base.class, Mixins.Base.class);
+      objectMapper.addMixIn(Tag.class, Mixins.Tag.class);
+      String tagsJson =
+          objectMapper.writeValueAsString(tagComposer.generatedItems.stream().toList());
+
+      assertThatJson(actualJson)
+          .when(Option.IGNORING_ARRAY_ORDER)
+          .node("scenario_tags")
+          .isArray()
+          .isEqualTo(tagsJson);
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioExportTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioExportTest.java
@@ -96,17 +96,15 @@ public class ScenarioExportTest extends IntegrationTest {
 
       String actualJson = getJsonExportFromZip(response, scenario.getName());
 
-      // Assert — inject-attached document must appear in scenario_documents
+      // Assert — inject-attached document must appear in scenario_documents regardless of order
+      String docId = docComposer.get().getId();
       assertThatJson(actualJson)
-          .when(Option.IGNORING_ARRAY_ORDER)
+          .when(
+              Option.IGNORING_ARRAY_ORDER,
+              Option.IGNORING_EXTRA_FIELDS,
+              Option.IGNORING_EXTRA_ARRAY_ITEMS)
           .node("scenario_documents")
-          .isArray()
-          .isNotEmpty();
-
-      assertThatJson(actualJson)
-          .when(Option.IGNORING_ARRAY_ORDER)
-          .node("scenario_documents[0].document_id")
-          .isEqualTo(docComposer.get().getId());
+          .isEqualTo("[{\"document_id\": \"%s\"}]".formatted(docId));
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioExportTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioExportTest.java
@@ -64,8 +64,7 @@ public class ScenarioExportTest extends IntegrationTest {
 
     @Test
     @WithMockUser(isAdmin = true)
-    @DisplayName(
-        "given_injectWithDirectDocument_should_includeDocumentInScenarioDocuments")
+    @DisplayName("given_injectWithDirectDocument_should_includeDocumentInScenarioDocuments")
     public void given_injectWithDirectDocument_should_includeDocumentInScenarioDocuments()
         throws Exception {
       // Arrange
@@ -134,8 +133,7 @@ public class ScenarioExportTest extends IntegrationTest {
                               .forInjectorContract(
                                   InjectorContractFixture.createDefaultInjectorContract())
                               .withInjector(injectorFixture.getWellKnownOaevImplantInjector())
-                              .withDomain(
-                                  domainComposer.forDomain(DomainFixture.getRandomDomain()))
+                              .withDomain(domainComposer.forDomain(DomainFixture.getRandomDomain()))
                               .withTag(
                                   tagComposer.forTag(
                                       TagFixture.getTagWithText("this is a payload tag")))


### PR DESCRIPTION
### Proposed changes

* Fix scenario export to include documents directly attached to injects (via \inject_documents\ join table)
* Update tag collection to include tags from inject-attached documents
* Add integration test asserting inject-attached documents appear in export

### Testing Instructions

1. Create a scenario with an inject
2. Attach a document directly to the inject (not via payload)
3. Export the scenario as ZIP
4. Verify the document appears in \scenario_documents\ in the exported JSON
5. Re-import the scenario and confirm no missing document errors

### Related issues

* Closes #6509

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

The export logic in \ScenarioService.exportScenario()\ was collecting documents from two sources but missing the third: documents directly linked to injects via the \InjectDocument\ join table. All three sources are now merged with \.distinct()\ to avoid ZIP duplicate-entry errors.