### PR TITLE
fix(executor): override document argument default_value with inject content in executable payload (#6509)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -288,16 +288,22 @@ public class ExecutableInjectService {
       Inject inject,
       List<ObjectNode> injectorContractFields,
       String obfuscator) {
-    switch (contract.getPayload().getTypeEnum()) {
-      case PayloadType.COMMAND:
-        return processCommandPayload(
-            payloadToExecute, contract, inject, injectorContractFields, obfuscator);
-      case PayloadType.DNS_RESOLUTION:
-        return processDnsResolutionPayload(payloadToExecute, inject);
-      default:
-        // All other payload types are intentionally passed through unchanged.
-        return payloadToExecute;
-    }
+    Payload processed =
+        switch (contract.getPayload().getTypeEnum()) {
+          case PayloadType.COMMAND ->
+              processCommandPayload(
+                  payloadToExecute, contract, inject, injectorContractFields, obfuscator);
+          case PayloadType.DNS_RESOLUTION -> processDnsResolutionPayload(payloadToExecute, inject);
+          default ->
+              // All other payload types are intentionally passed through unchanged.
+              payloadToExecute;
+        };
+    // Override the default_value of document-type arguments with the actual inject content value
+    // for all payload types. The implant uses payload_arguments[].default_value to download
+    // documents before execution; without this override it would download the payload's default
+    // document instead of the one configured on the inject.
+    resolveDocumentArgumentsFromInjectContent(processed, inject.getContent());
+    return processed;
   }
 
   private Payload processCommandPayload(
@@ -316,21 +322,16 @@ public class ExecutableInjectService {
             inject.getContent(),
             injectorContractFields,
             obfuscator));
