### PR TITLE
fix(platform): stop pinning DB connections during simulation reset and fix kill chain phase upsert race (#6851)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260722080000000__Dedupe_kill_chain_phases_natural_key.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260722080000000__Dedupe_kill_chain_phases_natural_key.java
@@ -19,15 +19,15 @@ import org.springframework.stereotype.Component;
  * <p>Steps, all idempotent:
  *
  * <ol>
- *   <li>Repoint {@code attack_patterns_kill_chain_phases} links from duplicate phases to the
- *       oldest surviving row (dropping links that would collide with an existing one).
+ *   <li>Repoint {@code attack_patterns_kill_chain_phases} links from duplicate phases to the oldest
+ *       surviving row (insert-then-delete with ON CONFLICT DO NOTHING, so links that already exist
+ *       on the keeper are simply collapsed).
  *   <li>Delete the duplicate phase rows, keeping the oldest per natural key.
  *   <li>Add the unique constraint on the natural key.
  * </ol>
  */
 @Component
-public class V6_20260722080000000__Dedupe_kill_chain_phases_natural_key
-    extends BaseJavaMigration {
+public class V6_20260722080000000__Dedupe_kill_chain_phases_natural_key extends BaseJavaMigration {
 
   @Override
   public void migrate(Context context) throws Exception {
@@ -47,24 +47,22 @@ public class V6_20260722080000000__Dedupe_kill_chain_phases_natural_key
           """
           DELETE FROM tmp_kcp_duplicates WHERE duplicate_id = keeper_id;
           """);
-      // Drop attack pattern links that would collide with an existing keeper link...
+      // Repoint attack pattern links as insert-then-delete rather than UPDATE: an in-place
+      // UPDATE would break the (attack_pattern_id, phase_id) primary key whenever an attack
+      // pattern links to the keeper already, or to several duplicates of the same keeper.
+      // ON CONFLICT DO NOTHING collapses all those cases onto the single surviving link.
+      statement.execute(
+          """
+          INSERT INTO attack_patterns_kill_chain_phases (attack_pattern_id, phase_id)
+          SELECT DISTINCT apkcp.attack_pattern_id, dup.keeper_id
+          FROM attack_patterns_kill_chain_phases apkcp
+          JOIN tmp_kcp_duplicates dup ON apkcp.phase_id = dup.duplicate_id
+          ON CONFLICT DO NOTHING;
+          """);
       statement.execute(
           """
           DELETE FROM attack_patterns_kill_chain_phases apkcp
           USING tmp_kcp_duplicates dup
-          WHERE apkcp.phase_id = dup.duplicate_id
-            AND EXISTS (
-              SELECT 1 FROM attack_patterns_kill_chain_phases existing
-              WHERE existing.attack_pattern_id = apkcp.attack_pattern_id
-                AND existing.phase_id = dup.keeper_id
-            );
-          """);
-      // ...and repoint the remaining ones to the keeper.
-      statement.execute(
-          """
-          UPDATE attack_patterns_kill_chain_phases apkcp
-          SET phase_id = dup.keeper_id
-          FROM tmp_kcp_duplicates dup
           WHERE apkcp.phase_id = dup.duplicate_id;
           """);
       statement.execute(

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260722080000000__Dedupe_kill_chain_phases_natural_key.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260722080000000__Dedupe_kill_chain_phases_natural_key.java
@@ -1,0 +1,94 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deduplicates {@code kill_chain_phases} on the upsert natural key {@code (phase_kill_chain_name,
+ * phase_shortname, tenant_id)} and enforces it with a unique constraint.
+ *
+ * <p>The collector upsert endpoint resolves existing phases by (kill chain name, short name), but
+ * until now the database only enforced uniqueness on (phase_name, ...) and (phase_stix_id, ...).
+ * Concurrent collector upserts right after startup (MITRE Enterprise / Mobile / ICS calling {@code
+ * /api/kill_chain_phases/upsert} at the same time) could insert the same phase twice, producing
+ * either {@code kill_chain_phases_stix_id_tenant_unique} violations (seen in production for the new
+ * ATT&CK "Stealth" tactic) or duplicate rows that make the natural-key lookup non-deterministic.
+ *
+ * <p>Steps, all idempotent:
+ *
+ * <ol>
+ *   <li>Repoint {@code attack_patterns_kill_chain_phases} links from duplicate phases to the
+ *       oldest surviving row (dropping links that would collide with an existing one).
+ *   <li>Delete the duplicate phase rows, keeping the oldest per natural key.
+ *   <li>Add the unique constraint on the natural key.
+ * </ol>
+ */
+@Component
+public class V6_20260722080000000__Dedupe_kill_chain_phases_natural_key
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // Map every duplicate phase to the oldest row sharing its natural key.
+      statement.execute(
+          """
+          CREATE TEMPORARY TABLE tmp_kcp_duplicates ON COMMIT DROP AS
+          SELECT phase_id AS duplicate_id,
+                 FIRST_VALUE(phase_id) OVER (
+                   PARTITION BY phase_kill_chain_name, phase_shortname, tenant_id
+                   ORDER BY phase_created_at ASC, phase_id ASC
+                 ) AS keeper_id
+          FROM kill_chain_phases;
+          """);
+      statement.execute(
+          """
+          DELETE FROM tmp_kcp_duplicates WHERE duplicate_id = keeper_id;
+          """);
+      // Drop attack pattern links that would collide with an existing keeper link...
+      statement.execute(
+          """
+          DELETE FROM attack_patterns_kill_chain_phases apkcp
+          USING tmp_kcp_duplicates dup
+          WHERE apkcp.phase_id = dup.duplicate_id
+            AND EXISTS (
+              SELECT 1 FROM attack_patterns_kill_chain_phases existing
+              WHERE existing.attack_pattern_id = apkcp.attack_pattern_id
+                AND existing.phase_id = dup.keeper_id
+            );
+          """);
+      // ...and repoint the remaining ones to the keeper.
+      statement.execute(
+          """
+          UPDATE attack_patterns_kill_chain_phases apkcp
+          SET phase_id = dup.keeper_id
+          FROM tmp_kcp_duplicates dup
+          WHERE apkcp.phase_id = dup.duplicate_id;
+          """);
+      statement.execute(
+          """
+          DELETE FROM kill_chain_phases kcp
+          USING tmp_kcp_duplicates dup
+          WHERE kcp.phase_id = dup.duplicate_id;
+          """);
+      // Enforce the natural key used by the upsert lookup. Guarded for idempotency:
+      // ADD CONSTRAINT has no IF NOT EXISTS in PostgreSQL.
+      statement.execute(
+          """
+          DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'kill_chain_phases_shortname_tenant_unique'
+            ) THEN
+              ALTER TABLE kill_chain_phases
+                ADD CONSTRAINT kill_chain_phases_shortname_tenant_unique
+                UNIQUE (phase_kill_chain_name, phase_shortname, tenant_id);
+            END IF;
+          END $$;
+          """);
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260722090000000__Remap_legacy_payload_argument_types.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260722090000000__Remap_legacy_payload_argument_types.java
@@ -30,10 +30,11 @@ import org.springframework.stereotype.Component;
  * the primitive that carries its main scalar projection.
  *
  * <p>Execution is batched to stay production-safe on large tables ({@code injects_statuses} can
- * hold millions of rows): the affected row ids are collected first with a read-only scan, then
- * rewritten in chunks of {@value #BATCH_SIZE} ids. The migration runs OUTSIDE a wrapping Flyway
- * transaction ({@link #canExecuteInTransaction()} returns false) so each chunked UPDATE commits on
- * its own and row locks / WAL churn stay bounded instead of accumulating in one long transaction.
+ * hold millions of rows): each iteration selects the next {@value #BATCH_SIZE} affected row ids
+ * (LIMIT page, no full id materialization in memory) and rewrites just those. The migration runs
+ * OUTSIDE a wrapping Flyway transaction ({@link #canExecuteInTransaction()} returns false) so each
+ * chunked UPDATE commits on its own and row locks / WAL churn stay bounded instead of accumulating
+ * in one long transaction.
  *
  * <p>Idempotent: the UPDATEs only match rows that still contain a legacy label; after the first run
  * (or an interrupted partial run) only the remaining rows are picked up again.
@@ -162,22 +163,28 @@ public class V6_20260722090000000__Remap_legacy_payload_argument_types extends B
   }
 
   /**
-   * Collects the ids of the rows still holding legacy labels, then applies the rewrite in chunks of
-   * {@value #BATCH_SIZE} ids so each UPDATE stays short-lived. The connection is in autocommit
-   * (non-transactional migration), so every chunk releases its row locks immediately.
+   * Applies the rewrite in chunks of {@value #BATCH_SIZE} ids so each UPDATE stays short-lived,
+   * without ever materializing the full id set in memory: each iteration selects the next {@value
+   * #BATCH_SIZE} rows still holding a legacy label (LIMIT page), rewrites them, and loops until the
+   * select comes back empty. No OFFSET is needed because the UPDATE removes the legacy labels, so
+   * processed rows stop matching the predicate. The connection is in autocommit (non-transactional
+   * migration), so every chunk releases its row locks immediately.
    */
   private void updateInBatches(Connection connection, String selectSql, String updateSql)
       throws SQLException {
-    List<String> ids = new ArrayList<>();
+    String pagedSelectSql = selectSql + " LIMIT " + BATCH_SIZE;
     try (Statement select = connection.createStatement();
-        ResultSet results = select.executeQuery(selectSql)) {
-      while (results.next()) {
-        ids.add(results.getString(1));
-      }
-    }
-    try (PreparedStatement update = connection.prepareStatement(updateSql)) {
-      for (int from = 0; from < ids.size(); from += BATCH_SIZE) {
-        List<String> chunk = ids.subList(from, Math.min(from + BATCH_SIZE, ids.size()));
+        PreparedStatement update = connection.prepareStatement(updateSql)) {
+      while (true) {
+        List<String> chunk = new ArrayList<>(BATCH_SIZE);
+        try (ResultSet results = select.executeQuery(pagedSelectSql)) {
+          while (results.next()) {
+            chunk.add(results.getString(1));
+          }
+        }
+        if (chunk.isEmpty()) {
+          return;
+        }
         update.setArray(1, connection.createArrayOf("varchar", chunk.toArray()));
         update.executeUpdate();
       }

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260722090000000__Remap_legacy_payload_argument_types.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260722090000000__Remap_legacy_payload_argument_types.java
@@ -1,0 +1,148 @@
+package io.openaev.migration;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Remaps legacy {@code ArgumentType} labels still stored in payload argument JSON to their {@code
+ * PrimitiveType} replacement.
+ *
+ * <p>Root cause: the chaining refactor (#6536) replaced the {@code ArgumentType} enum (labels such
+ * as {@code credentials}, {@code portscan}, {@code share}, ...) with {@code PrimitiveType}, which
+ * does not define most of those labels. The accompanying migration ({@code V6_20260720178453597})
+ * only stripped the {@code subtype} key - it never rewrote the {@code type} values. Every payload
+ * created before the refactor with a complex argument type therefore became unreadable: Jackson
+ * fails to map e.g. {@code "credentials"} to {@code PrimitiveType}, hypersistence's {@code
+ * JsonType} fallback rethrows as "cannot be transformed to Json object", and the whole entity load
+ * fails. In production this broke injector execution and trace logging for payloads such as NetExec
+ * (arguments {@code client_id: credentials} / {@code ip: targeted-asset}).
+ *
+ * <p>The mapping below mirrors {@code PrimitiveType.LEGACY_ARGUMENT_TYPE_LABELS} (which keeps reads
+ * tolerant for data written between deploy and migration): each legacy complex type is mapped to
+ * the primitive that carries its main scalar projection.
+ *
+ * <p>Idempotent: the UPDATE only matches rows that still contain a legacy label; after the first
+ * run there are none left.
+ */
+@Component
+public class V6_20260722090000000__Remap_legacy_payload_argument_types extends BaseJavaMigration {
+
+  private static final String[][] LEGACY_TO_PRIMITIVE = {
+    {"credentials", "username"},
+    {"portscan", "port"},
+    {"share", "share_name"},
+    {"admin_username", "username"},
+    {"group", "text"},
+    {"computer", "hostname"},
+    {"password_policy", "text"},
+    {"delegation", "text"},
+    {"sid", "text"},
+    {"vulnerability", "cve"},
+    {"account_with_password_not_required", "username"},
+    {"asreproastable_account", "username"},
+    {"kerberoastable_account", "username"}
+  };
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    String caseExpression = buildCaseExpression("argument ->> 'type'");
+    String legacyLabelList = buildLegacyLabelList();
+
+    try (Statement stmt = context.getConnection().createStatement()) {
+      remapPayloadArguments(stmt, caseExpression, legacyLabelList);
+      remapStatusPayloadOutput(stmt, caseExpression, legacyLabelList);
+    }
+  }
+
+  /** Rewrites legacy labels inside {@code payloads.payload_arguments} (json array column). */
+  private void remapPayloadArguments(Statement stmt, String caseExpression, String legacyLabelList)
+      throws SQLException {
+    stmt.execute(
+        String.format(
+            """
+            UPDATE payloads
+            SET payload_arguments = (
+              SELECT COALESCE(
+                jsonb_agg(
+                  CASE
+                    WHEN argument ->> 'type' IN (%2$s)
+                    THEN jsonb_set(argument, '{type}', to_jsonb(%1$s))
+                    ELSE argument
+                  END
+                ),
+                '[]'::jsonb
+              )::json
+              FROM jsonb_array_elements(payload_arguments::jsonb) argument
+            )
+            WHERE payload_arguments IS NOT NULL
+              AND json_typeof(payload_arguments) = 'array'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(payload_arguments::jsonb) argument
+                WHERE argument ->> 'type' IN (%2$s)
+              );
+            """,
+            caseExpression, legacyLabelList));
+  }
+
+  /**
+   * Rewrites legacy labels inside {@code injects_statuses.status_payload_output ->
+   * payload_arguments} (json object column embedding an argument array).
+   */
+  private void remapStatusPayloadOutput(
+      Statement stmt, String caseExpression, String legacyLabelList) throws SQLException {
+    stmt.execute(
+        String.format(
+            """
+            UPDATE injects_statuses
+            SET status_payload_output = jsonb_set(
+              status_payload_output::jsonb,
+              '{payload_arguments}',
+              (
+                SELECT COALESCE(
+                  jsonb_agg(
+                    CASE
+                      WHEN argument ->> 'type' IN (%2$s)
+                      THEN jsonb_set(argument, '{type}', to_jsonb(%1$s))
+                      ELSE argument
+                    END
+                  ),
+                  '[]'::jsonb
+                )
+                FROM jsonb_array_elements(status_payload_output::jsonb -> 'payload_arguments') argument
+              )
+            )::json
+            WHERE status_payload_output IS NOT NULL
+              AND jsonb_typeof(status_payload_output::jsonb -> 'payload_arguments') = 'array'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(status_payload_output::jsonb -> 'payload_arguments') argument
+                WHERE argument ->> 'type' IN (%2$s)
+              );
+            """,
+            caseExpression, legacyLabelList));
+  }
+
+  private String buildCaseExpression(String typeAccessor) {
+    StringBuilder sb = new StringBuilder("CASE ").append(typeAccessor);
+    for (String[] mapping : LEGACY_TO_PRIMITIVE) {
+      sb.append(" WHEN '").append(mapping[0]).append("' THEN '").append(mapping[1]).append("'");
+    }
+    sb.append(" END");
+    return sb.toString();
+  }
+
+  private String buildLegacyLabelList() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < LEGACY_TO_PRIMITIVE.length; i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("'").append(LEGACY_TO_PRIMITIVE[i][0]).append("'");
+    }
+    return sb.toString();
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260722090000000__Remap_legacy_payload_argument_types.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260722090000000__Remap_legacy_payload_argument_types.java
@@ -1,7 +1,12 @@
 package io.openaev.migration;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 import org.springframework.stereotype.Component;
@@ -24,11 +29,19 @@ import org.springframework.stereotype.Component;
  * tolerant for data written between deploy and migration): each legacy complex type is mapped to
  * the primitive that carries its main scalar projection.
  *
- * <p>Idempotent: the UPDATE only matches rows that still contain a legacy label; after the first
- * run there are none left.
+ * <p>Execution is batched to stay production-safe on large tables ({@code injects_statuses} can
+ * hold millions of rows): the affected row ids are collected first with a read-only scan, then
+ * rewritten in chunks of {@value #BATCH_SIZE} ids. The migration runs OUTSIDE a wrapping Flyway
+ * transaction ({@link #canExecuteInTransaction()} returns false) so each chunked UPDATE commits on
+ * its own and row locks / WAL churn stay bounded instead of accumulating in one long transaction.
+ *
+ * <p>Idempotent: the UPDATEs only match rows that still contain a legacy label; after the first run
+ * (or an interrupted partial run) only the remaining rows are picked up again.
  */
 @Component
 public class V6_20260722090000000__Remap_legacy_payload_argument_types extends BaseJavaMigration {
+
+  private static final int BATCH_SIZE = 1000;
 
   private static final String[][] LEGACY_TO_PRIMITIVE = {
     {"credentials", "username"},
@@ -46,21 +59,36 @@ public class V6_20260722090000000__Remap_legacy_payload_argument_types extends B
     {"kerberoastable_account", "username"}
   };
 
+  /** No wrapping transaction: each chunked UPDATE commits on its own to keep locks bounded. */
+  @Override
+  public boolean canExecuteInTransaction() {
+    return false;
+  }
+
   @Override
   public void migrate(Context context) throws Exception {
-    String caseExpression = buildCaseExpression("argument ->> 'type'");
-    String legacyLabelList = buildLegacyLabelList();
-
-    try (Statement stmt = context.getConnection().createStatement()) {
-      remapPayloadArguments(stmt, caseExpression, legacyLabelList);
-      remapStatusPayloadOutput(stmt, caseExpression, legacyLabelList);
-    }
+    Connection connection = context.getConnection();
+    remapPayloadArguments(connection);
+    remapStatusPayloadOutput(connection);
   }
 
   /** Rewrites legacy labels inside {@code payloads.payload_arguments} (json array column). */
-  private void remapPayloadArguments(Statement stmt, String caseExpression, String legacyLabelList)
-      throws SQLException {
-    stmt.execute(
+  private void remapPayloadArguments(Connection connection) throws SQLException {
+    String selectSql =
+        String.format(
+            """
+            SELECT payload_id
+            FROM payloads
+            WHERE payload_arguments IS NOT NULL
+              AND json_typeof(payload_arguments) = 'array'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(payload_arguments::jsonb) argument
+                WHERE argument ->> 'type' IN (%s)
+              )
+            """,
+            buildLegacyLabelList());
+    String updateSql =
         String.format(
             """
             UPDATE payloads
@@ -77,24 +105,34 @@ public class V6_20260722090000000__Remap_legacy_payload_argument_types extends B
               )::json
               FROM jsonb_array_elements(payload_arguments::jsonb) argument
             )
-            WHERE payload_arguments IS NOT NULL
+            WHERE payload_id = ANY (?)
+              AND payload_arguments IS NOT NULL
               AND json_typeof(payload_arguments) = 'array'
-              AND EXISTS (
-                SELECT 1
-                FROM jsonb_array_elements(payload_arguments::jsonb) argument
-                WHERE argument ->> 'type' IN (%2$s)
-              );
             """,
-            caseExpression, legacyLabelList));
+            buildCaseExpression("argument ->> 'type'"), buildLegacyLabelList());
+    updateInBatches(connection, selectSql, updateSql);
   }
 
   /**
    * Rewrites legacy labels inside {@code injects_statuses.status_payload_output ->
    * payload_arguments} (json object column embedding an argument array).
    */
-  private void remapStatusPayloadOutput(
-      Statement stmt, String caseExpression, String legacyLabelList) throws SQLException {
-    stmt.execute(
+  private void remapStatusPayloadOutput(Connection connection) throws SQLException {
+    String selectSql =
+        String.format(
+            """
+            SELECT status_id
+            FROM injects_statuses
+            WHERE status_payload_output IS NOT NULL
+              AND jsonb_typeof(status_payload_output::jsonb -> 'payload_arguments') = 'array'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(status_payload_output::jsonb -> 'payload_arguments') argument
+                WHERE argument ->> 'type' IN (%s)
+              )
+            """,
+            buildLegacyLabelList());
+    String updateSql =
         String.format(
             """
             UPDATE injects_statuses
@@ -115,15 +153,35 @@ public class V6_20260722090000000__Remap_legacy_payload_argument_types extends B
                 FROM jsonb_array_elements(status_payload_output::jsonb -> 'payload_arguments') argument
               )
             )::json
-            WHERE status_payload_output IS NOT NULL
+            WHERE status_id = ANY (?)
+              AND status_payload_output IS NOT NULL
               AND jsonb_typeof(status_payload_output::jsonb -> 'payload_arguments') = 'array'
-              AND EXISTS (
-                SELECT 1
-                FROM jsonb_array_elements(status_payload_output::jsonb -> 'payload_arguments') argument
-                WHERE argument ->> 'type' IN (%2$s)
-              );
             """,
-            caseExpression, legacyLabelList));
+            buildCaseExpression("argument ->> 'type'"), buildLegacyLabelList());
+    updateInBatches(connection, selectSql, updateSql);
+  }
+
+  /**
+   * Collects the ids of the rows still holding legacy labels, then applies the rewrite in chunks of
+   * {@value #BATCH_SIZE} ids so each UPDATE stays short-lived. The connection is in autocommit
+   * (non-transactional migration), so every chunk releases its row locks immediately.
+   */
+  private void updateInBatches(Connection connection, String selectSql, String updateSql)
+      throws SQLException {
+    List<String> ids = new ArrayList<>();
+    try (Statement select = connection.createStatement();
+        ResultSet results = select.executeQuery(selectSql)) {
+      while (results.next()) {
+        ids.add(results.getString(1));
+      }
+    }
+    try (PreparedStatement update = connection.prepareStatement(updateSql)) {
+      for (int from = 0; from < ids.size(); from += BATCH_SIZE) {
+        List<String> chunk = ids.subList(from, Math.min(from + BATCH_SIZE, ids.size()));
+        update.setArray(1, connection.createArrayOf("varchar", chunk.toArray()));
+        update.executeUpdate();
+      }
+    }
   }
 
   private String buildCaseExpression(String typeAccessor) {

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -625,8 +625,22 @@ public class ExerciseService {
       entityManager.clear();
       // Reload exercise after clearing entity manager to avoid detached entity issues
       exercise = this.exercise(exerciseId);
-      // Delete exercise transient files (communications, ...)
-      fileService.deleteDirectory(exerciseId);
+      // Delete exercise transient files (communications, ...) AFTER commit: this is an external
+      // MinIO/S3 call. Running it inside the transaction pinned the DB connection and every row
+      // lock taken by the deletes above for the whole duration of the object-storage roundtrips,
+      // which starved the Hikari pool platform-wide when storage was slow (simulation reset
+      // outage). Also avoids deleting files if the transaction ends up rolling back.
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              try {
+                fileService.deleteDirectory(exerciseId);
+              } catch (Exception e) {
+                log.error("Failed to delete directory for exercise {}", exerciseId, e);
+              }
+            }
+          });
       if (previewFeatureService.isFeatureEnabled(PreviewFeature.INJECT_CHAINING)
           && workflowService.isSimulationChaining(exercise.getId())) {
         // DELETE workflow states

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/KillChainPhaseApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/KillChainPhaseApi.java
@@ -15,29 +15,33 @@ import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.kill_chain_phase.form.KillChainPhaseCreateInput;
 import io.openaev.rest.kill_chain_phase.form.KillChainPhaseUpdateInput;
 import io.openaev.rest.kill_chain_phase.form.KillChainPhaseUpsertInput;
+import io.openaev.rest.kill_chain_phase.service.KillChainPhaseService;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.validation.Valid;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping({KillChainPhaseApi.KILL_CHAIN_PHASE_URI, TENANT_PREFIX + "/kill_chain_phases"})
 public class KillChainPhaseApi extends RestBehavior {
 
   public static final String KILL_CHAIN_PHASE_URI = "/api/kill_chain_phases";
 
   private final KillChainPhaseRepository killChainPhaseRepository;
+  private final KillChainPhaseService killChainPhaseService;
 
   @GetMapping
   @Transactional
@@ -96,48 +100,28 @@ public class KillChainPhaseApi extends RestBehavior {
     return killChainPhaseRepository.save(killChainPhase);
   }
 
+  /**
+   * Race-safe upsert. Several collectors (MITRE Enterprise / Mobile / ICS, Atlas...) call this
+   * endpoint concurrently right after platform startup; two threads can both miss the lookup for a
+   * brand new phase and both insert it, so the loser fails on the {@code
+   * kill_chain_phases_stix_id_tenant_unique} constraint. The losing transaction is fully rolled
+   * back, therefore a single retry in a fresh transaction sees the winner's committed row and
+   * updates it instead of inserting. {@code NOT_SUPPORTED} keeps this endpoint outside any
+   * transaction: each service call must run in its own transaction for the retry to work.
+   */
   @PostMapping("/upsert")
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.KILL_CHAIN_PHASE)
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
   public Iterable<KillChainPhase> upsertKillChainPhases(
       @Valid @RequestBody KillChainPhaseUpsertInput input) {
-    List<KillChainPhase> upserted = new ArrayList<>();
-    List<KillChainPhaseCreateInput> inputKillChainPhases = input.getKillChainPhases();
-    inputKillChainPhases.forEach(
-        killChainPhaseCreateInput -> {
-          String killChainName = killChainPhaseCreateInput.getKillChainName();
-          String shortName = killChainPhaseCreateInput.getShortName();
-          Optional<KillChainPhase> optionalKillChainPhase =
-              killChainPhaseRepository.findByKillChainNameAndShortName(killChainName, shortName);
-          if (optionalKillChainPhase.isEmpty()) {
-            KillChainPhase newKillChainPhase = new KillChainPhase();
-            newKillChainPhase.setKillChainName(killChainName);
-            newKillChainPhase.setStixId(killChainPhaseCreateInput.getStixId());
-            newKillChainPhase.setExternalId(killChainPhaseCreateInput.getExternalId());
-            newKillChainPhase.setShortName(shortName);
-            newKillChainPhase.setName(killChainPhaseCreateInput.getName());
-            newKillChainPhase.setDescription(killChainPhaseCreateInput.getDescription());
-            // Honor an explicit, non-zero order from the input (used by importers that know their
-            // own
-            // matrix ordering, e.g. MITRE ATLAS); otherwise resolve the canonical order from the
-            // kill chain name + short name (mitre-attack or mitre-atlas).
-            Long inputOrder = killChainPhaseCreateInput.getOrder();
-            newKillChainPhase.setOrder(
-                inputOrder != null && inputOrder != 0L
-                    ? inputOrder
-                    : KillChainPhaseUtils.orderFor(killChainName, shortName));
-            upserted.add(newKillChainPhase);
-          } else {
-            KillChainPhase killChainPhase = optionalKillChainPhase.get();
-            killChainPhase.setStixId(killChainPhaseCreateInput.getStixId());
-            killChainPhase.setShortName(killChainPhaseCreateInput.getShortName());
-            killChainPhase.setName(killChainPhaseCreateInput.getName());
-            killChainPhase.setExternalId(killChainPhaseCreateInput.getExternalId());
-            killChainPhase.setDescription(killChainPhaseCreateInput.getDescription());
-            upserted.add(killChainPhase);
-          }
-        });
-    return this.killChainPhaseRepository.saveAll(upserted);
+    try {
+      return killChainPhaseService.upsertKillChainPhases(input.getKillChainPhases());
+    } catch (DataIntegrityViolationException e) {
+      log.warn(
+          "Kill chain phase upsert lost a concurrent-insert race, retrying once: {}",
+          e.getMessage());
+      return killChainPhaseService.upsertKillChainPhases(input.getKillChainPhases());
+    }
   }
 
   @DeleteMapping("/{killChainPhaseId}")

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/KillChainPhaseApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/KillChainPhaseApi.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -117,11 +118,25 @@ public class KillChainPhaseApi extends RestBehavior {
     try {
       return killChainPhaseService.upsertKillChainPhases(input.getKillChainPhases());
     } catch (DataIntegrityViolationException e) {
+      if (!isKillChainPhaseUniqueViolation(e)) {
+        throw e;
+      }
       log.warn(
           "Kill chain phase upsert lost a concurrent-insert race, retrying once: {}",
           e.getMessage());
       return killChainPhaseService.upsertKillChainPhases(input.getKillChainPhases());
     }
+  }
+
+  /**
+   * Only a duplicate-key violation on one of the kill_chain_phases unique constraints is a
+   * concurrent-insert race worth retrying; any other integrity failure (not-null, foreign key...)
+   * would fail again identically and must propagate immediately.
+   */
+  private static boolean isKillChainPhaseUniqueViolation(DataIntegrityViolationException e) {
+    return e.getCause() instanceof ConstraintViolationException constraintViolation
+        && constraintViolation.getConstraintName() != null
+        && constraintViolation.getConstraintName().startsWith("kill_chain_phases_");
   }
 
   @DeleteMapping("/{killChainPhaseId}")

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseCreateInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseCreateInput.java
@@ -26,6 +26,9 @@ public class KillChainPhaseCreateInput {
   @JsonProperty("phase_stix_id")
   private String stixId;
 
+  // The entity is @NotBlank and the frontend form already treats it as required: validating here
+  // fails fast with a 400 instead of a late entity-validation failure at flush time.
+  @NotBlank(message = MANDATORY_MESSAGE)
   @JsonProperty("phase_external_id")
   private String externalId;
 

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseUpsertInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseUpsertInput.java
@@ -2,6 +2,7 @@ package io.openaev.rest.kill_chain_phase.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,7 +10,10 @@ public class KillChainPhaseUpsertInput {
 
   // @Valid cascades validation to each item: without it, blank kill chain / short names would
   // slip through and NPE in the upsert in-batch key building instead of returning a 400.
+  // @NotNull rejects an explicit "kill_chain_phases": null (the setter would overwrite the
+  // default empty list) with a 400 instead of an NPE downstream.
   @Valid
+  @NotNull
   @JsonProperty("kill_chain_phases")
   private List<KillChainPhaseCreateInput> killChainPhases = new ArrayList<>();
 

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseUpsertInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseUpsertInput.java
@@ -10,12 +10,13 @@ public class KillChainPhaseUpsertInput {
 
   // @Valid cascades validation to each item: without it, blank kill chain / short names would
   // slip through and NPE in the upsert in-batch key building instead of returning a 400.
-  // @NotNull rejects an explicit "kill_chain_phases": null (the setter would overwrite the
-  // default empty list) with a 400 instead of an NPE downstream.
+  // @NotNull on the field rejects an explicit "kill_chain_phases": null (the setter would
+  // overwrite the default empty list); @NotNull on the element rejects null entries ([null]).
+  // Both would otherwise NPE downstream instead of returning a 400.
   @Valid
   @NotNull
   @JsonProperty("kill_chain_phases")
-  private List<KillChainPhaseCreateInput> killChainPhases = new ArrayList<>();
+  private List<@NotNull KillChainPhaseCreateInput> killChainPhases = new ArrayList<>();
 
   public List<KillChainPhaseCreateInput> getKillChainPhases() {
     return killChainPhases;

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseUpsertInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/form/KillChainPhaseUpsertInput.java
@@ -1,11 +1,15 @@
 package io.openaev.rest.kill_chain_phase.form;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
 
 public class KillChainPhaseUpsertInput {
 
+  // @Valid cascades validation to each item: without it, blank kill chain / short names would
+  // slip through and NPE in the upsert in-batch key building instead of returning a 400.
+  @Valid
   @JsonProperty("kill_chain_phases")
   private List<KillChainPhaseCreateInput> killChainPhases = new ArrayList<>();
 

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/service/KillChainPhaseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/service/KillChainPhaseService.java
@@ -6,10 +6,13 @@ import io.openaev.helper.StreamHelper;
 import io.openaev.rest.kill_chain_phase.KillChainPhaseUtils;
 import io.openaev.rest.kill_chain_phase.form.KillChainPhaseCreateInput;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,30 +38,49 @@ public class KillChainPhaseService {
    */
   @Transactional(rollbackFor = Exception.class)
   public List<KillChainPhase> upsertKillChainPhases(List<KillChainPhaseCreateInput> inputs) {
-    // LinkedHashMap keeps collector ordering; the key collapses duplicates within the batch.
-    Map<String, KillChainPhase> phasesByKey = new LinkedHashMap<>();
+    // In-batch de-duplication tracks pending entities under BOTH unique keys the database
+    // enforces (STIX id and natural key). Keying on a single one is not enough: the same phase
+    // can appear once with a STIX id and once without, or two entries can share a STIX id under
+    // different natural keys — either way a single-key map would create two entities and
+    // deterministically violate a constraint at flush, which no retry can fix.
+    Map<String, KillChainPhase> byNaturalKey = new LinkedHashMap<>();
+    Map<String, KillChainPhase> byStixId = new LinkedHashMap<>();
     for (KillChainPhaseCreateInput input : inputs) {
-      String key = dedupeKey(input);
-      KillChainPhase phase = phasesByKey.get(key);
+      String naturalKey = naturalKey(input);
+      String stixId = normalizedStixId(input);
+      KillChainPhase phase = byNaturalKey.get(naturalKey);
+      if (phase == null && stixId != null) {
+        phase = byStixId.get(stixId);
+      }
       if (phase == null) {
         phase = resolveExisting(input).orElseGet(KillChainPhase::new);
-        phasesByKey.put(key, phase);
       }
       apply(phase, input);
+      byNaturalKey.put(naturalKey, phase);
+      if (stixId != null) {
+        byStixId.put(stixId, phase);
+      }
     }
-    return StreamHelper.fromIterable(killChainPhaseRepository.saveAll(phasesByKey.values()));
+    // The same entity instance can be registered under several natural keys when entries share
+    // a STIX id, but it must only be persisted once. Identity-based de-duplication on purpose:
+    // KillChainPhase#equals dereferences the id, which is still null for new entities.
+    Set<KillChainPhase> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+    List<KillChainPhase> phases = byNaturalKey.values().stream().filter(seen::add).toList();
+    return StreamHelper.fromIterable(killChainPhaseRepository.saveAll(phases));
   }
 
-  private String dedupeKey(KillChainPhaseCreateInput input) {
-    if (input.getStixId() != null && !input.getStixId().isBlank()) {
-      return "stix:" + input.getStixId();
-    }
-    return "name:" + input.getKillChainName() + "|" + input.getShortName();
+  private String naturalKey(KillChainPhaseCreateInput input) {
+    return input.getKillChainName() + "|" + input.getShortName();
+  }
+
+  private String normalizedStixId(KillChainPhaseCreateInput input) {
+    return input.getStixId() != null && !input.getStixId().isBlank() ? input.getStixId() : null;
   }
 
   private Optional<KillChainPhase> resolveExisting(KillChainPhaseCreateInput input) {
-    if (input.getStixId() != null && !input.getStixId().isBlank()) {
-      Optional<KillChainPhase> byStixId = killChainPhaseRepository.findByStixId(input.getStixId());
+    String stixId = normalizedStixId(input);
+    if (stixId != null) {
+      Optional<KillChainPhase> byStixId = killChainPhaseRepository.findByStixId(stixId);
       if (byStixId.isPresent()) {
         return byStixId;
       }
@@ -70,7 +92,12 @@ public class KillChainPhaseService {
   private void apply(KillChainPhase phase, KillChainPhaseCreateInput input) {
     boolean isNew = phase.getId() == null;
     phase.setKillChainName(input.getKillChainName());
-    phase.setStixId(input.getStixId());
+    // Never clobber a known STIX id with null: entries without a STIX id can target the same
+    // phase as entries with one, and the STIX id is part of the database unique key.
+    String stixId = normalizedStixId(input);
+    if (stixId != null) {
+      phase.setStixId(stixId);
+    }
     phase.setExternalId(input.getExternalId());
     phase.setShortName(input.getShortName());
     phase.setName(input.getName());

--- a/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/service/KillChainPhaseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/kill_chain_phase/service/KillChainPhaseService.java
@@ -1,0 +1,91 @@
+package io.openaev.rest.kill_chain_phase.service;
+
+import io.openaev.database.model.KillChainPhase;
+import io.openaev.database.repository.KillChainPhaseRepository;
+import io.openaev.helper.StreamHelper;
+import io.openaev.rest.kill_chain_phase.KillChainPhaseUtils;
+import io.openaev.rest.kill_chain_phase.form.KillChainPhaseCreateInput;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class KillChainPhaseService {
+
+  private final KillChainPhaseRepository killChainPhaseRepository;
+
+  /**
+   * Upserts a batch of kill chain phases.
+   *
+   * <p>The database unique key is {@code (phase_stix_id, tenant_id)} while collectors identify
+   * phases by {@code (kill chain name, short name)}. To stay consistent with both, an existing
+   * phase is resolved by STIX id first and by natural key as a fallback. The input batch is also
+   * de-duplicated: MITRE bundles can reference the same tactic several times (one per matrix), and
+   * persisting two new entities with the same STIX id in one flush violates the constraint.
+   *
+   * <p>This method is intentionally NOT retried internally (self-invocation would bypass the
+   * transactional proxy): on a concurrent-insert constraint violation the whole transaction is
+   * rolled back and the endpoint retries once in a fresh transaction.
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public List<KillChainPhase> upsertKillChainPhases(List<KillChainPhaseCreateInput> inputs) {
+    // LinkedHashMap keeps collector ordering; the key collapses duplicates within the batch.
+    Map<String, KillChainPhase> phasesByKey = new LinkedHashMap<>();
+    for (KillChainPhaseCreateInput input : inputs) {
+      String key = dedupeKey(input);
+      KillChainPhase phase = phasesByKey.get(key);
+      if (phase == null) {
+        phase = resolveExisting(input).orElseGet(KillChainPhase::new);
+        phasesByKey.put(key, phase);
+      }
+      apply(phase, input);
+    }
+    return StreamHelper.fromIterable(killChainPhaseRepository.saveAll(phasesByKey.values()));
+  }
+
+  private String dedupeKey(KillChainPhaseCreateInput input) {
+    if (input.getStixId() != null && !input.getStixId().isBlank()) {
+      return "stix:" + input.getStixId();
+    }
+    return "name:" + input.getKillChainName() + "|" + input.getShortName();
+  }
+
+  private Optional<KillChainPhase> resolveExisting(KillChainPhaseCreateInput input) {
+    if (input.getStixId() != null && !input.getStixId().isBlank()) {
+      Optional<KillChainPhase> byStixId = killChainPhaseRepository.findByStixId(input.getStixId());
+      if (byStixId.isPresent()) {
+        return byStixId;
+      }
+    }
+    return killChainPhaseRepository.findByKillChainNameAndShortName(
+        input.getKillChainName(), input.getShortName());
+  }
+
+  private void apply(KillChainPhase phase, KillChainPhaseCreateInput input) {
+    boolean isNew = phase.getId() == null;
+    phase.setKillChainName(input.getKillChainName());
+    phase.setStixId(input.getStixId());
+    phase.setExternalId(input.getExternalId());
+    phase.setShortName(input.getShortName());
+    phase.setName(input.getName());
+    phase.setDescription(input.getDescription());
+    if (isNew) {
+      // Honor an explicit, non-zero order from the input (used by importers that know their own
+      // matrix ordering, e.g. MITRE ATLAS); otherwise resolve the canonical order from the
+      // kill chain name + short name (mitre-attack or mitre-atlas).
+      Long inputOrder = input.getOrder();
+      phase.setOrder(
+          inputOrder != null && inputOrder != 0L
+              ? inputOrder
+              : KillChainPhaseUtils.orderFor(input.getKillChainName(), input.getShortName()));
+    } else {
+      phase.setUpdatedAt(Instant.now());
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
@@ -68,10 +68,10 @@ public class SecurityCoverageJob implements Job {
         openCTIConnectorService.pushSecurityCoverageStixBundle(resultBundle, tenantId);
         successfulJobs.add(securityCoverageSendJob);
       } catch (Exception e) {
-        // don't crash the job
+        // don't crash the job; getSimulation() can be null (that very case throws above)
         log.error(
             "Could not create the STIX bundle for coverage of simulation {}",
-            securityCoverageSendJob.getSimulation().getId(),
+            ofNullable(securityCoverageSendJob.getSimulation()).map(Exercise::getId).orElse("?"),
             e);
       } finally {
         TenantContext.clearCurrentTenant();

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
@@ -22,8 +22,6 @@ import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -34,8 +32,11 @@ public class SecurityCoverageJob implements Job {
   private final SecurityCoverageService securityCoverageService;
   private final OpenCTIConnectorService openCTIConnectorService;
 
+  // No job-level @Transactional here: a transaction spanning the whole loop held a pooled DB
+  // connection across every external OpenCTI HTTP push (potentially minutes when OpenCTI is slow
+  // or unreachable), contributing to Hikari pool exhaustion. Bundle creation is transactional
+  // inside SecurityCoverageService#createBundleFromSendJobs; the push runs connection-free.
   @Override
-  @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
   @LogExecutionTime
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
     List<SecurityCoverageSendJob> jobs =

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -452,16 +452,29 @@ public class SecurityCoverageService {
     }
   }
 
+  /**
+   * Builds the STIX bundle for the given send jobs inside its own short read-only transaction.
+   *
+   * <p>The transaction boundary is intentionally here and NOT around the caller's whole loop
+   * (which also pushes bundles to OpenCTI over HTTP): holding a pooled JDBC connection across
+   * external network calls exhausted the Hikari pool in production. Jobs may arrive detached, so
+   * the simulation is re-read within this transaction before navigating its lazy associations.
+   */
+  @Transactional(readOnly = true)
   public Bundle createBundleFromSendJobs(List<SecurityCoverageSendJob> securityCoverageSendJobs)
       throws ParsingException, JsonProcessingException {
     List<ObjectBase> objects = new ArrayList<>();
     for (SecurityCoverageSendJob securityCoverageSendJob : securityCoverageSendJobs) {
-      SecurityCoverage sa = securityCoverageSendJob.getSimulation().getSecurityCoverage();
-      if (sa == null) {
+      if (securityCoverageSendJob.getSimulation() == null) {
         continue;
       }
-
-      Exercise simulation = securityCoverageSendJob.getSimulation();
+      // Re-attach: the job entity may come from a closed session (the scheduler loads jobs
+      // outside a transaction). Lazy navigation on a detached Exercise would throw.
+      Exercise simulation =
+          exerciseService.exercise(securityCoverageSendJob.getSimulation().getId());
+      if (simulation.getSecurityCoverage() == null) {
+        continue;
+      }
       objects.addAll(this.getCoverageForSimulation(simulation));
     }
 

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -455,10 +455,10 @@ public class SecurityCoverageService {
   /**
    * Builds the STIX bundle for the given send jobs inside its own short read-only transaction.
    *
-   * <p>The transaction boundary is intentionally here and NOT around the caller's whole loop
-   * (which also pushes bundles to OpenCTI over HTTP): holding a pooled JDBC connection across
-   * external network calls exhausted the Hikari pool in production. Jobs may arrive detached, so
-   * the simulation is re-read within this transaction before navigating its lazy associations.
+   * <p>The transaction boundary is intentionally here and NOT around the caller's whole loop (which
+   * also pushes bundles to OpenCTI over HTTP): holding a pooled JDBC connection across external
+   * network calls exhausted the Hikari pool in production. Jobs may arrive detached, so the
+   * simulation is re-read within this transaction before navigating its lazy associations.
    */
   @Transactional(readOnly = true)
   public Bundle createBundleFromSendJobs(List<SecurityCoverageSendJob> securityCoverageSendJobs)

--- a/openaev-api/src/test/java/io/openaev/database/model/ChainingTypeRegistryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/ChainingTypeRegistryTest.java
@@ -1,6 +1,7 @@
 package io.openaev.database.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +52,15 @@ class ChainingTypeRegistryTest {
     assertThat(PrimitiveType.fromLabel("ip_subnet")).isEqualTo(PrimitiveType.IpSubnet);
     assertThat(PrimitiveType.fromLabel("asset_id")).isEqualTo(PrimitiveType.AssetId);
     assertThat(PrimitiveType.fromLabel("asset_group_id")).isEqualTo(PrimitiveType.AssetGroupId);
+  }
+
+  @Test
+  @DisplayName("Should keep a controlled failure on null or unknown primitive labels")
+  void given_nullOrUnknownLabel_should_throwIllegalArgument() {
+    assertThatThrownBy(() -> PrimitiveType.fromLabel(null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> PrimitiveType.fromLabel("definitely-not-a-type"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
@@ -6,7 +6,11 @@ import static io.openaev.database.specification.KillChainPhaseSpecification.byNa
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static io.openaev.utils.fixtures.KillChainPhaseFixture.getKillChainPhase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -19,6 +23,9 @@ import io.openaev.database.model.KillChainPhase;
 import io.openaev.database.repository.KillChainPhaseRepository;
 import io.openaev.database.specification.KillChainPhaseSpecification;
 import io.openaev.rest.kill_chain_phase.KillChainPhaseApi;
+import io.openaev.rest.kill_chain_phase.form.KillChainPhaseCreateInput;
+import io.openaev.rest.kill_chain_phase.form.KillChainPhaseUpsertInput;
+import io.openaev.rest.kill_chain_phase.service.KillChainPhaseService;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.fixtures.PaginationFixture;
 import io.openaev.utils.mockUser.WithMockUser;
@@ -33,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.MediaType;
@@ -251,6 +259,113 @@ public class KillChainPhaseApiTest extends IntegrationTest {
           .andExpect(jsonPath("$.content.[0].phase_name").value("name3"))
           .andExpect(jsonPath("$.content.[1].phase_name").value("name2"))
           .andExpect(jsonPath("$.content.[2].phase_name").value("name1"));
+    }
+  }
+
+  @Nested
+  @WithMockUser(isAdmin = true)
+  @DisplayName("Upserting kill chain phases")
+  class UpsertingKillChainPhases {
+
+    private static final String KILL_CHAIN = "upsert-test-chain";
+    private static final String STIX_ID = "x-mitre-tactic--upsert-test-0001";
+
+    @AfterEach
+    void cleanUp() {
+      for (String shortName : List.of("old-short", "new-short", "exec")) {
+        killChainPhaseRepository
+            .findByKillChainNameAndShortName(KILL_CHAIN, shortName)
+            .ifPresent(killChainPhaseRepository::delete);
+      }
+    }
+
+    private KillChainPhaseCreateInput createInput(String shortName, String name, String stixId) {
+      KillChainPhaseCreateInput input = new KillChainPhaseCreateInput();
+      input.setKillChainName(KILL_CHAIN);
+      input.setShortName(shortName);
+      input.setName(name);
+      input.setStixId(stixId);
+      input.setExternalId("TA-UPSERT-TEST");
+      return input;
+    }
+
+    private KillChainPhaseUpsertInput upsertInput(KillChainPhaseCreateInput... inputs) {
+      KillChainPhaseUpsertInput upsertInput = new KillChainPhaseUpsertInput();
+      upsertInput.setKillChainPhases(List.of(inputs));
+      return upsertInput;
+    }
+
+    @Test
+    @DisplayName("Upsert matches an existing phase by STIX id even when the short name changed")
+    void given_existing_stix_id_should_update_phase_instead_of_inserting() throws Exception {
+      KillChainPhase existing = getKillChainPhase("Old name", 1L);
+      existing.setKillChainName(KILL_CHAIN);
+      existing.setShortName("old-short");
+      existing.setStixId(STIX_ID);
+      String existingId = killChainPhaseRepository.save(existing).getId();
+
+      mvc.perform(
+              post("/api/kill_chain_phases/upsert")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(upsertInput(createInput("new-short", "New name", STIX_ID))))
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(jsonPath("$.length()").value(1))
+          .andExpect(jsonPath("$[0].phase_id").value(existingId))
+          .andExpect(jsonPath("$[0].phase_shortname").value("new-short"))
+          .andExpect(jsonPath("$[0].phase_name").value("New name"));
+
+      assertTrue(
+          killChainPhaseRepository
+              .findByKillChainNameAndShortName(KILL_CHAIN, "old-short")
+              .isEmpty(),
+          "the old natural key must not survive as a separate row");
+      assertEquals(
+          existingId,
+          killChainPhaseRepository
+              .findByKillChainNameAndShortName(KILL_CHAIN, "new-short")
+              .orElseThrow()
+              .getId());
+    }
+
+    @Test
+    @DisplayName("Duplicate entries in one request (with and without STIX id) persist a single row")
+    void given_duplicate_inputs_in_batch_should_persist_single_row() throws Exception {
+      mvc.perform(
+              post("/api/kill_chain_phases/upsert")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(
+                      asJsonString(
+                          upsertInput(
+                              createInput("exec", "Execution", STIX_ID),
+                              createInput("exec", "Execution updated", null))))
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(jsonPath("$.length()").value(1));
+
+      KillChainPhase persisted =
+          killChainPhaseRepository
+              .findByKillChainNameAndShortName(KILL_CHAIN, "exec")
+              .orElseThrow();
+      assertEquals("Execution updated", persisted.getName());
+      assertEquals(STIX_ID, persisted.getStixId(), "STIX id must survive the stix-less duplicate");
+    }
+
+    @Test
+    @DisplayName("Upsert retries once when the first attempt loses a concurrent-insert race")
+    void given_concurrent_insert_race_should_retry_once() {
+      KillChainPhaseService service = mock(KillChainPhaseService.class);
+      KillChainPhaseApi api = new KillChainPhaseApi(mock(KillChainPhaseRepository.class), service);
+      KillChainPhaseUpsertInput input = new KillChainPhaseUpsertInput();
+      List<KillChainPhase> winner = List.of(new KillChainPhase());
+      when(service.upsertKillChainPhases(input.getKillChainPhases()))
+          .thenThrow(new DataIntegrityViolationException("duplicate key"))
+          .thenReturn(winner);
+
+      Iterable<KillChainPhase> result = api.upsertKillChainPhases(input);
+
+      assertSame(winner, result);
+      verify(service, times(2)).upsertKillChainPhases(input.getKillChainPhases());
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
@@ -341,6 +341,17 @@ public class KillChainPhaseApiTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Upsert rejects an explicit null kill_chain_phases list")
+    void given_null_phase_list_should_return_bad_request() throws Exception {
+      mvc.perform(
+              post("/api/kill_chain_phases/upsert")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"kill_chain_phases\": null}")
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("Duplicate entries in one request (with and without STIX id) persist a single row")
     void given_duplicate_inputs_in_batch_should_persist_single_row() throws Exception {
       mvc.perform(

--- a/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
@@ -7,6 +7,7 @@ import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static io.openaev.utils.fixtures.KillChainPhaseFixture.getKillChainPhase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.Mockito.mock;
@@ -351,6 +352,13 @@ public class KillChainPhaseApiTest extends IntegrationTest {
       assertEquals(STIX_ID, persisted.getStixId(), "STIX id must survive the stix-less duplicate");
     }
 
+    private static DataIntegrityViolationException uniqueViolation(String constraintName) {
+      return new DataIntegrityViolationException(
+          "duplicate key",
+          new org.hibernate.exception.ConstraintViolationException(
+              "duplicate key", new java.sql.SQLException("duplicate key"), constraintName));
+    }
+
     @Test
     @DisplayName("Upsert retries once when the first attempt loses a concurrent-insert race")
     void given_concurrent_insert_race_should_retry_once() {
@@ -359,13 +367,31 @@ public class KillChainPhaseApiTest extends IntegrationTest {
       KillChainPhaseUpsertInput input = new KillChainPhaseUpsertInput();
       List<KillChainPhase> winner = List.of(new KillChainPhase());
       when(service.upsertKillChainPhases(input.getKillChainPhases()))
-          .thenThrow(new DataIntegrityViolationException("duplicate key"))
+          .thenThrow(uniqueViolation("kill_chain_phases_stix_id_tenant_unique"))
           .thenReturn(winner);
 
       Iterable<KillChainPhase> result = api.upsertKillChainPhases(input);
 
       assertSame(winner, result);
       verify(service, times(2)).upsertKillChainPhases(input.getKillChainPhases());
+    }
+
+    @Test
+    @DisplayName("Upsert does not retry integrity failures unrelated to the unique constraints")
+    void given_unrelated_integrity_violation_should_not_retry() {
+      KillChainPhaseService service = mock(KillChainPhaseService.class);
+      KillChainPhaseApi api = new KillChainPhaseApi(mock(KillChainPhaseRepository.class), service);
+      KillChainPhaseUpsertInput input = new KillChainPhaseUpsertInput();
+      DataIntegrityViolationException notNullViolation =
+          new DataIntegrityViolationException("null value in column phase_external_id");
+      when(service.upsertKillChainPhases(input.getKillChainPhases())).thenThrow(notNullViolation);
+
+      DataIntegrityViolationException thrown =
+          assertThrows(
+              DataIntegrityViolationException.class, () -> api.upsertKillChainPhases(input));
+
+      assertSame(notNullViolation, thrown);
+      verify(service, times(1)).upsertKillChainPhases(input.getKillChainPhases());
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
@@ -330,6 +330,17 @@ public class KillChainPhaseApiTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Upsert rejects entries with blank mandatory fields (cascaded validation)")
+    void given_blank_mandatory_fields_should_return_bad_request() throws Exception {
+      mvc.perform(
+              post("/api/kill_chain_phases/upsert")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(upsertInput(createInput("", "No short name", null))))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("Duplicate entries in one request (with and without STIX id) persist a single row")
     void given_duplicate_inputs_in_batch_should_persist_single_row() throws Exception {
       mvc.perform(

--- a/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/killChainPhase/KillChainPhaseApiTest.java
@@ -352,6 +352,31 @@ public class KillChainPhaseApiTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Upsert rejects null entries inside the kill_chain_phases list")
+    void given_null_phase_entry_should_return_bad_request() throws Exception {
+      mvc.perform(
+              post("/api/kill_chain_phases/upsert")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{\"kill_chain_phases\": [null]}")
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Upsert rejects entries without an external id")
+    void given_missing_external_id_should_return_bad_request() throws Exception {
+      KillChainPhaseCreateInput input = createInput("exec", "Execution", STIX_ID);
+      input.setExternalId(null);
+
+      mvc.perform(
+              post("/api/kill_chain_phases/upsert")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(upsertInput(input)))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("Duplicate entries in one request (with and without STIX id) persist a single row")
     void given_duplicate_inputs_in_batch_should_persist_single_row() throws Exception {
       mvc.perform(

--- a/openaev-api/src/test/java/io/openaev/rest/payload/PayloadUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/payload/PayloadUtilsTest.java
@@ -3,10 +3,13 @@ package io.openaev.rest.payload;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.database.model.PayloadArgument;
 import io.openaev.database.model.PrimitiveType;
 import io.openaev.rest.payload.form.PayloadCreateInput;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class PayloadUtilsTest {
@@ -14,7 +17,7 @@ class PayloadUtilsTest {
   private final ObjectMapper mapper = new ObjectMapper();
 
   @Test
-  void given_legacyComplexArgumentWithSubtype_should_throw() throws Exception {
+  void given_legacyComplexArgument_should_mapToReplacementPrimitive() throws Exception {
     JsonNode payloadNode =
         mapper.readTree(
             """
@@ -25,12 +28,53 @@ class PayloadUtilsTest {
               "payload_status":"VERIFIED",
               "payload_platforms":["Linux"],
               "payload_arguments":[
-                {"type":"portscan","subtype":"host","key":"target","default_value":"srv-01","description":"d"}
+                {"type":"portscan","subtype":"host","key":"target","default_value":"srv-01","description":"d"},
+                {"type":"credentials","key":"client_id","default_value":"??","description":"d"}
+              ]
+            }
+            """);
+
+    PayloadCreateInput payload = PayloadUtils.buildPayload(payloadNode);
+
+    assertEquals(PrimitiveType.Port, payload.getArguments().get(0).getType());
+    assertEquals(PrimitiveType.Username, payload.getArguments().get(1).getType());
+  }
+
+  @Test
+  void given_unknownArgumentType_should_throw() throws Exception {
+    JsonNode payloadNode =
+        mapper.readTree(
+            """
+            {
+              "payload_type":"command",
+              "payload_name":"bad-payload",
+              "payload_source":"MANUAL",
+              "payload_status":"VERIFIED",
+              "payload_platforms":["Linux"],
+              "payload_arguments":[
+                {"type":"definitely-not-a-type","key":"target","default_value":"x","description":"d"}
               ]
             }
             """);
 
     assertThrows(IllegalArgumentException.class, () -> PayloadUtils.buildPayload(payloadNode));
+  }
+
+  @Test
+  void given_legacyArgumentTypeInStoredJson_should_deserializeThroughJackson() throws Exception {
+    // Mirrors the hypersistence JsonType read path on pre-#6536 rows (e.g. the NetExec payload):
+    // Jackson must accept legacy ArgumentType labels, otherwise the entity row is unreadable.
+    String storedColumn =
+        """
+        [{"key": "client_id", "type": "credentials", "separator": null, "description": null, "default_value": "??"},
+         {"key": "ip", "type": "targeted-asset", "separator": ",", "description": null, "default_value": "local_ip"}]
+        """;
+
+    List<PayloadArgument> arguments =
+        mapper.readValue(storedColumn, new TypeReference<List<PayloadArgument>>() {});
+
+    assertEquals(PrimitiveType.Username, arguments.get(0).getType());
+    assertEquals(PrimitiveType.TargetedAsset, arguments.get(1).getType());
   }
 
   @Test

--- a/openaev-api/src/test/resources/archunit_store/35cf0fcb-5cd4-4e36-8ae9-347a2cf45caa
+++ b/openaev-api/src/test/resources/archunit_store/35cf0fcb-5cd4-4e36-8ae9-347a2cf45caa
@@ -1,2 +1,1 @@
 io.openaev.scheduler.jobs.ScenarioExecutionJob.execute(org.quartz.JobExecutionContext) is annotated with @Transactional
-io.openaev.scheduler.jobs.SecurityCoverageJob.execute(org.quartz.JobExecutionContext) is annotated with @Transactional

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -5840,7 +5840,8 @@ export interface KillChainPhaseCoverage {
 
 export interface KillChainPhaseCreateInput {
   phase_description?: string;
-  phase_external_id?: string;
+  /** @minLength 1 */
+  phase_external_id: string;
   /** @minLength 1 */
   phase_kill_chain_name: string;
   /** @minLength 1 */

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -5917,7 +5917,7 @@ export interface KillChainPhaseUpdateInput {
 }
 
 export interface KillChainPhaseUpsertInput {
-  kill_chain_phases?: KillChainPhaseCreateInput[];
+  kill_chain_phases: KillChainPhaseCreateInput[];
 }
 
 export interface LessonsAnswer {

--- a/openaev-model/src/main/java/io/openaev/database/model/PrimitiveType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/PrimitiveType.java
@@ -104,7 +104,10 @@ public enum PrimitiveType {
 
   @JsonCreator
   public static PrimitiveType fromLabel(String label) {
-    String effectiveLabel = LEGACY_ARGUMENT_TYPE_LABELS.getOrDefault(label, label);
+    // Immutable maps reject null keys: guard so a null label keeps failing with the controlled
+    // IllegalArgumentException below instead of an opaque NullPointerException.
+    String effectiveLabel =
+        label == null ? null : LEGACY_ARGUMENT_TYPE_LABELS.getOrDefault(label, label);
     return fromLabelOptional(effectiveLabel)
         .orElseThrow(
             () ->

--- a/openaev-model/src/main/java/io/openaev/database/model/PrimitiveType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/PrimitiveType.java
@@ -1,7 +1,9 @@
 package io.openaev.database.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 
 public enum PrimitiveType {
@@ -70,12 +72,40 @@ public enum PrimitiveType {
 
   public final String label;
 
+  /**
+   * Labels of the pre-#6536 {@code ArgumentType} enum that no longer exist in {@code
+   * PrimitiveType}, mapped to their closest primitive. Payload rows created before the chaining
+   * refactor still carry these labels in {@code payloads.payload_arguments} and {@code
+   * injects_statuses.status_payload_output}; without this mapping Jackson fails to deserialize the
+   * column and the whole entity row becomes unreadable (hypersistence JsonType then rethrows as
+   * "cannot be transformed to Json object"). A Flyway migration rewrites stored data, but this
+   * keeps reads safe for anything written between deploy and migration, and for external clients
+   * (injector contracts, imports) still sending legacy labels.
+   */
+  private static final Map<String, String> LEGACY_ARGUMENT_TYPE_LABELS =
+      Map.ofEntries(
+          Map.entry("credentials", "username"),
+          Map.entry("portscan", "port"),
+          Map.entry("share", "share_name"),
+          Map.entry("admin_username", "username"),
+          Map.entry("group", "text"),
+          Map.entry("computer", "hostname"),
+          Map.entry("password_policy", "text"),
+          Map.entry("delegation", "text"),
+          Map.entry("sid", "text"),
+          Map.entry("vulnerability", "cve"),
+          Map.entry("account_with_password_not_required", "username"),
+          Map.entry("asreproastable_account", "username"),
+          Map.entry("kerberoastable_account", "username"));
+
   PrimitiveType(String label) {
     this.label = label;
   }
 
+  @JsonCreator
   public static PrimitiveType fromLabel(String label) {
-    return fromLabelOptional(label)
+    String effectiveLabel = LEGACY_ARGUMENT_TYPE_LABELS.getOrDefault(label, label);
+    return fromLabelOptional(effectiveLabel)
         .orElseThrow(
             () ->
                 new IllegalArgumentException(

--- a/openaev-model/src/main/java/io/openaev/database/repository/KillChainPhaseRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/KillChainPhaseRepository.java
@@ -19,4 +19,9 @@ public interface KillChainPhaseRepository
 
   Optional<KillChainPhase> findByKillChainNameAndShortName(
       @NotNull String killChainName, @NotNull String shortName);
+
+  // The database unique key is (phase_stix_id, tenant_id): upserts must match on the STIX id
+  // first, otherwise a renamed phase (same STIX id, new short name) is treated as a new row and
+  // violates the constraint. The Hibernate tenant filter scopes this to the current tenant.
+  Optional<KillChainPhase> findByStixId(@NotNull String stixId);
 }

--- a/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/MinioDriver.java
@@ -49,9 +49,18 @@ public class MinioDriver {
     return minioClient;
   }
 
+  // OkHttp socket-level timeouts (connect / write / read). These are idle timeouts, not
+  // whole-request deadlines, so large uploads/downloads still work as long as bytes flow.
+  // Without them the client waits forever on an unresponsive endpoint; callers running inside
+  // a database transaction then pin their connection (and its row locks) indefinitely.
+  private static final long CONNECT_TIMEOUT_MS = 10_000L;
+  private static final long WRITE_TIMEOUT_MS = 60_000L;
+  private static final long READ_TIMEOUT_MS = 60_000L;
+
   @Bean
   public MinioClient minioClient() throws Exception {
     MinioClient minioClient = getMinioClient();
+    minioClient.setTimeout(CONNECT_TIMEOUT_MS, WRITE_TIMEOUT_MS, READ_TIMEOUT_MS);
     String bucket = minioConfig.getBucket();
 
     // Make bucket if not exist.


### PR DESCRIPTION
## Summary

Fixes #6851 - production-wide HikariCP pool exhaustion after resetting a simulation, the kill_chain_phases duplicate key errors seen at startup, and the unreadable legacy payload arguments that broke injector execution.

### Connection pool exhaustion

- Simulation reset (`ExerciseService.changeExerciseStatus` -> SCHEDULED) no longer calls MinIO/S3 inside the DB transaction: the transient-files cleanup is registered as an afterCommit synchronization (same pattern already used by `resetExercise`). The reset transaction previously pinned its JDBC connection and all row locks taken by the cascading deletes for the whole duration of the object-storage roundtrips, starving the pool platform-wide (total=20, active=20, idle=0, waiting=130+).
- The shared `MinioClient` now has connect/write/read timeouts (10s/60s/60s socket-level idle timeouts) instead of waiting forever on an unresponsive endpoint.
- `SecurityCoverageJob` no longer holds a job-level transaction across OpenCTI HTTP pushes; bundle creation got its own short read-only transaction in `SecurityCoverageService`, which re-attaches the simulation before navigating lazy associations.

### Kill chain phase upsert race

- `POST /api/kill_chain_phases/upsert` is now race-safe. Concurrent collector upserts (MITRE Enterprise / Mobile / ICS right after startup) could both insert a brand-new phase (e.g. the new ATT&CK "Stealth" tactic) and the loser failed on `kill_chain_phases_stix_id_tenant_unique`, rolled back everything and retried in a loop. The upsert logic moved to `KillChainPhaseService`: it resolves existing phases by STIX id first (the actual DB unique key) with natural-key fallback, de-duplicates the input batch under BOTH unique keys (STIX id and natural key, so mixed entries with and without STIX id collapse onto one entity), and the endpoint retries once in a fresh transaction when it loses a concurrent-insert race.
- New migration `V6_20260722080000000` de-duplicates `kill_chain_phases` on (kill chain name, short name, tenant), repoints `attack_patterns_kill_chain_phases` links to the surviving row with a PK-collision-safe insert-then-delete, and adds a unique constraint on that natural key so the schema matches the upsert lookup.

### Legacy payload argument types

- The #6536 chaining refactor replaced `ArgumentType` with `PrimitiveType` but never migrated stored payload_arguments JSON: legacy labels (`credentials`, `portscan`, `share`, ...) failed Jackson deserialization, making every pre-refactor payload row unreadable (hypersistence JsonType rethrows as "cannot be transformed to Json object") and breaking injector execution and trace logging (e.g. NetExec).
- New migration `V6_20260722090000000` remaps legacy labels in `payloads.payload_arguments` and `injects_statuses.status_payload_output`, plus a tolerant `@JsonCreator` on `PrimitiveType` for data written between deploy and migration and for external clients still sending legacy labels. The rewrite is streamed in LIMIT-sized pages of 1000 ids (no full id materialization in memory, so no OOM risk on millions of rows) in autocommit via `canExecuteInTransaction() = false`, so row locks and WAL churn stay bounded on large production tables and an interrupted run resumes where it left off.

### Review follow-ups (Copilot)

- In-batch de-duplication keyed on both DB unique keys (see above), identity-based final de-duplication before `saveAll`.
- `PrimitiveType.fromLabel` keeps its controlled `IllegalArgumentException` on null labels (immutable maps reject null keys, so the legacy lookup would have thrown an opaque NPE); after the rebase it delegates to main's `fromLabelOptional` helper.
- The upsert retry is narrowed to duplicate-key violations on `kill_chain_phases_*` constraints; unrelated integrity failures (not-null, FK) propagate immediately instead of being retried.
- `KillChainPhaseUpsertInput.killChainPhases` now carries the cascading `@Valid`, `@NotNull` on the field and `@NotNull` on the list elements, so blank mandatory fields, an explicit `"kill_chain_phases": null` and `[null]` entries all return a 400 instead of reaching the service.
- `KillChainPhaseCreateInput.phase_external_id` is now `@NotBlank` (the entity already enforces it at flush time and the frontend form treats it as required), so a missing external id fails fast with a 400 on both create and upsert; `api-types.d.ts` regenerated accordingly.
- The legacy label remap migration streams LIMIT-paged batches instead of collecting every affected row id up front.
- Test coverage added: upsert-by-STIX-id-with-renamed-shortname, in-batch duplicate collapse, retry-once-on-unique-violation, no-retry-on-unrelated-violation, blank-field rejection, null-list rejection, null-entry rejection, missing-external-id rejection, null/unknown label handling.

### ArchUnit frozen baseline

- Removing the job-level `@Transactional` from `SecurityCoverageJob` fixes a violation recorded in the locked background-transaction freeze store, so the baseline was re-frozen with the sanctioned one-off overrides (see `archunit_store/README.md`); the store diff only removes the solved `SecurityCoverageJob` line.

## Test plan

- `mvn install -pl openaev-api -am -DskipTests -Pdev` passes locally (after rebase on latest main, f660d6ddb)
- `mvn spotless:apply` clean locally (JDK 21)
- `ChainingTypeRegistryTest` (9 tests) passes locally after resolving the `PrimitiveType` rebase conflict with main's #6536 `fromLabelOptional` refactor
- Migration chain verified against main: latest on main is `V6_20260721190000000`, this PR adds `V6_20260722080000000` and `V6_20260722090000000` strictly after it (Migrations Guard green)
- `TenantBackgroundTransactionArchTest` passes locally with the shrunk frozen baseline
- Reset a finished/cancelled simulation with many injects and verify the pool stays healthy (no "Connection is not available" logs) even with slow object storage
- Restart the platform with several MITRE collectors enabled and verify no `kill_chain_phases_stix_id_tenant_unique` violations
- Verify migration on a copy of production data: duplicates merged, attack pattern links preserved, constraint added
- Backend test suite runs in CI (API Tests jobs)
