### PR TITLE
fix(multi_tenancy): defer agent FK constraints during agent id reassignment migration (#6559)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260701180000000__Reassign_agent_ids_for_external_executors.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260701180000000__Reassign_agent_ids_for_external_executors.java
@@ -13,16 +13,22 @@ import org.springframework.stereotype.Component;
  * platform. After this migration, {@code agent_id} is a random UUID and {@code
  * agent_external_reference} remains the external device ID used for API callbacks.
  *
- * <p>Because none of the FK constraints that reference {@code agents.agent_id} declare {@code ON
- * UPDATE CASCADE}, this migration builds an {@code old_id → new_id} remap table and manually
- * propagates the new PK to every child table before updating the parent row:
+ * <p>None of the FK constraints that reference {@code agents.agent_id} declare {@code ON UPDATE
+ * CASCADE}, and most of them are non-deferrable, so neither the parent PK nor the child references
+ * can be updated first without an immediate FK violation (see #6559). The migration therefore
+ * temporarily marks the non-deferrable constraints as {@code DEFERRABLE}, defers all FK checks to
+ * the end of the remap, and restores {@code NOT DEFERRABLE} once every table is consistent:
  *
  * <ol>
- *   <li>{@code injects_expectations.agent_id}
- *   <li>{@code execution_traces.execution_agent_id}
- *   <li>{@code asset_agent_jobs.asset_agent_agent}
- *   <li>{@code agents.agent_parent} (self-reference)
+ *   <li>{@code injects_expectations.agent_id} ({@code fk_agent})
+ *   <li>{@code execution_traces.execution_agent_id} (already {@code DEFERRABLE INITIALLY DEFERRED},
+ *       see V4_59)
+ *   <li>{@code asset_agent_jobs.asset_agent_agent} ({@code asset_agent_agent_fk})
+ *   <li>{@code agents.agent_parent} ({@code agent_parent_id_fk}, self-reference)
  * </ol>
+ *
+ * <p>Everything runs inside the single Flyway migration transaction, so a failure at any point
+ * rolls back both the data changes and the constraint alterations.
  */
 @Component
 public class V6_20260701180000000__Reassign_agent_ids_for_external_executors
@@ -32,64 +38,82 @@ public class V6_20260701180000000__Reassign_agent_ids_for_external_executors
   public void migrate(Context context) throws Exception {
     try (Statement stmt = context.getConnection().createStatement()) {
 
-      // Build a temporary mapping of old_id → new_id for affected agents.
-      // FK constraints on child tables have no ON UPDATE CASCADE, so we must
-      // update every referencing table manually before touching the PK.
+      // Allow the FK checks to be deferred until all parent and child rows are
+      // updated. ALTER CONSTRAINT only touches catalog metadata (no revalidation).
       stmt.execute(
           """
-                    CREATE TEMP TABLE agent_id_remap AS
-                    SELECT agent_id AS old_id, gen_random_uuid()::text AS new_id
-                    FROM agents
-                    WHERE agent_external_reference IS NOT NULL
-                      AND agent_id = agent_external_reference
-                    """);
+          ALTER TABLE injects_expectations ALTER CONSTRAINT fk_agent DEFERRABLE INITIALLY IMMEDIATE;
+          ALTER TABLE asset_agent_jobs ALTER CONSTRAINT asset_agent_agent_fk DEFERRABLE INITIALLY IMMEDIATE;
+          ALTER TABLE agents ALTER CONSTRAINT agent_parent_id_fk DEFERRABLE INITIALLY IMMEDIATE;
+          SET CONSTRAINTS ALL DEFERRED;
+          """);
 
-      // injects_expectations.agent_id → agents.agent_id
+      // Build a temporary mapping of old_id -> new_id for affected agents.
       stmt.execute(
           """
-                    UPDATE injects_expectations ie
-                    SET agent_id = r.new_id
-                    FROM agent_id_remap r
-                    WHERE ie.agent_id = r.old_id
-                    """);
+          CREATE TEMP TABLE agent_id_remap AS
+          SELECT agent_id AS old_id, gen_random_uuid()::text AS new_id
+          FROM agents
+          WHERE agent_external_reference IS NOT NULL
+            AND agent_id = agent_external_reference
+          """);
 
-      // execution_traces.execution_agent_id → agents.agent_id
+      // injects_expectations.agent_id -> agents.agent_id
       stmt.execute(
           """
-                    UPDATE execution_traces et
-                    SET execution_agent_id = r.new_id
-                    FROM agent_id_remap r
-                    WHERE et.execution_agent_id = r.old_id
-                    """);
+          UPDATE injects_expectations ie
+          SET agent_id = r.new_id
+          FROM agent_id_remap r
+          WHERE ie.agent_id = r.old_id
+          """);
 
-      // asset_agent_jobs.asset_agent_agent → agents.agent_id
+      // execution_traces.execution_agent_id -> agents.agent_id
       stmt.execute(
           """
-                    UPDATE asset_agent_jobs aaj
-                    SET asset_agent_agent = r.new_id
-                    FROM agent_id_remap r
-                    WHERE aaj.asset_agent_agent = r.old_id
-                    """);
+          UPDATE execution_traces et
+          SET execution_agent_id = r.new_id
+          FROM agent_id_remap r
+          WHERE et.execution_agent_id = r.old_id
+          """);
 
-      // agents.agent_parent → agents.agent_id (self-reference)
+      // asset_agent_jobs.asset_agent_agent -> agents.agent_id
       stmt.execute(
           """
-                    UPDATE agents a
-                    SET agent_parent = r.new_id
-                    FROM agent_id_remap r
-                    WHERE a.agent_parent = r.old_id
-                    """);
+          UPDATE asset_agent_jobs aaj
+          SET asset_agent_agent = r.new_id
+          FROM agent_id_remap r
+          WHERE aaj.asset_agent_agent = r.old_id
+          """);
 
-      // Finally reassign the PK itself.
+      // agents.agent_parent -> agents.agent_id (self-reference)
       stmt.execute(
           """
-                    UPDATE agents a
-                    SET agent_id = r.new_id
-                    FROM agent_id_remap r
-                    WHERE a.agent_id = r.old_id
-                    """);
+          UPDATE agents a
+          SET agent_parent = r.new_id
+          FROM agent_id_remap r
+          WHERE a.agent_parent = r.old_id
+          """);
+
+      // Reassign the PK itself.
+      stmt.execute(
+          """
+          UPDATE agents a
+          SET agent_id = r.new_id
+          FROM agent_id_remap r
+          WHERE a.agent_id = r.old_id
+          """);
 
       stmt.execute("DROP TABLE agent_id_remap");
+
+      // Validate all deferred FK checks now, then restore the original
+      // non-deferrable definitions.
+      stmt.execute(
+          """
+          SET CONSTRAINTS ALL IMMEDIATE;
+          ALTER TABLE injects_expectations ALTER CONSTRAINT fk_agent NOT DEFERRABLE;
+          ALTER TABLE asset_agent_jobs ALTER CONSTRAINT asset_agent_agent_fk NOT DEFERRABLE;
+          ALTER TABLE agents ALTER CONSTRAINT agent_parent_id_fk NOT DEFERRABLE;
+          """);
     }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260701180000000__Reassign_agent_ids_for_external_executors.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260701180000000__Reassign_agent_ids_for_external_executors.java
