### PR TITLE
fix(arsenal): link to doc output parser (#6207)

### DIFF
--- a/openaev-front/src/admin/components/threat_arsenal/form/OutputFormTab.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/form/OutputFormTab.tsx
@@ -30,9 +30,9 @@ const OutputFormTab = () => {
     <>
       <Typography>
         {t('Define structured outputs by parsing the raw output of your action.')}
-&nbsp;
+                &nbsp;
         <a
-          href="https://docs.openaev.io/latest/usage/payloads/payloads/#output-parser"
+          href="https://docs.openaev.io/latest/usage/threat-arsenals/threat-arsenals/#output-parsers"
           target="_blank"
           rel="noreferrer"
         >
@@ -47,7 +47,7 @@ const OutputFormTab = () => {
       >
         <Typography sx={{ marginBottom: 0 }} variant="h3">
           {`${t('Output mode')} :`}
-&nbsp;
+                    &nbsp;
         </Typography>
         <Typography>{t('Stdout')}</Typography>
         <Typography
@@ -58,7 +58,7 @@ const OutputFormTab = () => {
           variant="h3"
         >
           {`${t('Parsing')} :`}
-&nbsp;
+                    &nbsp;
         </Typography>
         <Typography>{t('Regex')}</Typography>
         <Button


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update the link to output parser from threat arsenal part

### Testing Instructions

1. Arsenal
2. New (+)
3. Tab Output
4. Click on : "[Learn more about parser.](https://docs.openaev.io/latest/usage/threat-arsenals/threat-arsenals/#output-parsers)" 
5. You should be redirected to the doc 


### Related issues

* Closes #6207 
