### PR TITLE
docs(mcp): document the OpenAEV MCP server exposed through XTM One (#6566)

### DIFF
--- a/docs/docs/deployment/ecosystem/mcp-server.md
+++ b/docs/docs/deployment/ecosystem/mcp-server.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-OpenAEV can be used from any [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) compatible client — Cursor, Claude Desktop, Claude Code, or custom AI agents — through the native MCP server embedded in [XTM One](https://docs.xtmone.io/).
+OpenAEV can be used from any [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)-compatible client — Cursor, Claude Desktop, Claude Code, or custom AI agents — through the native MCP server embedded in [XTM One](https://docs.xtmone.io/).
 
 When an OpenAEV instance is registered with XTM One, XTM One automatically exposes an MCP server for it. AI clients connect to XTM One and work with your adversarial exposure validation content: scenarios, simulations, payloads, injects, atomic tests, expectations, findings and vulnerabilities.
 
@@ -25,7 +25,7 @@ OpenAEV   REST API (acting as the calling user)
 
 - The MCP endpoint is served by XTM One at `https://<your-xtm-one>/mcp/openaev` using the MCP Streamable HTTP transport.
 - Clients authenticate with a personal XTM One API key (`fcp-...`) or an OAuth 2.1 access token.
-- For every tool call, XTM One signs a short-lived token for the calling user (matched by email in OpenAEV), so all operations run with that user's permissions and audit trail. The OpenAEV API token is never stored in or proxied through XTM One.
+- For every tool call, XTM One signs a short-lived token for the calling user (matched by email in OpenAEV), so all operations run with that user's permissions and audit trail. No long-lived OpenAEV credential is ever stored in XTM One or exposed to the MCP client: the only secret the client holds is its XTM One API key, and OpenAEV verifies the short-lived tokens through the XTM One JWKS.
 
 ## Prerequisites
 

--- a/docs/docs/deployment/ecosystem/mcp-server.md
+++ b/docs/docs/deployment/ecosystem/mcp-server.md
@@ -87,4 +87,4 @@ Administrators can disable the MCP servers globally in XTM One under `Settings >
 
 !!! note "Full documentation"
 
-    The complete guide (tool reference, authentication details, troubleshooting) is available in the [XTM One documentation](https://docs.xtmone.io/latest/resources/platform-mcp-servers/).
+    For more details about MCP endpoints, API keys and platform administration, please refer to the [XTM One documentation](https://docs.xtmone.io/).

--- a/docs/docs/deployment/ecosystem/mcp-server.md
+++ b/docs/docs/deployment/ecosystem/mcp-server.md
@@ -1,0 +1,90 @@
+# MCP server
+
+## Introduction
+
+OpenAEV can be used from any [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) compatible client — Cursor, Claude Desktop, Claude Code, or custom AI agents — through the native MCP server embedded in [XTM One](https://docs.xtmone.io/).
+
+When an OpenAEV instance is registered with XTM One, XTM One automatically exposes an MCP server for it. AI clients connect to XTM One and work with your adversarial exposure validation content: scenarios, simulations, payloads, injects, atomic tests, expectations, findings and vulnerabilities.
+
+!!! note "Community feature"
+
+    The OpenAEV MCP server is available in the Community Edition of XTM One. There is nothing to install on the OpenAEV side: the server activates as soon as the platform is registered with XTM One.
+
+## Architecture
+
+```
+MCP client (Cursor, Claude Desktop, ...)
+        |  Streamable HTTP (JSON-RPC 2.0)
+        |  Authorization: Bearer <XTM One API key>
+        v
+XTM One   POST /mcp/openaev
+        |  short-lived per-user token (verified via JWKS)
+        v
+OpenAEV   REST API (acting as the calling user)
+```
+
+- The MCP endpoint is served by XTM One at `https://<your-xtm-one>/mcp/openaev` using the MCP Streamable HTTP transport.
+- Clients authenticate with a personal XTM One API key (`fcp-...`) or an OAuth 2.1 access token.
+- For every tool call, XTM One signs a short-lived token for the calling user (matched by email in OpenAEV), so all operations run with that user's permissions and audit trail. The OpenAEV API token is never stored in or proxied through XTM One.
+
+## Prerequisites
+
+1. A running XTM One instance.
+2. The OpenAEV platform registered with XTM One (the same registration that powers the embedded AI experience).
+3. A user account existing on both platforms with the same email address.
+4. A personal API key created in XTM One (`My Profile > API Keys`).
+
+## Capabilities
+
+The MCP server exposes the business and knowledge tool surface of OpenAEV:
+
+| Category | Examples |
+| -------- | -------- |
+| Search & read | full-text search, scenarios, simulations (exercises), payloads, injector contracts, findings, CVEs, assets, asset groups, teams, players, MITRE ATT&CK patterns, kill chain phases, tags |
+| Scenarios & simulations | create / update / launch scenarios, manage simulations, manage injects and expectations, scenario variables |
+| Testing & payloads | create and manage payloads, create / launch / relaunch atomic tests |
+| Findings & vulnerabilities | create and manage findings, manage vulnerabilities (CVE + CVSS) |
+| Assets & content | manage endpoints and asset groups, documents, media channels, articles, challenges |
+| Lessons & reports | lessons-learned templates and answers, simulation reports |
+
+Platform administration is deliberately out of scope: no user, group, role, organization, security platform, taxonomy, connector or platform settings management is available through the MCP server.
+
+## Client configuration
+
+In XTM One, open `My Profile > MCP Endpoint` to find the endpoint URL, the live connection status, and a ready-to-copy configuration. The configuration for Cursor (`.cursor/mcp.json`) or Claude Desktop (`claude_desktop_config.json`) looks like this:
+
+```json
+{
+  "mcpServers": {
+    "openaev": {
+      "url": "https://<your-xtm-one>/mcp/openaev",
+      "headers": {
+        "Authorization": "Bearer fcp-..."
+      }
+    }
+  }
+}
+```
+
+You can verify the connection from a terminal:
+
+```bash
+curl -s -X POST https://<your-xtm-one>/mcp/openaev \
+  -H "Authorization: Bearer fcp-..." \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
+```
+
+## Administration
+
+Administrators can disable the MCP servers globally in XTM One under `Settings > MCP Endpoint` (Platform MCP Servers toggle). When disabled, the endpoint returns `403` for all clients.
+
+| Response | Meaning |
+| -------- | ------- |
+| `401` | Missing or invalid API key / token |
+| `403` | The platform MCP servers are disabled in XTM One settings |
+| `404` | No OpenAEV platform is registered with XTM One |
+
+!!! note "Full documentation"
+
+    The complete guide (tool reference, authentication details, troubleshooting) is available in the [XTM One documentation](https://docs.xtmone.io/latest/resources/platform-mcp-servers/).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Executors: deployment/ecosystem/executors.md
       - Injectors: deployment/ecosystem/injectors.md
       - Collectors: deployment/ecosystem/collectors.md
+      - MCP server (via XTM One): deployment/ecosystem/mcp-server.md
       - Integration Manager:
           - Overview: deployment/ecosystem/integration-manager/overview.md
           - Quick start: deployment/ecosystem/integration-manager/quick-start.md


### PR DESCRIPTION
## Proposed changes

- Add a dedicated "MCP server" documentation page (Deployment & Setup > Ecosystem) describing how OpenAEV is accessible from any MCP-compatible AI client (Cursor, Claude Desktop, custom agents) through the native MCP server embedded in XTM One:
  - architecture (XTM One bridge at `POST /mcp/openaev`, Streamable HTTP, per-user short-lived tokens verified via JWKS, operations run as the calling user)
  - prerequisites (XTM One instance, platform registration, matching user email, personal API key)
  - capability surface (scenarios, simulations, payloads, injects, atomic tests, expectations, findings, vulnerabilities, assets, content, lessons, reports) and deliberate exclusions (no platform administration)
  - client configuration for Cursor / Claude Desktop plus a curl smoke test
  - administration (global toggle in XTM One settings) and error responses
- Add the page to the mkdocs navigation under Deployment & Setup > Ecosystem.

## Related issues

- Closes #6566
- Feature implemented in XTM-One-Platform/xtm-one#2062 (XTM-One-Platform/xtm-one#2061)

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the change (documentation-only; nav entry and links verified against the docs tree)
- [x] I added/updated the relevant documentation

## Further comments

Documentation-only PR. The MCP server itself lives in XTM One and requires no OpenAEV-side deployment; this page makes the capability discoverable for OpenAEV users and administrators.


## Review pass

- ddf6b1782: hyphenated MCP-compatible wording, and the authentication bullet rephrased so the short-lived signed token and the no-long-lived-credential guarantee no longer read as contradictory.