### PR TITLE
fix(crowdstrike): propagate CrowdStrike API errors as exceptions (#6830)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java
+++ b/openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java
@@ -138,10 +138,16 @@ public class CrowdStrikeExecutorClient {
   }
 
   public ResourcesGroups hostGroup(String hostGroup) {
-    String jsonResponse;
     try {
-      jsonResponse = this.get(HOST_GROUPS_URI + "?ids=" + hostGroup);
-      return this.objectMapper.readValue(jsonResponse, new TypeReference<>() {});
+      String jsonResponse = this.get(HOST_GROUPS_URI + "?ids=" + hostGroup);
+      ResourcesGroups resourcesGroups =
+          this.objectMapper.readValue(jsonResponse, new TypeReference<>() {});
+      throwIfCrowdStrikeErrors(
+          "hostGroup",
+          "hostGroupId=" + hostGroup,
+          resourcesGroups.getErrors(),
+          resourcesGroups.getMeta() == null ? null : resourcesGroups.getMeta().getTraceId());
+      return resourcesGroups;
     } catch (Exception e) {
       log.error(
           String.format(
@@ -255,19 +261,44 @@ public class CrowdStrikeExecutorClient {
               .append(error.getMessage())
               .append(".");
         }
-        log.error(msg.toString());
-        return;
+        throw new ExecutorException(msg.toString(), CROWDSTRIKE_EXECUTOR_NAME);
       }
       if (auth.getAccess_token() == null || auth.getAccess_token().isBlank()) {
-        log.error(
+        throw new ExecutorException(
             "Crowdstrike authentication failed: no access token returned (expired or invalid"
-                + " credentials).");
-        return;
+                + " credentials).",
+            CROWDSTRIKE_EXECUTOR_NAME);
       }
       this.token = auth.getAccess_token();
       this.lastAuthentication = Instant.now();
     } catch (IOException e) {
       throw new ClientProtocolException("Unexpected response", e);
     }
+  }
+
+  private void throwIfCrowdStrikeErrors(
+      String endpoint, String context, List<CrowdstrikeError> errors, String traceId) {
+    if (errors == null || errors.isEmpty()) {
+      return;
+    }
+    StringBuilder message =
+        new StringBuilder(
+            "Crowdstrike API returned business errors for endpoint "
+                + endpoint
+                + " ("
+                + context
+                + ")");
+    if (traceId != null && !traceId.isBlank()) {
+      message.append(" [trace_id=").append(traceId).append("]");
+    }
+    for (CrowdstrikeError error : errors) {
+      message
+          .append("\nCode: ")
+          .append(error.getCode())
+          .append(", message: ")
+          .append(error.getMessage())
+          .append(".");
+    }
+    throw new ExecutorException(message.toString(), CROWDSTRIKE_EXECUTOR_NAME);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java
+++ b/openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java
@@ -95,7 +95,6 @@ public class CrowdStrikeExecutorClient {
     }
   }
 
-
   private ResourcesHosts getResourcesHosts(int offset, String hostGroup) {
     final String formattedDateTime =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")

--- a/openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java
+++ b/openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java
@@ -62,14 +62,15 @@ public class CrowdStrikeExecutorClient {
       int offset = 0;
       List<CrowdStrikeDevice> hosts = new ArrayList<>();
       ResourcesHosts partialResults = getResourcesHosts(offset, hostGroup);
-      if (partialResults.getErrors() != null && !partialResults.getErrors().isEmpty()) {
-        logErrors(partialResults.getErrors(), hostGroup);
+      throwIfCrowdStrikeErrors(
+          "devices",
+          "hostGroupId=" + hostGroup,
+          partialResults.getErrors(),
+          partialResults.getMeta() == null ? null : partialResults.getMeta().getTraceId());
+      if (partialResults.getResources() == null) {
         return hosts;
-      } else if (partialResults.getResources() == null) {
-        return hosts;
-      } else {
-        hosts.addAll(partialResults.getResources());
       }
+      hosts.addAll(partialResults.getResources());
       int numberOfExecution =
           Math.ceilDiv(
               partialResults.getMeta().getPagination().getTotal(),
@@ -77,11 +78,15 @@ public class CrowdStrikeExecutorClient {
       for (int callNumber = 1; callNumber < numberOfExecution; callNumber += 1) {
         offset += partialResults.getMeta().getPagination().getLimit();
         partialResults = getResourcesHosts(offset, hostGroup);
+        throwIfCrowdStrikeErrors(
+            "devices",
+            "hostGroupId=" + hostGroup + ", offset=" + offset,
+            partialResults.getErrors(),
+            partialResults.getMeta() == null ? null : partialResults.getMeta().getTraceId());
         if (partialResults.getResources() == null) {
           return hosts;
-        } else {
-          hosts.addAll(partialResults.getResources());
         }
+        hosts.addAll(partialResults.getResources());
       }
       return hosts;
     } catch (Exception e) {
@@ -90,21 +95,6 @@ public class CrowdStrikeExecutorClient {
     }
   }
 
-  private void logErrors(List<CrowdstrikeError> errors, String hostGroup) {
-    StringBuilder msg =
-        new StringBuilder(
-            "Error occurred while getting Crowdstrike devices API request for hostGroup id "
-                + hostGroup
-                + ".");
-    for (CrowdstrikeError error : errors) {
-      msg.append("\nCode: ")
-          .append(error.getCode())
-          .append(", message: ")
-          .append(error.getMessage())
-          .append(".");
-    }
-    log.error(msg.toString());
-  }
 
   private ResourcesHosts getResourcesHosts(int offset, String hostGroup) {
     final String formattedDateTime =

--- a/openaev-api/src/main/java/io/openaev/executors/crowdstrike/model/CrowdstrikeMeta.java
+++ b/openaev-api/src/main/java/io/openaev/executors/crowdstrike/model/CrowdstrikeMeta.java
@@ -1,11 +1,15 @@
 package io.openaev.executors.crowdstrike.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CrowdstrikeMeta {
+
+  @JsonProperty("trace_id")
+  private String traceId;
 
   private CrowdstrikePagination pagination;
 }

--- a/openaev-api/src/main/java/io/openaev/executors/crowdstrike/model/ResourcesGroups.java
+++ b/openaev-api/src/main/java/io/openaev/executors/crowdstrike/model/ResourcesGroups.java
@@ -9,5 +9,6 @@ import lombok.Data;
 public class ResourcesGroups {
 
   private List<CrowdStrikeHostGroup> resources;
+  private CrowdstrikeMeta meta;
   private List<CrowdstrikeError> errors;
 }


### PR DESCRIPTION
CrowdStrike integration errors were difficult to troubleshoot:
- non-JSON responses could lead to generic parsing errors (`Unexpected character '<' (code 60)`),
- valid JSON error payloads (e.g. `401 Unauthorized`) were parsed successfully but not treated as functional failures,
- `trace_id` returned by CrowdStrike support payloads was not surfaced in exception messages.

### What changed

#### `openaev-api/src/main/java/io/openaev/executors/crowdstrike/model/CrowdstrikeMeta.java`
- Added mapping for `trace_id` (`traceId`) to expose CrowdStrike support correlation id.

#### `openaev-api/src/main/java/io/openaev/executors/crowdstrike/model/ResourcesGroups.java`
- Added `meta` field so host-group responses can carry `trace_id`.

#### `openaev-api/src/main/java/io/openaev/executors/crowdstrike/client/CrowdStrikeExecutorClient.java`
- Added functional error guard `throwIfCrowdStrikeErrors(...)`.
- Updated `hostGroup(...)` to fail fast when CrowdStrike returns `errors[]`, including `trace_id` in the thrown message when available.
- Hardened `authenticate()`:
  - throw `ExecutorException` when authentication returns errors,
  - throw `ExecutorException` when access token is missing/blank,
  - removed silent `return` paths that allowed execution to continue with invalid auth state.

### Expected behavior after this change

- If CrowdStrike returns:
  ```json
  {
    "meta": {"trace_id":"..."},
    "errors":[{"code":401,"message":"Unauthorized..."}]
  }