### PR TITLE
fix(doc): fix the path to access to the tenant creation (#6829)

### DIFF
--- a/docs/docs/administration/multi-tenancy.md
+++ b/docs/docs/administration/multi-tenancy.md
@@ -50,7 +50,7 @@ A user or group can exist at both levels. For example, a platform administrator 
 
 ## Managing tenants
 
-Manage tenants from **Settings → Tenants**. You need the `Manage platform settings` capability (platform administrator).
+Manage tenants from **Settings → Security → Tenants**. You need the `Manage platform settings` capability (platform administrator).
 
 From this page you can create, edit, and delete tenants. When you create a tenant, it is immediately active and all built-in integrations (injectors, collectors) are automatically registered for it.
 

--- a/docs/docs/administration/multi-tenancy.md
+++ b/docs/docs/administration/multi-tenancy.md
@@ -50,7 +50,7 @@ A user or group can exist at both levels. For example, a platform administrator 
 
 ## Managing tenants
 
-Manage tenants from **Settings → Security → Tenants**. You need the `Manage platform settings` capability (platform administrator).
+Manage tenants from **Settings → Security → Platform → Tenants**. You need the `Manage platform settings` capability (platform administrator).
 
 From this page you can create, edit, and delete tenants. When you create a tenant, it is immediately active and all built-in integrations (injectors, collectors) are automatically registered for it.
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change the path for tenant creation from "Settings → Tenants" to  "Settings → Security → Platform → Tenants"

### Testing Instructions

1. Go on Settings → Security → Platform → Tenants
2. Check if the doc specified this path

### Related issues

* Closes #6829