### PR TITLE
fix(dashboard): fix inject issue undetected by security platform (#6497)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260701101500000__Reindex_inject_expectations_security_platform_widget.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260701101500000__Reindex_inject_expectations_security_platform_widget.java
@@ -1,0 +1,22 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+@Component
+public class V6_20260701101500000__Reindex_inject_expectations_security_platform_widget
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          """
+              DELETE FROM indexing_status
+              WHERE indexing_status_type = 'expectation-inject'
+              """);
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -308,6 +308,7 @@ class IndexingRegressionTest extends IntegrationTest {
 
       EndpointComposer.Composer endpointWrapper =
           endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+      endpointWrapper.persist();
 
       InjectExpectation agentlessExpectation =
           InjectExpectationFixture.createDefaultDetectionInjectExpectation();
@@ -318,10 +319,13 @@ class IndexingRegressionTest extends IntegrationTest {
 
       Agent agent = AgentFixture.createDefaultAgentService();
       agent.setAsset(endpointWrapper.get());
-      AgentComposer.Composer agentWrapper = agentComposer.forAgent(agent);
+      entityManager.persist(agent);
+      entityManager.flush();
+      Agent persistedAgent = entityManager.getReference(Agent.class, agent.getId());
 
       InjectExpectation agentExpectation =
           InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      agentExpectation.setAgent(persistedAgent);
       agentExpectation.setResults(
           List.of(
               InjectExpectationResult.builder()
@@ -332,7 +336,7 @@ class IndexingRegressionTest extends IntegrationTest {
                   .score(100.0)
                   .build()));
       InjectExpectationComposer.Composer agentExpectationWrapper =
-          injectExpectationComposer.forExpectation(agentExpectation).withAgent(agentWrapper);
+          injectExpectationComposer.forExpectation(agentExpectation).withEndpoint(endpointWrapper);
 
       InjectComposer.Composer injectWrapper =
           injectComposer

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -54,6 +54,9 @@ class IndexingRegressionTest extends IntegrationTest {
   @Autowired private InjectComposer injectComposer;
   @Autowired private EndpointComposer endpointComposer;
   @Autowired private InjectExpectationComposer injectExpectationComposer;
+  @Autowired private AgentComposer agentComposer;
+  @Autowired private CollectorComposer collectorComposer;
+  @Autowired private SecurityPlatformComposer securityPlatformComposer;
 
   /** A point in time used as the {@code :from} parameter — 1 hour ago. */
   private static final Instant FROM = Instant.now().minus(1, ChronoUnit.HOURS);
@@ -68,6 +71,9 @@ class IndexingRegressionTest extends IntegrationTest {
     injectComposer.reset();
     endpointComposer.reset();
     injectExpectationComposer.reset();
+    agentComposer.reset();
+    collectorComposer.reset();
+    securityPlatformComposer.reset();
   }
 
   // ---------------------------------------------------------------------------
@@ -281,6 +287,76 @@ class IndexingRegressionTest extends IntegrationTest {
 
       // Assert — expectation must appear because its linked inject is recent
       assertThat(results).anyMatch(es -> es.getBase_id().equals(expectation.getId()));
+    }
+
+    @Test
+    @DisplayName(
+        "Agentless expectation keeps security platforms side from agent-level expectation results")
+    void
+        given_agentless_expectation_should_index_security_platforms_from_agent_expectation_results() {
+      // Arrange
+      SecurityPlatformComposer.Composer securityPlatform =
+          securityPlatformComposer
+              .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR test", "EDR"))
+              .persist();
+      Collector collector =
+          collectorComposer
+              .forCollector(CollectorFixture.createDefaultCollector("collector-edr"))
+              .withSecurityPlatform(securityPlatform)
+              .persist()
+              .get();
+
+      EndpointComposer.Composer endpointWrapper =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+
+      InjectExpectation agentlessExpectation =
+          InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      InjectExpectationComposer.Composer agentlessExpectationWrapper =
+          injectExpectationComposer
+              .forExpectation(agentlessExpectation)
+              .withEndpoint(endpointWrapper);
+
+      Agent agent = AgentFixture.createDefaultAgentService();
+      agent.setAsset(endpointWrapper.get());
+      AgentComposer.Composer agentWrapper = agentComposer.forAgent(agent);
+
+      InjectExpectation agentExpectation =
+          InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      agentExpectation.setResults(
+          List.of(
+              InjectExpectationResult.builder()
+                  .sourceId(collector.getId())
+                  .sourceType("collector")
+                  .sourceName(collector.getName())
+                  .result("detected")
+                  .score(100.0)
+                  .build()));
+      InjectExpectationComposer.Composer agentExpectationWrapper =
+          injectExpectationComposer.forExpectation(agentExpectation).withAgent(agentWrapper);
+
+      InjectComposer.Composer injectWrapper =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withExpectation(agentlessExpectationWrapper)
+              .withExpectation(agentExpectationWrapper);
+      scenarioComposer
+          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+          .withInject(injectWrapper)
+          .persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<EsInjectExpectation> results = injectExpectationHandler.fetch(FROM, 5000);
+
+      // Assert
+      assertThat(results)
+          .filteredOn(es -> es.getBase_id().equals(agentlessExpectation.getId()))
+          .singleElement()
+          .satisfies(
+              es ->
+                  assertThat(es.getBase_security_platforms_side())
+                      .contains(securityPlatform.get().getId()));
     }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -369,6 +369,13 @@ WITH changed_expectations AS (
     SELECT ie.inject_expectation_id FROM injects_expectations ie
       WHERE ie.inject_expectation_updated_at > :from
     UNION
+    SELECT parent_ie.inject_expectation_id
+      FROM injects_expectations parent_ie
+      JOIN injects_expectations child_ie ON child_ie.inject_id = parent_ie.inject_id
+      WHERE parent_ie.agent_id IS NULL
+        AND child_ie.agent_id IS NOT NULL
+        AND child_ie.inject_expectation_updated_at > :from
+    UNION
     SELECT ie.inject_expectation_id FROM injects_expectations ie
       JOIN injects i ON i.inject_id = ie.inject_id
       WHERE i.inject_updated_at > :from
@@ -376,8 +383,7 @@ WITH changed_expectations AS (
     SELECT ie.inject_expectation_id FROM injects_expectations ie
       JOIN injects i ON i.inject_id = ie.inject_id
       JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
-      WHERE ic.injector_contract_updated_at > :from
-),
+      WHERE ic.injector_contract_updated_at > :from),
 agent_security_platforms AS (
     SELECT
         child_ie.inject_id,
@@ -396,8 +402,7 @@ agent_security_platforms AS (
     LEFT JOIN collectors child_c ON child_r.elem->>'sourceId' = child_c.collector_id::text
     LEFT JOIN assets child_a ON child_r.elem->>'sourceId' = child_a.asset_id::text
     WHERE child_ie.agent_id IS NOT NULL
-    GROUP BY child_ie.inject_id
-),
+    GROUP BY child_ie.inject_id),
 inject_expectation_data AS (
     SELECT
         ie.inject_expectation_id,

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -365,74 +365,102 @@ public interface InjectExpectationRepository
   @Query(
       value =
           """
-    WITH changed_expectations AS (
-        SELECT ie.inject_expectation_id FROM injects_expectations ie
-          WHERE ie.inject_expectation_updated_at > :from
-        UNION
-        SELECT ie.inject_expectation_id FROM injects_expectations ie
-          JOIN injects i ON i.inject_id = ie.inject_id
-          WHERE i.inject_updated_at > :from
-        UNION
-        SELECT ie.inject_expectation_id FROM injects_expectations ie
-          JOIN injects i ON i.inject_id = ie.inject_id
-          JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
-          WHERE ic.injector_contract_updated_at > :from
-    ),
-    inject_expectation_data AS (
-      SELECT
-      ie.inject_expectation_id,
-      ie.inject_expectation_name,
-      ie.inject_expectation_description,
-      ie.inject_expectation_type,
-      ie.inject_expectation_results,
-      ie.inject_expectation_score,
-      ie.inject_expectation_expected_score,
-      ie.inject_expiration_time,
-      ie.inject_expectation_group,
-      ie.inject_expectation_created_at,
-      GREATEST(ie.inject_expectation_updated_at, max(i.inject_updated_at), max(ic.injector_contract_updated_at)) as inject_expectation_updated_at,
-      ie.exercise_id,
-      ie.inject_id,
-      ie.user_id,
-      ie.team_id,
-      ie.agent_id,
-      ie.asset_id,
-      ie.asset_group_id,
-      i.tenant_id,
-      i.inject_title as inject_title,
-      MAX(ins.tracking_sent_date) AS tracking_sent_date,
-      array_agg(DISTINCT ap.attack_pattern_id) FILTER ( WHERE ap.attack_pattern_id IS NOT NULL ) AS attack_pattern_ids,
-      array_agg(DISTINCT ic_d.domain_id) FILTER (WHERE ic_d.domain_id IS NOT NULL ) AS domain_ids,
-      MAX(se.scenario_id) AS scenario_id,
-      array_agg(DISTINCT c.collector_security_platform) FILTER ( WHERE c.collector_security_platform IS NOT NULL ) ||
-      array_agg(DISTINCT a.asset_id) FILTER ( WHERE a.asset_id IS NOT NULL ) AS security_platform_ids
+WITH changed_expectations AS (
+    SELECT ie.inject_expectation_id FROM injects_expectations ie
+      WHERE ie.inject_expectation_updated_at > :from
+    UNION
+    SELECT ie.inject_expectation_id FROM injects_expectations ie
+      JOIN injects i ON i.inject_id = ie.inject_id
+      WHERE i.inject_updated_at > :from
+    UNION
+    SELECT ie.inject_expectation_id FROM injects_expectations ie
+      JOIN injects i ON i.inject_id = ie.inject_id
+      JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
+      WHERE ic.injector_contract_updated_at > :from
+),
+agent_security_platforms AS (
+    SELECT
+        child_ie.inject_id,
+        COALESCE(
+            array_agg(DISTINCT child_c.collector_security_platform::text)
+                FILTER ( WHERE child_c.collector_security_platform IS NOT NULL ),
+            ARRAY[]::text[]
+        )
+        || COALESCE(
+            array_agg(DISTINCT child_a.asset_id::text)
+                FILTER ( WHERE child_a.asset_id IS NOT NULL ),
+            ARRAY[]::text[]
+        ) AS security_platform_ids
+    FROM injects_expectations child_ie
+    LEFT JOIN LATERAL jsonb_array_elements(child_ie.inject_expectation_results::jsonb) AS child_r(elem) ON true
+    LEFT JOIN collectors child_c ON child_r.elem->>'sourceId' = child_c.collector_id::text
+    LEFT JOIN assets child_a ON child_r.elem->>'sourceId' = child_a.asset_id::text
+    WHERE child_ie.agent_id IS NOT NULL
+    GROUP BY child_ie.inject_id
+),
+inject_expectation_data AS (
+    SELECT
+        ie.inject_expectation_id,
+        ie.inject_expectation_name,
+        ie.inject_expectation_description,
+        ie.inject_expectation_type,
+        ie.inject_expectation_results,
+        ie.inject_expectation_score,
+        ie.inject_expectation_expected_score,
+        ie.inject_expiration_time,
+        ie.inject_expectation_group,
+        ie.inject_expectation_created_at,
+        GREATEST(ie.inject_expectation_updated_at, MAX(i.inject_updated_at), MAX(ic.injector_contract_updated_at)) AS inject_expectation_updated_at,
+        ie.exercise_id,
+        ie.inject_id,
+        ie.user_id,
+        ie.team_id,
+        ie.agent_id,
+        ie.asset_id,
+        ie.asset_group_id,
+        i.tenant_id,
+        i.inject_title AS inject_title,
+        MAX(ins.tracking_sent_date) AS tracking_sent_date,
+        array_agg(DISTINCT ap.attack_pattern_id) FILTER ( WHERE ap.attack_pattern_id IS NOT NULL ) AS attack_pattern_ids,
+        array_agg(DISTINCT ic_d.domain_id) FILTER ( WHERE ic_d.domain_id IS NOT NULL ) AS domain_ids,
+        MAX(se.scenario_id) AS scenario_id,
+        COALESCE(
+            array_agg(DISTINCT c.collector_security_platform::text)
+                FILTER ( WHERE c.collector_security_platform IS NOT NULL ),
+            ARRAY[]::text[]
+        )
+        || COALESCE(
+            array_agg(DISTINCT a.asset_id::text)
+                FILTER ( WHERE a.asset_id IS NOT NULL ),
+            ARRAY[]::text[]
+        )
+        || COALESCE(asp.security_platform_ids, ARRAY[]::text[]) AS security_platform_ids
     FROM injects_expectations ie
     JOIN changed_expectations ce ON ie.inject_expectation_id = ce.inject_expectation_id
-    LEFT JOIN exercises ex ON ex.exercise_id = ie.exercise_id
+    -- FIX 3 : JOINs inutilisés supprimés (exercises ex, users u, teams t, assets asset, asset_groups ag)
     LEFT JOIN injects i ON i.inject_id = ie.inject_id
     LEFT JOIN injects_statuses ins ON ins.status_inject = i.inject_id
     LEFT JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
     LEFT JOIN injectors_contracts_attack_patterns ic_ap ON ic_ap.injector_contract_id = ic.injector_contract_id
     LEFT JOIN attack_patterns ap ON ap.attack_pattern_id = ic_ap.attack_pattern_id
     LEFT JOIN injectors_contracts_domains ic_d ON ic_d.injector_contract_id = ic.injector_contract_id
-    LEFT JOIN users u ON u.user_id = ie.user_id
-    LEFT JOIN teams t ON t.team_id = ie.team_id
-    LEFT JOIN assets asset ON asset.asset_id = ie.asset_id
-    LEFT JOIN asset_groups ag ON ag.asset_group_id = ie.asset_group_id
     LEFT JOIN scenarios_exercises se ON se.exercise_id = ie.exercise_id
     LEFT JOIN LATERAL jsonb_array_elements(ie.inject_expectation_results::jsonb) AS r(elem) ON true
     LEFT JOIN collectors c ON r.elem->>'sourceId' = c.collector_id::text
     LEFT JOIN assets a ON r.elem->>'sourceId' = a.asset_id::text
+    -- FIX 1 : jointure sur la CTE à la place de la sous-requête corrélée
+    LEFT JOIN agent_security_platforms asp ON asp.inject_id = ie.inject_id
     GROUP BY
-      ie.inject_expectation_id,
-      ic.injector_contract_id,
-      i.inject_title,
-        i.tenant_id
-    )
-    SELECT * FROM inject_expectation_data ied
-    WHERE ied.agent_id IS NULL
-    ORDER BY ied.inject_expectation_updated_at ASC
-    LIMIT :limit
+        ie.inject_expectation_id,
+        ic.injector_contract_id,
+        i.inject_title,
+        i.tenant_id,
+        asp.security_platform_ids  -- nécessaire car pas une agrégation
+)
+SELECT * FROM inject_expectation_data ied
+WHERE ied.agent_id IS NULL
+ORDER BY ied.inject_expectation_updated_at ASC
+LIMIT :limit
     """,
       nativeQuery = true)
   List<RawInjectExpectationIndexing> findForIndexing(

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -437,7 +437,6 @@ inject_expectation_data AS (
         || COALESCE(asp.security_platform_ids, ARRAY[]::text[]) AS security_platform_ids
     FROM injects_expectations ie
     JOIN changed_expectations ce ON ie.inject_expectation_id = ce.inject_expectation_id
-    -- FIX 3 : JOINs inutilisés supprimés (exercises ex, users u, teams t, assets asset, asset_groups ag)
     LEFT JOIN injects i ON i.inject_id = ie.inject_id
     LEFT JOIN injects_statuses ins ON ins.status_inject = i.inject_id
     LEFT JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
@@ -448,14 +447,13 @@ inject_expectation_data AS (
     LEFT JOIN LATERAL jsonb_array_elements(ie.inject_expectation_results::jsonb) AS r(elem) ON true
     LEFT JOIN collectors c ON r.elem->>'sourceId' = c.collector_id::text
     LEFT JOIN assets a ON r.elem->>'sourceId' = a.asset_id::text
-    -- FIX 1 : jointure sur la CTE à la place de la sous-requête corrélée
     LEFT JOIN agent_security_platforms asp ON asp.inject_id = ie.inject_id
     GROUP BY
         ie.inject_expectation_id,
         ic.injector_contract_id,
         i.inject_title,
         i.tenant_id,
-        asp.security_platform_ids  -- nécessaire car pas une agrégation
+        asp.security_platform_ids
 )
 SELECT * FROM inject_expectation_data ied
 WHERE ied.agent_id IS NULL


### PR DESCRIPTION
## Description
On the home dashboard, the "Inject Undetected by Security Platform" default widget returned no data when using the default security platform breakdown, while the simulation breakdown worked correctly.

This was caused by how indexed expectations populate security_platform_ids: indexing only includes non-agent expectations (agent_id IS NULL), but expectation results were only initialized for agent-level expectations. As a result, security_platform_ids stayed empty in Elasticsearch, and the security platform aggregation produced no buckets.

## Expected Output
The "Inject Undetected by Security Platform" widget should display data correctly when breakdown is set to security platform, including with no filters applied.

## Testing Instructions
Open a dashboard containing the "Inject Undetected by Security Platform" widget.
Verify the default breakdown (security platform) now returns data.
Verify breakdown by simulation still works as expected.
Check behavior with and without filters to confirm aggregations are populated.

## Related issues
Closes #6497