@@ -16,8 +16,9 @@ import org.springframework.stereotype.Component;
  * <p>None of the FK constraints that reference {@code agents.agent_id} declare {@code ON UPDATE
  * CASCADE}, and most of them are non-deferrable, so neither the parent PK nor the child references
  * can be updated first without an immediate FK violation (see #6559). The migration therefore
- * temporarily marks the non-deferrable constraints as {@code DEFERRABLE}, defers all FK checks to
- * the end of the remap, and restores {@code NOT DEFERRABLE} once every table is consistent:
+ * temporarily marks the non-deferrable constraints as {@code DEFERRABLE}, defers the checks of
+ * exactly these constraints to the end of the remap, and restores {@code NOT DEFERRABLE} once every
+ * table is consistent:
  *
  * <ol>
  *   <li>{@code injects_expectations.agent_id} ({@code fk_agent})
@@ -29,6 +30,15 @@ import org.springframework.stereotype.Component;
  *
  * <p>Everything runs inside the single Flyway migration transaction, so a failure at any point
  * rolls back both the data changes and the constraint alterations.
+ *
+ * <p>Remapped agent ids are also embedded in Elasticsearch {@code vulnerable-endpoint} documents
+ * ({@code base_agents_side}); the incremental indexer cursors on asset/exercise timestamps that
+ * this migration does not touch, so it forces a full reindex of that type (same pattern as V4_08).
+ *
+ * <p>Note on in-place edit of this migration (shipped broken in 2.260703.2): Java-based migrations
+ * have no checksum ({@code BaseJavaMigration#getChecksum()} returns {@code null}), so environments
+ * where the original version already succeeded (only possible without child rows, where both
+ * versions are semantically identical) validate fine and are not re-run.
  */
 @Component
 public class V6_20260701180000000__Reassign_agent_ids_for_external_executors
@@ -40,12 +50,15 @@ public class V6_20260701180000000__Reassign_agent_ids_for_external_executors
 
       // Allow the FK checks to be deferred until all parent and child rows are
       // updated. ALTER CONSTRAINT only touches catalog metadata (no revalidation).
+      // Only the constraints involved in the remap are deferred, to stay
+      // insensitive to unrelated deferrable constraints in the same transaction.
       stmt.execute(
           """
           ALTER TABLE injects_expectations ALTER CONSTRAINT fk_agent DEFERRABLE INITIALLY IMMEDIATE;
           ALTER TABLE asset_agent_jobs ALTER CONSTRAINT asset_agent_agent_fk DEFERRABLE INITIALLY IMMEDIATE;
           ALTER TABLE agents ALTER CONSTRAINT agent_parent_id_fk DEFERRABLE INITIALLY IMMEDIATE;
-          SET CONSTRAINTS ALL DEFERRED;
+          SET CONSTRAINTS fk_agent, asset_agent_agent_fk, agent_parent_id_fk,
+                          execution_traces_execution_agent_id_fkey DEFERRED;
           """);
 
       // Build a temporary mapping of old_id -> new_id for affected agents.
@@ -105,15 +118,22 @@ public class V6_20260701180000000__Reassign_agent_ids_for_external_executors
 
       stmt.execute("DROP TABLE agent_id_remap");
 
-      // Validate all deferred FK checks now, then restore the original
+      // Validate the deferred FK checks now, then restore the original
       // non-deferrable definitions.
       stmt.execute(
           """
-          SET CONSTRAINTS ALL IMMEDIATE;
+          SET CONSTRAINTS fk_agent, asset_agent_agent_fk, agent_parent_id_fk,
+                          execution_traces_execution_agent_id_fkey IMMEDIATE;
           ALTER TABLE injects_expectations ALTER CONSTRAINT fk_agent NOT DEFERRABLE;
           ALTER TABLE asset_agent_jobs ALTER CONSTRAINT asset_agent_agent_fk NOT DEFERRABLE;
           ALTER TABLE agents ALTER CONSTRAINT agent_parent_id_fk NOT DEFERRABLE;
           """);
+
+      // Agent ids are denormalized into ES vulnerable-endpoint documents
+      // (base_agents_side); force a full reindex of that type since the
+      // incremental indexer would not pick up the PK change.
+      stmt.execute(
+          "DELETE FROM indexing_status WHERE indexing_status_type = 'vulnerable-endpoint'");
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #6559

Release 2.260703.2 fails to start on any instance where CrowdStrike / SentinelOne agents have related data: the migration `V6_20260701180000000__Reassign_agent_ids_for_external_executors` (introduced in #6526) updates the child tables to point at the new agent UUIDs before those UUIDs exist in `agents`, and the non-deferrable FK constraints (`fk_agent`, `asset_agent_agent_fk`, `agent_parent_id_fk`) reject the very first UPDATE. Observed on testing.oaev.staging.filigran.io (crash-loop, migration rolled back). Reordering does not help: updating the parent PK first fails the same way since no FK declares `ON UPDATE CASCADE`.

This PR patches the migration in place to make the remap atomic:

- temporarily mark the three non-deferrable FK constraints as `DEFERRABLE` (`ALTER CONSTRAINT` is metadata-only, no revalidation)
- `SET CONSTRAINTS ... DEFERRED` scoped to exactly the four constraints involved in the remap (per review, not `ALL`), run all child updates and the parent PK reassignment
- `SET CONSTRAINTS ... IMMEDIATE` on the same list to validate everything at once, then restore `NOT DEFERRABLE`
- force a full Elasticsearch reindex of `vulnerable-endpoint` documents (`DELETE FROM indexing_status WHERE indexing_status_type = 'vulnerable-endpoint'`, same pattern as V4_08): these documents embed `agents.agent_id` in `base_agents_side`, and the incremental indexer cursors on asset/exercise timestamps that this migration does not touch, so without this the ES documents would keep the stale agent ids

All of it runs inside the single Flyway migration transaction, so any failure rolls back both the data changes and the constraint alterations. The `execution_traces` FK is already `DEFERRABLE INITIALLY DEFERRED` (V4_59); it is included in the scoped `SET CONSTRAINTS` lists so its checks are also validated inside the migration rather than at commit.

In-place edit safety: Java-based migrations carry no checksum (`BaseJavaMigration#getChecksum()` returns `null`, verified against flyway-core 11.7.2), so environments where the original version already succeeded (only possible without child rows, where both variants are semantically identical) validate fine and are not re-run. This is documented in the migration JavaDoc.

## Test plan

- [x] Reproduced the staging failure against PostgreSQL 16: the released migration SQL fails with `violates foreign key constraint "fk_agent"` as soon as an affected agent has inject expectations
- [x] Ran the exact fixed SQL statements against the same dataset (agent with expectations, traces, jobs and a child service agent): commits cleanly
- [x] Verified post-migration consistency: agent PK remapped to a new UUID, external reference preserved, no orphan rows in any of the four referencing columns
- [x] Verified the constraints are restored to `NOT DEFERRABLE` and still enforce FK integrity after the migration
- [x] Verified the `vulnerable-endpoint` indexing_status row is deleted (reindex trigger) while other types are untouched
- [x] `mvn compile -pl openaev-api -am` and `mvn spotless:apply` pass
- [x] CI green
