### PR TITLE
fix(platform): cache stream permission decisions and add pool exhaustion diagnostics (#6868)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/diagnostics/PoolExhaustionWatchdog.java
+++ b/openaev-api/src/main/java/io/openaev/diagnostics/PoolExhaustionWatchdog.java
@@ -118,8 +118,10 @@ public class PoolExhaustionWatchdog {
           holders.append("    ... ").append(frames.length - limit).append(" more\n");
         }
       } else {
+        // Thread names are not unique (pool threads share patterns): suffix the id so
+        // colliding entries do not overwrite each other and under-report threads.
         others.put(
-            thread.getName(),
+            thread.getName() + " #" + thread.threadId(),
             thread.getState() + (frames.length > 0 ? " at " + frames[0] : " (no frames)"));
       }
     }
@@ -140,8 +142,9 @@ public class PoolExhaustionWatchdog {
 
   /**
    * A thread executing inside the Postgres driver, Hibernate's JDBC layer or Hikari's proxy is, by
-   * construction, holding a pooled connection right now (Hikari housekeeping threads are excluded
-   * by name below).
+   * construction, holding (or opening) a database connection right now. Hikari's own housekeeping
+   * threads can match too (e.g. the connection adder stuck dialing an unreachable database): that
+   * is intentional, their stacks are just as diagnostic as application holders.
    */
   private static boolean isSuspectedConnectionHolder(StackTraceElement[] frames) {
     for (StackTraceElement frame : frames) {

--- a/openaev-api/src/main/java/io/openaev/diagnostics/PoolExhaustionWatchdog.java
+++ b/openaev-api/src/main/java/io/openaev/diagnostics/PoolExhaustionWatchdog.java
@@ -1,0 +1,179 @@
+package io.openaev.diagnostics;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Always-on, zero-dependency watchdog that detects HikariCP pool exhaustion and logs actionable
+ * evidence at ERROR level (visible with production log levels, {@code io.openaev=error}).
+ *
+ * <p>When the pool is exhausted, every DB-bound code path in the platform is stuck, so nothing can
+ * be diagnosed from the outside: HTTP requests time out, scheduler jobs fail, and the only log line
+ * is Hikari's generic "Connection is not available". This watchdog samples the Hikari MXBean from
+ * its own scheduler thread (it never touches the database, so it keeps working while the pool is
+ * saturated) and, once saturation persists across consecutive samples, emits a single ERROR
+ * containing:
+ *
+ * <ul>
+ *   <li>the pool statistics (total / active / idle / threads awaiting connection);
+ *   <li>a thread dump in which threads currently inside JDBC / Hibernate / Hikari frames — the
+ *       actual connection holders — are dumped with their full stack, while all other threads are
+ *       summarized on one line each.
+ * </ul>
+ *
+ * <p>Combined with {@code spring.datasource.hikari.leak-detection-threshold} (which logs the
+ * acquisition stack of any connection held longer than the threshold), the logs of the next
+ * exhaustion episode directly name the code paths pinning the pool.
+ *
+ * <p>A cooldown bounds the log volume to one dump per {@link #DUMP_COOLDOWN} even if the outage
+ * lasts longer.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PoolExhaustionWatchdog {
+
+  /** Consecutive saturated samples (5s apart) required before dumping: filters out blips. */
+  private static final int SATURATION_SAMPLES_BEFORE_DUMP = 2;
+
+  private static final Duration DUMP_COOLDOWN = Duration.ofSeconds(60);
+
+  /** Full stacks are only printed for suspected holders; cap them to keep the log bounded. */
+  private static final int MAX_FRAMES_PER_THREAD = 40;
+
+  private final DataSource dataSource;
+
+  private HikariPoolMXBean pool;
+  private boolean unavailable;
+  private int consecutiveSaturatedSamples;
+  private Instant lastDumpAt = Instant.EPOCH;
+
+  @Scheduled(fixedDelay = 5_000, initialDelay = 30_000)
+  public void sample() {
+    HikariPoolMXBean poolBean = resolvePool();
+    if (poolBean == null) {
+      return;
+    }
+    int total = poolBean.getTotalConnections();
+    int active = poolBean.getActiveConnections();
+    int awaiting = poolBean.getThreadsAwaitingConnection();
+    if (total > 0 && active >= total && awaiting > 0) {
+      consecutiveSaturatedSamples++;
+      if (consecutiveSaturatedSamples >= SATURATION_SAMPLES_BEFORE_DUMP
+          && Instant.now().isAfter(lastDumpAt.plus(DUMP_COOLDOWN))) {
+        lastDumpAt = Instant.now();
+        log.error(
+            "Connection pool exhausted for >{}s (total={}, active={}, idle={}, awaiting={})."
+                + " Thread dump with suspected connection holders follows.\n{}",
+            (consecutiveSaturatedSamples - 1) * 5,
+            total,
+            active,
+            poolBean.getIdleConnections(),
+            awaiting,
+            buildThreadDump(Thread.getAllStackTraces()));
+      }
+    } else {
+      consecutiveSaturatedSamples = 0;
+    }
+  }
+
+  /**
+   * Formats the dump so the connection holders stand out: threads with JDBC / Hibernate / Hikari
+   * frames get their full stack (they are the ones executing on a borrowed connection), everything
+   * else is one line, so the ERROR entry stays readable and bounded.
+   */
+  @VisibleForTesting
+  static String buildThreadDump(Map<Thread, StackTraceElement[]> stacks) {
+    StringBuilder holders = new StringBuilder();
+    // TreeMap for a stable, name-sorted summary section
+    Map<String, String> others = new TreeMap<>();
+    int holderCount = 0;
+    for (Map.Entry<Thread, StackTraceElement[]> entry : stacks.entrySet()) {
+      Thread thread = entry.getKey();
+      StackTraceElement[] frames = entry.getValue();
+      if (isSuspectedConnectionHolder(frames)) {
+        holderCount++;
+        holders
+            .append("\n--- HOLDER \"")
+            .append(thread.getName())
+            .append("\" ")
+            .append(thread.getState())
+            .append('\n');
+        int limit = Math.min(frames.length, MAX_FRAMES_PER_THREAD);
+        for (int i = 0; i < limit; i++) {
+          holders.append("    at ").append(frames[i]).append('\n');
+        }
+        if (frames.length > limit) {
+          holders.append("    ... ").append(frames.length - limit).append(" more\n");
+        }
+      } else {
+        others.put(
+            thread.getName(),
+            thread.getState() + (frames.length > 0 ? " at " + frames[0] : " (no frames)"));
+      }
+    }
+    StringBuilder dump =
+        new StringBuilder()
+            .append(holderCount)
+            .append(" thread(s) inside JDBC/Hibernate/Hikari frames (suspected connection")
+            .append(" holders):")
+            .append(holders)
+            .append("\n--- OTHER THREADS (")
+            .append(others.size())
+            .append(")\n");
+    others.forEach(
+        (name, summary) ->
+            dump.append('"').append(name).append("\" ").append(summary).append('\n'));
+    return dump.toString();
+  }
+
+  /**
+   * A thread executing inside the Postgres driver, Hibernate's JDBC layer or Hikari's proxy is, by
+   * construction, holding a pooled connection right now (Hikari housekeeping threads are excluded
+   * by name below).
+   */
+  private static boolean isSuspectedConnectionHolder(StackTraceElement[] frames) {
+    for (StackTraceElement frame : frames) {
+      String className = frame.getClassName();
+      if (className.startsWith("org.postgresql.")
+          || className.startsWith("org.hibernate.engine.jdbc.")
+          || className.startsWith("org.hibernate.resource.jdbc.")
+          || className.startsWith("com.zaxxer.hikari.pool.ProxyConnection")
+          || className.startsWith("com.zaxxer.hikari.pool.ProxyStatement")
+          || className.startsWith("com.zaxxer.hikari.pool.ProxyPreparedStatement")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private HikariPoolMXBean resolvePool() {
+    if (pool != null || unavailable) {
+      return pool;
+    }
+    try {
+      if (dataSource.isWrapperFor(HikariDataSource.class)) {
+        // May still be null before the pool served its first connection: retried next sample.
+        pool = dataSource.unwrap(HikariDataSource.class).getHikariPoolMXBean();
+      } else {
+        // Non-Hikari datasource (some test setups): nothing to watch, disable permanently.
+        unavailable = true;
+      }
+    } catch (SQLException e) {
+      unavailable = true;
+      log.warn("Pool exhaustion watchdog disabled, cannot access Hikari pool: {}", e.getMessage());
+    }
+    return pool;
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
@@ -8,6 +8,8 @@ import static java.time.Instant.now;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.openaev.aop.AccessControl;
 import io.openaev.config.OpenAEVPrincipal;
 import io.openaev.context.TenantContext;
@@ -65,6 +67,18 @@ public class StreamApi extends RestBehavior {
   private final Map<String, CachedUser> userCache = new ConcurrentHashMap<>();
   private static final Duration USER_CACHE_TTL = Duration.ofSeconds(60);
 
+  // Short-lived per-(principal, resource) permission decisions for the broadcast path.
+  // hasPermission is @Transactional and, for inject events (the most frequent mutation while a
+  // simulation is running), resolves the parent permission by loading the FULL Inject entity
+  // graph plus a grant query — per event, per consumer. Under a running simulation this produced
+  // hundreds of queries per second, saturated Postgres and exhausted the Hikari pool, freezing
+  // the whole platform (#6868). Repeated mutations of the same resource are the norm (every
+  // trace/status/expectation update re-touches the same inject), so a 30s TTL absorbs almost all
+  // of it; permission changes propagate to the stream within 30s, consistent with the 60s user
+  // cache above. Bounded so mass disconnects / huge simulations cannot grow it unboundedly.
+  private final Cache<PermissionCacheKey, Boolean> permissionDecisionCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(30)).maximumSize(100_000).build();
+
   private final PermissionService permissionService;
   private final UserService userService;
 
@@ -74,6 +88,37 @@ public class StreamApi extends RestBehavior {
       OpenAEVPrincipal principal, String tenantId, FluxSink<Object> fluxSink) {}
 
   private record CachedUser(User user, Instant fetchedAt) {}
+
+  private record PermissionCacheKey(
+      String principalId, String resourceId, ResourceType resourceType, String tenantId) {}
+
+  /**
+   * Resolves the per-event READ permission through the short-lived decision cache. Must be called
+   * with the consumer's tenant context already set (the underlying check is tenant-aware). Cache
+   * misses of the same key may race and both hit the database: bounded and far cheaper than one
+   * resolution per event per consumer.
+   */
+  private boolean hasReadPermission(StreamConsumer consumer, User user, BaseEvent event) {
+    PermissionCacheKey key =
+        new PermissionCacheKey(
+            consumer.principal().getId(),
+            event.getInstance().getId(),
+            event.getInstance().getResourceType(),
+            consumer.tenantId());
+    Boolean cached = permissionDecisionCache.getIfPresent(key);
+    if (cached != null) {
+      return cached;
+    }
+    boolean allowed =
+        permissionService.hasPermission(
+            user,
+            Optional.empty(),
+            event.getInstance().getId(),
+            event.getInstance().getResourceType(),
+            Action.READ);
+    permissionDecisionCache.put(key, allowed);
+    return allowed;
+  }
 
   /**
    * Resolves a consumer's user for the per-event permission check without hitting the database on
@@ -157,12 +202,7 @@ public class StreamApi extends RestBehavior {
 
           try {
             FluxSink<Object> fluxSink = consumer.fluxSink();
-            if (!permissionService.hasPermission(
-                user,
-                Optional.empty(),
-                event.getInstance().getId(),
-                event.getInstance().getResourceType(),
-                Action.READ)) {
+            if (!hasReadPermission(consumer, user, event)) {
               try {
                 String propertyId =
                     event

--- a/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/stream/StreamApi.java
@@ -195,9 +195,14 @@ public class StreamApi extends RestBehavior {
           // Set the tenant context for permission checks on the async thread.
           // Without this, TenantContext defaults to DEFAULT_TENANT_UUID, causing
           // tenant-scoped capabilities to be invisible and incorrect DELETE events
-          // to be sent for entities on non-default tenants.
+          // to be sent for entities on non-default tenants. Legacy consumers
+          // (blank tenant) are explicitly cleared so a reused @Async pool thread
+          // can never evaluate (and cache) their decisions under a tenant leaked
+          // by a previous task.
           if (consumer.tenantId() != null && !consumer.tenantId().isBlank()) {
             TenantContext.setCurrentTenant(consumer.tenantId());
+          } else {
+            TenantContext.clearCurrentTenant();
           }
 
           try {
@@ -226,10 +231,9 @@ public class StreamApi extends RestBehavior {
               sendStreamEvent(fluxSink, event);
             }
           } finally {
-            // Reset tenant context to avoid leaking into other consumers in the loop
-            if (consumer.tenantId() != null && !consumer.tenantId().isBlank()) {
-              TenantContext.clearCurrentTenant();
-            }
+            // Reset tenant context unconditionally to avoid leaking into other
+            // consumers in the loop or into later tasks on this pooled thread
+            TenantContext.clearCurrentTenant();
           }
         });
   }

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -53,6 +53,12 @@ spring.jpa.properties.hibernate.jdbc.batch_size=30
 # The model has many EAGER collections without @Fetch(SUBSELECT); this caps the N+1 cost.
 spring.jpa.properties.hibernate.default_batch_fetch_size=50
 spring.datasource.hikari.maximum-pool-size=20
+# Log the acquisition stack trace of any thread holding a connection for more than 30s ("Apparent
+# connection leak detected", WARN on com.zaxxer.hikari — visible with production log levels).
+# Together with io.openaev.diagnostics.PoolExhaustionWatchdog (ERROR + thread dump on sustained
+# saturation), this names the code paths pinning connections whenever the pool gets exhausted.
+# The connection is NOT killed: legit long holders (bulk indexing, migrations) just log evidence.
+spring.datasource.hikari.leak-detection-threshold=30000
 spring.datasource.hikari.data-source-properties.cachePrepStmts=true
 spring.datasource.hikari.data-source-properties.prepStmtCacheSize=250
 spring.datasource.hikari.data-source-properties.prepStmtCacheSqlLimit=2048

--- a/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
+++ b/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
@@ -1,12 +1,144 @@
 package io.openaev.diagnostics;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 public class PoolExhaustionWatchdogTest {
+
+  private ListAppender<ILoggingEvent> appender;
+  private Logger watchdogLogger;
+
+  @BeforeEach
+  void setUpLogCapture() {
+    watchdogLogger = (Logger) LoggerFactory.getLogger(PoolExhaustionWatchdog.class);
+    appender = new ListAppender<>();
+    appender.start();
+    watchdogLogger.addAppender(appender);
+  }
+
+  @AfterEach
+  void tearDownLogCapture() {
+    watchdogLogger.detachAppender(appender);
+    appender.stop();
+  }
+
+  private List<ILoggingEvent> errorEvents() {
+    return appender.list.stream().filter(e -> e.getLevel() == Level.ERROR).toList();
+  }
+
+  private static PoolExhaustionWatchdog watchdogFor(HikariPoolMXBean poolBean) throws SQLException {
+    DataSource dataSource = mock(DataSource.class);
+    HikariDataSource hikariDataSource = mock(HikariDataSource.class);
+    when(dataSource.isWrapperFor(HikariDataSource.class)).thenReturn(true);
+    when(dataSource.unwrap(HikariDataSource.class)).thenReturn(hikariDataSource);
+    when(hikariDataSource.getHikariPoolMXBean()).thenReturn(poolBean);
+    return new PoolExhaustionWatchdog(dataSource);
+  }
+
+  private static void saturate(HikariPoolMXBean poolBean) {
+    when(poolBean.getTotalConnections()).thenReturn(20);
+    when(poolBean.getActiveConnections()).thenReturn(20);
+    when(poolBean.getIdleConnections()).thenReturn(0);
+    when(poolBean.getThreadsAwaitingConnection()).thenReturn(31);
+  }
+
+  private static void recover(HikariPoolMXBean poolBean) {
+    when(poolBean.getTotalConnections()).thenReturn(20);
+    when(poolBean.getActiveConnections()).thenReturn(3);
+    when(poolBean.getIdleConnections()).thenReturn(17);
+    when(poolBean.getThreadsAwaitingConnection()).thenReturn(0);
+  }
+
+  @Test
+  @DisplayName("sustained saturation dumps once and respects the cooldown")
+  void given_sustained_saturation_should_dump_once_with_cooldown() throws SQLException {
+    HikariPoolMXBean poolBean = mock(HikariPoolMXBean.class);
+    PoolExhaustionWatchdog watchdog = watchdogFor(poolBean);
+    saturate(poolBean);
+
+    // First saturated sample: below the persistence threshold, no dump yet
+    watchdog.sample();
+    assertThat(errorEvents()).isEmpty();
+
+    // Second consecutive saturated sample: one ERROR with the pool stats and the dump
+    watchdog.sample();
+    assertThat(errorEvents()).hasSize(1);
+    String message = errorEvents().get(0).getFormattedMessage();
+    assertThat(message).contains("total=20, active=20, idle=0, awaiting=31");
+    assertThat(message).contains("OTHER THREADS");
+
+    // Still saturated within the cooldown window: no additional dump
+    watchdog.sample();
+    watchdog.sample();
+    assertThat(errorEvents()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("a saturation blip between recoveries never dumps")
+  void given_saturation_blip_should_not_dump() throws SQLException {
+    HikariPoolMXBean poolBean = mock(HikariPoolMXBean.class);
+    PoolExhaustionWatchdog watchdog = watchdogFor(poolBean);
+
+    saturate(poolBean);
+    watchdog.sample();
+    // Recovery resets the consecutive-sample counter...
+    recover(poolBean);
+    watchdog.sample();
+    // ...so a new single saturated sample is again below the persistence threshold
+    saturate(poolBean);
+    watchdog.sample();
+
+    assertThat(errorEvents()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("non-Hikari datasource disables the watchdog permanently without probing again")
+  void given_non_hikari_datasource_should_disable_permanently() throws SQLException {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.isWrapperFor(HikariDataSource.class)).thenReturn(false);
+    PoolExhaustionWatchdog watchdog = new PoolExhaustionWatchdog(dataSource);
+
+    watchdog.sample();
+    watchdog.sample();
+
+    // Probed once, then disabled: no repeated unwrap attempts, no log noise
+    verify(dataSource, times(1)).isWrapperFor(HikariDataSource.class);
+    assertThat(errorEvents()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("datasource unwrap failure disables the watchdog with a single warning")
+  void given_unwrap_failure_should_disable_with_warning() throws SQLException {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.isWrapperFor(HikariDataSource.class)).thenThrow(new SQLException("no wrapper"));
+    PoolExhaustionWatchdog watchdog = new PoolExhaustionWatchdog(dataSource);
+
+    watchdog.sample();
+    watchdog.sample();
+
+    verify(dataSource, times(1)).isWrapperFor(HikariDataSource.class);
+    assertThat(appender.list.stream().filter(e -> e.getLevel() == Level.WARN).toList()).hasSize(1);
+    assertThat(errorEvents()).isEmpty();
+  }
 
   private static StackTraceElement frame(String className) {
     return new StackTraceElement(className, "method", "File.java", 42);

--- a/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
+++ b/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
@@ -40,7 +40,8 @@ public class PoolExhaustionWatchdogTest {
     assertThat(dump).contains("io.openaev.service.SomeService");
     // The idle thread is summarized on a single line, not dumped in full
     assertThat(dump).contains("--- OTHER THREADS (1)");
-    assertThat(dump).contains("\"idle-worker\"");
+    // Summarized entries are disambiguated with the thread id (names are not unique)
+    assertThat(dump).containsPattern("\"idle-worker #\\d+\"");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
+++ b/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
@@ -26,10 +26,15 @@ public class PoolExhaustionWatchdogTest {
 
   private ListAppender<ILoggingEvent> appender;
   private Logger watchdogLogger;
+  private Level originalLevel;
 
   @BeforeEach
   void setUpLogCapture() {
     watchdogLogger = (Logger) LoggerFactory.getLogger(PoolExhaustionWatchdog.class);
+    // The CI test logback config caps io.openaev above WARN: force the level so the
+    // WARN assertions see the events, and restore it afterwards.
+    originalLevel = watchdogLogger.getLevel();
+    watchdogLogger.setLevel(Level.WARN);
     appender = new ListAppender<>();
     appender.start();
     watchdogLogger.addAppender(appender);
@@ -39,6 +44,7 @@ public class PoolExhaustionWatchdogTest {
   void tearDownLogCapture() {
     watchdogLogger.detachAppender(appender);
     appender.stop();
+    watchdogLogger.setLevel(originalLevel);
   }
 
   private List<ILoggingEvent> errorEvents() {

--- a/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
+++ b/openaev-api/src/test/java/io/openaev/diagnostics/PoolExhaustionWatchdogTest.java
@@ -1,0 +1,59 @@
+package io.openaev.diagnostics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class PoolExhaustionWatchdogTest {
+
+  private static StackTraceElement frame(String className) {
+    return new StackTraceElement(className, "method", "File.java", 42);
+  }
+
+  private static Thread thread(String name) {
+    // Never started: state NEW, only used as a dump key
+    return new Thread(() -> {}, name);
+  }
+
+  @Test
+  @DisplayName("threads inside JDBC frames are dumped with a full stack as suspected holders")
+  void given_thread_inside_postgres_driver_should_be_flagged_as_holder() {
+    Map<Thread, StackTraceElement[]> stacks =
+        Map.of(
+            thread("http-nio-8080-exec-1"),
+            new StackTraceElement[] {
+              frame("java.net.SocketInputStream"),
+              frame("org.postgresql.core.v3.QueryExecutorImpl"),
+              frame("org.hibernate.engine.jdbc.internal.StatementPreparerImpl"),
+              frame("io.openaev.service.SomeService"),
+            },
+            thread("idle-worker"),
+            new StackTraceElement[] {frame("java.lang.Object")});
+
+    String dump = PoolExhaustionWatchdog.buildThreadDump(stacks);
+
+    assertThat(dump).contains("1 thread(s) inside JDBC/Hibernate/Hikari frames");
+    assertThat(dump).contains("--- HOLDER \"http-nio-8080-exec-1\"");
+    // The holder's application frame is visible so the root cause is directly readable
+    assertThat(dump).contains("io.openaev.service.SomeService");
+    // The idle thread is summarized on a single line, not dumped in full
+    assertThat(dump).contains("--- OTHER THREADS (1)");
+    assertThat(dump).contains("\"idle-worker\"");
+  }
+
+  @Test
+  @DisplayName("threads without JDBC frames are only summarized")
+  void given_no_jdbc_thread_should_report_zero_holders() {
+    Map<Thread, StackTraceElement[]> stacks =
+        Map.of(
+            thread("scheduler-1"),
+            new StackTraceElement[] {frame("java.util.concurrent.locks.LockSupport")});
+
+    String dump = PoolExhaustionWatchdog.buildThreadDump(stacks);
+
+    assertThat(dump).contains("0 thread(s) inside JDBC/Hibernate/Hikari frames");
+    assertThat(dump).doesNotContain("--- HOLDER");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/stream/StreamApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/stream/StreamApiTest.java
@@ -157,6 +157,26 @@ public class StreamApiTest {
   }
 
   @Test
+  public void test_listenDatabaseUpdate_WHEN_same_resource_should_resolve_permission_once() {
+    // The broadcast path used to resolve permissions per event per consumer, flooding the
+    // database while viewing a running simulation (#6868): repeated events on the same
+    // resource must be served from the decision cache.
+    when(permissionService.hasPermission(
+            mockUser, Optional.empty(), RESOURCE_ID, ResourceType.SCENARIO, Action.READ))
+        .thenReturn(true);
+
+    Scenario scenario = ScenarioFixture.getScenario();
+    scenario.setId(RESOURCE_ID);
+
+    streamApi.listenDatabaseUpdate(new BaseEvent(DATA_UPDATE, scenario, mock(ObjectMapper.class)));
+    streamApi.listenDatabaseUpdate(new BaseEvent(DATA_UPDATE, scenario, mock(ObjectMapper.class)));
+
+    verify(permissionService, times(1))
+        .hasPermission(mockUser, Optional.empty(), RESOURCE_ID, ResourceType.SCENARIO, Action.READ);
+    verify(mockSink, times(2)).next(any());
+  }
+
+  @Test
   public void test_given_databaseEvent_when_eventIsCVE_then_doNothing() {
     Vulnerability vulnerability = new Vulnerability();
     BaseEvent event = new BaseEvent(DATA_UPDATE, vulnerability, mock(ObjectMapper.class));


### PR DESCRIPTION
## Summary

Fixes the recurring production HikariCP pool exhaustion (total=20, active=20, waiting=31, everything frozen) and, because when the pool is stuck NOTHING can be diagnosed from the outside, ships always-on diagnostics that name the connection holders in the logs the next time anything saturates the pool.

Closes #6868

## Root cause

The SSE stream broadcast path (StreamApi.listenDatabaseUpdate) runs for every database mutation and, for every connected consumer, calls PermissionService.hasPermission. That method is @Transactional and, for inject events (the most frequent mutation while a simulation is running: traces, statuses, expectations), resolves the parent permission by loading the FULL Inject entity graph (resolveTarget -> injectService.inject, eager collections) plus a grant query - per event, per consumer. The recent user-cache fix removed the per-event user reload but not these queries. With a running simulation and several connected users this floods Postgres with hundreds of queries per second, every query slows down, each in-flight query holds its pool connection past the 30s timeout, and the whole platform locks up.

## Changes

### Structural fix
- StreamApi: short-TTL (30s) bounded Caffeine cache of per-(principal, resource, type, tenant) READ decisions in the broadcast path. Repeated mutations of the same resource (the norm during a running simulation) stop re-resolving permissions per event per consumer. Permission changes propagate to the stream within 30s, consistent with the existing 60s user cache.

### Always-on diagnostics (visible with production log levels)
- spring.datasource.hikari.leak-detection-threshold=30000: Hikari logs the acquisition stack trace of any thread holding a connection for more than 30s (WARN on com.zaxxer.hikari, already at warn in production). The connection is not killed; legit long holders just log evidence.
- New io.openaev.diagnostics.PoolExhaustionWatchdog: samples the Hikari MXBean every 5s from its own scheduler thread (never touches the database, so it keeps working while the pool is stuck). On sustained saturation (2 consecutive samples) it logs ONE ERROR (60s cooldown) with the pool statistics and a thread dump in which threads currently inside JDBC/Hibernate/Hikari frames - the actual connection holders - are dumped with their full stack, while all other threads are summarized on one line each.

With both in place, the next exhaustion episode produces logs that directly name the code paths pinning the pool instead of only the generic "Connection is not available".

## Test plan

- [x] Unit test: repeated events on the same resource resolve the permission once (cache hit) and still emit to the sink
- [x] Unit test: watchdog thread dump flags JDBC threads as holders with full stacks and summarizes the rest
- [x] Unit tests: watchdog saturation state machine (persistence threshold, one dump per cooldown, counter reset on recovery blips, permanent disable for non-Hikari datasources and on unwrap failure)
- [x] mvn spotless:apply clean
- [x] openaev-api compiles (main + tests), StreamApiTest and PoolExhaustionWatchdogTest green locally
- [x] CI green
