### PR TITLE
chore(catalog): sync XTM One collector schema with new scheduling parameters (#6823)

### DIFF
--- a/openaev-api/src/main/resources/catalog/catalog-integrators.json
+++ b/openaev-api/src/main/resources/catalog/catalog-integrators.json
@@ -3988,8 +3988,19 @@
                         "type": "string"
                     },
                     "COLLECTOR_PERIOD": {
+                        "default": "PT5M",
+                        "description": "Duration between two scheduled runs of the collector (ISO 8601 format). Expectation validation runs on every cycle, so this is effectively the expectation-matching cadence; the agent import is additionally throttled by COLLECTOR_IMPORT_PERIOD.",
+                        "format": "duration",
+                        "type": "string"
+                    },
+                    "COLLECTOR_PLATFORM": {
+                        "default": "LLM_FIREWALL",
+                        "description": "Security platform type registered for this collector so XTM One appears in the OpenAEV inventory as a security platform (like any EDR/XDR collector) and detection/prevention expectation results are attributed to it. XTM One acts as an AI defense that flags prompt injections, hence LLM_FIREWALL by default. Accepted values: EDR, XDR, SIEM, SOAR, NDR, ISPM, LLM_FIREWALL, AI_GATEWAY.",
+                        "type": "string"
+                    },
+                    "COLLECTOR_IMPORT_PERIOD": {
                         "default": "PT1H",
-                        "description": "Duration between two scheduled runs of the collector (ISO 8601 format).",
+                        "description": "Minimum duration between two imports of the XTM One agents/models catalog (ISO 8601 format). The import runs on the first cycle and then only when this much time has elapsed since the previous import; set it lower than or equal to the collector period to import on every cycle.",
                         "format": "duration",
                         "type": "string"
                     },
@@ -3998,15 +4009,15 @@
                         "type": "string"
                     },
                     "COLLECTOR_XTM_ONE_TOKEN": {
-                        "description": "XTM One API key (fcp-...) used to read the agents and models catalog.",
+                        "description": "XTM One API key (fcp-...) used to read the agents and models catalog and the security audit log, and written onto each seeded AI target so the injector can authenticate to XTM One directly. Reading the audit log to validate detection expectations requires this key to belong to an XTM One administrator.",
                         "format": "password",
                         "type": "string",
                         "writeOnly": true
                     },
-                    "COLLECTOR_XTM_ONE_API_KEY_VARIABLE": {
-                        "default": "XTM_ONE_API_KEY",
-                        "description": "Name of the injector environment variable holding the credential the AI red team injector uses to reach XTM One at execution time. The secret value itself is never stored on the AI target.",
-                        "type": "string"
+                    "COLLECTOR_VALIDATE_EXPECTATIONS": {
+                        "default": true,
+                        "description": "When true, the collector also validates AI detection/prevention expectations by matching XTM One 'Prompt injection detected' security events to the AI red team injects that triggered them. Requires the XTM One token to have administrator access to the audit log.",
+                        "type": "boolean"
                     },
                     "COLLECTOR_INCLUDE_BARE_MODELS": {
                         "default": false,


### PR DESCRIPTION
## Proposed changes

Closes #6823.

Refreshes the `config_schema` of the `openaev_xtm_one` collector contract in `catalog-integrators.json` so the marketplace deployment form matches the collector's actual configuration schema (`python -m xtm_one.openaev_xtm_one --dump-config-schema`), following the scheduling change in OpenAEV-Platform/collectors#521:

- `COLLECTOR_PERIOD`: default changed from `PT1H` to `PT5M`; the description now explains it is the expectation-matching cadence.
- New `COLLECTOR_IMPORT_PERIOD` (ISO 8601 duration, default `PT1H`): minimum interval between two imports of the XTM One agents/models catalog.
- New `COLLECTOR_PLATFORM` (default `LLM_FIREWALL`): security platform type registered for the collector (added by OpenAEV-Platform/collectors#488, missing from the catalog).
- New `COLLECTOR_VALIDATE_EXPECTATIONS` (boolean, default `true`): toggles AI detection/prevention expectation validation (also from OpenAEV-Platform/collectors#488).
- Removed `COLLECTOR_XTM_ONE_API_KEY_VARIABLE`: the collector now stores the key on each seeded AI target (`ai_target_token`) and this parameter no longer exists.
- Updated the `COLLECTOR_XTM_ONE_TOKEN` description (audit-log access, admin key requirement).

No other contract is touched; the file remains valid JSON (verified by loading it with a JSON parser) and the `required` list is unchanged.

## Related issues

- #6823
- OpenAEV-Platform/collectors#520 / OpenAEV-Platform/collectors#521 (scheduling change)

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (JSON validity + schema parity with the collector dump)
