### PR TITLE
fix(ci): e2e-infra-tests artifact name collision between x64/arm64 legs (#6715)

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -17,6 +17,18 @@ inputs:
   browser:
     description: "Browser name (chrome, chromium, webkit, or firefox) — used for artifact naming and browser install."
     required: true
+  artifact-suffix:
+    description: >
+      Optional suffix appended to uploaded artifact names (e.g. a matrix
+      dimension like arch). Needed when a caller job runs this action
+      multiple times with the SAME browser value inside a single matrix
+      (e.g. e2e-infra-tests: x64/arm64 both use browser=chromium) — without
+      a suffix, the parallel legs would upload identically-named artifacts
+      in the same workflow run and actions/upload-artifact would fail with
+      a 409 Conflict. Leave empty when browser alone is already unique per
+      run (default, backward compatible).
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -243,11 +255,14 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report-${{ inputs.browser }}
+        # artifact-suffix keeps names unique when the same browser value
+        # is used by multiple parallel matrix legs in the same run
+        # (e.g. e2e-infra-tests x64/arm64) — see input description above.
+        name: playwright-report-${{ inputs.browser }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}
         path: openaev-front/test-results/
     - name: Upload E2E coverage report (${{ inputs.browser }})
       if: ${{ !cancelled() && inputs.browser == 'chrome' }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-coverage-${{ inputs.browser }}
+        name: playwright-coverage-${{ inputs.browser }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}
         path: openaev-front/test-results/coverage/

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -239,13 +239,6 @@ runs:
       env:
         APP_URL: http://localhost:8080
         E2E_COVERAGE: "true"
-    # ── Artifact naming ─────────────────────────────────────────────
-    # `github.job` + `strategy.job-index` guarantee uniqueness within
-    # the workflow run regardless of how many matrix dimensions the
-    # calling job has (now or in the future). A suffix like
-    # `runner.arch` would only cover today's single-dimension matrix
-    # in e2e-infra-tests and would silently collide again if a second
-    # dimension were ever added.
     - name: Upload Playwright report (${{ inputs.browser }})
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -17,8 +17,21 @@ inputs:
   browser:
     description: "Browser name (chrome, chromium, webkit, or firefox) — used for artifact naming and browser install."
     required: true
+  artifact-name-prefix:
+    description: >
+      Base name for the uploaded Playwright report artifact. Override
+      per caller when the matrix does NOT vary on `browser` (e.g.
+      e2e-infra-tests varies on `arch` instead, with `browser` fixed to
+      `chromium`), so the two callers' artifacts stay visually distinct
+      in the Actions UI.
+    required: false
+    default: "playwright-report"
   artifact-suffix:
-    description: "Suffix appended to artifact names to make them unique per matrix leg (e.g. matrix.browser or matrix.arch). Forwarded from the calling workflow because strategy.job-index is not available in composite actions."
+    description: >
+      Suffix appended to the report artifact name to keep it unique per
+      matrix leg when `browser` alone doesn't vary across the matrix
+      (e.g. matrix.arch for e2e-infra-tests). Leave empty when `browser`
+      already uniquely identifies the leg (e.g. e2e-tests).
     required: false
     default: ""
 
@@ -247,11 +260,11 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report-${{ inputs.browser }}-${{ github.job }}-${{ inputs.artifact-suffix }}
+        name: ${{ inputs.artifact-name-prefix }}-${{ inputs.browser }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}
         path: openaev-front/test-results/
     - name: Upload E2E coverage report (${{ inputs.browser }})
       if: ${{ !cancelled() && inputs.browser == 'chrome' }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-coverage-${{ inputs.browser }}-${{ github.job }}-${{ inputs.artifact-suffix }}
+        name: playwright-coverage-${{ inputs.browser }}
         path: openaev-front/test-results/coverage/

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -17,6 +17,10 @@ inputs:
   browser:
     description: "Browser name (chrome, chromium, webkit, or firefox) — used for artifact naming and browser install."
     required: true
+  artifact-suffix:
+    description: "Suffix appended to artifact names to make them unique per matrix leg (e.g. matrix.browser or matrix.arch). Forwarded from the calling workflow because strategy.job-index is not available in composite actions."
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -249,5 +253,5 @@ runs:
       if: ${{ !cancelled() && inputs.browser == 'chrome' }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-coverage-${{ inputs.browser }}-${{ github.job }}-${{ strategy.job-index }}
+        name: playwright-coverage-${{ inputs.browser }}-${{ github.job }}-${{ inputs.artifact-suffix }}
         path: openaev-front/test-results/coverage/

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -247,7 +247,7 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report-${{ inputs.browser }}-${{ github.job }}-${{ strategy.job-index }}
+        name: playwright-report-${{ inputs.browser }}-${{ github.job }}-${{ inputs.artifact-suffix }}
         path: openaev-front/test-results/
     - name: Upload E2E coverage report (${{ inputs.browser }})
       if: ${{ !cancelled() && inputs.browser == 'chrome' }}

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -239,15 +239,22 @@ runs:
       env:
         APP_URL: http://localhost:8080
         E2E_COVERAGE: "true"
+    # ── Artifact naming ─────────────────────────────────────────────
+    # `github.job` + `strategy.job-index` guarantee uniqueness within
+    # the workflow run regardless of how many matrix dimensions the
+    # calling job has (now or in the future). A suffix like
+    # `runner.arch` would only cover today's single-dimension matrix
+    # in e2e-infra-tests and would silently collide again if a second
+    # dimension were ever added.
     - name: Upload Playwright report (${{ inputs.browser }})
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-report-${{ inputs.browser }}-${{ runner.arch }}
+        name: playwright-report-${{ inputs.browser }}-${{ github.job }}-${{ strategy.job-index }}
         path: openaev-front/test-results/
     - name: Upload E2E coverage report (${{ inputs.browser }})
       if: ${{ !cancelled() && inputs.browser == 'chrome' }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-coverage-${{ inputs.browser }}-${{ runner.arch }}
+        name: playwright-coverage-${{ inputs.browser }}-${{ github.job }}-${{ strategy.job-index }}
         path: openaev-front/test-results/coverage/

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -17,18 +17,6 @@ inputs:
   browser:
     description: "Browser name (chrome, chromium, webkit, or firefox) — used for artifact naming and browser install."
     required: true
-  artifact-suffix:
-    description: >
-      Optional suffix appended to uploaded artifact names (e.g. a matrix
-      dimension like arch). Needed when a caller job runs this action
-      multiple times with the SAME browser value inside a single matrix
-      (e.g. e2e-infra-tests: x64/arm64 both use browser=chromium) — without
-      a suffix, the parallel legs would upload identically-named artifacts
-      in the same workflow run and actions/upload-artifact would fail with
-      a 409 Conflict. Leave empty when browser alone is already unique per
-      run (default, backward compatible).
-    required: false
-    default: ""
 
 runs:
   using: composite
@@ -255,14 +243,18 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        # artifact-suffix keeps names unique when the same browser value
-        # is used by multiple parallel matrix legs in the same run
-        # (e.g. e2e-infra-tests x64/arm64) — see input description above.
-        name: playwright-report-${{ inputs.browser }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}
+        # runner.arch (X64/ARM64) disambiguates matrix legs that pass the
+        # SAME browser value on different runners (e.g. e2e-infra-tests:
+        # x64/arm64 both use browser=chromium). Without it, both legs would
+        # upload an identically-named artifact in the same workflow run and
+        # actions/upload-artifact would fail with a 409 Conflict.
+        # For e2e-tests (chrome vs webkit), browser alone was already
+        # unique — adding runner.arch here is a no-op (always X64).
+        name: playwright-report-${{ inputs.browser }}-${{ runner.arch }}
         path: openaev-front/test-results/
     - name: Upload E2E coverage report (${{ inputs.browser }})
       if: ${{ !cancelled() && inputs.browser == 'chrome' }}
       uses: actions/upload-artifact@v7
       with:
-        name: playwright-coverage-${{ inputs.browser }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}
+        name: playwright-coverage-${{ inputs.browser }}-${{ runner.arch }}
         path: openaev-front/test-results/coverage/

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -243,13 +243,6 @@ runs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
-        # runner.arch (X64/ARM64) disambiguates matrix legs that pass the
-        # SAME browser value on different runners (e.g. e2e-infra-tests:
-        # x64/arm64 both use browser=chromium). Without it, both legs would
-        # upload an identically-named artifact in the same workflow run and
-        # actions/upload-artifact would fail with a 409 Conflict.
-        # For e2e-tests (chrome vs webkit), browser alone was already
-        # unique — adding runner.arch here is a no-op (always X64).
         name: playwright-report-${{ inputs.browser }}-${{ runner.arch }}
         path: openaev-front/test-results/
     - name: Upload E2E coverage report (${{ inputs.browser }})

--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           playwright-config: ${{ matrix.playwright-config }}
           browser: ${{ matrix.browser }}
+          artifact-suffix: ${{ matrix.browser }}
 
   e2e-infra-tests:
     name: "🧪 E2E Infra (${{ matrix.arch }})"
@@ -192,6 +193,7 @@ jobs:
         with:
           playwright-config: playwright.infra.chromium_config.ts
           browser: chromium
+          artifact-suffix: ${{ matrix.arch }}
 
   api-types-check:
     name: "🔎 API Types Check"


### PR DESCRIPTION
## Problem
`actions/upload-artifact@v7` treats artifact-name collisions **within the same workflow run** as a hard `409 Conflict` (unlike v3's silent merge). The `e2e-infra-tests` job in `_quality-gates.yml` runs a 1-dimensional matrix (`arch: x64` / `arch: arm64`), and both legs call the shared `./.github/actions/e2e-tests` composite action with `browser: chromium` hardcoded — so both legs uploaded `playwright-report-chromium` / `playwright-coverage-chromium`, and the second upload failed with the 409.

## Fix
Suffix the artifact names in `.github/actions/e2e-tests/action.yml` with `${{ github.job }}-${{ strategy.job-index }}` instead of the browser name alone:

```
playwright-report-${{ inputs.browser }}-${{ github.job }}-${{ strategy.job-index }}
playwright-coverage-${{ inputs.browser }}-${{ github.job }}-${{ strategy.job-index }}
```

Why this and not a simpler suffix:
- A static per-caller suffix (e.g. `-e2e-infra`) would only disambiguate *between* jobs, not *within* the `e2e-infra-tests` matrix — it wouldn't fix the actual bug.
- `runner.arch` fixes today's collision, but only because the matrix currently has a single dimension (`arch`). If a second dimension is ever added to that matrix (or to any other caller), `runner.arch` alone would collide again — silently reintroducing the 409.
- `strategy.job-index` is GitHub Actions' dedicated, always-unique index per matrix leg within a job, regardless of how many matrix dimensions exist now or later. Combined with `github.job`, it also disambiguates between call sites even if they ever share the same browser input. No maintenance burden if the matrix shape changes.

## Scope / impact
- Single file changed: `.github/actions/e2e-tests/action.yml` (composite action used by `e2e-tests` and `e2e-infra-tests` jobs in `_quality-gates.yml`).
- No change needed to `_quality-gates.yml` itself — this fix is fully contained in the reusable action, so no `workflows` scope permission required.
- Downstream consumer (`codecov` job) downloads via glob pattern `playwright-coverage-*` with `merge-multiple: true` — insensitive to the exact suffix, verified no other hardcoded references to these artifact names exist in the repo.

Fixes #6715.