### PR TITLE
chore(perf): sql request review (#6681)

### DIFF
--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -354,16 +354,6 @@ public interface InjectExpectationRepository
             AND child_ie.agent_id IS NOT NULL
             AND child_ie.inject_expectation_updated_at > :from
     ),
-    ranked_expectations AS (
-      SELECT ce.inject_expectation_id,
-        GREATEST(ie.inject_expectation_updated_at, i.inject_updated_at, COALESCE(ic.injector_contract_updated_at, ie.inject_expectation_updated_at)) AS sort_ts
-      FROM changed_expectations ce
-      JOIN injects_expectations ie ON ie.inject_expectation_id = ce.inject_expectation_id
-      JOIN injects i ON i.inject_id = ie.inject_id
-      LEFT JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
-      ORDER BY sort_ts ASC
-      LIMIT :limit
-    ),
     agent_security_platforms AS (
       SELECT
           child_ie.inject_id,
@@ -382,9 +372,12 @@ public interface InjectExpectationRepository
       LEFT JOIN collectors child_c ON child_r.elem->>'sourceId' = child_c.collector_id::text
       LEFT JOIN assets child_a ON child_r.elem->>'sourceId' = child_a.asset_id::text
       WHERE child_ie.agent_id IS NOT NULL
-      GROUP BY child_ie.inject_id),
-    inject_expectation_data AS (
-      SELECT
+        AND child_ie.inject_id IN (
+          SELECT ie2.inject_id FROM injects_expectations ie2
+          JOIN changed_expectations ce2 ON ce2.inject_expectation_id = ie2.inject_expectation_id
+        )
+      GROUP BY child_ie.inject_id)
+    SELECT
       ie.inject_expectation_id,
       ie.inject_expectation_name,
       ie.inject_expectation_description,
@@ -421,17 +414,13 @@ public interface InjectExpectationRepository
       )
       || COALESCE(asp.security_platform_ids, ARRAY[]::text[]) AS security_platform_ids
     FROM injects_expectations ie
-    JOIN ranked_expectations re ON ie.inject_expectation_id = re.inject_expectation_id
-    LEFT JOIN exercises ex ON ex.exercise_id = ie.exercise_id
+    JOIN changed_expectations ce ON ie.inject_expectation_id = ce.inject_expectation_id
     LEFT JOIN injects i ON i.inject_id = ie.inject_id
     LEFT JOIN injects_statuses ins ON ins.status_inject = i.inject_id
     LEFT JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
     LEFT JOIN injectors_contracts_attack_patterns ic_ap ON ic_ap.injector_contract_id = ic.injector_contract_id
     LEFT JOIN attack_patterns ap ON ap.attack_pattern_id = ic_ap.attack_pattern_id
     LEFT JOIN injectors_contracts_domains ic_d ON ic_d.injector_contract_id = ic.injector_contract_id
-    LEFT JOIN teams t ON t.team_id = ie.team_id
-    LEFT JOIN assets asset ON asset.asset_id = ie.asset_id
-    LEFT JOIN asset_groups ag ON ag.asset_group_id = ie.asset_group_id
     LEFT JOIN scenarios_exercises se ON se.exercise_id = ie.exercise_id
     LEFT JOIN LATERAL jsonb_array_elements(ie.inject_expectation_results::jsonb) AS r(elem) ON true
     LEFT JOIN collectors c ON r.elem->>'sourceId' = c.collector_id::text
@@ -443,10 +432,8 @@ public interface InjectExpectationRepository
       i.inject_title,
       i.tenant_id,
       asp.security_platform_ids
-    )
-    SELECT * FROM inject_expectation_data ied
-    WHERE ied.agent_id IS NULL
-    ORDER BY ied.inject_expectation_updated_at ASC
+    ORDER BY GREATEST(ie.inject_expectation_updated_at, max(i.inject_updated_at), max(ic.injector_contract_updated_at)) ASC
+    LIMIT :limit
     """,
       nativeQuery = true)
   List<RawInjectExpectationIndexing> findForIndexing(


### PR DESCRIPTION
**Problem:** The ES indexing query for expectations ran for 2+ hours, exhausting the connection pool (20/20 active, 25 waiting).
**Root cause:** The agent_security_platforms CTE performed LATERAL jsonb_array_elements on the entire injects_expectations table (every row with an agent), regardless of the :from time filter. On large datasets this is catastrophically slow.
**Proposed changes (3 optimizations):**
1.Removed ranked_expectations CTE — it re-joined all changed expectations just to sort+limit, duplicating work. The sort + LIMIT :limit is now on the final SELECT.
2.Scoped agent_security_platforms — added a WHERE child_ie.inject_id IN (SELECT ... FROM changed_expectations) filter so it only processes JSON for expectations that actually changed, not the entire table.
3.Removed inject_expectation_data wrapper CTE + unused JOINs (exercises, teams, assets, asset_groups) — flattened into a single direct SELECT, reducing planning overhead.

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
