### PR TITLE
feat(chaining): attack-path execution rows with asset and agent details (#5048)

### DIFF
--- a/docs/docs/development/attack-path.md
+++ b/docs/docs/development/attack-path.md
@@ -57,6 +57,9 @@ erDiagram
         varchar inject_id "ref injects, no FK; #204 per-output lookup key"
         text source_kind "INJECTOR or AGENT_ASSET"
         varchar source_injector
+        varchar source_hostname "agent-based source endpoint, frozen"
+        varchar source_ip
+        varchar source_platform
         varchar target_asset_id "ref assets, no FK"
         text target_key "asset id or raw value"
         varchar target_hostname

--- a/docs/docs/development/attack-path.md
+++ b/docs/docs/development/attack-path.md
@@ -54,6 +54,7 @@ erDiagram
         varchar id PK
         varchar tenant_id FK
         varchar simulation_id "ref exercises, no FK"
+        varchar inject_id "ref injects, no FK; #204 per-output lookup key"
         text source_kind "INJECTOR or AGENT_ASSET"
         varchar source_injector
         varchar target_asset_id "ref assets, no FK"

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -28,8 +28,10 @@ import io.openaev.rest.inject.service.InjectService;
 import io.openaev.rest.inject.service.StructuredOutputUtils;
 import io.openaev.rest.injector_contract.InjectorContractContentUtils;
 import io.openaev.rest.injector_contract.InjectorContractService;
+import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.rest.tag.TagService;
 import io.openaev.service.*;
+import io.openaev.service.attackpath.ingestion.AttackPathExecutionIngestionService;
 import io.openaev.service.chaining.ConditionService;
 import io.openaev.service.chaining.ScopeService;
 import io.openaev.service.chaining.StepService;
@@ -80,6 +82,8 @@ public class InjectExecutionStep implements ActionStep {
   private final ConditionService conditionService;
   private final WorkflowStateService workflowStateService;
   private final ScopeService scopeService;
+  private final PreviewFeatureService previewFeatureService;
+  private final AttackPathExecutionIngestionService attackPathIngestion;
 
   private final InjectorContractRepository injectorContractRepository;
 
@@ -186,6 +190,8 @@ public class InjectExecutionStep implements ActionStep {
                             + readyStep.getId()));
     prepareGetStatusPayloadFromInject(injectorContract);
 
+    recordAttackPathExecution(readyStep, inject, injectorContract);
+
     try {
       String data = setInjectId(inject.getId(), readyStep.getData());
       readyStep.setData(data);
@@ -210,6 +216,22 @@ public class InjectExecutionStep implements ActionStep {
     } catch (Exception e) {
       throw new ChainingException(
           "Inject execution failed. Inject ID: " + injectId + " (transaction rolled back)", e);
+    }
+  }
+
+  /**
+   * Records the attack-path execution rows at RUN (issue 5048, #203). Flag-gated by {@code
+   * ATTACK_PATH} and guarded: a failure here is logged and never fails the inject execution.
+   */
+  private void recordAttackPathExecution(
+      Step readyStep, Inject inject, InjectorContract injectorContract) {
+    if (!previewFeatureService.isFeatureEnabled(PreviewFeature.ATTACK_PATH)) {
+      return;
+    }
+    try {
+      attackPathIngestion.onRun(readyStep, inject, injectorContract);
+    } catch (Exception e) {
+      log.warn("Attack-path ingestion skipped for inject {} (non-fatal)", inject.getId(), e);
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260716140000000__Add_attackpath_execution_inject_id.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260716140000000__Add_attackpath_execution_inject_id.java
@@ -1,0 +1,32 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds the queryable inject id to {@code attackpath_execution} (issue 5048, #203). The execution
+ * row's primary key already embeds the inject id, but it is not queryable on its own (it also
+ * embeds the target key), so #204's per-output update — which arrives with an inject id + an agent
+ * id and must find all of that run's target rows — needs a plain column. Filled at creation by
+ * #203; additive and nullable, so rows created before this migration (and the synthetic seed) carry
+ * no inject id.
+ */
+@Component
+public class V6_20260716140000000__Add_attackpath_execution_inject_id extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "ALTER TABLE attackpath_execution "
+              + "ADD COLUMN IF NOT EXISTS attackpath_execution_inject_id varchar(255);");
+      // #204 looks the run's rows up by (inject id, agent id) to attach the terminal and status.
+      statement.execute(
+          "CREATE INDEX IF NOT EXISTS idx_ap_exec_inject_agent "
+              + "ON attackpath_execution (attackpath_execution_inject_id, "
+              + "attackpath_execution_agent_id);");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260716150000000__Add_attackpath_execution_source_endpoint.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260716150000000__Add_attackpath_execution_source_endpoint.java
@@ -1,0 +1,29 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Freezes the source endpoint's hostname/ip/platform on {@code attackpath_execution} (issue 5048,
+ * #203). For an agent-based run the source is the agent's endpoint; the target's frozen info was
+ * already captured, but the source endpoint's was not, so a source-only endpoint (an agent host
+ * never itself a target) had no attributes to display. Captured at run time as a snapshot (it
+ * cannot be recovered later). Additive and nullable: injector-sourced rows and the seed carry none.
+ */
+@Component
+public class V6_20260716150000000__Add_attackpath_execution_source_endpoint
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "ALTER TABLE attackpath_execution "
+              + "ADD COLUMN IF NOT EXISTS attackpath_execution_source_hostname text, "
+              + "ADD COLUMN IF NOT EXISTS attackpath_execution_source_ip text, "
+              + "ADD COLUMN IF NOT EXISTS attackpath_execution_source_platform text;");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -66,6 +66,9 @@ public class AttackPathExecutionIngestionService {
     row.setSourceKind(edge.sourceKind());
     row.setSourceInjector(edge.sourceInjector());
     row.setSourceAssetId(edge.sourceAssetId());
+    row.setSourceHostname(edge.sourceHostname());
+    row.setSourceIp(edge.sourceIp());
+    row.setSourcePlatform(edge.sourcePlatform());
     row.setAgentId(edge.agentId());
     row.setAgentName(edge.agentName());
     row.setAgentPrivilege(edge.agentPrivilege());

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Attack-path ingestion — Phase A (issue 5048, #203). At RUN, create one EXECUTION row per resolved
  * edge from the run's source/target resolution, on the store columns the read already consumes. The
  * tenant is set by {@code TenantBaseListener} from the current tenant context. #204/#202 update
- * these rows later (Phase B), found by the same deterministic id.
+ * these rows later (Phase B), found by the queryable {@code (inject_id, agent_id)} written here.
  */
 @Service
 @RequiredArgsConstructor
@@ -56,6 +56,9 @@ public class AttackPathExecutionIngestionService {
     // Deterministic natural key so #204/#202 (Phase B) and retries converge on this same row.
     row.setId(AttackPathIds.executionNode(ctx.injectExecId(), edge.targetKey(), edge.agentId()));
     row.setSimulationId(ctx.simulationId());
+    // Queryable lookup key so #204's per-output update finds the run's rows by (inject id, agent
+    // id).
+    row.setInjectId(ctx.injectExecId());
     row.setStepId(ctx.stepId());
     row.setStepTemplateId(ctx.stepTemplateId());
     row.setExecutedAt(ctx.executedAt());

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -1,0 +1,184 @@
+package io.openaev.service.attackpath.ingestion;
+
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.Asset;
+import io.openaev.database.model.Command;
+import io.openaev.database.model.DnsResolution;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.Payload;
+import io.openaev.database.model.Step;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.service.attackpath.AttackPathIds;
+import io.openaev.service.attackpath.ingestion.ResolutionInput.Endpoint;
+import io.openaev.service.attackpath.ingestion.ResolutionInput.PayloadKind;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Attack-path ingestion — Phase A (issue 5048, #203). At RUN, create one EXECUTION row per resolved
+ * edge from the run's source/target resolution, on the store columns the read already consumes. The
+ * tenant is set by {@code TenantBaseListener} from the current tenant context. #204/#202 update
+ * these rows later (Phase B), found by the same deterministic id.
+ */
+@Service
+@RequiredArgsConstructor
+public class AttackPathExecutionIngestionService {
+
+  private final AttackPathExecutionRepository executionRepository;
+  private final AttackPathSourceTargetResolver resolver;
+
+  /** The run context shared by all of a run's execution rows. */
+  public record ExecutionContext(
+      String simulationId,
+      String stepId,
+      String stepTemplateId,
+      String injectExecId,
+      Instant executedAt,
+      String payloadName,
+      String command) {}
+
+  @Transactional
+  public void createRows(ExecutionContext ctx, List<ResolvedExecutionEdge> edges) {
+    // saveAll batches the run's N rows in one round-trip (an inject can hit N targets).
+    executionRepository.saveAll(edges.stream().map(edge -> toRow(ctx, edge)).toList());
+  }
+
+  /**
+   * One frozen EXECUTION row (source → target) for a resolved edge, keyed by the deterministic id.
+   */
+  private AttackPathExecution toRow(ExecutionContext ctx, ResolvedExecutionEdge edge) {
+    AttackPathExecution row = new AttackPathExecution();
+    // Deterministic natural key so #204/#202 (Phase B) and retries converge on this same row.
+    row.setId(AttackPathIds.executionNode(ctx.injectExecId(), edge.targetKey(), edge.agentId()));
+    row.setSimulationId(ctx.simulationId());
+    row.setStepId(ctx.stepId());
+    row.setStepTemplateId(ctx.stepTemplateId());
+    row.setExecutedAt(ctx.executedAt());
+    row.setPayloadName(ctx.payloadName());
+    row.setCommand(ctx.command());
+    row.setSourceKind(edge.sourceKind());
+    row.setSourceInjector(edge.sourceInjector());
+    row.setSourceAssetId(edge.sourceAssetId());
+    row.setAgentId(edge.agentId());
+    row.setAgentName(edge.agentName());
+    row.setAgentPrivilege(edge.agentPrivilege());
+    row.setTargetKind(edge.targetKind());
+    row.setTargetAssetId(edge.targetAssetId());
+    row.setTargetRawValue(edge.targetRawValue());
+    row.setTargetKey(edge.targetKey());
+    row.setTargetHostname(edge.targetHostname());
+    row.setTargetIp(edge.targetIp());
+    row.setTargetPlatform(edge.targetPlatform());
+    return row;
+  }
+
+  /**
+   * Phase A entry point, called (guarded) at RUN: extract the run context + resolution input from
+   * the executed inject, resolve the edges, create the rows. Joins the caller's RUN transaction, so
+   * the rows commit with the inject and a rolled-back run leaves none.
+   *
+   * <p>Scope and assumptions (agent-based; injector path is TBD): the sources are the inject's
+   * direct asset endpoints and their installed agents (asset-group expansion is a follow-up); the
+   * agent label is the endpoint hostname; the command is stored only when faithful ({@code Command}
+   * content) and left empty otherwise, never reconstructed. Documented, not final.
+   */
+  @Transactional
+  public void onRun(Step step, Inject inject, InjectorContract contract) {
+    // The attack path is simulation-scoped, so an inject with no simulation records nothing.
+    if (inject.getExercise() == null) {
+      return;
+    }
+    createRows(
+        context(step, inject, contract), resolver.resolve(resolutionInput(inject, contract)));
+  }
+
+  private ExecutionContext context(Step step, Inject inject, InjectorContract contract) {
+    Payload payload = contract.getPayload();
+    return new ExecutionContext(
+        inject.getExercise() != null ? inject.getExercise().getId() : null,
+        step.getId(),
+        null, // stepTemplateId — wired from the step template later
+        inject.getId(),
+        Instant.now(),
+        payload != null ? payload.getName() : null,
+        command(payload));
+  }
+
+  private ResolutionInput resolutionInput(Inject inject, InjectorContract contract) {
+    Payload payload = contract.getPayload();
+    return new ResolutionInput(
+        contract.getNeedsExecutorEffective(),
+        inject.getInjector() != null ? inject.getInjector().getName() : null,
+        agentEndpoints(inject),
+        payloadKind(payload),
+        payload instanceof DnsResolution dns ? dns.getHostname() : null,
+        List.of(), // command args — TBD (command retrieval under investigation)
+        null, // content selector — injector path TBD
+        List.of(), // manual targets — injector path TBD
+        assetEndpoints(inject));
+  }
+
+  /** The inject's asset endpoints as targets (no agent). */
+  private List<Endpoint> assetEndpoints(Inject inject) {
+    List<Endpoint> out = new ArrayList<>();
+    for (Asset asset : inject.getAssets()) {
+      if (asset instanceof io.openaev.database.model.Endpoint e) {
+        out.add(
+            new Endpoint(e.getId(), e.getHostname(), firstIp(e), platform(e), null, null, null));
+      }
+    }
+    return out;
+  }
+
+  /** The agents on the inject's asset endpoints, as the agent-based sources. */
+  private List<Endpoint> agentEndpoints(Inject inject) {
+    List<Endpoint> out = new ArrayList<>();
+    for (Asset asset : inject.getAssets()) {
+      if (asset instanceof io.openaev.database.model.Endpoint e) {
+        for (Agent agent : e.getAgents()) {
+          out.add(
+              new Endpoint(
+                  e.getId(),
+                  e.getHostname(),
+                  firstIp(e),
+                  platform(e),
+                  agent.getId(),
+                  e.getHostname(), // assumed agent label = its endpoint hostname (to confirm)
+                  agent.getPrivilege() != null ? agent.getPrivilege().name() : null));
+        }
+      }
+    }
+    return out;
+  }
+
+  private static String firstIp(io.openaev.database.model.Endpoint e) {
+    return e.getIps() != null && e.getIps().length > 0 ? e.getIps()[0] : null;
+  }
+
+  private static String platform(io.openaev.database.model.Endpoint e) {
+    return e.getPlatform() != null ? e.getPlatform().name() : null;
+  }
+
+  private static PayloadKind payloadKind(Payload payload) {
+    if (payload instanceof Command) {
+      return PayloadKind.COMMAND;
+    }
+    if (payload instanceof DnsResolution) {
+      return PayloadKind.DNS_RESOLUTION;
+    }
+    return PayloadKind
+        .OTHER; // FileDrop/Executable → OTHER (same target rule as FILE in the resolver)
+  }
+
+  private static String command(Payload payload) {
+    // Store only the faithful command (the Command payload's content); other payload types are left
+    // empty rather than reconstructed, so a copy-pasted command always reproduces the real run.
+    return payload instanceof Command c ? c.getContent() : null;
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -40,8 +40,7 @@ public class AttackPathExecutionIngestionService {
       String stepTemplateId,
       String injectExecId,
       Instant executedAt,
-      String payloadName,
-      String command) {}
+      String payloadName) {}
 
   @Transactional
   public void createRows(ExecutionContext ctx, List<ResolvedExecutionEdge> edges) {
@@ -61,7 +60,6 @@ public class AttackPathExecutionIngestionService {
     row.setStepTemplateId(ctx.stepTemplateId());
     row.setExecutedAt(ctx.executedAt());
     row.setPayloadName(ctx.payloadName());
-    row.setCommand(ctx.command());
     row.setSourceKind(edge.sourceKind());
     row.setSourceInjector(edge.sourceInjector());
     row.setSourceAssetId(edge.sourceAssetId());
@@ -85,8 +83,7 @@ public class AttackPathExecutionIngestionService {
    *
    * <p>Scope and assumptions (agent-based; injector path is TBD): the sources are the inject's
    * direct asset endpoints and their installed agents (asset-group expansion is a follow-up); the
-   * agent label is the endpoint hostname; the command is stored only when faithful ({@code Command}
-   * content) and left empty otherwise, never reconstructed. Documented, not final.
+   * agent label is the endpoint hostname. Documented, not final.
    */
   @Transactional
   public void onRun(Step step, Inject inject, InjectorContract contract) {
@@ -106,8 +103,7 @@ public class AttackPathExecutionIngestionService {
         null, // stepTemplateId — wired from the step template later
         inject.getId(),
         Instant.now(),
-        payload != null ? payload.getName() : null,
-        command(payload));
+        payload != null ? payload.getName() : null);
   }
 
   private ResolutionInput resolutionInput(Inject inject, InjectorContract contract) {
@@ -174,11 +170,5 @@ public class AttackPathExecutionIngestionService {
     }
     return PayloadKind
         .OTHER; // FileDrop/Executable → OTHER (same target rule as FILE in the resolver)
-  }
-
-  private static String command(Payload payload) {
-    // Store only the faithful command (the Command payload's content); other payload types are left
-    // empty rather than reconstructed, so a copy-pasted command always reproduces the real run.
-    return payload instanceof Command c ? c.getContent() : null;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -100,7 +100,7 @@ public class AttackPathExecutionIngestionService {
     return new ExecutionContext(
         inject.getExercise() != null ? inject.getExercise().getId() : null,
         step.getId(),
-        null, // stepTemplateId — wired from the step template later
+        step.getStepTemplate() != null ? step.getStepTemplate().getId() : null,
         inject.getId(),
         Instant.now(),
         payload != null ? payload.getName() : null);

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolver.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolver.java
@@ -1,0 +1,123 @@
+package io.openaev.service.attackpath.ingestion;
+
+import io.openaev.service.attackpath.ingestion.ResolutionInput.Endpoint;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves an executed inject into attack-path edges (source → target), per the product's
+ * source/target rules (issue 5048, #203). Pure: no persistence, no entities. Extracting {@link
+ * ResolutionInput} from the live inject (reusing the engine's asset resolution) happens at the
+ * hook.
+ *
+ * <p>Source: injector-based → the injector; agent-based → each executing agent's endpoint. Target
+ * by payload: DnsResolution → the resolved hostname (raw); File → the inject's assets; Command →
+ * the inject's assets, else the raw argument values; injector selector {@code assets}/{@code
+ * manual} → the inject's assets / the raw manual targets.
+ */
+@Component
+public class AttackPathSourceTargetResolver {
+
+  static final String SOURCE_INJECTOR = "INJECTOR";
+  static final String SOURCE_ASSET = "ASSET";
+  static final String TARGET_ASSET = "ASSET";
+  static final String TARGET_DISCOVERED = "DISCOVERED";
+  static final String SELECTOR_MANUAL = "manual";
+
+  public List<ResolvedExecutionEdge> resolve(ResolutionInput input) {
+    List<ResolvedTarget> targets = resolveTargets(input);
+    List<ResolvedExecutionEdge> edges = new ArrayList<>();
+    if (input.withAgent()) {
+      // One edge per (executing agent's endpoint, target): source = the agent's endpoint. The
+      // extraction (the hook) is responsible for passing the correct agent/target pairing; this
+      // pure step takes the cross product of what it is given.
+      for (Endpoint agent : input.agentEndpoints()) {
+        for (ResolvedTarget t : targets) {
+          edges.add(
+              edge(
+                  SOURCE_ASSET,
+                  null,
+                  agent.assetId(),
+                  t,
+                  agent.agentName(),
+                  agent.agentPrivilege()));
+        }
+      }
+    } else {
+      // Injector-based: source = the injector.
+      for (ResolvedTarget t : targets) {
+        edges.add(edge(SOURCE_INJECTOR, input.injectorName(), null, t, null, null));
+      }
+    }
+    return edges;
+  }
+
+  private List<ResolvedTarget> resolveTargets(ResolutionInput input) {
+    if (input.withAgent()) {
+      return switch (input.payloadKind()) {
+        case DNS_RESOLUTION ->
+            input.dnsHostname() == null ? List.of() : List.of(rawTarget(input.dnsHostname()));
+        case COMMAND ->
+            input.injectAssets().isEmpty()
+                ? input.commandArgs().stream().map(this::rawTarget).toList()
+                : assetTargets(input.injectAssets());
+        case FILE, OTHER -> assetTargets(input.injectAssets());
+      };
+    }
+    if (SELECTOR_MANUAL.equals(input.contentSelector())) {
+      return input.manualTargets().stream().map(this::rawTarget).toList();
+    }
+    return assetTargets(input.injectAssets());
+  }
+
+  private List<ResolvedTarget> assetTargets(List<Endpoint> assets) {
+    return assets.stream()
+        .map(
+            a ->
+                new ResolvedTarget(
+                    TARGET_ASSET,
+                    a.assetId(),
+                    null,
+                    a.assetId(),
+                    a.hostname(),
+                    a.ip(),
+                    a.platform()))
+        .toList();
+  }
+
+  private ResolvedTarget rawTarget(String raw) {
+    return new ResolvedTarget(TARGET_DISCOVERED, null, raw, raw, null, null, null);
+  }
+
+  private ResolvedExecutionEdge edge(
+      String sourceKind,
+      String sourceInjector,
+      String sourceAssetId,
+      ResolvedTarget t,
+      String agentName,
+      String agentPrivilege) {
+    return new ResolvedExecutionEdge(
+        sourceKind,
+        sourceInjector,
+        sourceAssetId,
+        t.kind(),
+        t.assetId(),
+        t.rawValue(),
+        t.key(),
+        t.hostname(),
+        t.ip(),
+        t.platform(),
+        agentName,
+        agentPrivilege);
+  }
+
+  private record ResolvedTarget(
+      String kind,
+      String assetId,
+      String rawValue,
+      String key,
+      String hostname,
+      String ip,
+      String platform) {}
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolver.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolver.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class AttackPathSourceTargetResolver {
 
   static final String SOURCE_INJECTOR = "INJECTOR";
-  static final String SOURCE_ASSET = "ASSET";
+  static final String SOURCE_AGENT_ASSET = "AGENT_ASSET";
   static final String TARGET_ASSET = "ASSET";
   static final String TARGET_DISCOVERED = "DISCOVERED";
   static final String SELECTOR_MANUAL = "manual";
@@ -36,10 +36,11 @@ public class AttackPathSourceTargetResolver {
         for (ResolvedTarget t : targets) {
           edges.add(
               edge(
-                  SOURCE_ASSET,
+                  SOURCE_AGENT_ASSET,
                   null,
                   agent.assetId(),
                   t,
+                  agent.agentId(),
                   agent.agentName(),
                   agent.agentPrivilege()));
         }
@@ -47,7 +48,7 @@ public class AttackPathSourceTargetResolver {
     } else {
       // Injector-based: source = the injector.
       for (ResolvedTarget t : targets) {
-        edges.add(edge(SOURCE_INJECTOR, input.injectorName(), null, t, null, null));
+        edges.add(edge(SOURCE_INJECTOR, input.injectorName(), null, t, null, null, null));
       }
     }
     return edges;
@@ -95,6 +96,7 @@ public class AttackPathSourceTargetResolver {
       String sourceInjector,
       String sourceAssetId,
       ResolvedTarget t,
+      String agentId,
       String agentName,
       String agentPrivilege) {
     return new ResolvedExecutionEdge(
@@ -108,6 +110,7 @@ public class AttackPathSourceTargetResolver {
         t.hostname(),
         t.ip(),
         t.platform(),
+        agentId,
         agentName,
         agentPrivilege);
   }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolver.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolver.java
@@ -39,6 +39,9 @@ public class AttackPathSourceTargetResolver {
                   SOURCE_AGENT_ASSET,
                   null,
                   agent.assetId(),
+                  agent.hostname(),
+                  agent.ip(),
+                  agent.platform(),
                   t,
                   agent.agentId(),
                   agent.agentName(),
@@ -48,7 +51,18 @@ public class AttackPathSourceTargetResolver {
     } else {
       // Injector-based: source = the injector.
       for (ResolvedTarget t : targets) {
-        edges.add(edge(SOURCE_INJECTOR, input.injectorName(), null, t, null, null, null));
+        edges.add(
+            edge(
+                SOURCE_INJECTOR,
+                input.injectorName(),
+                null,
+                null,
+                null,
+                null,
+                t,
+                null,
+                null,
+                null));
       }
     }
     return edges;
@@ -95,6 +109,9 @@ public class AttackPathSourceTargetResolver {
       String sourceKind,
       String sourceInjector,
       String sourceAssetId,
+      String sourceHostname,
+      String sourceIp,
+      String sourcePlatform,
       ResolvedTarget t,
       String agentId,
       String agentName,
@@ -103,6 +120,9 @@ public class AttackPathSourceTargetResolver {
         sourceKind,
         sourceInjector,
         sourceAssetId,
+        sourceHostname,
+        sourceIp,
+        sourcePlatform,
         t.kind(),
         t.assetId(),
         t.rawValue(),

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolutionInput.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolutionInput.java
@@ -32,6 +32,7 @@ public record ResolutionInput(
       String hostname,
       String ip,
       String platform,
+      String agentId,
       String agentName,
       String agentPrivilege) {}
 

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolutionInput.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolutionInput.java
@@ -1,0 +1,44 @@
+package io.openaev.service.attackpath.ingestion;
+
+import java.util.List;
+
+/**
+ * The primitives the source/target resolver needs, extracted from the executed inject at the hook.
+ * Deliberately free of JPA entities so the resolver stays a pure, unit-testable function; the
+ * extraction (reusing the engine's asset resolution) lives at the hook, not here.
+ */
+public record ResolutionInput(
+    boolean withAgent,
+    String injectorName, // the source, when injector-based (no agent)
+    List<Endpoint> agentEndpoints, // the sources, when agent-based (one per executing agent)
+    PayloadKind payloadKind,
+    String dnsHostname, // DnsResolution target (raw)
+    List<String> commandArgs, // Command raw argument values
+    String contentSelector, // "assets" | "manual" (injector-based)
+    List<String> manualTargets, // injector-based manual raw targets
+    List<Endpoint> injectAssets) { // the inject's resolved asset targets
+
+  /** Normalise null lists to empty so the resolver never has to null-check. */
+  public ResolutionInput {
+    agentEndpoints = agentEndpoints == null ? List.of() : agentEndpoints;
+    commandArgs = commandArgs == null ? List.of() : commandArgs;
+    manualTargets = manualTargets == null ? List.of() : manualTargets;
+    injectAssets = injectAssets == null ? List.of() : injectAssets;
+  }
+
+  /** An endpoint (asset), optionally carrying the agent that ran on it. */
+  public record Endpoint(
+      String assetId,
+      String hostname,
+      String ip,
+      String platform,
+      String agentName,
+      String agentPrivilege) {}
+
+  public enum PayloadKind {
+    DNS_RESOLUTION,
+    COMMAND,
+    FILE,
+    OTHER
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolvedExecutionEdge.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolvedExecutionEdge.java
@@ -10,6 +10,9 @@ public record ResolvedExecutionEdge(
     String sourceKind, // "INJECTOR" or "ASSET" (an agent's endpoint)
     String sourceInjector, // the injector name, when the source is an injector
     String sourceAssetId, // the agent endpoint's asset id, when the source is an asset
+    String sourceHostname, // the source endpoint's frozen hostname (agent-based only)
+    String sourceIp, // the source endpoint's frozen ip (agent-based only)
+    String sourcePlatform, // the source endpoint's frozen platform (agent-based only)
     String targetKind, // "ASSET" or "DISCOVERED"
     String targetAssetId,
     String targetRawValue,

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolvedExecutionEdge.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolvedExecutionEdge.java
@@ -1,0 +1,21 @@
+package io.openaev.service.attackpath.ingestion;
+
+/**
+ * One resolved attack-path edge (source → target) for an executed inject: the #203 slice of the
+ * EXECUTION row — the source/target framing plus the asset/agent attributes frozen at run time. The
+ * kind literals match what the graph read branches on ({@code INJECTOR} source; {@code ASSET} /
+ * {@code DISCOVERED} target).
+ */
+public record ResolvedExecutionEdge(
+    String sourceKind, // "INJECTOR" or "ASSET" (an agent's endpoint)
+    String sourceInjector, // the injector name, when the source is an injector
+    String sourceAssetId, // the agent endpoint's asset id, when the source is an asset
+    String targetKind, // "ASSET" or "DISCOVERED"
+    String targetAssetId,
+    String targetRawValue,
+    String targetKey, // coalesce(targetAssetId, targetRawValue)
+    String targetHostname,
+    String targetIp,
+    String targetPlatform,
+    String agentName,
+    String agentPrivilege) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolvedExecutionEdge.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/ResolvedExecutionEdge.java
@@ -17,5 +17,6 @@ public record ResolvedExecutionEdge(
     String targetHostname,
     String targetIp,
     String targetPlatform,
+    String agentId,
     String agentName,
     String agentPrivilege) {}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -84,6 +84,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
 
     assertThat(row.getTenant().getId()).isEqualTo(tenant.getId());
     assertThat(row.getSimulationId()).isEqualTo("SIM-INGEST");
+    assertThat(row.getInjectId()).isEqualTo("exec-1");
     assertThat(row.getStepId()).isEqualTo("step-1");
     assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(row.getSourceAssetId()).isEqualTo("src-asset-1");

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -1,0 +1,223 @@
+package io.openaev.service.attackpath.ingestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.Command;
+import io.openaev.database.model.Endpoint;
+import io.openaev.database.model.Exercise;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Injector;
+import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.Step;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.service.attackpath.AttackPathIds;
+import io.openaev.service.attackpath.ingestion.AttackPathExecutionIngestionService.ExecutionContext;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Phase A create (issue 5048, #203): at RUN, one EXECUTION row per resolved edge, tenant-attributed
+ * from the current tenant context and keyed by the deterministic id, on the columns the read
+ * consumes.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("attack path Phase A: create EXECUTION rows")
+class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
+
+  @Autowired private AttackPathExecutionIngestionService ingestionService;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clearCurrentTenant();
+  }
+
+  @Test
+  @DisplayName(
+      "Agent-based run creates one tenant-scoped row per (target, agent) with frozen columns")
+  void createsRowPerEdge() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-ingest-tenant"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    ExecutionContext ctx =
+        new ExecutionContext(
+            "SIM-INGEST",
+            "step-1",
+            "tmpl-1",
+            "exec-1",
+            Instant.parse("2026-07-16T08:00:00Z"),
+            "crackmapexec",
+            "cme --target victim");
+
+    ResolvedExecutionEdge edge =
+        new ResolvedExecutionEdge(
+            "AGENT_ASSET",
+            null,
+            "src-asset-1",
+            "ASSET",
+            "victim-1",
+            null,
+            "victim-1",
+            "victim",
+            "10.0.0.9",
+            "Linux",
+            "agt-1",
+            "agent-1",
+            "admin");
+
+    ingestionService.createRows(ctx, List.of(edge));
+
+    String id = AttackPathIds.executionNode("exec-1", "victim-1", "agt-1");
+    AttackPathExecution row = executionRepository.findById(id).orElseThrow();
+
+    assertThat(row.getTenant().getId()).isEqualTo(tenant.getId());
+    assertThat(row.getSimulationId()).isEqualTo("SIM-INGEST");
+    assertThat(row.getStepId()).isEqualTo("step-1");
+    assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
+    assertThat(row.getSourceAssetId()).isEqualTo("src-asset-1");
+    assertThat(row.getTargetKind()).isEqualTo("ASSET");
+    assertThat(row.getTargetAssetId()).isEqualTo("victim-1");
+    assertThat(row.getTargetKey()).isEqualTo("victim-1");
+    assertThat(row.getTargetHostname()).isEqualTo("victim");
+    assertThat(row.getTargetPlatform()).isEqualTo("Linux");
+    assertThat(row.getAgentId()).isEqualTo("agt-1");
+    assertThat(row.getAgentName()).isEqualTo("agent-1");
+    assertThat(row.getAgentPrivilege()).isEqualTo("admin");
+    assertThat(row.getExecutedAt()).isEqualTo(Instant.parse("2026-07-16T08:00:00Z"));
+    assertThat(row.getPayloadName()).isEqualTo("crackmapexec");
+    assertThat(row.getCommand()).isEqualTo("cme --target victim");
+  }
+
+  @Test
+  @DisplayName(
+      "Re-running the same edge converges on the same row (deterministic id, no duplicate)")
+  void idempotentOnSameKey() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-ingest-idem"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    ExecutionContext ctx =
+        new ExecutionContext(
+            "SIM-IDEM",
+            "step-1",
+            "tmpl-1",
+            "exec-idem",
+            Instant.parse("2026-07-16T08:00:00Z"),
+            "crackmapexec",
+            "cme --target victim");
+    ResolvedExecutionEdge edge =
+        new ResolvedExecutionEdge(
+            "AGENT_ASSET",
+            null,
+            "src-asset-1",
+            "ASSET",
+            "victim-1",
+            null,
+            "victim-1",
+            "victim",
+            "10.0.0.9",
+            "Linux",
+            "agt-1",
+            "agent-1",
+            "admin");
+
+    ingestionService.createRows(ctx, List.of(edge));
+    ingestionService.createRows(ctx, List.of(edge)); // same (execId, target, agent) → same row
+
+    // The deterministic id makes the second write an update, not a new row.
+    assertThat(executionRepository.count()).isEqualTo(1);
+    assertThat(
+            executionRepository.findById(
+                AttackPathIds.executionNode("exec-idem", "victim-1", "agt-1")))
+        .isPresent();
+  }
+
+  @Test
+  @DisplayName("onRun extracts agent-based source/target from the inject and creates the row")
+  void onRunExtractsFromInject() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-onrun-tenant"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    // In-memory inject graph: only read by the extraction; only the EXECUTION rows are persisted.
+    Agent agent = new Agent();
+    agent.setId("agt-1");
+    agent.setPrivilege(Agent.PRIVILEGE.admin);
+
+    Endpoint endpoint = new Endpoint();
+    endpoint.setId("ep-1");
+    endpoint.setHostname("corp-dc");
+    endpoint.setIps(new String[] {"10.0.0.5"});
+    endpoint.setPlatform(Endpoint.PLATFORM_TYPE.Windows);
+    endpoint.setAgents(List.of(agent));
+
+    Command command = new Command();
+    command.setId("cmd-1");
+    command.setName("crackmapexec");
+    command.setContent("cme --local-auth");
+
+    InjectorContract contract = new InjectorContract();
+    contract.setNeedsExecutor(true);
+    contract.setPayload(command);
+
+    Injector injector = new Injector();
+    injector.setName("OpenAEV Implant");
+
+    Exercise exercise = new Exercise();
+    exercise.setId("SIM-ONRUN");
+
+    Inject inject = new Inject();
+    inject.setId("inj-1");
+    inject.setExercise(exercise);
+    inject.setInjector(injector);
+    inject.setAssets(List.of(endpoint));
+
+    Step step = new Step();
+    step.setId("step-1");
+
+    ingestionService.onRun(step, inject, contract);
+
+    // Local Command (assets, no remote arg): source = the agent's endpoint, target = that endpoint.
+    AttackPathExecution row =
+        executionRepository
+            .findById(AttackPathIds.executionNode("inj-1", "ep-1", "agt-1"))
+            .orElseThrow();
+    assertThat(row.getSimulationId()).isEqualTo("SIM-ONRUN");
+    assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
+    assertThat(row.getSourceAssetId()).isEqualTo("ep-1");
+    assertThat(row.getAgentId()).isEqualTo("agt-1");
+    assertThat(row.getAgentName()).isEqualTo("corp-dc");
+    assertThat(row.getAgentPrivilege()).isEqualTo("admin");
+    assertThat(row.getTargetKind()).isEqualTo("ASSET");
+    assertThat(row.getTargetKey()).isEqualTo("ep-1");
+    assertThat(row.getTargetHostname()).isEqualTo("corp-dc");
+    assertThat(row.getPayloadName()).isEqualTo("crackmapexec");
+    assertThat(row.getCommand()).isEqualTo("cme --local-auth");
+  }
+
+  @Test
+  @DisplayName("onRun records nothing for an inject with no simulation (out of attack-path scope)")
+  void onRunSkipsWhenNoSimulation() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-nosim-tenant"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Inject inject = new Inject();
+    inject.setId("inj-nosim");
+    // no exercise set → out of the simulation-scoped attack path
+
+    ingestionService.onRun(new Step(), inject, new InjectorContract());
+
+    assertThat(executionRepository.count()).isZero();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -59,8 +59,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "tmpl-1",
             "exec-1",
             Instant.parse("2026-07-16T08:00:00Z"),
-            "crackmapexec",
-            "cme --target victim");
+            "crackmapexec");
 
     ResolvedExecutionEdge edge =
         new ResolvedExecutionEdge(
@@ -98,7 +97,6 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getAgentPrivilege()).isEqualTo("admin");
     assertThat(row.getExecutedAt()).isEqualTo(Instant.parse("2026-07-16T08:00:00Z"));
     assertThat(row.getPayloadName()).isEqualTo("crackmapexec");
-    assertThat(row.getCommand()).isEqualTo("cme --target victim");
   }
 
   @Test
@@ -115,8 +113,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "tmpl-1",
             "exec-idem",
             Instant.parse("2026-07-16T08:00:00Z"),
-            "crackmapexec",
-            "cme --target victim");
+            "crackmapexec");
     ResolvedExecutionEdge edge =
         new ResolvedExecutionEdge(
             "AGENT_ASSET",
@@ -203,7 +200,6 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getTargetKey()).isEqualTo("ep-1");
     assertThat(row.getTargetHostname()).isEqualTo("corp-dc");
     assertThat(row.getPayloadName()).isEqualTo("crackmapexec");
-    assertThat(row.getCommand()).isEqualTo("cme --local-auth");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -180,8 +180,11 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     inject.setInjector(injector);
     inject.setAssets(List.of(endpoint));
 
+    Step template = new Step();
+    template.setId("tmpl-1");
     Step step = new Step();
     step.setId("step-1");
+    step.setStepTemplate(template);
 
     ingestionService.onRun(step, inject, contract);
 
@@ -200,6 +203,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getTargetKey()).isEqualTo("ep-1");
     assertThat(row.getTargetHostname()).isEqualTo("corp-dc");
     assertThat(row.getPayloadName()).isEqualTo("crackmapexec");
+    assertThat(row.getStepTemplateId()).isEqualTo("tmpl-1");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -66,6 +66,9 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "AGENT_ASSET",
             null,
             "src-asset-1",
+            "src-host",
+            "10.0.0.1",
+            "Windows",
             "ASSET",
             "victim-1",
             null,
@@ -88,6 +91,9 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getStepId()).isEqualTo("step-1");
     assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(row.getSourceAssetId()).isEqualTo("src-asset-1");
+    assertThat(row.getSourceHostname()).isEqualTo("src-host");
+    assertThat(row.getSourceIp()).isEqualTo("10.0.0.1");
+    assertThat(row.getSourcePlatform()).isEqualTo("Windows");
     assertThat(row.getTargetKind()).isEqualTo("ASSET");
     assertThat(row.getTargetAssetId()).isEqualTo("victim-1");
     assertThat(row.getTargetKey()).isEqualTo("victim-1");
@@ -120,6 +126,9 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "AGENT_ASSET",
             null,
             "src-asset-1",
+            "src-host",
+            "10.0.0.1",
+            "Windows",
             "ASSET",
             "victim-1",
             null,
@@ -197,6 +206,9 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getSimulationId()).isEqualTo("SIM-ONRUN");
     assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(row.getSourceAssetId()).isEqualTo("ep-1");
+    assertThat(row.getSourceHostname()).isEqualTo("corp-dc");
+    assertThat(row.getSourceIp()).isEqualTo("10.0.0.5");
+    assertThat(row.getSourcePlatform()).isEqualTo("Windows");
     assertThat(row.getAgentId()).isEqualTo("agt-1");
     assertThat(row.getAgentName()).isEqualTo("corp-dc");
     assertThat(row.getAgentPrivilege()).isEqualTo("admin");

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolverTest.java
@@ -1,0 +1,189 @@
+package io.openaev.service.attackpath.ingestion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.service.attackpath.ingestion.ResolutionInput.Endpoint;
+import io.openaev.service.attackpath.ingestion.ResolutionInput.PayloadKind;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests for the source/target resolution (issue 5048, #203). */
+class AttackPathSourceTargetResolverTest {
+
+  private final AttackPathSourceTargetResolver resolver = new AttackPathSourceTargetResolver();
+
+  private static Endpoint asset(String id, String host, String ip, String platform) {
+    return new Endpoint(id, host, ip, platform, null, null);
+  }
+
+  private static Endpoint agent(
+      String assetId, String host, String ip, String platform, String name, String priv) {
+    return new Endpoint(assetId, host, ip, platform, name, priv);
+  }
+
+  @Test
+  @DisplayName(
+      "Injector-based, selector 'assets': one edge per asset, source = injector, target frozen")
+  void injectorAssets() {
+    ResolutionInput input =
+        new ResolutionInput(
+            false,
+            "Nmap",
+            List.of(),
+            PayloadKind.OTHER,
+            null,
+            List.of(),
+            "assets",
+            List.of(),
+            List.of(
+                asset("a1", "host1", "10.0.0.1", "Linux"),
+                asset("a2", "host2", "10.0.0.2", "Windows")));
+
+    List<ResolvedExecutionEdge> edges = resolver.resolve(input);
+
+    assertThat(edges).hasSize(2);
+    assertThat(edges)
+        .allSatisfy(
+            e -> {
+              assertThat(e.sourceKind()).isEqualTo("INJECTOR");
+              assertThat(e.sourceInjector()).isEqualTo("Nmap");
+              assertThat(e.sourceAssetId()).isNull();
+              assertThat(e.targetKind()).isEqualTo("ASSET");
+              assertThat(e.agentName()).isNull();
+            });
+    assertThat(edges.get(0).targetAssetId()).isEqualTo("a1");
+    assertThat(edges.get(0).targetKey()).isEqualTo("a1");
+    assertThat(edges.get(0).targetHostname()).isEqualTo("host1");
+    assertThat(edges.get(0).targetPlatform()).isEqualTo("Linux");
+  }
+
+  @Test
+  @DisplayName("Injector-based, selector 'manual': raw target, DISCOVERED kind, key = raw, no host")
+  void injectorManual() {
+    ResolutionInput input =
+        new ResolutionInput(
+            false,
+            "NetExec",
+            List.of(),
+            PayloadKind.OTHER,
+            null,
+            List.of(),
+            "manual",
+            List.of("honey.scanme.sh"),
+            List.of());
+
+    List<ResolvedExecutionEdge> edges = resolver.resolve(input);
+
+    assertThat(edges).hasSize(1);
+    ResolvedExecutionEdge e = edges.get(0);
+    assertThat(e.sourceKind()).isEqualTo("INJECTOR");
+    assertThat(e.targetKind()).isEqualTo("DISCOVERED");
+    assertThat(e.targetAssetId()).isNull();
+    assertThat(e.targetRawValue()).isEqualTo("honey.scanme.sh");
+    assertThat(e.targetKey()).isEqualTo("honey.scanme.sh");
+    assertThat(e.targetHostname()).isNull();
+  }
+
+  @Test
+  @DisplayName(
+      "Agent-based, DnsResolution: source = agent endpoint, target = dns hostname (DISCOVERED)")
+  void agentDns() {
+    ResolutionInput input =
+        new ResolutionInput(
+            true,
+            null,
+            List.of(agent("agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agent-1", "admin")),
+            PayloadKind.DNS_RESOLUTION,
+            "internal.corp",
+            List.of(),
+            null,
+            List.of(),
+            List.of());
+
+    List<ResolvedExecutionEdge> edges = resolver.resolve(input);
+
+    assertThat(edges).hasSize(1);
+    ResolvedExecutionEdge e = edges.get(0);
+    assertThat(e.sourceKind()).isEqualTo("ASSET");
+    assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
+    assertThat(e.sourceInjector()).isNull();
+    assertThat(e.targetKind()).isEqualTo("DISCOVERED");
+    assertThat(e.targetRawValue()).isEqualTo("internal.corp");
+    assertThat(e.targetKey()).isEqualTo("internal.corp");
+    assertThat(e.agentName()).isEqualTo("agent-1");
+    assertThat(e.agentPrivilege()).isEqualTo("admin");
+  }
+
+  @Test
+  @DisplayName("Agent-based, Command with an inject asset: source = agent, target = the asset")
+  void agentCommandAsset() {
+    ResolutionInput input =
+        new ResolutionInput(
+            true,
+            null,
+            List.of(agent("agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agent-1", "admin")),
+            PayloadKind.COMMAND,
+            null,
+            List.of("--target victim"),
+            null,
+            List.of(),
+            List.of(asset("victim-1", "victim", "10.0.0.9", "Linux")));
+
+    List<ResolvedExecutionEdge> edges = resolver.resolve(input);
+
+    assertThat(edges).hasSize(1);
+    ResolvedExecutionEdge e = edges.get(0);
+    assertThat(e.sourceKind()).isEqualTo("ASSET");
+    assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
+    assertThat(e.targetKind()).isEqualTo("ASSET");
+    assertThat(e.targetAssetId()).isEqualTo("victim-1");
+    assertThat(e.targetKey()).isEqualTo("victim-1");
+    assertThat(e.targetHostname()).isEqualTo("victim");
+    assertThat(e.agentName()).isEqualTo("agent-1");
+  }
+
+  @Test
+  @DisplayName("Agent-based, File on two assets: one edge per target asset, source = the agent")
+  void agentFileTwoAssets() {
+    ResolutionInput input =
+        new ResolutionInput(
+            true,
+            null,
+            List.of(agent("agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agent-1", "user")),
+            PayloadKind.FILE,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of(
+                asset("a1", "host1", "10.0.0.1", "Linux"),
+                asset("a2", "host2", "10.0.0.2", "Windows")));
+
+    List<ResolvedExecutionEdge> edges = resolver.resolve(input);
+
+    assertThat(edges).hasSize(2);
+    assertThat(edges)
+        .allSatisfy(
+            e -> {
+              assertThat(e.sourceKind()).isEqualTo("ASSET");
+              assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
+              assertThat(e.targetKind()).isEqualTo("ASSET");
+              assertThat(e.agentName()).isEqualTo("agent-1");
+            });
+    assertThat(edges).extracting(ResolvedExecutionEdge::targetAssetId).containsExactly("a1", "a2");
+  }
+
+  @Test
+  @DisplayName("Null lists are tolerated (normalised to empty), no NPE")
+  void nullListsTolerated() {
+    ResolutionInput input =
+        new ResolutionInput(
+            false, "Nmap", null, PayloadKind.OTHER, null, null, "assets", null, null);
+
+    // Robustness only: with no assets there is no edge (the targetless/local-execution semantics
+    // are
+    // an open product question, tracked in the plan — not asserted as correct here).
+    assertThat(resolver.resolve(input)).isEmpty();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolverTest.java
@@ -14,12 +14,18 @@ class AttackPathSourceTargetResolverTest {
   private final AttackPathSourceTargetResolver resolver = new AttackPathSourceTargetResolver();
 
   private static Endpoint asset(String id, String host, String ip, String platform) {
-    return new Endpoint(id, host, ip, platform, null, null);
+    return new Endpoint(id, host, ip, platform, null, null, null);
   }
 
   private static Endpoint agent(
-      String assetId, String host, String ip, String platform, String name, String priv) {
-    return new Endpoint(assetId, host, ip, platform, name, priv);
+      String assetId,
+      String host,
+      String ip,
+      String platform,
+      String agentId,
+      String name,
+      String priv) {
+    return new Endpoint(assetId, host, ip, platform, agentId, name, priv);
   }
 
   @Test
@@ -93,7 +99,15 @@ class AttackPathSourceTargetResolverTest {
         new ResolutionInput(
             true,
             null,
-            List.of(agent("agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agent-1", "admin")),
+            List.of(
+                agent(
+                    "agent-asset-1",
+                    "corp-dc",
+                    "10.0.0.5",
+                    "Windows",
+                    "agt-1",
+                    "agent-1",
+                    "admin")),
             PayloadKind.DNS_RESOLUTION,
             "internal.corp",
             List.of(),
@@ -105,7 +119,7 @@ class AttackPathSourceTargetResolverTest {
 
     assertThat(edges).hasSize(1);
     ResolvedExecutionEdge e = edges.get(0);
-    assertThat(e.sourceKind()).isEqualTo("ASSET");
+    assertThat(e.sourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
     assertThat(e.sourceInjector()).isNull();
     assertThat(e.targetKind()).isEqualTo("DISCOVERED");
@@ -122,7 +136,15 @@ class AttackPathSourceTargetResolverTest {
         new ResolutionInput(
             true,
             null,
-            List.of(agent("agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agent-1", "admin")),
+            List.of(
+                agent(
+                    "agent-asset-1",
+                    "corp-dc",
+                    "10.0.0.5",
+                    "Windows",
+                    "agt-1",
+                    "agent-1",
+                    "admin")),
             PayloadKind.COMMAND,
             null,
             List.of("--target victim"),
@@ -134,7 +156,7 @@ class AttackPathSourceTargetResolverTest {
 
     assertThat(edges).hasSize(1);
     ResolvedExecutionEdge e = edges.get(0);
-    assertThat(e.sourceKind()).isEqualTo("ASSET");
+    assertThat(e.sourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
     assertThat(e.targetKind()).isEqualTo("ASSET");
     assertThat(e.targetAssetId()).isEqualTo("victim-1");
@@ -150,7 +172,9 @@ class AttackPathSourceTargetResolverTest {
         new ResolutionInput(
             true,
             null,
-            List.of(agent("agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agent-1", "user")),
+            List.of(
+                agent(
+                    "agent-asset-1", "corp-dc", "10.0.0.5", "Windows", "agt-1", "agent-1", "user")),
             PayloadKind.FILE,
             null,
             List.of(),
@@ -166,7 +190,7 @@ class AttackPathSourceTargetResolverTest {
     assertThat(edges)
         .allSatisfy(
             e -> {
-              assertThat(e.sourceKind()).isEqualTo("ASSET");
+              assertThat(e.sourceKind()).isEqualTo("AGENT_ASSET");
               assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
               assertThat(e.targetKind()).isEqualTo("ASSET");
               assertThat(e.agentName()).isEqualTo("agent-1");

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathSourceTargetResolverTest.java
@@ -55,6 +55,7 @@ class AttackPathSourceTargetResolverTest {
               assertThat(e.sourceKind()).isEqualTo("INJECTOR");
               assertThat(e.sourceInjector()).isEqualTo("Nmap");
               assertThat(e.sourceAssetId()).isNull();
+              assertThat(e.sourceHostname()).isNull();
               assertThat(e.targetKind()).isEqualTo("ASSET");
               assertThat(e.agentName()).isNull();
             });
@@ -121,6 +122,9 @@ class AttackPathSourceTargetResolverTest {
     ResolvedExecutionEdge e = edges.get(0);
     assertThat(e.sourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(e.sourceAssetId()).isEqualTo("agent-asset-1");
+    assertThat(e.sourceHostname()).isEqualTo("corp-dc");
+    assertThat(e.sourceIp()).isEqualTo("10.0.0.5");
+    assertThat(e.sourcePlatform()).isEqualTo("Windows");
     assertThat(e.sourceInjector()).isNull();
     assertThat(e.targetKind()).isEqualTo("DISCOVERED");
     assertThat(e.targetRawValue()).isEqualTo("internal.corp");

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathExecution.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathExecution.java
@@ -62,6 +62,15 @@ public class AttackPathExecution implements TenantBase {
   @Column(name = "attackpath_execution_source_asset_id")
   private String sourceAssetId;
 
+  @Column(name = "attackpath_execution_source_hostname")
+  private String sourceHostname;
+
+  @Column(name = "attackpath_execution_source_ip")
+  private String sourceIp;
+
+  @Column(name = "attackpath_execution_source_platform")
+  private String sourcePlatform;
+
   @Column(name = "attackpath_execution_agent_id")
   private String agentId;
 

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathExecution.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathExecution.java
@@ -44,6 +44,9 @@ public class AttackPathExecution implements TenantBase {
   @Column(name = "attackpath_execution_simulation_id", nullable = false)
   private String simulationId;
 
+  @Column(name = "attackpath_execution_inject_id")
+  private String injectId;
+
   @Column(name = "attackpath_execution_step_id")
   private String stepId;
 


### PR DESCRIPTION
## What this PR does (#203 — asset & agent details)

At each agent-based run, it creates one `attackpath_execution` row per (target, agent). Each row holds the **asset and agent details**: the source (the agent's endpoint), the target (resolved from the payload — a DNS host, a command target, or file assets), and the frozen `source_kind`, `source_asset_id`, `target_kind/key/hostname/ip/platform`, `agent_id/agent_name/agent_privilege`, `payload_name`.

Two parts:
1. **`AttackPathSourceTargetResolver`** — a pure function. It turns an inject into source→target edges.
2. **`AttackPathExecutionIngestionService`** — at RUN (`InjectExecutionStep.run()`), it resolves the edges and creates the rows. The hook is **flag-gated** by `ATTACK_PATH` and **guarded** (a failure never breaks the inject execution).

The row id is **deterministic**: `AttackPathIds.executionNode(injectExecId, targetKey, agentId)`. So a retry writes the same row, never a duplicate.

> The source/target resolution is nominally **#205** ("endpoint & injector definition"). It is covered here, so #205 can be absorbed into #203 or closed.

Tests: `AttackPathSourceTargetResolverTest` (pure) and `AttackPathExecutionIngestionServiceTest` (real Postgres).

---

## For #204 (command, executed_at, traces) and #202 (status, outputs)

This PR writes **only** the asset/agent columns. Your columns (`command`, `terminal_output`, `executed_at`, `prevention_status`, `detection_status`, findings) are **not** written here. Here is what you need to build Phase B on top of it:

- **Same row.** Your Phase B updates the same rows I create. Join on the deterministic id above — so your data lands on the same row, no duplicate.

- **Finding the rows (open point — let's confirm).** In the callback you have `injectId + agentId`. The row id also embeds `targetKey`, which you do not know from the callback, so you cannot rebuild the id. You need a **queryable `inject_id` column** (`simulation_id + agent_id` is too wide — one agent runs many injects). This is the *"il faut mettre à jour l'id de l'inject"* from our chat: it is a **create-time value**, so #203 can set it when it creates the row. I prototyped the column and removed it during the scope split — putting it back on the #203 create is easy. **Let's confirm who adds it.**

- **Where to hook.** Both callback paths — the single one (`InjectExecutionService.handleInjectExecutionCallback`) and the batch one (`BatchingInjectStatusService`) — go through **`InjectExecutionService.processInjectExecutionWithAgent`**. That is the right place to hook. Do **not** use the AOP aspect (`@WorkflowUpdateEvent`): it only has the inject id, not the agent or the traces.

- **Per-agent terminal.** `ExecutionTrace` has an `agent`, a `message`, and a `time`. Filter the inject's traces by agent, order by time, join the messages. **Overwrite** (do not append) so a re-processing stays idempotent.

- **⚠️ Tenant scoping — please read this.** The ingestion runs in a **background/queue context** with **no `TxCtx`**. On the active tables (`attackpath_execution` is in `openaev.tenant.active-tables`), the statement inspector **fails closed** without a scope: your `find` will return **empty in production**. You must set the tenant scope with the background-tx primitive (**PR #6642**, `TenantScopedTransaction.executeNew(TxCtx.forTenant(injectTenant), ...)`). Two warnings:
  - The **test harness does not enable the inspector** (no `active-tables` in the test config). So your tests can be **green even if the scope is wrong**. Activate the inspector in a test to check the real tenant behaviour.
  - My Phase A create has the same issue (its idempotent merge-SELECT fails closed too). I will convert it to the primitive when #6642 lands. We stay on the current base until then.

- **Open question — `executed_at`.** The board lists it under #204 (yours). But the column is **NOT NULL**, so the create cannot leave it empty. I set it as a creation stamp (the RUN time) for now. We should decide together: keep it here, or make it **nullable** and you own it fully.

- **Open point — source endpoint info (a #203 gap).** You noted #203 should also freeze the **source** endpoint's `hostname/ip/platform` (the agent's endpoint, for agent-based runs). Right now the create sets `source_asset_id` + `agent_name` (= the endpoint hostname) but **not** the source `ip/platform`. So we need `source_hostname/ip/platform` columns filled at create — a small #203 addition. Confirm and I add them.

---

## Not in this PR (follow-ups)

- Asset-group expansion (`computeDynamicAssets`) — Phase A covers the inject's **direct** assets only.
- Injector-triggered path — TBD (injectors do not run through chaining yet).
- Tenant scoping of the create — waits for **#6642**, then converted at rebase.
- Performance gate.

> Not production-ready until the tenant scoping (#6642) is applied. It is safe on the base branch because the whole path is behind the `ATTACK_PATH` flag (off by default).
