### PR TITLE
fix(migration): delete legacy platform home dashboard row instead of nulling it (#6772)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260717221000000__Force_default_home_dashboard.java
@@ -27,17 +27,13 @@ public class V6_20260717221000000__Force_default_home_dashboard extends BaseJava
       statement.execute(
           "UPDATE users SET user_home_dashboard = NULL WHERE user_home_dashboard IS NOT NULL;");
 
-      // -- 2. Clear the tenant-level Settings override. Tenant settings live in the parameters
-      // table since V5_03 merged (and dropped) the transient tenant_settings table: tenant-scoped
-      // rows carry a NON NULL tenant_id. Delete them so resolution falls through to the default. --
-      statement.execute(
-          "DELETE FROM parameters "
-              + "WHERE parameter_key = 'platform_home_dashboard' AND tenant_id IS NOT NULL;");
-
-      // -- 3. Clear the legacy platform-level parameter (tenant_id IS NULL) --
-      statement.execute(
-          "UPDATE parameters SET parameter_value = NULL "
-              + "WHERE parameter_key = 'platform_home_dashboard' AND parameter_value IS NOT NULL;");
+      // -- 2. Clear the tenant-level Settings override AND the legacy platform-level parameter.
+      // Tenant settings live in the parameters table since V5_03 merged (and dropped) the
+      // transient tenant_settings table: tenant-scoped rows carry a NON NULL tenant_id; legacy
+      // pre-tenancy installs may still have a platform-level row (tenant_id IS NULL). DELETE both
+      // (parameter_value is NOT NULL since the original schema, so setting it to NULL is not an
+      // option): every reader goes through Optional and falls through to the built-in default. --
+      statement.execute("DELETE FROM parameters WHERE parameter_key = 'platform_home_dashboard';");
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #6772 - hotfix for the production startup failure introduced by #6755.

`V6_20260717221000000__Force_default_home_dashboard` nulled the legacy platform-level `platform_home_dashboard` parameter, but `parameters.parameter_value` is NOT NULL since the original schema (V3_80 only changed the column type, which preserves the constraint). Any long-lived install that still has the legacy pre-tenancy row fails the migration with 23502 and crash-loops at startup. Fresh CI databases have no such row (UPDATE matched 0 rows), so all test legs were green.

## Fix

Replace the UPDATE-to-NULL with a DELETE of the row (merged with the tenant-scoped DELETE of step 2 into a single statement). All readers resolve the setting through Optional (`TenantSettingsService.findSetting`) and fall through to the built-in default, which is exactly the migration's intent.

## Why in-place fix is safe

- The failed migration is transactional: it was fully rolled back, including its `flyway_schema_history` entry, so affected instances simply re-run the fixed version.
- Java-based migrations have a null checksum, so instances where the original version already succeeded (fresh installs, no legacy row) will not fail validation.

## Test plan

- Migration guard / API test legs re-run the migration from scratch in CI
- Post-merge: rolling production instance restarts and applies the migration successfully