### PR TITLE
fix(injects): initialize kill chain phases before external inject serialization (#6774)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/helper/InjectHelper.java
+++ b/openaev-api/src/main/java/io/openaev/helper/InjectHelper.java
@@ -136,6 +136,17 @@ public class InjectHelper {
     // TODO This is inefficient, we need to refactor this with our own query
     Hibernate.initialize(inject.getTags());
     Hibernate.initialize(inject.getUser());
+    // The contract's attack patterns are fetched eagerly, but their kill chain phases are lazy.
+    // External injectors serialize the whole inject (detached, outside any session) in
+    // Executor.executeExternal, so initialize them here while the session is still open to
+    // avoid a LazyInitializationException on attack_pattern_kill_chain_phases.
+    inject
+        .getInjectorContract()
+        .ifPresent(
+            injectorContract ->
+                injectorContract
+                    .getAttackPatterns()
+                    .forEach(ap -> Hibernate.initialize(ap.getKillChainPhases())));
     return new ExecutableInject(
         true,
         false,


### PR DESCRIPTION
## Proposed changes

- Initialize `AttackPattern.killChainPhases` in `InjectHelper.toExecutableInject()` while the `getInjectsToRun()` transaction (and its Hibernate session) is still open.

Fixes #6774

## Why

When an inject is launched via the scheduler, `Executor.executeExternal()` serializes the detached `Inject` entity to JSON for RabbitMQ. The contract's `attackPatterns` list is eager, but each `AttackPattern.killChainPhases` is lazy and serialized by the custom `MultiIdListSerializer`, which streams the collection directly and bypasses the `Hibernate6Module` null-fallback for uninitialized lazy collections. Outside a session this throws:

```
failed to lazily initialize a collection of role: io.openaev.database.model.AttackPattern.killChainPhases: could not initialize proxy - no Session
```

This breaks every external injector whose contracts have attack patterns linked (AI Red Team with ATLAS techniques, and any catalog injector with ATT&CK mappings) when executed through `InjectsExecutionJob`. The API `directExecute` path is unaffected (open-in-view).

Initializing the collections inside the loading transaction also protects the `inject_kill_chain_phases` JSON getter, which streams the same lazy collections and would fail next. With `hibernate.default_batch_fetch_size=50` the added cost is a single batched query per scheduler run.

## Checklist

- [x] I consider this code ready for review
- [x] I have signed my commits
