### PR TITLE
fix(chaining): correctly copy chaining entities when launching a scenario (#4824)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/ConditionApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/ConditionApi.java
@@ -84,9 +84,7 @@ public class ConditionApi extends RestBehavior {
       resourceType = ResourceType.WORKFLOW)
   @GetMapping(params = "workflow_id")
   public List<EventOutput> findAllByWorkflow(@RequestParam("workflow_id") String workflowId) {
-    return conditionService.findNonMapperConditionsByWorkflowId(workflowId).stream()
-        .map(ConditionMapper::toOutput)
-        .toList();
+    return conditionService.findEventsByWorkflowId(workflowId);
   }
 
   // -- UPDATE --

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -593,7 +593,12 @@ public class ConditionService {
     // AND node: all children must be satisfied
     if (condition.getType() == ConditionType.AND) {
       if (condition.getConditionChildren() == null || condition.getConditionChildren().isEmpty()) {
-        return true;
+        // A childless AND cannot be produced by any creation path: an action with no condition
+        // creates no Condition at all, and an AND group is always created with >=1 child. This case
+        // means an abnormal/corrupted condition tree.
+        // The fail-safe is to keep the gate closed, and so, we return false here.
+        // Consistent with the empty-OR case, which also returns false.
+        return false;
       }
       return condition.getConditionChildren().stream()
           .allMatch(child -> isFilterTreeSatisfied(child, contextSupplier));

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -111,10 +111,12 @@ public class ConditionService {
     }
     List<ConditionCreateInput> rootInputs = findRootConditionInputs(conditionInputs);
 
-    // Multiple roots are only allowed when all roots are MAPPER conditions
+    // Allow one event/filter root plus any number of mapper roots.
+    // In chaining, mapper conditions are independent root mappings.
     if (rootInputs.size() > 1) {
-      boolean allMapper = rootInputs.stream().allMatch(r -> r.getType() == ConditionType.MAPPER);
-      if (!allMapper) {
+      long nonMapperRootCount =
+          rootInputs.stream().filter(r -> r.getType() != ConditionType.MAPPER).count();
+      if (nonMapperRootCount > 1) {
         throw new IllegalArgumentException(
             "New step (TEMPLATE): Only 1 condition can be first parent");
       }

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -6,6 +6,7 @@ import static io.openaev.utils.JsonUtils.gson;
 import io.openaev.api.chaining.ConditionMapper;
 import io.openaev.api.chaining.dto.ConditionCreateInput;
 import io.openaev.api.chaining.dto.EventInput;
+import io.openaev.api.chaining.dto.EventOutput;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ConditionRepository;
 import io.openaev.database.repository.StepRepository;
@@ -306,6 +307,61 @@ public class ConditionService {
   public List<Condition> findNonMapperConditionsByWorkflowId(String workflowId) {
     return conditionRepository.findAllByWorkflowIdAndConditionParentIsNullAndTypeNot(
         workflowId, ConditionType.MAPPER);
+  }
+
+  /**
+   * Returns all non-MAPPER conditions (roots AND descendants) for a given workflow.
+   *
+   * @param workflowId the workflow identifier
+   * @return flat list of all non-MAPPER conditions belonging to the workflow
+   */
+  @Transactional(readOnly = true)
+  public List<Condition> findAllNonMapperConditionsByWorkflowId(String workflowId) {
+    return conditionRepository.findAllByWorkflowIdAndTypeNot(workflowId, ConditionType.MAPPER);
+  }
+
+  /**
+   * Returns complete event outputs for a workflow, with full condition trees resolved from a flat
+   * query. This avoids reliance on lazy-loaded {@code conditionChildren} collections, which may not
+   * be initialized in a cold read transaction.
+   *
+   * @param workflowId the workflow identifier
+   * @return list of fully populated {@link EventOutput} DTOs
+   */
+  @Transactional(readOnly = true)
+  public List<EventOutput> findEventsByWorkflowId(String workflowId) {
+    List<Condition> all =
+        conditionRepository.findAllByWorkflowIdAndTypeNot(workflowId, ConditionType.MAPPER);
+
+    // Index children by parent id for O(1) lookups
+    Map<String, List<Condition>> childrenByParentId = new HashMap<>();
+    for (Condition c : all) {
+      Condition parent = c.getConditionParent();
+      if (parent != null) {
+        childrenByParentId.computeIfAbsent(parent.getId(), k -> new ArrayList<>()).add(c);
+      }
+    }
+
+    List<Condition> roots = all.stream().filter(c -> c.getConditionParent() == null).toList();
+
+    List<EventOutput> events = new ArrayList<>();
+    for (Condition root : roots) {
+      List<Condition> subtree = new ArrayList<>();
+      collectSubtree(root, childrenByParentId, subtree);
+      events.add(ConditionMapper.toOutput(root, subtree));
+    }
+    return events;
+  }
+
+  private static void collectSubtree(
+      Condition node, Map<String, List<Condition>> childrenByParentId, List<Condition> acc) {
+    acc.add(node);
+    List<Condition> children = childrenByParentId.get(node.getId());
+    if (children != null) {
+      for (Condition child : children) {
+        collectSubtree(child, childrenByParentId, acc);
+      }
+    }
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -412,6 +412,8 @@ public class StepService {
               .value(firstCondition.getValue())
               .caseSensitive(firstCondition.isCaseSensitive())
               .mappingType(firstCondition.getMappingType())
+              .name(firstCondition.getName())
+              .workflowId(stepCopied.getWorkflow().getId())
               .stepFrom(stepFrom)
               .build();
 
@@ -449,6 +451,8 @@ public class StepService {
                 .value(condition.getValue())
                 .caseSensitive(condition.isCaseSensitive())
                 .mappingType(condition.getMappingType())
+                .name(condition.getName())
+                .workflowId(stepCopied.getWorkflow().getId())
                 .conditionParent(temporaryIdAndSaveId.get(condition.getConditionParent().getId()))
                 .stepFrom(stepFromCondition)
                 .build();

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -425,11 +425,11 @@ public class StepService {
               .keyType(firstCondition.getKeyType())
               .value(firstCondition.getValue())
               .caseSensitive(firstCondition.isCaseSensitive())
-.mappingType(firstCondition.getMappingType())
-.name(firstCondition.getName())
-.description(firstCondition.getDescription())
-.workflowId(stepCopied.getWorkflow().getId())
-.stepFrom(stepFrom)
+              .mappingType(firstCondition.getMappingType())
+              .name(firstCondition.getName())
+              .description(firstCondition.getDescription())
+              .workflowId(stepCopied.getWorkflow().getId())
+              .stepFrom(stepFrom)
               .build();
 
       conditionService.linkToStep(first, stepCopied, true);

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -460,6 +460,13 @@ public class StepService {
         conditionService.linkToStep(current, stepCopied, false);
         current = conditionService.saveCondition(current);
 
+        // Keep the in-memory graph consistent for API mapping (mirrors persistConditionTree)
+        Condition parent = current.getConditionParent();
+        if (parent.getConditionChildren() == null) {
+          parent.setConditionChildren(new ArrayList<>());
+        }
+        parent.getConditionChildren().add(current);
+
         temporaryIdAndSaveId.put(condition.getId(), current);
 
         currentId.add(condition.getId());

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -408,7 +408,10 @@ public class StepService {
           Condition.builder()
               .type(firstCondition.getType())
               .key(firstCondition.getKey())
+              .keyType(firstCondition.getKeyType())
               .value(firstCondition.getValue())
+              .caseSensitive(firstCondition.isCaseSensitive())
+              .mappingType(firstCondition.getMappingType())
               .stepFrom(stepFrom)
               .build();
 
@@ -442,7 +445,10 @@ public class StepService {
             Condition.builder()
                 .type(condition.getType())
                 .key(condition.getKey())
+                .keyType(condition.getKeyType())
                 .value(condition.getValue())
+                .caseSensitive(condition.isCaseSensitive())
+                .mappingType(condition.getMappingType())
                 .conditionParent(temporaryIdAndSaveId.get(condition.getConditionParent().getId()))
                 .stepFrom(stepFromCondition)
                 .build();

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -374,12 +374,15 @@ public class StepService {
    */
   @Transactional(rollbackFor = Exception.class)
   void copyStepConditionTemplate(Step step, Step stepCopied) {
-    List<Condition> conditions = conditionService.findAllConditionsByStepId(step.getId());
-    if (conditions == null || conditions.isEmpty()) {
+    // Roots linked to this step (source of truth for which trees to copy)
+    List<Condition> linkedConditions = conditionService.findAllConditionsByStepId(step.getId());
+    if (linkedConditions == null || linkedConditions.isEmpty()) {
       return;
     }
     List<Condition> rootConditions =
-        conditions.stream().filter(condition -> condition.getConditionParent() == null).toList();
+        linkedConditions.stream()
+            .filter(condition -> condition.getConditionParent() == null)
+            .toList();
 
     if (rootConditions.isEmpty()) {
       throw new IllegalArgumentException(
@@ -395,6 +398,16 @@ public class StepService {
             "New step (TEMPLATE): Only 1 condition can be first parent");
       }
     }
+
+    // Full set of the source workflow's non-MAPPER conditions, to resolve children by parent id
+    // independent of conditions_steps linkage (Event-API links only the root to the step).
+    List<Condition> allSourceConditions =
+        conditionService.findAllNonMapperConditionsByWorkflowId(step.getWorkflow().getId());
+
+    Map<String, List<Condition>> temporaryConditions =
+        allSourceConditions.stream()
+            .filter(condition -> condition.getConditionParent() != null)
+            .collect(Collectors.groupingBy(condition -> condition.getConditionParent().getId()));
 
     Map<String, Condition> temporaryIdAndSaveId = new HashMap<>();
 
@@ -422,11 +435,6 @@ public class StepService {
 
       temporaryIdAndSaveId.put(firstCondition.getId(), first);
     }
-
-    Map<String, List<Condition>> temporaryConditions =
-        conditions.stream()
-            .filter(condition -> condition.getConditionParent() != null)
-            .collect(Collectors.groupingBy(condition -> condition.getConditionParent().getId()));
 
     Queue<String> currentId = new LinkedList<>();
     rootConditions.forEach(rc -> currentId.add(rc.getId()));

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -389,11 +389,12 @@ public class StepService {
           "New step (TEMPLATE): At least 1 condition must be a root (no parent)");
     }
 
-    // Multiple roots are only allowed when all roots are MAPPER conditions
+    // Allow one event/filter root plus any number of mapper roots.
+    // This happens when a step has one linked event root and one or more action mappings.
     if (rootConditions.size() > 1) {
-      boolean allMapper =
-          rootConditions.stream().allMatch(c -> c.getType() == ConditionType.MAPPER);
-      if (!allMapper) {
+      long nonMapperRootCount =
+          rootConditions.stream().filter(c -> c.getType() != ConditionType.MAPPER).count();
+      if (nonMapperRootCount > 1) {
         throw new IllegalArgumentException(
             "New step (TEMPLATE): Only 1 condition can be first parent");
       }

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -425,10 +425,11 @@ public class StepService {
               .keyType(firstCondition.getKeyType())
               .value(firstCondition.getValue())
               .caseSensitive(firstCondition.isCaseSensitive())
-              .mappingType(firstCondition.getMappingType())
-              .name(firstCondition.getName())
-              .workflowId(stepCopied.getWorkflow().getId())
-              .stepFrom(stepFrom)
+.mappingType(firstCondition.getMappingType())
+.name(firstCondition.getName())
+.description(firstCondition.getDescription())
+.workflowId(stepCopied.getWorkflow().getId())
+.stepFrom(stepFrom)
               .build();
 
       conditionService.linkToStep(first, stepCopied, true);

--- a/openaev-api/src/test/java/io/openaev/api/chaining/ConditionApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/ConditionApiTest.java
@@ -53,14 +53,16 @@ class ConditionApiTest {
   @Test
   void findAllByWorkflow_shouldReturnMappedList() {
     Condition root = conditionTree("c-wf", "wf-9", "ev-9", "d");
-    when(conditionService.findNonMapperConditionsByWorkflowId("wf-9")).thenReturn(List.of(root));
+
+    EventOutput expectedOutput = ConditionMapper.toOutput(root);
+    when(conditionService.findEventsByWorkflowId("wf-9")).thenReturn(List.of(expectedOutput));
 
     List<EventOutput> result = conditionApi.findAllByWorkflow("wf-9");
 
     assertEquals(1, result.size());
     assertEquals("c-wf", result.getFirst().getId());
     assertEquals("wf-9", result.getFirst().getWorkflowId());
-    verify(conditionService).findNonMapperConditionsByWorkflowId("wf-9");
+    verify(conditionService).findEventsByWorkflowId("wf-9");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -1824,4 +1824,54 @@ public class ConditionServiceTest {
       }
     }
   }
+
+  /* ============================================================
+   * isFilterTreeSatisfied — empty AND node defense
+   * ============================================================ */
+  @Nested
+  class FilterTreeEmptyAndNode {
+
+    @Test
+    void given_andNodeWithNoChildren_should_returnFalse() throws Exception {
+      // Arrange: AND node with empty children list
+      Condition andNode =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .build(); // conditionChildren defaults to empty
+
+      // Access private method via reflection
+      java.lang.reflect.Method method =
+          ConditionService.class.getDeclaredMethod(
+              "isFilterTreeSatisfied", Condition.class, java.util.function.Supplier.class);
+      method.setAccessible(true);
+
+      java.util.function.Supplier<?> dummySupplier = () -> null;
+
+      // Act
+      boolean result = (boolean) method.invoke(conditionService, andNode, dummySupplier);
+
+      // Assert — an empty AND must NOT be satisfied (gate must stay closed)
+      assertFalse(result);
+    }
+
+    @Test
+    void given_andNodeWithNullChildren_should_returnFalse() throws Exception {
+      // Arrange: AND node with null children
+      Condition andNode = Condition.builder().type(ConditionType.AND).build();
+      andNode.setConditionChildren(null);
+
+      java.lang.reflect.Method method =
+          ConditionService.class.getDeclaredMethod(
+              "isFilterTreeSatisfied", Condition.class, java.util.function.Supplier.class);
+      method.setAccessible(true);
+
+      java.util.function.Supplier<?> dummySupplier = () -> null;
+
+      // Act
+      boolean result = (boolean) method.invoke(conditionService, andNode, dummySupplier);
+
+      // Assert
+      assertFalse(result);
+    }
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.openaev.api.chaining.dto.ConditionCreateInput;
 import io.openaev.api.chaining.dto.EventInput;
+import io.openaev.api.chaining.dto.EventOutput;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ConditionRepository;
 import io.openaev.database.repository.StepRepository;
@@ -1872,6 +1873,128 @@ public class ConditionServiceTest {
 
       // Assert
       assertFalse(result);
+    }
+  }
+
+  /* ============================================================
+   * findEventsByWorkflowId — cold read with complete tree
+   * ============================================================ */
+  @Nested
+  class FindEventsByWorkflowId {
+
+    @Test
+    void given_deepEventTree_when_readByWorkflow_should_returnCompleteContent_withoutLazyInit() {
+      // GIVEN a workflow with a root AND "totoCond" -> child OR group -> leaf EQ "toto"
+      //       root.getConditionChildren() is left EMPTY to simulate the cold read
+      String workflowId = "wf-1";
+
+      Condition root = Condition.builder().type(ConditionType.AND).build();
+      root.setId("root-id");
+      root.setName("totoCond");
+      root.setWorkflowId(workflowId);
+      root.setConditionChildren(List.of()); // simulate uninitialized lazy collection
+
+      Condition childGroup =
+          Condition.builder().type(ConditionType.OR).conditionParent(root).build();
+      childGroup.setId("child-group-id");
+      childGroup.setWorkflowId(workflowId);
+      childGroup.setConditionChildren(List.of()); // not initialized
+
+      Condition leaf =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("text")
+              .value("toto")
+              .conditionParent(childGroup)
+              .build();
+      leaf.setId("leaf-id");
+      leaf.setWorkflowId(workflowId);
+
+      // Repository returns the FLAT list (root + descendants)
+      when(conditionRepository.findAllByWorkflowIdAndTypeNot(workflowId, ConditionType.MAPPER))
+          .thenReturn(List.of(root, childGroup, leaf));
+
+      // WHEN
+      List<EventOutput> events = conditionService.findEventsByWorkflowId(workflowId);
+
+      // THEN one event returned
+      assertEquals(1, events.size());
+      EventOutput event = events.get(0);
+      assertEquals("totoCond", event.getName());
+
+      // The event contains root + child group + leaf = 3 conditions
+      assertEquals(3, event.getConditions().size());
+
+      // The leaf value "toto" is present in the mapped output
+      assertTrue(
+          event.getConditions().stream().anyMatch(c -> "toto".equals(c.getValue())),
+          "Leaf condition with value 'toto' should be in the event output");
+    }
+
+    @Test
+    void given_twoIndependentEvents_when_readByWorkflow_should_notContaminateEachOther() {
+      // GIVEN two independent root events in the same workflow
+      String workflowId = "wf-2";
+
+      Condition rootA = Condition.builder().type(ConditionType.AND).build();
+      rootA.setId("root-a");
+      rootA.setName("EventA");
+      rootA.setWorkflowId(workflowId);
+      rootA.setConditionChildren(List.of());
+
+      Condition leafA =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("field_a")
+              .value("valueA")
+              .conditionParent(rootA)
+              .build();
+      leafA.setId("leaf-a");
+      leafA.setWorkflowId(workflowId);
+
+      Condition rootB = Condition.builder().type(ConditionType.OR).build();
+      rootB.setId("root-b");
+      rootB.setName("EventB");
+      rootB.setWorkflowId(workflowId);
+      rootB.setConditionChildren(List.of());
+
+      Condition leafB =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("field_b")
+              .value("valueB")
+              .conditionParent(rootB)
+              .build();
+      leafB.setId("leaf-b");
+      leafB.setWorkflowId(workflowId);
+
+      when(conditionRepository.findAllByWorkflowIdAndTypeNot(workflowId, ConditionType.MAPPER))
+          .thenReturn(List.of(rootA, leafA, rootB, leafB));
+
+      // WHEN
+      List<EventOutput> events = conditionService.findEventsByWorkflowId(workflowId);
+
+      // THEN two events returned
+      assertEquals(2, events.size());
+
+      EventOutput eventA =
+          events.stream().filter(e -> "EventA".equals(e.getName())).findFirst().orElseThrow();
+      EventOutput eventB =
+          events.stream().filter(e -> "EventB".equals(e.getName())).findFirst().orElseThrow();
+
+      // EventA has root + leafA = 2 conditions, NOT leafB
+      assertEquals(2, eventA.getConditions().size());
+      assertTrue(eventA.getConditions().stream().anyMatch(c -> "valueA".equals(c.getValue())));
+      assertFalse(
+          eventA.getConditions().stream().anyMatch(c -> "valueB".equals(c.getValue())),
+          "EventA must not contain EventB's leaf");
+
+      // EventB has root + leafB = 2 conditions, NOT leafA
+      assertEquals(2, eventB.getConditions().size());
+      assertTrue(eventB.getConditions().stream().anyMatch(c -> "valueB".equals(c.getValue())));
+      assertFalse(
+          eventB.getConditions().stream().anyMatch(c -> "valueA".equals(c.getValue())),
+          "EventB must not contain EventA's leaf");
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1501,5 +1501,74 @@ class StepServiceTest {
       assertEquals(1, copiedGroup.getConditionChildren().size());
       assertSame(copiedLeaf, copiedGroup.getConditionChildren().get(0));
     }
+
+    @Test
+    void given_mixedEventAndMapperRoots_should_allowSingleNonMapperRoot() {
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("src-wf");
+
+      Step sourceStep = new Step();
+      sourceStep.setId("src-step");
+      sourceStep.setWorkflow(sourceWorkflow);
+
+      Workflow targetWorkflow = new Workflow();
+      targetWorkflow.setId("tgt-wf");
+
+      Step targetStep = new Step();
+      targetStep.setId("tgt-step");
+      targetStep.setWorkflow(targetWorkflow);
+
+      Condition eventRoot =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .name("event-root")
+              .workflowId("src-wf")
+              .build();
+      eventRoot.setId("event-root-id");
+
+      Condition eventLeaf =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("text")
+              .value("leaf")
+              .workflowId("src-wf")
+              .conditionParent(eventRoot)
+              .build();
+      eventLeaf.setId("event-leaf-id");
+
+      Condition mapperRoot =
+          Condition.builder()
+              .type(ConditionType.MAPPER)
+              .mappingType(MappingType.LOCAL)
+              .workflowId("src-wf")
+              .build();
+      mapperRoot.setId("mapper-root-id");
+
+      // Step has one event root and one mapper root linked.
+      when(conditionService.findAllConditionsByStepId("src-step"))
+          .thenReturn(List.of(eventRoot, mapperRoot));
+
+      // Workflow non-mapper query must still provide the full event subtree.
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("src-wf"))
+          .thenReturn(List.of(eventRoot, eventLeaf));
+
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      stepService.copyStepConditionTemplate(sourceStep, targetStep);
+
+      // event root + mapper root + event leaf
+      assertEquals(3, savedConditions.size());
+      assertEquals(ConditionType.AND, savedConditions.get(0).getType());
+      assertEquals(ConditionType.MAPPER, savedConditions.get(1).getType());
+      assertEquals("leaf", savedConditions.get(2).getValue());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1064,4 +1064,122 @@ class StepServiceTest {
       verify(stepRepository).findAllByStepTemplateIdIsNull();
     }
   }
+
+  /* ============================================================
+   * copyStepConditionTemplate — field preservation
+   * ============================================================ */
+  @Nested
+  class CopyStepConditionTemplateFields {
+
+    @Test
+    void given_conditionWithAllFields_should_copyAllConfigFieldsToNewCondition() {
+      // Arrange
+      Step sourceStep = new Step();
+      sourceStep.setId("source-step-id");
+
+      Step targetStep = new Step();
+      targetStep.setId("target-step-id");
+
+      // Build a root AND condition with all config fields set to non-default values
+      Condition rootCondition =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .key("test_key")
+              .keyType(PrimitiveType.AssetGroupId)
+              .value("test_value")
+              .caseSensitive(false) // non-default (default is true)
+              .mappingType(MappingType.GLOBAL)
+              .build();
+      rootCondition.setId("root-id");
+
+      // Build a child EQ leaf condition
+      Condition childCondition =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("child_key")
+              .keyType(PrimitiveType.AssetGroupId)
+              .value("child_value")
+              .caseSensitive(false)
+              .mappingType(MappingType.LOCAL)
+              .conditionParent(rootCondition)
+              .build();
+      childCondition.setId("child-id");
+
+      when(conditionService.findAllConditionsByStepId("source-step-id"))
+          .thenReturn(List.of(rootCondition, childCondition));
+
+      // Capture saved conditions
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      // Act
+      stepService.copyStepConditionTemplate(sourceStep, targetStep);
+
+      // Assert — root condition fields
+      assertEquals(2, savedConditions.size());
+      Condition copiedRoot = savedConditions.get(0);
+      assertEquals(rootCondition.getKey(), copiedRoot.getKey());
+      assertEquals(rootCondition.getKeyType(), copiedRoot.getKeyType());
+      assertEquals(rootCondition.getType(), copiedRoot.getType());
+      assertEquals(rootCondition.getValue(), copiedRoot.getValue());
+      assertEquals(rootCondition.isCaseSensitive(), copiedRoot.isCaseSensitive());
+      assertEquals(rootCondition.getMappingType(), copiedRoot.getMappingType());
+
+      // Assert — child condition fields
+      Condition copiedChild = savedConditions.get(1);
+      assertEquals(childCondition.getKey(), copiedChild.getKey());
+      assertEquals(childCondition.getKeyType(), copiedChild.getKeyType());
+      assertEquals(childCondition.getType(), copiedChild.getType());
+      assertEquals(childCondition.getValue(), copiedChild.getValue());
+      assertEquals(childCondition.isCaseSensitive(), copiedChild.isCaseSensitive());
+      assertEquals(childCondition.getMappingType(), copiedChild.getMappingType());
+
+      // Assert — structural link: child's parent is the copied root
+      assertSame(copiedRoot, copiedChild.getConditionParent());
+    }
+
+    @Test
+    void given_caseSensitiveFalse_should_notRevertToDefaultTrue() {
+      // This specifically catches the @Builder.Default=true regression
+      Step sourceStep = new Step();
+      sourceStep.setId("src");
+
+      Step targetStep = new Step();
+      targetStep.setId("tgt");
+
+      Condition root =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("k")
+              .value("v")
+              .caseSensitive(false)
+              .mappingType(MappingType.DEFAULT)
+              .build();
+      root.setId("r");
+
+      when(conditionService.findAllConditionsByStepId("src")).thenReturn(List.of(root));
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                return c;
+              });
+
+      // Act
+      stepService.copyStepConditionTemplate(sourceStep, targetStep);
+
+      // Assert
+      ArgumentCaptor<Condition> captor = ArgumentCaptor.forClass(Condition.class);
+      verify(conditionService).saveCondition(captor.capture());
+      assertFalse(captor.getValue().isCaseSensitive());
+    }
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1258,5 +1258,71 @@ class StepServiceTest {
       // Verify it's NOT the old source workflowId
       assertNotEquals("old-scenario-workflow-id", copiedRoot.getWorkflowId());
     }
+
+    @Test
+    void given_scenarioEventWithLeaf_when_copied_should_exposeLeafInConditionChildren() {
+      // GIVEN a scenario template step with a named root AND condition (event "totoCond")
+      //       having one leaf child (text equals "toto")
+      Step sourceStep = new Step();
+      sourceStep.setId("scenario-step");
+
+      Workflow simulationWorkflow = new Workflow();
+      simulationWorkflow.setId("sim-wf-id");
+
+      Step stepCopied = new Step();
+      stepCopied.setId("sim-step");
+      stepCopied.setWorkflow(simulationWorkflow);
+
+      Condition sourceRoot =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .key("event_key")
+              .name("totoCond")
+              .workflowId("old-wf")
+              .mappingType(MappingType.GLOBAL)
+              .build();
+      sourceRoot.setId("root-id");
+
+      Condition sourceLeaf =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("text")
+              .value("toto")
+              .name("leaf-label")
+              .workflowId("old-wf")
+              .mappingType(MappingType.LOCAL)
+              .conditionParent(sourceRoot)
+              .build();
+      sourceLeaf.setId("leaf-id");
+
+      when(conditionService.findAllConditionsByStepId("scenario-step"))
+          .thenReturn(List.of(sourceRoot, sourceLeaf));
+
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      // WHEN copyStepConditionTemplate copies the step into the simulation workflow
+      stepService.copyStepConditionTemplate(sourceStep, stepCopied);
+
+      // THEN the copied root exposes its child in memory (inverse side populated)
+      assertEquals(2, savedConditions.size());
+      Condition copiedRoot = savedConditions.get(0);
+      Condition copiedChild = savedConditions.get(1);
+
+      assertNotNull(copiedRoot.getConditionChildren());
+      assertEquals(1, copiedRoot.getConditionChildren().size());
+      assertSame(copiedChild, copiedRoot.getConditionChildren().get(0));
+      assertEquals(sourceLeaf.getValue(), copiedRoot.getConditionChildren().get(0).getValue());
+
+      // AND the child's conditionParent points back to the copied root
+      assertSame(copiedRoot, copiedChild.getConditionParent());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1095,10 +1095,11 @@ class StepServiceTest {
               .key("test_key")
               .keyType(PrimitiveType.AssetGroupId)
               .value("test_value")
-              .caseSensitive(false) // non-default (default is true)
-              .mappingType(MappingType.GLOBAL)
-              .name("root-event-name")
-              .build();
+.caseSensitive(false) // non-default (default is true)
+.mappingType(MappingType.GLOBAL)
+.name("root-event-name")
+.description("root-event-description")
+.build();
       rootCondition.setId("root-id");
 
       // Build a child EQ leaf condition

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1095,11 +1095,11 @@ class StepServiceTest {
               .key("test_key")
               .keyType(PrimitiveType.AssetGroupId)
               .value("test_value")
-.caseSensitive(false) // non-default (default is true)
-.mappingType(MappingType.GLOBAL)
-.name("root-event-name")
-.description("root-event-description")
-.build();
+              .caseSensitive(false) // non-default (default is true)
+              .mappingType(MappingType.GLOBAL)
+              .name("root-event-name")
+              .description("root-event-description")
+              .build();
       rootCondition.setId("root-id");
 
       // Build a child EQ leaf condition

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1074,8 +1074,12 @@ class StepServiceTest {
     @Test
     void given_conditionWithAllFields_should_copyAllConfigFieldsToNewCondition() {
       // Arrange
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("source-workflow-id");
+
       Step sourceStep = new Step();
       sourceStep.setId("source-step-id");
+      sourceStep.setWorkflow(sourceWorkflow);
 
       Workflow targetWorkflow = new Workflow();
       targetWorkflow.setId("target-workflow-id");
@@ -1112,6 +1116,9 @@ class StepServiceTest {
       childCondition.setId("child-id");
 
       when(conditionService.findAllConditionsByStepId("source-step-id"))
+          .thenReturn(List.of(rootCondition, childCondition));
+
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("source-workflow-id"))
           .thenReturn(List.of(rootCondition, childCondition));
 
       // Capture saved conditions
@@ -1154,8 +1161,12 @@ class StepServiceTest {
     @Test
     void given_caseSensitiveFalse_should_notRevertToDefaultTrue() {
       // This specifically catches the @Builder.Default=true regression
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("src-wf");
+
       Step sourceStep = new Step();
       sourceStep.setId("src");
+      sourceStep.setWorkflow(sourceWorkflow);
 
       Workflow targetWorkflow = new Workflow();
       targetWorkflow.setId("tgt-wf");
@@ -1175,6 +1186,8 @@ class StepServiceTest {
       root.setId("r");
 
       when(conditionService.findAllConditionsByStepId("src")).thenReturn(List.of(root));
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("src-wf"))
+          .thenReturn(List.of(root));
       when(conditionService.saveCondition(any(Condition.class)))
           .thenAnswer(
               invocation -> {
@@ -1195,8 +1208,12 @@ class StepServiceTest {
     @Test
     void given_scenarioEvent_when_copiedToSimulation_should_preserveWorkflowIdAndName() {
       // GIVEN a scenario template step with a named root condition (event)
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("old-scenario-workflow-id");
+
       Step sourceStep = new Step();
       sourceStep.setId("scenario-step");
+      sourceStep.setWorkflow(sourceWorkflow);
 
       Workflow simulationWorkflow = new Workflow();
       simulationWorkflow.setId("simulation-workflow-id");
@@ -1227,6 +1244,9 @@ class StepServiceTest {
       sourceChild.setId("src-child");
 
       when(conditionService.findAllConditionsByStepId("scenario-step"))
+          .thenReturn(List.of(sourceRoot, sourceChild));
+
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("old-scenario-workflow-id"))
           .thenReturn(List.of(sourceRoot, sourceChild));
 
       List<Condition> savedConditions = new ArrayList<>();
@@ -1263,8 +1283,12 @@ class StepServiceTest {
     void given_scenarioEventWithLeaf_when_copied_should_exposeLeafInConditionChildren() {
       // GIVEN a scenario template step with a named root AND condition (event "totoCond")
       //       having one leaf child (text equals "toto")
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("old-wf");
+
       Step sourceStep = new Step();
       sourceStep.setId("scenario-step");
+      sourceStep.setWorkflow(sourceWorkflow);
 
       Workflow simulationWorkflow = new Workflow();
       simulationWorkflow.setId("sim-wf-id");
@@ -1298,6 +1322,8 @@ class StepServiceTest {
       when(conditionService.findAllConditionsByStepId("scenario-step"))
           .thenReturn(List.of(sourceRoot, sourceLeaf));
 
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("old-wf"))
+          .thenReturn(List.of(sourceRoot, sourceLeaf));
       List<Condition> savedConditions = new ArrayList<>();
       when(conditionService.saveCondition(any(Condition.class)))
           .thenAnswer(
@@ -1323,6 +1349,157 @@ class StepServiceTest {
 
       // AND the child's conditionParent points back to the copied root
       assertSame(copiedRoot, copiedChild.getConditionParent());
+    }
+
+    @Test
+    void given_eventApiCreation_rootOnlyLinkedToStep_should_stillCopyChild() {
+      // Reproduces the Event-API case: only the ROOT is linked to the step (via
+      // conditions_steps), the child is NOT linked but belongs to the same workflow.
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("src-wf");
+
+      Step sourceStep = new Step();
+      sourceStep.setId("src-step");
+      sourceStep.setWorkflow(sourceWorkflow);
+
+      Workflow targetWorkflow = new Workflow();
+      targetWorkflow.setId("tgt-wf");
+
+      Step targetStep = new Step();
+      targetStep.setId("tgt-step");
+      targetStep.setWorkflow(targetWorkflow);
+
+      Condition root =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .name("EventApiEvent")
+              .workflowId("src-wf")
+              .mappingType(MappingType.GLOBAL)
+              .build();
+      root.setId("root-1");
+
+      Condition leaf =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("text")
+              .value("toto")
+              .workflowId("src-wf")
+              .mappingType(MappingType.LOCAL)
+              .conditionParent(root)
+              .build();
+      leaf.setId("leaf-1");
+
+      // findAllConditionsByStepId returns ONLY the root (Event-API links only root)
+      when(conditionService.findAllConditionsByStepId("src-step")).thenReturn(List.of(root));
+
+      // findAllNonMapperConditionsByWorkflowId returns root + child
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("src-wf"))
+          .thenReturn(List.of(root, leaf));
+
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      // Act
+      stepService.copyStepConditionTemplate(sourceStep, targetStep);
+
+      // Assert — both root and child are copied
+      assertEquals(2, savedConditions.size());
+      Condition copiedRoot = savedConditions.get(0);
+      Condition copiedChild = savedConditions.get(1);
+
+      assertEquals("toto", copiedChild.getValue());
+      assertSame(copiedRoot, copiedChild.getConditionParent());
+      assertEquals(1, copiedRoot.getConditionChildren().size());
+    }
+
+    @Test
+    void given_eventApiCreation_deepTree_should_copyAllLevels() {
+      // Deep tree: root -> group (OR) -> leaf (EQ), all from workflow query
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("src-wf");
+
+      Step sourceStep = new Step();
+      sourceStep.setId("src-step");
+      sourceStep.setWorkflow(sourceWorkflow);
+
+      Workflow targetWorkflow = new Workflow();
+      targetWorkflow.setId("tgt-wf");
+
+      Step targetStep = new Step();
+      targetStep.setId("tgt-step");
+      targetStep.setWorkflow(targetWorkflow);
+
+      Condition root =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .name("DeepEvent")
+              .workflowId("src-wf")
+              .build();
+      root.setId("root-deep");
+
+      Condition group =
+          Condition.builder()
+              .type(ConditionType.OR)
+              .workflowId("src-wf")
+              .conditionParent(root)
+              .build();
+      group.setId("group-deep");
+
+      Condition leaf =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("field")
+              .value("deep-value")
+              .workflowId("src-wf")
+              .mappingType(MappingType.LOCAL)
+              .conditionParent(group)
+              .build();
+      leaf.setId("leaf-deep");
+
+      // Only root linked to step
+      when(conditionService.findAllConditionsByStepId("src-step")).thenReturn(List.of(root));
+
+      // Full workflow tree returned
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("src-wf"))
+          .thenReturn(List.of(root, group, leaf));
+
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      // Act
+      stepService.copyStepConditionTemplate(sourceStep, targetStep);
+
+      // Assert — all 3 levels copied
+      assertEquals(3, savedConditions.size());
+      Condition copiedRoot = savedConditions.get(0);
+      Condition copiedGroup = savedConditions.get(1);
+      Condition copiedLeaf = savedConditions.get(2);
+
+      // Structural links
+      assertSame(copiedRoot, copiedGroup.getConditionParent());
+      assertSame(copiedGroup, copiedLeaf.getConditionParent());
+
+      // Leaf value preserved
+      assertEquals("deep-value", copiedLeaf.getValue());
+
+      // In-memory tree is navigable from root
+      assertEquals(1, copiedRoot.getConditionChildren().size());
+      assertEquals(1, copiedGroup.getConditionChildren().size());
+      assertSame(copiedLeaf, copiedGroup.getConditionChildren().get(0));
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1077,8 +1077,12 @@ class StepServiceTest {
       Step sourceStep = new Step();
       sourceStep.setId("source-step-id");
 
+      Workflow targetWorkflow = new Workflow();
+      targetWorkflow.setId("target-workflow-id");
+
       Step targetStep = new Step();
       targetStep.setId("target-step-id");
+      targetStep.setWorkflow(targetWorkflow);
 
       // Build a root AND condition with all config fields set to non-default values
       Condition rootCondition =
@@ -1089,6 +1093,7 @@ class StepServiceTest {
               .value("test_value")
               .caseSensitive(false) // non-default (default is true)
               .mappingType(MappingType.GLOBAL)
+              .name("root-event-name")
               .build();
       rootCondition.setId("root-id");
 
@@ -1101,6 +1106,7 @@ class StepServiceTest {
               .value("child_value")
               .caseSensitive(false)
               .mappingType(MappingType.LOCAL)
+              .name("child-name")
               .conditionParent(rootCondition)
               .build();
       childCondition.setId("child-id");
@@ -1151,8 +1157,12 @@ class StepServiceTest {
       Step sourceStep = new Step();
       sourceStep.setId("src");
 
+      Workflow targetWorkflow = new Workflow();
+      targetWorkflow.setId("tgt-wf");
+
       Step targetStep = new Step();
       targetStep.setId("tgt");
+      targetStep.setWorkflow(targetWorkflow);
 
       Condition root =
           Condition.builder()
@@ -1180,6 +1190,73 @@ class StepServiceTest {
       ArgumentCaptor<Condition> captor = ArgumentCaptor.forClass(Condition.class);
       verify(conditionService).saveCondition(captor.capture());
       assertFalse(captor.getValue().isCaseSensitive());
+    }
+
+    @Test
+    void given_scenarioEvent_when_copiedToSimulation_should_preserveWorkflowIdAndName() {
+      // GIVEN a scenario template step with a named root condition (event)
+      Step sourceStep = new Step();
+      sourceStep.setId("scenario-step");
+
+      Workflow simulationWorkflow = new Workflow();
+      simulationWorkflow.setId("simulation-workflow-id");
+
+      Step stepCopied = new Step();
+      stepCopied.setId("simulation-step");
+      stepCopied.setWorkflow(simulationWorkflow);
+
+      Condition sourceRoot =
+          Condition.builder()
+              .type(ConditionType.AND)
+              .key("event_key")
+              .name("My Event Name")
+              .workflowId("old-scenario-workflow-id")
+              .mappingType(MappingType.GLOBAL)
+              .build();
+      sourceRoot.setId("src-root");
+
+      Condition sourceChild =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("child_key")
+              .name("Child Label")
+              .workflowId("old-scenario-workflow-id")
+              .mappingType(MappingType.LOCAL)
+              .conditionParent(sourceRoot)
+              .build();
+      sourceChild.setId("src-child");
+
+      when(conditionService.findAllConditionsByStepId("scenario-step"))
+          .thenReturn(List.of(sourceRoot, sourceChild));
+
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      // WHEN copyStepConditionTemplate copies the step into the simulation workflow
+      stepService.copyStepConditionTemplate(sourceStep, stepCopied);
+
+      // THEN the copied root condition has:
+      assertEquals(2, savedConditions.size());
+      Condition copiedRoot = savedConditions.get(0);
+      Condition copiedChild = savedConditions.get(1);
+
+      // workflowId == stepCopied.getWorkflow().getId() (target workflow, NOT the source)
+      assertEquals(simulationWorkflow.getId(), copiedRoot.getWorkflowId());
+      assertEquals(simulationWorkflow.getId(), copiedChild.getWorkflowId());
+
+      // name == source name (preserved from template)
+      assertEquals(sourceRoot.getName(), copiedRoot.getName());
+      assertEquals(sourceChild.getName(), copiedChild.getName());
+
+      // Verify it's NOT the old source workflowId
+      assertNotEquals("old-scenario-workflow-id", copiedRoot.getWorkflowId());
     }
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/ConditionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ConditionRepository.java
@@ -66,6 +66,16 @@ public interface ConditionRepository extends JpaRepository<Condition, String> {
   List<Condition> findAllByWorkflowIdAndConditionParentIsNullAndTypeNot(
       String workflowId, ConditionType excludedType);
 
+  /**
+   * Retrieves all conditions (roots AND descendants) for a given workflow, excluding those of the
+   * specified type. Used to build complete event trees without relying on lazy-loaded children.
+   *
+   * @param workflowId the workflow identifier
+   * @param excludedType the condition type to exclude (e.g. MAPPER)
+   * @return all non-excluded conditions for the given workflow
+   */
+  List<Condition> findAllByWorkflowIdAndTypeNot(String workflowId, ConditionType excludedType);
+
   List<Condition> findAllByKeyTypeIn(Set<PrimitiveType> outputKeyTypes);
 
   /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Inverted value for AND conditions without children
* Propagated missing condition properties from TEMPLATE conditions to RUN condtions

### Testing Instructions

1. Create snceario chaining with actions and conditions (update scope local, global linking)
2. Launch scenario

### Related issues

* Related #4824 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
