### PR TITLE
fix(api): avoid restreaming unchanged entities on collector upserts (#6778)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/database/model/AssetTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/AssetTest.java
@@ -1,0 +1,50 @@
+package io.openaev.database.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AssetTest {
+
+  private static final Instant SENTINEL = Instant.EPOCH;
+
+  private static Tag tag(String id) {
+    Tag tag = new Tag();
+    tag.setId(id);
+    tag.setName(id);
+    return tag;
+  }
+
+  private static Asset assetAtSentinel() {
+    Asset asset = new Asset();
+    asset.setTags(new HashSet<>(Set.of(tag("t1"), tag("t2"))));
+    asset.setUpdatedAt(SENTINEL);
+    return asset;
+  }
+
+  @Test
+  @DisplayName(
+      "setTags with the same tag ids does not bump updatedAt, so no-op collector upserts do not"
+          + " force an UPDATE and an SSE restream (#6778)")
+  void setTags_same_ids_does_not_bump() {
+    Asset asset = assetAtSentinel();
+
+    asset.setTags(new HashSet<>(Set.of(tag("t2"), tag("t1"))));
+
+    assertThat(asset.getUpdatedAt()).isEqualTo(SENTINEL);
+  }
+
+  @Test
+  @DisplayName("setTags with different tag ids bumps updatedAt")
+  void setTags_different_ids_bumps() {
+    Asset asset = assetAtSentinel();
+
+    asset.setTags(new HashSet<>(Set.of(tag("t1"), tag("t3"))));
+
+    assertThat(asset.getUpdatedAt()).isAfter(SENTINEL);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/database/model/AttackPatternTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/AttackPatternTest.java
@@ -1,0 +1,51 @@
+package io.openaev.database.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AttackPatternTest {
+
+  private static final Instant SENTINEL = Instant.EPOCH;
+
+  private static KillChainPhase killChainPhase(String id) {
+    KillChainPhase phase = new KillChainPhase();
+    phase.setId(id);
+    return phase;
+  }
+
+  private static AttackPattern attackPatternAtSentinel() {
+    AttackPattern attackPattern = new AttackPattern();
+    attackPattern.setKillChainPhases(
+        new ArrayList<>(List.of(killChainPhase("k1"), killChainPhase("k2"))));
+    attackPattern.setUpdatedAt(SENTINEL);
+    return attackPattern;
+  }
+
+  @Test
+  @DisplayName(
+      "setKillChainPhases with the same phase ids does not bump updatedAt, so no-op collector"
+          + " upserts do not force an UPDATE and an SSE restream (#6778)")
+  void setKillChainPhases_same_ids_does_not_bump() {
+    AttackPattern attackPattern = attackPatternAtSentinel();
+
+    attackPattern.setKillChainPhases(
+        new ArrayList<>(List.of(killChainPhase("k2"), killChainPhase("k1"))));
+
+    assertThat(attackPattern.getUpdatedAt()).isEqualTo(SENTINEL);
+  }
+
+  @Test
+  @DisplayName("setKillChainPhases with different phase ids bumps updatedAt")
+  void setKillChainPhases_different_ids_bumps() {
+    AttackPattern attackPattern = attackPatternAtSentinel();
+
+    attackPattern.setKillChainPhases(new ArrayList<>(List.of(killChainPhase("k3"))));
+
+    assertThat(attackPattern.getUpdatedAt()).isAfter(SENTINEL);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/database/model/InjectorContractTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/InjectorContractTest.java
@@ -3,7 +3,13 @@ package io.openaev.database.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class InjectorContractTest {
@@ -45,5 +51,126 @@ class InjectorContractTest {
     contract.addInjector(injector("email", "email", "tenant-A"));
 
     assertThat(contract.getInjectors()).extracting(Injector::getId).containsExactly("email");
+  }
+
+  @Nested
+  @DisplayName(
+      "updatedAt sync bumps only happen on real association changes, so no-op collector upserts"
+          + " do not force an UPDATE and an SSE restream (#6778)")
+  class UpdatedAtSyncBump {
+
+    private static final Instant SENTINEL = Instant.EPOCH;
+
+    private static Tag tag(String id) {
+      Tag tag = new Tag();
+      tag.setId(id);
+      tag.setName(id);
+      return tag;
+    }
+
+    private static AttackPattern attackPattern(String id) {
+      AttackPattern attackPattern = new AttackPattern();
+      attackPattern.setId(id);
+      return attackPattern;
+    }
+
+    private static Vulnerability vulnerability(String id) {
+      Vulnerability vulnerability = new Vulnerability();
+      vulnerability.setId(id);
+      return vulnerability;
+    }
+
+    private static InjectorContract contractAtSentinel() {
+      InjectorContract contract = new InjectorContract();
+      contract.setTags(new HashSet<>(Set.of(tag("t1"), tag("t2"))));
+      contract.setAttackPatterns(
+          new ArrayList<>(List.of(attackPattern("a1"), attackPattern("a2"))));
+      contract.setVulnerabilities(new HashSet<>(Set.of(vulnerability("v1"))));
+      contract.setUpdatedAt(SENTINEL);
+      return contract;
+    }
+
+    @Test
+    @DisplayName("setTags with the same tag ids does not bump updatedAt")
+    void setTags_same_ids_does_not_bump() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setTags(new HashSet<>(Set.of(tag("t2"), tag("t1"))));
+
+      assertThat(contract.getUpdatedAt()).isEqualTo(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("setTags with different tag ids bumps updatedAt")
+    void setTags_different_ids_bumps() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setTags(new HashSet<>(Set.of(tag("t1"), tag("t3"))));
+
+      assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("setAttackPatterns with the same ids in a different order does not bump updatedAt")
+    void setAttackPatterns_same_ids_does_not_bump() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setAttackPatterns(
+          new ArrayList<>(List.of(attackPattern("a2"), attackPattern("a1"))));
+
+      assertThat(contract.getUpdatedAt()).isEqualTo(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("setAttackPatterns with an added attack pattern bumps updatedAt")
+    void setAttackPatterns_different_ids_bumps() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setAttackPatterns(
+          new ArrayList<>(List.of(attackPattern("a1"), attackPattern("a2"), attackPattern("a3"))));
+
+      assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("setAttackPatterns clearing existing attack patterns bumps updatedAt")
+    void setAttackPatterns_cleared_bumps() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setAttackPatterns(new ArrayList<>());
+
+      assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("setVulnerabilities with the same ids does not bump updatedAt")
+    void setVulnerabilities_same_ids_does_not_bump() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setVulnerabilities(new HashSet<>(Set.of(vulnerability("v1"))));
+
+      assertThat(contract.getUpdatedAt()).isEqualTo(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("setVulnerabilities with different ids bumps updatedAt")
+    void setVulnerabilities_different_ids_bumps() {
+      InjectorContract contract = contractAtSentinel();
+
+      contract.setVulnerabilities(new HashSet<>(Set.of(vulnerability("v2"))));
+
+      assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
+    }
+
+    @Test
+    @DisplayName("first association assignment on a new contract bumps updatedAt")
+    void first_assignment_bumps() {
+      InjectorContract contract = new InjectorContract();
+      contract.setUpdatedAt(SENTINEL);
+
+      contract.setTags(new HashSet<>(Set.of(tag("t1"))));
+
+      assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/database/model/InjectorContractTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/InjectorContractTest.java
@@ -172,5 +172,19 @@ class InjectorContractTest {
 
       assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
     }
+
+    @Test
+    @DisplayName(
+        "replacing a transient tag (no id yet) with another transient tag bumps updatedAt:"
+            + " {null} ids are never considered equal")
+    void transient_entities_are_never_considered_equal() {
+      InjectorContract contract = new InjectorContract();
+      contract.setTags(new HashSet<>(Set.of(new Tag())));
+      contract.setUpdatedAt(SENTINEL);
+
+      contract.setTags(new HashSet<>(Set.of(new Tag())));
+
+      assertThat(contract.getUpdatedAt()).isAfter(SENTINEL);
+    }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/model/Asset.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Asset.java
@@ -296,9 +296,13 @@ public class Asset implements TenantBase {
   @JsonProperty("asset_tags")
   private Set<Tag> tags = new HashSet<>();
 
-  // UpdatedAt now used to sync with linked object
+  // UpdatedAt is synced manually with linked objects because join-table changes do not dirty this
+  // row. Only bump when contents actually change: an unconditional bump forces an UPDATE (and an
+  // SSE restream) on every no-op collector upsert (#6778).
   public void setTags(Set<Tag> tags) {
-    this.updatedAt = now();
+    if (!Base.haveSameIds(this.tags, tags)) {
+      this.updatedAt = now();
+    }
     this.tags = tags;
   }
 

--- a/openaev-model/src/main/java/io/openaev/database/model/AttackPattern.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/AttackPattern.java
@@ -114,9 +114,13 @@ public class AttackPattern implements TenantBase {
   @Transient
   private final ResourceType resourceType = ResourceType.ATTACK_PATTERN;
 
-  // UpdatedAt now used to sync with linked object
+  // UpdatedAt is synced manually with linked objects because join-table changes do not dirty this
+  // row. Only bump when contents actually change: an unconditional bump forces an UPDATE (and an
+  // SSE restream) on every no-op collector upsert (#6778).
   public void setKillChainPhases(List<KillChainPhase> killChainPhases) {
-    this.updatedAt = now();
+    if (!Base.haveSameIds(this.killChainPhases, killChainPhases)) {
+      this.updatedAt = now();
+    }
     this.killChainPhases = killChainPhases;
   }
 

--- a/openaev-model/src/main/java/io/openaev/database/model/Base.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Base.java
@@ -124,12 +124,20 @@ public interface Base {
    * @param current the currently stored association (possibly an uninitialized lazy collection)
    * @param updated the incoming association
    * @return {@code true} when both collections reference the same entity ids, {@code false} when
-   *     they differ or when the stored association cannot be read without an active session
+   *     they differ, when any entity has no id yet (two distinct transient entities are never
+   *     considered equal), or when the stored association cannot be read without an active session
    */
   static boolean haveSameIds(
       Collection<? extends Base> current, Collection<? extends Base> updated) {
     try {
-      return collectIds(current).equals(collectIds(updated));
+      Set<String> currentIds = collectIds(current);
+      Set<String> updatedIds = collectIds(updated);
+      // A transient entity (no id yet) is not comparable: {null} == {null} would wrongly equate
+      // two different unsaved entities, so fail towards "changed" (bump).
+      if (currentIds.contains(null) || updatedIds.contains(null)) {
+        return false;
+      }
+      return currentIds.equals(updatedIds);
     } catch (LazyInitializationException e) {
       // No session to read the stored association: we cannot prove it is unchanged, so callers
       // keep the legacy behavior and bump the timestamp.

--- a/openaev-model/src/main/java/io/openaev/database/model/Base.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Base.java
@@ -3,6 +3,10 @@ package io.openaev.database.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Transient;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.hibernate.LazyInitializationException;
 import org.springframework.beans.BeanUtils;
 
 /**
@@ -106,5 +110,38 @@ public interface Base {
   @JsonIgnore
   default ResourceType getResourceType() {
     return ResourceType.UNKNOWN;
+  }
+
+  /**
+   * Compares two entity collections by their ids, ignoring ordering and duplicates.
+   *
+   * <p>Used by entities that manually bump their {@code updatedAt} timestamp when an association
+   * changes (join-table updates do not dirty the owning row). The bump must only happen when the
+   * association contents actually changed: an unconditional bump turns no-op upserts (e.g.
+   * collectors re-registering unchanged data on restart) into SQL UPDATEs, which restream the
+   * entity to every connected client through {@code ModelBaseListener}.
+   *
+   * @param current the currently stored association (possibly an uninitialized lazy collection)
+   * @param updated the incoming association
+   * @return {@code true} when both collections reference the same entity ids, {@code false} when
+   *     they differ or when the stored association cannot be read without an active session
+   */
+  static boolean haveSameIds(
+      Collection<? extends Base> current, Collection<? extends Base> updated) {
+    try {
+      return collectIds(current).equals(collectIds(updated));
+    } catch (LazyInitializationException e) {
+      // No session to read the stored association: we cannot prove it is unchanged, so callers
+      // keep the legacy behavior and bump the timestamp.
+      return false;
+    }
+  }
+
+  private static Set<String> collectIds(Collection<? extends Base> entities) {
+    Set<String> ids = new HashSet<>();
+    if (entities != null) {
+      entities.forEach(entity -> ids.add(entity.getId()));
+    }
+    return ids;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
@@ -173,9 +173,13 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   @Queryable(filterable = true, dynamicValues = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
-  // UpdatedAt now used to sync with linked object
+  // UpdatedAt is synced manually with linked objects because join-table changes do not dirty this
+  // row. Only bump when contents actually change: an unconditional bump forces an UPDATE (and an
+  // SSE restream) on every no-op collector/injector upsert (#6778).
   public void setTags(Set<Tag> tags) {
-    this.updatedAt = now();
+    if (!Base.haveSameIds(this.tags, tags)) {
+      this.updatedAt = now();
+    }
     this.tags = tags;
   }
 
@@ -295,9 +299,11 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   @Queryable(searchable = true, filterable = true, path = "attackPatterns.externalId")
   private List<AttackPattern> attackPatterns = new ArrayList<>();
 
-  // UpdatedAt now used to sync with linked object
+  // UpdatedAt synced with linked objects; only bump on real changes (see setTags)
   public void setAttackPatterns(List<AttackPattern> attackPatterns) {
-    this.updatedAt = now();
+    if (!Base.haveSameIds(this.attackPatterns, attackPatterns)) {
+      this.updatedAt = now();
+    }
     this.attackPatterns = attackPatterns;
   }
 
@@ -331,9 +337,11 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   @Queryable(searchable = true, filterable = true, path = "vulnerabilities.externalId")
   private Set<Vulnerability> vulnerabilities = new HashSet<>();
 
-  // UpdatedAt now used to sync with linked object
+  // UpdatedAt synced with linked objects; only bump on real changes (see setTags)
   public void setVulnerabilities(Set<Vulnerability> vulnerabilities) {
-    this.updatedAt = now();
+    if (!Base.haveSameIds(this.vulnerabilities, vulnerabilities)) {
+      this.updatedAt = now();
+    }
     this.vulnerabilities = vulnerabilities;
   }
 


### PR DESCRIPTION
## Related issue

Closes #6778

## What

When collectors and injectors restart, they re-upsert their full datasets (e.g. 800 payloads from atomic-red-team, all injector contracts on registration, all MITRE techniques). Even when the incoming data is identical to what is stored, every entity was re-streamed as `DATA_UPDATE_SUCCESS` over `/api/stream`, pushing 40+ MB to every connected browser and making the UI unusable for minutes after a production deployment restart.

## Why

Hibernate only fires `@PostUpdate` (which `ModelBaseListener` turns into a stream event) when a real SQL UPDATE is issued, so a re-save of identical data should be silent. But several entities force-bump `updated_at` in their association setters, unconditionally dirtying the row:

- `InjectorContract.setTags` / `setAttackPatterns` / `setVulnerabilities` - hit by every `POST /api/payloads/upsert` (via `PayloadService.synchroniseInjectorContractBasedOnPayload`) and by every injector registration (`InjectorService.updateExistingExternalInjector`, builtin registration).
- `AttackPattern.setKillChainPhases` - hit by `POST /api/attack_patterns/upsert` on every MITRE collector run.
- `Asset.setTags` - hit by endpoint upserts from EDR collectors.

These manual bumps exist because ManyToMany join-table changes do not dirty the owning row - a real association change would otherwise not be reflected in `updated_at`. The bug is that they are applied unconditionally.

## How

The streaming logic is untouched. The `updated_at` sync bumps become conditional: a new `Base.haveSameIds()` helper compares the stored association with the incoming one by entity ids (order-insensitive), and the timestamp is only bumped when the contents actually changed. Unchanged upserts then produce no SQL UPDATE, no `@PostUpdate`, and no stream event, while real association changes keep the exact same behavior as before.

Two safety fallbacks keep every legitimate update: if the stored association is an uninitialized lazy collection with no active session, or if any entity has no id yet (two distinct transient entities must never be considered equal), the comparison falls back to the legacy behavior (bump).

## Tests

- `InjectorContractTest` - 9 new unit tests covering same-ids (no bump, order-insensitive), different ids (bump), cleared association (bump), first assignment (bump) and transient entities (bump) for tags, attack patterns and vulnerabilities.
- `AttackPatternTest` (new) - kill chain phases same/different ids.
- `AssetTest` (new) - tags same/different ids.

All 15 tests pass locally (`mvn test -pl openaev-api -Dtest="InjectorContractTest,AttackPatternTest,AssetTest"`), `mvn spotless:apply` clean.

## Follow-ups (out of scope)

- The same unconditional bump pattern exists on user-driven entities (`Exercise.setInjects/setTeams/setTags`, `Scenario.setInjects/setTeams/setTags`, `Inject.setDependsOn/setStatus/setTags`, ...). Those are not hit by collector hot loops, so they are left untouched here, but they could adopt `Base.haveSameIds()` for the same silence-on-no-op behavior.
- If profiling ever shows the association-id reads as a DB hotspot on large collector runs, fetching the association ids in the upsert query (`@EntityGraph` / fetch join) would avoid initializing the lazy collections (Copilot suggestion, non-blocking).