-    // Override the default_value of document-type arguments with the actual inject content value.
-    // The implant uses payload_arguments[].default_value to download documents before execution;
-    // without this override it would download the payload's default document instead of the one
-    // configured on the inject.
-    resolveDocumentArgumentsFromInjectContent(payloadCommand, inject.getContent());
     return payloadCommand;
   }
 
   private void resolveDocumentArgumentsFromInjectContent(
-      Command payloadCommand, ObjectNode injectContent) {
-    if (isEmpty(payloadCommand.getArguments()) || injectContent == null) {
+      Payload payload, ObjectNode injectContent) {
+    if (isEmpty(payload.getArguments()) || injectContent == null) {
       return;
     }
     List<PayloadArgument> resolved =
-        payloadCommand.getArguments().stream()
+        payload.getArguments().stream()
             .map(
                 arg -> {
                   if (ArgumentType.Document != arg.getType()) {
@@ -352,7 +353,7 @@ public class ExecutableInjectService {
                   return copy;
                 })
             .toList();
-    payloadCommand.setArguments(new ArrayList<>(resolved));
+    payload.setArguments(new ArrayList<>(resolved));
   }
 
   private Payload processDnsResolutionPayload(Payload payloadToExecute, Inject inject) {

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -316,7 +316,43 @@ public class ExecutableInjectService {
             inject.getContent(),
             injectorContractFields,
             obfuscator));
+    // Override the default_value of document-type arguments with the actual inject content value.
+    // The implant uses payload_arguments[].default_value to download documents before execution;
+    // without this override it would download the payload's default document instead of the one
+    // configured on the inject.
+    resolveDocumentArgumentsFromInjectContent(payloadCommand, inject.getContent());
     return payloadCommand;
+  }
+
+  private void resolveDocumentArgumentsFromInjectContent(
+      Command payloadCommand, ObjectNode injectContent) {
+    if (isEmpty(payloadCommand.getArguments()) || injectContent == null) {
+      return;
+    }
+    List<PayloadArgument> resolved =
+        payloadCommand.getArguments().stream()
+            .map(
+                arg -> {
+                  if (ArgumentType.Document != arg.getType()) {
+                    return arg;
+                  }
+                  String actualValue =
+                      getArgumentValueOrDefault(arg.getKey(), injectContent, arg.getDefaultValue());
+                  if (!hasText(actualValue) || actualValue.equals(arg.getDefaultValue())) {
+                    return arg;
+                  }
+                  // Create a copy to avoid mutating the shared original PayloadArgument.
+                  PayloadArgument copy = new PayloadArgument();
+                  copy.setType(arg.getType());
+                  copy.setSubtype(arg.getSubtype());
+                  copy.setKey(arg.getKey());
+                  copy.setDefaultValue(actualValue);
+                  copy.setDescription(arg.getDescription());
+                  copy.setSeparator(arg.getSeparator());
+                  return copy;
+                })
+            .toList();
+    payloadCommand.setArguments(new ArrayList<>(resolved));
   }
 
   private Payload processDnsResolutionPayload(Payload payloadToExecute, Inject inject) {

--- a/openaev-api/src/test/java/io/openaev/rest/inject/InjectApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/InjectApiTest.java
@@ -987,6 +987,71 @@ class InjectApiTest extends IntegrationTest {
                   .with(csrf()))
           .andExpect(status().isBadRequest());
     }
+
+    @DisplayName(
+        "Should override document argument default_value with the inject content value so the implant downloads the right document")
+    @Test
+    void
+        given_documentArgumentOverriddenInInjectContent_should_returnActualDocumentIdInPayloadArguments()
+            throws Exception {
+      // -- PREPARE --
+      // Simulate a payload whose document argument has a generic default (e.g., a template UUID)
+      String payloadDefaultDocumentId = UUID.randomUUID().toString();
+      PayloadArgument docArg =
+          PayloadFixture.createPayloadArgument(
+              "zip_file", ArgumentType.Document, payloadDefaultDocumentId, null);
+
+      Command payloadCommand =
+          PayloadFixture.createCommand(
+              "psh", "Expand-Archive -Path '#{zip_file}'", List.of(), null);
+      payloadCommand.setArguments(new ArrayList<>(List.of(docArg)));
+
+      // The inject content selects DOCUMENT1, not the payload default
+      Map<String, Object> payloadArguments = new HashMap<>();
+      payloadArguments.put("zip_file", DOCUMENT1.getId());
+
+      Inject injectSaved =
+          injectComposer
+              .forInject(InjectFixture.createInjectWithPayloadArg(payloadArguments))
+              .withInjectorContract(
+                  injectorContractComposer
+                      .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                      .withDomain(domainComposer.forDomain(DomainFixture.getRandomDomain()))
+                      .withInjector(InjectorFixture.createDefaultPayloadInjector())
+                      .withPayload(payloadComposer.forPayload(payloadCommand)))
+              .persist()
+              .get();
+
+      doNothing()
+          .when(injectStatusService)
+          .addStartImplantExecutionTraceByInject(any(), any(), any(), any());
+
+      // -- EXECUTE --
+      String response =
+          mvc.perform(
+                  get(INJECT_URI + "/" + injectSaved.getId() + "/fakeId/executable-payload")
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -- ASSERT --
+      assertNotNull(response);
+      // The implant reads payload_arguments[].default_value to decide which document to download.
+      // It must equal the inject content value (DOCUMENT1), not the payload's template default.
+      String returnedDefaultValue = JsonPath.read(response, "$.payload_arguments[0].default_value");
+      assertEquals(
+          DOCUMENT1.getId(),
+          returnedDefaultValue,
+          "The returned default_value must be the inject content value so the implant downloads the"
+              + " correct document");
+      assertNotEquals(
+          payloadDefaultDocumentId,
+          returnedDefaultValue,
+          "The payload template default should have been overridden");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

Fixes the \[FAIL] zip_file arg did not stage on disk\ error when executing DEEP#DRIVE (and any other payload with document-type arguments).

## Root Cause

The implant calls \GET /api/tenants/{tenantId}/injects/{injectId}/{agentId}/executable-payload\ to retrieve the payload to execute. It iterates \payload_arguments\, and for each argument of type \document\, it downloads the file using \default_value\ as the document UUID.

Previously, \processCommandPayload()\ correctly encoded the command content (replacing \#{zip_file}\ with \#{location}/filename.zip\ using the inject content value), but it returned \payload_arguments\ **unchanged** — still carrying the payload template's \default_value\ UUID, not the one selected in the inject.

Result: the implant downloaded the wrong (or non-existent) document, causing the file staging to fail.

## Fix

Added \esolveDocumentArgumentsFromInjectContent()\ in \ExecutableInjectService\: after encoding the command, this method iterates the payload arguments and, for any \Document\-type argument, creates a copy with \default_value\ set to the actual inject content value (falling back to the original default if not set).

Copies are created to avoid mutating shared Hibernate-managed \PayloadArgument\ instances.

## Test

Added \given_documentArgumentOverriddenInInjectContent_should_returnActualDocumentIdInPayloadArguments()\ in \InjectApiTest.RetrievingExecutablePayloadInject\: creates a Command payload with a document arg (random default UUID), overrides it in the inject content with \DOCUMENT1\, and asserts that \payload_arguments[0].default_value\ in the response equals \DOCUMENT1.getId()\.

Closes #6509