### PR TITLE
docs(chaining): document execution flow (#5511)

### DIFF
--- a/docs/docs/usage/autonomous-attack-path.md
+++ b/docs/docs/usage/autonomous-attack-path.md
@@ -7,7 +7,8 @@ and keeps going until the objective is reached or it needs your input - all anim
 and a decision timeline.
 
 This is the highest level of automation in OpenAEV. It builds directly on **chained Scenarios**: a chained Scenario is
-a Scenario whose Injects are linked into an attack-path workflow (see **inject chaining**). **Autonomy is not a separate
+a Scenario whose Injects are linked into an attack-path workflow (see
+[Inject chaining](evaluate/injects/inject-overview.md#conditional-execution-of-injects)). **Autonomy is not a separate
 kind of Scenario - it is a way to launch a chained Scenario.** You author (or AI-plan) the chained Scenario once, then
 choose at launch time whether to run it yourself (normal mode) or hand it to the orchestrator (autonomous mode), which
 seeds itself with your authored steps and then adapts, extends, and drives them live.
@@ -176,7 +177,7 @@ back into its plan. This keeps a run progressing instead of stalling on a single
 
 ## What's next?
 
-- Inject chaining and transfer - the conditional-execution engine autonomous runs build on.
+- [Inject chaining](evaluate/injects/inject-overview.md#conditional-execution-of-injects) - the conditional-execution engine autonomous runs build on.
 - [Scenarios and Simulations](foundations/scenarios-and-simulations.md) - the hand-authored counterpart to autonomous runs.
 - [Threat Arsenal](build/threat-arsenals/threat-arsenals.md) - the injectors and contracts the AI draws from.
 - [Enterprise editions](../administration/enterprise.md) - enabling the license required for AI features.

--- a/docs/docs/usage/evaluate/injects/inject-overview.md
+++ b/docs/docs/usage/evaluate/injects/inject-overview.md
@@ -71,6 +71,78 @@ Many community and official integrations are available. Check the
 [OpenAEV integrations repository](https://github.com/OpenAEV-Platform) for the full list of supported tools and
 connectors.
 
+## Conditional execution of Injects
+
+Conditional execution (also called **Inject chaining**) links Injects together so that a child Inject only runs when
+specific conditions on its parent are met at execution time. Conditions can be based on
+[Expectation](../expectations/expectations.md) results (prevention, detection) or on execution success or failure.
+
+### Why chain Injects?
+
+- **Model real attack chains**: execute lateral movement only if initial access succeeded.
+- **Reduce noise**: skip follow-up Injects when a prerequisite was blocked.
+- **Test decision trees**: simulate branching attacker behavior depending on defensive outcomes.
+
+### Link Injects from the Inject update form
+
+1. Open an Inject and go to the **Logical chains** tab.
+2. Assign a **Parent**. The current Inject only executes if the Parent's conditions are met.
+3. Assign **Children**. They execute only if the current Inject's conditions are satisfied.
+4. Select the conditions: choose the relevant Expectation and toggle **Success** or **Fail**.
+5. Toggle the **AND / OR** operator to control whether all conditions must be met or just one.
+
+!!! note
+
+    The AND/OR setting applies globally to all conditions of the Inject. You cannot mix operators.
+
+### Link Injects from the timeline
+
+1. Switch to the **timeline view** of the Injects list.
+2. Hover over the connection point (small dot) on the left or right of an Inject.
+3. Drag and drop a link to another Inject.
+
+Links created this way default to the condition **Execution is Success**. Edit them via the Inject update form to set
+more specific conditions. You can reposition or remove links by dragging them to an empty area.
+
+### How chained execution works
+
+When a Simulation runs, OpenAEV evaluates each chained Inject at execution time: the platform reads the outcome of the
+parent Inject (execution status or Expectation results), applies the AND/OR operator across the configured conditions,
+and either executes or skips the child Inject.
+
+Chained [Scenarios](../../build/scenario/scenario.md) extend this model with a full execution workflow. When the
+`INJECT_CHAINING` preview feature is enabled, you can create a chained Scenario whose Injects are linked into an
+attack-path workflow. The chain definition acts as a template, and OpenAEV creates a workflow run with runtime steps
+when the Scenario is launched. Each step moves through a single lifecycle: ready, then running, then ended. Before
+starting a child step, OpenAEV evaluates its conditions, which can compare execution results, Expectation values,
+mapped output values, or dependencies between steps. When a parent step finishes, OpenAEV records its outputs in the
+workflow state and propagates them to dependent steps before evaluating the next condition.
+
+Chained workflow runs behave as follows:
+
+| Behavior | Description |
+|----------|-------------|
+| Output reuse | Outputs produced during the run (statuses, Expectation results, findings) are stored so later steps can use them in conditions. |
+| Asynchronous processing | Steps whose conditions are met are queued for execution, and Inject lifecycle events feed results back into the run. |
+| Delays | Time-based waits between steps are scheduled by the platform without blocking execution. |
+| Timeouts | A run that exceeds its configured execution window is ended automatically, together with its remaining steps. |
+
+!!! note
+
+    Chained Scenarios and the workflow view depend on the `INJECT_CHAINING` preview feature being enabled on the
+    platform (see [Parameters](../../../administration/parameters.md)). The **Logical chains** tab on an Inject is
+    always available and does not require the preview feature.
+
+### In practice
+
+You are simulating a multi-stage attack:
+
+1. **Inject 1**: phishing email with a malicious attachment.
+2. **Inject 2**: Threat arsenal action execution on the endpoint (child of Inject 1, condition: *Prevention expectation = Fail*).
+3. **Inject 3**: lateral movement (child of Inject 2, condition: *Execution = Success*).
+
+If the EDR blocks the attachment (Prevention = Success), Inject 2 and 3 are automatically skipped.
+
 ## What's next?
 
 - [Inject tests](inject-tests.md) -- Dry-run email and SMS Injects before launching a Simulation.


### PR DESCRIPTION
## Summary

- Add a "Conditional execution of Injects" section to the Injects overview page (docs/docs/usage/evaluate/injects/inject-overview.md), documenting Inject chaining at user-doc level: why chain Injects, linking from the Logical chains form and from the timeline, and how chained execution works (workflow runs, step lifecycle, condition evaluation, output propagation, delays, timeouts).
- State precisely which parts depend on the INJECT_CHAINING preview feature: chained Scenarios and the workflow view are gated, while the Logical chains tab on an Inject is always available.
- Link the previously dangling "inject chaining" references on the autonomous attack path page to the new section, and provide the #conditional-execution-of-injects anchor that the Threat Arsenal page already links to.

Closes #5511.

## Context

The original version of this PR added a "How chaining works" section to docs/docs/usage/inject-chaining.md. That page was removed by the docs restructure that landed on main in the meantime, so during the rebase the content was re-homed into the new docs structure and fact-checked against the current chaining implementation. The branch was rebased onto the latest main and squashed into a single signed commit, preserving the original author's attribution via a Co-authored-by trailer.

## Validation

- Docs build check (MkDocs) in CI.
- Content verified against the chaining implementation on main (preview feature flag, step lifecycle, workflow behavior) and the docs style guide.
