### PR TITLE
fix(implant): add a timeout for the implant command (#6878)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
@@ -42,7 +42,7 @@ final class OpenaevImplantCommandBuilder {
     }
   }
 
-  static Map<String, String> buildExecutorCommands() {
+  static Map<String, String> buildExecutorCommands(int timeoutSeconds) {
     Map<String, String> commands = new HashMap<>();
     CommandVars vars = new CommandVars();
     // --- PALO ALTO WINDOWS SPECIFIC ---
@@ -54,14 +54,14 @@ final class OpenaevImplantCommandBuilder {
     buildMdeWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars);
     buildMdeWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars);
     // --- WINDOWS ---
-    buildGenericWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars);
-    buildGenericWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars);
+    buildGenericWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars, timeoutSeconds);
+    buildGenericWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars, timeoutSeconds);
     // --- LINUX ---
-    buildGenericLinuxCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars);
-    buildGenericLinuxCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars);
+    buildGenericLinuxCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars, timeoutSeconds);
+    buildGenericLinuxCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars, timeoutSeconds);
     // --- MACOS ---
-    buildGenericMacOSCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars);
-    buildGenericMacOSCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars);
+    buildGenericMacOSCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars, timeoutSeconds);
+    buildGenericMacOSCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars, timeoutSeconds);
     return commands;
   }
 
@@ -188,7 +188,10 @@ final class OpenaevImplantCommandBuilder {
   }
 
   private static void buildGenericWindowsCommand(
-      Endpoint.PLATFORM_ARCH arch, Map<String, String> commands, CommandVars vars) {
+      Endpoint.PLATFORM_ARCH arch,
+      Map<String, String> commands,
+      CommandVars vars,
+      int timeoutSeconds) {
     commands.put(
         Endpoint.PLATFORM_TYPE.Windows.name() + "." + arch.name(),
         "[Net.ServicePointManager]::SecurityProtocol +="
@@ -213,14 +216,21 @@ final class OpenaevImplantCommandBuilder {
             + " Inbound -Program \"$location\\$filename\" -Action Allow |"
             + " Out-Null;Remove-NetFirewallRule -DisplayName \"Allow OpenAEV"
             + " Outbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction"
-            + " Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;Start-Process"
+            + " Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;$proc=Start-Process"
             + " -FilePath \"$location\\$filename\" -ArgumentList \"--uri $server --token $token"
             + " --unsecured-certificate $unsecured_certificate --with-proxy $with_proxy --agent-id"
-            + " #{agent} --inject-id #{inject} --tenant-id #{tenant}\" -WindowStyle hidden;");
+            + " #{agent} --inject-id #{inject} --tenant-id #{tenant}\" -WindowStyle hidden -PassThru;"
+            + "if(-not $proc.WaitForExit("
+            + (timeoutSeconds * 1000L)
+            + ")){Stop-Process -Id $proc.Id -Force;exit 124};"
+            + "exit $proc.ExitCode;");
   }
 
   private static void buildGenericLinuxCommand(
-      Endpoint.PLATFORM_ARCH arch, Map<String, String> commands, CommandVars vars) {
+      Endpoint.PLATFORM_ARCH arch,
+      Map<String, String> commands,
+      CommandVars vars,
+      int timeoutSeconds) {
     commands.put(
         Endpoint.PLATFORM_TYPE.Linux.name() + "." + arch.name(),
         "x=\"#{location}\";location=$(echo \"$x\" | sed"
@@ -238,11 +248,19 @@ final class OpenaevImplantCommandBuilder {
             + dlUri("linux", arch.name())
             + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri"
             + " $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy"
-            + " $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} &");
+            + " $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} & pid=$!;"
+            + "(sleep "
+            + timeoutSeconds
+            + ";if kill -0 $pid 2>/dev/null;then kill -TERM $pid 2>/dev/null;sleep 5;"
+            + "kill -KILL $pid 2>/dev/null;fi) & watchdog=$!;wait $pid 2>/dev/null;exit_code=$?;"
+            + "kill $watchdog 2>/dev/null;wait $watchdog 2>/dev/null;exit $exit_code");
   }
 
   private static void buildGenericMacOSCommand(
-      Endpoint.PLATFORM_ARCH arch, Map<String, String> commands, CommandVars vars) {
+      Endpoint.PLATFORM_ARCH arch,
+      Map<String, String> commands,
+      CommandVars vars,
+      int timeoutSeconds) {
     commands.put(
         Endpoint.PLATFORM_TYPE.MacOS.name() + "." + arch.name(),
         "x=\"#{location}\";location=$(echo \"$x\" | sed"
@@ -262,6 +280,11 @@ final class OpenaevImplantCommandBuilder {
             + dlUri("macos", arch.name())
             + " > $location/$filename;chmod +x $location/$filename;$location/$filename --uri"
             + " $server --token $token --unsecured-certificate $unsecured_certificate --with-proxy"
-            + " $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} &");
+            + " $with_proxy --agent-id #{agent} --inject-id #{inject} --tenant-id #{tenant} & pid=$!;"
+            + "(sleep "
+            + timeoutSeconds
+            + ";if kill -0 $pid 2>/dev/null;then kill -TERM $pid 2>/dev/null;sleep 5;"
+            + "kill -KILL $pid 2>/dev/null;fi) & watchdog=$!;wait $pid 2>/dev/null;exit_code=$?;"
+            + "kill $watchdog 2>/dev/null;wait $watchdog 2>/dev/null;exit $exit_code");
   }
 }

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegrationFactory.java
@@ -18,7 +18,7 @@ import io.openaev.service.connector_instances.ConnectorInstanceService;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,7 +31,12 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
   private final InjectorContext injectorContext;
   private final InjectExpectationService injectExpectationService;
   private final InjectService injectService;
