### PR TITLE
fix(auth): restore SSO broken by session cookie SameSite=Lax (#6793)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/SpringSessionConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/SpringSessionConfig.java
@@ -1,6 +1,7 @@
 package io.openaev.config;
 
 import java.time.Duration;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +35,22 @@ public class SpringSessionConfig {
   @Value("${server.servlet.session.timeout:1440m}")
   private Duration sessionTimeout;
 
+  /**
+   * SameSite attribute of the session cookie.
+   *
+   * <p>Left blank by default so the attribute is OMITTED, which is what the platform did before
+   * sessions moved to Spring Session (the servlet container never set SameSite). Omitting it lets
+   * the browser apply its default policy, which still delivers the cookie on the cross-site SSO
+   * callback (SAML ACS POST and OIDC {@code form_post}). An explicit {@code Lax} would drop the
+   * cookie on that POST and break SSO.
+   *
+   * <p>Production SSO deployments behind HTTPS should set this to {@code None} (which forces the
+   * {@code Secure} attribute) for a robust, spec-compliant cross-site session cookie. Accepted
+   * values: {@code None}, {@code Lax}, {@code Strict}, or blank to omit.
+   */
+  @Value("${openbas.session-cookie-same-site:${openaev.session-cookie-same-site:}}")
+  private String sessionCookieSameSite;
+
   @Bean
   public CookieSerializer cookieSerializer() {
     DefaultCookieSerializer serializer = new DefaultCookieSerializer();
@@ -47,7 +64,7 @@ public class SpringSessionConfig {
     // /login?error). We therefore honor the configured value and, by default, OMIT the attribute
     // (restoring the pre-Spring-Session behavior where the cookie is still delivered on the SSO
     // callback). SameSite=None additionally requires Secure to be accepted by browsers.
-    String sameSite = normalizeSameSite(openAEVConfig.getSessionCookieSameSite());
+    String sameSite = normalizeSameSite(sessionCookieSameSite);
     serializer.setSameSite(sameSite);
     boolean secure = openAEVConfig.isCookieSecure() || "None".equals(sameSite);
     serializer.setUseSecureCookie(secure);
@@ -70,7 +87,7 @@ public class SpringSessionConfig {
     if (configured == null) {
       return null;
     }
-    return switch (configured.trim().toLowerCase()) {
+    return switch (configured.trim().toLowerCase(Locale.ROOT)) {
       case "none" -> "None";
       case "lax" -> "Lax";
       case "strict" -> "Strict";

--- a/openaev-api/src/main/java/io/openaev/config/SpringSessionConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/SpringSessionConfig.java
@@ -40,8 +40,18 @@ public class SpringSessionConfig {
     serializer.setCookieName(SESSION_COOKIE_NAME);
     serializer.setCookiePath("/");
     serializer.setUseHttpOnlyCookie(true);
-    serializer.setUseSecureCookie(openAEVConfig.isCookieSecure());
-    serializer.setSameSite("Lax");
+
+    // SameSite handling is critical for SSO: the SAML ACS response and OIDC form_post callback
+    // arrive as a cross-site POST, and an explicit SameSite=Lax would drop the session cookie on
+    // that POST, losing the stored authorization request and failing the login (redirect to
+    // /login?error). We therefore honor the configured value and, by default, OMIT the attribute
+    // (restoring the pre-Spring-Session behavior where the cookie is still delivered on the SSO
+    // callback). SameSite=None additionally requires Secure to be accepted by browsers.
+    String sameSite = normalizeSameSite(openAEVConfig.getSessionCookieSameSite());
+    serializer.setSameSite(sameSite);
+    boolean secure = openAEVConfig.isCookieSecure() || "None".equals(sameSite);
+    serializer.setUseSecureCookie(secure);
+
     if (!openAEVConfig.isSessionCookie()) {
       // Persistent cookie: users stay logged in across browser restarts, capped at the session
       // timeout (the cookie is only written at session creation, so this is an absolute cap).
@@ -49,6 +59,23 @@ public class SpringSessionConfig {
     }
     // Default max-age (-1) = browser-session cookie: dies when the browser closes.
     return serializer;
+  }
+
+  /**
+   * Maps the configured value to a valid SameSite token, or {@code null} to omit the attribute
+   * entirely. Unknown / blank values omit the attribute so a misconfiguration can never silently
+   * break SSO with an over-restrictive policy.
+   */
+  private static String normalizeSameSite(String configured) {
+    if (configured == null) {
+      return null;
+    }
+    return switch (configured.trim().toLowerCase()) {
+      case "none" -> "None";
+      case "lax" -> "Lax";
+      case "strict" -> "Strict";
+      default -> null;
+    };
   }
 
   /**

--- a/openaev-api/src/main/resources/application-dev.properties.example
+++ b/openaev-api/src/main/resources/application-dev.properties.example
@@ -50,6 +50,9 @@ spring.session.jdbc.cleanup-cron=-
 openaev.session-idle-timeout=0
 ## When true, the session cookie dies when the browser closes
 openaev.session-cookie=false
+## SameSite of the session cookie. Blank omits it (keeps SSO working over the cross-site callback);
+## set "None" (forces Secure) on HTTPS SSO deployments. Accepted: None, Lax, Strict, or blank.
+openaev.session-cookie-same-site=
 server.ssl.enabled=false
 server.http2.enabled=${server.ssl.enabled}
 server.ssl.key-store-type=PKCS12

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -159,6 +159,12 @@ openaev.session-idle-timeout=0
 ## When true, the session cookie has no Expires attribute and dies when the browser closes
 ## (server-side timeout still applies). When false, the cookie persists for the session timeout.
 openaev.session-cookie=false
+## SameSite attribute of the session cookie. Blank (default) OMITS the attribute, which keeps the
+## cookie flowing on the cross-site SSO callback (SAML ACS POST / OIDC form_post) - an explicit
+## "Lax" would drop it and break SSO (redirect to /login?error). HTTPS SSO deployments may set this
+## to "None" (which forces Secure) for a stricter, spec-compliant cross-site session cookie.
+## Accepted values: None, Lax, Strict, or blank to omit.
+openaev.session-cookie-same-site=
 server.ssl.enabled=false
 server.http2.enabled=true
 server.ssl.key-store-type=PKCS12

--- a/openaev-api/src/test/java/io/openaev/config/SpringSessionConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/SpringSessionConfigTest.java
@@ -21,11 +21,12 @@ class SpringSessionConfigTest {
 
   @Mock private OpenAEVConfig openAEVConfig;
 
-  private String writeCookie() {
+  private String writeCookie(String configuredSameSite) {
     SpringSessionConfig config = new SpringSessionConfig(openAEVConfig);
     // Persistent-cookie branch is irrelevant here; keep it a browser-session cookie.
     when(openAEVConfig.isSessionCookie()).thenReturn(true);
     ReflectionTestUtils.setField(config, "sessionTimeout", java.time.Duration.ofMinutes(1440));
+    ReflectionTestUtils.setField(config, "sessionCookieSameSite", configuredSameSite);
     CookieSerializer serializer = config.cookieSerializer();
 
     MockHttpServletRequest request = new MockHttpServletRequest();
@@ -44,13 +45,25 @@ class SpringSessionConfigTest {
     @DisplayName("given blank config should omit the SameSite attribute")
     void given_blankConfig_should_omitSameSite() {
       // Arrange
-      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("");
       when(openAEVConfig.isCookieSecure()).thenReturn(false);
 
       // Act
-      String setCookie = writeCookie();
+      String setCookie = writeCookie("");
 
       // Assert - the pre-Spring-Session behavior: no SameSite attribute at all.
+      assertFalse(setCookie.contains("SameSite"), setCookie);
+    }
+
+    @Test
+    @DisplayName("given a null config should omit the SameSite attribute")
+    void given_nullConfig_should_omitSameSite() {
+      // Arrange
+      when(openAEVConfig.isCookieSecure()).thenReturn(false);
+
+      // Act
+      String setCookie = writeCookie(null);
+
+      // Assert
       assertFalse(setCookie.contains("SameSite"), setCookie);
     }
 
@@ -58,11 +71,10 @@ class SpringSessionConfigTest {
     @DisplayName("given None should set SameSite=None and force Secure")
     void given_none_should_setSameSiteNoneAndSecure() {
       // Arrange
-      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("None");
       when(openAEVConfig.isCookieSecure()).thenReturn(false);
 
       // Act
-      String setCookie = writeCookie();
+      String setCookie = writeCookie("None");
 
       // Assert
       assertTrue(setCookie.contains("SameSite=None"), setCookie);
@@ -73,11 +85,10 @@ class SpringSessionConfigTest {
     @DisplayName("given Lax should set SameSite=Lax without forcing Secure")
     void given_lax_should_setSameSiteLax() {
       // Arrange
-      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("Lax");
       when(openAEVConfig.isCookieSecure()).thenReturn(false);
 
       // Act
-      String setCookie = writeCookie();
+      String setCookie = writeCookie("Lax");
 
       // Assert
       assertTrue(setCookie.contains("SameSite=Lax"), setCookie);
@@ -85,14 +96,28 @@ class SpringSessionConfigTest {
     }
 
     @Test
+    @DisplayName(
+        "given Strict (any case, padded) should set SameSite=Strict without forcing Secure")
+    void given_strict_should_setSameSiteStrict() {
+      // Arrange
+      when(openAEVConfig.isCookieSecure()).thenReturn(false);
+
+      // Act - mixed case and surrounding whitespace must still normalize.
+      String setCookie = writeCookie("  sTrIcT  ");
+
+      // Assert
+      assertTrue(setCookie.contains("SameSite=Strict"), setCookie);
+      assertFalse(setCookie.contains("Secure"), setCookie);
+    }
+
+    @Test
     @DisplayName("given an unknown value should omit the SameSite attribute rather than guess")
     void given_unknownValue_should_omitSameSite() {
       // Arrange
-      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("banana");
       when(openAEVConfig.isCookieSecure()).thenReturn(false);
 
       // Act
-      String setCookie = writeCookie();
+      String setCookie = writeCookie("banana");
 
       // Assert
       assertFalse(setCookie.contains("SameSite"), setCookie);
@@ -102,11 +127,10 @@ class SpringSessionConfigTest {
     @DisplayName("given cookie-secure true should keep Secure even when SameSite is omitted")
     void given_cookieSecure_should_keepSecure() {
       // Arrange
-      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("");
       when(openAEVConfig.isCookieSecure()).thenReturn(true);
 
       // Act
-      String setCookie = writeCookie();
+      String setCookie = writeCookie("");
 
       // Assert
       assertTrue(setCookie.contains("Secure"), setCookie);

--- a/openaev-api/src/test/java/io/openaev/config/SpringSessionConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/SpringSessionConfigTest.java
@@ -1,0 +1,116 @@
+package io.openaev.config;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Spring session cookie serialization")
+class SpringSessionConfigTest {
+
+  @Mock private OpenAEVConfig openAEVConfig;
+
+  private String writeCookie() {
+    SpringSessionConfig config = new SpringSessionConfig(openAEVConfig);
+    // Persistent-cookie branch is irrelevant here; keep it a browser-session cookie.
+    when(openAEVConfig.isSessionCookie()).thenReturn(true);
+    ReflectionTestUtils.setField(config, "sessionTimeout", java.time.Duration.ofMinutes(1440));
+    CookieSerializer serializer = config.cookieSerializer();
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setSecure(true);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    serializer.writeCookieValue(
+        new CookieSerializer.CookieValue(request, response, "the-session-id"));
+    return response.getHeader("Set-Cookie");
+  }
+
+  @Nested
+  @DisplayName("SameSite handling (SSO must not be broken by an over-restrictive attribute)")
+  class SameSiteHandling {
+
+    @Test
+    @DisplayName("given blank config should omit the SameSite attribute")
+    void given_blankConfig_should_omitSameSite() {
+      // Arrange
+      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("");
+      when(openAEVConfig.isCookieSecure()).thenReturn(false);
+
+      // Act
+      String setCookie = writeCookie();
+
+      // Assert - the pre-Spring-Session behavior: no SameSite attribute at all.
+      assertFalse(setCookie.contains("SameSite"), setCookie);
+    }
+
+    @Test
+    @DisplayName("given None should set SameSite=None and force Secure")
+    void given_none_should_setSameSiteNoneAndSecure() {
+      // Arrange
+      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("None");
+      when(openAEVConfig.isCookieSecure()).thenReturn(false);
+
+      // Act
+      String setCookie = writeCookie();
+
+      // Assert
+      assertTrue(setCookie.contains("SameSite=None"), setCookie);
+      assertTrue(setCookie.contains("Secure"), setCookie);
+    }
+
+    @Test
+    @DisplayName("given Lax should set SameSite=Lax without forcing Secure")
+    void given_lax_should_setSameSiteLax() {
+      // Arrange
+      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("Lax");
+      when(openAEVConfig.isCookieSecure()).thenReturn(false);
+
+      // Act
+      String setCookie = writeCookie();
+
+      // Assert
+      assertTrue(setCookie.contains("SameSite=Lax"), setCookie);
+      assertFalse(setCookie.contains("Secure"), setCookie);
+    }
+
+    @Test
+    @DisplayName("given an unknown value should omit the SameSite attribute rather than guess")
+    void given_unknownValue_should_omitSameSite() {
+      // Arrange
+      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("banana");
+      when(openAEVConfig.isCookieSecure()).thenReturn(false);
+
+      // Act
+      String setCookie = writeCookie();
+
+      // Assert
+      assertFalse(setCookie.contains("SameSite"), setCookie);
+    }
+
+    @Test
+    @DisplayName("given cookie-secure true should keep Secure even when SameSite is omitted")
+    void given_cookieSecure_should_keepSecure() {
+      // Arrange
+      when(openAEVConfig.getSessionCookieSameSite()).thenReturn("");
+      when(openAEVConfig.isCookieSecure()).thenReturn(true);
+
+      // Act
+      String setCookie = writeCookie();
+
+      // Assert
+      assertTrue(setCookie.contains("Secure"), setCookie);
+      assertFalse(setCookie.contains("SameSite"), setCookie);
+    }
+  }
+}

--- a/openaev-framework/src/main/java/io/openaev/config/OpenAEVConfig.java
+++ b/openaev-framework/src/main/java/io/openaev/config/OpenAEVConfig.java
@@ -137,23 +137,6 @@ public class OpenAEVConfig {
   @Value("${openbas.session-cookie:${openaev.session-cookie:false}}")
   private boolean sessionCookie;
 
-  /**
-   * SameSite attribute of the session cookie.
-   *
-   * <p>Left blank by default so the attribute is OMITTED, which is what the platform did before
-   * sessions moved to Spring Session (the servlet container never set SameSite). Omitting it lets
-   * the browser apply its default policy, which still delivers the cookie on the cross-site SSO
-   * callback (SAML ACS POST and OIDC {@code form_post}). An explicit {@code Lax} would drop the
-   * cookie on that POST and break SSO.
-   *
-   * <p>Production SSO deployments behind HTTPS should set this to {@code None} (which forces the
-   * {@code Secure} attribute) for a robust, spec-compliant cross-site session cookie. Accepted
-   * values: {@code None}, {@code Lax}, {@code Strict}, or blank to omit.
-   */
-  @JsonIgnore
-  @Value("${openbas.session-cookie-same-site:${openaev.session-cookie-same-site:}}")
-  private String sessionCookieSameSite;
-
   @JsonProperty("application_agent_url")
   @Value("${openbas.agent-url:${openaev.agent-url:#{null}}}")
   private String agentUrl;

--- a/openaev-framework/src/main/java/io/openaev/config/OpenAEVConfig.java
+++ b/openaev-framework/src/main/java/io/openaev/config/OpenAEVConfig.java
@@ -137,6 +137,23 @@ public class OpenAEVConfig {
   @Value("${openbas.session-cookie:${openaev.session-cookie:false}}")
   private boolean sessionCookie;
 
+  /**
+   * SameSite attribute of the session cookie.
+   *
+   * <p>Left blank by default so the attribute is OMITTED, which is what the platform did before
+   * sessions moved to Spring Session (the servlet container never set SameSite). Omitting it lets
+   * the browser apply its default policy, which still delivers the cookie on the cross-site SSO
+   * callback (SAML ACS POST and OIDC {@code form_post}). An explicit {@code Lax} would drop the
+   * cookie on that POST and break SSO.
+   *
+   * <p>Production SSO deployments behind HTTPS should set this to {@code None} (which forces the
+   * {@code Secure} attribute) for a robust, spec-compliant cross-site session cookie. Accepted
+   * values: {@code None}, {@code Lax}, {@code Strict}, or blank to omit.
+   */
+  @JsonIgnore
+  @Value("${openbas.session-cookie-same-site:${openaev.session-cookie-same-site:}}")
+  private String sessionCookieSameSite;
+
   @JsonProperty("application_agent_url")
   @Value("${openbas.agent-url:${openaev.agent-url:#{null}}}")
   private String agentUrl;


### PR DESCRIPTION
## Related issue

Closes #6793

## Summary

**Emergency fix: all SSO login is broken on `main` / rolling since sessions moved to Spring Session JDBC (#6784).**

The SSO round-trip reaches the IdP and returns to the callback, which fails and redirects to `/login?error` (not served by the backend, so a Whitelabel 404). Nothing shows in the backend logs because the callback fails with a normal `AuthenticationException` (authorization request / relay state not found), logged at DEBUG.

### Root cause

`SpringSessionConfig` hardcoded `SameSite=Lax` on the new `openaev_session` cookie. The servlet container never set a SameSite attribute before, so browsers delivered the session cookie on the cross-site SSO callback (SAML ACS POST, OIDC `form_post`) under the default Lax+POST allowance. An explicit `Lax` removes that allowance, so the session that stores the OAuth2/SAML authorization request is missing at the callback and login fails.

### Fix

- New setting `openaev.session-cookie-same-site` (accepts `None` / `Lax` / `Strict` / blank), injected directly in `SpringSessionConfig` (`openaev-api`) - no new code in the deprecated `openaev-framework` module.
- Default is blank = OMIT the attribute, restoring the exact pre-#6784 behavior so SSO works again out of the box.
- `None` forces `Secure` for HTTPS SSO deployments that want a strict, spec-compliant cross-site session cookie.
- Unknown or blank values omit the attribute rather than risk an over-restrictive policy that silently breaks SSO; normalization is locale-independent (`Locale.ROOT`).

## Test plan

- `SpringSessionConfigTest` (7 tests): blank/null omits SameSite; `None` sets `SameSite=None` + `Secure`; `Lax` stays non-secure; mixed-case padded `Strict` normalizes; unknown omits; `cookie-secure=true` keeps `Secure` while omitting SameSite. All green locally.
- Manual: on the staging/rolling deployment, set nothing (default) and confirm SAML/OIDC login completes; optionally set `openaev.session-cookie-same-site=None` on HTTPS for a strict cookie.
