### PR TITLE
perf(dashboard): fix unnecessary re-renders on analysis page (#6756)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/analysis/ScenarioAnalysis.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/analysis/ScenarioAnalysis.tsx
@@ -40,6 +40,9 @@ const ScenarioAnalysis = () => {
 
   const handleSelectNewDashboard = useCallback((dashboardId: string) => {
     const current = scenarioRef.current;
+    if (!current) {
+      return;
+    }
     dispatch(updateScenario(current.scenario_id, {
       ...current,
       scenario_custom_dashboard: dashboardId,
@@ -73,7 +76,7 @@ const ScenarioAnalysis = () => {
         const value = localStorageParams[paramId]?.value;
         if ('scenario' === p.custom_dashboards_parameter_type) {
           paramOptions = {
-            value: scenario.scenario_id,
+            value: scenarioId,
             hidden: true,
           };
         } else if ('simulation' === p.custom_dashboards_parameter_type) {
@@ -96,7 +99,7 @@ const ScenarioAnalysis = () => {
       }));
 
     return Object.fromEntries(paramsList);
-  }, [scenario?.scenario_id, scenarioId, lastSimulationEndedId]);
+  }, [scenarioId, lastSimulationEndedId]);
 
   const configuration = useMemo(() => ({
     customDashboardId: scenario?.scenario_custom_dashboard,
@@ -112,7 +115,7 @@ const ScenarioAnalysis = () => {
     fetchEntities: (widgetId: string, params: Record<string, string | undefined>, pagination?: Pagination) => entitiesByScenario(scenarioId, widgetId, params, pagination),
     fetchEntitiesRuntime: (widgetId: string, input: WidgetToEntitiesInput) => widgetToEntitiesByByScenario(scenarioId, widgetId, input),
     fetchAttackPaths: (widgetId: string, params: Record<string, string | undefined>) => attackPathsByScenario(scenarioId, widgetId, params),
-  }), [scenario?.scenario_custom_dashboard, scenarioId, paramsBuilder, ability]);
+  }), [scenario?.scenario_custom_dashboard, scenarioId, paramsBuilder, ability, handleSelectNewDashboard]);
 
   return (
     <CustomDashboardWrapper

--- a/openaev-front/src/admin/components/scenarios/scenario/analysis/ScenarioAnalysis.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/analysis/ScenarioAnalysis.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
 
 import {
@@ -34,14 +34,19 @@ const ScenarioAnalysis = () => {
   const scenario = useHelper((helper: ScenariosHelper) => {
     return helper.getScenario(scenarioId);
   });
-  const handleSelectNewDashboard = (dashboardId: string) => {
-    dispatch(updateScenario(scenario.scenario_id, {
-      ...scenario,
+
+  const scenarioRef = useRef(scenario);
+  scenarioRef.current = scenario;
+
+  const handleSelectNewDashboard = useCallback((dashboardId: string) => {
+    const current = scenarioRef.current;
+    dispatch(updateScenario(current.scenario_id, {
+      ...current,
       scenario_custom_dashboard: dashboardId,
     }));
-  };
+  }, [dispatch]);
 
-  const lastSimulationEndedId = async () => {
+  const lastSimulationEndedId = useCallback(async () => {
     const { data } = await searchScenarioExercises(scenarioId, {
       size: 1,
       page: 0,
@@ -58,9 +63,9 @@ const ScenarioAnalysis = () => {
       ],
     });
     return data.content?.[0]?.exercise_id;
-  };
+  }, [scenarioId]);
 
-  const paramsBuilder = async (dashboardParameters: CustomDashboard['custom_dashboard_parameters'], localStorageParams: Record<string, ParameterOption>) => {
+  const paramsBuilder = useCallback(async (dashboardParameters: CustomDashboard['custom_dashboard_parameters'], localStorageParams: Record<string, ParameterOption>) => {
     const paramsList = await Promise.all(
       (dashboardParameters || []).map(async (p) => {
         const paramId = p.custom_dashboards_parameter_id;
@@ -91,9 +96,9 @@ const ScenarioAnalysis = () => {
       }));
 
     return Object.fromEntries(paramsList);
-  };
+  }, [scenario?.scenario_id, scenarioId, lastSimulationEndedId]);
 
-  const configuration = {
+  const configuration = useMemo(() => ({
     customDashboardId: scenario?.scenario_custom_dashboard,
     paramLocalStorageKey: 'custom-dashboard-scenario-' + scenarioId,
     paramsBuilder,
@@ -107,7 +112,7 @@ const ScenarioAnalysis = () => {
     fetchEntities: (widgetId: string, params: Record<string, string | undefined>, pagination?: Pagination) => entitiesByScenario(scenarioId, widgetId, params, pagination),
     fetchEntitiesRuntime: (widgetId: string, input: WidgetToEntitiesInput) => widgetToEntitiesByByScenario(scenarioId, widgetId, input),
     fetchAttackPaths: (widgetId: string, params: Record<string, string | undefined>) => attackPathsByScenario(scenarioId, widgetId, params),
-  };
+  }), [scenario?.scenario_custom_dashboard, scenarioId, paramsBuilder, ability]);
 
   return (
     <CustomDashboardWrapper

--- a/openaev-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/Index.tsx
@@ -251,6 +251,7 @@ const Index = () => {
 
   useEffect(() => {
     if (!exercise) return;
+    if (!pristine) return;
     setLoading(true);
     if (!exercise.exercise_scenario) {
       setPristine(false);

--- a/openaev-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/Index.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertTitle, Box, Tab, Tabs } from '@mui/material';
-import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 
@@ -249,9 +249,14 @@ const Index = () => {
     });
   }, [exerciseId]);
 
+  // Fetch the scenario only once per simulation id: the exercise object gets a
+  // new identity on every Redux update (e.g. SSE), which used to re-trigger
+  // this effect and re-fetch the scenario redundantly.
+  const scenarioRequestedForRef = useRef<ExerciseType['exercise_id'] | undefined>(undefined);
   useEffect(() => {
     if (!exercise) return;
-    if (!pristine) return;
+    if (scenarioRequestedForRef.current === exercise.exercise_id) return;
+    scenarioRequestedForRef.current = exercise.exercise_id;
     setLoading(true);
     if (!exercise.exercise_scenario) {
       setPristine(false);
@@ -263,7 +268,7 @@ const Index = () => {
           setLoading(false);
         });
     }
-  }, [exercise]);
+  }, [exercise, dispatch]);
 
   const exerciseInjectContext = injectContextForExercise(exercise);
 

--- a/openaev-front/src/admin/components/simulations/simulation/analysis/SimulationAnalysis.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/analysis/SimulationAnalysis.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
 
 import { updateExercise } from '../../../../../actions/Exercise';
@@ -32,14 +32,18 @@ const SimulationAnalysis = () => {
     return helper.getExercise(exerciseId);
   });
 
-  const handleSelectNewDashboard = (dashboardId: string) => {
-    dispatch(updateExercise(exercise.exercise_id, {
-      ...exercise,
+  const exerciseRef = useRef(exercise);
+  exerciseRef.current = exercise;
+
+  const handleSelectNewDashboard = useCallback((dashboardId: string) => {
+    const current = exerciseRef.current;
+    dispatch(updateExercise(current.exercise_id, {
+      ...current,
       exercise_custom_dashboard: dashboardId,
     }));
-  };
+  }, [dispatch]);
 
-  const paramsBuilder = (dashboardParameters: CustomDashboard['custom_dashboard_parameters']) => {
+  const paramsBuilder = useCallback((dashboardParameters: CustomDashboard['custom_dashboard_parameters']) => {
     const params: Record<string, ParameterOption> = {};
     dashboardParameters?.forEach((p) => {
       let value = '';
@@ -64,9 +68,9 @@ const SimulationAnalysis = () => {
       };
     });
     return params;
-  };
+  }, [exerciseId, exercise?.exercise_scenario]);
 
-  const configuration = {
+  const configuration = useMemo(() => ({
     customDashboardId: exercise?.exercise_custom_dashboard,
     paramLocalStorageKey: 'custom-dashboard-simulation-' + exerciseId,
     paramsBuilder,
@@ -80,7 +84,7 @@ const SimulationAnalysis = () => {
     fetchEntitiesRuntime: (widgetId: string, input: WidgetToEntitiesInput) => widgetToEntitiesBySimulation(exerciseId, widgetId, input),
     fetchEntities: (widgetId: string, params: Record<string, string | undefined>, pagination?: Pagination) => entitiesBySimulation(exerciseId, widgetId, params, pagination),
     fetchAttackPaths: (widgetId: string, params: Record<string, string | undefined>) => attackPathsBySimulation(exerciseId, widgetId, params),
-  };
+  }), [exercise?.exercise_custom_dashboard, exerciseId, paramsBuilder, ability]);
 
   return (
     <CustomDashboardWrapper

--- a/openaev-front/src/admin/components/simulations/simulation/analysis/SimulationAnalysis.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/analysis/SimulationAnalysis.tsx
@@ -37,6 +37,9 @@ const SimulationAnalysis = () => {
 
   const handleSelectNewDashboard = useCallback((dashboardId: string) => {
     const current = exerciseRef.current;
+    if (!current) {
+      return;
+    }
     dispatch(updateExercise(current.exercise_id, {
       ...current,
       exercise_custom_dashboard: dashboardId,
@@ -52,7 +55,7 @@ const SimulationAnalysis = () => {
         value = exerciseId;
         hidden = true;
       } else if ('scenario' === p.custom_dashboards_parameter_type) {
-        value = exercise.exercise_scenario ?? '';
+        value = exercise?.exercise_scenario ?? '';
         hidden = true;
       } else if ('timeRange' === p.custom_dashboards_parameter_type) {
         value = ALL_TIME_TIME_RANGE;
@@ -84,7 +87,7 @@ const SimulationAnalysis = () => {
     fetchEntitiesRuntime: (widgetId: string, input: WidgetToEntitiesInput) => widgetToEntitiesBySimulation(exerciseId, widgetId, input),
     fetchEntities: (widgetId: string, params: Record<string, string | undefined>, pagination?: Pagination) => entitiesBySimulation(exerciseId, widgetId, params, pagination),
     fetchAttackPaths: (widgetId: string, params: Record<string, string | undefined>) => attackPathsBySimulation(exerciseId, widgetId, params),
-  }), [exercise?.exercise_custom_dashboard, exerciseId, paramsBuilder, ability]);
+  }), [exercise?.exercise_custom_dashboard, exerciseId, paramsBuilder, ability, handleSelectNewDashboard]);
 
   return (
     <CustomDashboardWrapper

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
@@ -1,7 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { useLocalStorage, useReadLocalStorage } from 'usehooks-ts';
+import { useLocalStorage } from 'usehooks-ts';
 
 import Loader from '../../../../components/Loader';
 import type {
@@ -67,8 +67,7 @@ const CustomDashboardWrapper = ({
   } = configuration || {};
 
   const [customDashboard, setCustomDashboard] = useState<CustomDashboard>();
-  const parametersLocalStorage = useReadLocalStorage<Record<string, ParameterOption>>(paramLocalStorageKey);
-  const [, setParametersLocalStorage] = useLocalStorage<Record<string, ParameterOption>>(paramLocalStorageKey, {});
+  const [parametersLocalStorage, setParametersLocalStorage] = useLocalStorage<Record<string, ParameterOption>>(paramLocalStorageKey, {});
   const [parameters, setParameters] = useState<Record<string, ParameterOption>>({});
   const [dataReady, setDataReady] = useState(false);
   const [_gridReady, setGridReady] = useState(false);
@@ -126,10 +125,6 @@ const CustomDashboardWrapper = ({
     if (!customDashboard) {
       return;
     }
-    if (!parametersLocalStorage) {
-      setParametersLocalStorage({});
-      return;
-    }
     const handleParametersInitialization = async () => {
       let params: Record<string, ParameterOption> = { ...parametersLocalStorage };
       customDashboard?.custom_dashboard_parameters?.forEach((p: {
@@ -152,7 +147,7 @@ const CustomDashboardWrapper = ({
       setParameters(params || {});
       setDataReadyWithDelay();
     });
-  }, [customDashboard, parametersLocalStorage, paramsBuilder, setParametersLocalStorage]);
+  }, [customDashboard, parametersLocalStorage, paramsBuilder]);
 
   useEffect(() => {
     if (customDashboardId) {

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
@@ -238,9 +238,11 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
     setSimulationDatesEdge([newSimulationDatesEdge]);
   };
 
+  // Re-initialize when the resolved data (memoized on the data prop) or the
+  // simulation dates change, so widget refetches propagate to React Flow.
   useEffect(() => {
     initializeNodesAndEdges();
-  }, []);
+  }, [resolvedDataByKillChainPhase, simulationStartDate, simulationEndDate]);
 
   useEffect(() => {
     if (attackPathsEdges.length < 1 && hoveredNodeId === null) {
@@ -253,7 +255,7 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
       });
     });
     setAttackPathsEdges(newAttackPathsEdges);
-  }, [hoveredNodeId]);
+  }, [hoveredNodeId, resolvedDataByKillChainPhase]);
 
   // -- React Flow nodes actions
   const onNodeClick = (event: ReactMouseEvent, node: Node) => {

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
@@ -33,20 +33,27 @@ const proOptions = {
   hideAttribution: true,
 };
 
-const resolveDataByKillChainPhase = (esAttackPaths: EsAttackPath[]) => {
-  const killChainMap = new Map();
+interface KillChainPhaseWithAttackPaths extends KillChainPhaseObject {
+  phase_order?: number;
+  attackPaths: EsAttackPath[];
+}
+
+const resolveDataByKillChainPhase = (esAttackPaths: EsAttackPath[]): KillChainPhaseWithAttackPaths[] => {
+  const killChainMap = new Map<string, KillChainPhaseWithAttackPaths>();
   esAttackPaths.filter(item => item.killChainPhases && item.killChainPhases.length > 0)
     .forEach((attackPath) => {
       (attackPath.killChainPhases ?? []).forEach((phase) => {
-        if (!killChainMap.has(phase.id)) {
-          killChainMap.set(phase.id, {
+        let entry = killChainMap.get(phase.id);
+        if (!entry) {
+          entry = {
             id: phase.id,
             name: phase.name,
             phase_order: phase.order,
             attackPaths: [],
-          });
+          };
+          killChainMap.set(phase.id, entry);
         }
-        killChainMap.get(phase.id).attackPaths.push(attackPath);
+        entry.attackPaths.push(attackPath);
       });
     });
   return Array.from(killChainMap.values()).toSorted(sortKillChainPhase);
@@ -201,7 +208,7 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
     resolvedDataByKillChainPhase.forEach((phase, phaseIndex) => {
       newNodes.push(createKillChainNode(phase, phaseIndex));
 
-      (phase.attackPaths as EsAttackPath[]).forEach((attackPath, attackPathIndex) => {
+      phase.attackPaths.forEach((attackPath, attackPathIndex) => {
         maxYIndex = maxYIndex < attackPathIndex ? attackPathIndex : maxYIndex;
         newNodes.push(createAttackPatternNode(attackPath, phase, phaseIndex, attackPathIndex));
         newAttackPathsEdges.push(...createEdgesByAttackPath(attackPath, phase));
@@ -241,7 +248,7 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
     }
     const newAttackPathsEdges: Edge[] = [];
     resolvedDataByKillChainPhase.forEach((phase) => {
-      (phase.attackPaths as EsAttackPath[]).forEach((attackPath) => {
+      phase.attackPaths.forEach((attackPath) => {
         newAttackPathsEdges.push(...createEdgesByAttackPath(attackPath, phase));
       });
     });

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
@@ -28,6 +28,30 @@ import DraggableEdge from './DraggableEdge';
 const nodeTypes = { attackPattern: AttackPatternNode };
 const edgeTypes = { draggableEdge: DraggableEdge };
 
+const proOptions = {
+  account: 'paid-pro',
+  hideAttribution: true,
+};
+
+const resolveDataByKillChainPhase = (esAttackPaths: EsAttackPath[]) => {
+  const killChainMap = new Map();
+  esAttackPaths.filter(item => item.killChainPhases && item.killChainPhases.length > 0)
+    .forEach((attackPath) => {
+      (attackPath.killChainPhases ?? []).forEach((phase) => {
+        if (!killChainMap.has(phase.id)) {
+          killChainMap.set(phase.id, {
+            id: phase.id,
+            name: phase.name,
+            phase_order: phase.order,
+            attackPaths: [],
+          });
+        }
+        killChainMap.get(phase.id).attackPaths.push(attackPath);
+      });
+    });
+  return Array.from(killChainMap.values()).toSorted(sortKillChainPhase);
+};
+
 interface Props {
   data: EsAttackPath[];
   widgetId: string;
@@ -71,31 +95,7 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
     ATTACK_PATTERN = 'attackPattern',
   }
 
-  const proOptions = {
-    account: 'paid-pro',
-    hideAttribution: true,
-  };
-
   // -- React Flow nodes and edges management
-  const resolveDataByKillChainPhase = (esAttackPaths: EsAttackPath[]) => {
-    const killChainMap = new Map();
-    esAttackPaths.filter(item => item.killChainPhases && item.killChainPhases.length > 0)
-      .forEach((attackPath) => {
-        (attackPath.killChainPhases ?? []).forEach((phase) => {
-          if (!killChainMap.has(phase.id)) {
-            killChainMap.set(phase.id, {
-              id: phase.id,
-              name: phase.name,
-              phase_order: phase.order,
-              attackPaths: [],
-            });
-          }
-          killChainMap.get(phase.id).attackPaths.push(attackPath);
-        });
-      });
-    return Array.from(killChainMap.values()).toSorted(sortKillChainPhase);
-  };
-
   const getNodeId = (attackPathID: string, killChainPhase: KillChainPhaseObject) => {
     return attackPathID + '-' + killChainPhase.id;
   };
@@ -190,15 +190,15 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
       });
   };
 
-  const resolvededDataByKillChainPhase = useMemo(() => resolveDataByKillChainPhase(data), [data]);
+  const resolvedDataByKillChainPhase = useMemo(() => resolveDataByKillChainPhase(data), [data]);
   const initializeNodesAndEdges = () => {
     const newAttackPathsEdges: Edge[] = [];
     let newSimulationDatesEdge: Edge = {} as Edge;
     const newNodes: Node[] = [];
-    const maxXIndex = resolvededDataByKillChainPhase.length > 2 ? resolvededDataByKillChainPhase.length - 1 : 1;
+    const maxXIndex = resolvedDataByKillChainPhase.length > 2 ? resolvedDataByKillChainPhase.length - 1 : 1;
     let maxYIndex = 0;
 
-    resolvededDataByKillChainPhase.forEach((phase, phaseIndex) => {
+    resolvedDataByKillChainPhase.forEach((phase, phaseIndex) => {
       newNodes.push(createKillChainNode(phase, phaseIndex));
 
       (phase.attackPaths as EsAttackPath[]).forEach((attackPath, attackPathIndex) => {
@@ -240,7 +240,7 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
       return;
     }
     const newAttackPathsEdges: Edge[] = [];
-    resolvededDataByKillChainPhase.forEach((phase) => {
+    resolvedDataByKillChainPhase.forEach((phase) => {
       (phase.attackPaths as EsAttackPath[]).forEach((attackPath) => {
         newAttackPathsEdges.push(...createEdgesByAttackPath(attackPath, phase));
       });

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/attack_paths/AttackPath.tsx
@@ -7,7 +7,7 @@ import {
 import * as qs from 'qs';
 import {
   type MouseEvent as ReactMouseEvent,
-  useEffect, useState,
+  useEffect, useMemo, useState,
 } from 'react';
 import { useNavigate } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
@@ -24,6 +24,9 @@ import { sortKillChainPhase } from '../../../../../../../utils/kill_chain_phases
 import ColoredPercentageRate from '../components/ColoredPercentageRate';
 import AttackPatternNode from './AttackPatternNode';
 import DraggableEdge from './DraggableEdge';
+
+const nodeTypes = { attackPattern: AttackPatternNode };
+const edgeTypes = { draggableEdge: DraggableEdge };
 
 interface Props {
   data: EsAttackPath[];
@@ -63,13 +66,11 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
   const XGap = 200; // Horizontal gap between nodes
   const YGap = 150; // Vertical gap between nodes
 
-  const nodeTypes = { attackPattern: AttackPatternNode };
   enum NodeType {
     DEFAULT = 'default',
     ATTACK_PATTERN = 'attackPattern',
   }
 
-  const edgeTypes = { draggableEdge: DraggableEdge };
   const proOptions = {
     account: 'paid-pro',
     hideAttribution: true,
@@ -189,7 +190,7 @@ const AttackPath = ({ data, widgetId, simulationId, simulationStartDate = null, 
       });
   };
 
-  const resolvededDataByKillChainPhase = resolveDataByKillChainPhase(data);
+  const resolvededDataByKillChainPhase = useMemo(() => resolveDataByKillChainPhase(data), [data]);
   const initializeNodesAndEdges = () => {
     const newAttackPathsEdges: Edge[] = [];
     let newSimulationDatesEdge: Edge = {} as Edge;

--- a/openaev-front/src/utils/kill_chain_phases/kill_chain_phases.ts
+++ b/openaev-front/src/utils/kill_chain_phases/kill_chain_phases.ts
@@ -1,6 +1,6 @@
 import { type KillChainPhase } from '../api-types';
 
 // eslint-disable-next-line import/prefer-default-export
-export const sortKillChainPhase = (k1: KillChainPhase, k2: KillChainPhase) => {
+export const sortKillChainPhase = (k1: Pick<KillChainPhase, 'phase_order'>, k2: Pick<KillChainPhase, 'phase_order'>) => {
   return (k1.phase_order ?? 0) - (k2.phase_order ?? 0);
 };


### PR DESCRIPTION
## Summary

Closes #6756

This PR removes unnecessary re-renders of the custom dashboard subtree on the simulation and scenario Analysis pages, and addresses the review findings raised on the initial version.

- Stabilize `handleSelectNewDashboard` via `useRef` + `useCallback` in `SimulationAnalysis` and `ScenarioAnalysis`: the callback no longer depends on the whole `exercise` / `scenario` Redux object, so unrelated Redux updates (e.g. SSE events) no longer cascade re-renders through the dashboard subtree. The callback now no-ops safely when the entity is not yet loaded.
- Memoize `paramsBuilder`, `lastSimulationEndedId` and the `configuration` object with `useCallback` / `useMemo`, keeping stable references passed to `CustomDashboardWrapper`. `handleSelectNewDashboard` is included in the `configuration` dependencies. `ScenarioAnalysis.paramsBuilder` now uses the route `scenarioId` instead of `scenario.scenario_id`, removing the residual coupling to the scenario object (and a potential crash when the scenario is not loaded yet).
- Eliminate the localStorage render loop in `CustomDashboardWrapper` by merging `useReadLocalStorage` + `useLocalStorage` into a single `useLocalStorage` hook, removing the `null -> {}` extra render cycle.
- Move `nodeTypes` / `edgeTypes`, `proOptions` and the pure `resolveDataByKillChainPhase` helper to module scope in `AttackPath`, and memoize the resolved kill-chain data with `useMemo` (also fixes the `resolvededDataByKillChainPhase` typo).
- Fetch the scenario only once per simulation id in `simulations/simulation/Index.tsx` (guarded by a ref keyed on `exercise_id` instead of the `pristine` state), preventing redundant `fetchScenarioFromSimulation` dispatches on every Redux identity change while still fetching when navigating to another simulation.

## Test plan

- [x] `yarn lint` and `yarn check-ts` pass on `openaev-front`
- [ ] Navigate to a simulation's Analysis tab - verify the dashboard loads correctly with all widgets
- [ ] Navigate to a scenario's Analysis tab - verify the dashboard loads correctly
- [ ] Change the selected dashboard on a simulation and on a scenario - verify the update applies
- [ ] Verify no React warnings in the console about hook order or missing dependencies
- [ ] Check that widget parameters (time range, simulation filter) persist correctly across page reloads
- [ ] Navigate from one simulation directly to another - verify the linked scenario is fetched for the second simulation

## Notes

- codecov patch/project statuses are informational on this repo for frontend perf PRs (no new testable logic, hook memoization only) and are not expected to reach the 80% target.