### PR TITLE
feat(chaining): expose the attack-path execution fields the front needs (#5048)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260720100000000__Add_attackpath_execution_payload_and_injector_type.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260720100000000__Add_attackpath_execution_payload_and_injector_type.java
@@ -1,0 +1,28 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds the run's payload id and injector type on {@code attackpath_execution} (issue 5048). The
+ * payload id lets the execution detail resolve the payload's detection remediations; the injector
+ * type lets the graph label the injector node with its real type instead of the front guessing an
+ * icon slug from the label. Both are captured at run time, additive and nullable (the seed and
+ * injector-less rows carry none).
+ */
+@Component
+public class V6_20260720100000000__Add_attackpath_execution_payload_and_injector_type
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "ALTER TABLE attackpath_execution "
+              + "ADD COLUMN IF NOT EXISTS attackpath_execution_payload_id varchar(255), "
+              + "ADD COLUMN IF NOT EXISTS attackpath_execution_injector_type varchar(255);");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -11,9 +11,11 @@ import io.openaev.database.model.attackpath.projection.AttackPathFindingListRow;
 import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
 import io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow;
 import io.openaev.database.model.attackpath.projection.AttackPathTypeCountRow;
+import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
 import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
 import io.openaev.expectation.ExpectationType;
+import io.openaev.service.attackpath.dto.AttackPathAttackPatternDTO;
 import io.openaev.service.attackpath.dto.AttackPathCounters;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
 import io.openaev.service.attackpath.dto.AttackPathEdges;
