### PR TITLE
test(e2e): bound infra poll click actions below the poll cadence (#6787)

### DIFF
--- a/openaev-front/tests_e2e/tests/infra/agent-implant-multitenant.spec.ts
+++ b/openaev-front/tests_e2e/tests/infra/agent-implant-multitenant.spec.ts
@@ -152,9 +152,11 @@ test.describe('Multi-tenancy — agent on new tenant', () => {
     await expect(async () => {
       await page.reload();
       if (await endpointsTab.isVisible().catch(() => false)) {
-        await endpointsTab.click();
+        await endpointsTab.click({ timeout: 5_000 });
       }
-      await endpointRow.first().click();
+      // Keep every action bounded well under the 10s poll cadence so a not-yet-ready
+      // row can never block on the global 60s action timeout and stall the loop.
+      await endpointRow.first().click({ timeout: 5_000 });
       await expect(spawnTrace).toBeVisible({ timeout: 5_000 });
     }).toPass({
       intervals: [10_000],

--- a/openaev-front/tests_e2e/tests/infra/agent-implant.spec.ts
+++ b/openaev-front/tests_e2e/tests/infra/agent-implant.spec.ts
@@ -110,9 +110,11 @@ test.describe('Agent implant registration', () => {
     await expect(async () => {
       await page.reload();
       if (await endpointsTab.isVisible().catch(() => false)) {
-        await endpointsTab.click();
+        await endpointsTab.click({ timeout: 5_000 });
       }
-      await endpointRow.first().click();
+      // Keep every action bounded well under the 10s poll cadence so a not-yet-ready
+      // row can never block on the global 60s action timeout and stall the loop.
+      await endpointRow.first().click({ timeout: 5_000 });
       // The START trace is only rendered once the agent has executed and reported.
       await expect(spawnTrace).toBeVisible({ timeout: 5_000 });
     }).toPass({


### PR DESCRIPTION
## Related issue

Closes #6787

## Summary

Follow-up nit from the review of #6786. Inside the `toPass()` poll loops of the agent infra specs, the Endpoints-tab and endpoint-row clicks relied on the global 60s Playwright `actionTimeout`. If the row was not yet present in a given iteration, a single click could block for up to 60s, defeating the intended 10s poll cadence and risking the very job-level timeouts the migration set out to remove.

Both clicks now take an explicit 5s timeout, keeping every poll iteration well under the 10s cadence.

## Test plan

- `E2E Infra (x64)` and `E2E Infra (arm64)` stay green and bounded.
