### PR TITLE
fix(healthcheck): stop pinning DB connections during external dependency checks (#6837)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/health_check/HealthCheckApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/health_check/HealthCheckApi.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,7 +47,11 @@ public class HealthCheckApi extends RestBehavior {
   @Operation(
       summary = "Run an healthcheck ",
       description = "Tries to connect to dependencies (DB/Minio/RabbitMQ)")
-  @Transactional
+  // NOT_SUPPORTED: this endpoint performs external network I/O (RabbitMQ, MinIO). Opening a
+  // transaction here pins a Hikari connection for the whole request, which exhausts the pool
+  // when a dependency is slow (frequent LB probes x 30s+ waits). The DB check runs in its own
+  // short-lived repository transaction instead.
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
   @ApiResponses(
       value = {
         @ApiResponse(responseCode = "200", description = "Service is healthy"),

--- a/openaev-api/src/main/java/io/openaev/service/HealthCheckService.java
+++ b/openaev-api/src/main/java/io/openaev/service/HealthCheckService.java
@@ -55,7 +55,7 @@ public class HealthCheckService {
     MinioClient minioClient = minioDriver.getMinioClient();
     minioClient.setTimeout(2000L, 2000L, 2000L);
     try {
-      minioService.isTenantPathExists();
+      minioService.isTenantPathExists(minioClient);
     } catch (Exception e) {
       throw new HealthCheckFailureException("FileStorage check failure", e);
     }

--- a/openaev-api/src/test/java/io/openaev/service/HealthCheckServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/HealthCheckServiceTest.java
@@ -38,14 +38,14 @@ class HealthCheckServiceTest {
   void test_runFileStorageCheck() throws Exception {
     when(minioDriver.getMinioClient()).thenReturn(minioClient);
     healthCheckService.runFileStorageCheck();
-    verify(minioService).isTenantPathExists();
+    verify(minioService).isTenantPathExists(minioClient);
   }
 
   @DisplayName("Test runFileStorageCheck when check fails ")
   @Test
   void test_runFileStorageCheck_WHEN_client_throws_exception() throws Exception {
     when(minioDriver.getMinioClient()).thenReturn(minioClient);
-    doThrow(new IOException("test")).when(minioService).isTenantPathExists();
+    doThrow(new IOException("test")).when(minioService).isTenantPathExists(minioClient);
     assertThrows(
         HealthCheckFailureException.class,
         () -> {

--- a/openaev-model/src/main/java/io/openaev/service/MinioService.java
+++ b/openaev-model/src/main/java/io/openaev/service/MinioService.java
@@ -183,7 +183,15 @@ public class MinioService implements DependenciesManager {
   // -- HELPERS --
 
   public void isTenantPathExists() throws Exception {
-    minioClient.statObject(
+    isTenantPathExists(minioClient);
+  }
+
+  /**
+   * Same as {@link #isTenantPathExists()} but using the provided client, so callers (e.g. health
+   * checks) can use a client configured with short timeouts.
+   */
+  public void isTenantPathExists(MinioClient client) throws Exception {
+    client.statObject(
         StatObjectArgs.builder().bucket(bucket()).object(getTenantPath("")).build());
   }
 

--- a/openaev-model/src/main/java/io/openaev/service/MinioService.java
+++ b/openaev-model/src/main/java/io/openaev/service/MinioService.java
@@ -191,8 +191,7 @@ public class MinioService implements DependenciesManager {
    * checks) can use a client configured with short timeouts.
    */
   public void isTenantPathExists(MinioClient client) throws Exception {
-    client.statObject(
-        StatObjectArgs.builder().bucket(bucket()).object(getTenantPath("")).build());
+    client.statObject(StatObjectArgs.builder().bucket(bucket()).object(getTenantPath("")).build());
   }
 
   // -- PRIVATE --

--- a/openaev-model/src/main/java/io/openaev/service/RabbitmqService.java
+++ b/openaev-model/src/main/java/io/openaev/service/RabbitmqService.java
@@ -319,21 +319,34 @@ public class RabbitmqService {
     return cachedVersion;
   }
 
+  /** Cached factory for health check probes (thread-safe lazy initialization). */
+  private volatile ConnectionFactory healthCheckConnectionFactory;
+
   /**
    * Checks the health of the RabbitMQ broker by opening and immediately closing a connection and
    * channel.
    *
    * <p>Uses a dedicated {@link ConnectionFactory} with a short connection timeout instead of the
    * shared factory (default 60s timeout), so health probes fail fast when the broker is degraded
-   * and never pile up on request threads.
+   * and never pile up on request threads. The factory is created once and reused: with SSL enabled,
+   * factory creation loads the truststore from disk, which should not happen on every probe.
    *
    * @throws IOException if the broker is unreachable
    * @throws TimeoutException if the connection times out
    */
   public void checkHealth() throws IOException, TimeoutException {
-    ConnectionFactory healthCheckFactory = rabbitmqDriver.createConnectionFactory();
-    healthCheckFactory.setConnectionTimeout(HEALTH_CHECK_CONNECTION_TIMEOUT_MS);
-    try (Connection connection = healthCheckFactory.newConnection()) {
+    ConnectionFactory factory = this.healthCheckConnectionFactory;
+    if (factory == null) {
+      synchronized (this) {
+        factory = this.healthCheckConnectionFactory;
+        if (factory == null) {
+          factory = rabbitmqDriver.createConnectionFactory();
+          factory.setConnectionTimeout(HEALTH_CHECK_CONNECTION_TIMEOUT_MS);
+          this.healthCheckConnectionFactory = factory;
+        }
+      }
+    }
+    try (Connection connection = factory.newConnection()) {
       connection.createChannel().close();
     }
   }

--- a/openaev-model/src/main/java/io/openaev/service/RabbitmqService.java
+++ b/openaev-model/src/main/java/io/openaev/service/RabbitmqService.java
@@ -59,6 +59,9 @@ public class RabbitmqService {
   private static final String X_QUEUE_TYPE = "x-queue-type";
   private static final String INJECTOR_PREFIX = "_injector_";
 
+  /** Connection timeout for health check probes, so a degraded broker fails fast. */
+  private static final int HEALTH_CHECK_CONNECTION_TIMEOUT_MS = 5_000;
+
   private final RabbitmqConfig rabbitmqConfig;
   private final ConnectionFactory connectionFactory;
   private final RabbitmqDriver rabbitmqDriver;
@@ -320,11 +323,17 @@ public class RabbitmqService {
    * Checks the health of the RabbitMQ broker by opening and immediately closing a connection and
    * channel.
    *
+   * <p>Uses a dedicated {@link ConnectionFactory} with a short connection timeout instead of the
+   * shared factory (default 60s timeout), so health probes fail fast when the broker is degraded
+   * and never pile up on request threads.
+   *
    * @throws IOException if the broker is unreachable
    * @throws TimeoutException if the connection times out
    */
   public void checkHealth() throws IOException, TimeoutException {
-    try (Connection connection = connectionFactory.newConnection()) {
+    ConnectionFactory healthCheckFactory = rabbitmqDriver.createConnectionFactory();
+    healthCheckFactory.setConnectionTimeout(HEALTH_CHECK_CONNECTION_TIMEOUT_MS);
+    try (Connection connection = healthCheckFactory.newConnection()) {
       connection.createChannel().close();
     }
   }


### PR DESCRIPTION
## Proposed changes

Fixes the production outage where the Hikari pool (20 connections) is fully exhausted (active=20, waiting=70+) and the whole platform deadlocks, including Spring Session JDBC lookups.

Closes #6837

### Root cause

da5c70bfa (#6212 / #6229) added `@Transactional` to `HealthCheckApi.healthCheck()` (`GET /api/health`) as part of the blanket endpoint-transactional alignment. `JpaTransactionManager` acquires a pooled connection eagerly at transaction begin, so every health probe pins a DB connection while the endpoint performs external network I/O:

- RabbitMQ check uses the shared `ConnectionFactory` with the default 60s connection timeout.
- MinIO check builds a client with 2s timeouts but never uses it: `isTenantPathExists()` goes through the Spring-injected client with default timeouts.

When RabbitMQ or MinIO degrades, frequent LB/orchestrator probes each hold a DB connection for up to 60s+, exhausting the pool and taking the whole platform down.

### Changes

1. `HealthCheckApi.healthCheck()`: `@Transactional(propagation = Propagation.NOT_SUPPORTED)` - no transaction (and no pooled connection) is held during external checks; the DB check runs in its own short-lived repository transaction. Still satisfies the `EndpointTransactionalRule` annotation processor.
2. `RabbitmqService.checkHealth()`: dedicated `ConnectionFactory` with a 5s connection timeout so probes fail fast instead of hanging 60s. The factory is lazily created and cached (same pattern as `cachedVersion`), so the SSL truststore is not reloaded from disk on every probe (addresses the Copilot review comment); the shared factory is not mutated.
3. `MinioService.isTenantPathExists(MinioClient)` overload + `HealthCheckService.runFileStorageCheck()` now actually uses the 2s-timeout client that was previously created and discarded.
4. Updated `HealthCheckServiceTest` accordingly.

### Impact

- `GET /api/health` no longer consumes a Hikari connection for the duration of RabbitMQ/MinIO checks.
- Worst-case health probe latency drops from 60s+ (RabbitMQ default) / minutes (MinIO default) to ~5s / 2s.
- No behavior change for healthy dependencies: same checks, same 200/503 contract.

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (`HealthCheckServiceTest` passes locally; full API/E2E suites green on CI)
- [x] I added test cases to avoid regression (updated `HealthCheckServiceTest` verifies the short-timeout MinIO client is the one used)
- [ ] The change is described in the documentation (not needed - no config or API contract change)
