### PR TITLE
fix(chaining): add timeout default 1h (#5042)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -100,7 +100,7 @@ public class WorkflowService {
 
   /**
    * Creates a new workflow template for a simulation with safe defaults for the inline
-   * configuration (rate-limit and timeout disabled, safe-mode enabled).
+   * configuration (rate-limit disabled, timeout enabled to 1 hour, safe-mode enabled).
    *
    * @param simulation the simulation to create the workflow for
    */
@@ -111,7 +111,7 @@ public class WorkflowService {
             .status(WorkflowStatus.TEMPLATE)
             .simulation(simulation)
             .rateLimitEnabled(false)
-            .timeoutEnabled(false)
+            .timeoutEnabled(true)
             .timeoutSeconds(DEFAULT_TIMEOUT_SECONDS)
             .safeModeEnabled(true)
             .build();
@@ -130,7 +130,7 @@ public class WorkflowService {
             .status(WorkflowStatus.TEMPLATE)
             .scenario(scenario)
             .rateLimitEnabled(false)
-            .timeoutEnabled(false)
+            .timeoutEnabled(true)
             .timeoutSeconds(DEFAULT_TIMEOUT_SECONDS)
             .safeModeEnabled(true)
             .build();

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingIntegrationTest.java
@@ -187,7 +187,7 @@ class ChainingIntegrationTest extends IntegrationTest {
       assertNull(
           workflowTemplate.getSimulation(), "The Workflow TEMPLATE must not have a simulation");
       // Timeout defaults must be set on creation
-      assertFalse(workflowTemplate.isTimeoutEnabled(), "Timeout must be disabled by default");
+      assertTrue(workflowTemplate.isTimeoutEnabled(), "Timeout must be enabled by default");
       assertEquals(
           WorkflowService.DEFAULT_TIMEOUT_SECONDS,
           workflowTemplate.getTimeoutSeconds(),
@@ -629,7 +629,7 @@ class ChainingIntegrationTest extends IntegrationTest {
           workflowTemplate.getScenario(),
           "Template workflow for simulation must not link scenario");
       // Timeout defaults must be set on creation
-      assertFalse(workflowTemplate.isTimeoutEnabled(), "Timeout must be disabled by default");
+      assertTrue(workflowTemplate.isTimeoutEnabled(), "Timeout must be enabled by default");
       assertEquals(
           WorkflowService.DEFAULT_TIMEOUT_SECONDS,
           workflowTemplate.getTimeoutSeconds(),

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -130,7 +130,7 @@ class WorkflowServiceTest {
       assertEquals(exercise, savedWorkflow.getSimulation());
       // Configuration defaults stored inline on the workflow row
       assertFalse(savedWorkflow.isRateLimitEnabled());
-      assertFalse(savedWorkflow.isTimeoutEnabled());
+      assertTrue(savedWorkflow.isTimeoutEnabled());
       assertEquals(
           WorkflowService.DEFAULT_TIMEOUT_SECONDS,
           savedWorkflow.getTimeoutSeconds(),
@@ -154,7 +154,7 @@ class WorkflowServiceTest {
       assertEquals(WorkflowStatus.TEMPLATE, savedWorkflow.getStatus());
       assertEquals(scenario, savedWorkflow.getScenario());
       assertFalse(savedWorkflow.isRateLimitEnabled());
-      assertFalse(savedWorkflow.isTimeoutEnabled());
+      assertTrue(savedWorkflow.isTimeoutEnabled());
       assertEquals(
           WorkflowService.DEFAULT_TIMEOUT_SECONDS,
           savedWorkflow.getTimeoutSeconds(),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add time out default of 1h in chaining scenarios/simulations

### Testing Instructions

1. Create a simulation chaining
2. Check timeout was available and of 1h

<img width="1318" height="572" alt="image" src="https://github.com/user-attachments/assets/0efa69ed-747b-432f-988a-77c8f22a4399" />
<img width="1800" height="529" alt="image" src="https://github.com/user-attachments/assets/e1943eb2-d288-46c1-b416-e556a01eb6d5" />

### Related issues

* Related #5042 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
