### PR TITLE
test: dummy PR for sync-status-on-merge testing (#6619)

### DIFF
--- a/.github/TEST_SYNC_STATUS.md
+++ b/.github/TEST_SYNC_STATUS.md
@@ -1,5 +1,1 @@
-# Test file for sync-status-on-merge workflow
-
-This file is used to trigger a dummy PR for testing `.github/workflows/sync-status-on-merge.yml`.
-
-Test run: v5 - checking Issues permission (addLabelsToLabelable / closeIssue) after App permission update.
+Test file for sync-status-on-merge workflow validation (v6).


### PR DESCRIPTION
Retest v6 — validates the `|| true` fix (commit cff7ecff) for the silent grep failure when no issue reference is found. Title format intentionally kept as `(#6619)` at the very end, no trailing suffix.