@@ -79,6 +81,7 @@ public class AttackPathGraphService {
 
   private final AttackPathExecutionRepository executionRepository;
   private final AttackPathFindingRepository findingRepository;
+  private final InjectorContractRepository injectorContractRepository;
 
   /**
    * Above this many executions a simulation is served collapsed by default. Tied to the front
@@ -186,11 +189,29 @@ public class AttackPathGraphService {
         }
       }
     }
+    // ATT&CK techniques of the run's injector contract, for the drawer's technique chips. One
+    // bounded lookup by the frozen contract external id (the accessor matches on id OR external id,
+    // so the external id is passed for both).
+    List<AttackPathAttackPatternDTO> attackPatterns = new ArrayList<>();
+    if (e.getContractExternalId() != null) {
+      injectorContractRepository
+          .findByIdOrExternalId(e.getContractExternalId(), e.getContractExternalId())
+          .ifPresent(
+              contract ->
+                  contract
+                      .getAttackPatterns()
+                      .forEach(
+                          pattern ->
+                              attackPatterns.add(
+                                  new AttackPathAttackPatternDTO(
+                                      pattern.getExternalId(), pattern.getName()))));
+    }
     return new AttackPathExecutionDetailDTO(
         e.getPayloadName(),
         e.getInjectId(),
         e.getAgentName(),
         e.getAgentPrivilege(),
+        attackPatterns,
         e.getTargetKey(),
         e.getTargetHostname(),
         e.getTargetIp(),

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -209,6 +209,7 @@ public class AttackPathGraphService {
     return new AttackPathExecutionDetailDTO(
         e.getPayloadName(),
         e.getInjectId(),
+        e.getPayloadId(),
         e.getAgentName(),
         e.getAgentPrivilege(),
         attackPatterns,

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -12,9 +12,11 @@ import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
 import io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow;
 import io.openaev.database.model.attackpath.projection.AttackPathTypeCountRow;
 import io.openaev.database.repository.InjectorContractRepository;
+import io.openaev.database.repository.PayloadRepository;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
 import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
 import io.openaev.expectation.ExpectationType;
+import io.openaev.rest.payload.form.DetectionRemediationOutput;
 import io.openaev.service.attackpath.dto.AttackPathAttackPatternDTO;
 import io.openaev.service.attackpath.dto.AttackPathCounters;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
@@ -26,6 +28,7 @@ import io.openaev.service.attackpath.dto.AttackPathExpandDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingItemDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
+import io.openaev.utils.mapper.PayloadMapper;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -82,6 +85,8 @@ public class AttackPathGraphService {
   private final AttackPathExecutionRepository executionRepository;
   private final AttackPathFindingRepository findingRepository;
   private final InjectorContractRepository injectorContractRepository;
+  private final PayloadRepository payloadRepository;
+  private final PayloadMapper payloadMapper;
 
   /**
    * Above this many executions a simulation is served collapsed by default. Tied to the front
@@ -206,6 +211,17 @@ public class AttackPathGraphService {
                                   new AttackPathAttackPatternDTO(
                                       pattern.getExternalId(), pattern.getName()))));
     }
+    // Detection remediations of the payload that actually ran (the frozen payload id, not the
+    // inject's current one). The mapper carries the EE gate: an inactive licence yields an empty
+    // list, which is exactly what the drawer already renders.
+    List<DetectionRemediationOutput> detectionRemediations =
+        e.getPayloadId() == null
+            ? List.of()
+            : payloadMapper.toDetectionRemediationOutputs(
+                payloadRepository
+                    .findById(e.getPayloadId())
+                    .map(p -> p.getDetectionRemediations())
+                    .orElse(List.of()));
     return new AttackPathExecutionDetailDTO(
         e.getPayloadName(),
         e.getInjectId(),
@@ -213,6 +229,7 @@ public class AttackPathGraphService {
         e.getAgentName(),
         e.getAgentPrivilege(),
         attackPatterns,
+        detectionRemediations,
         e.getTargetKey(),
         e.getTargetHostname(),
         e.getTargetIp(),

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -188,6 +188,7 @@ public class AttackPathGraphService {
     }
     return new AttackPathExecutionDetailDTO(
         e.getPayloadName(),
+        e.getInjectId(),
         e.getAgentName(),
         e.getAgentPrivilege(),
         e.getTargetKey(),

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathAttackPatternDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathAttackPatternDTO.java
@@ -1,0 +1,7 @@
+package io.openaev.service.attackpath.dto;
+
+/**
+ * One MITRE ATT&amp;CK technique of the execution's injector contract (issue 5048): its external id
+ * (for example {@code T1046}) and its name, for the technique chips in the execution detail drawer.
+ */
+public record AttackPathAttackPatternDTO(String externalId, String name) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -12,6 +12,7 @@ public record AttackPathExecutionDetailDTO(
     // header
     String payloadName,
     String injectId,
+    String payloadId,
     String agentName,
     String agentPrivilege,
     List<AttackPathAttackPatternDTO> attackPatterns,

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -1,5 +1,6 @@
 package io.openaev.service.attackpath.dto;
 
+import io.openaev.rest.payload.form.DetectionRemediationOutput;
 import java.util.List;
 
 /**
@@ -16,6 +17,7 @@ public record AttackPathExecutionDetailDTO(
     String agentName,
     String agentPrivilege,
     List<AttackPathAttackPatternDTO> attackPatterns,
+    List<DetectionRemediationOutput> detectionRemediations,
     // result
     String endpointKey,
     String targetHostname,

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -11,6 +11,7 @@ import java.util.List;
 public record AttackPathExecutionDetailDTO(
     // header
     String payloadName,
+    String injectId,
     String agentName,
     String agentPrivilege,
     // result

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -14,6 +14,7 @@ public record AttackPathExecutionDetailDTO(
     String injectId,
     String agentName,
     String agentPrivilege,
+    List<AttackPathAttackPatternDTO> attackPatterns,
     // result
     String endpointKey,
     String targetHostname,

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -40,7 +40,8 @@ public class AttackPathExecutionIngestionService {
       String stepTemplateId,
       String injectExecId,
       Instant executedAt,
-      String payloadName) {}
+      String payloadName,
+      String contractExternalId) {}
 
   @Transactional
   public void createRows(ExecutionContext ctx, List<ResolvedExecutionEdge> edges) {
@@ -63,6 +64,8 @@ public class AttackPathExecutionIngestionService {
     row.setStepTemplateId(ctx.stepTemplateId());
     row.setExecutedAt(ctx.executedAt());
     row.setPayloadName(ctx.payloadName());
+    // The run's injector contract, so the read can resolve its ATT&CK techniques.
+    row.setContractExternalId(ctx.contractExternalId());
     row.setSourceKind(edge.sourceKind());
     row.setSourceInjector(edge.sourceInjector());
     row.setSourceAssetId(edge.sourceAssetId());
@@ -109,7 +112,8 @@ public class AttackPathExecutionIngestionService {
         step.getStepTemplate() != null ? step.getStepTemplate().getId() : null,
         inject.getId(),
         Instant.now(),
-        payload != null ? payload.getName() : null);
+        payload != null ? payload.getName() : null,
+        contract.getExternalId());
   }
 
   private ResolutionInput resolutionInput(Inject inject, InjectorContract contract) {

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -41,7 +41,9 @@ public class AttackPathExecutionIngestionService {
       String injectExecId,
       Instant executedAt,
       String payloadName,
-      String contractExternalId) {}
+      String contractExternalId,
+      String payloadId,
+      String injectorType) {}
 
   @Transactional
   public void createRows(ExecutionContext ctx, List<ResolvedExecutionEdge> edges) {
@@ -66,6 +68,10 @@ public class AttackPathExecutionIngestionService {
     row.setPayloadName(ctx.payloadName());
     // The run's injector contract, so the read can resolve its ATT&CK techniques.
     row.setContractExternalId(ctx.contractExternalId());
+    // The run's payload (so the read can resolve its detection remediations) and injector type (so
+    // the graph can label the injector node with its real type).
+    row.setPayloadId(ctx.payloadId());
+    row.setInjectorType(ctx.injectorType());
     row.setSourceKind(edge.sourceKind());
     row.setSourceInjector(edge.sourceInjector());
     row.setSourceAssetId(edge.sourceAssetId());
@@ -113,7 +119,9 @@ public class AttackPathExecutionIngestionService {
         inject.getId(),
         Instant.now(),
         payload != null ? payload.getName() : null,
-        contract.getExternalId());
+        contract.getExternalId(),
+        payload != null ? payload.getId() : null,
+        inject.getInjector() != null ? inject.getInjector().getType() : null);
   }
 
   private ResolutionInput resolutionInput(Inject inject, InjectorContract contract) {

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
@@ -72,6 +72,7 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     e.setSimulationId(SIM);
     e.setInjectId("inject-detail-1");
     e.setContractExternalId(contract.getExternalId());
+    e.setPayloadId("payload-detail-1");
     e.setSourceKind("INJECTOR");
     e.setSourceInjector("hydra");
     e.setTargetKind("ASSET");
@@ -121,6 +122,7 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     // header
     assertThat(d.injectId()).isEqualTo("inject-detail-1");
     assertThat(d.payloadName()).isEqualTo("hydra-payload");
+    assertThat(d.payloadId()).isEqualTo("payload-detail-1");
     // the run's contract resolves to its ATT&CK techniques (the drawer's chips)
     assertThat(d.attackPatterns()).hasSize(1);
     assertThat(d.attackPatterns().get(0).externalId()).isEqualTo("T1046");

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
@@ -3,6 +3,7 @@ package io.openaev.api.attackpath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openaev.IntegrationTest;
+import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
@@ -11,6 +12,11 @@ import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
 import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
 import io.openaev.service.attackpath.AttackPathGraphService;
 import io.openaev.service.attackpath.dto.AttackPathExecutionDetailDTO;
+import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.InjectorFixture;
+import io.openaev.utils.fixtures.composers.AttackPatternComposer;
+import io.openaev.utils.fixtures.composers.InjectorContractComposer;
+import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.time.Instant;
@@ -36,6 +42,9 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
   @Autowired private AttackPathGraphService graphService;
   @Autowired private AttackPathExecutionRepository executionRepository;
   @Autowired private AttackPathFindingRepository findingRepository;
+  @Autowired private InjectorContractComposer injectorContractComposer;
+  @Autowired private AttackPatternComposer attackPatternComposer;
+  @Autowired private InjectorFixture injectorFixture;
 
   private Tenant tenant;
   private String executionId;
@@ -44,10 +53,25 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
   void seed() {
     tenant = tenantRepository.save(TenantFixture.getTenant("ap-detail-tenant"));
 
+    // A real injector contract carrying an ATT&CK technique, referenced by the row's external id:
+    // the read resolves the techniques from it for the drawer's chips.
+    InjectorContract contract =
+        injectorContractComposer
+            .forInjectorContract(
+                InjectorContractFixture.createDefaultInjectorContractWithExternalId(
+                    "contract-ext-1"))
+            .withInjector(injectorFixture.getWellKnownOaevImplantInjector())
+            .withAttackPattern(
+                attackPatternComposer.forAttackPattern(
+                    AttackPatternFixture.createAttackPatternsWithExternalId("T1046")))
+            .persist()
+            .get();
+
     AttackPathExecution e = new AttackPathExecution();
     e.setTenant(tenant);
     e.setSimulationId(SIM);
     e.setInjectId("inject-detail-1");
+    e.setContractExternalId(contract.getExternalId());
     e.setSourceKind("INJECTOR");
     e.setSourceInjector("hydra");
     e.setTargetKind("ASSET");
@@ -97,6 +121,9 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     // header
     assertThat(d.injectId()).isEqualTo("inject-detail-1");
     assertThat(d.payloadName()).isEqualTo("hydra-payload");
+    // the run's contract resolves to its ATT&CK techniques (the drawer's chips)
+    assertThat(d.attackPatterns()).hasSize(1);
+    assertThat(d.attackPatterns().get(0).externalId()).isEqualTo("T1046");
     assertThat(d.agentName()).isEqualTo("agent-1");
     assertThat(d.agentPrivilege()).isEqualTo("user");
     // result

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
@@ -47,6 +47,7 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     AttackPathExecution e = new AttackPathExecution();
     e.setTenant(tenant);
     e.setSimulationId(SIM);
+    e.setInjectId("inject-detail-1");
     e.setSourceKind("INJECTOR");
     e.setSourceInjector("hydra");
     e.setTargetKind("ASSET");
@@ -94,6 +95,7 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
 
     assertThat(d).isNotNull();
     // header
+    assertThat(d.injectId()).isEqualTo("inject-detail-1");
     assertThat(d.payloadName()).isEqualTo("hydra-payload");
     assertThat(d.agentName()).isEqualTo("agent-1");
     assertThat(d.agentPrivilege()).isEqualTo("user");

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
@@ -1,21 +1,31 @@
 package io.openaev.api.attackpath;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.Payload;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
 import io.openaev.database.model.attackpath.AttackPathFinding;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
 import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
+import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.service.attackpath.AttackPathGraphService;
 import io.openaev.service.attackpath.dto.AttackPathExecutionDetailDTO;
+import io.openaev.utils.fixtures.CollectorTypeFixture;
+import io.openaev.utils.fixtures.DetectionRemediationFixture;
 import io.openaev.utils.fixtures.InjectorContractFixture;
 import io.openaev.utils.fixtures.InjectorFixture;
+import io.openaev.utils.fixtures.PayloadFixture;
 import io.openaev.utils.fixtures.composers.AttackPatternComposer;
+import io.openaev.utils.fixtures.composers.CollectorTypeComposer;
+import io.openaev.utils.fixtures.composers.DetectionRemediationComposer;
 import io.openaev.utils.fixtures.composers.InjectorContractComposer;
+import io.openaev.utils.fixtures.composers.PayloadComposer;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
@@ -24,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -45,9 +56,18 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
   @Autowired private InjectorContractComposer injectorContractComposer;
   @Autowired private AttackPatternComposer attackPatternComposer;
   @Autowired private InjectorFixture injectorFixture;
+  @Autowired private PayloadComposer payloadComposer;
+  @Autowired private DetectionRemediationComposer detectionRemediationComposer;
+  @Autowired private CollectorTypeComposer collectorTypeComposer;
+
+  // The remediation mapping is Enterprise-gated. The test environment has no active licence, so the
+  // gate is driven explicitly here: that is the only way to exercise the resolution itself rather
+  // than the degraded empty-list path.
+  @MockitoBean private EnterpriseEditionService enterpriseEditionService;
 
   private Tenant tenant;
   private String executionId;
+  private String payloadId;
 
   @BeforeEach
   void seed() {
@@ -71,8 +91,24 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     e.setTenant(tenant);
     e.setSimulationId(SIM);
     e.setInjectId("inject-detail-1");
+    // A real payload carrying a detection remediation: the read resolves the remediations from the
+    // payload that actually ran (the frozen payload id), for the drawer's Remediation tab.
+    Payload payload =
+        payloadComposer
+            .forPayload(PayloadFixture.createDefaultCommand())
+            .withDetectionRemediation(
+                detectionRemediationComposer
+                    .forDetectionRemediation(
+                        DetectionRemediationFixture.createDefaultDetectionRemediation())
+                    .withCollectorType(
+                        collectorTypeComposer.forCollectorType(
+                            CollectorTypeFixture.createDefaultCollectorType())))
+            .persist()
+            .get();
+    payloadId = payload.getId();
+
     e.setContractExternalId(contract.getExternalId());
-    e.setPayloadId("payload-detail-1");
+    e.setPayloadId(payloadId);
     e.setSourceKind("INJECTOR");
     e.setSourceInjector("hydra");
     e.setTargetKind("ASSET");
@@ -122,7 +158,7 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     // header
     assertThat(d.injectId()).isEqualTo("inject-detail-1");
     assertThat(d.payloadName()).isEqualTo("hydra-payload");
-    assertThat(d.payloadId()).isEqualTo("payload-detail-1");
+    assertThat(d.payloadId()).isEqualTo(payloadId);
     // the run's contract resolves to its ATT&CK techniques (the drawer's chips)
     assertThat(d.attackPatterns()).hasSize(1);
     assertThat(d.attackPatterns().get(0).externalId()).isEqualTo("T1046");
@@ -155,5 +191,26 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
   void unknownExecutionOrSimulationIsNull() {
     assertThat(graphService.executionDetail(SIM, "does-not-exist")).isNull();
     assertThat(graphService.executionDetail("OTHER-SIM", executionId)).isNull();
+  }
+
+  @Test
+  @DisplayName(
+      "with an active Enterprise licence, the remediations of the payload that ran are returned")
+  void returnsDetectionRemediationsWhenEnterpriseActive() {
+    when(enterpriseEditionService.isLicenseActive(any())).thenReturn(true);
+
+    AttackPathExecutionDetailDTO d = graphService.executionDetail(SIM, executionId);
+
+    assertThat(d.detectionRemediations()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("without an active Enterprise licence, the remediations are omitted")
+  void omitsDetectionRemediationsWhenEnterpriseInactive() {
+    when(enterpriseEditionService.isLicenseActive(any())).thenReturn(false);
+
+    AttackPathExecutionDetailDTO d = graphService.executionDetail(SIM, executionId);
+
+    assertThat(d.detectionRemediations()).isEmpty();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -60,7 +60,9 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "exec-1",
             Instant.parse("2026-07-16T08:00:00Z"),
             "crackmapexec",
-            "contract-ext-1");
+            "contract-ext-1",
+            "payload-1",
+            "openaev_implant");
 
     ResolvedExecutionEdge edge =
         new ResolvedExecutionEdge(
@@ -122,6 +124,8 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "exec-idem",
             Instant.parse("2026-07-16T08:00:00Z"),
             "crackmapexec",
+            null,
+            null,
             null);
     ResolvedExecutionEdge edge =
         new ResolvedExecutionEdge(
@@ -183,6 +187,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
 
     Injector injector = new Injector();
     injector.setName("OpenAEV Implant");
+    injector.setType("openaev_implant");
 
     Exercise exercise = new Exercise();
     exercise.setId("SIM-ONRUN");
@@ -209,6 +214,10 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getSimulationId()).isEqualTo("SIM-ONRUN");
     // The run's contract external id, so the read can resolve its ATT&CK techniques.
     assertThat(row.getContractExternalId()).isEqualTo("contract-ext-1");
+    // The run's payload (for the remediations read) and injector type (for the injector node
+    // label).
+    assertThat(row.getPayloadId()).isEqualTo("cmd-1");
+    assertThat(row.getInjectorType()).isEqualTo("openaev_implant");
     assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(row.getSourceAssetId()).isEqualTo("ep-1");
     assertThat(row.getSourceHostname()).isEqualTo("corp-dc");

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -59,7 +59,8 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "tmpl-1",
             "exec-1",
             Instant.parse("2026-07-16T08:00:00Z"),
-            "crackmapexec");
+            "crackmapexec",
+            "contract-ext-1");
 
     ResolvedExecutionEdge edge =
         new ResolvedExecutionEdge(
@@ -120,7 +121,8 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             "tmpl-1",
             "exec-idem",
             Instant.parse("2026-07-16T08:00:00Z"),
-            "crackmapexec");
+            "crackmapexec",
+            null);
     ResolvedExecutionEdge edge =
         new ResolvedExecutionEdge(
             "AGENT_ASSET",
@@ -177,6 +179,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     InjectorContract contract = new InjectorContract();
     contract.setNeedsExecutor(true);
     contract.setPayload(command);
+    contract.setExternalId("contract-ext-1");
 
     Injector injector = new Injector();
     injector.setName("OpenAEV Implant");
@@ -204,6 +207,8 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
             .findById(AttackPathIds.executionNode("inj-1", "ep-1", "agt-1"))
             .orElseThrow();
     assertThat(row.getSimulationId()).isEqualTo("SIM-ONRUN");
+    // The run's contract external id, so the read can resolve its ATT&CK techniques.
+    assertThat(row.getContractExternalId()).isEqualTo("contract-ext-1");
     assertThat(row.getSourceKind()).isEqualTo("AGENT_ASSET");
     assertThat(row.getSourceAssetId()).isEqualTo("ep-1");
     assertThat(row.getSourceHostname()).isEqualTo("corp-dc");

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -733,6 +733,7 @@ export interface AttackPathExecutionDetailDTO {
   executedAt?: string;
   findings?: AttackPathExecutionFindingItemDTO[];
   injectId?: string;
+  payloadId?: string;
   payloadName?: string;
   preventionStatus?: string;
   targetHostname?: string;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -726,6 +726,7 @@ export interface AttackPathExecutionDetailDTO {
   endpointKey?: string;
   executedAt?: string;
   findings?: AttackPathExecutionFindingItemDTO[];
+  injectId?: string;
   payloadName?: string;
   preventionStatus?: string;
   targetHostname?: string;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -718,9 +718,15 @@ export interface AttackPathEndpointRelationsDTO {
   executions?: AttackPathNodeDTO[];
 }
 
+export interface AttackPathAttackPatternDTO {
+  externalId?: string;
+  name?: string;
+}
+
 export interface AttackPathExecutionDetailDTO {
   agentName?: string;
   agentPrivilege?: string;
+  attackPatterns?: AttackPathAttackPatternDTO[];
   command?: string;
   detectionStatus?: string;
   endpointKey?: string;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -728,6 +728,7 @@ export interface AttackPathExecutionDetailDTO {
   agentPrivilege?: string;
   attackPatterns?: AttackPathAttackPatternDTO[];
   command?: string;
+  detectionRemediations?: DetectionRemediationOutput[];
   detectionStatus?: string;
   endpointKey?: string;
   executedAt?: string;

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathExecution.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathExecution.java
@@ -83,6 +83,9 @@ public class AttackPathExecution implements TenantBase {
   @Column(name = "attackpath_execution_source_injector")
   private String sourceInjector;
 
+  @Column(name = "attackpath_execution_injector_type")
+  private String injectorType;
+
   @Column(name = "attackpath_execution_target_kind", nullable = false)
   private String targetKind;
 
@@ -106,6 +109,9 @@ public class AttackPathExecution implements TenantBase {
 
   @Column(name = "attackpath_execution_payload_name")
   private String payloadName;
+
+  @Column(name = "attackpath_execution_payload_id")
+  private String payloadId;
 
   @Column(name = "attackpath_execution_executed_at", nullable = false)
   private Instant executedAt;


### PR DESCRIPTION
## Summary

Exposes the per-execution fields the Attack Path front is already built to consume, but that the backend did
not surface. Source of the ask: the front team's backend-requirements doc (its P0/P1 items). Four additive,
individually reviewed commits, on top of the execution store.

| Field | Where | What it unblocks on the front |
|---|---|---|
| `injectId` | execution detail | the "Action details" button (redirect to the inject) |
| `attackPatterns[]` | execution detail | the MITRE technique chips, replacing the front's static `attack-path-mitre.ts` table |
| `payloadId` | execution detail | the detection remediations below |
| `detectionRemediations[]` | execution detail | the Remediation tab (Enterprise-gated) |

Two columns are now also **written** by the ingestion create: `contractExternalId` (the column already
existed but was never populated on real rows, only the seed wrote a synthetic value) and `injectorType`.

## How it resolves

- **ATT&CK techniques**: from the frozen `contractExternalId` to `InjectorContract.getAttackPatterns()`, in
  one bounded lookup.
- **Detection remediations**: from the frozen `payloadId`, that is the payload which actually ran rather than
  the inject's current one, reusing `PayloadMapper.toDetectionRemediationOutputs`. That mapper already carries
  the Enterprise gate, so nothing about EE was re-implemented: an inactive licence yields an empty list, which
  is exactly what the drawer renders today.

## Scope decisions (deliberate, not omissions)

- The techniques are resolved on the **execution detail**, where the front shows the chips. Exposing them on
  the **injector node** instead requires touching the graph projections, so that exposure is grouped with
  `injectorType` into a single follow-up, to touch the projections once instead of twice.
- `injectorType` is therefore **written but not yet exposed**. It is captured at run time on purpose: it is a
  snapshot, and it could not be recovered later if the injector changed or was removed.

## Testing

TDD per commit: the failing test was observed before each implementation. The full `AttackPath*` suite is
green (80 tests), including the schema migration, the graph service, the seed and the HTTP tenant-isolation
tests.

The detection-remediation test drives the Enterprise gate explicitly. The test environment has no active
licence, so asserting the happy path any other way would have been a false green. Both paths are covered:
licence active, the remediation is returned; licence inactive, the list is empty.

## Not in this PR

The remaining ingestion columns (command, terminal, status, findings) are #204/#202. The injector-node
exposure is the grouped follow-up described above. The ingestion create's tenant fix and its write-path
optimisation ride with the #6642 rebase, deliberately, because they touch the same code.
