### PR TITLE
fix(engine): make Elastic statistics always match PostgreSQL (#6753)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260717220000000__Engine_accuracy_full_reindex.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260717220000000__Engine_accuracy_full_reindex.java
@@ -1,0 +1,44 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converges the search engine back to database truth after the accuracy fixes (issue #6753).
+ *
+ * <ol>
+ *   <li>Completes the asset taxonomy remodel: agentless {@code Endpoint} rows categorized {@code
+ *       AI_TARGET} or {@code SECURITY_PLATFORM} were missed by the original demotion list and kept
+ *       inflating the endpoint index versus the Host inventory.
+ *   <li>Deletes EVERY {@code indexing_status} row: at the next startup the engine drivers drop and
+ *       recreate all indexes and fully re-feed them from PostgreSQL. All historical garbage
+ *       accumulated by the delete-propagation and cursor bugs (stale simulations, injects,
+ *       expectations, findings, per-player expectation docs, wrong platform attributions) is
+ *       eliminated by construction, with no manual action: statistics are exact as soon as the
+ *       rebuild completes.
+ * </ol>
+ *
+ * <p>Both steps are idempotent and lock-light (targeted UPDATE on a small table + full DELETE on a
+ * tiny bookkeeping table).
+ */
+@Component
+public class V6_20260717220000000__Engine_accuracy_full_reindex extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // -- 1. Demote the taxonomy remodel leftovers (agent-bearing rows are never demoted:
+      // agents only exist on Endpoint, demoting would orphan them) --
+      statement.execute(
+          "UPDATE assets SET asset_type = 'Asset' "
+              + "WHERE asset_type = 'Endpoint' "
+              + "AND asset_category IN ('AI_TARGET', 'SECURITY_PLATFORM') "
+              + "AND NOT EXISTS (SELECT 1 FROM agents ag WHERE ag.agent_asset = assets.asset_id);");
+
+      // -- 2. Force a full drop-and-rebuild of every search index at startup --
+      statement.execute("DELETE FROM indexing_status;");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
@@ -27,11 +27,14 @@ public class V6_20260717221000000__Force_default_home_dashboard extends BaseJava
       statement.execute(
           "UPDATE users SET user_home_dashboard = NULL WHERE user_home_dashboard IS NOT NULL;");
 
-      // -- 2. Clear the tenant-level Settings override --
+      // -- 2. Clear the tenant-level Settings override. Tenant settings live in the parameters
+      // table since V5_03 merged (and dropped) the transient tenant_settings table: tenant-scoped
+      // rows carry a NON NULL tenant_id. Delete them so resolution falls through to the default. --
       statement.execute(
-          "DELETE FROM tenant_settings WHERE tenant_setting_key = 'platform_home_dashboard';");
+          "DELETE FROM parameters "
+              + "WHERE parameter_key = 'platform_home_dashboard' AND tenant_id IS NOT NULL;");
 
-      // -- 3. Clear the legacy platform parameter (pre-tenant-settings installs) --
+      // -- 3. Clear the legacy platform-level parameter (tenant_id IS NULL) --
       statement.execute(
           "UPDATE parameters SET parameter_value = NULL "
               + "WHERE parameter_key = 'platform_home_dashboard' AND parameter_value IS NOT NULL;");

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
@@ -1,0 +1,40 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Forces the new built-in default home dashboard for every user after the home redesign (issue
+ * #6753): resets BOTH override levels of the home resolution chain (user profile preference, then
+ * tenant setting) so everyone lands on the platform default command center after the release.
+ * Users and admins can re-select a custom dashboard afterwards in Profile / Settings - custom
+ * dashboards themselves are untouched.
+ *
+ * <p>The starter pack cannot re-seed the tenant setting: it only runs once, guarded by the
+ * platform-level {@code starterpack} setting key which is left in place.
+ *
+ * <p>Idempotent and lock-light (targeted UPDATE / DELETE on small tables).
+ */
+@Component
+public class V6_20260717221000000__Force_default_home_dashboard extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // -- 1. Clear the per-user Profile override --
+      statement.execute(
+          "UPDATE users SET user_home_dashboard = NULL WHERE user_home_dashboard IS NOT NULL;");
+
+      // -- 2. Clear the tenant-level Settings override --
+      statement.execute(
+          "DELETE FROM tenant_settings WHERE tenant_setting_key = 'platform_home_dashboard';");
+
+      // -- 3. Clear the legacy platform parameter (pre-tenant-settings installs) --
+      statement.execute(
+          "UPDATE parameters SET parameter_value = NULL "
+              + "WHERE parameter_key = 'platform_home_dashboard' AND parameter_value IS NOT NULL;");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Component;
 /**
  * Forces the new built-in default home dashboard for every user after the home redesign (issue
  * #6753): resets BOTH override levels of the home resolution chain (user profile preference, then
- * tenant setting) so everyone lands on the platform default command center after the release.
- * Users and admins can re-select a custom dashboard afterwards in Profile / Settings - custom
- * dashboards themselves are untouched.
+ * tenant setting) so everyone lands on the platform default command center after the release. Users
+ * and admins can re-select a custom dashboard afterwards in Profile / Settings - custom dashboards
+ * themselves are untouched.
  *
  * <p>The starter pack cannot re-seed the tenant setting: it only runs once, guarded by the
  * platform-level {@code starterpack} setting key which is left in place.

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -1044,6 +1044,10 @@ public class ExerciseService {
     this.injectService.removeTeamsForSimulation(exerciseId, teamIds);
     // Remove all association between lessons learned and teams
     this.lessonsService.removeTeamsForSimulation(exerciseId, teamIds);
+    // The join-table deletes above are native queries that bypass JPA timestamps: bump the
+    // exercise and its injects so the incremental indexer refreshes the denormalized team sides.
+    this.exerciseRepository.touchUpdatedAt(exerciseId);
+    this.injectRepository.touchUpdatedAtByExerciseId(exerciseId);
     return teamService.find(fromIds(teamIds));
   }
 
@@ -1063,6 +1067,10 @@ public class ExerciseService {
       this.injectRepository.removeTeamsForExercise(exerciseId, removedTeamIdsList);
       this.lessonsCategoryRepository.removeTeamsForExercise(exerciseId, removedTeamIdsList);
     }
+    // Team changes alter the denormalized inject_teams of the exercise's injects (including
+    // all-teams injects, derived from exercises_teams): bump the injects so the incremental
+    // indexer refreshes them (the native join-table mutations bypass JPA timestamps).
+    this.injectRepository.touchUpdatedAtByExerciseId(exerciseId);
 
     // Replace teams from exercise
     List<Team> teams = fromIterable(this.teamRepository.findAllById(targetTeamIds));

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -23,6 +23,8 @@ import io.openaev.api.url_access_token.UrlAccessTokenService;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.context.TenantContext;
+import io.openaev.database.audit.IndexEvent;
+import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.model.*;
 import io.openaev.database.raw.RawExerciseSimple;
 import io.openaev.database.raw.RawInjectExpectationIndexing;
@@ -78,6 +80,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.query.criteria.HibernateCriteriaBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -145,6 +148,8 @@ public class ExerciseService {
   private final StepService stepService;
 
   private final HealthCheckUtils healthCheckUtils;
+
+  private final ApplicationEventPublisher eventPublisher;
 
   // region properties
   @Value("${openaev.mail.imap.enabled}")
@@ -555,6 +560,10 @@ public class ExerciseService {
   public void deleteById(String simulationId) {
     existsByIdAndTenantId(simulationId);
     exerciseRepository.deleteById(simulationId);
+    // The repository delete is a native query: no JPA lifecycle event fires, so the search engine
+    // must be notified explicitly or the simulation (and its cascade-deleted injects,
+    // expectations, findings...) would remain in the indexes forever.
+    eventPublisher.publishEvent(new IndexEvent(ModelBaseListener.DATA_DELETE, simulationId));
     log.info("Simulation {} deleted by user {}", simulationId, currentUser().getId());
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.config.cache.LicenseCacheManager;
+import io.openaev.database.audit.IndexEvent;
+import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.model.*;
 import io.openaev.database.raw.RawInject;
 import io.openaev.database.repository.*;
@@ -81,6 +83,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -125,6 +128,7 @@ public class InjectService {
   private final InjectorContractContentUtils injectorContractContentUtils;
   private final InjectUtils injectUtils;
   private final ThreatArsenalService threatArsenalService;
+  private final ApplicationEventPublisher eventPublisher;
 
   private InjectStatusService injectStatusService;
 
@@ -315,6 +319,10 @@ public class InjectService {
   public void deleteAllByIds(List<String> injectIds) {
     if (!CollectionUtils.isEmpty(injectIds)) {
       injectRepository.deleteByAllIdsNative(injectIds);
+      // Native delete: no JPA lifecycle event fires, notify the search engine explicitly so the
+      // inject docs (and their expectation/finding docs via dependency cascade) are removed.
+      injectIds.forEach(
+          id -> eventPublisher.publishEvent(new IndexEvent(ModelBaseListener.DATA_DELETE, id)));
     }
   }
 
@@ -489,6 +497,9 @@ public class InjectService {
   public void deleteForRelaunch(String oldId, String newId) {
     injectDocumentRepository.updateInjectId(newId, oldId);
     injectRepository.deleteByIdNative(oldId);
+    // Native delete: notify the search engine so the old inject and its expectation/finding docs
+    // don't survive the relaunch (they would double-count against the duplicated inject).
+    eventPublisher.publishEvent(new IndexEvent(ModelBaseListener.DATA_DELETE, oldId));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.database.audit.AuditLoggedService;
+import io.openaev.database.audit.IndexEvent;
+import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.database.specification.AssetAgentJobSpecification;
@@ -54,6 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
@@ -125,6 +128,7 @@ public class EndpointService implements AuditLoggedService {
   private final EnterpriseEditionService enterpriseEditionService;
   private final LicenseCacheManager licenseCacheManager;
   private final TenantRepository tenantRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   // -- CRUD --
   public Endpoint createEndpoint(@NotNull final Endpoint endpoint) {
@@ -216,6 +220,9 @@ public class EndpointService implements AuditLoggedService {
 
   public void deleteEndpoint(@NotBlank final String endpointId) {
     this.endpointRepository.deleteById(endpointId);
+    // The repository delete is a native query: no JPA lifecycle event fires, so the search engine
+    // must be notified explicitly (endpoint + vulnerable-endpoint docs would stay stale).
+    eventPublisher.publishEvent(new IndexEvent(ModelBaseListener.DATA_DELETE, endpointId));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -781,6 +781,10 @@ public class ScenarioService {
     this.injectRepository.removeTeamsForScenario(scenarioId, teamIds);
     // Remove all association between lessons learned and teams
     this.lessonsCategoryRepository.removeTeamsForScenario(scenarioId, teamIds);
+    // The join-table deletes above are native queries that bypass JPA timestamps: bump the
+    // scenario and its injects so the incremental indexer refreshes the denormalized team sides.
+    this.scenarioRepository.touchUpdatedAt(scenarioId);
+    this.injectRepository.touchUpdatedAtByScenarioId(scenarioId);
     return teamService.find(fromIds(teamIds));
   }
 
@@ -800,6 +804,10 @@ public class ScenarioService {
       this.injectRepository.removeTeamsForScenario(scenarioId, removedTeamIdsList);
       this.lessonsCategoryRepository.removeTeamsForScenario(scenarioId, removedTeamIdsList);
     }
+    // Team changes alter the denormalized inject_teams of the scenario's injects (including
+    // all-teams injects, derived from scenarios_teams): bump the injects so the incremental
+    // indexer refreshes them (the native join-table mutations bypass JPA timestamps).
+    this.injectRepository.touchUpdatedAtByScenarioId(scenarioId);
 
     // Replace teams from a scenario
     List<Team> teams = fromIterable(this.teamRepository.findAllById(targetTeamIds));

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageInjectService.java
@@ -5,6 +5,8 @@ import static io.openaev.rest.payload.service.PayloadService.DYNAMIC_DNS_RESOLUT
 import static io.openaev.rest.payload.service.PayloadService.DYNAMIC_DNS_RESOLUTION_HOSTNAME_VARIABLE;
 import static io.openaev.utils.AssetUtils.extractPlatformArchPairs;
 
+import io.openaev.database.audit.IndexEvent;
+import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectorContractRepository;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -57,6 +60,17 @@ public class SecurityCoverageInjectService {
 
   private final SecurityCoverageUtils securityCoverageUtils;
   private final ScenarioService scenarioService;
+  private final ApplicationEventPublisher eventPublisher;
+
+  /**
+   * The scenario inject rebuild deletes are native queries: no JPA lifecycle event fires, so the
+   * search engine must be notified explicitly or the deleted inject docs (and their dependent
+   * expectation/finding docs) would remain in the indexes forever.
+   */
+  private void notifyEngineOfDeletedInjects(List<String> injectIds) {
+    injectIds.forEach(
+        id -> eventPublisher.publishEvent(new IndexEvent(ModelBaseListener.DATA_DELETE, id)));
+  }
 
   /**
    * Creates and manages injects for the given scenario based on the associated security coverage.
@@ -111,8 +125,12 @@ public class SecurityCoverageInjectService {
   }
 
   private void cleanInjectPlaceholders(String scenarioId) {
+    List<String> deletedIds =
+        injectRepository.findInjectIdsByScenarioIdAndInjectorContract(
+            ManualContract.MANUAL_DEFAULT, scenarioId);
     injectRepository.deleteAllByScenarioIdAndInjectorContract(
         ManualContract.MANUAL_DEFAULT, scenarioId);
+    notifyEngineOfDeletedInjects(deletedIds);
   }
 
   // -- INJECTS BY ARTIFACTS --
@@ -154,7 +172,10 @@ public class SecurityCoverageInjectService {
     // manage
 
     if (fileDropRefs.isEmpty()) {
+      List<String> deletedIds =
+          injectRepository.findInjectIdsWithFileDropContractsByScenarioId(scenario.getId());
       injectRepository.deleteAllInjectsWithFileDropContractsByScenarioId(scenario.getId());
+      notifyEngineOfDeletedInjects(deletedIds);
       Set<String> allInjectIds =
           scenario.getInjects().stream().map(Inject::getId).collect(Collectors.toSet());
       cleanScenarioFromDocuments(scenario, previousDocuments, allInjectIds);
@@ -314,7 +335,10 @@ public class SecurityCoverageInjectService {
     // 1. Remove Inject with contract related to Dns Resolution if there is no any DNS Indicator to
     // manage
     if (dnsResolutionRefs.isEmpty()) {
+      List<String> deletedIds =
+          injectRepository.findInjectIdsWithDnsResolutionContractsByScenarioId(scenario.getId());
       injectRepository.deleteAllInjectsWithDnsResolutionContractsByScenarioId(scenario.getId());
+      notifyEngineOfDeletedInjects(deletedIds);
       return;
     }
 
@@ -384,7 +408,10 @@ public class SecurityCoverageInjectService {
 
     // 1. Remove Inject with contract related to vulnerabilities if vulnerabilityRefs is empty
     if (vulnerabilityRefs.isEmpty()) {
+      List<String> deletedIds =
+          injectRepository.findInjectIdsWithVulnerableContractsByScenarioId(scenario.getId());
       injectRepository.deleteAllInjectsWithVulnerableContractsByScenarioId(scenario.getId());
+      notifyEngineOfDeletedInjects(deletedIds);
     }
 
     // 2. Fetch internal Ids for Vulnerabilities
@@ -502,7 +529,10 @@ public class SecurityCoverageInjectService {
 
     // 1. Remove Inject with contract related to attack patterns if attackPattern is empty
     if (attackPatternRefs.isEmpty()) {
+      List<String> deletedIds =
+          injectRepository.findInjectIdsWithAttackPatternContractsByScenarioId(scenario.getId());
       injectRepository.deleteAllInjectsWithAttackPatternContractsByScenarioId(scenario.getId());
+      notifyEngineOfDeletedInjects(deletedIds);
       return;
     }
 

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantService.java
@@ -7,6 +7,7 @@ import io.openaev.api.tenants.TenantInput;
 import io.openaev.api.tenants.TenantOutput;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.repository.TenantRepository;
+import io.openaev.engine.EngineService;
 import io.openaev.multitenancy.DependenciesManager;
 import io.openaev.multitenancy.DependenciesManagerException;
 import io.openaev.rest.exception.BadRequestException;
@@ -35,6 +36,7 @@ public class TenantService {
 
   private final TenantRepository tenantRepository;
   private final List<DependenciesManager> dependencies;
+  private final EngineService engineService;
   @PersistenceContext private EntityManager entityManager;
 
   // -- CREATE --
@@ -213,6 +215,9 @@ public class TenantService {
 
     if (!purgedIds.isEmpty()) {
       tenantRepository.deleteAllByIdsNative(purgedIds);
+      // Tenant data is removed via native SQL (no JPA lifecycle events): clean the search engine
+      // explicitly so the purged tenant's documents don't survive as permanent index garbage.
+      purgedIds.forEach(engineService::deleteByTenant);
     }
     return purgedIds.size();
   }

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantService.java
@@ -24,6 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.ClassUtils;
 
 @Slf4j
@@ -216,8 +218,21 @@ public class TenantService {
     if (!purgedIds.isEmpty()) {
       tenantRepository.deleteAllByIdsNative(purgedIds);
       // Tenant data is removed via native SQL (no JPA lifecycle events): clean the search engine
-      // explicitly so the purged tenant's documents don't survive as permanent index garbage.
-      purgedIds.forEach(engineService::deleteByTenant);
+      // explicitly so the purged tenants' documents don't survive as permanent index garbage.
+      // Deferred to after commit: if the surrounding transaction rolls back, the SQL data is
+      // restored and the index must not have been wiped. Single batched delete-by-query.
+      List<String> idsToClean = List.copyOf(purgedIds);
+      if (TransactionSynchronizationManager.isSynchronizationActive()) {
+        TransactionSynchronizationManager.registerSynchronization(
+            new TransactionSynchronization() {
+              @Override
+              public void afterCommit() {
+                engineService.deleteByTenants(idsToClean);
+              }
+            });
+      } else {
+        engineService.deleteByTenants(idsToClean);
+      }
     }
     return purgedIds.size();
   }

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingRegressionTest.java
@@ -6,6 +6,8 @@ import io.openaev.IntegrationTest;
 import io.openaev.database.model.*;
 import io.openaev.engine.model.endpoint.EndpointHandler;
 import io.openaev.engine.model.endpoint.EsEndpoint;
+import io.openaev.engine.model.finding.EsFinding;
+import io.openaev.engine.model.finding.FindingHandler;
 import io.openaev.engine.model.inject.EsInject;
 import io.openaev.engine.model.inject.InjectHandler;
 import io.openaev.engine.model.injectexpectation.EsInjectExpectation;
@@ -56,6 +58,7 @@ class IndexingRegressionTest extends IntegrationTest {
   @Autowired private ScenarioHandler scenarioHandler;
   @Autowired private InjectExpectationHandler injectExpectationHandler;
   @Autowired private VulnerableEndpointHandler vulnerableEndpointHandler;
+  @Autowired private FindingHandler findingHandler;
 
   @Autowired private ScenarioComposer scenarioComposer;
   @Autowired private ExerciseComposer exerciseComposer;
@@ -66,6 +69,8 @@ class IndexingRegressionTest extends IntegrationTest {
   @Autowired private CollectorComposer collectorComposer;
   @Autowired private SecurityPlatformComposer securityPlatformComposer;
   @Autowired private FindingComposer findingComposer;
+  @Autowired private TeamComposer teamComposer;
+  @Autowired private UserComposer userComposer;
 
   /** A point in time used as the {@code :from} parameter — 1 hour ago. */
   private static final Instant FROM = Instant.now().minus(1, ChronoUnit.HOURS);
@@ -84,6 +89,8 @@ class IndexingRegressionTest extends IntegrationTest {
     collectorComposer.reset();
     securityPlatformComposer.reset();
     findingComposer.reset();
+    teamComposer.reset();
+    userComposer.reset();
   }
 
   // ---------------------------------------------------------------------------
@@ -734,6 +741,125 @@ class IndexingRegressionTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Per-player expectations are excluded, the team-level row is indexed")
+    void given_perPlayerExpectation_should_indexOnlyTeamLevelRow() {
+      // Per-player rows (user_id NOT NULL) double-counted every manual expectation: the
+      // team-level row already represents the players, so only it must be indexed.
+      TeamComposer.Composer teamWrapper = teamComposer.forTeam(TeamFixture.getDefaultTeam());
+      UserComposer.Composer userWrapper = userComposer.forUser(UserFixture.getUser());
+
+      ManualInjectExpectation teamExpectation =
+          InjectExpectationFixture.createManualInjectExpectation(null, null);
+      InjectExpectationComposer.Composer teamExpectationWrapper =
+          injectExpectationComposer.forExpectation(teamExpectation).withTeam(teamWrapper);
+
+      ManualInjectExpectation playerExpectation =
+          InjectExpectationFixture.createManualInjectExpectation(null, null);
+      InjectExpectationComposer.Composer playerExpectationWrapper =
+          injectExpectationComposer
+              .forExpectation(playerExpectation)
+              .withTeam(teamWrapper)
+              .withUser(userWrapper);
+
+      InjectComposer.Composer injectWrapper =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withExpectation(teamExpectationWrapper)
+              .withExpectation(playerExpectationWrapper);
+      scenarioComposer
+          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+          .withInject(injectWrapper)
+          .persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      List<EsInjectExpectation> results = injectExpectationHandler.fetch(null, 5000);
+
+      assertThat(results)
+          .as("the team-level expectation must be indexed")
+          .anyMatch(es -> es.getBase_id().equals(teamExpectation.getId()));
+      assertThat(results)
+          .as("the per-player expectation must NOT be indexed (double-counting)")
+          .noneMatch(es -> es.getBase_id().equals(playerExpectation.getId()));
+    }
+
+    @Test
+    @DisplayName(
+        "Security platform attribution ignores agent-level children of a different expectation"
+            + " type")
+    void given_agentChildOfDifferentType_should_notAttributeItsPlatformsToParent() {
+      // The agent_security_platforms CTE is scoped to the SAME expectation type as the parent:
+      // a platform that DETECTED must not be blamed on (or credited to) a PREVENTION doc of the
+      // same inject.
+      SecurityPlatformComposer.Composer securityPlatform =
+          securityPlatformComposer
+              .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR scoping", "EDR"))
+              .persist();
+      Collector collector =
+          collectorComposer
+              .forCollector(CollectorFixture.createDefaultCollector("collector-edr-scoping"))
+              .withSecurityPlatform(securityPlatform)
+              .persist()
+              .get();
+
+      EndpointComposer.Composer endpointWrapper =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+      endpointWrapper.persist();
+
+      BaseInjectExpectation agentlessDetection =
+          InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+      InjectExpectationComposer.Composer agentlessDetectionWrapper =
+          injectExpectationComposer
+              .forExpectation(agentlessDetection)
+              .withEndpoint(endpointWrapper);
+
+      Agent agent = AgentFixture.createDefaultAgentService();
+      agent.setAsset(endpointWrapper.get());
+      entityManager.persist(agent);
+      entityManager.flush();
+      Agent persistedAgent = entityManager.getReference(Agent.class, agent.getId());
+
+      // Agent-level child of a DIFFERENT type (prevention) carrying the collector result
+      PreventionInjectExpectation agentPrevention =
+          InjectExpectationFixture.createPreventionInjectExpectation(null, persistedAgent);
+      agentPrevention.setAsset(endpointWrapper.get());
+      agentPrevention.setResults(
+          List.of(
+              InjectExpectationResult.builder()
+                  .sourceId(collector.getId())
+                  .sourceType("collector")
+                  .sourceName(collector.getName())
+                  .result("prevented")
+                  .score(100.0)
+                  .build()));
+      InjectExpectationComposer.Composer agentPreventionWrapper =
+          injectExpectationComposer.forExpectation(agentPrevention).withEndpoint(endpointWrapper);
+
+      InjectComposer.Composer injectWrapper =
+          injectComposer
+              .forInject(InjectFixture.getDefaultInject())
+              .withExpectation(agentlessDetectionWrapper)
+              .withExpectation(agentPreventionWrapper);
+      scenarioComposer
+          .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+          .withInject(injectWrapper)
+          .persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      List<EsInjectExpectation> results = injectExpectationHandler.fetch(FROM, 5000);
+
+      assertThat(results)
+          .filteredOn(es -> es.getBase_id().equals(agentlessDetection.getId()))
+          .singleElement()
+          .satisfies(
+              es ->
+                  assertThat(es.getBase_security_platforms_side())
+                      .as("a prevention child's platform must not leak into the detection doc")
+                      .doesNotContain(securityPlatform.get().getId()));
+    }
+
+    @Test
     @DisplayName("Agent-level expectations are excluded by the CTE filter")
     void agent_expectations_are_excluded() {
       EndpointComposer.Composer endpointWrapper =
@@ -828,12 +954,124 @@ class IndexingRegressionTest extends IntegrationTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Finding
+  // ---------------------------------------------------------------------------
+
+  @Nested
+  @DisplayName("FindingHandler.findForIndexing")
+  class FindingIndexing {
+
+    @Test
+    @DisplayName("Multi-asset finding is indexed as ONE doc aggregating ALL asset ids")
+    void given_findingOnSeveralAssets_should_indexSingleDocWithAllAssets() {
+      // The previous per-(finding, asset) rows shared the same base_id: each bulk upsert
+      // overwrote the previous row, so only one arbitrary asset survived (last-asset-wins).
+      EndpointComposer.Composer endpointOne =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+      EndpointComposer.Composer endpointTwo =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+      FindingComposer.Composer findingWrapper =
+          findingComposer
+              .forFinding(FindingFixture.createDefaultCveFindingWithRandomTitle())
+              .withEndpoint(endpointOne)
+              .withEndpoint(endpointTwo);
+      InjectComposer.Composer injectWrapper =
+          injectComposer.forInject(InjectFixture.getDefaultInject()).withFinding(findingWrapper);
+      exerciseComposer
+          .forExercise(ExerciseFixture.createDefaultExercise())
+          .withInject(injectWrapper)
+          .persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      List<EsFinding> results = findingHandler.fetch(FROM, 5000);
+
+      String findingId = findingWrapper.get().getId();
+      assertThat(results)
+          .filteredOn(es -> es.getBase_id().equals(findingId))
+          .as("exactly ONE doc per finding (no per-asset row fan-out)")
+          .singleElement()
+          .satisfies(
+              es ->
+                  assertThat(es.getBase_endpoint_side())
+                      .as("base_endpoint_side must aggregate ALL linked assets")
+                      .containsExactlyInAnyOrder(
+                          endpointOne.get().getId(), endpointTwo.get().getId()));
+    }
+
+    @Test
+    @DisplayName("Finding without assets is indexed with an empty endpoint side")
+    void given_findingWithoutAssets_should_indexWithEmptyEndpointSide() {
+      FindingComposer.Composer findingWrapper =
+          findingComposer.forFinding(FindingFixture.createDefaultCveFindingWithRandomTitle());
+      InjectComposer.Composer injectWrapper =
+          injectComposer.forInject(InjectFixture.getDefaultInject()).withFinding(findingWrapper);
+      exerciseComposer
+          .forExercise(ExerciseFixture.createDefaultExercise())
+          .withInject(injectWrapper)
+          .persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      List<EsFinding> results = findingHandler.fetch(FROM, 5000);
+
+      String findingId = findingWrapper.get().getId();
+      assertThat(results)
+          .filteredOn(es -> es.getBase_id().equals(findingId))
+          .singleElement()
+          .satisfies(es -> assertThat(es.getBase_endpoint_side()).isEmpty());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // VulnerableEndpoint
   // ---------------------------------------------------------------------------
 
   @Nested
   @DisplayName("VulnerableEndpointHandler.findForIndexing")
   class VulnerableEndpointIndexing {
+
+    @Test
+    @DisplayName(
+        "VulnerableEndpoint appears when only its CVE finding was updated after :from"
+            + " (finding_updated_at cursor branch)")
+    void given_onlyFindingRecentlyUpdated_should_reindexVulnerableEndpoint() {
+      // Regression for the dashboard KPI stuck at 0: a new CVE finding must create/refresh the
+      // vulnerable-endpoint doc even when neither the asset nor the exercise row was touched.
+      EndpointComposer.Composer endpointWrapper =
+          endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+      FindingComposer.Composer findingWrapper =
+          findingComposer
+              .forFinding(FindingFixture.createDefaultCveFindingWithRandomTitle())
+              .withEndpoint(endpointWrapper);
+      InjectComposer.Composer injectWrapper =
+          injectComposer.forInject(InjectFixture.getDefaultInject()).withFinding(findingWrapper);
+      Exercise exercise =
+          exerciseComposer
+              .forExercise(ExerciseFixture.createDefaultExercise())
+              .withInject(injectWrapper)
+              .persist()
+              .get();
+      entityManager.flush();
+
+      // Push asset and exercise into the past: the ONLY recent row is the finding itself
+      pushEndpointToPast(endpointWrapper.get().getId());
+      pushExerciseToPast(exercise.getId());
+      entityManager
+          .createNativeQuery(
+              "UPDATE findings SET finding_updated_at = now() WHERE finding_id = :id")
+          .setParameter("id", findingWrapper.get().getId())
+          .executeUpdate();
+      entityManager.flush();
+      entityManager.clear();
+
+      List<EsVulnerableEndpoint> results = vulnerableEndpointHandler.fetch(FROM, 5000);
+
+      String expectedBaseId = endpointWrapper.get().getId() + "_" + exercise.getId();
+      assertThat(results)
+          .as("the vulnerable-endpoint doc must be produced from the finding timestamp alone")
+          .anyMatch(es -> es.getBase_id().equals(expectedBaseId));
+    }
 
     @Test
     @DisplayName("VulnerableEndpoint appears when its exercise was updated after :from")

--- a/openaev-api/src/test/java/io/openaev/rest/exercise/service/ExerciseServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/exercise/service/ExerciseServiceTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -87,6 +88,7 @@ class ExerciseServiceTest extends IntegrationTest {
   @Mock private ExerciseTeamUserService exerciseTeamUserService;
   @Mock private io.openaev.healthcheck.utils.HealthCheckUtils healthCheckUtils;
   @Mock private UrlAccessTokenService urlAccessTokenService;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @Mock private InjectExpectationMapper injectExpectationMapper;
 
@@ -136,7 +138,8 @@ class ExerciseServiceTest extends IntegrationTest {
             pauseExerciseService,
             fileService,
             stepService,
-            healthCheckUtils);
+            healthCheckUtils,
+            eventPublisher);
 
     scenarioComposer.reset();
     exerciseComposer.reset();

--- a/openaev-api/src/test/java/io/openaev/rest/exercise/service/ExerciseServiceUnitTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/exercise/service/ExerciseServiceUnitTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class ExerciseServiceUnitTest {
@@ -80,6 +81,7 @@ class ExerciseServiceUnitTest {
 
   @Mock private WorkflowService workflowService;
   @Mock private LessonsService lessonsService;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @Spy @InjectMocks private ExerciseService mockedExerciseService;
 

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectServiceTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -131,6 +132,8 @@ class InjectServiceTest {
   @Mock private AssetAgentJobRepository assetAgentJobRepository;
 
   @Spy private InjectorContractContentUtils injectorContractContentUtils;
+
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   ObjectMapper mapper;
 

--- a/openaev-api/src/test/java/io/openaev/service/EsIndexingUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/EsIndexingUtilsTest.java
@@ -1,0 +1,126 @@
+package io.openaev.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.engine.model.EsBase;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit tests for the shared incremental-indexing helpers used by both engine implementations
+ * (Elasticsearch and OpenSearch): LIMIT-boundary-safe cursor advancement and deterministic (poison)
+ * bulk error classification.
+ */
+@DisplayName("EsIndexingUtils cursor and poison-error helpers")
+class EsIndexingUtilsTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EsIndexingUtilsTest.class);
+  private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+  private static EsBase row(Instant updatedAt) {
+    EsBase row = new EsBase();
+    row.setBase_updated_at(updatedAt);
+    return row;
+  }
+
+  private static Instant ts(long plusSeconds) {
+    return T0.plusSeconds(plusSeconds);
+  }
+
+  @Nested
+  @DisplayName("isPoisonError")
+  class IsPoisonError {
+
+    @Test
+    @DisplayName("Deterministic mapping/parsing error types are poison")
+    void given_deterministicErrorTypes_should_classifyAsPoison() {
+      assertThat(EsIndexingUtils.isPoisonError("strict_dynamic_mapping_exception")).isTrue();
+      assertThat(EsIndexingUtils.isPoisonError("mapper_parsing_exception")).isTrue();
+      assertThat(EsIndexingUtils.isPoisonError("document_parsing_exception")).isTrue();
+      assertThat(EsIndexingUtils.isPoisonError("illegal_argument_exception")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Transient error types and null are not poison")
+    void given_transientErrorTypesOrNull_should_notClassifyAsPoison() {
+      assertThat(EsIndexingUtils.isPoisonError("es_rejected_execution_exception")).isFalse();
+      assertThat(EsIndexingUtils.isPoisonError("circuit_breaking_exception")).isFalse();
+      assertThat(EsIndexingUtils.isPoisonError("cluster_block_exception")).isFalse();
+      assertThat(EsIndexingUtils.isPoisonError(null)).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("computeNewCursor")
+  class ComputeNewCursor {
+
+    @Test
+    @DisplayName("Partial batch advances the cursor to the boundary timestamp")
+    void given_partialBatch_should_advanceToBoundary() {
+      List<EsBase> batch = List.of(row(ts(1)), row(ts(2)), row(ts(3)));
+
+      Instant cursor = EsIndexingUtils.computeNewCursor(batch, 10, "model", LOG);
+
+      assertThat(cursor).isEqualTo(ts(3));
+    }
+
+    @Test
+    @DisplayName("Full batch steps back to the last complete timestamp group")
+    void given_fullBatchWithDistinctTimestamps_should_advanceToLastCompleteGroup() {
+      // The boundary group may have been cut by the LIMIT: rows sharing ts(3) could exist beyond
+      // the batch, so the cursor must stop at ts(2) and re-fetch the ts(3) group next round.
+      List<EsBase> batch = List.of(row(ts(1)), row(ts(2)), row(ts(3)));
+
+      Instant cursor = EsIndexingUtils.computeNewCursor(batch, 3, "model", LOG);
+
+      assertThat(cursor).isEqualTo(ts(2));
+    }
+
+    @Test
+    @DisplayName("Full batch cut inside a shared boundary group does not skip the group")
+    void given_fullBatchEndingOnSharedTimestamp_should_notAdvancePastSharedGroup() {
+      // Rows 3 and 4 share ts(2) and the LIMIT cut the group: advancing to ts(2) would skip the
+      // remaining ts(2) rows forever (queries fetch with strictly-greater-than).
+      List<EsBase> batch = List.of(row(ts(1)), row(ts(1)), row(ts(2)), row(ts(2)));
+
+      Instant cursor = EsIndexingUtils.computeNewCursor(batch, 4, "model", LOG);
+
+      assertThat(cursor).isEqualTo(ts(1));
+    }
+
+    @Test
+    @DisplayName("Degenerate full batch sharing one timestamp advances past it to keep progress")
+    void given_fullBatchWithSingleSharedTimestamp_should_advancePastItToAvoidInfiniteLoop() {
+      List<EsBase> batch = List.of(row(ts(5)), row(ts(5)), row(ts(5)));
+
+      Instant cursor = EsIndexingUtils.computeNewCursor(batch, 3, "model", LOG);
+
+      assertThat(cursor).isEqualTo(ts(5));
+    }
+
+    @Test
+    @DisplayName("Null boundary timestamp yields a null cursor (caller keeps the old cursor)")
+    void given_nullBoundaryTimestamp_should_returnNull() {
+      List<EsBase> batch = List.of(row(ts(1)), row(null));
+
+      Instant cursor = EsIndexingUtils.computeNewCursor(batch, 10, "model", LOG);
+
+      assertThat(cursor).isNull();
+    }
+
+    @Test
+    @DisplayName("Single-row partial batch advances to that row's timestamp")
+    void given_singleRowPartialBatch_should_advanceToItsTimestamp() {
+      List<EsBase> batch = List.of(row(ts(7)));
+
+      Instant cursor = EsIndexingUtils.computeNewCursor(batch, 10, "model", LOG);
+
+      assertThat(cursor).isEqualTo(ts(7));
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/ExerciseServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ExerciseServiceIntegrationTest.java
@@ -37,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -89,6 +90,7 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
 
   @Autowired private WorkflowService workflowService;
   @Autowired private io.openaev.healthcheck.utils.HealthCheckUtils healthCheckUtils;
+  @Autowired private ApplicationEventPublisher eventPublisher;
 
   private static String USER_ID;
   private static String TEAM_ID;
@@ -139,7 +141,8 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
             pauseExerciseService,
             fileService,
             stepService,
-            healthCheckUtils);
+            healthCheckUtils,
+            eventPublisher);
   }
 
   @AfterAll

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -53,6 +54,7 @@ class EndpointServiceTest {
   @Mock private AssetService assetService;
   @Mock private EndpointMapper endpointMapper;
   @Mock private ServiceAccountPrivilegeService privilegeService;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks private EndpointService endpointService;
 

--- a/openaev-front/src/__tests__/widgets/SecurityDomainsWidgetUtils.test.ts
+++ b/openaev-front/src/__tests__/widgets/SecurityDomainsWidgetUtils.test.ts
@@ -2,8 +2,11 @@ import { type Theme } from '@mui/material';
 import { describe, expect, it } from 'vitest';
 
 import {
+  calcPercentage,
   colorByAverageForExpectation,
+  colorByLabel,
   EMPTY_DATA,
+  isStatus,
 } from '../../admin/components/workspaces/custom_dashboards/widgets/viz/domains/SecurityDomainsWidgetUtils';
 
 const mockTheme = {
@@ -84,5 +87,50 @@ describe('colorByAverageForExpectation', () => {
     it('returns unknown color for 101', () => {
       expect(colorByAverageForExpectation(101, mockTheme)).toBe(colors.unknown);
     });
+  });
+});
+
+describe('isStatus', () => {
+  it('matches statuses case-insensitively (raw ES bucket keys)', () => {
+    expect(isStatus('success', 'SUCCESS')).toBe(true);
+    expect(isStatus('SUCCESS', 'SUCCESS')).toBe(true);
+    expect(isStatus('Failed', 'FAILED')).toBe(true);
+  });
+
+  it('does not match different statuses', () => {
+    expect(isStatus('PENDING', 'SUCCESS')).toBe(false);
+    expect(isStatus('failed', 'SUCCESS')).toBe(false);
+  });
+
+  it('handles null and undefined values', () => {
+    expect(isStatus(null, 'SUCCESS')).toBe(false);
+    expect(isStatus(undefined, 'SUCCESS')).toBe(false);
+    expect(isStatus('', 'SUCCESS')).toBe(false);
+  });
+});
+
+describe('calcPercentage', () => {
+  it('computes the percentage over the given total', () => {
+    expect(calcPercentage(1, 4)).toBe(25);
+    expect(calcPercentage(3, 3)).toBe(100);
+    expect(calcPercentage(0, 5)).toBe(0);
+  });
+
+  it('returns -1 (empty state) when the total is zero, e.g. pending-only domains', () => {
+    expect(calcPercentage(0, 0)).toBe(-1);
+  });
+});
+
+describe('colorByLabel', () => {
+  it('resolves success and failed colors case-insensitively', () => {
+    expect(colorByLabel('success', mockTheme)).toBe(colors.success);
+    expect(colorByLabel('SUCCESS', mockTheme)).toBe(colors.success);
+    expect(colorByLabel('failed', mockTheme)).toBe(colors.failed);
+    expect(colorByLabel('FAILED', mockTheme)).toBe(colors.failed);
+  });
+
+  it('falls back to the pending color for anything else', () => {
+    expect(colorByLabel('PENDING', mockTheme)).toBe(colors.pending);
+    expect(colorByLabel(null, mockTheme)).toBe(colors.pending);
   });
 });

--- a/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
+++ b/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
@@ -299,14 +299,15 @@ export const buildDefaultHomeWidgets = (timeRange: DefaultTimeRange, t: Translat
   widget(
     'default-weekly-failures',
     'vertical-barchart',
+    // eq FAILED (not "not_eq SUCCESS"): pending/unknown expectations are not misses.
     temporal(t('Missed injects by week'), [
       series('Not Detected', ...expectation([
         filter('inject_expectation_type', ['DETECTION']),
-        filter('inject_expectation_status', ['SUCCESS'], 'not_eq'),
+        filter('inject_expectation_status', ['FAILED']),
       ])),
       series('Not Prevented', ...expectation([
         filter('inject_expectation_type', ['PREVENTION']),
-        filter('inject_expectation_status', ['SUCCESS'], 'not_eq'),
+        filter('inject_expectation_status', ['FAILED']),
       ])),
     ], timeRange),
     layout(0, 40, 4, 6),

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/ResilienceGaugeWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/ResilienceGaugeWidget.tsx
@@ -214,7 +214,7 @@ const ResilienceGaugeWidget: FunctionComponent<Props> = ({ widgetId, widgetConfi
           <svg
             className="noDrag"
             viewBox={`0 0 ${size} ${size}`}
-            onClick={() => investigate(['SUCCESS', 'FAILED', 'PENDING'])}
+            onClick={() => investigate(['SUCCESS', 'FAILED', 'PENDING', 'UNKNOWN'])}
             style={{
               maxHeight: '100%',
               maxWidth: '100%',

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/domains/SecurityDomainCardWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/domains/SecurityDomainCardWidget.tsx
@@ -18,6 +18,7 @@ import {
   type EsExpectationByDomainTypeAndStatus,
   formatPercentage,
   getIconByDomain,
+  isStatus,
 } from './SecurityDomainsWidgetUtils';
 
 interface Props {
@@ -43,19 +44,25 @@ const SecurityDomainCardWidget: FunctionComponent<Props> = ({
 
   const hasData = esDomainDatas.data.length > 0;
 
-  // Overall success rate for the domain: sum of successful expectations over total expectations.
+  // Overall success rate for the domain: successful expectations over RESOLVED (success + failed)
+  // expectations, matching statuses case-insensitively - same math as the resilience gauges so the
+  // domain band can never contradict them. Pending/unknown docs are excluded from the denominator.
   const score = useMemo(() => {
     const totals = esDomainDatas.data.reduce(
       (acc, serie) => ({
-        success: acc.success + (serie.data.find(d => d.key === 'success')?.value ?? 0),
-        total: acc.total + (serie.value ?? 0),
+        success: acc.success + serie.data
+          .filter(d => isStatus(d.key, 'SUCCESS'))
+          .reduce((sum, d) => sum + (d.value ?? 0), 0),
+        resolved: acc.resolved + serie.data
+          .filter(d => isStatus(d.key, 'SUCCESS') || isStatus(d.key, 'FAILED'))
+          .reduce((sum, d) => sum + (d.value ?? 0), 0),
       }),
       {
         success: 0,
-        total: 0,
+        resolved: 0,
       },
     );
-    return calcPercentage(totals.success, totals.total);
+    return calcPercentage(totals.success, totals.resolved);
   }, [esDomainDatas.data]);
 
   const hasScore = score >= 0;

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/domains/SecurityDomainsWidgetUtils.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/domains/SecurityDomainsWidgetUtils.tsx
@@ -183,19 +183,25 @@ export const colorByAverageForExpectation = (average: number, theme: Theme): str
 };
 
 /**
+ * Case-insensitive status matcher: ES bucket keys depend on the keyword normalizer of the live
+ * mapping (may be "SUCCESS" or "success"), so status comparisons must never be case-sensitive.
+ */
+export const isStatus = (value: string | null | undefined, status: string): boolean =>
+  (value ?? '').toUpperCase() === status.toUpperCase();
+
+/**
  * Define the colors of the percentage displayed on each lines of a domain
  * @param label to calculate
  * @param theme to get colors values
  */
 export const colorByLabel = (label: string | null, theme: Theme): string => {
-  switch (label) {
-    case 'success':
-      return theme.palette.widgets.securityDomains.colors.success;
-    case 'failed':
-      return theme.palette.widgets.securityDomains.colors.failed;
-    default:
-      return theme.palette.widgets.securityDomains.colors.pending;
+  if (isStatus(label, 'SUCCESS')) {
+    return theme.palette.widgets.securityDomains.colors.success;
   }
+  if (isStatus(label, 'FAILED')) {
+    return theme.palette.widgets.securityDomains.colors.failed;
+  }
+  return theme.palette.widgets.securityDomains.colors.pending;
 };
 
 /**
@@ -235,11 +241,16 @@ const manageExpectationByDomainAndType = (esSerie: EsSeries, theme: Theme): EsEx
     } as EsExpectationByDomainTypeAndStatus;
   });
 
-  // Determine the information for the icon of the expectation line of a domain, from the success value
-  const successExpectationByDomainAndType = esSerie.data?.find(expectationData => expectationData.key === 'success');
-  const successRate = successExpectationByDomainAndType?.value && esSerie?.value
-    ? calcPercentage(successExpectationByDomainAndType.value, esSerie.value)
-    : 0;
+  // Success rate over RESOLVED expectations only (success + failed): pending/unknown docs must
+  // not deflate the rate (the resilience gauges use the same denominator). Status keys are
+  // matched case-insensitively (raw ES bucket keys). No resolved data -> -1 (empty state, grey).
+  const success = esSerie.data
+    ?.filter(d => isStatus(d.key, 'SUCCESS'))
+    .reduce((acc, d) => acc + (d.value ?? 0), 0) ?? 0;
+  const failed = esSerie.data
+    ?.filter(d => isStatus(d.key, 'FAILED'))
+    .reduce((acc, d) => acc + (d.value ?? 0), 0) ?? 0;
+  const successRate = calcPercentage(success, success + failed);
 
   return {
     ...esSerie,

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -3556,6 +3556,7 @@ export interface EsEndpoint {
   /** @format date-time */
   base_updated_at?: string;
   endpoint_arch?: string;
+  endpoint_category?: string;
   endpoint_description?: string;
   endpoint_external_reference?: string;
   endpoint_hostname?: string;
@@ -3598,6 +3599,7 @@ export interface EsFinding {
   /** @format date-time */
   base_created_at?: string;
   base_dependencies?: string[];
+  /** @uniqueItems true */
   base_endpoint_side?: string[];
   base_entity?: string;
   base_id?: string;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -3598,7 +3598,7 @@ export interface EsFinding {
   /** @format date-time */
   base_created_at?: string;
   base_dependencies?: string[];
-  base_endpoint_side?: string;
+  base_endpoint_side?: string[];
   base_entity?: string;
   base_id?: string;
   base_inject_side?: string;

--- a/openaev-model/src/main/java/io/openaev/database/raw/RawEndpoint.java
+++ b/openaev-model/src/main/java/io/openaev/database/raw/RawEndpoint.java
@@ -84,4 +84,11 @@ public interface RawEndpoint extends RawAssetIndexing {
    * @return the update timestamp
    */
   Instant getEndpoint_updated_at();
+
+  /**
+   * Returns the product taxonomy category of the asset (HOST, CONTAINER_WORKLOAD...).
+   *
+   * @return the asset category
+   */
+  String getAsset_category();
 }

--- a/openaev-model/src/main/java/io/openaev/database/raw/RawFindingIndexing.java
+++ b/openaev-model/src/main/java/io/openaev/database/raw/RawFindingIndexing.java
@@ -1,6 +1,7 @@
 package io.openaev.database.raw;
 
 import java.time.Instant;
+import java.util.Set;
 
 /**
  * Spring Data projection interface for finding data.
@@ -77,9 +78,9 @@ public interface RawFindingIndexing extends RawTenant {
   String getScenario_id();
 
   /**
-   * Returns the ID of the asset where this finding was discovered.
+   * Returns the IDs of the assets where this finding was discovered.
    *
-   * @return the asset ID
+   * @return the asset IDs
    */
-  String getAsset_id();
+  Set<String> getAsset_ids();
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/EndpointRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/EndpointRepository.java
@@ -204,7 +204,7 @@ public interface EndpointRepository
               + "FROM injects_assets ia JOIN ranked_assets ra ON ra.asset_id = ia.asset_id JOIN injects i ON i.inject_id = ia.inject_id "
               + "GROUP BY ia.asset_id"
               + ") "
-              + "SELECT a.asset_id, a.asset_type, a.asset_name, a.asset_external_reference, "
+              + "SELECT a.asset_id, a.asset_type, a.asset_category, a.asset_name, a.asset_external_reference, "
               + "a.asset_ips as endpoint_ips, a.asset_hostname as endpoint_hostname, a.endpoint_platform, a.endpoint_arch, "
               + "a.asset_mac_addresses as endpoint_mac_addresses, a.asset_seen_ip as endpoint_seen_ip, a.asset_created_at, a.endpoint_is_eol, a.asset_description, a.tenant_id, "
               + "ra.asset_sort as endpoint_updated_at, "

--- a/openaev-model/src/main/java/io/openaev/database/repository/ExerciseRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ExerciseRepository.java
@@ -269,6 +269,17 @@ public interface ExerciseRepository
   void removeTeams(
       @Param("exerciseId") final String exerciseId, @Param("teamIds") final List<String> teamIds);
 
+  /**
+   * Bumps the exercise updated_at so the incremental search-engine indexer picks up denormalized
+   * changes (e.g. join-table mutations done via native queries that bypass JPA timestamps).
+   */
+  @Modifying
+  @Query(
+      value = "UPDATE exercises SET exercise_updated_at = now() WHERE exercise_id = :exerciseId",
+      nativeQuery = true)
+  @Transactional
+  void touchUpdatedAt(@Param("exerciseId") final String exerciseId);
+
   @Query(
       value =
           " SELECT ex.exercise_id, ex.exercise_end_date, "

--- a/openaev-model/src/main/java/io/openaev/database/repository/FindingRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/FindingRepository.java
@@ -38,15 +38,22 @@ public interface FindingRepository
 
   // -- INDEXING --
 
+  // One row PER FINDING: assets are aggregated. The previous per-(finding, asset) rows shared the
+  // same base_id, so multi-asset findings kept only one arbitrary asset in the search index (each
+  // bulk upsert overwrote the previous row) and the LIMIT applied to joined rows, not findings.
   @Query(
       value =
           "SELECT f.finding_id, f.finding_value, f.finding_type, f.finding_field,"
-              + " f.finding_inject_id, i.inject_exercise, se.scenario_id, fa.asset_id, f.finding_created_at, f.finding_updated_at, f.tenant_id "
+              + " f.finding_inject_id, i.inject_exercise, MAX(se.scenario_id) AS scenario_id,"
+              + " array_agg(DISTINCT fa.asset_id) FILTER ( WHERE fa.asset_id IS NOT NULL ) AS asset_ids,"
+              + " f.finding_created_at, f.finding_updated_at, f.tenant_id "
               + "FROM findings f "
               + "LEFT JOIN injects i ON i.inject_id = f.finding_inject_id "
               + "LEFT JOIN scenarios_exercises se ON i.inject_exercise = se.exercise_id "
               + "LEFT JOIN findings_assets fa ON f.finding_id = fa.finding_id "
-              + "WHERE f.finding_updated_at > :from ORDER BY f.finding_updated_at LIMIT :limit;",
+              + "WHERE f.finding_updated_at > :from "
+              + "GROUP BY f.finding_id, i.inject_exercise "
+              + "ORDER BY f.finding_updated_at LIMIT :limit;",
       nativeQuery = true)
   List<RawFindingIndexing> findForIndexing(@Param("from") Instant from, @Param("limit") int limit);
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -339,24 +339,29 @@ public interface InjectExpectationRepository
       value =
           """
     WITH changed_expectations AS (
+        -- Per-player rows (user_id NOT NULL) are excluded everywhere: the team-level row already
+        -- represents the players (same rule as the global-score queries above), and indexing both
+        -- would double-count every manual expectation in dashboard statistics.
         SELECT ie.inject_expectation_id FROM injects_expectations ie
-          WHERE ie.agent_id IS NULL AND ie.inject_expectation_updated_at > :from
+          WHERE ie.agent_id IS NULL AND ie.user_id IS NULL
+            AND ie.inject_expectation_updated_at > :from
         UNION
         SELECT ie.inject_expectation_id FROM injects_expectations ie
           JOIN injects i ON i.inject_id = ie.inject_id
-          WHERE ie.agent_id IS NULL AND i.inject_updated_at > :from
+          WHERE ie.agent_id IS NULL AND ie.user_id IS NULL AND i.inject_updated_at > :from
         UNION
         SELECT ie.inject_expectation_id FROM injects_expectations ie
           JOIN injects i ON i.inject_id = ie.inject_id
           JOIN injectors_contracts ic ON ic.injector_contract_id = i.inject_injector_contract
                                      AND ic.tenant_id = i.tenant_id
-          WHERE ie.agent_id IS NULL AND ic.injector_contract_updated_at > :from
+          WHERE ie.agent_id IS NULL AND ie.user_id IS NULL
+            AND ic.injector_contract_updated_at > :from
         UNION
         -- Parent (agentless) expectation must be reindexed when one of its agent-level
         -- children changed. EXISTS avoids the parent x child cartesian self-join.
         SELECT parent_ie.inject_expectation_id
           FROM injects_expectations parent_ie
-          WHERE parent_ie.agent_id IS NULL
+          WHERE parent_ie.agent_id IS NULL AND parent_ie.user_id IS NULL
             AND EXISTS (
               SELECT 1 FROM injects_expectations child_ie
               WHERE child_ie.inject_id = parent_ie.inject_id
@@ -425,16 +430,24 @@ public interface InjectExpectationRepository
         GROUP BY b.inject_expectation_id
     ),
     agent_security_platforms AS (
-        -- Security platforms contributed by sibling agent-level expectations (restricted to base injects).
-        SELECT child_ie.inject_id,
+        -- Security platforms contributed by agent-level children, scoped to the SAME expectation
+        -- type and (when the parent is asset-level) the SAME asset as the parent doc. Keyed per
+        -- parent expectation: joining only on inject_id would attribute every platform that
+        -- returned any result for any expectation of the inject (e.g. blame a platform that
+        -- detected for a prevention miss on another asset).
+        SELECT b.inject_expectation_id,
                COALESCE(array_agg(DISTINCT child_c.collector_security_platform::text) FILTER (WHERE child_c.collector_security_platform IS NOT NULL), ARRAY[]::text[])
                || COALESCE(array_agg(DISTINCT child_a.asset_id::text) FILTER (WHERE child_a.asset_id IS NOT NULL), ARRAY[]::text[]) AS security_platform_ids
-        FROM injects_expectations child_ie
+        FROM base b
+        JOIN injects_expectations child_ie
+          ON child_ie.inject_id = b.inject_id
+         AND child_ie.agent_id IS NOT NULL
+         AND child_ie.inject_expectation_type = b.inject_expectation_type
+         AND (b.asset_id IS NULL OR child_ie.asset_id = b.asset_id)
         LEFT JOIN LATERAL jsonb_array_elements(child_ie.inject_expectation_results::jsonb) AS child_r(elem) ON true
         LEFT JOIN collectors child_c ON child_r.elem->>'sourceId' = child_c.collector_id::text
         LEFT JOIN assets child_a ON child_r.elem->>'sourceId' = child_a.asset_id::text
-        WHERE child_ie.agent_id IS NOT NULL AND child_ie.inject_id IN (SELECT inject_id FROM base WHERE inject_id IS NOT NULL)
-        GROUP BY child_ie.inject_id
+        GROUP BY b.inject_expectation_id
     )
     SELECT b.inject_expectation_id, b.inject_expectation_name, b.inject_expectation_description, b.inject_expectation_type,
            b.inject_expectation_results, b.inject_expectation_score, b.inject_expectation_expected_score, b.inject_expiration_time,
@@ -452,7 +465,7 @@ public interface InjectExpectationRepository
     LEFT JOIN track_agg ta ON ta.inject_id = b.inject_id
     LEFT JOIN scen_agg sa ON sa.exercise_id = b.exercise_id
     LEFT JOIN sp_self spself ON spself.inject_expectation_id = b.inject_expectation_id
-    LEFT JOIN agent_security_platforms asp ON asp.inject_id = b.inject_id
+    LEFT JOIN agent_security_platforms asp ON asp.inject_expectation_id = b.inject_expectation_id
     WHERE b.agent_id IS NULL
     ORDER BY b.inject_expectation_updated_at ASC
     """,

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectRepository.java
@@ -439,6 +439,19 @@ public interface InjectRepository
    */
   boolean existsByIdAndScenarioIsNullAndExerciseIsNull(String id);
 
+  @Query(
+      value =
+          "SELECT i.inject_id FROM injects i "
+              + "JOIN injectors_contracts ic ON i.inject_injector_contract = ic.injector_contract_id "
+              + "JOIN payloads p ON ic.injector_contract_payload = p.payload_id "
+              + "WHERE p.payload_type = '"
+              + DNS_RESOLUTION_TYPE
+              + "' "
+              + "AND i.inject_scenario = :scenarioId",
+      nativeQuery = true)
+  List<String> findInjectIdsWithDnsResolutionContractsByScenarioId(
+      @Param("scenarioId") String scenarioId);
+
   @Modifying
   @Query(
       value =
@@ -452,6 +465,19 @@ public interface InjectRepository
               + "AND i.inject_scenario = :scenarioId",
       nativeQuery = true)
   void deleteAllInjectsWithDnsResolutionContractsByScenarioId(
+      @Param("scenarioId") String scenarioId);
+
+  @Query(
+      value =
+          "SELECT i.inject_id FROM injects i "
+              + "JOIN injectors_contracts ic ON i.inject_injector_contract = ic.injector_contract_id "
+              + "JOIN payloads p ON ic.injector_contract_payload = p.payload_id "
+              + "WHERE p.payload_type = '"
+              + FILE_DROP_TYPE
+              + "' "
+              + "AND i.inject_scenario = :scenarioId",
+      nativeQuery = true)
+  List<String> findInjectIdsWithFileDropContractsByScenarioId(
       @Param("scenarioId") String scenarioId);
 
   @Modifying
@@ -468,6 +494,16 @@ public interface InjectRepository
       nativeQuery = true)
   void deleteAllInjectsWithFileDropContractsByScenarioId(@Param("scenarioId") String scenarioId);
 
+  @Query(
+      value =
+          "SELECT DISTINCT i.inject_id FROM injects i "
+              + "JOIN injectors_contracts ic ON i.inject_injector_contract = ic.injector_contract_id "
+              + "JOIN injectors_contracts_vulnerabilities icv ON ic.injector_contract_id = icv.injector_contract_id "
+              + "WHERE i.inject_scenario = :scenarioId",
+      nativeQuery = true)
+  List<String> findInjectIdsWithVulnerableContractsByScenarioId(
+      @Param("scenarioId") String scenarioId);
+
   @Modifying
   @Query(
       value =
@@ -478,6 +514,16 @@ public interface InjectRepository
               + "AND i.inject_scenario = :scenarioId",
       nativeQuery = true)
   void deleteAllInjectsWithVulnerableContractsByScenarioId(@Param("scenarioId") String scenarioId);
+
+  @Query(
+      value =
+          "SELECT DISTINCT i.inject_id FROM injects i "
+              + "JOIN injectors_contracts ic ON i.inject_injector_contract = ic.injector_contract_id "
+              + "JOIN injectors_contracts_attack_patterns icap ON ic.injector_contract_id = icap.injector_contract_id "
+              + "WHERE i.inject_scenario = :scenarioId",
+      nativeQuery = true)
+  List<String> findInjectIdsWithAttackPatternContractsByScenarioId(
+      @Param("scenarioId") String scenarioId);
 
   @Modifying
   @Query(
@@ -490,6 +536,13 @@ public interface InjectRepository
       nativeQuery = true)
   void deleteAllInjectsWithAttackPatternContractsByScenarioId(
       @Param("scenarioId") String scenarioId);
+
+  @Query(
+      value =
+          "SELECT i.inject_id FROM injects i WHERE i.inject_injector_contract = :injectorContract AND i.inject_scenario = :scenarioId",
+      nativeQuery = true)
+  List<String> findInjectIdsByScenarioIdAndInjectorContract(
+      @Param("injectorContract") String injectorContract, @Param("scenarioId") String scenarioId);
 
   @Modifying
   @Query(

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectRepository.java
@@ -364,6 +364,25 @@ public interface InjectRepository
 
   // -- TEAM --
 
+  /**
+   * Bumps all injects of an exercise so the incremental search-engine indexer refreshes their
+   * denormalized team linkage (inject_teams, all-teams derivation, expectation team sides).
+   */
+  @Modifying
+  @Query(
+      value = "UPDATE injects SET inject_updated_at = now() WHERE inject_exercise = :exerciseId",
+      nativeQuery = true)
+  @Transactional
+  void touchUpdatedAtByExerciseId(@Param("exerciseId") String exerciseId);
+
+  /** Same as {@link #touchUpdatedAtByExerciseId(String)} for scenario injects. */
+  @Modifying
+  @Query(
+      value = "UPDATE injects SET inject_updated_at = now() WHERE inject_scenario = :scenarioId",
+      nativeQuery = true)
+  @Transactional
+  void touchUpdatedAtByScenarioId(@Param("scenarioId") String scenarioId);
+
   @Modifying
   @Query(
       value =

--- a/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ScenarioRepository.java
@@ -315,6 +315,17 @@ public interface ScenarioRepository
   void removeTeams(
       @Param("scenarioId") final String scenarioId, @Param("teamIds") final List<String> teamIds);
 
+  /**
+   * Bumps the scenario updated_at so the incremental search-engine indexer picks up denormalized
+   * changes (e.g. join-table mutations done via native queries that bypass JPA timestamps).
+   */
+  @Modifying
+  @Query(
+      value = "UPDATE scenarios SET scenario_updated_at = now() WHERE scenario_id = :scenarioId",
+      nativeQuery = true)
+  @Transactional
+  void touchUpdatedAt(@Param("scenarioId") final String scenarioId);
+
   Optional<Scenario> findByExercises_Id(String exerciseId);
 
   Optional<Scenario> findByIdAndTenantId(String id, String tenantId);

--- a/openaev-model/src/main/java/io/openaev/database/repository/VulnerableEndpointRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/VulnerableEndpointRepository.java
@@ -34,14 +34,32 @@ public interface VulnerableEndpointRepository extends JpaRepository<Endpoint, St
         WHERE e.exercise_updated_at > :from
           AND f.finding_type = 'CVE'
           AND a.asset_type = :#{T(io.openaev.database.model.AssetType.Values).ENDPOINT_TYPE}
+        UNION
+        -- A new/updated CVE finding must create or refresh the vulnerable-endpoint doc even when
+        -- neither the asset nor the exercise row was touched.
+        SELECT DISTINCT a.asset_id, i.inject_exercise
+        FROM findings f
+        JOIN findings_assets fa ON f.finding_id = fa.finding_id
+        JOIN assets a ON a.asset_id = fa.asset_id
+        JOIN injects i ON i.inject_id = f.finding_inject_id
+        WHERE f.finding_updated_at > :from
+          AND f.finding_type = 'CVE'
+          AND a.asset_type = :#{T(io.openaev.database.model.AssetType.Values).ENDPOINT_TYPE}
     ),
     ranked_vulnerable_endpoints AS (
         SELECT cve.asset_id, cve.inject_exercise
         FROM changed_vulnerable_endpoints cve
         JOIN exercises e ON e.exercise_id = cve.inject_exercise
         JOIN assets a ON a.asset_id = cve.asset_id
-        WHERE GREATEST(e.exercise_updated_at, a.asset_updated_at) > :from
-        ORDER BY GREATEST(e.exercise_updated_at, a.asset_updated_at) ASC
+        LEFT JOIN LATERAL (
+            SELECT max(f.finding_updated_at) AS max_finding
+            FROM findings f
+            JOIN findings_assets fa ON fa.finding_id = f.finding_id AND fa.asset_id = cve.asset_id
+            JOIN injects i ON i.inject_id = f.finding_inject_id AND i.inject_exercise = cve.inject_exercise
+            WHERE f.finding_type = 'CVE'
+        ) fm ON true
+        WHERE GREATEST(e.exercise_updated_at, a.asset_updated_at, fm.max_finding) > :from
+        ORDER BY GREATEST(e.exercise_updated_at, a.asset_updated_at, fm.max_finding) ASC
         LIMIT :limit
     )
     SELECT
@@ -55,8 +73,7 @@ public interface VulnerableEndpointRepository extends JpaRepository<Endpoint, St
       a.endpoint_arch as vulnerable_endpoint_architecture,
       a.tenant_id,
       e.exercise_created_at as vulnerable_endpoint_created_at,
-      CASE WHEN e.exercise_updated_at > a.asset_updated_at
-        THEN e.exercise_updated_at ELSE a.asset_updated_at END as vulnerable_endpoint_updated_at,
+      GREATEST(e.exercise_updated_at, a.asset_updated_at, max(f.finding_updated_at)) as vulnerable_endpoint_updated_at,
       array_agg(fa.finding_id) FILTER ( WHERE fa.finding_id IS NOT NULL ) as vulnerable_endpoint_findings,
       array_agg(distinct at.tag_id) FILTER ( WHERE at.tag_id IS NOT NULL ) as vulnerable_endpoint_tags,
       (SELECT array_agg(ag.agent_id) FILTER (WHERE ag.agent_id IS NOT NULL)
@@ -75,7 +92,7 @@ public interface VulnerableEndpointRepository extends JpaRepository<Endpoint, St
     JOIN findings f ON f.finding_inject_id = i.inject_id AND f.finding_type = 'CVE'
     JOIN findings_assets fa ON f.finding_id = fa.finding_id AND fa.asset_id = a.asset_id
     GROUP BY a.asset_id, rve.inject_exercise, e.exercise_updated_at, e.exercise_created_at, a.asset_updated_at
-    ORDER BY GREATEST(e.exercise_updated_at, a.asset_updated_at) ASC
+    ORDER BY GREATEST(e.exercise_updated_at, a.asset_updated_at, max(f.finding_updated_at)) ASC
     """,
       nativeQuery = true)
   List<RawVulnerableEndpointIndexing> findForIndexing(

--- a/openaev-model/src/main/java/io/openaev/engine/EngineService.java
+++ b/openaev-model/src/main/java/io/openaev/engine/EngineService.java
@@ -44,6 +44,15 @@ public interface EngineService {
   void bulkDelete(List<String> ids);
 
   /**
+   * Deletes every document belonging to a tenant across all indexes. Used when a tenant is
+   * permanently purged: tenant data is removed via native SQL (no JPA lifecycle events), so the
+   * engine must be cleaned explicitly by tenant id.
+   *
+   * @param tenantId the tenant whose documents must be removed
+   */
+  void deleteByTenant(String tenantId);
+
+  /**
    * Count using parameters
    *
    * @param user the user to use

--- a/openaev-model/src/main/java/io/openaev/engine/EngineService.java
+++ b/openaev-model/src/main/java/io/openaev/engine/EngineService.java
@@ -44,13 +44,13 @@ public interface EngineService {
   void bulkDelete(List<String> ids);
 
   /**
-   * Deletes every document belonging to a tenant across all indexes. Used when a tenant is
-   * permanently purged: tenant data is removed via native SQL (no JPA lifecycle events), so the
-   * engine must be cleaned explicitly by tenant id.
+   * Deletes every document belonging to the given tenants across all indexes, in a single
+   * delete-by-query. Used when tenants are permanently purged: tenant data is removed via native
+   * SQL (no JPA lifecycle events), so the engine must be cleaned explicitly by tenant id.
    *
-   * @param tenantId the tenant whose documents must be removed
+   * @param tenantIds the tenants whose documents must be removed
    */
-  void deleteByTenant(String tenantId);
+  void deleteByTenants(List<String> tenantIds);
 
   /**
    * Count using parameters

--- a/openaev-model/src/main/java/io/openaev/engine/model/endpoint/EndpointHandler.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/endpoint/EndpointHandler.java
@@ -40,6 +40,7 @@ public class EndpointHandler implements Handler<EsEndpoint> {
               esEndpoint.setEndpoint_name(endpoint.getAsset_name());
               esEndpoint.setEndpoint_description(endpoint.getAsset_description());
               esEndpoint.setEndpoint_external_reference(endpoint.getAsset_external_reference());
+              esEndpoint.setEndpoint_category(endpoint.getAsset_category());
               esEndpoint.setEndpoint_ips(endpoint.getEndpoint_ips());
               esEndpoint.setEndpoint_hostname(endpoint.getEndpoint_hostname());
               esEndpoint.setEndpoint_platform(endpoint.getEndpoint_platform());

--- a/openaev-model/src/main/java/io/openaev/engine/model/endpoint/EsEndpoint.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/endpoint/EsEndpoint.java
@@ -3,6 +3,7 @@ package io.openaev.engine.model.endpoint;
 import io.openaev.annotation.EsQueryable;
 import io.openaev.annotation.Indexable;
 import io.openaev.annotation.Queryable;
+import io.openaev.database.model.AssetCategory;
 import io.openaev.database.model.Endpoint;
 import io.openaev.database.model.Filters;
 import io.openaev.engine.model.tenant.EsTenantBase;
@@ -29,6 +30,13 @@ public class EsEndpoint extends EsTenantBase {
   @Queryable(label = "endpoint external reference")
   @EsQueryable(keyword = true)
   private String endpoint_external_reference;
+
+  @Queryable(
+      label = "endpoint category",
+      filterable = true,
+      refEnumClazz = AssetCategory.class)
+  @EsQueryable(keyword = true)
+  private String endpoint_category;
 
   // -- ENDPOINT SPECIFIC --
   // NOTE: the SQL columns were renamed endpoint_* -> asset_* (asset taxonomy remodel), but the ES

--- a/openaev-model/src/main/java/io/openaev/engine/model/endpoint/EsEndpoint.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/endpoint/EsEndpoint.java
@@ -31,10 +31,7 @@ public class EsEndpoint extends EsTenantBase {
   @EsQueryable(keyword = true)
   private String endpoint_external_reference;
 
-  @Queryable(
-      label = "endpoint category",
-      filterable = true,
-      refEnumClazz = AssetCategory.class)
+  @Queryable(label = "endpoint category", filterable = true, refEnumClazz = AssetCategory.class)
   @EsQueryable(keyword = true)
   private String endpoint_category;
 

--- a/openaev-model/src/main/java/io/openaev/engine/model/finding/EsFinding.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/finding/EsFinding.java
@@ -5,6 +5,7 @@ import io.openaev.annotation.Indexable;
 import io.openaev.annotation.Queryable;
 import io.openaev.database.model.ContractOutputType;
 import io.openaev.engine.model.tenant.EsTenantBase;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -40,7 +41,7 @@ public class EsFinding extends EsTenantBase {
   @EsQueryable(keyword = true)
   private String base_scenario_side; // Must finish by _side
 
-  @Queryable(label = "endpoint", filterable = true, dynamicValues = true)
+  @Queryable(label = "endpoint", filterable = true, dynamicValues = true, clazz = String.class)
   @EsQueryable(keyword = true)
-  private String base_endpoint_side; // Must finish by _side
+  private Set<String> base_endpoint_side; // Must finish by _side
 }

--- a/openaev-model/src/main/java/io/openaev/engine/model/finding/FindingHandler.java
+++ b/openaev-model/src/main/java/io/openaev/engine/model/finding/FindingHandler.java
@@ -1,6 +1,7 @@
 package io.openaev.engine.model.finding;
 
 import static io.openaev.engine.EsUtils.buildRestrictions;
+import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.hasText;
 
 import io.openaev.database.raw.RawFindingIndexing;
@@ -9,6 +10,7 @@ import io.openaev.engine.Handler;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -61,11 +63,11 @@ public class FindingHandler implements Handler<EsFinding> {
               } else {
                 esFinding.setBase_scenario_side(null);
               }
-              if (hasText(finding.getAsset_id())) {
-                dependencies.add(finding.getAsset_id());
-                esFinding.setBase_endpoint_side(finding.getAsset_id());
+              if (!isEmpty(finding.getAsset_ids())) {
+                dependencies.addAll(finding.getAsset_ids());
+                esFinding.setBase_endpoint_side(finding.getAsset_ids());
               } else {
-                esFinding.setBase_endpoint_side(null);
+                esFinding.setBase_endpoint_side(Set.of());
               }
               esFinding.setBase_dependencies(dependencies);
               return esFinding;

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -371,12 +371,7 @@ public class ElasticService implements EngineService {
                       if (result.errors()) {
                         long errorCount =
                             result.items().stream().filter(item -> item.error() != null).count();
-                        log.error(
-                            "Bulk indexing failed for model {} ({}/{} items with errors, cursor not advanced, from={})",
-                            model.getName(),
-                            errorCount,
-                            result.items().size(),
-                            fetchInstant);
+                        boolean allPoison = true;
                         for (BulkResponseItem item : result.items()) {
                           if (item.error() != null) {
                             log.error(
@@ -384,36 +379,58 @@ public class ElasticService implements EngineService {
                                 model.getName(),
                                 item.id(),
                                 item.error().reason());
+                            allPoison =
+                                allPoison && EsIndexingUtils.isPoisonError(item.error().type());
                           }
                         }
-                      } else {
-                        // Update the status for the next round
-                        Instant newCursor = results.getLast().getBase_updated_at();
-                        if (newCursor == null) {
+                        // Deterministic document-level failures (mapping/parsing) would fail
+                        // identically forever: retrying blocks the whole model's indexing
+                        // (head-of-line). Skip them by advancing the cursor; they will be retried
+                        // naturally the next time their row is updated. Transient failures keep
+                        // the cursor so the batch is retried.
+                        if (!allPoison) {
                           log.error(
-                              "Bulk indexing returned a null cursor for model {} (cursor not advanced, from={})",
+                              "Bulk indexing failed for model {} ({}/{} items with transient errors, cursor not advanced, from={})",
                               model.getName(),
+                              errorCount,
+                              result.items().size(),
                               fetchInstant);
                           return null;
                         }
-                        if (fetchInstant != null && !newCursor.isAfter(fetchInstant)) {
-                          log.error(
-                              "Stuck cursor detected for model {} — cursor did not advance (from={}, last_row={}). "
-                                  + "This indicates a query bug: ranked rows have sort_ts <= cursor.",
-                              model.getName(),
-                              fetchInstant,
-                              newCursor);
-                        }
-                        if (indexingStatus.isPresent()) {
-                          IndexingStatus status = indexingStatus.get();
-                          status.setLastIndexing(newCursor);
-                          return status;
-                        } else {
-                          IndexingStatus status = new IndexingStatus();
-                          status.setType(model.getName());
-                          status.setLastIndexing(newCursor);
-                          return status;
-                        }
+                        log.error(
+                            "Bulk indexing skipped {} poison document(s) for model {} (deterministic mapping/parsing errors, cursor advanced, from={})",
+                            errorCount,
+                            model.getName(),
+                            fetchInstant);
+                      }
+                      // Update the status for the next round
+                      Instant newCursor =
+                          EsIndexingUtils.computeNewCursor(
+                              results, engineConfig.getIndexingBatchSize(), model.getName(), log);
+                      if (newCursor == null) {
+                        log.error(
+                            "Bulk indexing returned a null cursor for model {} (cursor not advanced, from={})",
+                            model.getName(),
+                            fetchInstant);
+                        return null;
+                      }
+                      if (fetchInstant != null && !newCursor.isAfter(fetchInstant)) {
+                        log.error(
+                            "Stuck cursor detected for model {} — cursor did not advance (from={}, last_row={}). "
+                                + "This indicates a query bug: ranked rows have sort_ts <= cursor.",
+                            model.getName(),
+                            fetchInstant,
+                            newCursor);
+                      }
+                      if (indexingStatus.isPresent()) {
+                        IndexingStatus status = indexingStatus.get();
+                        status.setLastIndexing(newCursor);
+                        return status;
+                      } else {
+                        IndexingStatus status = new IndexingStatus();
+                        status.setType(model.getName());
+                        status.setLastIndexing(newCursor);
+                        return status;
                       }
                     } catch (IOException e) {
                       log.error(

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -511,13 +511,24 @@ public class ElasticService implements EngineService {
   }
 
   @Override
-  public void deleteByTenant(String tenantId) {
-    if (tenantId == null || tenantId.isBlank()) {
+  public void deleteByTenants(List<String> tenantIds) {
+    List<FieldValue> values =
+        tenantIds == null
+            ? List.of()
+            : tenantIds.stream()
+                .filter(id -> id != null && !id.isBlank())
+                .map(FieldValue::of)
+                .toList();
+    if (values.isEmpty()) {
       return;
     }
     try {
       Query query =
-          TermQuery.of(t -> t.field("base_tenant_side.keyword").value(tenantId))._toQuery();
+          TermsQuery.of(
+                  t ->
+                      t.field("base_tenant_side.keyword")
+                          .terms(TermsQueryField.of(tq -> tq.value(values))))
+              ._toQuery();
       elasticClient.deleteByQuery(
           new DeleteByQueryRequest.Builder()
               .index(engineConfig.getIndexPrefix() + "*")
@@ -526,7 +537,7 @@ public class ElasticService implements EngineService {
               .conflicts(Conflicts.Proceed)
               .build());
     } catch (IOException e) {
-      log.error(String.format("deleteByTenant exception: %s", e.getMessage()), e);
+      log.error("deleteByTenants failed for tenants {}: {}", tenantIds, e.getMessage(), e);
     }
   }
 

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -493,6 +493,26 @@ public class ElasticService implements EngineService {
     }
   }
 
+  @Override
+  public void deleteByTenant(String tenantId) {
+    if (tenantId == null || tenantId.isBlank()) {
+      return;
+    }
+    try {
+      Query query =
+          TermQuery.of(t -> t.field("base_tenant_side.keyword").value(tenantId))._toQuery();
+      elasticClient.deleteByQuery(
+          new DeleteByQueryRequest.Builder()
+              .index(engineConfig.getIndexPrefix() + "*")
+              .query(query)
+              .refresh(true)
+              .conflicts(Conflicts.Proceed)
+              .build());
+    } catch (IOException e) {
+      log.error(String.format("deleteByTenant exception: %s", e.getMessage()), e);
+    }
+  }
+
   // endregion
 
   // region query

--- a/openaev-model/src/main/java/io/openaev/service/EsIndexingUtils.java
+++ b/openaev-model/src/main/java/io/openaev/service/EsIndexingUtils.java
@@ -1,0 +1,85 @@
+package io.openaev.service;
+
+import io.openaev.engine.model.EsBase;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+
+/**
+ * Shared helpers for the incremental indexing loop of both engine implementations (Elasticsearch
+ * and OpenSearch): cursor advancement that is safe at LIMIT boundaries, and classification of
+ * deterministic (poison) bulk item errors.
+ */
+public final class EsIndexingUtils {
+
+  /**
+   * Bulk item error types that are deterministic for a given document: retrying the exact same
+   * document can never succeed, so keeping the cursor would block the model's indexing forever.
+   */
+  private static final Set<String> POISON_ERROR_TYPES =
+      Set.of(
+          "strict_dynamic_mapping_exception",
+          "mapper_parsing_exception",
+          "document_parsing_exception",
+          "illegal_argument_exception");
+
+  private EsIndexingUtils() {}
+
+  /**
+   * Returns true when the bulk item error type identifies a deterministic document-level failure
+   * (mapping/parsing) that would fail identically on every retry.
+   */
+  public static boolean isPoisonError(String errorType) {
+    return errorType != null && POISON_ERROR_TYPES.contains(errorType);
+  }
+
+  /**
+   * Computes the next indexing cursor for a processed batch.
+   *
+   * <p>All {@code findForIndexing} queries fetch rows with a strictly-greater-than comparison on
+   * the cursor. When a FULL batch ends on a timestamp shared by several rows, the LIMIT may have
+   * cut the group in the middle: advancing the cursor to that timestamp would permanently skip the
+   * cut-off rows. In that case the cursor only advances past the last fully included timestamp
+   * group; the boundary group is re-fetched (and harmlessly re-upserted) on the next round.
+   *
+   * @param results the batch rows, ordered by ascending update timestamp
+   * @param batchSize the fetch limit used to obtain the batch
+   * @param modelName the model name (logging only)
+   * @param log the caller's logger
+   * @return the new cursor, or null when it cannot be computed (null timestamps)
+   */
+  public static Instant computeNewCursor(
+      List<? extends EsBase> results, int batchSize, String modelName, Logger log) {
+    Instant boundary = results.getLast().getBase_updated_at();
+    if (boundary == null) {
+      return null;
+    }
+    if (results.size() < batchSize) {
+      // Partial batch: everything with a timestamp <= boundary has been fetched, safe to advance.
+      return boundary;
+    }
+    // Full batch: find the greatest timestamp strictly before the boundary group.
+    Instant lastComplete = null;
+    for (EsBase row : results) {
+      Instant ts = row.getBase_updated_at();
+      if (ts != null
+          && ts.isBefore(boundary)
+          && (lastComplete == null || ts.isAfter(lastComplete))) {
+        lastComplete = ts;
+      }
+    }
+    if (lastComplete != null) {
+      return lastComplete;
+    }
+    // Degenerate case: every row of a full batch shares the exact same timestamp. The cursor must
+    // advance (or the loop would never progress), but ties beyond the batch limit may be skipped.
+    log.warn(
+        "Full indexing batch for model {} shares a single timestamp {} ({} rows): advancing past it, "
+            + "rows beyond the batch limit with this exact timestamp may be skipped until their next update.",
+        modelName,
+        boundary,
+        results.size());
+    return boundary;
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -575,13 +575,23 @@ public class OpenSearchService implements EngineService {
   }
 
   @Override
-  public void deleteByTenant(String tenantId) {
-    if (tenantId == null || tenantId.isBlank()) {
+  public void deleteByTenants(List<String> tenantIds) {
+    List<FieldValue> values =
+        tenantIds == null
+            ? List.of()
+            : tenantIds.stream()
+                .filter(id -> id != null && !id.isBlank())
+                .map(FieldValue::of)
+                .toList();
+    if (values.isEmpty()) {
       return;
     }
     try {
       Query query =
-          TermQuery.of(t -> t.field("base_tenant_side.keyword").value(FieldValue.of(tenantId)))
+          TermsQuery.of(
+                  t ->
+                      t.field("base_tenant_side.keyword")
+                          .terms(TermsQueryField.of(tq -> tq.value(values))))
               .toQuery();
       openSearchClient.deleteByQuery(
           new DeleteByQueryRequest.Builder()
@@ -591,7 +601,7 @@ public class OpenSearchService implements EngineService {
               .conflicts(Conflicts.Proceed)
               .build());
     } catch (IOException e) {
-      log.error(String.format("deleteByTenant exception: %s", e.getMessage()), e);
+      log.error("deleteByTenants failed for tenants {}: {}", tenantIds, e.getMessage(), e);
     }
   }
 

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -557,6 +557,27 @@ public class OpenSearchService implements EngineService {
     }
   }
 
+  @Override
+  public void deleteByTenant(String tenantId) {
+    if (tenantId == null || tenantId.isBlank()) {
+      return;
+    }
+    try {
+      Query query =
+          TermQuery.of(t -> t.field("base_tenant_side.keyword").value(FieldValue.of(tenantId)))
+              .toQuery();
+      openSearchClient.deleteByQuery(
+          new DeleteByQueryRequest.Builder()
+              .index(engineConfig.getIndexPrefix() + "*")
+              .query(query)
+              .refresh(Refresh.True)
+              .conflicts(Conflicts.Proceed)
+              .build());
+    } catch (IOException e) {
+      log.error(String.format("deleteByTenant exception: %s", e.getMessage()), e);
+    }
+  }
+
   // endregion
 
   // region query

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -438,12 +438,7 @@ public class OpenSearchService implements EngineService {
                       if (result.errors()) {
                         long errorCount =
                             result.items().stream().filter(item -> item.error() != null).count();
-                        log.error(
-                            "Bulk indexing failed for model {} ({}/{} items with errors, cursor not advanced, from={})",
-                            model.getName(),
-                            errorCount,
-                            result.items().size(),
-                            fetchInstant);
+                        boolean allPoison = true;
                         for (BulkResponseItem item : result.items()) {
                           if (item.error() != null) {
                             log.error(
@@ -451,36 +446,58 @@ public class OpenSearchService implements EngineService {
                                 model.getName(),
                                 item.id(),
                                 item.error().reason());
+                            allPoison =
+                                allPoison && EsIndexingUtils.isPoisonError(item.error().type());
                           }
                         }
-                      } else {
-                        // Update the status for the next round
-                        Instant newCursor = results.getLast().getBase_updated_at();
-                        if (newCursor == null) {
+                        // Deterministic document-level failures (mapping/parsing) would fail
+                        // identically forever: retrying blocks the whole model's indexing
+                        // (head-of-line). Skip them by advancing the cursor; they will be retried
+                        // naturally the next time their row is updated. Transient failures keep
+                        // the cursor so the batch is retried.
+                        if (!allPoison) {
                           log.error(
-                              "Bulk indexing returned a null cursor for model {} (cursor not advanced, from={})",
+                              "Bulk indexing failed for model {} ({}/{} items with transient errors, cursor not advanced, from={})",
                               model.getName(),
+                              errorCount,
+                              result.items().size(),
                               fetchInstant);
                           return null;
                         }
-                        if (fetchInstant != null && !newCursor.isAfter(fetchInstant)) {
-                          log.error(
-                              "Stuck cursor detected for model {} — cursor did not advance (from={}, last_row={}). "
-                                  + "This indicates a query bug: ranked rows have sort_ts <= cursor.",
-                              model.getName(),
-                              fetchInstant,
-                              newCursor);
-                        }
-                        if (indexingStatus.isPresent()) {
-                          IndexingStatus status = indexingStatus.get();
-                          status.setLastIndexing(newCursor);
-                          return status;
-                        } else {
-                          IndexingStatus status = new IndexingStatus();
-                          status.setType(model.getName());
-                          status.setLastIndexing(newCursor);
-                          return status;
-                        }
+                        log.error(
+                            "Bulk indexing skipped {} poison document(s) for model {} (deterministic mapping/parsing errors, cursor advanced, from={})",
+                            errorCount,
+                            model.getName(),
+                            fetchInstant);
+                      }
+                      // Update the status for the next round
+                      Instant newCursor =
+                          EsIndexingUtils.computeNewCursor(
+                              results, engineConfig.getIndexingBatchSize(), model.getName(), log);
+                      if (newCursor == null) {
+                        log.error(
+                            "Bulk indexing returned a null cursor for model {} (cursor not advanced, from={})",
+                            model.getName(),
+                            fetchInstant);
+                        return null;
+                      }
+                      if (fetchInstant != null && !newCursor.isAfter(fetchInstant)) {
+                        log.error(
+                            "Stuck cursor detected for model {} — cursor did not advance (from={}, last_row={}). "
+                                + "This indicates a query bug: ranked rows have sort_ts <= cursor.",
+                            model.getName(),
+                            fetchInstant,
+                            newCursor);
+                      }
+                      if (indexingStatus.isPresent()) {
+                        IndexingStatus status = indexingStatus.get();
+                        status.setLastIndexing(newCursor);
+                        return status;
+                      } else {
+                        IndexingStatus status = new IndexingStatus();
+                        status.setType(model.getName());
+                        status.setLastIndexing(newCursor);
+                        return status;
                       }
                     } catch (IOException e) {
                       log.error(


### PR DESCRIPTION
## Summary

Fixes #6753 - Elastic statistics were structurally inaccurate versus PostgreSQL: deleted data survived forever in the indexes, several mutations never triggered reindexing, the expectation index double-counted rows, and the domain widget math contradicted the gauges. This PR fixes every root cause found in the audit and ships two migrations so that everything converges at deploy time with NO manual action and NO delay.

## What happens at deploy (zero-delay convergence)

1. `V6_20260717220000000__Engine_accuracy_full_reindex` deletes all `indexing_status` rows (and completes the asset taxonomy demotion for `AI_TARGET` / `SECURITY_PLATFORM` categorized agentless endpoints). At startup, the engine drivers drop and recreate EVERY index and fully re-feed them from PostgreSQL: all historical garbage (stale simulations/injects/expectations/findings, per-player docs, wrong platform attributions) is eliminated by construction.
2. `V6_20260717221000000__Force_default_home_dashboard` resets `users.user_home_dashboard` and the tenant-level `platform_home_dashboard` override (tenant-scoped rows in `parameters`, plus the platform-level parameter) so every user lands on the new built-in default home; people re-adjust in Profile / Settings afterwards. The starter pack cannot re-seed the setting (single-run guard key untouched).

## Fixes so drift can never re-accumulate

- fix(engine): propagate native SQL deletes to the search engine
  - simulation delete, UI bulk inject delete, inject relaunch, endpoint delete, security-coverage scenario inject rebuilds now publish `IndexEvent(DATA_DELETE)` explicitly (native queries bypass JPA lifecycle events)
  - new `EngineService.deleteByTenants` cleans all documents of purged tenants in a single delete-by-query (terms query), deferred to after commit so a rollback of the purge transaction cannot leave the indexes wiped
- fix(engine): expectation indexing scope
  - per-player expectation rows are no longer indexed (team-level row already represents players; they double-counted every manual expectation)
  - `agent_security_platforms` attribution is now scoped per parent expectation (same type + same asset): "Missed by security platform" no longer blames platforms that actually detected
- fix(engine): cursor robustness (Elastic + OpenSearch)
  - a full batch ending on a shared timestamp no longer permanently skips the cut-off rows (cursor advances only past the last complete timestamp group)
  - deterministic poison documents (mapping/parsing failures) are skipped instead of head-of-line blocking a model's indexing forever with error logs every 15s
- fix(engine): denormalization staleness
  - `removeTeams` / `replaceTeams` (simulation + scenario) bump the parent and inject timestamps after native join-table deletes (covers all-teams injects)
  - vulnerable-endpoint cursor now watches `finding_updated_at`: a new CVE finding creates/refreshes the doc immediately (dashboard KPI was stuck at 0)
  - findings now index ONE doc per finding with ALL assets aggregated in `base_endpoint_side` (was last-asset-wins)
- fix(front): widget math consistency
  - domain widget ("Performance by security domain"): case-insensitive status matching, success rate over resolved (success+failed) docs only - same math as the resilience gauges, so the band can never contradict the rings again; pending-only domains render as empty instead of 0% failed
  - "Missed injects by week": `eq FAILED` instead of `not_eq SUCCESS` (pending/unknown are not misses)
- feat(engine): endpoint docs now carry `endpoint_category` (asset category) so KPIs can be aligned with the inventory Host view

## Review fixes (post-Copilot pass)

- `V6_20260717221000000__Force_default_home_dashboard` no longer references the `tenant_settings` table (merged into `parameters` and dropped by `V5_03`): tenant-level overrides are cleared from `parameters` with `tenant_id IS NOT NULL` (this was failing Flyway with 42P01 on all API test legs)
- `ExerciseServiceTest` / `ExerciseServiceIntegrationTest` updated for the new `ApplicationEventPublisher` constructor argument (fixes the red Backend Compile CI leg); `EndpointServiceTest`, `ExerciseServiceUnitTest` and `InjectServiceTest` mock the publisher so `@InjectMocks` stops passing null (delete paths NPEd in the API test legs)
- tenant purge engine cleanup batched (`deleteByTenants`, single terms delete-by-query) and moved to `afterCommit`; failure logs are parameterized and include the tenant ids
- `api-types.d.ts` synced with the generator output (`endpoint_category` on `EsEndpoint`, `uniqueItems` marker on `EsFinding.base_endpoint_side`)

## New test coverage

- `EsIndexingUtilsTest` (8 unit tests): poison-error classification, cursor advancement on partial batches, full-batch step-back, shared-boundary groups, degenerate single-timestamp batches, null timestamps
- `IndexingRegressionTest` additions: per-player expectation exclusion, cross-type security platform attribution scoping, multi-asset finding aggregation (one doc, all asset ids), empty endpoint side, vulnerable-endpoint doc produced from `finding_updated_at` alone
- frontend unit tests for `isStatus`, `calcPercentage` and `colorByLabel` (case-insensitive status matching, resolved-only denominator, -1 empty state)

## Not in this PR (follow-up)

- Removing the missing-tenant-field fallback in `ElasticService.buildQuery`: every handler sets `base_tenant_side` and the full rebuild removes legacy docs, but platform-level rows with NULL tenant would go invisible if the fallback were dropped blindly - needs its own verification pass.

## Test plan

- Backend `mvn test-compile -Pdev` green locally (main + test sources, all modules), spotless applied
- `EsIndexingUtilsTest` (8), `IndexingRegressionTest` (21), `TenantServiceTest` (15), `EndpointServiceTest` / `ExerciseServiceUnitTest` / `InjectServiceTest` (111) green locally against the Docker test stack
- Full CI green (compile, all API test legs, E2E chrome/webkit, E2E infra x64/arm64, API types check, CodeQL, coverage)
- Frontend `check-ts`, eslint and `vitest` (widget utils suite, 19 tests) pass
- Post-deploy check on staging: per-model ES `_count` == SQL count; gauges, domain band and KPIs consistent
