### PR TITLE
test(e2e): migrate multi-tenant agent infra test to redesigned atomic-testing UI (#6785)

### DIFF
--- a/openaev-front/tests_e2e/tests/infra/agent-implant-multitenant.spec.ts
+++ b/openaev-front/tests_e2e/tests/infra/agent-implant-multitenant.spec.ts
@@ -35,13 +35,11 @@ test.describe('Multi-tenancy — agent on new tenant', () => {
 
   let newTenantId: string | null = null;
   let hostname: string;
-  let agentUser: string;
   const echoToken = `e2e-tenant-${Date.now()}`;
   const payloadName = `E2E Payload ${echoToken}`;
 
   test.beforeAll(async ({ browser }) => {
     hostname = os.hostname().toLowerCase();
-    agentUser = execSync('whoami', { encoding: 'utf-8' }).trim();
     const platform = getOsPlatform();
 
     const context = await browser.newContext({
@@ -143,17 +141,26 @@ test.describe('Multi-tenancy — agent on new tenant', () => {
     await atomicTestingForm.launch();
 
     // ─── Wait for execution result ───
+    // The redesigned atomic-testing detail only fills the "Results by target"
+    // panel once a target is selected in the left "Targets" panel, and a reload
+    // clears that selection. So each poll iteration reloads, (re-)opens the
+    // Endpoints tab, selects the endpoint row and checks for the agent traces.
+    const endpointsTab = page.getByRole('tab', { name: 'Endpoints' });
+    const endpointRow = page.getByRole('button', { name: new RegExp(hostname, 'i') });
+    const spawnTrace = page.getByText('Implant spawn by the agent');
+
     await expect(async () => {
       await page.reload();
-      await expect(page.getByRole('button', { name: new RegExp(`${agentUser}.*Executed`, 'i') })).toBeVisible();
+      if (await endpointsTab.isVisible().catch(() => false)) {
+        await endpointsTab.click();
+      }
+      await endpointRow.first().click();
+      await expect(spawnTrace).toBeVisible({ timeout: 5_000 });
     }).toPass({
       intervals: [10_000],
       timeout: 240_000,
     });
 
-    // Expand the agent row to reveal traces
-    await page.getByRole('button', { name: new RegExp(`${agentUser}.*Executed`, 'i') }).click();
-    await expect(page.getByText('Implant spawn by the agent')).toBeVisible();
     await expect(page.getByText(new RegExp(`"stdout":".*${echoToken}`))).toBeVisible();
   });
 });


### PR DESCRIPTION
## Related issue

Closes #6785

## Summary

Follow-up to #6784 (already merged to `main`). The multi-tenant agent infra e2e (`agent-implant-multitenant.spec.ts`) was still using the pre-redesign atomic-testing selector `getByRole('button', { name: /<agentUser>.*Executed/ })`, which no longer exists after the atomic-testing results redesign. The test never matched, exhausted its 240s poll window plus retries, and drove the `E2E Infra` job to its 30 min timeout.

This applies the same migration already shipped for the single-tenant `agent-implant.spec.ts`:

- after launch, reload, open the Endpoints tab, select the endpoint target in the left "Targets" panel;
- assert the agent execution traces in the right panel (START "Implant spawn by the agent" and the echo token in `stdout`);
- drop the now-unused `agentUser` capture.

## Test plan

- `E2E Infra (x64)` and `E2E Infra (arm64)` must go green without hitting the job timeout.
