### PR TITLE
test: retry dummy PR for sync-status-on-merge testing (#6619)

### DIFF
--- a/.github/SCRATCH_TEST_SYNC_STATUS.md
+++ b/.github/SCRATCH_TEST_SYNC_STATUS.md
@@ -1,6 +1,5 @@
-# Disposable test file
+# Scratch test file
 
-This file exists only to open a throwaway PR used to manually test the
-`sync-status-on-merge` GitHub Action via `workflow_dispatch` (dry-run first).
-
-Safe to delete once the test is complete.
+Disposable file used to trigger a test PR for validating the
+`sync-status-on-merge` action against issue #6619 (retry after
+Projects org permission was added to the GitHub App).


### PR DESCRIPTION
⚠️ Disposable test PR — do not merge for real review, do not treat as a real change.

Retry of #6620, used to validate `sync-status-on-merge` action against the dummy test issue #6619 (`[TEST] for sync status`, labeled `feature-flag`) now that the `OPENAEV_PR_CHECKS_APP_ID` GitHub App has the `Projects: Read and write` organization permission.

To be closed and its branch deleted once the test is done.