### PR TITLE
feat(chaining): add methods to extract command and execution trace

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -528,6 +528,9 @@ public class InjectExecutionStep implements ActionStep {
 
     InjectStatus status = inject.getStatus().get();
     StatusPayload statusPayload = status.getPayloadOutput();
+    if (statusPayload == null || statusPayload.getPayloadCommandBlocks() == null) {
+      return "";
+    }
     StringBuilder command = new StringBuilder();
     statusPayload
         .getPayloadCommandBlocks()

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -549,7 +549,9 @@ public class InjectExecutionStep implements ActionStep {
     if (inject.getInjector() == null) {
       executionTraces.forEach(
           executionTrace -> {
-            // TODO BUILD INDEX
+            if (executionTrace.getAgent() == null || executionTrace.getAgent().getAsset() == null) {
+              return;
+            }
             String agentId =
                 executionTrace.getAgent().getId() + executionTrace.getAgent().getAsset().getId();
             tracesByEndpointSource

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -523,6 +523,56 @@ public class InjectExecutionStep implements ActionStep {
     return setField(dataStep, "inject_id", injectId);
   }
 
+  private String getCommand(Inject inject){
+      if(inject.getStatus().isEmpty()) return "";
+
+      InjectStatus status = inject.getStatus().get();
+      StatusPayload statusPayload = status.getPayloadOutput();
+      StringBuilder command = new StringBuilder();
+      statusPayload.getPayloadCommandBlocks().forEach(
+          payloadCommandBlock -> {
+              command.append(payloadCommandBlock.getExecutor())
+                  .append(payloadCommandBlock.getContent());
+            }
+          );
+      return command.toString();
+  }
+
+  private Map<String, StringBuilder> getExecutionTracesByEndpointIndex(Inject inject) {
+    Map<String, StringBuilder> tracesByEndpointSource = new HashMap<>();
+    if (inject.getStatus().isEmpty()) return tracesByEndpointSource;
+
+    InjectStatus status = inject.getStatus().get();
+    List<ExecutionTrace> executionTraces = status.getTraces();
+
+    if(inject.getInjector() == null) {
+      executionTraces.forEach(
+          executionTrace -> {
+            // TODO BUILD INDEX
+            String agentId = executionTrace.getAgent().getId()+ executionTrace.getAgent().getAsset().getId();
+            tracesByEndpointSource
+                .computeIfAbsent(agentId, k -> new StringBuilder())
+                .append(executionTrace.getStatus().name())
+                .append(" ")
+                .append(executionTrace.getMessage())
+                .append("\n");
+          });
+    } else {
+      // TODO BUILD INDEX
+      String injectorId = inject.getInjector().getId();
+      executionTraces.forEach(
+          executionTrace -> {
+            tracesByEndpointSource
+                .computeIfAbsent(injectorId, k -> new StringBuilder())
+                .append(executionTrace.getStatus().name())
+                .append(" ")
+                .append(executionTrace.getMessage())
+                .append("\n");
+          });
+    }
+    return tracesByEndpointSource;
+  }
+
   /**
    * Converts an {@link InjectInput} into a list of {@link StepsCreateInput.StepInput}.
    *

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -531,8 +531,7 @@ public class InjectExecutionStep implements ActionStep {
       StringBuilder command = new StringBuilder();
       statusPayload.getPayloadCommandBlocks().forEach(
           payloadCommandBlock -> {
-              command.append(payloadCommandBlock.getExecutor())
-                  .append(payloadCommandBlock.getContent());
+              command.append(payloadCommandBlock.getContent());
             }
           );
       return command.toString();

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -523,18 +523,20 @@ public class InjectExecutionStep implements ActionStep {
     return setField(dataStep, "inject_id", injectId);
   }
 
-  private String getCommand(Inject inject){
-      if(inject.getStatus().isEmpty()) return "";
+  private String getCommand(Inject inject) {
+    if (inject.getStatus().isEmpty()) return "";
 
-      InjectStatus status = inject.getStatus().get();
-      StatusPayload statusPayload = status.getPayloadOutput();
-      StringBuilder command = new StringBuilder();
-      statusPayload.getPayloadCommandBlocks().forEach(
-          payloadCommandBlock -> {
+    InjectStatus status = inject.getStatus().get();
+    StatusPayload statusPayload = status.getPayloadOutput();
+    StringBuilder command = new StringBuilder();
+    statusPayload
+        .getPayloadCommandBlocks()
+        .forEach(
+            payloadCommandBlock -> {
               command.append(payloadCommandBlock.getContent());
-            }
-          );
-      return command.toString();
+              command.append("\n");
+            });
+    return command.toString();
   }
 
   private Map<String, StringBuilder> getExecutionTracesByEndpointIndex(Inject inject) {
@@ -544,11 +546,12 @@ public class InjectExecutionStep implements ActionStep {
     InjectStatus status = inject.getStatus().get();
     List<ExecutionTrace> executionTraces = status.getTraces();
 
-    if(inject.getInjector() == null) {
+    if (inject.getInjector() == null) {
       executionTraces.forEach(
           executionTrace -> {
             // TODO BUILD INDEX
-            String agentId = executionTrace.getAgent().getId()+ executionTrace.getAgent().getAsset().getId();
+            String agentId =
+                executionTrace.getAgent().getId() + executionTrace.getAgent().getAsset().getId();
             tracesByEndpointSource
                 .computeIfAbsent(agentId, k -> new StringBuilder())
                 .append(executionTrace.getStatus().name())

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -559,6 +559,8 @@ public class InjectExecutionStep implements ActionStep {
                 executionTrace.getAgent().getId() + executionTrace.getAgent().getAsset().getId();
             tracesByEndpointSource
                 .computeIfAbsent(agentId, k -> new StringBuilder())
+                .append(executionTrace.getTime())
+                .append(" ")
                 .append(executionTrace.getStatus().name())
                 .append(" ")
                 .append(executionTrace.getMessage())
@@ -571,6 +573,8 @@ public class InjectExecutionStep implements ActionStep {
           executionTrace -> {
             tracesByEndpointSource
                 .computeIfAbsent(injectorId, k -> new StringBuilder())
+                .append(executionTrace.getTime())
+                .append(" ")
                 .append(executionTrace.getStatus().name())
                 .append(" ")
                 .append(executionTrace.getMessage())

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -908,4 +908,42 @@ public class InjectExecutionStepTest extends IntegrationTest {
         "EXECUTED first\nERROR second\n", tracesByEndpointSource.get("agent-1asset-1").toString());
     assertEquals("INFO third\n", tracesByEndpointSource.get("agent-2asset-2").toString());
   }
+
+  @Test
+  void given_injectWithoutInjector_whenTraceHasNoAgent_thenSkipAgentlessTrace() {
+    // Arrange
+    Inject inject = new Inject();
+
+    Asset asset = new Asset();
+    asset.setId("asset-1");
+    Agent agent = new Agent();
+    agent.setId("agent-1");
+    agent.setAsset(asset);
+
+    ExecutionTrace globalTrace = new ExecutionTrace();
+    globalTrace.setAgent(null);
+    globalTrace.setStatus(ExecutionTraceStatus.WARNING);
+    globalTrace.setMessage("global warning");
+
+    ExecutionTrace endpointTrace = new ExecutionTrace();
+    endpointTrace.setAgent(agent);
+    endpointTrace.setStatus(ExecutionTraceStatus.EXECUTED);
+    endpointTrace.setMessage("endpoint ok");
+
+    InjectStatus status = new InjectStatus();
+    status.addTrace(globalTrace);
+    status.addTrace(endpointTrace);
+    inject.setStatus(status);
+
+    // Act
+    Map<String, StringBuilder> tracesByEndpointSource =
+        ReflectionTestUtils.invokeMethod(
+            injectExecutionStep, "getExecutionTracesByEndpointIndex", inject);
+
+    // Assert
+    assertNotNull(tracesByEndpointSource);
+    assertEquals(1, tracesByEndpointSource.size());
+    assertTrue(tracesByEndpointSource.containsKey("agent-1asset-1"));
+    assertEquals("EXECUTED endpoint ok\n", tracesByEndpointSource.get("agent-1asset-1").toString());
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -775,4 +775,137 @@ public class InjectExecutionStepTest extends IntegrationTest {
         StepService.getField(stepTemplate.getInput(), "input.keyType"));
     assertNull(StepService.getField(stepTemplate.getInput(), "input.keySubtype"));
   }
+
+  @Test
+  void given_injectWithoutStatus_whenGetCommand_thenReturnEmptyString() {
+    // Arrange
+    Inject inject = new Inject();
+
+    // Act
+    String command = ReflectionTestUtils.invokeMethod(injectExecutionStep, "getCommand", inject);
+
+    // Assert
+    assertEquals("", command);
+  }
+
+  @Test
+  void given_injectWithPayloadCommands_whenGetCommand_thenConcatenateCommandContents() {
+    // Arrange
+    Inject inject = new Inject();
+    InjectStatus status = new InjectStatus();
+    StatusPayload payload = new StatusPayload();
+    payload.setPayloadCommandBlocks(
+        List.of(
+            new PayloadCommandBlock("bash", "whoami", List.of()),
+            new PayloadCommandBlock("cmd", "hostname", List.of())));
+    status.setPayloadOutput(payload);
+    inject.setStatus(status);
+
+    // Act
+    String command = ReflectionTestUtils.invokeMethod(injectExecutionStep, "getCommand", inject);
+
+    // Assert
+    assertEquals("whoami\nhostname\n", command);
+  }
+
+  @Test
+  void given_injectWithoutStatus_whenGetExecutionTracesByEndpointIndex_thenReturnEmptyMap() {
+    // Arrange
+    Inject inject = new Inject();
+
+    // Act
+    Map<String, StringBuilder> tracesByEndpointSource =
+        ReflectionTestUtils.invokeMethod(
+            injectExecutionStep, "getExecutionTracesByEndpointIndex", inject);
+
+    // Assert
+    assertNotNull(tracesByEndpointSource);
+    assertTrue(tracesByEndpointSource.isEmpty());
+  }
+
+  @Test
+  void given_injectWithInjector_whenGetExecutionTracesByEndpointIndex_thenGroupByInjectorId() {
+    // Arrange
+    Inject inject = new Inject();
+    Injector injector = new Injector();
+    injector.setId("injector-1");
+    inject.setInjector(injector);
+
+    ExecutionTrace firstTrace = new ExecutionTrace();
+    firstTrace.setStatus(ExecutionTraceStatus.EXECUTED);
+    firstTrace.setMessage("first");
+
+    ExecutionTrace secondTrace = new ExecutionTrace();
+    secondTrace.setStatus(ExecutionTraceStatus.ERROR);
+    secondTrace.setMessage("second");
+
+    InjectStatus status = new InjectStatus();
+    status.addTrace(firstTrace);
+    status.addTrace(secondTrace);
+    inject.setStatus(status);
+
+    // Act
+    Map<String, StringBuilder> tracesByEndpointSource =
+        ReflectionTestUtils.invokeMethod(
+            injectExecutionStep, "getExecutionTracesByEndpointIndex", inject);
+
+    // Assert
+    assertNotNull(tracesByEndpointSource);
+    assertEquals(1, tracesByEndpointSource.size());
+    assertTrue(tracesByEndpointSource.containsKey("injector-1"));
+    assertEquals(
+        "EXECUTED first\nERROR second\n", tracesByEndpointSource.get("injector-1").toString());
+  }
+
+  @Test
+  void
+      given_injectWithoutInjector_whenGetExecutionTracesByEndpointIndex_thenGroupByAgentAndAsset() {
+    // Arrange
+    Inject inject = new Inject();
+
+    Asset assetOne = new Asset();
+    assetOne.setId("asset-1");
+    Agent agentOne = new Agent();
+    agentOne.setId("agent-1");
+    agentOne.setAsset(assetOne);
+
+    Asset assetTwo = new Asset();
+    assetTwo.setId("asset-2");
+    Agent agentTwo = new Agent();
+    agentTwo.setId("agent-2");
+    agentTwo.setAsset(assetTwo);
+
+    ExecutionTrace firstTrace = new ExecutionTrace();
+    firstTrace.setAgent(agentOne);
+    firstTrace.setStatus(ExecutionTraceStatus.EXECUTED);
+    firstTrace.setMessage("first");
+
+    ExecutionTrace secondTrace = new ExecutionTrace();
+    secondTrace.setAgent(agentOne);
+    secondTrace.setStatus(ExecutionTraceStatus.ERROR);
+    secondTrace.setMessage("second");
+
+    ExecutionTrace thirdTrace = new ExecutionTrace();
+    thirdTrace.setAgent(agentTwo);
+    thirdTrace.setStatus(ExecutionTraceStatus.INFO);
+    thirdTrace.setMessage("third");
+
+    InjectStatus status = new InjectStatus();
+    status.addTrace(firstTrace);
+    status.addTrace(secondTrace);
+    status.addTrace(thirdTrace);
+    inject.setStatus(status);
+
+    // Act
+    Map<String, StringBuilder> tracesByEndpointSource =
+        ReflectionTestUtils.invokeMethod(
+            injectExecutionStep, "getExecutionTracesByEndpointIndex", inject);
+
+    // Assert
+    assertNotNull(tracesByEndpointSource);
+    assertEquals(2, tracesByEndpointSource.size());
+    assertEquals(
+        "EXECUTED first\nERROR second\n", tracesByEndpointSource.get("agent-1asset-1").toString());
+    assertEquals("INFO third\n", tracesByEndpointSource.get("agent-2asset-2").toString());
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/database/repository/ExecutionTraceRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/repository/ExecutionTraceRepositoryTest.java
@@ -1,0 +1,326 @@
+package io.openaev.database.repository;
+
+import static io.openaev.utils.fixtures.AgentFixture.createDefaultAgentService;
+import static io.openaev.utils.fixtures.EndpointFixture.createEndpoint;
+import static io.openaev.utils.fixtures.TeamFixture.getDefaultTeam;
+import static io.openaev.utils.fixtures.UserFixture.getUserWithDefaultEmail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.ExecutionTrace;
+import io.openaev.database.model.ExecutionTraceAction;
+import io.openaev.database.model.ExecutionTraceStatus;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectStatus;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.InjectStatusFixture;
+import io.openaev.utils.fixtures.composers.AgentComposer;
+import io.openaev.utils.fixtures.composers.EndpointComposer;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectStatusComposer;
+import io.openaev.utils.fixtures.composers.TeamComposer;
+import io.openaev.utils.fixtures.composers.UserComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(PER_CLASS)
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("ExecutionTraceRepository integration tests")
+class ExecutionTraceRepositoryTest extends IntegrationTest {
+
+  @Autowired private ExecutionTraceRepository executionTraceRepository;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectStatusComposer injectStatusComposer;
+  @Autowired private EndpointComposer endpointComposer;
+  @Autowired private AgentComposer agentComposer;
+  @Autowired private TeamComposer teamComposer;
+  @Autowired private UserComposer userComposer;
+
+  @BeforeEach
+  void beforeEach() {
+    injectComposer.reset();
+    injectStatusComposer.reset();
+    endpointComposer.reset();
+    agentComposer.reset();
+    teamComposer.reset();
+    userComposer.reset();
+  }
+
+  @Nested
+  @DisplayName("findByInjectIdAndAgentId")
+  class FindByInjectIdAndAgentId {
+
+    @Test
+    @DisplayName("should return traces ordered by time")
+    void given_unorderedTracesForAgent_should_returnOrderedByTime() {
+      // Arrange
+      InjectStatus injectStatus = createInjectStatus();
+      Agent agent = createAgent();
+
+      executionTraceRepository.saveAll(
+          List.of(
+              createTrace(injectStatus, "late", Instant.parse("2026-01-01T10:00:03Z"), agent, List.of()),
+              createTrace(injectStatus, "early", Instant.parse("2026-01-01T10:00:01Z"), agent, List.of()),
+              createTrace(
+                  injectStatus,
+                  "middle",
+                  Instant.parse("2026-01-01T10:00:02Z"),
+                  agent,
+                  List.of())));
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<ExecutionTrace> traces =
+          executionTraceRepository.findByInjectIdAndAgentId(
+              injectStatus.getInject().getId(), agent.getId());
+
+      // Assert
+      assertThat(traces).extracting(ExecutionTrace::getMessage).containsExactly("early", "middle", "late");
+    }
+  }
+
+  @Nested
+  @DisplayName("findByInjectIdAndAssetId")
+  class FindByInjectIdAndAssetId {
+
+    @Test
+    @DisplayName("should return traces ordered by time when matched by agent asset")
+    void given_unorderedTracesMatchedByAgentAsset_should_returnOrderedByTime() {
+      // Arrange
+      InjectStatus injectStatus = createInjectStatus();
+      Agent matchedAgent = createAgent();
+      String endpointId = matchedAgent.getAsset().getId();
+
+      executionTraceRepository.saveAll(
+          List.of(
+              createTrace(
+                  injectStatus,
+                  "late",
+                  Instant.parse("2026-01-01T11:00:03Z"),
+                  matchedAgent,
+                  List.of()),
+              createTrace(
+                  injectStatus,
+                  "early",
+                  Instant.parse("2026-01-01T11:00:01Z"),
+                  matchedAgent,
+                  List.of()),
+              createTrace(
+                  injectStatus,
+                  "middle",
+                  Instant.parse("2026-01-01T11:00:02Z"),
+                  matchedAgent,
+                  List.of()),
+              createTrace(
+                  injectStatus,
+                  "ignored",
+                  Instant.parse("2026-01-01T11:00:00Z"),
+                  null,
+                  List.of("another-asset"))));
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<ExecutionTrace> traces =
+          executionTraceRepository.findByInjectIdAndAssetId(
+              injectStatus.getInject().getId(), endpointId);
+
+      // Assert
+      assertThat(traces).extracting(ExecutionTrace::getMessage).containsExactly("early", "middle", "late");
+    }
+
+    @Test
+    @DisplayName("should return traces ordered by time when matched by identifiers")
+    void given_unorderedTracesMatchedByIdentifiers_should_returnOrderedByTime() {
+      // Arrange
+      InjectStatus injectStatus = createInjectStatus();
+      String assetIdentifier = "asset-id-identifier";
+
+      executionTraceRepository.saveAll(
+          List.of(
+              createTrace(
+                  injectStatus,
+                  "late",
+                  Instant.parse("2026-01-01T12:00:03Z"),
+                  null,
+                  List.of(assetIdentifier)),
+              createTrace(
+                  injectStatus,
+                  "early",
+                  Instant.parse("2026-01-01T12:00:01Z"),
+                  null,
+                  List.of(assetIdentifier)),
+              createTrace(
+                  injectStatus,
+                  "middle",
+                  Instant.parse("2026-01-01T12:00:02Z"),
+                  null,
+                  List.of(assetIdentifier)),
+              createTrace(
+                  injectStatus,
+                  "ignored",
+                  Instant.parse("2026-01-01T12:00:00Z"),
+                  null,
+                  List.of("another-asset"))));
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<ExecutionTrace> traces =
+          executionTraceRepository.findByInjectIdAndAssetId(
+              injectStatus.getInject().getId(), assetIdentifier);
+
+      // Assert
+      assertThat(traces).extracting(ExecutionTrace::getMessage).containsExactly("early", "middle", "late");
+    }
+  }
+
+  @Nested
+  @DisplayName("findByInjectIdAndTeamId")
+  class FindByInjectIdAndTeamId {
+
+    @Test
+    @DisplayName("should return traces ordered by time")
+    void given_unorderedTracesForTeamUserIdentifier_should_returnOrderedByTime() {
+      // Arrange
+      InjectStatus injectStatus = createInjectStatus();
+
+      var user = userComposer.forUser(getUserWithDefaultEmail()).persist().get();
+      var team = teamComposer.forTeam(getDefaultTeam()).withUser(userComposer.forUser(user)).persist().get();
+
+      executionTraceRepository.saveAll(
+          List.of(
+              createTrace(
+                  injectStatus,
+                  "late",
+                  Instant.parse("2026-01-01T13:00:03Z"),
+                  null,
+                  List.of(user.getId())),
+              createTrace(
+                  injectStatus,
+                  "early",
+                  Instant.parse("2026-01-01T13:00:01Z"),
+                  null,
+                  List.of(user.getId())),
+              createTrace(
+                  injectStatus,
+                  "middle",
+                  Instant.parse("2026-01-01T13:00:02Z"),
+                  null,
+                  List.of(user.getId())),
+              createTrace(
+                  injectStatus,
+                  "ignored",
+                  Instant.parse("2026-01-01T13:00:00Z"),
+                  null,
+                  List.of("another-user"))));
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<ExecutionTrace> traces =
+          executionTraceRepository.findByInjectIdAndTeamId(
+              injectStatus.getInject().getId(), team.getId());
+
+      // Assert
+      assertThat(traces).extracting(ExecutionTrace::getMessage).containsExactly("early", "middle", "late");
+    }
+  }
+
+  @Nested
+  @DisplayName("findByInjectIdAndPlayerId")
+  class FindByInjectIdAndPlayerId {
+
+    @Test
+    @DisplayName("should return traces ordered by time")
+    void given_unorderedTracesForPlayerIdentifier_should_returnOrderedByTime() {
+      // Arrange
+      InjectStatus injectStatus = createInjectStatus();
+      String playerId = "player-123";
+
+      executionTraceRepository.saveAll(
+          List.of(
+              createTrace(
+                  injectStatus,
+                  "late",
+                  Instant.parse("2026-01-01T14:00:03Z"),
+                  null,
+                  List.of(playerId)),
+              createTrace(
+                  injectStatus,
+                  "early",
+                  Instant.parse("2026-01-01T14:00:01Z"),
+                  null,
+                  List.of(playerId)),
+              createTrace(
+                  injectStatus,
+                  "middle",
+                  Instant.parse("2026-01-01T14:00:02Z"),
+                  null,
+                  List.of(playerId)),
+              createTrace(
+                  injectStatus,
+                  "ignored",
+                  Instant.parse("2026-01-01T14:00:00Z"),
+                  null,
+                  List.of("another-player"))));
+      entityManager.flush();
+      entityManager.clear();
+
+      // Act
+      List<ExecutionTrace> traces =
+          executionTraceRepository.findByInjectIdAndPlayerId(
+              injectStatus.getInject().getId(), playerId);
+
+      // Assert
+      assertThat(traces).extracting(ExecutionTrace::getMessage).containsExactly("early", "middle", "late");
+    }
+  }
+
+  private InjectStatus createInjectStatus() {
+    Inject inject =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withInjectStatus(
+                injectStatusComposer.forInjectStatus(InjectStatusFixture.createPendingInjectStatus()))
+            .persist()
+            .get();
+    return inject.getStatus().orElseThrow();
+  }
+
+  private Agent createAgent() {
+    var endpoint =
+        endpointComposer
+            .forEndpoint(createEndpoint())
+            .withAgent(agentComposer.forAgent(createDefaultAgentService()))
+            .persist()
+            .get();
+    return endpoint.getAgents().get(0);
+  }
+
+  private ExecutionTrace createTrace(
+      InjectStatus status, String message, Instant time, Agent agent, List<String> identifiers) {
+    return new ExecutionTrace(
+        status,
+        ExecutionTraceStatus.INFO,
+        identifiers,
+        message,
+        ExecutionTraceAction.START,
+        agent,
+        time);
+  }
+}
+
+

--- a/openaev-api/src/test/java/io/openaev/database/repository/InjectStatusRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/repository/InjectStatusRepositoryTest.java
@@ -1,0 +1,98 @@
+package io.openaev.database.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.ExecutionTrace;
+import io.openaev.database.model.ExecutionTraceAction;
+import io.openaev.database.model.ExecutionTraceStatus;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectStatus;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.InjectStatusFixture;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectStatusComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@TestInstance(PER_CLASS)
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("InjectStatusRepository integration tests")
+class InjectStatusRepositoryTest extends IntegrationTest {
+
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectStatusComposer injectStatusComposer;
+  @Autowired private InjectStatusRepository injectStatusRepository;
+  @Autowired private ExecutionTraceRepository executionTraceRepository;
+
+  @BeforeEach
+  void beforeEach() {
+    injectComposer.reset();
+    injectStatusComposer.reset();
+  }
+
+  @Test
+  @DisplayName("findInjectStatusWithGlobalExecutionTraces should return traces ordered by time")
+  void given_globalExecutionTracesWithUnorderedInsert_should_returnTracesOrderedByTime() {
+    // Arrange
+    Inject inject =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withInjectStatus(
+                injectStatusComposer.forInjectStatus(InjectStatusFixture.createPendingInjectStatus()))
+            .persist()
+            .get();
+
+    InjectStatus injectStatus = inject.getStatus().orElseThrow();
+    ExecutionTrace lateTrace =
+        new ExecutionTrace(
+            injectStatus,
+            ExecutionTraceStatus.INFO,
+            List.of(),
+            "late",
+            ExecutionTraceAction.START,
+            null,
+            Instant.parse("2026-01-01T10:00:03Z"));
+    ExecutionTrace earlyTrace =
+        new ExecutionTrace(
+            injectStatus,
+            ExecutionTraceStatus.INFO,
+            List.of(),
+            "early",
+            ExecutionTraceAction.START,
+            null,
+            Instant.parse("2026-01-01T10:00:01Z"));
+    ExecutionTrace middleTrace =
+        new ExecutionTrace(
+            injectStatus,
+            ExecutionTraceStatus.INFO,
+            List.of(),
+            "middle",
+            ExecutionTraceAction.START,
+            null,
+            Instant.parse("2026-01-01T10:00:02Z"));
+
+    executionTraceRepository.saveAll(List.of(lateTrace, earlyTrace, middleTrace));
+    entityManager.flush();
+    entityManager.clear();
+
+    // Act
+    InjectStatus foundStatus =
+        injectStatusRepository.findInjectStatusWithGlobalExecutionTraces(inject.getId()).orElseThrow();
+
+    // Assert
+    assertThat(foundStatus.getTraces())
+        .extracting(ExecutionTrace::getMessage)
+        .containsExactly("early", "middle", "late");
+  }
+}
+

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectStatus.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectStatus.java
@@ -40,6 +40,7 @@ public class InjectStatus extends BaseInjectStatus {
       cascade = CascadeType.ALL,
       orphanRemoval = true,
       fetch = FetchType.EAGER)
+  @OrderBy("time ASC, id ASC")
   @Fetch(FetchMode.SUBSELECT)
   @JsonProperty("status_traces")
   private List<ExecutionTrace> traces = new ArrayList<>();

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectTestStatus.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectTestStatus.java
@@ -22,6 +22,7 @@ public class InjectTestStatus extends BaseInjectStatus {
       cascade = CascadeType.ALL,
       orphanRemoval = true,
       fetch = FetchType.EAGER)
+  @OrderBy("time ASC, id ASC")
   @Fetch(FetchMode.SUBSELECT)
   @JsonProperty("status_traces")
   private List<ExecutionTrace> traces = new ArrayList<>();

--- a/openaev-model/src/main/java/io/openaev/database/repository/ExecutionTraceRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ExecutionTraceRepository.java
@@ -21,7 +21,8 @@ public interface ExecutionTraceRepository
               + "INNER JOIN injects_statuses ins ON t.execution_inject_status_id = ins.status_id "
               + "INNER JOIN injects i ON ins.status_inject = i.inject_id "
               + "INNER JOIN Agents a ON t.execution_agent_id = a.agent_id "
-              + "WHERE i.inject_id = :injectId AND t.execution_agent_id = :targetId",
+              + "WHERE i.inject_id = :injectId AND t.execution_agent_id = :targetId "
+              + "ORDER BY t.execution_time ASC, t.execution_trace_id ASC",
       nativeQuery = true)
   List<ExecutionTrace> findByInjectIdAndAgentId(
       @Param("injectId") String injectId, @Param("targetId") String targetId);
@@ -32,7 +33,8 @@ public interface ExecutionTraceRepository
               + "INNER JOIN injects_statuses ins ON t.execution_inject_status_id = ins.status_id "
               + "INNER JOIN injects i ON ins.status_inject = i.inject_id "
               + "LEFT JOIN Agents a ON t.execution_agent_id = a.agent_id "
-              + "WHERE i.inject_id = :injectId AND (a.agent_asset = :targetId OR :targetId = ANY(t.execution_context_identifiers))",
+              + "WHERE i.inject_id = :injectId AND (a.agent_asset = :targetId OR :targetId = ANY(t.execution_context_identifiers)) "
+              + "ORDER BY t.execution_time ASC, t.execution_trace_id ASC",
       nativeQuery = true)
   List<ExecutionTrace> findByInjectIdAndAssetId(
       @Param("injectId") String injectId, @Param("targetId") String targetId);
@@ -43,7 +45,8 @@ public interface ExecutionTraceRepository
               + "INNER JOIN injects_statuses ins ON t.execution_inject_status_id = ins.status_id "
               + "INNER JOIN injects i ON ins.status_inject = i.inject_id "
               + "INNER JOIN users_teams ut ON ut.user_id = ANY(t.execution_context_identifiers) "
-              + "WHERE i.inject_id = :injectId AND ut.team_id = :targetId",
+              + "WHERE i.inject_id = :injectId AND ut.team_id = :targetId "
+              + "ORDER BY t.execution_time ASC, t.execution_trace_id ASC",
       nativeQuery = true)
   List<ExecutionTrace> findByInjectIdAndTeamId(
       @Param("injectId") String injectId, @Param("targetId") String targetId);
@@ -53,7 +56,8 @@ public interface ExecutionTraceRepository
           "SELECT t.* FROM execution_traces t "
               + "INNER JOIN injects_statuses ins ON t.execution_inject_status_id = ins.status_id "
               + "INNER JOIN injects i ON ins.status_inject = i.inject_id "
-              + "WHERE i.inject_id = :injectId AND :targetId = ANY(t.execution_context_identifiers)",
+              + "WHERE i.inject_id = :injectId AND :targetId = ANY(t.execution_context_identifiers) "
+              + "ORDER BY t.execution_time ASC, t.execution_trace_id ASC",
       nativeQuery = true)
   List<ExecutionTrace> findByInjectIdAndPlayerId(
       @Param("injectId") String injectId, @Param("targetId") String targetId);

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
@@ -29,7 +29,8 @@ public interface InjectStatusRepository
               + "  ON t.execution_inject_status_id = ins.status_id"
               + "  AND t.execution_agent_id IS NULL"
               + "  AND cardinality(t.execution_context_identifiers) = 0"
-              + " WHERE i.inject_id = :injectId",
+              + " WHERE i.inject_id = :injectId"
+              + " ORDER BY t.execution_time ASC, t.execution_trace_id ASC",
       nativeQuery = true)
   Optional<InjectStatus> findInjectStatusWithGlobalExecutionTraces(String injectId);
 


### PR DESCRIPTION
### Proposed changes

- Add support to extract command information and execution traces from inject runs.
- Group execution results by endpoint source to make outputs easier to read and follow.
- Clarify command availability: runs executed with an injector and a non-Command payload may have an empty `command` field, because command content is not available for those payload types.
- Executed at is handle by AttackPathExecution. 

### Testing Instructions

1. Create and run an Chaining simulation with a Command action, then verify command and execution trace information are extract.
2. Create and run an Chaining simulation with a non-Command action, then verify execution traces are present and `command` can be empty.

### Related issues
- #6647 

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

- For some executions, the `command` field can be empty by design when the payload or injector does not expose command.
