### PR TITLE
feat(chaining): attack path finding widgets and findings drawer

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
@@ -14,10 +14,12 @@ import io.openaev.service.attackpath.AttackPathSeedService;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
 import io.openaev.service.attackpath.dto.AttackPathEndpointRelationsDTO;
 import io.openaev.service.attackpath.dto.AttackPathExpandDTO;
+import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
 import io.openaev.service.attackpath.dto.AttackPathSeedInput;
 import io.openaev.service.attackpath.dto.AttackPathSeedResultDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,6 +49,9 @@ import org.springframework.web.server.ResponseStatusException;
 public class AttackPathApi extends RestBehavior {
 
   public static final String ATTACK_PATH_URI = "/api/attack-path";
+
+  /** Upper bound on the findings page size, so a client cannot request an unbounded read. */
+  private static final int MAX_FINDINGS_PAGE_SIZE = 200;
 
   private final AttackPathGraphService graphService;
   private final AttackPathSeedService seedService;
@@ -112,6 +117,28 @@ public class AttackPathApi extends RestBehavior {
       TxCtx ctx, @PathVariable String simulationId, @RequestParam String ref) {
     requireAttackPathFeature();
     return graphService.endpointRelations(simulationId, ref);
+  }
+
+  /**
+   * A page of a widget category's findings for the drawer (issue 5048, US5). {@code category} is
+   * one of {@code credentials|users|files|cves}; an unknown category returns an empty page. The
+   * page is size-capped ({@value #MAX_FINDINGS_PAGE_SIZE}) so a client cannot request an unbounded
+   * read. Each item carries the endpoint's map node id and its producing execution ids for the
+   * front's cross-focus. Tenant-scoped through the {@link TxCtx} like every other read.
+   */
+  @GetMapping("/simulations/{simulationId}/findings")
+  @Transactional(readOnly = true)
+  @AccessControl(skipRBAC = true)
+  public AttackPathFindingPageDTO findings(
+      TxCtx ctx,
+      @PathVariable String simulationId,
+      @RequestParam String category,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "50") int size) {
+    requireAttackPathFeature();
+    int safePage = Math.max(page, 0);
+    int safeSize = Math.min(Math.max(size, 1), MAX_FINDINGS_PAGE_SIZE);
+    return graphService.listFindings(simulationId, category, PageRequest.of(safePage, safeSize));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -552,6 +552,9 @@ public class AttackPathGraphService {
     AttackPathNodeDTO node = new AttackPathNodeDTO();
     node.setId(AttackPathIds.executionNode(e.id(), e.targetKey(), e.agentId()));
     node.setType(TYPE_EXECUTION);
+    // The raw execution id, so a findings drawer item can match and highlight its producing
+    // executions in the feed (US5 cross-focus); the map node id above is not the raw id.
+    node.setRef(e.id());
     node.setLabel(e.payloadName());
     node.setStatus(severity(e.preventionStatus(), e.detectionStatus()));
     node.setPayloadName(e.payloadName());

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -5,6 +5,8 @@ import io.openaev.database.model.attackpath.projection.AttackPathEndpointFinding
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointGroupRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointTypeCountRow;
 import io.openaev.database.model.attackpath.projection.AttackPathExecutionRow;
+import io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow;
+import io.openaev.database.model.attackpath.projection.AttackPathFindingListRow;
 import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
 import io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow;
 import io.openaev.database.model.attackpath.projection.AttackPathTypeCountRow;
@@ -16,6 +18,8 @@ import io.openaev.service.attackpath.dto.AttackPathDTO;
 import io.openaev.service.attackpath.dto.AttackPathEdges;
 import io.openaev.service.attackpath.dto.AttackPathEndpointRelationsDTO;
 import io.openaev.service.attackpath.dto.AttackPathExpandDTO;
+import io.openaev.service.attackpath.dto.AttackPathFindingItemDTO;
+import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -23,11 +27,14 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,6 +70,8 @@ public class AttackPathGraphService {
   private static final String GREEN = "GREEN";
   private static final String ORANGE = "ORANGE";
   private static final String RED = "RED";
+
+  private static final String CATEGORY_CREDENTIALS = "credentials";
 
   private final AttackPathExecutionRepository executionRepository;
   private final AttackPathFindingRepository findingRepository;
@@ -103,6 +112,84 @@ public class AttackPathGraphService {
   @Transactional(readOnly = true)
   public List<AttackPathSimSummaryRow> listSimulations() {
     return executionRepository.findSimulationSummaries();
+  }
+
+  /**
+   * A page of a widget category's findings for the drawer (issue 5048, US5). Reads the page of
+   * findings of the category's types (restricted to those a producing execution links to, the same
+   * invariant as the graph reads), then attaches each finding's producing-execution ids and its
+   * endpoint's map node id for cross-focus, and masks the value for the credentials category (a
+   * credential value never leaves the server in the clear). An unknown category yields an empty
+   * page.
+   */
+  @Transactional(readOnly = true)
+  public AttackPathFindingPageDTO listFindings(
+      String simulationId, String category, Pageable pageable) {
+    Set<String> types = categoryTypes(category);
+    if (types.isEmpty()) {
+      return new AttackPathFindingPageDTO(List.of(), 0);
+    }
+    Page<AttackPathFindingListRow> page =
+        findingRepository.findPageByTypes(simulationId, types, pageable);
+    List<AttackPathFindingListRow> rows = page.getContent();
+    Map<String, List<String>> executionIdsByFinding = executionIdsByFinding(rows);
+    boolean maskValue = CATEGORY_CREDENTIALS.equalsIgnoreCase(category);
+    List<AttackPathFindingItemDTO> items =
+        rows.stream()
+            .map(
+                r ->
+                    new AttackPathFindingItemDTO(
+                        r.type(),
+                        maskValue ? maskCredential(r.value()) : r.value(),
+                        r.endpointKey(),
+                        AttackPathIds.endpointNode(r.endpointKey()),
+                        executionIdsByFinding.getOrDefault(r.id(), List.of())))
+            .toList();
+    return new AttackPathFindingPageDTO(items, page.getTotalElements());
+  }
+
+  /**
+   * The producing-execution ids per finding for a page of rows, from a single link read. The
+   * finding ids come from a tenant-scoped page, so the read is already bounded to the tenant.
+   */
+  private Map<String, List<String>> executionIdsByFinding(List<AttackPathFindingListRow> rows) {
+    if (rows.isEmpty()) {
+      return Map.of();
+    }
+    List<String> findingIds = rows.stream().map(AttackPathFindingListRow::id).toList();
+    Map<String, List<String>> byFinding = new LinkedHashMap<>();
+    for (AttackPathFindingExecutionRow link : findingRepository.findExecutionLinks(findingIds)) {
+      byFinding.computeIfAbsent(link.findingId(), k -> new ArrayList<>()).add(link.executionId());
+    }
+    return byFinding;
+  }
+
+  /**
+   * The finding types each product widget aggregates (spec 5048 US5 section 2:
+   * Files/Credentials/Users/CVEs; Endpoints is a separate endpoint-group read, not a finding type).
+   * {@code port} is a graph finding type but not a product widget, so it has no category here;
+   * {@code file} has no seed finding type yet (an open question), so the files drawer is empty
+   * until ingestion produces one. An unknown category yields no types (an empty page).
+   */
+  private static Set<String> categoryTypes(String category) {
+    if (category == null) {
+      return Set.of();
+    }
+    return switch (category.toLowerCase(Locale.ROOT)) {
+      case CATEGORY_CREDENTIALS -> Set.of("credentials");
+      case "users" -> Set.of("username", "admin_username");
+      case "cves" -> Set.of("cve");
+      case "files" -> Set.of("file");
+      default -> Set.of();
+    };
+  }
+
+  /** Masks a credential value, keeping only its first two characters. */
+  private static String maskCredential(String value) {
+    if (value == null || value.length() <= 2) {
+      return "**";
+    }
+    return value.substring(0, 2) + "*".repeat(value.length() - 2);
   }
 
   @Transactional(readOnly = true)

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -72,6 +72,7 @@ public class AttackPathGraphService {
   private static final String RED = "RED";
 
   private static final String CATEGORY_CREDENTIALS = "credentials";
+  private static final String CREDENTIAL_MASK = "••••";
 
   private final AttackPathExecutionRepository executionRepository;
   private final AttackPathFindingRepository findingRepository;
@@ -184,12 +185,20 @@ public class AttackPathGraphService {
     };
   }
 
-  /** Masks a credential value, keeping only its first two characters. */
+  /**
+   * Masks a credential for the drawer: for a {@code username:password} pair, keep the username and
+   * mask only the secret; otherwise mask the whole value. The mask is fixed-length so it never
+   * reveals the secret's length, and the clear secret never leaves the server.
+   */
   private static String maskCredential(String value) {
-    if (value == null || value.length() <= 2) {
-      return "**";
+    if (value == null || value.isEmpty()) {
+      return value;
     }
-    return value.substring(0, 2) + "*".repeat(value.length() - 2);
+    int separator = value.indexOf(':');
+    if (separator >= 0) {
+      return value.substring(0, separator + 1) + CREDENTIAL_MASK;
+    }
+    return CREDENTIAL_MASK;
   }
 
   @Transactional(readOnly = true)

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathSeedService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathSeedService.java
@@ -62,6 +62,9 @@ public class AttackPathSeedService {
   private static final Instant BASE_TIME = Instant.parse("2026-01-01T00:00:00Z");
 
   private static final String[] FINDING_TYPES = {"credentials", "username", "cve", "port"};
+  private static final String[] CREDENTIAL_USERS = {
+    "administrator", "svc-sql", "jdoe", "root", "backup-svc", "web-app"
+  };
   private static final String[] PLATFORMS = {"Windows", "Linux", "MacOS"};
   private static final String[] PRIVILEGES = {"user", "admin", "system"};
   private static final String[] INJECTORS = {
@@ -311,8 +314,19 @@ public class AttackPathSeedService {
       return pool.get(random.nextInt(pool.size()));
     }
     String type = FINDING_TYPES[random.nextInt(FINDING_TYPES.length)];
-    FindingKind kind =
-        new FindingKind(type, type + "-" + simulationId + "-" + endpoint.key() + "-" + index);
+    // Credentials look like a realistic username:secret pair so the drawer's server-side masking
+    // (keep the username, hide the secret) is meaningful; the secret keeps the value unique.
+    String value =
+        "credentials".equals(type)
+            ? CREDENTIAL_USERS[Math.floorMod(index, CREDENTIAL_USERS.length)]
+                + ":pwd-"
+                + simulationId
+                + "-"
+                + endpoint.key()
+                + "-"
+                + index
+            : type + "-" + simulationId + "-" + endpoint.key() + "-" + index;
+    FindingKind kind = new FindingKind(type, value);
     pool.add(kind);
     return kind;
   }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingItemDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingItemDTO.java
@@ -1,0 +1,17 @@
+package io.openaev.service.attackpath.dto;
+
+import java.util.List;
+
+/**
+ * One row of a finding-widget drawer (issue 5048, US5): a finding on an endpoint, with the
+ * producing execution ids so the front can cross-focus the map edge and the execution feed. {@code
+ * value} is masked server-side for the credentials category. {@code endpointNodeId} is the
+ * deterministic map node id of the endpoint (from {@code AttackPathIds}), so the front can centre
+ * and highlight it.
+ */
+public record AttackPathFindingItemDTO(
+    String type,
+    String value,
+    String endpointKey,
+    String endpointNodeId,
+    List<String> executionIds) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingPageDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingPageDTO.java
@@ -1,0 +1,9 @@
+package io.openaev.service.attackpath.dto;
+
+import java.util.List;
+
+/**
+ * A page of finding-widget drawer rows (issue 5048, US5): the items for the current page and the
+ * total count across the simulation, so the drawer can show a count and paginate on scroll.
+ */
+public record AttackPathFindingPageDTO(List<AttackPathFindingItemDTO> items, long total) {}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiDisabledTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiDisabledTest.java
@@ -26,4 +26,13 @@ class AttackPathApiDisabledTest extends IntegrationTest {
     mvc.perform(get(AttackPathApi.ATTACK_PATH_URI + "/simulations/any/graph"))
         .andExpect(status().isNotFound());
   }
+
+  @Test
+  @DisplayName("The findings endpoint returns 404 when the attack-path preview feature is off")
+  void findings_endpoint_is_404_when_feature_off() throws Exception {
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/any/findings")
+                .param("category", "credentials"))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiTest.java
@@ -1,6 +1,8 @@
 package io.openaev.api.attackpath;
 
 import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -167,6 +169,52 @@ class AttackPathApiTest extends IntegrationTest {
         .andExpect(jsonPath("$[0].simulationId").value("SIM-LIST"))
         .andExpect(jsonPath("$[0].endpointCount").value(1))
         .andExpect(jsonPath("$[0].executionCount").value(1));
+  }
+
+  @Test
+  @DisplayName("GET /simulations/{id}/findings?category=credentials returns a masked, paged list")
+  void findings_endpoint_returns_masked_page() throws Exception {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-findings-api"));
+    String sim = "SIM-FINDINGS-API";
+
+    AttackPathExecution execution = new AttackPathExecution();
+    execution.setTenant(tenant);
+    execution.setSimulationId(sim);
+    execution.setSourceKind("INJECTOR");
+    execution.setSourceInjector("nmap");
+    execution.setTargetKind("ASSET");
+    execution.setTargetAssetId("dc-01");
+    execution.setTargetKey("dc-01");
+    execution.setExecutedAt(Instant.parse("2026-06-18T08:00:00Z"));
+    execution.setPreventionStatus("Prevented");
+    execution = executionRepository.save(execution);
+
+    AttackPathFinding finding = new AttackPathFinding();
+    finding.setTenant(tenant);
+    finding.setSimulationId(sim);
+    finding.setType("credentials");
+    finding.setValue("admin:secret");
+    finding.setEndpointId("dc-01");
+    finding.setEndpointKey("dc-01");
+    finding = findingRepository.save(finding);
+
+    AttackPathExecutionFinding link = new AttackPathExecutionFinding();
+    link.setExecutionId(execution.getId());
+    link.setFindingId(finding.getId());
+    entityManager.persist(link);
+    entityManager.flush();
+
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + sim + "/findings")
+                .param("category", "credentials")
+                .param("page", "0")
+                .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.items[0].type").value("credentials"))
+        .andExpect(jsonPath("$.items[0].value", not(containsString("secret"))))
+        .andExpect(jsonPath("$.items[0].endpointKey").value("dc-01"))
+        .andExpect(jsonPath("$.items[0].executionIds").isNotEmpty());
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
@@ -1,0 +1,158 @@
+package io.openaev.api.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
+import io.openaev.database.model.attackpath.AttackPathFinding;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
+import io.openaev.service.attackpath.AttackPathGraphService;
+import io.openaev.service.attackpath.AttackPathIds;
+import io.openaev.service.attackpath.dto.AttackPathFindingItemDTO;
+import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The finding-widget drawer read (issue 5048, US5). Listing a widget category's findings for a
+ * simulation returns one item per (value, endpoint) with the producing execution ids (for the
+ * cross-focus) and the resolved endpoint node id; it excludes orphan findings (the CF1 invariant),
+ * filters by the category's finding types, and masks credential values server-side.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("attack path finding-widget drawer list read")
+class AttackPathFindingsListTest extends IntegrationTest {
+
+  private static final String SIM = "SIM-FINDINGS";
+
+  @Autowired private AttackPathGraphService graphService;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+  @Autowired private AttackPathFindingRepository findingRepository;
+
+  private Tenant tenant;
+  private String executionId;
+
+  @BeforeEach
+  void seed() {
+    tenant = tenantRepository.save(TenantFixture.getTenant("ap-findings-tenant"));
+    executionId = execution("nmap", "host-x");
+    // A credentials finding produced by the execution, a cve produced too, and an orphan credential
+    // with no producing execution (must be excluded).
+    linkedFinding("host-x", "credentials", "admin:secret", executionId);
+    linkedFinding("host-x", "cve", "CVE-2026-1", executionId);
+    orphanFinding("host-x", "credentials", "orphan:nolink");
+    entityManager.flush();
+  }
+
+  @Test
+  @DisplayName("credentials category: one masked item, orphan and other types excluded")
+  void listsCredentialsMaskedAndExcludesOrphanAndOtherTypes() {
+    AttackPathFindingPageDTO page =
+        graphService.listFindings(SIM, "credentials", PageRequest.of(0, 10));
+
+    assertThat(page.total()).as("only the linked credential; orphan and cve excluded").isEqualTo(1);
+    assertThat(page.items()).hasSize(1);
+
+    AttackPathFindingItemDTO item = page.items().get(0);
+    assertThat(item.type()).isEqualTo("credentials");
+    assertThat(item.value())
+        .as("credential value is masked server-side")
+        .doesNotContain("secret")
+        .startsWith("ad");
+    assertThat(item.endpointKey()).isEqualTo("host-x");
+    assertThat(item.endpointNodeId()).isEqualTo(AttackPathIds.endpointNode("host-x"));
+    assertThat(item.executionIds())
+        .as("the producing execution, for the cross-focus")
+        .containsExactly(executionId);
+  }
+
+  @Test
+  @DisplayName("cve category: one item, value not masked")
+  void listsCvesUnmasked() {
+    AttackPathFindingPageDTO page = graphService.listFindings(SIM, "cves", PageRequest.of(0, 10));
+
+    assertThat(page.total()).isEqualTo(1);
+    assertThat(page.items().get(0).type()).isEqualTo("cve");
+    assertThat(page.items().get(0).value()).as("cve value is not masked").isEqualTo("CVE-2026-1");
+  }
+
+  @Test
+  @DisplayName("a value shared across endpoints is one item per endpoint")
+  void sharedValueAcrossEndpointsYieldsOneItemPerEndpoint() {
+    // The same credential discovered on a second endpoint: two drawer items (one per endpoint), not
+    // one collapsed item, so the drawer shows where each was found. Its own producing execution.
+    String execYId = execution("nmap", "host-y");
+    linkedFinding("host-y", "credentials", "admin:secret", execYId);
+    entityManager.flush();
+
+    AttackPathFindingPageDTO page =
+        graphService.listFindings(SIM, "credentials", PageRequest.of(0, 10));
+
+    assertThat(page.total()).as("the shared credential is one item per endpoint").isEqualTo(2);
+    assertThat(page.items())
+        .extracting(AttackPathFindingItemDTO::endpointNodeId)
+        .containsExactlyInAnyOrder(
+            AttackPathIds.endpointNode("host-x"), AttackPathIds.endpointNode("host-y"));
+    assertThat(page.items())
+        .allSatisfy(i -> assertThat(i.value()).doesNotContain("secret").startsWith("ad"));
+  }
+
+  @Test
+  @DisplayName("an unknown category (e.g. ports, not a product widget) yields an empty page")
+  void unknownCategoryYieldsEmptyPage() {
+    AttackPathFindingPageDTO page = graphService.listFindings(SIM, "ports", PageRequest.of(0, 10));
+
+    assertThat(page.total()).isZero();
+    assertThat(page.items()).isEmpty();
+  }
+
+  private String execution(String injector, String endpoint) {
+    AttackPathExecution e = new AttackPathExecution();
+    e.setTenant(tenant);
+    e.setSimulationId(SIM);
+    e.setSourceKind("INJECTOR");
+    e.setSourceInjector(injector);
+    e.setTargetKind("ASSET");
+    e.setTargetAssetId(endpoint);
+    e.setTargetKey(endpoint);
+    e.setTargetHostname(endpoint);
+    e.setExecutedAt(Instant.parse("2026-06-18T08:00:00Z"));
+    e.setPreventionStatus("Prevented");
+    e.setDetectionStatus("Not Detected");
+    return executionRepository.save(e).getId();
+  }
+
+  private void linkedFinding(String endpoint, String type, String value, String execId) {
+    String findingId = saveFinding(endpoint, type, value);
+    AttackPathExecutionFinding link = new AttackPathExecutionFinding();
+    link.setExecutionId(execId);
+    link.setFindingId(findingId);
+    entityManager.persist(link);
+  }
+
+  private void orphanFinding(String endpoint, String type, String value) {
+    saveFinding(endpoint, type, value);
+  }
+
+  private String saveFinding(String endpoint, String type, String value) {
+    AttackPathFinding f = new AttackPathFinding();
+    f.setTenant(tenant);
+    f.setSimulationId(SIM);
+    f.setType(type);
+    f.setValue(value);
+    f.setEndpointId(endpoint);
+    f.setEndpointKey(endpoint);
+    return findingRepository.save(f).getId();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
@@ -67,9 +67,9 @@ class AttackPathFindingsListTest extends IntegrationTest {
     AttackPathFindingItemDTO item = page.items().get(0);
     assertThat(item.type()).isEqualTo("credentials");
     assertThat(item.value())
-        .as("credential value is masked server-side")
-        .doesNotContain("secret")
-        .startsWith("ad");
+        .as("the username is kept, the secret is masked, server-side")
+        .startsWith("admin:")
+        .doesNotContain("secret");
     assertThat(item.endpointKey()).isEqualTo("host-x");
     assertThat(item.endpointNodeId()).isEqualTo(AttackPathIds.endpointNode("host-x"));
     assertThat(item.executionIds())
@@ -105,7 +105,7 @@ class AttackPathFindingsListTest extends IntegrationTest {
         .containsExactlyInAnyOrder(
             AttackPathIds.endpointNode("host-x"), AttackPathIds.endpointNode("host-y"));
     assertThat(page.items())
-        .allSatisfy(i -> assertThat(i.value()).doesNotContain("secret").startsWith("ad"));
+        .allSatisfy(i -> assertThat(i.value()).startsWith("admin:").doesNotContain("secret"));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
@@ -117,6 +117,34 @@ class AttackPathFindingsListTest extends IntegrationTest {
     assertThat(page.items()).isEmpty();
   }
 
+  @Test
+  @DisplayName("pagination is stable: pages are ordered by endpoint and do not overlap")
+  void paginationIsStableAndOrdered() {
+    // host-a and host-b in addition to seed()'s host-x credential: three credentials across
+    // endpoints.
+    String execA = execution("nmap", "host-a");
+    String execB = execution("nmap", "host-b");
+    linkedFinding("host-a", "credentials", "aaa:1", execA);
+    linkedFinding("host-b", "credentials", "bbb:2", execB);
+    entityManager.flush();
+
+    AttackPathFindingPageDTO p0 =
+        graphService.listFindings(SIM, "credentials", PageRequest.of(0, 1));
+    AttackPathFindingPageDTO p1 =
+        graphService.listFindings(SIM, "credentials", PageRequest.of(1, 1));
+
+    assertThat(p0.total()).as("count is across all pages").isEqualTo(3);
+    assertThat(p0.items())
+        .singleElement()
+        .extracting(AttackPathFindingItemDTO::endpointKey)
+        .isEqualTo("host-a");
+    assertThat(p1.items())
+        .as("the next page is the next endpoint, no overlap")
+        .singleElement()
+        .extracting(AttackPathFindingItemDTO::endpointKey)
+        .isEqualTo("host-b");
+  }
+
   private String execution(String injector, String endpoint) {
     AttackPathExecution e = new AttackPathExecution();
     e.setTenant(tenant);

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathHttpIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathHttpIsolationTest.java
@@ -52,6 +52,8 @@ class AttackPathHttpIsolationTest extends IntegrationTest {
   private static final String RELATIONS =
       "/api/tenants/{tenantId}/attack-path/simulations/{simulationId}/endpoint/relations";
   private static final String LIST = "/api/tenants/{tenantId}/attack-path/simulations";
+  private static final String FINDINGS =
+      "/api/tenants/{tenantId}/attack-path/simulations/{simulationId}/findings";
 
   @Autowired private MockMvc mvc;
   @Autowired private TenantIsolationTestHelper tenantHelper;
@@ -143,6 +145,24 @@ class AttackPathHttpIsolationTest extends IntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.executions").isEmpty())
         .andExpect(jsonPath("$.edges").isEmpty());
+  }
+
+  @Test
+  @DisplayName("under the owner tenant's path: the findings list returns the category's findings")
+  void findingsUnderOwnerTenantIsVisible() throws Exception {
+    mvc.perform(get(FINDINGS, tenantA, SIM).param("category", "credentials"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(1))
+        .andExpect(jsonPath("$.items").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("under another tenant's path: the findings list is empty (no leak)")
+  void findingsUnderOtherTenantIsHidden() throws Exception {
+    mvc.perform(get(FINDINGS, tenantB, SIM).param("category", "credentials"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.total").value(0))
+        .andExpect(jsonPath("$.items").isEmpty());
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
@@ -150,6 +150,9 @@ class AttackPathGraphServiceTest extends IntegrationTest {
             .orElseThrow();
     assertThat(feedNode.getFindingsNodeIds())
         .containsExactly(AttackPathIds.findingNode("credentials", "admin:secret"));
+    assertThat(feedNode.getRef())
+        .as("the feed node carries the raw execution id for the drawer cross-focus")
+        .isEqualTo(exec1Id);
   }
 
   @Test

--- a/openaev-front/src/__tests__/actions/attack-path/attack-path-actions.test.ts
+++ b/openaev-front/src/__tests__/actions/attack-path/attack-path-actions.test.ts
@@ -41,4 +41,16 @@ describe('attack path POC actions', () => {
     await fetchAttackPathSimulations();
     expect(simpleCall).toHaveBeenCalledWith('/api/attack-path/simulations');
   });
+
+  it('fetchFindingsByCategory builds the paginated findings query with defaults', async () => {
+    const { fetchFindingsByCategory } = await importActions();
+    await fetchFindingsByCategory('SIM-1', 'credentials');
+    expect(simpleCall).toHaveBeenCalledWith('/api/attack-path/simulations/SIM-1/findings?category=credentials&page=0&size=50');
+  });
+
+  it('fetchFindingsByCategory forwards the page and size and encodes the category', async () => {
+    const { fetchFindingsByCategory } = await importActions();
+    await fetchFindingsByCategory('SIM-1', 'cves', 2, 25);
+    expect(simpleCall).toHaveBeenCalledWith('/api/attack-path/simulations/SIM-1/findings?category=cves&page=2&size=25');
+  });
 });

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -1,0 +1,136 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import type * as ReactRouter from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import SimulationAttackPath from '../../../../../../admin/components/simulations/simulation/attack_path/SimulationAttackPath';
+
+// Capture the props AttackPathFlow receives (mocked so ReactFlow is not instantiated), and stub the
+// action layer + i18n + router so the test drives only the drawer and the cross-focus wiring.
+const mocks = vi.hoisted(() => ({
+  fetchAttackPathGraph: vi.fn(),
+  fetchAttackPathSimulations: vi.fn(),
+  fetchEndpointFindings: vi.fn(),
+  fetchEndpointRelations: vi.fn(),
+  fetchFindingsByCategory: vi.fn(),
+  flowProps: { current: null as { focusRequest?: { nodeId: string } } | null },
+}));
+
+vi.mock('../../../../../../actions/attack-path/attack-path-actions', () => ({
+  fetchAttackPathGraph: mocks.fetchAttackPathGraph,
+  fetchAttackPathSimulations: mocks.fetchAttackPathSimulations,
+  fetchEndpointFindings: mocks.fetchEndpointFindings,
+  fetchEndpointRelations: mocks.fetchEndpointRelations,
+  fetchFindingsByCategory: mocks.fetchFindingsByCategory,
+}));
+
+vi.mock('../../../../../../components/i18n', () => ({ useFormatter: () => ({ t: (s: string) => s }) }));
+
+vi.mock('../../../../../../admin/components/simulations/simulation/attack_path/AttackPathFlow', () => ({
+  default: (props: { focusRequest?: { nodeId: string } }) => {
+    mocks.flowProps.current = props;
+    return <div data-testid="attack-path-flow" />;
+  },
+}));
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  return {
+    ...actual,
+    useParams: () => ({ exerciseId: 'sim-1' }),
+  };
+});
+
+const ENDPOINT_NODE = 'NODE_ENDPOINT|host-x';
+
+const graphDto = {
+  mode: 'collapsed',
+  counters: {
+    endpoints: 1,
+    credentials: 1,
+    users: 0,
+    cves: 0,
+    ports: 0,
+  },
+  attackPathNodes: [{
+    id: ENDPOINT_NODE,
+    type: 'ASSET',
+    label: 'CORP-HOST',
+    hostname: 'CORP-HOST',
+    ref: 'host-x',
+  }],
+  attackPathEdges: [],
+  attackPathExecutions: [],
+  staticAttackPathFindings: [],
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider theme={createTheme()}>{children}</ThemeProvider>
+);
+
+describe('SimulationAttackPath findings drawer + cross-focus', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mocks.flowProps.current = null;
+  });
+
+  const setup = () => {
+    mocks.fetchAttackPathGraph.mockResolvedValue({ data: graphDto });
+    mocks.fetchAttackPathSimulations.mockResolvedValue({ data: [] });
+    mocks.fetchEndpointFindings.mockResolvedValue({
+      data: {
+        findingTypes: [],
+        findings: [],
+      },
+    });
+    mocks.fetchEndpointRelations.mockResolvedValue({
+      data: {
+        executions: [{
+          id: 'NODE_EXEC|exec-1',
+          ref: 'exec-1',
+          type: 'EXECUTION',
+          payloadName: 'nmap',
+          status: 'RED',
+        }],
+        edges: [],
+      },
+    });
+    mocks.fetchFindingsByCategory.mockResolvedValue({
+      data: {
+        total: 1,
+        items: [{
+          type: 'credentials',
+          value: 'admin:••••',
+          endpointKey: 'host-x',
+          endpointNodeId: ENDPOINT_NODE,
+          executionIds: ['exec-1'],
+        }],
+      },
+    });
+    return render(<SimulationAttackPath />, { wrapper });
+  };
+
+  it('opens a category drawer, lists the fetched findings, and focuses the endpoint on item click', async () => {
+    setup();
+
+    // Widgets appear once the graph counters are loaded; open the credentials drawer.
+    const credentialsWidget = await screen.findByRole('button', { name: /Credentials/ });
+    fireEvent.click(credentialsWidget);
+    expect(mocks.fetchFindingsByCategory).toHaveBeenCalledWith('sim-1', 'credentials');
+
+    // The drawer renders the fetched finding (credential value masked by the server).
+    const item = await screen.findByText('admin:••••');
+    fireEvent.click(item);
+
+    // Cross-focus (US5 A3): the endpoint's feed is loaded and the map receives a focus request on it.
+    await waitFor(() => {
+      expect(mocks.fetchEndpointRelations).toHaveBeenCalledWith('sim-1', 'host-x');
+      expect(mocks.flowProps.current?.focusRequest?.nodeId).toBe(ENDPOINT_NODE);
+    });
+
+    // The feed panel is titled with the endpoint's friendly hostname, not the raw key.
+    expect(await screen.findByText(/CORP-HOST/)).toBeTruthy();
+  });
+});

--- a/openaev-front/src/actions/attack-path/attack-path-actions.ts
+++ b/openaev-front/src/actions/attack-path/attack-path-actions.ts
@@ -1,5 +1,5 @@
 import { simpleCall } from '../../utils/Action';
-import type { AttackPathDTO, AttackPathEndpointRelationsDTO, AttackPathExpandDTO, AttackPathSimSummaryRow } from '../../utils/api-types';
+import type { AttackPathDTO, AttackPathEndpointRelationsDTO, AttackPathExpandDTO, AttackPathFindingPageDTO, AttackPathSimSummaryRow } from '../../utils/api-types';
 
 // Attack-path execution-store POC (issue 6647), gated by the ATTACK_PATH preview feature.
 // The tenant prefix is added centrally by Action.buildUri, so these use the plain /api paths.
@@ -33,3 +33,13 @@ export const fetchEndpointRelations = (
   ref: string,
 ): Promise<{ data: AttackPathEndpointRelationsDTO }> =>
   simpleCall(`${simulationUri(simulationId)}/endpoint/relations?ref=${encodeURIComponent(ref)}`);
+
+// A page of a widget category's findings for the drawer (issue 5048, US5).
+// category is one of credentials | users | files | cves; the value is masked server-side for credentials.
+export const fetchFindingsByCategory = (
+  simulationId: string,
+  category: string,
+  page = 0,
+  size = 50,
+): Promise<{ data: AttackPathFindingPageDTO }> =>
+  simpleCall(`${simulationUri(simulationId)}/findings?category=${encodeURIComponent(category)}&page=${page}&size=${size}`);

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathFlow.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathFlow.tsx
@@ -9,6 +9,7 @@ import {
   ReactFlow,
   useEdgesState,
   useNodesState,
+  useReactFlow,
 } from '@xyflow/react';
 import { useEffect } from 'react';
 
@@ -21,16 +22,24 @@ const proOptions = {
   hideAttribution: true,
 };
 
+// A request to center the map on a node; the nonce lets the same node be re-focused on a repeat click.
+export interface AttackPathFocusRequest {
+  nodeId: string;
+  nonce: number;
+}
+
 interface AttackPathFlowProps {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
   onEndpointClick?: (nodeId: string, ref?: string, label?: string) => void;
+  focusRequest?: AttackPathFocusRequest | null;
 }
 
 // Thin ReactFlow wrapper: it renders the nodes/edges the helper produced and reports endpoint
 // clicks up to the page, which loads that endpoint's detail on demand (T12).
-const AttackPathFlow = ({ nodes, edges, onEndpointClick }: AttackPathFlowProps) => {
+const AttackPathFlow = ({ nodes, edges, onEndpointClick, focusRequest }: AttackPathFlowProps) => {
   const theme = useTheme();
+  const reactFlow = useReactFlow();
   const [flowNodes, setFlowNodes, onNodesChange] = useNodesState<Node>(nodes);
   const [flowEdges, setFlowEdges, onEdgesChange] = useEdgesState<Edge>(edges);
 
@@ -41,6 +50,18 @@ const AttackPathFlow = ({ nodes, edges, onEndpointClick }: AttackPathFlowProps) 
   useEffect(() => {
     setFlowEdges(edges);
   }, [edges, setFlowEdges]);
+
+  // Center and zoom onto the requested node (US5 cross-focus): clicking a finding item brings its
+  // endpoint into view. fitView on a single node centers it; the nonce re-fires on a repeat click.
+  useEffect(() => {
+    if (focusRequest?.nodeId) {
+      reactFlow.fitView({
+        nodes: [{ id: focusRequest.nodeId }],
+        duration: 600,
+        maxZoom: 1.5,
+      });
+    }
+  }, [focusRequest, reactFlow]);
 
   return (
     <ReactFlow

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2,16 +2,16 @@ import { Close, Refresh } from '@mui/icons-material';
 import { Alert, Autocomplete, Box, Button, Chip, Drawer, IconButton, Paper, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { ReactFlowProvider } from '@xyflow/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router';
 
 import { fetchAttackPathGraph, fetchAttackPathSimulations, fetchEndpointFindings, fetchEndpointRelations, fetchFindingsByCategory } from '../../../../../actions/attack-path/attack-path-actions';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
-import type { AttackPathDTO, AttackPathEdges, AttackPathExpandDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow } from '../../../../../utils/api-types';
+import type { AttackPathDTO, AttackPathEdges, AttackPathExpandDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow } from '../../../../../utils/api-types';
 import attackPathStatusColor from './attack-path-colors';
 import { buildAttackPathFlow } from './attack-path-flow-helpers';
-import AttackPathFlow from './AttackPathFlow';
+import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 
 type Mode = 'auto' | 'full' | 'collapsed';
 
@@ -92,6 +92,12 @@ const SimulationAttackPath = () => {
   const [findingsPage, setFindingsPage] = useState<AttackPathFindingPageDTO | null>(null);
   const [findingsLoading, setFindingsLoading] = useState(false);
 
+  // Cross-focus (US5): clicking a finding item centers its endpoint (focusRequest) and highlights
+  // the producing executions in the feed (by their raw ids).
+  const [focusRequest, setFocusRequest] = useState<AttackPathFocusRequest | null>(null);
+  const [highlightedExecutionIds, setHighlightedExecutionIds] = useState<Set<string>>(new Set());
+  const feedRowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
   const load = useCallback(() => {
     if (!simulationId) {
       return;
@@ -103,8 +109,10 @@ const SimulationAttackPath = () => {
     setExpandedRefs(new Set());
     setSelectedNodeId(null);
     setExecutions([]);
-    // Close the findings drawer so it never shows the previous simulation's findings.
+    // Close the findings drawer and clear any cross-focus so nothing carries over between simulations.
     setDrawerCategory(null);
+    setHighlightedExecutionIds(new Set());
+    setFocusRequest(null);
     fetchAttackPathGraph(simulationId, mode === 'auto' ? undefined : mode)
       .then(r => setDto(r.data))
       .catch(() => {
@@ -130,6 +138,8 @@ const SimulationAttackPath = () => {
     setSelectedNodeId(nodeId);
     setSelectedLabel(label ?? '');
     setExecutions([]);
+    // A plain node click focuses no specific execution; a finding-item click sets these after.
+    setHighlightedExecutionIds(new Set());
     if (!ref) {
       return;
     }
@@ -177,6 +187,43 @@ const SimulationAttackPath = () => {
       }))
       .finally(() => setFindingsLoading(false));
   }, [simulationId]);
+
+  // Cross-focus (US5 acceptance A3): clicking a finding item closes the drawer, focuses its endpoint
+  // on the map (center + select, which highlights the edges into it), loads that endpoint's feed, and
+  // highlights the producing executions in it.
+  const onFindingItemClick = useCallback(
+    (item: AttackPathFindingItemDTO) => {
+      if (!item.endpointNodeId || !item.endpointKey) {
+        return;
+      }
+      setDrawerCategory(null);
+      // Use the endpoint's friendly label (hostname) for the panel title, like a direct node click,
+      // not the raw key.
+      const node = (dto?.attackPathNodes ?? []).find(n => n.id === item.endpointNodeId);
+      const label = node?.hostname || node?.label || item.endpointKey;
+      onEndpointClick(item.endpointNodeId, item.endpointKey, label);
+      setHighlightedExecutionIds(new Set(item.executionIds ?? []));
+      setFocusRequest(prev => ({
+        nodeId: item.endpointNodeId as string,
+        nonce: (prev?.nonce ?? 0) + 1,
+      }));
+    },
+    [onEndpointClick, dto?.attackPathNodes],
+  );
+
+  // Scroll the feed to the first producing execution once the highlight or the loaded feed changes.
+  useEffect(() => {
+    if (highlightedExecutionIds.size === 0) {
+      return;
+    }
+    const firstId = executions.find(e => e.ref && highlightedExecutionIds.has(e.ref))?.id;
+    if (firstId) {
+      feedRowRefs.current.get(firstId)?.scrollIntoView({
+        block: 'nearest',
+        behavior: 'smooth',
+      });
+    }
+  }, [highlightedExecutionIds, executions]);
 
   // Merge the base graph with whatever endpoints have been expanded, then lay it out; finally mark
   // the selected endpoint and the edges touching it so the click highlights its path.
@@ -367,7 +414,7 @@ const SimulationAttackPath = () => {
           )}
           {!loading && !error && nodes.length > 0 && (
             <ReactFlowProvider>
-              <AttackPathFlow nodes={nodes} edges={edges} onEndpointClick={onEndpointClick} />
+              <AttackPathFlow nodes={nodes} edges={edges} onEndpointClick={onEndpointClick} focusRequest={focusRequest} />
             </ReactFlowProvider>
           )}
         </Paper>
@@ -385,32 +432,50 @@ const SimulationAttackPath = () => {
             <Typography variant="subtitle2" color="text.secondary" gutterBottom>
               {`${t('Executions')} (${executions.length})`}
             </Typography>
-            {executions.slice(0, EXEC_DISPLAY_CAP).map(e => (
-              <Box
-                key={e.id}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  py: 0.5,
-                  borderBottom: `1px solid ${theme.palette.divider}`,
-                }}
-              >
-                <span style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: '50%',
-                  background: attackPathStatusColor(theme, e.status),
-                }}
-                />
-                <div style={{ minWidth: 0 }}>
-                  <Typography variant="body2" noWrap>{e.payloadName || e.label}</Typography>
-                  <Typography variant="caption" color="text.secondary" noWrap>
-                    {[e.agentName, e.privilege].filter(Boolean).join(' · ')}
-                  </Typography>
-                </div>
-              </Box>
-            ))}
+            {executions.slice(0, EXEC_DISPLAY_CAP).map((e) => {
+              const highlighted = !!e.ref && highlightedExecutionIds.has(e.ref);
+              return (
+                <Box
+                  key={e.id}
+                  ref={(el: HTMLDivElement | null) => {
+                    if (!e.id) {
+                      return;
+                    }
+                    if (el) {
+                      feedRowRefs.current.set(e.id, el);
+                    } else {
+                      feedRowRefs.current.delete(e.id);
+                    }
+                  }}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    py: 0.5,
+                    px: 0.5,
+                    borderRadius: 1,
+                    borderBottom: `1px solid ${theme.palette.divider}`,
+                    backgroundColor: highlighted ? 'action.selected' : undefined,
+                    // A left accent so the finding's producing execution stands out in the feed.
+                    borderLeft: highlighted ? `2px solid ${theme.palette.primary.main}` : '2px solid transparent',
+                  }}
+                >
+                  <span style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    background: attackPathStatusColor(theme, e.status),
+                  }}
+                  />
+                  <div style={{ minWidth: 0 }}>
+                    <Typography variant="body2" noWrap>{e.payloadName || e.label}</Typography>
+                    <Typography variant="caption" color="text.secondary" noWrap>
+                      {[e.agentName, e.privilege].filter(Boolean).join(' · ')}
+                    </Typography>
+                  </div>
+                </Box>
+              );
+            })}
             {executions.length > EXEC_DISPLAY_CAP && (
               <Typography
                 variant="caption"
@@ -462,9 +527,27 @@ const SimulationAttackPath = () => {
           {!findingsLoading && (findingsPage?.items ?? []).map((item, index) => (
             <Box
               key={`${item.endpointKey}-${item.value}-${index}`}
+              role="button"
+              tabIndex={0}
+              onClick={() => onFindingItemClick(item)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onFindingItemClick(item);
+                }
+              }}
               sx={{
-                py: 0.75,
-                borderBottom: `1px solid ${theme.palette.divider}`,
+                'py': 0.75,
+                'px': 0.5,
+                'borderRadius': 1,
+                'borderBottom': `1px solid ${theme.palette.divider}`,
+                'cursor': 'pointer',
+                '&:hover': { backgroundColor: 'action.hover' },
+                '&:focus-visible': {
+                  backgroundColor: 'action.hover',
+                  outline: `2px solid ${theme.palette.primary.main}`,
+                  outlineOffset: -2,
+                },
               }}
             >
               <Typography variant="body2" noWrap title={item.value}>{item.value}</Typography>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1,14 +1,14 @@
-import { Refresh } from '@mui/icons-material';
-import { Alert, Autocomplete, Box, Chip, IconButton, Paper, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
+import { Close, Refresh } from '@mui/icons-material';
+import { Alert, Autocomplete, Box, Button, Chip, Drawer, IconButton, Paper, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { ReactFlowProvider } from '@xyflow/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
-import { fetchAttackPathGraph, fetchAttackPathSimulations, fetchEndpointFindings, fetchEndpointRelations } from '../../../../../actions/attack-path/attack-path-actions';
+import { fetchAttackPathGraph, fetchAttackPathSimulations, fetchEndpointFindings, fetchEndpointRelations, fetchFindingsByCategory } from '../../../../../actions/attack-path/attack-path-actions';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
-import type { AttackPathDTO, AttackPathEdges, AttackPathExpandDTO, AttackPathNodeDTO, AttackPathSimSummaryRow } from '../../../../../utils/api-types';
+import type { AttackPathDTO, AttackPathEdges, AttackPathExpandDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow } from '../../../../../utils/api-types';
 import attackPathStatusColor from './attack-path-colors';
 import { buildAttackPathFlow } from './attack-path-flow-helpers';
 import AttackPathFlow from './AttackPathFlow';
@@ -86,6 +86,12 @@ const SimulationAttackPath = () => {
   const [selectedLabel, setSelectedLabel] = useState<string>('');
   const [executions, setExecutions] = useState<AttackPathNodeDTO[]>([]);
 
+  // Findings drawer (US5): a widget opens a right drawer listing that category's findings.
+  const [drawerCategory, setDrawerCategory] = useState<string | null>(null);
+  const [drawerLabel, setDrawerLabel] = useState<string>('');
+  const [findingsPage, setFindingsPage] = useState<AttackPathFindingPageDTO | null>(null);
+  const [findingsLoading, setFindingsLoading] = useState(false);
+
   const load = useCallback(() => {
     if (!simulationId) {
       return;
@@ -97,6 +103,8 @@ const SimulationAttackPath = () => {
     setExpandedRefs(new Set());
     setSelectedNodeId(null);
     setExecutions([]);
+    // Close the findings drawer so it never shows the previous simulation's findings.
+    setDrawerCategory(null);
     fetchAttackPathGraph(simulationId, mode === 'auto' ? undefined : mode)
       .then(r => setDto(r.data))
       .catch(() => {
@@ -154,6 +162,21 @@ const SimulationAttackPath = () => {
       .then(r => setExecutions(r.data.executions ?? []))
       .catch(() => setExecutions([]));
   }, [simulationId, dto?.mode, expandedRefs]);
+
+  // Open the findings drawer for a widget category and load its first page.
+  const openFindingsDrawer = useCallback((category: string, label: string) => {
+    setDrawerCategory(category);
+    setDrawerLabel(label);
+    setFindingsPage(null);
+    setFindingsLoading(true);
+    fetchFindingsByCategory(simulationId, category)
+      .then(r => setFindingsPage(r.data))
+      .catch(() => setFindingsPage({
+        items: [],
+        total: 0,
+      }))
+      .finally(() => setFindingsLoading(false));
+  }, [simulationId]);
 
   // Merge the base graph with whatever endpoints have been expanded, then lay it out; finally mark
   // the selected endpoint and the edges touching it so the click highlights its path.
@@ -274,13 +297,43 @@ const SimulationAttackPath = () => {
             gap: theme.spacing(1),
             marginLeft: 'auto',
             flexWrap: 'wrap',
+            alignItems: 'center',
           }}
           >
+            {/* Endpoints is a count only for now; its per-endpoint drawer is a follow-up. */}
             <Chip label={`${t('Endpoints')} ${counters.endpoints ?? 0}`} size="small" />
-            <Chip label={`${t('Credentials')} ${counters.credentials ?? 0}`} size="small" />
-            <Chip label={`${t('Users')} ${counters.users ?? 0}`} size="small" />
-            <Chip label={`${t('CVEs')} ${counters.cves ?? 0}`} size="small" />
-            <Chip label={`${t('Ports')} ${counters.ports ?? 0}`} size="small" />
+            {/* Files has no finding type in the seed yet, so its count is 0 until ingestion (US5 open question). */}
+            {[
+              {
+                category: 'files',
+                label: t('Files'),
+                count: 0,
+              },
+              {
+                category: 'credentials',
+                label: t('Credentials'),
+                count: counters.credentials ?? 0,
+              },
+              {
+                category: 'users',
+                label: t('Users'),
+                count: counters.users ?? 0,
+              },
+              {
+                category: 'cves',
+                label: t('CVEs'),
+                count: counters.cves ?? 0,
+              },
+            ].map(w => (
+              <Button
+                key={w.category}
+                size="small"
+                variant="outlined"
+                onClick={() => openFindingsDrawer(w.category, w.label)}
+              >
+                {`${w.label} ${w.count}`}
+              </Button>
+            ))}
             {dto?.mode && <Chip label={dto.mode} size="small" color="primary" variant="outlined" />}
           </div>
         )}
@@ -373,6 +426,68 @@ const SimulationAttackPath = () => {
           </Paper>
         )}
       </div>
+
+      <Drawer
+        anchor="right"
+        open={drawerCategory !== null}
+        onClose={() => setDrawerCategory(null)}
+      >
+        <Box
+          role="presentation"
+          sx={{
+            width: 360,
+            p: 2,
+          }}
+        >
+          <Box sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            mb: 1,
+          }}
+          >
+            <Typography variant="h6">{`${drawerLabel} (${findingsPage?.total ?? 0})`}</Typography>
+            <IconButton size="small" aria-label={t('Close')} onClick={() => setDrawerCategory(null)}>
+              <Close />
+            </IconButton>
+          </Box>
+          {findingsLoading && (
+            <Box sx={{ minHeight: 120 }}>
+              <Loader variant="inElement" size="sm" />
+            </Box>
+          )}
+          {!findingsLoading && (findingsPage?.items?.length ?? 0) === 0 && (
+            <Alert severity="info">{t('No findings')}</Alert>
+          )}
+          {!findingsLoading && (findingsPage?.items ?? []).map((item, index) => (
+            <Box
+              key={`${item.endpointKey}-${item.value}-${index}`}
+              sx={{
+                py: 0.75,
+                borderBottom: `1px solid ${theme.palette.divider}`,
+              }}
+            >
+              <Typography variant="body2" noWrap title={item.value}>{item.value}</Typography>
+              <Typography variant="caption" color="text.secondary" noWrap title={item.endpointKey}>
+                {item.endpointKey}
+              </Typography>
+            </Box>
+          ))}
+          {!findingsLoading && findingsPage
+            && (findingsPage.items?.length ?? 0) < (findingsPage.total ?? 0) && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                display: 'block',
+                pt: 1,
+              }}
+            >
+              {`+${(findingsPage.total ?? 0) - (findingsPage.items?.length ?? 0)} ${t('more')}`}
+            </Typography>
+          )}
+        </Box>
+      </Drawer>
     </div>
   );
 };

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -723,6 +723,20 @@ export interface AttackPathExpandDTO {
   findings?: AttackPathNodeDTO[];
 }
 
+export interface AttackPathFindingItemDTO {
+  endpointKey?: string;
+  endpointNodeId?: string;
+  executionIds?: string[];
+  type?: string;
+  value?: string;
+}
+
+export interface AttackPathFindingPageDTO {
+  items?: AttackPathFindingItemDTO[];
+  /** @format int64 */
+  total?: number;
+}
+
 export interface AttackPathNodeDTO {
   agentName?: string;
   agents?: string[];

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "Keine Erwartungen an diese Maßnahme.",
   "No explanation": "Keine Erklärung",
   "No file selected.": "Keine Datei ausgewählt.",
+  "No findings": "No findings",
   "No inject in this scenario": "Keine Injektion in diesem Szenario",
   "No injector contracts found": "Keine Injektorverträge gefunden",
   "No injects to send in this platform.": "Keine Injektionen in dieser Plattform zu senden.",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "No expectations for this action.",
   "No explanation": "No explanation",
   "No file selected.": "No file selected.",
+  "No findings": "No findings",
   "No inject in this scenario": "No inject in this scenario",
   "No injector contracts found": "No injector contracts found",
   "No injects to send in this platform.": "No injects to send in this platform.",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "No hay expectativas respecto a esta medida.",
   "No explanation": "Ninguna explicación",
   "No file selected.": "Ningún fichero seleccionado",
+  "No findings": "No findings",
   "No inject in this scenario": "No inyectar en este escenario",
   "No injector contracts found": "No se han encontrado contratos de inyectores",
   "No injects to send in this platform.": "No hay injects para enviar en esta plataforma.",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "Aucune attente concernant cette action.",
   "No explanation": "Aucune explication",
   "No file selected.": "Aucun fichier sélectionné.",
+  "No findings": "Aucun résultat",
   "No inject in this scenario": "Aucun stimuli dans ce scénario",
   "No injector contracts found": "Aucun contrat d'injecteur trouvé",
   "No injects to send in this platform.": "Aucun stimuli à envoyer dans cette plateforme.",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "Non ci sono aspettative riguardo a questa azione.",
   "No explanation": "Nessuna spiegazione",
   "No file selected.": "Nessun file selezionato.",
+  "No findings": "No findings",
   "No inject in this scenario": "Nessuna iniezione in questo scenario",
   "No injector contracts found": "Nessun contratto iniettore trovato",
   "No injects to send in this platform.": "Nessuna iniezione da inviare in questa piattaforma.",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "このアクションについては、特に期待はしていません。",
   "No explanation": "説明なし",
   "No file selected.": "ファイルが選択されていません。",
+  "No findings": "No findings",
   "No inject in this scenario": "このシナリオではインジェクトはありません",
   "No injector contracts found": "インジェクター契約なし",
   "No injects to send in this platform.": "このプラットフォームで送信するインジェクトはありません。",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "이 조치에 대해서는 별다른 기대가 없습니다.",
   "No explanation": "설명 없음",
   "No file selected.": "선택한 파일이 없습니다.",
+  "No findings": "No findings",
   "No inject in this scenario": "이 시나리오에서는 주입 없음",
   "No injector contracts found": "인젝터 계약을 찾을 수 없습니다",
   "No injects to send in this platform.": "이 플랫폼에 보낼 인젝트가 없습니다.",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "По данному действию никаких ожиданий нет.",
   "No explanation": "Нет объяснения",
   "No file selected.": "Не выбран ни один файл.",
+  "No findings": "No findings",
   "No inject in this scenario": "В этом сценарии нет инъекций",
   "No injector contracts found": "Контракты инжектора не найдены",
   "No injects to send in this platform.": "Нет инъекций для отправки в этой платформе.",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -1585,6 +1585,7 @@
   "No expectations for this action.": "对这一行动不抱任何期望。",
   "No explanation": "无说明",
   "No file selected.": "未选择文件。",
+  "No findings": "No findings",
   "No inject in this scenario": "场景中无注入",
   "No injector contracts found": "未找到喷射器合同",
   "No injects to send in this platform.": "平台中没有要发送的注入.",

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingExecutionRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingExecutionRow.java
@@ -1,0 +1,8 @@
+package io.openaev.database.model.attackpath.projection;
+
+/**
+ * One (finding, producing execution) link (issue 5048, US5), used to attach the executions that
+ * discovered each finding to the drawer rows so the front can cross-focus the map edge and the
+ * feed.
+ */
+public record AttackPathFindingExecutionRow(String findingId, String executionId) {}

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingListRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingListRow.java
@@ -1,0 +1,8 @@
+package io.openaev.database.model.attackpath.projection;
+
+/**
+ * One finding row for the widget drawer list (issue 5048, US5): its id (to fetch the producing
+ * executions), its type and value, and its endpoint key. Read paginated, restricted to findings a
+ * producing execution links to (the CF1 invariant).
+ */
+public record AttackPathFindingListRow(String id, String type, String value, String endpointKey) {}

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
@@ -80,7 +80,9 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    * restricted to findings a producing execution links to (the same {@code EXISTS} invariant as the
    * graph reads, so a drawer never lists a finding the graph omits). The explicit {@code
    * countQuery} keeps the paged total consistent with that invariant; the tenant filter is added by
-   * the statement inspector.
+   * the statement inspector. A stable {@code ORDER BY (endpointKey, value, id)} makes paging
+   * deterministic, so scrolling the drawer never repeats or skips a row ({@code id} is the unique
+   * tiebreaker).
    */
   @Query(
       value =
@@ -88,7 +90,8 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
               + "f.id, f.type, f.value, f.endpointKey) "
               + "FROM AttackPathFinding f "
               + "WHERE f.simulationId = :simulationId AND f.type IN :types "
-              + "AND EXISTS (SELECT ef FROM AttackPathExecutionFinding ef WHERE ef.findingId = f.id)",
+              + "AND EXISTS (SELECT ef FROM AttackPathExecutionFinding ef WHERE ef.findingId = f.id) "
+              + "ORDER BY f.endpointKey, f.value, f.id",
       countQuery =
           "SELECT count(f) FROM AttackPathFinding f "
               + "WHERE f.simulationId = :simulationId AND f.type IN :types "
@@ -106,7 +109,8 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow("
           + "ef.findingId, ef.executionId) "
-          + "FROM AttackPathExecutionFinding ef WHERE ef.findingId IN :findingIds")
+          + "FROM AttackPathExecutionFinding ef WHERE ef.findingId IN :findingIds "
+          + "ORDER BY ef.executionId")
   List<AttackPathFindingExecutionRow> findExecutionLinks(
       @Param("findingIds") Collection<String> findingIds);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
@@ -3,9 +3,14 @@ package io.openaev.database.repository.attackpath;
 import io.openaev.database.model.attackpath.AttackPathFinding;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointTypeCountRow;
+import io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow;
+import io.openaev.database.model.attackpath.projection.AttackPathFindingListRow;
 import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
 import io.openaev.database.model.attackpath.projection.AttackPathTypeCountRow;
+import java.util.Collection;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -69,4 +74,39 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
           + "GROUP BY f.endpointKey, f.type")
   List<AttackPathEndpointTypeCountRow> findEndpointTypeCounts(
       @Param("simulationId") String simulationId);
+
+  /**
+   * Widget drawer (issue 5048, US5): a page of a simulation's findings of the given types,
+   * restricted to findings a producing execution links to (the same {@code EXISTS} invariant as the
+   * graph reads, so a drawer never lists a finding the graph omits). The explicit {@code
+   * countQuery} keeps the paged total consistent with that invariant; the tenant filter is added by
+   * the statement inspector.
+   */
+  @Query(
+      value =
+          "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingListRow("
+              + "f.id, f.type, f.value, f.endpointKey) "
+              + "FROM AttackPathFinding f "
+              + "WHERE f.simulationId = :simulationId AND f.type IN :types "
+              + "AND EXISTS (SELECT ef FROM AttackPathExecutionFinding ef WHERE ef.findingId = f.id)",
+      countQuery =
+          "SELECT count(f) FROM AttackPathFinding f "
+              + "WHERE f.simulationId = :simulationId AND f.type IN :types "
+              + "AND EXISTS (SELECT ef FROM AttackPathExecutionFinding ef WHERE ef.findingId = f.id)")
+  Page<AttackPathFindingListRow> findPageByTypes(
+      @Param("simulationId") String simulationId,
+      @Param("types") Collection<String> types,
+      Pageable pageable);
+
+  /**
+   * Widget drawer (issue 5048, US5): the (finding, producing execution) links for a page of
+   * findings, so each drawer row can carry its execution ids for cross-focus. The finding ids come
+   * from a tenant-scoped finding page, so this link read is already bounded to the tenant.
+   */
+  @Query(
+      "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow("
+          + "ef.findingId, ef.executionId) "
+          + "FROM AttackPathExecutionFinding ef WHERE ef.findingId IN :findingIds")
+  List<AttackPathFindingExecutionRow> findExecutionLinks(
+      @Param("findingIds") Collection<String> findingIds);
 }


### PR DESCRIPTION
## What this adds

The Attack Path tab's top-bar finding counters become **clickable widgets**. Clicking one opens a right-side
**findings drawer** listing that category's findings, and clicking a finding **cross-focuses** the graph: the
map centers on the endpoint where it was found, and the execution feed highlights the executions that
discovered it.

This is the "navigate from findings" direction product asked for (US5 of #5048). It reuses the POC's
normalized store from #6647, so the reads stay cheap (the `attackpath_finding` table is far smaller than the
executions).

## Backend

- **Paginated category read** (`AttackPathGraphService.listFindings`): lists a widget category's findings for
  a simulation. A widget maps to a set of finding types (`credentials`, `users = {username, admin_username}`,
  `cves`, `files`); an unknown category returns an empty page.
- **Two reads, not a join**: page the findings (`findPageByTypes`, `EXISTS` + explicit `countQuery`), then
  read that page's producing-execution links (`findExecutionLinks`). Paginating a `finding JOIN
  execution_finding` would split a finding's executions across pages and miscount the total.
- **Honours the graph invariant (CF1)**: the read only lists findings a producing execution links to, so the
  drawer never shows something the graph omits. A stable `ORDER BY (endpointKey, value, id)` keeps scroll
  pagination from repeating or skipping rows.
- **HTTP endpoint**: `GET /simulations/{id}/findings?category=&page=&size=` on `AttackPathApi`, flag-gated by
  the `ATTACK_PATH` preview feature (404 when off), base and tenant-prefixed, size-capped at 200. Tenant
  isolation is enforced by the statement inspector, like every other attack-path read.
- **Credential masking** is server-side: for a `username:password` pair the username is kept and only the
  secret is masked with a fixed-length mask (`admin:••••`), so rows stay distinguishable without leaking the
  secret or its length. The clear secret never leaves the server.
- Execution feed nodes now carry their raw execution id in `ref`, so a drawer item can match and highlight
  its producing executions in the feed.
- The synthetic seed now produces realistic `username:secret` credentials so the masking is meaningful.

## Frontend

- The counter chips for Files, Credentials, Users and CVEs become buttons that open a right-side MUI drawer
  (Ports is dropped, it is not a product widget; Files reads 0 until ingestion adds a `file` finding type).
- The drawer lists each finding's value and endpoint (credentials masked), with the total in the header and a
  `+N more` when the page is shorter than the total. Drawer rows are keyboard-accessible.
- Clicking a finding centers the endpoint node on the map, selects it (which highlights the edges into it),
  loads that endpoint's execution feed, and highlights and scrolls to the producing executions.
- One new i18n key (`No findings`) added to all 9 locales.

## Testing

- Backend: `AttackPath*` suite (62) plus `TenantNonOrmAccessArchTest` green. Covers the paginated read
  (masking, orphan exclusion, shared-value-per-endpoint, stable pagination), the HTTP endpoint (admin
  happy-path, flag-off 404, two-tenant isolation), and the feed cross-focus id.
- Frontend: `check-ts`, `i18n-checker`, eslint `--max-warnings 0`, and the attack-path vitest (12) green,
  including a component test that drives the drawer and asserts the cross-focus wiring.

## Open questions for product (none blocking)

- **Widget count vs drawer total**: the widget counts distinct values, the drawer total counts (value,
  endpoint) rows, so a shared credential reads lower on the widget (6) than in its drawer (9). Reconcile to
  one metric, or label them distinctly?
- **Masking format**: confirm `user:••••` as the final format.
- **Files finding type**: no `file` type exists today (widget reads 0). Real source is a model/ingestion
  decision.
- **Finding uniqueness per (type, value, endpoint)**: the drawer assumes at most one finding row per
  (type, value, endpoint). Worth making a store invariant on the ingestion side.
- **Status granularity**: the endpoint status is a two-state simplification of the product's four-state model.
- **Pagination**: page size and the scroll threshold for the drawer.

## Notes

- Stacked on #6647 (the POC). Base this PR on `lgi/6647-attack-path-execution-step-poc`, not `main`.
- Part of #5048 (Attack Path Creation / Live Tracking), user story US5.
