### PR TITLE
feat(debug): configurable SQL log rotation, caller (user) in trace, ORM summary to file (#6862)

### DIFF
--- a/docs/docs/administration/debug-mode.md
+++ b/docs/docs/administration/debug-mode.md
@@ -9,21 +9,23 @@ no parameter capture, no extra per-request work and no extra files written.
 
 ## What it produces
 
-- **Correlation id on every log line (tenant in the SQL detail).** Each request carries a `traceId`
-  (and `spanId`) in the MDC (Mapped Diagnostic Context, the per-thread key/value bag the logging
+- **Correlation id on every log line (tenant and user in the SQL detail).** Each request carries a
+  `traceId` (and `spanId`) in the MDC (Mapped Diagnostic Context, the per-thread key/value bag the logging
   library attaches to every line it emits), shown on the console as the `[traceId-spanId]` slot, so all the lines
-  emitted while handling it can be grouped together. Tenant-scoped requests also carry the `tenant` in
-  the MDC; it is rendered in the SQL file (not the console slot), so the SQL can be filtered per
-  tenant. This uses Micrometer Tracing; no tracing backend is required, the ids are written to the
-  normal log output.
+  emitted while handling it can be grouped together. Requests also carry the `tenant` and the `user`
+  (the caller's id, `anonymous` when unauthenticated) in the MDC; both are rendered in the SQL file
+  (not the console slot), so the SQL can be filtered per tenant or per user. This uses Micrometer
+  Tracing; no tracing backend is required, the ids are written to the normal log output.
 - **SQL detail.** Every SQL statement, both ORM (Object-Relational Mapping)-generated and native, is logged with its execution time
   and its masked parameters, on the dedicated `io.openaev.debug.sql` logger. To keep this high-volume
   output off the console and the production log pipeline, it is written to a rotated file
   (`openaev-debug-sql.log`) under the debug output directory rather than to stdout.
-- **ORM insight.** One summary line per request on `io.openaev.debug.orm` (total queries and time),
-  flagging N+1 queries (the same SELECT repeated many times, the classic lazy-loading symptom) and
-  chatty requests. No configuration of its own; it rides on the SQL detail above. This summary stays
-  on the console so it remains visible.
+- **ORM insight.** One summary per request (a single log event) on `io.openaev.debug.orm` (total
+  queries and time, plus the caller as `user=`), flagging N+1 queries (the same SELECT repeated many
+  times, the classic lazy-loading symptom) and chatty requests. It rides on the SQL detail above and
+  stays on the console by default so it remains visible; on instances whose console is shipped to
+  centralised logging, set `openaev.debug.orm.summary-to-file=true` to route it to a rotated file
+  (`openaev-debug-orm.log`) instead.
 - **JVM (Java Virtual Machine) profiling.** A bounded Java Flight Recorder (JFR) recording is started, dumped on a timer and
   flushed on shutdown to the debug output directory. JFR is part of the JDK (Java Development Kit), there is no extra agent.
 
@@ -41,7 +43,7 @@ slot `[traceId-spanId]` (ids shortened here for readability):
 ```text
 INFO  [OpenAEV API] [http-nio-exec-3] [6a3c4dea…0b-7bd42e33…] ...ScenarioApi : Loading scenario sc-42
 INFO  [OpenAEV API] [http-nio-exec-3] [6a3c4dea…0b-7bd42e33…] ...ScenarioApi : Scenario sc-42 loaded
-WARN  [OpenAEV API] [http-nio-exec-3] [6a3c4dea…0b-7bd42e33…] ...debug.orm   : ORM GET /api/scenarios/sc-42: 13 queries (2 distinct), 7ms
+WARN  [OpenAEV API] [http-nio-exec-3] [6a3c4dea…0b-7bd42e33…] ...debug.orm   : ORM GET /api/scenarios/sc-42: 13 queries (2 distinct), 7ms user=8f2b-user-alice
   N+1 SUSPECTED: 'select team_name from teams where team_id = ?' executed 12x (6ms total)
 ```
 
@@ -51,9 +53,9 @@ only in the SQL file below, which uses its own pattern.
 The rotated SQL file `openaev-debug-sql.log`, one line per statement, with masked parameters:
 
 ```text
-2026-06-24 23:36:42.165 INFO [trace=6a3c4dea... tenant=0e7c2f1a-tenant-acme] sql success=true time=1ms statement=insert into users (user_id, user_email, user_password) values (?, ?, ?) params=[{user_id=u-1, user_email=***MASKED***, user_password=***MASKED***}]
-2026-06-24 23:36:42.179 INFO [trace=6a3c4dea... tenant=0e7c2f1a-tenant-acme] sql success=true time=5ms statement=select team_name from teams where team_id = ? params=[{team_id=team-0}]
-2026-06-24 23:36:42.181 INFO [trace=6a3c4dea... tenant=0e7c2f1a-tenant-acme] sql success=true time=0ms statement=select team_name from teams where team_id = ? params=[{team_id=team-1}]
+2026-06-24 23:36:42.165 INFO [trace=6a3c4dea... tenant=0e7c2f1a-tenant-acme user=8f2b-user-alice] sql success=true time=1ms statement=insert into users (user_id, user_email, user_password) values (?, ?, ?) params=[{user_id=u-1, user_email=***MASKED***, user_password=***MASKED***}]
+2026-06-24 23:36:42.179 INFO [trace=6a3c4dea... tenant=0e7c2f1a-tenant-acme user=8f2b-user-alice] sql success=true time=5ms statement=select team_name from teams where team_id = ? params=[{team_id=team-0}]
+2026-06-24 23:36:42.181 INFO [trace=6a3c4dea... tenant=0e7c2f1a-tenant-acme user=8f2b-user-alice] sql success=true time=0ms statement=select team_name from teams where team_id = ? params=[{team_id=team-1}]
 ... the same SELECT 10 more times, one per team -- the N+1 the summary flagged
 ```
 
@@ -64,6 +66,8 @@ What each field means:
   Filter on it to reconstruct the whole request across application logs and SQL.
 - `tenant=...` (SQL file only) -- the tenant the request targets (the default tenant when the request
   is not tenant-scoped). It is not rendered in the console slot.
+- `user=...` (SQL file only) -- the id of the user who triggered the request (`anonymous` when
+  unauthenticated), so it is clear who ran a given statement. The ORM summary line carries it too.
 - `time=1ms` -- the statement's JDBC (Java Database Connectivity) execution time, so slow statements stand out.
 - `statement=...` -- the real SQL sent to PostgreSQL (Hibernate-generated or native), with `?`
   placeholders.
@@ -147,6 +151,41 @@ is logged at startup and repeated at `warning-interval`, and the verbose tracing
 itself after `auto-disable-after` (the datasource proxy is then inert until a restart fully removes
 it).
 
+### A production-safe, low-noise setup
+
+When you need to debug on a real (production) instance and want signal over noise, this is a good
+starting point. It focuses on slow queries and N+1s, keeps the output off centralised logging, and
+disables itself so it cannot be left running by accident:
+
+```properties
+# On, allowed in production (no dev/test/ci profile), auto-off after 30 min as a safety net.
+openaev.debug.enabled=true
+openaev.debug.allow-in-production=true
+openaev.debug.auto-disable-after=30m
+
+# Write to a persistent volume so the files survive a container recycle.
+openaev.debug.output-dir=/var/debug
+
+# Signal over noise:
+# only slow statements (keeps far more history for the same disk)
+openaev.debug.sql.slow-query-threshold=50ms
+# keep the per-request ORM/N+1 summary out of Loki/Grafana
+openaev.debug.orm.summary-to-file=true
+# skip CPU/allocation profiling when you are chasing queries
+openaev.debug.jfr.enabled=false
+
+# Masking stays on by default. For maximum safety on sensitive data, mask every value (keep column + type):
+# openaev.debug.masking.mask-all-parameters=true
+```
+
+As environment variables (the recommended way in a container), each key is its uppercased form with
+`.` and `-` replaced by `_`, for example `OPENAEV_DEBUG_SQL_SLOW_QUERY_THRESHOLD=50ms`.
+
+Then read the SQL detail in `/var/debug/openaev-debug-sql.log` and the N+1 summaries in
+`/var/debug/openaev-debug-orm.log`, filtering by `trace=` or `user=` (see "Reading the SQL log in
+practice"). Turn it off with `OPENAEV_DEBUG_ENABLED=false`, or just let the 30-minute auto-disable
+kick in.
+
 ## Configuration reference
 
 All settings live under `openaev.debug.*` and use standard Spring configuration (properties file or
@@ -158,10 +197,14 @@ environment variables). Every setting only takes effect when `openaev.debug.enab
 | `openaev.debug.allow-in-production` | `false` | Override required to start the mode in production (no `dev`/`test`/`ci` profile). |
 | `openaev.debug.auto-disable-after` | `0` | Auto-disable the verbose tracing after this duration (`0` = never). |
 | `openaev.debug.warning-interval` | `5m` | How often the "debug mode is active" warning repeats. |
-| `openaev.debug.output-dir` | `./logs/debug` | Writable directory for all debug artifacts: the JFR recordings and the rotated SQL log file. |
+| `openaev.debug.output-dir` | `./logs/debug` | Writable directory for all debug artifacts: the JFR recordings, the rotated SQL log file and, when `orm.summary-to-file` is on, the rotated ORM summary file. |
 | `openaev.debug.sql.enabled` | `true` | Log SQL statements (to the rotated file) with timing and masked parameters. |
 | `openaev.debug.sql.slow-query-threshold` | `0ms` | Only log statements slower than this (`0` logs all). |
 | `openaev.debug.sql.max-parameter-length` | `200` | Truncate rendered parameter values longer than this (after masking). |
+| `openaev.debug.sql.max-file-size` | `500MB` | Rotated SQL file: size a single file reaches before it rolls over. |
+| `openaev.debug.sql.max-history` | `7` | Rotated SQL file: days of history to keep. |
+| `openaev.debug.sql.total-size-cap` | `2GB` | Rotated SQL file: total size kept before the oldest are deleted. Raise it on high-traffic instances where the log fills fast, to keep more history. |
+| `openaev.debug.orm.summary-to-file` | `false` | Write the per-request ORM summary to `openaev-debug-orm.log` instead of the console (keeps it out of centralised logging). |
 | `openaev.debug.jfr.enabled` | `true` | Start a JFR recording (skipped when the Pyroscope agent is enabled). |
 | `openaev.debug.jfr.max-size` | `100MB` | Hard cap on a single recording's on-disk size. |
 | `openaev.debug.jfr.max-age` | `1h` | Maximum age of events kept in the buffer. |
@@ -225,11 +268,36 @@ Everything debug mode writes goes under `openaev.debug.output-dir` (default `./l
 - the JFR recordings (`openaev-debug-*.jfr`). A single recording is bounded by `jfr.max-size` and
   `jfr.max-age`; the periodic dumps are kept bounded by a retention pass that deletes the oldest past
   `jfr.max-dump-files` (12) or `jfr.max-total-dump-size` (500 MB);
-- the SQL log (`openaev-debug-sql.log`), a rotated file capped at 50 MB per file, 7 files and 500 MB
-  total. The per-statement SQL flood is kept off the console / production log pipeline; the ORM
-  summary, the activation banner and the JFR status stay on the console.
+- the SQL log (`openaev-debug-sql.log`), a rotated file. The rotation is configurable via
+  `openaev.debug.sql.max-file-size` (500 MB), `max-history` (7 days) and `total-size-cap` (2 GB total).
+  The sizes and the history must be positive and the total cap at least the file size; invalid values
+  are corrected to safe ones at startup, with a warning stating the effective settings. On a
+  high-traffic instance the log fills fast, so the total cap is the binding limit: raise it to
+  keep more history. The per-statement SQL flood is kept off the console / production log pipeline;
+  the ORM summary, the activation banner and the JFR status stay on the console by default;
+- the ORM summary file (`openaev-debug-orm.log`), only when `openaev.debug.orm.summary-to-file` is on.
+  Use it on instances that ship the console to centralised logging, to keep the per-request summaries
+  out of it. It uses the same rotation settings.
 
-The application's own logs (with `traceId` and `tenant` in the MDC) keep going to their usual sink.
+The application's own logs (with `traceId`, `tenant` and `user` in the MDC) keep going to their usual
+sink.
+
+### Tuning for a high-traffic or centrally-logged instance
+
+On a busy instance the SQL file fills fast and only a short window of history survives. The right lever
+depends on the goal:
+
+- **Keep more history** without more disk: raise `openaev.debug.sql.slow-query-threshold` (for example
+  `50ms`) so only slow statements are written. This cuts the volume drastically, so the same
+  `total-size-cap` covers many more hours. The per-request ORM summary still counts every query, so
+  N+1 detection is unaffected. `max-file-size` does not change how long history is kept (only the file
+  count); the retention window is governed by `total-size-cap`.
+- **Keep every statement** (to inspect a specific fast query): raise `total-size-cap` instead, at the
+  cost of disk.
+- **Keep the debug logs out of centralised logging** (Loki/Grafana): set
+  `openaev.debug.orm.summary-to-file=true` so the per-request summaries go to a file rather than the
+  console. The per-statement SQL is already off the console. Or simply turn debug mode off when you
+  are not actively investigating.
 
 The default `./logs/debug` is relative to the working directory, so in a container it lives on the
 ephemeral layer and is wiped on every recycle. To keep the SQL logs and JFR dumps across restarts,
@@ -257,7 +325,7 @@ volumes:
 
 If no writable path is available, JFR fails loudly with a clear error and reports a failed state, and
 the SQL log falls back to the console instead of the file; the rest of the application keeps running.
-Look for log lines starting with `Debug mode: failed to start JFR recording` and `Debug mode: SQL log
+Look for log lines starting with `Debug mode: failed to start JFR recording` and `Debug mode: log
 directory is not writable`.
 
 ## Cost and bounding

--- a/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 
 /**
@@ -29,10 +29,16 @@ import org.springframework.web.servlet.HandlerMapping;
  * update/delete/reactivate). For those, the {@code tenantId} is the managed target rather than a
  * scope the caller must belong to; authorization is enforced by the RBAC capability check ({@code
  * MANAGE_TENANTS}/{@code DELETE_TENANTS}) in the {@code AccessControlAspect}.
+ *
+ * <p>{@link AsyncHandlerInterceptor} (not just {@code HandlerInterceptor}): on an async dispatch
+ * (e.g. a {@code StreamingResponseBody} endpoint) the initial servlet thread exits through {@link
+ * #afterConcurrentHandlingStarted} instead of {@code afterCompletion}, and the {@link
+ * TenantContext} thread-local must be cleared there too so the pooled thread does not carry the
+ * previous request's tenant into an unrelated request.
  */
 @Component
 @RequiredArgsConstructor
-public class TenantInterceptor implements HandlerInterceptor {
+public class TenantInterceptor implements AsyncHandlerInterceptor {
 
   private final TenantMembershipCacheManager tenantMembershipCacheManager;
 
@@ -79,6 +85,12 @@ public class TenantInterceptor implements HandlerInterceptor {
   @Override
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    TenantContext.clearCurrentTenant();
+  }
+
+  @Override
+  public void afterConcurrentHandlingStarted(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
     TenantContext.clearCurrentTenant();
   }
 }

--- a/openaev-api/src/main/java/io/openaev/debug/DebugConfiguration.java
+++ b/openaev-api/src/main/java/io/openaev/debug/DebugConfiguration.java
@@ -59,8 +59,8 @@ public class DebugConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   public OrmInsightFilter ormInsightFilter(
-      SensitiveDataMasker masker, DebugRuntimeState runtimeState) {
-    return new OrmInsightFilter(masker, runtimeState);
+      SensitiveDataMasker masker, DebugRuntimeState runtimeState, DebugUserSource userSource) {
+    return new OrmInsightFilter(masker, runtimeState, userSource);
   }
 
   @Bean
@@ -76,7 +76,8 @@ public class DebugConfiguration {
       havingValue = "true",
       matchIfMissing = true)
   public DebugSqlLogFileConfigurer debugSqlLogFileConfigurer(DebugProperties properties) {
-    return new DebugSqlLogFileConfigurer(properties.getOutputDir());
+    return new DebugSqlLogFileConfigurer(
+        properties.getOutputDir(), properties.getSql(), properties.getOrm().isSummaryToFile());
   }
 
   @Bean
@@ -90,9 +91,19 @@ public class DebugConfiguration {
   }
 
   @Bean
+  public DebugUserSource debugUserSource() {
+    return new DebugUserSource();
+  }
+
+  @Bean
+  public DebugUserMdcInterceptor debugUserMdcInterceptor(DebugUserSource userSource) {
+    return new DebugUserMdcInterceptor(userSource);
+  }
+
+  @Bean
   public DebugWebMvcConfigurer debugWebMvcConfigurer(
-      DebugTenantMdcInterceptor tenantMdcInterceptor) {
-    return new DebugWebMvcConfigurer(tenantMdcInterceptor);
+      DebugTenantMdcInterceptor tenantMdcInterceptor, DebugUserMdcInterceptor userMdcInterceptor) {
+    return new DebugWebMvcConfigurer(tenantMdcInterceptor, userMdcInterceptor);
   }
 
   @Bean

--- a/openaev-api/src/main/java/io/openaev/debug/DebugProperties.java
+++ b/openaev-api/src/main/java/io/openaev/debug/DebugProperties.java
@@ -31,10 +31,14 @@ public class DebugProperties {
   /** How often the "debug mode is active" warning repeats. */
   private Duration warningInterval = Duration.ofMinutes(5);
 
-  /** Writable directory for the JFR recordings and the rotated SQL log file. */
+  /**
+   * Writable directory for the JFR recordings and the rotated debug log files (SQL, and the ORM
+   * summary when {@code orm.summary-to-file} is on).
+   */
   private String outputDir = "./logs/debug";
 
   private final Sql sql = new Sql();
+  private final Orm orm = new Orm();
   private final Jfr jfr = new Jfr();
   private final Masking masking = new Masking();
 
@@ -49,6 +53,28 @@ public class DebugProperties {
 
     /** Truncate rendered parameter values longer than this. */
     private int maxParameterLength = 200;
+
+    /** Rotated SQL file: size a single file reaches before it rolls over. */
+    private DataSize maxFileSize = DataSize.ofMegabytes(500);
+
+    /** Rotated SQL file: number of days of history to keep. */
+    private int maxHistory = 7;
+
+    /**
+     * Rotated SQL file: total size kept across all files before the oldest are deleted. Raise this
+     * on high-traffic instances where the log fills fast, to keep more history.
+     */
+    private DataSize totalSizeCap = DataSize.ofGigabytes(2);
+  }
+
+  /** Per-request ORM/N+1 summary (one log event per request on {@code io.openaev.debug.orm}). */
+  @Data
+  public static class Orm {
+    /**
+     * Write the ORM summary to a rotated file instead of the console. Useful on instances whose
+     * console is shipped to centralised logging, to keep the per-request summaries out of it.
+     */
+    private boolean summaryToFile = false;
   }
 
   /** Java Flight Recorder capture via the JDK {@code jdk.jfr} engine. */

--- a/openaev-api/src/main/java/io/openaev/debug/DebugSqlLogFileConfigurer.java
+++ b/openaev-api/src/main/java/io/openaev/debug/DebugSqlLogFileConfigurer.java
@@ -12,27 +12,49 @@ import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.unit.DataSize;
 
 /**
- * Routes the verbose SQL log ({@code io.openaev.debug.sql}) to a rotated file under {@code
- * output-dir}, off the console, so it does not flood stdout. If the dir is not writable it warns
- * and leaves the logger on the console.
+ * Routes the verbose debug logs to rotated files under {@code output-dir}, off the console, so they
+ * do not flood stdout (and, on instances shipping the console to centralised logging, that
+ * pipeline). The SQL log ({@code io.openaev.debug.sql}) is always routed; the per-request ORM
+ * summary ({@code io.openaev.debug.orm}) is routed too when {@code
+ * openaev.debug.orm.summary-to-file} is on. File rotation is configurable via {@code
+ * openaev.debug.sql.*}; invalid rotation values are corrected to safe ones (with a warning) rather
+ * than fed to Logback, where they would silently disable cleanup or prevent the rolling policy from
+ * starting. If the dir is not writable it warns and leaves the loggers on the console.
  */
 public class DebugSqlLogFileConfigurer {
 
   private static final org.slf4j.Logger log =
       LoggerFactory.getLogger(DebugSqlLogFileConfigurer.class);
+
   private static final String SQL_LOGGER = "io.openaev.debug.sql";
-  private static final String FILE_NAME = "openaev-debug-sql.log";
+  private static final String SQL_FILE = "openaev-debug-sql";
+  private static final String SQL_PATTERN =
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level "
+          + "[trace=%X{traceId:-} tenant=%X{tenant:-} user=%X{user:-}] %msg%n";
+
+  private static final String ORM_LOGGER = "io.openaev.debug.orm";
+  private static final String ORM_FILE = "openaev-debug-orm";
+  private static final String ORM_PATTERN =
+      "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [trace=%X{traceId:-} tenant=%X{tenant:-}] %msg%n";
 
   private final String outputDirPath;
+  private final DebugProperties.Sql sqlConfig;
+  private final boolean ormSummaryToFile;
 
-  private RollingFileAppender<ILoggingEvent> appender;
+  private final List<RoutedLogger> routed = new ArrayList<>();
   private volatile boolean attached;
 
-  public DebugSqlLogFileConfigurer(String outputDirPath) {
+  public DebugSqlLogFileConfigurer(
+      String outputDirPath, DebugProperties.Sql sqlConfig, boolean ormSummaryToFile) {
     this.outputDirPath = outputDirPath;
+    this.sqlConfig = sqlConfig;
+    this.ormSummaryToFile = ormSummaryToFile;
   }
 
   public boolean isAttached() {
@@ -52,47 +74,111 @@ public class DebugSqlLogFileConfigurer {
       }
     } catch (IOException e) {
       log.warn(
-          "Debug mode: SQL log directory is not writable ({}). SQL statements stay on the console "
-              + "instead of a rotated file. Point openaev.debug.output-dir at a writable volume.",
+          "Debug mode: log directory is not writable ({}). Debug logs stay on the console instead "
+              + "of a rotated file. Point openaev.debug.output-dir at a writable volume.",
           e.getMessage());
       return;
     }
 
+    DebugProperties.Sql rotation = sanitizedRotation(sqlConfig);
+
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    Path file = dir.resolve(FILE_NAME);
+    routeToFile(context, dir, rotation, SQL_LOGGER, SQL_FILE, SQL_PATTERN);
+    if (ormSummaryToFile) {
+      routeToFile(context, dir, rotation, ORM_LOGGER, ORM_FILE, ORM_PATTERN);
+    }
+    attached = true;
+  }
+
+  /**
+   * Returns rotation settings that are safe to hand to Logback, correcting invalid values with a
+   * warning: a non-positive {@code max-file-size} or {@code total-size-cap} falls back to its
+   * default; {@code max-history} must be at least 1 (in Logback, {@code 0} means unbounded history
+   * and disables the cleanup pass entirely, including the total size cap); {@code total-size-cap}
+   * is raised to {@code max-file-size} when smaller (a smaller cap prevents the rolling policy from
+   * starting).
+   */
+  static DebugProperties.Sql sanitizedRotation(DebugProperties.Sql config) {
+    DebugProperties.Sql defaults = new DebugProperties.Sql();
+    DebugProperties.Sql sanitized = new DebugProperties.Sql();
+    boolean corrected = false;
+
+    DataSize maxFileSize = config.getMaxFileSize();
+    if (maxFileSize == null || maxFileSize.toBytes() <= 0) {
+      maxFileSize = defaults.getMaxFileSize();
+      corrected = true;
+    }
+    sanitized.setMaxFileSize(maxFileSize);
+
+    int maxHistory = config.getMaxHistory();
+    if (maxHistory <= 0) {
+      maxHistory = defaults.getMaxHistory();
+      corrected = true;
+    }
+    sanitized.setMaxHistory(maxHistory);
+
+    DataSize totalSizeCap = config.getTotalSizeCap();
+    if (totalSizeCap == null || totalSizeCap.toBytes() <= 0) {
+      totalSizeCap = defaults.getTotalSizeCap();
+      corrected = true;
+    }
+    if (totalSizeCap.toBytes() < maxFileSize.toBytes()) {
+      totalSizeCap = maxFileSize;
+      corrected = true;
+    }
+    sanitized.setTotalSizeCap(totalSizeCap);
+
+    if (corrected) {
+      log.warn(
+          "Debug mode: invalid SQL log rotation settings corrected. Effective values: "
+              + "max-file-size={}, max-history={}, total-size-cap={} "
+              + "(max-file-size and total-size-cap must be positive, max-history at least 1, "
+              + "and total-size-cap at least max-file-size).",
+          sanitized.getMaxFileSize(),
+          sanitized.getMaxHistory(),
+          sanitized.getTotalSizeCap());
+    }
+    return sanitized;
+  }
+
+  private void routeToFile(
+      LoggerContext context,
+      Path dir,
+      DebugProperties.Sql rotation,
+      String loggerName,
+      String baseName,
+      String pattern) {
+    Path file = dir.resolve(baseName + ".log");
 
     PatternLayoutEncoder encoder = new PatternLayoutEncoder();
     encoder.setContext(context);
-    encoder.setPattern(
-        "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [trace=%X{traceId:-} tenant=%X{tenant:-}] %msg%n");
+    encoder.setPattern(pattern);
     encoder.start();
 
     RollingFileAppender<ILoggingEvent> fileAppender = new RollingFileAppender<>();
     fileAppender.setContext(context);
-    fileAppender.setName("openaev-debug-sql");
+    fileAppender.setName(baseName);
     fileAppender.setFile(file.toString());
     fileAppender.setEncoder(encoder);
 
     SizeAndTimeBasedRollingPolicy<ILoggingEvent> policy = new SizeAndTimeBasedRollingPolicy<>();
     policy.setContext(context);
     policy.setParent(fileAppender);
-    policy.setFileNamePattern(dir.resolve("openaev-debug-sql.%d{yyyy-MM-dd}.%i.log").toString());
-    policy.setMaxFileSize(FileSize.valueOf("50MB"));
-    policy.setMaxHistory(7);
-    policy.setTotalSizeCap(FileSize.valueOf("500MB"));
+    policy.setFileNamePattern(dir.resolve(baseName + ".%d{yyyy-MM-dd}.%i.log").toString());
+    policy.setMaxFileSize(new FileSize(rotation.getMaxFileSize().toBytes()));
+    policy.setMaxHistory(rotation.getMaxHistory());
+    policy.setTotalSizeCap(new FileSize(rotation.getTotalSizeCap().toBytes()));
     policy.start();
 
     fileAppender.setRollingPolicy(policy);
     fileAppender.start();
 
-    Logger sqlLogger = context.getLogger(SQL_LOGGER);
-    sqlLogger.setAdditive(false); // off the console
-    sqlLogger.addAppender(fileAppender);
+    Logger logger = context.getLogger(loggerName);
+    logger.setAdditive(false); // off the console
+    logger.addAppender(fileAppender);
 
-    this.appender = fileAppender;
-    this.attached = true;
-    log.warn(
-        "Debug mode: SQL statements are written to the rotated file {}", file.toAbsolutePath());
+    routed.add(new RoutedLogger(loggerName, fileAppender));
+    log.warn("Debug mode: {} is written to the rotated file {}", loggerName, file.toAbsolutePath());
   }
 
   @PreDestroy
@@ -101,11 +187,15 @@ public class DebugSqlLogFileConfigurer {
       return;
     }
     LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-    Logger sqlLogger = context.getLogger(SQL_LOGGER);
-    sqlLogger.detachAppender(appender);
-    sqlLogger.setAdditive(true);
-    appender.stop();
-    appender = null;
+    for (RoutedLogger r : routed) {
+      Logger logger = context.getLogger(r.loggerName());
+      logger.detachAppender(r.appender());
+      logger.setAdditive(true);
+      r.appender().stop();
+    }
+    routed.clear();
     attached = false;
   }
+
+  private record RoutedLogger(String loggerName, RollingFileAppender<ILoggingEvent> appender) {}
 }

--- a/openaev-api/src/main/java/io/openaev/debug/DebugUserMdcInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/debug/DebugUserMdcInterceptor.java
@@ -6,40 +6,41 @@ import org.slf4j.MDC;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 
 /**
- * Tags a request's log lines with {@code tenant=...} (from {@link DebugTenantSource}). Lowest
- * precedence, so it runs after the platform tenant interceptor and the handler mapping.
+ * Tags a request's log lines with {@code user=...} (the id of the caller, from {@link
+ * DebugUserSource}), so it is clear who triggered a given request. Lowest precedence, so it runs
+ * after authentication has populated the security context.
  *
  * <p>{@link AsyncHandlerInterceptor} (not just {@code HandlerInterceptor}): on an async dispatch
  * (e.g. a {@code StreamingResponseBody} endpoint) the initial servlet thread exits through {@link
  * #afterConcurrentHandlingStarted} instead of {@code afterCompletion}, and the MDC key must be
- * cleared there too so the pooled thread does not keep the previous request's {@code tenant=}.
+ * cleared there too so the pooled thread does not keep the previous caller's {@code user=}.
  */
-public class DebugTenantMdcInterceptor implements AsyncHandlerInterceptor {
+public class DebugUserMdcInterceptor implements AsyncHandlerInterceptor {
 
-  static final String TENANT_MDC_KEY = "tenant";
+  static final String USER_MDC_KEY = "user";
 
-  private final DebugTenantSource tenantSource;
+  private final DebugUserSource userSource;
 
-  public DebugTenantMdcInterceptor(DebugTenantSource tenantSource) {
-    this.tenantSource = tenantSource;
+  public DebugUserMdcInterceptor(DebugUserSource userSource) {
+    this.userSource = userSource;
   }
 
   @Override
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    MDC.put(TENANT_MDC_KEY, tenantSource.currentTenant(request));
+    MDC.put(USER_MDC_KEY, userSource.currentUser());
     return true;
   }
 
   @Override
   public void afterCompletion(
       HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-    MDC.remove(TENANT_MDC_KEY);
+    MDC.remove(USER_MDC_KEY);
   }
 
   @Override
   public void afterConcurrentHandlingStarted(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    MDC.remove(TENANT_MDC_KEY);
+    MDC.remove(USER_MDC_KEY);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/debug/DebugUserSource.java
+++ b/openaev-api/src/main/java/io/openaev/debug/DebugUserSource.java
@@ -1,0 +1,31 @@
+package io.openaev.debug;
+
+import io.openaev.config.OpenAEVAnonymous;
+import io.openaev.config.SessionHelper;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * The id of the user who triggered the current request, to tag debug logs with {@code user=...}.
+ * Reads the security context ({@link SessionHelper}); returns {@code "anonymous"} when there is no
+ * authenticated user (no token, or a token whose {@link Authentication#isAuthenticated()} is false)
+ * and {@code "-"} if the context cannot be read. Never throws.
+ */
+public class DebugUserSource {
+
+  static final String UNKNOWN = "-";
+
+  public String currentUser() {
+    try {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      if (authentication == null || !authentication.isAuthenticated()) {
+        // An unauthenticated token must not be attributed as a user.
+        return OpenAEVAnonymous.ANONYMOUS;
+      }
+      String id = SessionHelper.currentUser().getId();
+      return (id == null || id.isBlank()) ? UNKNOWN : id;
+    } catch (RuntimeException e) {
+      return UNKNOWN;
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/debug/DebugWebMvcConfigurer.java
+++ b/openaev-api/src/main/java/io/openaev/debug/DebugWebMvcConfigurer.java
@@ -8,14 +8,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class DebugWebMvcConfigurer implements WebMvcConfigurer {
 
   private final DebugTenantMdcInterceptor tenantMdcInterceptor;
+  private final DebugUserMdcInterceptor userMdcInterceptor;
 
-  public DebugWebMvcConfigurer(DebugTenantMdcInterceptor tenantMdcInterceptor) {
+  public DebugWebMvcConfigurer(
+      DebugTenantMdcInterceptor tenantMdcInterceptor, DebugUserMdcInterceptor userMdcInterceptor) {
     this.tenantMdcInterceptor = tenantMdcInterceptor;
+    this.userMdcInterceptor = userMdcInterceptor;
   }
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    // After the platform tenant interceptor.
+    // Lowest precedence: after the platform tenant interceptor and after authentication.
     registry.addInterceptor(tenantMdcInterceptor).order(Ordered.LOWEST_PRECEDENCE);
+    registry.addInterceptor(userMdcInterceptor).order(Ordered.LOWEST_PRECEDENCE);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/debug/OrmInsightFilter.java
+++ b/openaev-api/src/main/java/io/openaev/debug/OrmInsightFilter.java
@@ -29,10 +29,13 @@ public class OrmInsightFilter extends OncePerRequestFilter {
 
   private final SensitiveDataMasker masker;
   private final DebugRuntimeState runtimeState;
+  private final DebugUserSource userSource;
 
-  public OrmInsightFilter(SensitiveDataMasker masker, DebugRuntimeState runtimeState) {
+  public OrmInsightFilter(
+      SensitiveDataMasker masker, DebugRuntimeState runtimeState, DebugUserSource userSource) {
     this.masker = masker;
     this.runtimeState = runtimeState;
+    this.userSource = userSource;
   }
 
   @Override
@@ -59,24 +62,23 @@ public class OrmInsightFilter extends OncePerRequestFilter {
     List<RequestQueryStats.StatementStat> repeated = stats.repeatedStatements(N_PLUS_ONE_THRESHOLD);
     boolean chatty = stats.totalQueries() > CHATTY_THRESHOLD;
 
-    if (repeated.isEmpty() && !chatty) {
-      log.info(
-          "ORM {}: {} queries ({} distinct), {}ms",
-          stats.requestDescription(),
-          stats.totalQueries(),
-          stats.distinctStatements(),
-          stats.totalMillis());
-      return;
-    }
-
-    StringBuilder sb = new StringBuilder();
-    sb.append(
+    // Pre-formatted (not SLF4J placeholders) so a JSON log encoder that keeps the raw message
+    // pattern still shows the resolved values, and so both branches carry user=.
+    String summary =
         String.format(
-            "ORM %s: %d queries (%d distinct), %dms",
+            "ORM %s: %d queries (%d distinct), %dms user=%s",
             stats.requestDescription(),
             stats.totalQueries(),
             stats.distinctStatements(),
-            stats.totalMillis()));
+            stats.totalMillis(),
+            userSource.currentUser());
+
+    if (repeated.isEmpty() && !chatty) {
+      log.info(summary);
+      return;
+    }
+
+    StringBuilder sb = new StringBuilder(summary);
     if (chatty) {
       sb.append(
           String.format(

--- a/openaev-api/src/test/java/io/openaev/config/TenantInterceptorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantInterceptorTest.java
@@ -8,61 +8,63 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.Tenant;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.HandlerMapping;
 
+@DisplayName("TenantInterceptor")
 class TenantInterceptorTest {
 
-  private final TenantMembershipCacheManager tenantMembershipCacheManager =
-      mock(TenantMembershipCacheManager.class);
-  private final TenantInterceptor interceptor = new TenantInterceptor(tenantMembershipCacheManager);
-
-  private final MockHttpServletRequest request = new MockHttpServletRequest();
-  private final MockHttpServletResponse response = new MockHttpServletResponse();
+  private final TenantInterceptor interceptor =
+      new TenantInterceptor(mock(TenantMembershipCacheManager.class));
 
   @AfterEach
-  void tearDown() {
+  void cleanup() {
     TenantContext.clearCurrentTenant();
   }
 
-  @Test
-  void given_tenant_id_in_path_prehandle_should_set_context_and_after_completion_should_clear() {
-    // -- ARRANGE --
-    String tenantId = "abc-123";
+  private MockHttpServletRequest tenantScopedRequest(String tenantId) {
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/api/tenants/" + tenantId + "/x");
     request.setAttribute(
         HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("tenantId", tenantId));
-
-    // -- ACT --
-    boolean result = interceptor.preHandle(request, response, new Object());
-
-    // -- ASSERT --
-    assertThat(result).isTrue();
-    assertThat(TenantContext.getCurrentTenant()).isEqualTo(tenantId);
-
-    // -- ACT --
-    interceptor.afterCompletion(request, response, new Object(), null);
-
-    // -- ASSERT --
-    assertThat(TenantContext.getCurrentTenant()).isEqualTo(Tenant.DEFAULT_TENANT_UUID);
+    return request;
   }
 
   @Test
-  void given_no_tenant_id_in_path_prehandle_should_fallback_to_default_tenant() {
-    // -- ACT -- no path variables at all
-    boolean resultNoVars = interceptor.preHandle(request, response, new Object());
+  @DisplayName("sets the tenant from the path variable and clears it on afterCompletion")
+  void setsAndClearsTenant() {
+    MockHttpServletRequest request = tenantScopedRequest("tenant-123");
+    MockHttpServletResponse response = new MockHttpServletResponse();
 
-    // -- ASSERT --
-    assertThat(resultNoVars).isTrue();
-    assertThat(TenantContext.getCurrentTenant()).isEqualTo(Tenant.DEFAULT_TENANT_UUID);
+    interceptor.preHandle(request, response, new Object());
+    assertThat(TenantContext.getCurrentTenant()).isEqualTo("tenant-123");
 
-    // -- ACT -- path variables present but no tenantId key
-    request.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, Map.of("otherId", "xyz"));
-    boolean resultNoTenantKey = interceptor.preHandle(request, response, new Object());
+    interceptor.afterCompletion(request, response, new Object(), null);
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
 
-    // -- ASSERT --
-    assertThat(resultNoTenantKey).isTrue();
+  @Test
+  @DisplayName("clears the tenant when the request goes async, so the next request is not stale")
+  void clearsTenantOnAsyncDispatch() {
+    // Async requests (e.g. StreamingResponseBody) do not call afterCompletion on the initial
+    // dispatch: without afterConcurrentHandlingStarted the pooled servlet thread would keep the
+    // previous request's tenant in the TenantContext thread-local.
+    MockHttpServletRequest request = tenantScopedRequest("tenant-123");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+    assertThat(TenantContext.getCurrentTenant()).isEqualTo("tenant-123");
+
+    interceptor.afterConcurrentHandlingStarted(request, response, new Object());
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+
+    // The next non-tenant-scoped request on this (pooled) thread resolves the default tenant,
+    // not the stale one.
+    MockHttpServletRequest nextRequest = new MockHttpServletRequest("GET", "/api/tags");
+    interceptor.preHandle(nextRequest, new MockHttpServletResponse(), new Object());
     assertThat(TenantContext.getCurrentTenant()).isEqualTo(Tenant.DEFAULT_TENANT_UUID);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/debug/DebugSqlLogFileConfigurerTest.java
+++ b/openaev-api/src/test/java/io/openaev/debug/DebugSqlLogFileConfigurerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.unit.DataSize;
 
 @DisplayName("DebugSqlLogFileConfigurer")
 class DebugSqlLogFileConfigurerTest {
@@ -29,11 +32,27 @@ class DebugSqlLogFileConfigurerTest {
     return (Logger) LoggerFactory.getLogger("io.openaev.debug.sql");
   }
 
+  private Logger ormLogger() {
+    return (Logger) LoggerFactory.getLogger("io.openaev.debug.orm");
+  }
+
+  private RollingFileAppender<?> sqlFileAppenderUnder(Path dir) {
+    var appenders = sqlLogger().iteratorForAppenders();
+    while (appenders.hasNext()) {
+      if (appenders.next() instanceof RollingFileAppender<?> rfa
+          && rfa.getFile() != null
+          && rfa.getFile().startsWith(dir.toString())) {
+        return rfa;
+      }
+    }
+    throw new AssertionError("no SQL file appender under " + dir);
+  }
+
   @Test
   @DisplayName("routes SQL logs to a rotated file, off the console (additivity false)")
   void routesToFile(@TempDir Path tmp) throws Exception {
     sqlLogger().setLevel(Level.INFO);
-    configurer = new DebugSqlLogFileConfigurer(tmp.toString());
+    configurer = new DebugSqlLogFileConfigurer(tmp.toString(), new DebugProperties.Sql(), false);
     configurer.start();
 
     assertThat(configurer.isAttached()).isTrue();
@@ -47,16 +66,126 @@ class DebugSqlLogFileConfigurerTest {
   }
 
   @Test
-  @DisplayName("restores the console route on stop")
+  @DisplayName("applies the configured rotation onto a size+time based policy")
+  void appliesConfiguredRotation(@TempDir Path tmp) {
+    // maxHistory is the readable proxy for the whole rotation config: the three values are set on
+    // the same policy from the same config object, so a wired maxHistory proves the plumbing (file
+    // size and total-size cap have no public getter on the logback policy to assert directly).
+    DebugProperties.Sql cfg = new DebugProperties.Sql();
+    cfg.setMaxFileSize(DataSize.ofMegabytes(10));
+    cfg.setMaxHistory(3);
+    cfg.setTotalSizeCap(DataSize.ofGigabytes(5));
+    configurer = new DebugSqlLogFileConfigurer(tmp.toString(), cfg, false);
+    configurer.start();
+
+    // Find the appender this configurer created by its file (a cached debug-on E2E context may have
+    // attached another appender of the same name to the shared sql logger).
+    RollingFileAppender<?> appender = sqlFileAppenderUnder(tmp);
+    assertThat(appender.getRollingPolicy()).isInstanceOf(SizeAndTimeBasedRollingPolicy.class);
+    SizeAndTimeBasedRollingPolicy<?> policy =
+        (SizeAndTimeBasedRollingPolicy<?>) appender.getRollingPolicy();
+
+    assertThat(policy.getMaxHistory()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("corrects maxHistory=0 (unbounded in Logback, disables cleanup) to the default")
+  void correctsZeroMaxHistory(@TempDir Path tmp) {
+    // In Logback, maxHistory=0 means unbounded history and disables the cleanup pass entirely,
+    // including the total size cap: it must never be handed to the policy as-is.
+    DebugProperties.Sql cfg = new DebugProperties.Sql();
+    cfg.setMaxHistory(0);
+    configurer = new DebugSqlLogFileConfigurer(tmp.toString(), cfg, false);
+    configurer.start();
+
+    RollingFileAppender<?> appender = sqlFileAppenderUnder(tmp);
+    SizeAndTimeBasedRollingPolicy<?> policy =
+        (SizeAndTimeBasedRollingPolicy<?>) appender.getRollingPolicy();
+    assertThat(policy.getMaxHistory()).isEqualTo(new DebugProperties.Sql().getMaxHistory());
+  }
+
+  @Test
+  @DisplayName("sanitizes invalid rotation values (positives, cap >= file size)")
+  void sanitizesInvalidRotation() {
+    DebugProperties.Sql cfg = new DebugProperties.Sql();
+    cfg.setMaxFileSize(DataSize.ofBytes(0));
+    cfg.setMaxHistory(-3);
+    cfg.setTotalSizeCap(DataSize.ofMegabytes(-1));
+    DebugProperties.Sql defaults = new DebugProperties.Sql();
+
+    DebugProperties.Sql sanitized = DebugSqlLogFileConfigurer.sanitizedRotation(cfg);
+
+    assertThat(sanitized.getMaxFileSize()).isEqualTo(defaults.getMaxFileSize());
+    assertThat(sanitized.getMaxHistory()).isEqualTo(defaults.getMaxHistory());
+    assertThat(sanitized.getTotalSizeCap()).isEqualTo(defaults.getTotalSizeCap());
+  }
+
+  @Test
+  @DisplayName("raises a total-size-cap smaller than max-file-size (blocks the rolling policy)")
+  void raisesTooSmallTotalSizeCap() {
+    DebugProperties.Sql cfg = new DebugProperties.Sql();
+    cfg.setMaxFileSize(DataSize.ofMegabytes(500));
+    cfg.setTotalSizeCap(DataSize.ofMegabytes(100));
+
+    DebugProperties.Sql sanitized = DebugSqlLogFileConfigurer.sanitizedRotation(cfg);
+
+    assertThat(sanitized.getTotalSizeCap()).isEqualTo(DataSize.ofMegabytes(500));
+  }
+
+  @Test
+  @DisplayName("keeps valid rotation values unchanged")
+  void keepsValidRotation() {
+    DebugProperties.Sql cfg = new DebugProperties.Sql();
+    cfg.setMaxFileSize(DataSize.ofMegabytes(10));
+    cfg.setMaxHistory(3);
+    cfg.setTotalSizeCap(DataSize.ofGigabytes(5));
+
+    DebugProperties.Sql sanitized = DebugSqlLogFileConfigurer.sanitizedRotation(cfg);
+
+    assertThat(sanitized.getMaxFileSize()).isEqualTo(DataSize.ofMegabytes(10));
+    assertThat(sanitized.getMaxHistory()).isEqualTo(3);
+    assertThat(sanitized.getTotalSizeCap()).isEqualTo(DataSize.ofGigabytes(5));
+  }
+
+  @Test
+  @DisplayName("routes the ORM summary to its own file when summary-to-file is on")
+  void routesOrmToFileWhenEnabled(@TempDir Path tmp) throws Exception {
+    ormLogger().setLevel(Level.INFO);
+    configurer = new DebugSqlLogFileConfigurer(tmp.toString(), new DebugProperties.Sql(), true);
+    configurer.start();
+
+    assertThat(ormLogger().isAdditive()).as("ORM summary off the console").isFalse();
+    LoggerFactory.getLogger("io.openaev.debug.orm").info("orm summary for the file");
+
+    Path file = tmp.resolve("openaev-debug-orm.log");
+    assertThat(Files.exists(file)).isTrue();
+    assertThat(Files.readString(file)).contains("orm summary for the file");
+  }
+
+  @Test
+  @DisplayName("leaves the ORM logger on the console when summary-to-file is off (default)")
+  void ormStaysOnConsoleByDefault(@TempDir Path tmp) {
+    ormLogger().setAdditive(true);
+    configurer = new DebugSqlLogFileConfigurer(tmp.toString(), new DebugProperties.Sql(), false);
+    configurer.start();
+
+    assertThat(ormLogger().isAdditive()).isTrue();
+    assertThat(Files.exists(tmp.resolve("openaev-debug-orm.log"))).isFalse();
+  }
+
+  @Test
+  @DisplayName("restores the console route on stop (both loggers)")
   void restoresOnStop(@TempDir Path tmp) {
-    configurer = new DebugSqlLogFileConfigurer(tmp.toString());
+    configurer = new DebugSqlLogFileConfigurer(tmp.toString(), new DebugProperties.Sql(), true);
     configurer.start();
     assertThat(sqlLogger().isAdditive()).isFalse();
+    assertThat(ormLogger().isAdditive()).isFalse();
 
     configurer.stop();
 
     assertThat(configurer.isAttached()).isFalse();
-    assertThat(sqlLogger().isAdditive()).as("console route restored").isTrue();
+    assertThat(sqlLogger().isAdditive()).as("SQL console route restored").isTrue();
+    assertThat(ormLogger().isAdditive()).as("ORM console route restored").isTrue();
   }
 
   @Test
@@ -64,7 +193,8 @@ class DebugSqlLogFileConfigurerTest {
   void fallsBackWhenNotWritable(@TempDir Path tmp) throws IOException {
     Path blockingFile = Files.createFile(tmp.resolve("not-a-dir"));
     Path unwritable = blockingFile.resolve("debug");
-    configurer = new DebugSqlLogFileConfigurer(unwritable.toString());
+    configurer =
+        new DebugSqlLogFileConfigurer(unwritable.toString(), new DebugProperties.Sql(), false);
 
     configurer.start(); // must not throw
 

--- a/openaev-api/src/test/java/io/openaev/debug/DebugTenantMdcInterceptorTest.java
+++ b/openaev-api/src/test/java/io/openaev/debug/DebugTenantMdcInterceptorTest.java
@@ -37,6 +37,20 @@ class DebugTenantMdcInterceptorTest {
   }
 
   @Test
+  @DisplayName("removes tenant= when the request goes async (afterConcurrentHandlingStarted)")
+  void removesTenantOnAsyncDispatch() {
+    TenantContext.setCurrentTenant("tenant-123");
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/tenants/tenant-123/x");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+    assertThat(MDC.get("tenant")).isEqualTo("tenant-123");
+
+    interceptor.afterConcurrentHandlingStarted(request, response, new Object());
+    assertThat(MDC.get("tenant")).isNull();
+  }
+
+  @Test
   @DisplayName("records the default tenant for non-tenant-scoped requests")
   void defaultTenantWhenNotScoped() {
     // No tenant set -> TenantContext returns the default, which is the correct thing to record.

--- a/openaev-api/src/test/java/io/openaev/debug/DebugUserMdcInterceptorTest.java
+++ b/openaev-api/src/test/java/io/openaev/debug/DebugUserMdcInterceptorTest.java
@@ -1,0 +1,56 @@
+package io.openaev.debug;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayName("DebugUserMdcInterceptor")
+class DebugUserMdcInterceptorTest {
+
+  private final DebugUserMdcInterceptor interceptor =
+      new DebugUserMdcInterceptor(
+          new DebugUserSource() {
+            @Override
+            public String currentUser() {
+              return "u-9";
+            }
+          });
+
+  @AfterEach
+  void clear() {
+    MDC.clear();
+  }
+
+  @Test
+  @DisplayName("tags the request with user= on preHandle and removes it on afterCompletion")
+  void putsAndRemovesUser() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+    assertThat(MDC.get("user")).isEqualTo("u-9");
+
+    interceptor.afterCompletion(request, response, new Object(), null);
+    assertThat(MDC.get("user")).isNull();
+  }
+
+  @Test
+  @DisplayName("removes user= when the request goes async (afterConcurrentHandlingStarted)")
+  void removesUserOnAsyncDispatch() {
+    // Async requests (e.g. StreamingResponseBody) do not call afterCompletion on the initial
+    // dispatch: the servlet thread must not go back to the pool with the caller still in MDC.
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    interceptor.preHandle(request, response, new Object());
+    assertThat(MDC.get("user")).isEqualTo("u-9");
+
+    interceptor.afterConcurrentHandlingStarted(request, response, new Object());
+    assertThat(MDC.get("user")).isNull();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/debug/DebugUserSourceTest.java
+++ b/openaev-api/src/test/java/io/openaev/debug/DebugUserSourceTest.java
@@ -1,0 +1,75 @@
+package io.openaev.debug;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.config.OpenAEVPrincipal;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayName("DebugUserSource")
+class DebugUserSourceTest {
+
+  private final DebugUserSource source = new DebugUserSource();
+
+  @AfterEach
+  void clear() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("returns 'anonymous' when there is no authenticated user")
+  void anonymousWhenNoAuthentication() {
+    SecurityContextHolder.clearContext();
+    assertThat(source.currentUser()).isEqualTo("anonymous");
+  }
+
+  @Test
+  @DisplayName("returns the id of the authenticated user")
+  void returnsAuthenticatedUserId() {
+    // The three-argument constructor produces an authenticated token.
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal("user-123"), null, List.of()));
+    assertThat(source.currentUser()).isEqualTo("user-123");
+  }
+
+  @Test
+  @DisplayName("returns 'anonymous' for an unauthenticated token (isAuthenticated() false)")
+  void anonymousWhenTokenNotAuthenticated() {
+    // The two-argument constructor produces an explicitly unauthenticated token: its principal
+    // must not be attributed as the caller.
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(principal("user-123"), null));
+    assertThat(source.currentUser()).isEqualTo("anonymous");
+  }
+
+  private static OpenAEVPrincipal principal(String id) {
+    return new OpenAEVPrincipal() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+      }
+
+      @Override
+      public boolean isAdmin() {
+        return false;
+      }
+
+      @Override
+      public String getLang() {
+        return "auto";
+      }
+    };
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/debug/OrmInsightFilterTest.java
+++ b/openaev-api/src/test/java/io/openaev/debug/OrmInsightFilterTest.java
@@ -54,7 +54,14 @@ class OrmInsightFilterTest {
     MaskingSqlLoggingListener listener =
         new MaskingSqlLoggingListener(masker, new DebugRuntimeState(), properties.getSql());
     proxy = ProxyDataSourceBuilder.create(h2).name("orm").listener(listener).build();
-    filter = new OrmInsightFilter(masker, new DebugRuntimeState());
+    DebugUserSource userSource =
+        new DebugUserSource() {
+          @Override
+          public String currentUser() {
+            return "u-42";
+          }
+        };
+    filter = new OrmInsightFilter(masker, new DebugRuntimeState(), userSource);
 
     ormLogger = (Logger) LoggerFactory.getLogger("io.openaev.debug.orm");
     ormLogger.setLevel(Level.INFO);
@@ -179,6 +186,43 @@ class OrmInsightFilterTest {
         });
 
     assertThat(summary()).contains("N+1 SUSPECTED").doesNotContain("victim@example.com");
+  }
+
+  @Test
+  @DisplayName("the summary names the caller (user=...) on both the INFO and WARN paths")
+  void summaryCarriesCaller() throws Exception {
+    runThroughFilter("GET", "/api/tags", () -> exec("select 1", null)); // clean -> INFO
+    assertThat(summaryLevel()).isEqualTo(Level.INFO);
+    assertThat(summary()).contains("user=u-42");
+
+    appender.list.clear();
+    runThroughFilter(
+        "POST",
+        "/api/injectors",
+        () -> {
+          for (int i = 0; i < 12; i++) {
+            exec("select user_id from users where user_email = ?", "u" + i);
+          }
+        }); // N+1 -> WARN
+    assertThat(summaryLevel()).isEqualTo(Level.WARN);
+    assertThat(summary()).contains("user=u-42");
+  }
+
+  @Test
+  @DisplayName("the INFO summary is fully rendered (no unresolved {} placeholders)")
+  void infoSummaryIsPreFormatted() throws Exception {
+    runThroughFilter("GET", "/api/tags", () -> exec("select 1", null));
+
+    // The message itself carries the resolved values, so a JSON encoder that keeps the raw pattern
+    // still shows real numbers instead of "ORM {}: {} queries ...".
+    ILoggingEvent event =
+        new ArrayList<>(appender.list)
+            .stream()
+                .filter(e -> e.getFormattedMessage().startsWith("ORM "))
+                .findFirst()
+                .orElseThrow();
+    assertThat(event.getMessage()).doesNotContain("{}").contains("GET /api/tags", "1 queries");
+    assertThat(event.getArgumentArray()).isNullOrEmpty();
   }
 
   @Test


### PR DESCRIPTION
Follow-up to the global debug mode (#6378). Makes it usable on high-traffic and centrally-logged instances, and adds the caller to the trace. Closes #6862.

## What and why

### Configurable SQL log rotation

The rotated SQL file was hardcoded (50 MB / 7 / 500 MB), so on a busy instance only ~1h of history survived and it could not be tuned. Rotation is now configurable and the defaults are larger:

- `openaev.debug.sql.max-file-size` (default `500MB`)
- `openaev.debug.sql.max-history` (default `7`)
- `openaev.debug.sql.total-size-cap` (default `2GB`)

Invalid combinations are corrected to safe values at startup with a warning: the sizes and the history must be positive and the total cap at least the file size (in Logback, `maxHistory=0` means unbounded history and disables cleanup entirely, and a total cap below the file size prevents the rolling policy from starting).

The docs also explain that `total-size-cap` governs the retention window (not `max-file-size`), and that raising `slow-query-threshold` is the cheapest way to keep more history without more disk.

### Caller in the trace

A new `DebugUserSource` resolves the current user id from the security context (`anonymous` when there is no authenticated user, including explicitly unauthenticated tokens; never throws). A `DebugUserMdcInterceptor` tags each request with `user=` in the MDC, so it appears in the SQL file, and the per-request ORM summary now names the caller too. It is clear who triggered a given request or N+1.

### Async-safe request context cleanup

Both debug MDC interceptors (`user` and `tenant`) and the platform `TenantInterceptor` implement `AsyncHandlerInterceptor` and clean up in `afterConcurrentHandlingStarted`, so async dispatches (e.g. `StreamingResponseBody` endpoints) cannot leak the previous caller's MDC tags or `TenantContext` onto a pooled servlet thread and misattribute the next request.

### Less centralised-logging noise

- New `openaev.debug.orm.summary-to-file`: writes the ORM/N+1 summary to `openaev-debug-orm.log` instead of the console, to keep it out of Loki/Grafana. Off by default.
- The clean-request ORM summary is now pre-formatted, so it renders correctly under the JSON encoder (no more `ORM {}: {} queries ...`).

### Docs

- New "A production-safe, low-noise setup" example (enabled + allow-in-production + auto-disable + persistent volume + slow-query-threshold + orm.summary-to-file + jfr off), with each explanation on its own `#` line (Java `.properties` has no inline comments).
- New "Tuning for a high-traffic or centrally-logged instance" note.
- Config reference, the SQL file format (now with `user=`) and the output section updated; the overview now describes the ORM summary-to-file routing consistently.

## Behaviour when off

Unchanged: no beans, no interceptors, no cost. All new wiring is gated by the same debug condition.

## Testing

- Unit tests for the rotation config and its sanitization, the ORM `user=`/pre-format, the ORM-to-file routing, the user source (authenticated, unauthenticated token, no authentication), both debug MDC interceptors (sync and async dispatch) and the platform `TenantInterceptor` (sync, async, and the following non-tenant request).
- Debug unit suite green locally after the rebase onto main.

## Notes

- `user=` is the user id (a UUID), not the email, to avoid a DB lookup on every request.
- The ORM file reuses the SQL rotation settings (the ORM summary is one log event per request, so it fills slowly).
- Branch rebased onto latest main and squashed into a single signed commit (original work by @laugiov, kept as co-author).
