### PR TITLE
fix(capability): allow csv export for users with asset role (#5805)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/PermissionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/PermissionService.java
@@ -37,7 +37,8 @@ public class PermissionService {
           ResourceType.ORGANIZATION,
           // INJECTOR is open for READ/SEARCH because multiple views (e.g. threat arsenal)
           // need to list injectors for filtering, and injector names are not sensitive.
-          ResourceType.INJECTOR);
+          ResourceType.INJECTOR,
+          ResourceType.MAPPER);
 
   private static final EnumSet<ResourceType> RESOURCES_MANAGED_BY_GRANTS =
       EnumSet.of(

--- a/openaev-model/src/main/java/io/openaev/database/model/Capability.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Capability.java
@@ -292,8 +292,6 @@ public enum Capability {
       pair(ResourceType.USER_GROUP, Action.SEARCH),
       pair(ResourceType.USER, Action.READ),
       pair(ResourceType.USER, Action.SEARCH),
-      pair(ResourceType.MAPPER, Action.READ),
-      pair(ResourceType.MAPPER, Action.SEARCH),
       pair(ResourceType.COLLECTOR, Action.READ),
       pair(ResourceType.COLLECTOR, Action.SEARCH),
       pair(ResourceType.INJECTOR, Action.READ),


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
  Add the Mapper capability as an open capability

### Testing Instructions

As an Admin:
- Navigate to Settings → Security → Roles
- Create a new role with the following capabilities enabled for Asset:
        - Access
        - Manage
        - Delete
- Navigate to Settings → Security → Groups
- Create a new group and assign the role created above to it
- Add a user to this group — ensure this user belongs only to this group

As the user in the newly created group:
- Navigate to Assets → Endpoints
- Click the Export CSV button

### Related issues
* Closes #5805 