### PR TITLE
feat(telemetry): add TELEMETRY_TAGS deployment dimensions and component inventory by catalog identity (#6553)

### DIFF
--- a/docs/docs/reference/deployment/telemetry.md
+++ b/docs/docs/reference/deployment/telemetry.md
@@ -29,12 +29,14 @@ The application collects statistical data related to its usage. Here is an exhau
 - The current platform version
 - The platform's unique identifier
 - The platform creation date
+- The deployment tags, when configured by the operator (`telemetry.tags` / `TELEMETRY_TAGS` - comma-separated freeform tags such as `saas,eu-west`, normalized to lowercase and sorted before export)
 - Enterprise Edition status (activated or not)
 - The total number of users
 - The total number of agents deployed
 - The total number of agents deployed as services or sessions
 - The total number of agents deployed for users or admins
 - The total number of agents deployed for each executor (e.g. Caldera, OpenAEV, CrowdStrike, Tanium, SentinelOne, etc.)
+- The deployed injectors, collectors, and executors broken down by catalog identity (the catalog connector slug for components deployed from the catalog, otherwise the component's own type identifier, with a managed/manual flag). No component configuration is ever collected.
 - The number of simulations, scenarios, and atomic tests created
 - The number of simulations or injects executed
 

--- a/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
@@ -33,6 +33,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -195,7 +196,7 @@ public class OpenTelemetryConfig {
    */
   public static String normalizeTelemetryTags(String rawTags) {
     return Arrays.stream((rawTags == null ? "" : rawTags).split(","))
-        .map(tag -> tag.trim().toLowerCase())
+        .map(tag -> tag.trim().toLowerCase(Locale.ROOT))
         .filter(tag -> !tag.isEmpty())
         .distinct()
         .sorted()

--- a/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/OpenTelemetryConfig.java
@@ -33,6 +33,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -163,6 +164,15 @@ public class OpenTelemetryConfig {
                 stringKey("service.instance.creation"),
                 ZonedDateTime.of(creationDate, ZoneId.systemDefault()).toInstant().toString());
 
+    // Optional deployment tags (telemetry.tags property / TELEMETRY_TAGS env var,
+    // normalized to a canonical sorted/lowercased comma string). One resource
+    // attribute on every export so analytics can slice any metric by deployment
+    // dimension (e.g. "saas,eu-west"). Omitted entirely when not configured.
+    String telemetryTags = normalizeTelemetryTags(environment.getProperty("telemetry.tags"));
+    if (!telemetryTags.isEmpty()) {
+      resourceBuilder.put(stringKey("filigran.telemetry.tags"), telemetryTags);
+    }
+
     try {
       String hostAddress = InetAddress.getLocalHost().getHostAddress();
       resourceBuilder.putAll(Attributes.of(ServerAttributes.SERVER_ADDRESS, hostAddress));
@@ -175,5 +185,20 @@ public class OpenTelemetryConfig {
 
   private String getRequiredProperty(@NotBlank final String key) {
     return requireNonNull(environment.getProperty(key), "Property " + key + " must not be null");
+  }
+
+  /**
+   * Normalizes the deployment tags configured via {@code telemetry.tags} ({@code TELEMETRY_TAGS}):
+   * split on ",", trim, lowercase, drop empties, dedupe, sort, re-join. Shared Filigran contract
+   * (same normalization in OpenCTI and XTM One) so an identical tag set always produces the
+   * identical string in the analytics warehouse.
+   */
+  public static String normalizeTelemetryTags(String rawTags) {
+    return Arrays.stream((rawTags == null ? "" : rawTags).split(","))
+        .map(tag -> tag.trim().toLowerCase())
+        .filter(tag -> !tag.isEmpty())
+        .distinct()
+        .sorted()
+        .collect(Collectors.joining(","));
   }
 }

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
@@ -1,5 +1,6 @@
 package io.openaev.telemetry.metric_collectors;
 
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
 import io.openaev.database.model.BaseConnectorEntity;
@@ -14,7 +15,9 @@ import io.opentelemetry.api.common.Attributes;
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,9 +26,9 @@ import org.springframework.stereotype.Service;
  * Telemetry inventory of the deployed injectors, collectors and executors, broken down by catalog
  * identity. Components deployed from the catalog (XTM Composer) resolve to their catalog connector
  * slug through the connector_instances join (the user-set label is irrelevant); manually deployed
- * components fall back to their own code-level type slug, flagged managed=false. Same resolution
- * as {@code AbstractConnectorService.getConnectorRelationsId()}. Anonymous only: identity slugs
- * and counts, never any component configuration.
+ * components fall back to their own code-level type slug, flagged managed=false. Same resolution as
+ * {@code AbstractConnectorService.getConnectorRelationsId()}. Anonymous only: identity slugs and
+ * counts, never any component configuration.
  */
 @Slf4j
 @Service
@@ -47,23 +50,24 @@ public class InventoryMetricCollector {
     metricRegistry.registerMultiGauge(
         "injectors_deployed_by_identity",
         "Deployed injectors broken down by catalog identity (slug, managed, type)",
-        () -> collectInventory(ConnectorType.INJECTOR, injectorRepository.findAll()));
+        () -> collectInventory(ConnectorType.INJECTOR, injectorRepository::findAll));
     metricRegistry.registerMultiGauge(
         "collectors_deployed_by_identity",
         "Deployed collectors broken down by catalog identity (slug, managed, type)",
-        () -> collectInventory(ConnectorType.COLLECTOR, collectorRepository.findAll()));
+        () -> collectInventory(ConnectorType.COLLECTOR, collectorRepository::findAll));
     metricRegistry.registerMultiGauge(
         "executors_deployed_by_identity",
         "Deployed executors broken down by catalog identity (slug, managed, type)",
-        () -> collectInventory(ConnectorType.EXECUTOR, executorRepository.findAll()));
+        () -> collectInventory(ConnectorType.EXECUTOR, executorRepository::findAll));
   }
 
   private Map<Attributes, Long> collectInventory(
-      ConnectorType connectorType, Iterable<? extends BaseConnectorEntity> entities) {
+      ConnectorType connectorType,
+      Supplier<? extends Iterable<? extends BaseConnectorEntity>> entitiesSupplier) {
     Map<Attributes, Long> inventory = new HashMap<>();
     try {
       Map<String, CatalogConnector> catalogByConnectorId = mapCatalogByConnectorId(connectorType);
-      for (BaseConnectorEntity entity : entities) {
+      for (BaseConnectorEntity entity : entitiesSupplier.get()) {
         CatalogConnector catalogConnector = catalogByConnectorId.get(entity.getId());
         boolean managed = catalogConnector != null;
         String slug = managed ? catalogConnector.getSlug() : entity.getType();
@@ -72,9 +76,12 @@ public class InventoryMetricCollector {
         }
         Attributes attributes =
             Attributes.of(
-                stringKey(ATTRIBUTE_SLUG), slug.trim().toLowerCase(),
-                stringKey(ATTRIBUTE_MANAGED), String.valueOf(managed),
-                stringKey(ATTRIBUTE_TYPE), entity.getType() == null ? "" : entity.getType());
+                stringKey(ATTRIBUTE_SLUG),
+                slug.trim().toLowerCase(Locale.ROOT),
+                booleanKey(ATTRIBUTE_MANAGED),
+                managed,
+                stringKey(ATTRIBUTE_TYPE),
+                entity.getType() == null ? "" : entity.getType());
         inventory.merge(attributes, 1L, Long::sum);
       }
     } catch (Exception e) {

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
@@ -68,9 +68,13 @@ public class InventoryMetricCollector {
     try {
       Map<String, CatalogConnector> catalogByConnectorId = mapCatalogByConnectorId(connectorType);
       for (BaseConnectorEntity entity : entitiesSupplier.get()) {
+        String type = entity.getType();
+        if (type == null || type.isBlank()) {
+          continue;
+        }
         CatalogConnector catalogConnector = catalogByConnectorId.get(entity.getId());
         boolean managed = catalogConnector != null;
-        String slug = managed ? catalogConnector.getSlug() : entity.getType();
+        String slug = managed ? catalogConnector.getSlug() : type;
         if (slug == null || slug.isBlank()) {
           continue;
         }
@@ -81,7 +85,7 @@ public class InventoryMetricCollector {
                 booleanKey(ATTRIBUTE_MANAGED),
                 managed,
                 stringKey(ATTRIBUTE_TYPE),
-                entity.getType() == null ? "" : entity.getType());
+                type);
         inventory.merge(attributes, 1L, Long::sum);
       }
     } catch (Exception e) {

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
@@ -3,8 +3,10 @@ package io.openaev.telemetry.metric_collectors;
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.openaev.database.model.BaseConnectorEntity;
 import io.openaev.database.model.CatalogConnector;
+import io.openaev.database.model.ConnectorInstanceConfiguration;
 import io.openaev.database.model.ConnectorInstancePersisted;
 import io.openaev.database.model.ConnectorType;
 import io.openaev.database.repository.CollectorRepository;
@@ -68,8 +70,8 @@ public class InventoryMetricCollector {
     try {
       Map<String, CatalogConnector> catalogByConnectorId = mapCatalogByConnectorId(connectorType);
       for (BaseConnectorEntity entity : entitiesSupplier.get()) {
-        String type = entity.getType();
-        if (type == null || type.isBlank()) {
+        String type = entity.getType() == null ? "" : entity.getType().trim();
+        if (type.isEmpty()) {
           continue;
         }
         CatalogConnector catalogConnector = catalogByConnectorId.get(entity.getId());
@@ -109,8 +111,12 @@ public class InventoryMetricCollector {
       }
       instance.getConfigurations().stream()
           .filter(configuration -> connectorType.getIdKeyName().equals(configuration.getKey()))
-          .map(configuration -> configuration.getValue().asText())
-          .filter(connectorId -> connectorId != null && !connectorId.isBlank())
+          .map(ConnectorInstanceConfiguration::getValue)
+          // Only textual nodes are valid connector ids: asText() on a JSON null
+          // yields the literal "null" and would shadow a later valid value.
+          .filter(value -> value != null && value.isTextual())
+          .map(JsonNode::asText)
+          .filter(connectorId -> !connectorId.isBlank())
           .findFirst()
           .ifPresent(
               connectorId -> catalogByConnectorId.put(connectorId, instance.getCatalogConnector()));

--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
@@ -1,0 +1,109 @@
+package io.openaev.telemetry.metric_collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+import io.openaev.database.model.BaseConnectorEntity;
+import io.openaev.database.model.CatalogConnector;
+import io.openaev.database.model.ConnectorInstancePersisted;
+import io.openaev.database.model.ConnectorType;
+import io.openaev.database.repository.CollectorRepository;
+import io.openaev.database.repository.ConnectorInstanceRepository;
+import io.openaev.database.repository.ExecutorRepository;
+import io.openaev.database.repository.InjectorRepository;
+import io.opentelemetry.api.common.Attributes;
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Telemetry inventory of the deployed injectors, collectors and executors, broken down by catalog
+ * identity. Components deployed from the catalog (XTM Composer) resolve to their catalog connector
+ * slug through the connector_instances join (the user-set label is irrelevant); manually deployed
+ * components fall back to their own code-level type slug, flagged managed=false. Same resolution
+ * as {@code AbstractConnectorService.getConnectorRelationsId()}. Anonymous only: identity slugs
+ * and counts, never any component configuration.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InventoryMetricCollector {
+
+  private static final String ATTRIBUTE_SLUG = "slug";
+  private static final String ATTRIBUTE_MANAGED = "managed";
+  private static final String ATTRIBUTE_TYPE = "type";
+
+  private final MetricRegistry metricRegistry;
+  private final InjectorRepository injectorRepository;
+  private final CollectorRepository collectorRepository;
+  private final ExecutorRepository executorRepository;
+  private final ConnectorInstanceRepository connectorInstanceRepository;
+
+  @PostConstruct
+  public void init() {
+    metricRegistry.registerMultiGauge(
+        "injectors_deployed_by_identity",
+        "Deployed injectors broken down by catalog identity (slug, managed, type)",
+        () -> collectInventory(ConnectorType.INJECTOR, injectorRepository.findAll()));
+    metricRegistry.registerMultiGauge(
+        "collectors_deployed_by_identity",
+        "Deployed collectors broken down by catalog identity (slug, managed, type)",
+        () -> collectInventory(ConnectorType.COLLECTOR, collectorRepository.findAll()));
+    metricRegistry.registerMultiGauge(
+        "executors_deployed_by_identity",
+        "Deployed executors broken down by catalog identity (slug, managed, type)",
+        () -> collectInventory(ConnectorType.EXECUTOR, executorRepository.findAll()));
+  }
+
+  private Map<Attributes, Long> collectInventory(
+      ConnectorType connectorType, Iterable<? extends BaseConnectorEntity> entities) {
+    Map<Attributes, Long> inventory = new HashMap<>();
+    try {
+      Map<String, CatalogConnector> catalogByConnectorId = mapCatalogByConnectorId(connectorType);
+      for (BaseConnectorEntity entity : entities) {
+        CatalogConnector catalogConnector = catalogByConnectorId.get(entity.getId());
+        boolean managed = catalogConnector != null;
+        String slug = managed ? catalogConnector.getSlug() : entity.getType();
+        if (slug == null || slug.isBlank()) {
+          continue;
+        }
+        Attributes attributes =
+            Attributes.of(
+                stringKey(ATTRIBUTE_SLUG), slug.trim().toLowerCase(),
+                stringKey(ATTRIBUTE_MANAGED), String.valueOf(managed),
+                stringKey(ATTRIBUTE_TYPE), entity.getType() == null ? "" : entity.getType());
+        inventory.merge(attributes, 1L, Long::sum);
+      }
+    } catch (Exception e) {
+      log.error("Telemetry - Failed to collect connector inventory metrics", e);
+    }
+    return inventory;
+  }
+
+  /**
+   * Maps each registered connector id to its catalog connector through the catalog-deployed
+   * connector instances, joined via the {@code INJECTOR_ID} / {@code COLLECTOR_ID} / {@code
+   * EXECUTOR_ID} instance-configuration key.
+   */
+  private Map<String, CatalogConnector> mapCatalogByConnectorId(ConnectorType connectorType) {
+    Map<String, CatalogConnector> catalogByConnectorId = new HashMap<>();
+    List<ConnectorInstancePersisted> instances =
+        connectorInstanceRepository.findAllByCatalogConnectorContainerType(connectorType);
+    for (ConnectorInstancePersisted instance : instances) {
+      if (instance.getCatalogConnector() == null) {
+        continue;
+      }
+      instance.getConfigurations().stream()
+          .filter(configuration -> connectorType.getIdKeyName().equals(configuration.getKey()))
+          .map(configuration -> configuration.getValue().asText())
+          .filter(connectorId -> connectorId != null && !connectorId.isBlank())
+          .findFirst()
+          .ifPresent(
+              connectorId -> catalogByConnectorId.put(connectorId, instance.getCatalogConnector()));
+    }
+    return catalogByConnectorId;
+  }
+}

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -25,6 +25,11 @@ openaev.extra-trusted-certs-dir=
 #openaev.admin.encryption_salt=ChangeMe #mandatory - should be at least 8 bytes long
 openaev.starterpack.enabled=true
 
+# Telemetry deployment tags (optional): comma-separated freeform tags (e.g. saas,eu-west)
+# attached to the anonymous usage telemetry as a resource attribute so adoption analytics
+# can slice metrics by deployment dimension. Normalized (trim, lowercase, dedupe, sort).
+telemetry.tags=
+
 ########################
 # RUNTIME DEPENDENCIES #
 ########################

--- a/openaev-api/src/test/java/io/openaev/config/NoOpOpenTelemetryConfig.java
+++ b/openaev-api/src/test/java/io/openaev/config/NoOpOpenTelemetryConfig.java
@@ -7,6 +7,7 @@ import io.openaev.telemetry.OpenTelemetryConfig;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.telemetry.metric_collectors.AgentMetricCollector;
 import io.openaev.telemetry.metric_collectors.ChainingSafetyPolicyMetricCollector;
+import io.openaev.telemetry.metric_collectors.InventoryMetricCollector;
 import io.openaev.telemetry.metric_collectors.MetricRegistry;
 import io.openaev.telemetry.metric_collectors.ScopeMetricCollector;
 import io.opentelemetry.api.OpenTelemetry;
@@ -47,6 +48,11 @@ public class NoOpOpenTelemetryConfig {
   public ChainingSafetyPolicyMetricCollector chainingSafetyPolicyMetricCollector(
       MetricRegistry metricRegistry) {
     return Mockito.mock(ChainingSafetyPolicyMetricCollector.class);
+  }
+
+  @Bean
+  public InventoryMetricCollector inventoryMetricCollector(MetricRegistry metricRegistry) {
+    return Mockito.mock(InventoryMetricCollector.class);
   }
 
   @Bean

--- a/openaev-api/src/test/java/io/openaev/telemetry/OpenTelemetryConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/OpenTelemetryConfigTest.java
@@ -1,0 +1,28 @@
+package io.openaev.telemetry;
+
+import static io.openaev.telemetry.OpenTelemetryConfig.normalizeTelemetryTags;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OpenTelemetryConfigTest {
+
+  @Test
+  @DisplayName("Telemetry tags normalization returns empty string when no tags are configured")
+  void shouldReturnEmptyStringWhenNoTagsConfigured() {
+    assertThat(normalizeTelemetryTags(null)).isEmpty();
+    assertThat(normalizeTelemetryTags("")).isEmpty();
+    assertThat(normalizeTelemetryTags("   ")).isEmpty();
+    assertThat(normalizeTelemetryTags(" , ,, ")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Telemetry tags normalization trims, lowercases, dedupes and sorts tags")
+  void shouldNormalizeTagsIntoCanonicalString() {
+    assertThat(normalizeTelemetryTags("saas")).isEqualTo("saas");
+    assertThat(normalizeTelemetryTags("saas,eu-west")).isEqualTo("eu-west,saas");
+    assertThat(normalizeTelemetryTags("  EU-West ,SAAS, saas,, ")).isEqualTo("eu-west,saas");
+    assertThat(normalizeTelemetryTags("b,a,c,a")).isEqualTo("a,b,c");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/telemetry/OpenTelemetryConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/OpenTelemetryConfigTest.java
@@ -10,7 +10,7 @@ class OpenTelemetryConfigTest {
 
   @Test
   @DisplayName("Telemetry tags normalization returns empty string when no tags are configured")
-  void shouldReturnEmptyStringWhenNoTagsConfigured() {
+  void given_noTagsConfigured_should_returnEmptyString() {
     assertThat(normalizeTelemetryTags(null)).isEmpty();
     assertThat(normalizeTelemetryTags("")).isEmpty();
     assertThat(normalizeTelemetryTags("   ")).isEmpty();
@@ -19,7 +19,7 @@ class OpenTelemetryConfigTest {
 
   @Test
   @DisplayName("Telemetry tags normalization trims, lowercases, dedupes and sorts tags")
-  void shouldNormalizeTagsIntoCanonicalString() {
+  void given_rawTags_should_normalizeIntoCanonicalString() {
     assertThat(normalizeTelemetryTags("saas")).isEqualTo("saas");
     assertThat(normalizeTelemetryTags("saas,eu-west")).isEqualTo("eu-west,saas");
     assertThat(normalizeTelemetryTags("  EU-West ,SAAS, saas,, ")).isEqualTo("eu-west,saas");

--- a/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.openaev.database.model.CatalogConnector;
 import io.openaev.database.model.ConnectorInstanceConfiguration;
@@ -56,11 +57,16 @@ class InventoryMetricCollectorTest {
 
   private static ConnectorInstancePersisted catalogInstance(
       String slug, String idKey, String connectorId) {
+    return catalogInstance(slug, idKey, JsonNodeFactory.instance.textNode(connectorId));
+  }
+
+  private static ConnectorInstancePersisted catalogInstance(
+      String slug, String idKey, JsonNode connectorIdValue) {
     CatalogConnector catalogConnector = new CatalogConnector();
     catalogConnector.setSlug(slug);
     ConnectorInstanceConfiguration configuration = new ConnectorInstanceConfiguration();
     configuration.setKey(idKey);
-    configuration.setValue(JsonNodeFactory.instance.textNode(connectorId));
+    configuration.setValue(connectorIdValue);
     ConnectorInstancePersisted instance = new ConnectorInstancePersisted();
     instance.setCatalogConnector(catalogConnector);
     instance.setConfigurations(Set.of(configuration));
@@ -176,6 +182,57 @@ class InventoryMetricCollectorTest {
 
     // Assert
     assertThat(inventory).isEmpty();
+  }
+
+  @Test
+  @DisplayName("given a type with surrounding whitespace should trim it for both type and slug")
+  void given_typeWithWhitespace_should_trimTypeAndSlug() {
+    // Arrange
+    when(injectorRepository.findAll())
+        .thenReturn(List.of(injector("injector-1", "  OpenAEV_Email  ")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(List.of());
+
+    // Act
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    // Assert
+    assertThat(inventory)
+        .containsExactly(
+            Map.entry(
+                Attributes.of(
+                    stringKey("slug"), "openaev_email",
+                    booleanKey("managed"), false,
+                    stringKey("type"), "OpenAEV_Email"),
+                1L));
+  }
+
+  @Test
+  @DisplayName(
+      "given a non-textual connector id configuration should classify the component as manual")
+  void given_nonTextualConnectorIdConfiguration_should_classifyAsManual() {
+    // Arrange: a JSON null id value must not become the literal string "null"
+    when(injectorRepository.findAll()).thenReturn(List.of(injector("injector-1", "openaev_email")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(
+            List.of(
+                catalogInstance(
+                    "Email-Injector",
+                    ConnectorType.INJECTOR.getIdKeyName(),
+                    JsonNodeFactory.instance.nullNode())));
+
+    // Act
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    // Assert
+    assertThat(inventory)
+        .containsExactly(
+            Map.entry(
+                Attributes.of(
+                    stringKey("slug"), "openaev_email",
+                    booleanKey("managed"), false,
+                    stringKey("type"), "openaev_email"),
+                1L));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
@@ -79,6 +79,7 @@ class InventoryMetricCollectorTest {
   @Test
   @DisplayName("given a catalog-deployed injector should report the catalog slug as managed")
   void given_catalogDeployedInjector_should_reportCatalogSlugAsManaged() {
+    // Arrange
     when(injectorRepository.findAll()).thenReturn(List.of(injector("injector-1", "openaev_email")));
     when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
         .thenReturn(
@@ -86,8 +87,10 @@ class InventoryMetricCollectorTest {
                 catalogInstance(
                     "Email-Injector", ConnectorType.INJECTOR.getIdKeyName(), "injector-1")));
 
+    // Act
     Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
 
+    // Assert
     assertThat(inventory)
         .containsExactly(
             Map.entry(
@@ -101,13 +104,16 @@ class InventoryMetricCollectorTest {
   @Test
   @DisplayName("given a manually deployed injector should fall back to its type slug as unmanaged")
   void given_manuallyDeployedInjector_should_fallBackToTypeSlugAsUnmanaged() {
+    // Arrange
     when(injectorRepository.findAll())
         .thenReturn(List.of(injector("injector-1", "openaev_caldera")));
     when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
         .thenReturn(List.of());
 
+    // Act
     Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
 
+    // Assert
     assertThat(inventory)
         .containsExactly(
             Map.entry(
@@ -121,6 +127,7 @@ class InventoryMetricCollectorTest {
   @Test
   @DisplayName("given identical identities should aggregate counts per attribute set")
   void given_identicalIdentities_should_aggregateCountsPerAttributeSet() {
+    // Arrange
     when(injectorRepository.findAll())
         .thenReturn(
             List.of(
@@ -128,31 +135,59 @@ class InventoryMetricCollectorTest {
     when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
         .thenReturn(List.of());
 
+    // Act
     Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
 
+    // Assert
     assertThat(inventory).hasSize(1);
     assertThat(inventory.values()).containsExactly(2L);
   }
 
   @Test
-  @DisplayName("given a blank identity should skip the component")
-  void given_blankIdentity_should_skipComponent() {
-    when(injectorRepository.findAll()).thenReturn(List.of(injector("injector-1", " ")));
+  @DisplayName("given a blank type should skip the component even when catalog-managed")
+  void given_blankType_should_skipComponentEvenWhenManaged() {
+    // Arrange
+    when(injectorRepository.findAll())
+        .thenReturn(List.of(injector("injector-1", " "), injector("injector-2", null)));
     when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
-        .thenReturn(List.of());
+        .thenReturn(
+            List.of(
+                catalogInstance(
+                    "Email-Injector", ConnectorType.INJECTOR.getIdKeyName(), "injector-1")));
 
+    // Act
     Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
 
+    // Assert
+    assertThat(inventory).isEmpty();
+  }
+
+  @Test
+  @DisplayName("given a catalog row without slug should skip the managed component")
+  void given_catalogRowWithoutSlug_should_skipManagedComponent() {
+    // Arrange
+    when(injectorRepository.findAll()).thenReturn(List.of(injector("injector-1", "openaev_email")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(
+            List.of(catalogInstance(null, ConnectorType.INJECTOR.getIdKeyName(), "injector-1")));
+
+    // Act
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    // Assert
     assertThat(inventory).isEmpty();
   }
 
   @Test
   @DisplayName("given a repository failure should return an empty inventory instead of throwing")
   void given_repositoryFailure_should_returnEmptyInventory() {
+    // Arrange
     when(injectorRepository.findAll()).thenThrow(new IllegalStateException("database is down"));
 
+    // Act
     Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
 
+    // Assert
     assertThat(inventory).isEmpty();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
@@ -1,0 +1,158 @@
+package io.openaev.telemetry.metric_collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.openaev.database.model.CatalogConnector;
+import io.openaev.database.model.ConnectorInstanceConfiguration;
+import io.openaev.database.model.ConnectorInstancePersisted;
+import io.openaev.database.model.ConnectorType;
+import io.openaev.database.model.Injector;
+import io.openaev.database.repository.CollectorRepository;
+import io.openaev.database.repository.ConnectorInstanceRepository;
+import io.openaev.database.repository.ExecutorRepository;
+import io.openaev.database.repository.InjectorRepository;
+import io.opentelemetry.api.common.Attributes;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InventoryMetricCollector")
+class InventoryMetricCollectorTest {
+
+  @Mock private MetricRegistry metricRegistry;
+  @Mock private InjectorRepository injectorRepository;
+  @Mock private CollectorRepository collectorRepository;
+  @Mock private ExecutorRepository executorRepository;
+  @Mock private ConnectorInstanceRepository connectorInstanceRepository;
+
+  @InjectMocks private InventoryMetricCollector inventoryMetricCollector;
+
+  @Captor private ArgumentCaptor<Supplier<Map<Attributes, Long>>> supplierCaptor;
+
+  private static Injector injector(String id, String type) {
+    Injector injector = new Injector();
+    injector.setId(id);
+    injector.setName(type);
+    injector.setType(type);
+    return injector;
+  }
+
+  private static ConnectorInstancePersisted catalogInstance(
+      String slug, String idKey, String connectorId) {
+    CatalogConnector catalogConnector = new CatalogConnector();
+    catalogConnector.setSlug(slug);
+    ConnectorInstanceConfiguration configuration = new ConnectorInstanceConfiguration();
+    configuration.setKey(idKey);
+    configuration.setValue(JsonNodeFactory.instance.textNode(connectorId));
+    ConnectorInstancePersisted instance = new ConnectorInstancePersisted();
+    instance.setCatalogConnector(catalogConnector);
+    instance.setConfigurations(Set.of(configuration));
+    return instance;
+  }
+
+  private Supplier<Map<Attributes, Long>> capturedInjectorSupplier() {
+    inventoryMetricCollector.init();
+    verify(metricRegistry)
+        .registerMultiGauge(eq("injectors_deployed_by_identity"), any(), supplierCaptor.capture());
+    verify(metricRegistry).registerMultiGauge(eq("collectors_deployed_by_identity"), any(), any());
+    verify(metricRegistry).registerMultiGauge(eq("executors_deployed_by_identity"), any(), any());
+    return supplierCaptor.getValue();
+  }
+
+  @Test
+  @DisplayName("given a catalog-deployed injector should report the catalog slug as managed")
+  void given_catalogDeployedInjector_should_reportCatalogSlugAsManaged() {
+    when(injectorRepository.findAll()).thenReturn(List.of(injector("injector-1", "openaev_email")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(
+            List.of(
+                catalogInstance(
+                    "Email-Injector", ConnectorType.INJECTOR.getIdKeyName(), "injector-1")));
+
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    assertThat(inventory)
+        .containsExactly(
+            Map.entry(
+                Attributes.of(
+                    stringKey("slug"), "email-injector",
+                    booleanKey("managed"), true,
+                    stringKey("type"), "openaev_email"),
+                1L));
+  }
+
+  @Test
+  @DisplayName("given a manually deployed injector should fall back to its type slug as unmanaged")
+  void given_manuallyDeployedInjector_should_fallBackToTypeSlugAsUnmanaged() {
+    when(injectorRepository.findAll())
+        .thenReturn(List.of(injector("injector-1", "openaev_caldera")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(List.of());
+
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    assertThat(inventory)
+        .containsExactly(
+            Map.entry(
+                Attributes.of(
+                    stringKey("slug"), "openaev_caldera",
+                    booleanKey("managed"), false,
+                    stringKey("type"), "openaev_caldera"),
+                1L));
+  }
+
+  @Test
+  @DisplayName("given identical identities should aggregate counts per attribute set")
+  void given_identicalIdentities_should_aggregateCountsPerAttributeSet() {
+    when(injectorRepository.findAll())
+        .thenReturn(
+            List.of(
+                injector("injector-1", "openaev_http"), injector("injector-2", "openaev_http")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(List.of());
+
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    assertThat(inventory).hasSize(1);
+    assertThat(inventory.values()).containsExactly(2L);
+  }
+
+  @Test
+  @DisplayName("given a blank identity should skip the component")
+  void given_blankIdentity_should_skipComponent() {
+    when(injectorRepository.findAll()).thenReturn(List.of(injector("injector-1", " ")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(List.of());
+
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    assertThat(inventory).isEmpty();
+  }
+
+  @Test
+  @DisplayName("given a repository failure should return an empty inventory instead of throwing")
+  void given_repositoryFailure_should_returnEmptyInventory() {
+    when(injectorRepository.findAll()).thenThrow(new IllegalStateException("database is down"));
+
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    assertThat(inventory).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Closes #6553. Part of the cross-product TELEMETRY_TAGS effort (XTM One, OpenCTI, enterprise-data-platform, helm-xtm-suite companion PRs).

### 1. TELEMETRY_TAGS deployment dimensions

- New Spring property `telemetry.tags` (env `TELEMETRY_TAGS` via relaxed binding, default empty in `application.properties`): comma-separated freeform deployment tags, e.g. `saas,eu-west`.
- `OpenTelemetryConfig.normalizeTelemetryTags()`: trim, lowercase (`Locale.ROOT`, locale-independent), drop empties, dedupe, sort, re-join - the shared Filigran normalization contract (same in OpenCTI / XTM One) so an identical tag set always produces the identical string in the analytics warehouse.
- Exported as one OTLP resource attribute `filigran.telemetry.tags` in `buildResource()` (omitted entirely when not configured) - zero per-gauge changes; the enterprise data platform lands it as a `tags` column on every telemetry row.

### 2. Injector / collector / executor inventory by catalog identity

New `InventoryMetricCollector` (next to the existing five collectors) registering three multi-dimensional gauges via the existing `MetricRegistry.registerMultiGauge()` facade:

- `injectors_deployed_by_identity`, `collectors_deployed_by_identity`, `executors_deployed_by_identity` - one datapoint per registered component with attributes:
  - `slug` (string): the catalog connector slug when the component resolves to a catalog-deployed `connector_instances` row (XTM Composer deployment - exact catalog truth, independent of any user-set label); otherwise the component's own code-level `type` slug (reliable even for manual/community deployments); normalized with `Locale.ROOT`;
  - `managed` (boolean attribute, consistent with `ChainingSafetyPolicyMetricCollector`): catalog-deployed vs manual;
  - `type` (string): the component's `type` field, trimmed and guaranteed non-blank (components with a null/blank/whitespace-only type are skipped for both managed and manual deployments so the dimension is always reliable).
- Resolution reuses the product's own logic: `ConnectorInstanceRepository.findAllByCatalogConnectorContainerType()` (instances + catalog eagerly loaded via `@EntityGraph`) joined via the `INJECTOR_ID`/`COLLECTOR_ID`/`EXECUTOR_ID` instance-configuration key - same as `AbstractConnectorService.getConnectorRelationsId()`. Only textual JSON configuration values are accepted as connector ids (a JSON null cannot become the literal string "null").
- The dynamic `total_<executor.type>_deployed` agent gauges are untouched (they measure agents, not inventory).
- Collection is fully guarded: the repository lookups are invoked inside the try/catch (passed as suppliers), so any DB failure at export time logs and returns an empty map, never breaking the export cycle.

### Docs / tests

- `docs/docs/reference/deployment/telemetry.md` collected-metrics inventory updated (deployment tags + component inventory).
- `NoOpOpenTelemetryConfig` (test profile) extended with the new collector mock.
- New `OpenTelemetryConfigTest` unit test covering the normalization table (empty/trim/lowercase/dedupe/sort), method names following the `given_X_should_Y` convention.
- New `InventoryMetricCollectorTest` (AAA-structured, 8 tests) covering catalog-slug resolution, manual fallback, aggregation per identity, blank-type skip (managed and manual), whitespace trimming, non-textual connector id values, missing-catalog-slug skip, and the DB-failure guard.

## Test plan

- [x] `mvn compile -pl openaev-api -am` - BUILD SUCCESS
- [x] `mvn test -pl openaev-api -am -Dtest=OpenTelemetryConfigTest,InventoryMetricCollectorTest` - 10 passed
- [x] `mvn spotless:apply` - clean
