### PR TITLE
test(sync-status): re-test in-review + feature-flag (#6619)

### DIFF
--- a/.github/test-fictive-status-sync-6619-v10.md
+++ b/.github/test-fictive-status-sync-6619-v10.md
@@ -1,0 +1,7 @@
+# Fictive test file
+
+Used to trigger the `sync-status-on-merge` workflow for test case:
+- Status: "In review"
+- Label: `feature-flag` present on the linked issue
+
+Related issue: #6619 (this file will be removed after testing).


### PR DESCRIPTION
Fictive test PR to re-trigger `sync-status-on-merge` for the case:
- Status: "In review"
- Label: `feature-flag` present

Related to #6619 (test issue, to be deleted after testing).