### PR TITLE
fix(telemetry): exclude placeholder dummy injectors from deployed inventory metric (#6632)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
+++ b/openaev-api/src/main/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollector.java
@@ -1,5 +1,6 @@
 package io.openaev.telemetry.metric_collectors;
 
+import static io.openaev.service.InjectorService.DUMMY_SUFFIX;
 import static io.opentelemetry.api.common.AttributeKey.booleanKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
@@ -72,6 +73,11 @@ public class InventoryMetricCollector {
       for (BaseConnectorEntity entity : entitiesSupplier.get()) {
         String type = entity.getType() == null ? "" : entity.getType().trim();
         if (type.isEmpty()) {
+          continue;
+        }
+        // Placeholder injectors created by the starter-pack import (before the real
+        // injector registers) are not deployed components; keep them out of the inventory.
+        if (type.endsWith(DUMMY_SUFFIX)) {
           continue;
         }
         CatalogConnector catalogConnector = catalogByConnectorId.get(entity.getId());

--- a/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/telemetry/metric_collectors/InventoryMetricCollectorTest.java
@@ -150,6 +150,33 @@ class InventoryMetricCollectorTest {
   }
 
   @Test
+  @DisplayName("given a placeholder dummy injector should exclude it from the inventory")
+  void given_placeholderDummyInjector_should_excludeItFromInventory() {
+    // Arrange: dummy injectors are created by the starter-pack import before the real
+    // injector registers; they are not deployed components.
+    when(injectorRepository.findAll())
+        .thenReturn(
+            List.of(
+                injector("openaev_nmap_dummy_tenant-1", "openaev_nmap_dummy"),
+                injector("injector-1", "openaev_email")));
+    when(connectorInstanceRepository.findAllByCatalogConnectorContainerType(ConnectorType.INJECTOR))
+        .thenReturn(List.of());
+
+    // Act
+    Map<Attributes, Long> inventory = capturedInjectorSupplier().get();
+
+    // Assert
+    assertThat(inventory)
+        .containsExactly(
+            Map.entry(
+                Attributes.of(
+                    stringKey("slug"), "openaev_email",
+                    booleanKey("managed"), false,
+                    stringKey("type"), "openaev_email"),
+                1L));
+  }
+
+  @Test
   @DisplayName("given a blank type should skip the component even when catalog-managed")
   void given_blankType_should_skipComponentEvenWhenManaged() {
     // Arrange


### PR DESCRIPTION
## Summary

- Excludes placeholder `_dummy` injectors from the `injectors_deployed_by_identity` telemetry metric collected by `InventoryMetricCollector`.
- These placeholders are created by `InjectorService.createOrGetDummyInjector()` when a starter pack is imported before the real external injectors (nmap, nuclei, ...) have registered. On instances where the real injector is never deployed, the placeholder row stays in the `injectors` table forever and was reported as a deployed injector (e.g. `openaev_nmap_dummy` / `openaev_nuclei_dummy` on telemetry dashboards).
- Adds a unit test covering the exclusion.

Closes #6632

## Test plan

- [x] `InventoryMetricCollectorTest` passes (9 tests, including the new dummy-exclusion case)
- [x] `mvn clean install -DskipTests -Pdev` builds successfully
- [x] `mvn spotless:apply` produces no extra changes