-  private final Environment env;
+
+  @Value(
+      "${inject.execution.threshold.minutes:"
+          + InjectsExecutionJob.DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES
+          + "}")
+  private Integer injectExecutionThresholdMinutes;
 
   public OpenaevInjectorIntegrationFactory(
       ComponentRequestEngine componentRequestEngine,
@@ -42,8 +47,7 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
       HttpClientFactory httpClientFactory,
       InjectorContext injectorContext,
       InjectExpectationService injectExpectationService,
-      InjectService injectService,
-      Environment env) {
+      InjectService injectService) {
     super(connectorInstanceService, catalogConnectorService, httpClientFactory);
     this.componentRequestEngine = componentRequestEngine;
     this.connectorInstanceService = connectorInstanceService;
@@ -52,7 +56,6 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
     this.injectorContext = injectorContext;
     this.injectExpectationService = injectExpectationService;
     this.injectService = injectService;
-    this.env = env;
   }
 
   @Override
@@ -99,11 +102,7 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
 
   @Override
   public void registerConnectorForTenant(String tenantId) throws Exception {
-    String threshold = env.getProperty("inject.execution.threshold.minutes");
-    if (threshold == null || threshold.isBlank()) {
-      threshold = InjectsExecutionJob.DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES;
-    }
-    int timeoutSeconds = Integer.parseInt(threshold) * 60;
+    int timeoutSeconds = injectExecutionThresholdMinutes * 60;
     Map<String, String> executorCommands =
         OpenaevImplantCommandBuilder.buildExecutorCommands(timeoutSeconds);
     Map<String, String> executorClearCommands =

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegrationFactory.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevInjectorIntegrationFactory.java
@@ -10,6 +10,7 @@ import io.openaev.integration.BuiltinIntegrationFactory;
 import io.openaev.integration.ComponentRequestEngine;
 import io.openaev.integration.Integration;
 import io.openaev.rest.inject.service.InjectService;
+import io.openaev.scheduler.jobs.InjectsExecutionJob;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.service.InjectorService;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
@@ -17,6 +18,7 @@ import io.openaev.service.connector_instances.ConnectorInstanceService;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,6 +31,7 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
   private final InjectorContext injectorContext;
   private final InjectExpectationService injectExpectationService;
   private final InjectService injectService;
+  private final Environment env;
 
   public OpenaevInjectorIntegrationFactory(
       ComponentRequestEngine componentRequestEngine,
@@ -39,7 +42,8 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
       HttpClientFactory httpClientFactory,
       InjectorContext injectorContext,
       InjectExpectationService injectExpectationService,
-      InjectService injectService) {
+      InjectService injectService,
+      Environment env) {
     super(connectorInstanceService, catalogConnectorService, httpClientFactory);
     this.componentRequestEngine = componentRequestEngine;
     this.connectorInstanceService = connectorInstanceService;
@@ -48,6 +52,7 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
     this.injectorContext = injectorContext;
     this.injectExpectationService = injectExpectationService;
     this.injectService = injectService;
+    this.env = env;
   }
 
   @Override
@@ -94,7 +99,13 @@ public class OpenaevInjectorIntegrationFactory extends BuiltinIntegrationFactory
 
   @Override
   public void registerConnectorForTenant(String tenantId) throws Exception {
-    Map<String, String> executorCommands = OpenaevImplantCommandBuilder.buildExecutorCommands();
+    String threshold = env.getProperty("inject.execution.threshold.minutes");
+    if (threshold == null || threshold.isBlank()) {
+      threshold = InjectsExecutionJob.DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES;
+    }
+    int timeoutSeconds = Integer.parseInt(threshold) * 60;
+    Map<String, String> executorCommands =
+        OpenaevImplantCommandBuilder.buildExecutorCommands(timeoutSeconds);
     Map<String, String> executorClearCommands =
         OpenaevImplantCommandBuilder.buildExecutorClearCommands();
     injectorService.registerBuiltinInjector(

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -29,7 +29,6 @@ import io.openaev.service.SecurityCoverageSendJobService;
 import io.openaev.service.chaining.WorkflowService;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.utils.ExecutionTraceUtils;
-import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -49,7 +48,6 @@ import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.Expression;
@@ -65,7 +63,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class InjectsExecutionJob implements Job {
 
-  public static final String DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES = "10";
+  public static final int DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES = 10;
 
   // Thread-safe and expensive to instantiate; never recreate per dependency evaluation
   private static final ExpressionParser SPEL_PARSER = new SpelExpressionParser();
@@ -73,8 +71,9 @@ public class InjectsExecutionJob implements Job {
   @Value("${openaev.notification.simulation-completed-delay-seconds:3600}")
   private long delayForSimulationCompletedEvent;
 
-  private final Environment env;
-  private int injectExecutionThreshold;
+  @Value(
+      "${inject.execution.threshold.minutes:" + DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES + "}")
+  private Integer injectExecutionThreshold;
 
   private final InjectHelper injectHelper;
   private final InjectService injectService;
@@ -102,15 +101,6 @@ public class InjectsExecutionJob implements Job {
 
   private final WorkflowService workflowService;
   private final HealthCheckUtils healthCheckUtils;
-
-  @PostConstruct
-  private void init() {
-    String threshold = env.getProperty("inject.execution.threshold.minutes");
-    if (threshold == null || threshold.isBlank()) {
-      threshold = DEFAULT_EXECUTION_THRESHOLD_TIME_IN_MINUTES;
-    }
-    this.injectExecutionThreshold = Integer.parseInt(threshold);
-  }
 
   public void handleAutoStartExercises() {
     // Disable tenant filter — called from InjectsExecutionJob which runs cross-tenant

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -271,7 +271,7 @@ ai.model=mistral
 ai.model_images=
 
 # Inject execution threshold, by default it's 10minutes
-inject.execution.threshold.minutes=
+inject.execution.threshold.minutes=10
 
 # Agent queue threshold: max number of pending jobs per agent before marking it overloaded.
 # 0 disables the check. Configurable via env var OPENAEV_AGENT_QUEUE_THRESHOLD.


### PR DESCRIPTION
### Proposed changes

* Add a timeout when the implant is executed. If the timeout is reached, the implant is killed.

### Testing Instructions

1. Launch a command that takes more than 10 minutes ("sleep XXX" or "Remote Process Injection in LSASS via mimikatz" from ART for example),
2. Look in the VM, the implant is not killed.

### Related issues

* Closes #6878

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
