### PR TITLE
fix(i18n): correct Chinese translation of Exposure validation (#6848)

### DIFF
--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -1056,7 +1056,7 @@
   "Exposure command center": "暴露指挥中心",
   "Exposure score": "暴露评分",
   "Exposure score {score} / 100 - click to understand how it is computed": "暴露评分 {score} / 100 - 点击了解计算方式",
-  "Exposure validation": "暴面验证",
+  "Exposure validation": "暴露验证",
   "External": "外部",
   "External Id": "外部ID",
   "External ID": "外部ID",


### PR DESCRIPTION
## Summary

Follow-up to #6849 (merged while its last review pass was in flight): corrects the Chinese translation of the "Exposure validation" key from "????" to "????", matching every other exposure-related string in the catalog. Raised by the Copilot review on #6849. Relates to #6848.

## Test plan

- [x] yarn i18n-checker green (key present in all catalogs).
