### PR TITLE
fix(api): increment simulation created telemetry when creating simulation from scenario (#6677)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/ScenarioToExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/service/ScenarioToExerciseService.java
@@ -11,6 +11,7 @@ import io.openaev.injectors.channel.ChannelContract;
 import io.openaev.injectors.channel.model.ChannelContent;
 import io.openaev.rest.custom_dashboard.CustomDashboardService;
 import io.openaev.service.settings.TenantSettingsService;
+import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.utils.CopyObjectListUtils;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.Resource;
@@ -43,6 +44,7 @@ public class ScenarioToExerciseService {
   private final GrantService grantService;
   private final TenantSettingsService tenantSettingsService;
   private final CustomDashboardService customDashboardService;
+  private final ActionMetricCollector actionMetricCollector;
   @Resource protected ObjectMapper mapper;
 
   @Transactional(rollbackFor = Exception.class)
@@ -82,6 +84,7 @@ public class ScenarioToExerciseService {
             .orElse(null));
 
     Exercise exerciseSaved = this.exerciseRepository.save(exercise);
+    this.actionMetricCollector.addSimulationCreatedCount();
 
     // Grants
     List<Grant> exerciseGrants =

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioToExerciseServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioToExerciseServiceTest.java
@@ -11,6 +11,8 @@ import static io.openaev.utils.fixtures.TagFixture.getTagNoId;
 import static io.openaev.utils.fixtures.TeamFixture.getTeam;
 import static io.openaev.utils.fixtures.UserFixture.getUser;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
 
 import io.openaev.IntegrationTest;
 import io.openaev.context.TenantContext;
@@ -19,6 +21,7 @@ import io.openaev.database.repository.*;
 import io.openaev.service.LoadService;
 import io.openaev.service.ScenarioToExerciseService;
 import io.openaev.service.scenario.ScenarioService;
+import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.utils.fixtures.InjectorContractFixture;
 import io.openaev.utils.fixtures.ScenarioFixture;
 import io.openaev.utilstest.RabbitMQTestListener;
@@ -58,6 +61,7 @@ class ScenarioToExerciseServiceTest extends IntegrationTest {
   @Autowired private SettingRepository settingRepository;
   @Autowired private CustomDashboardRepository customDashboardRepository;
   @Autowired private InjectorContractFixture injectorContractFixture;
+  @Autowired private ActionMetricCollector actionMetricCollector;
 
   @DisplayName("Scenario to Exercise test")
   @Test
@@ -226,6 +230,7 @@ class ScenarioToExerciseServiceTest extends IntegrationTest {
                   return s;
                 }));
     // -- EXECUTE --
+    clearInvocations(actionMetricCollector);
     Exercise exercise = this.scenarioToExerciseService.toExercise(scenario, null, false);
     String exerciseId = exercise.getId();
     entityManager.flush();
@@ -235,6 +240,8 @@ class ScenarioToExerciseServiceTest extends IntegrationTest {
     // -- ASSERT --
     assertNotNull(exerciseSaved);
     assertEquals(name, exerciseSaved.getName());
+    // Telemetry
+    verify(actionMetricCollector).addSimulationCreatedCount();
     // User & Teams
     assertEquals(2, (long) exerciseSaved.getTeams().size());
     assertTrue(


### PR DESCRIPTION
## Summary

- Simulations created from a scenario (both the scheduled/recurring path via `ScenarioExecutionJob` and the manual launch path via `ScenarioApi`) never incremented the `simulations_created_count` telemetry counter, so platforms relying on scheduled scenarios reported 0 simulation creations.
- `ScenarioToExerciseService.toExercise` now calls `ActionMetricCollector.addSimulationCreatedCount()` right after saving the new simulation, aligning it with the other creation paths (`ExerciseService.createExercise`, duplication, import).
- Added a regression assertion in `ScenarioToExerciseServiceTest` verifying that the conversion increments the counter exactly once.

## Design notes

- The increment is intentionally inline (not an `afterCommit` hook): all other simulation-creation paths increment the same way inside their transactions, and the counter is a best-effort in-memory gauge that is read-and-reset on each telemetry scrape. See the resolved review thread for details.

## Test plan

- [x] `ScenarioToExerciseServiceTest` verifies `simulations_created_count` is incremented once by the scenario-to-simulation conversion (covers both the scheduler path and the manual launch path, which share `toExercise`)
- [x] Existing paths (manual simulation creation, duplication, import) still increment the counter once each (unchanged call sites)

Closes #6677
