### PR TITLE
test(sync-status): re-test ready-to-merge no-ff (#6619)

### DIFF
--- a/.github/actions/sync-status-on-merge/TEST_NOTES.md
+++ b/.github/actions/sync-status-on-merge/TEST_NOTES.md
@@ -1,0 +1,4 @@
+# Test run log
+
+- Test case: "Ready to merge" status, no `feature-flag` label, targeting issue #6619
+- Expected: status -> "Final product validation", issue closed, label "solved" added, milestone "0. Candidate" assigned if found (warning + skip otherwise, no failure)


### PR DESCRIPTION
Test case: issue #6619, status "Ready to merge", no `feature-flag` label.

Expected on merge: status -> "Final product validation", issue closed, label "solved" added, milestone "0. Candidate" assigned if found (warning + skip otherwise).