### PR TITLE
test: dummy PR for sync-status-on-merge testing v8 (#6619)

### DIFF
--- a/.github/test-fixtures/sync-status-test-v8.md
+++ b/.github/test-fixtures/sync-status-test-v8.md
@@ -1,0 +1,5 @@
+# Test fixture
+
+Dummy file for testing workflow "[OpenAEV] Sync Project Status on PR Merge" — use case: `In review` + `feature-flag` label present (issue #6619).
+
+Expected result: Project status moves from `In review` to `Test PO main-ff`, issue stays open, no `solved` label added.


### PR DESCRIPTION
Test use case: `In review` + `feature-flag` label present on issue #6619.

Expected: Status → `Test PO main-ff`, issue stays open, no `solved` label.