### PR TITLE
fix(api): support eq and starts_with filters on array columns (#6884)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -692,7 +692,11 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           "Windows and MacOS should match no contract");
 
       // not_eq is the negation of the membership predicate: contracts without the
-      // value — including those with an empty platforms array — are kept.
+      // value — including those with an empty platforms array — are kept. Assert
+      // relative to the unfiltered total: the environment may register extra
+      // contracts (without platforms) after the setup's deleteAll.
+      int unfilteredTotal =
+          JsonPath.read(searchWith(PaginationFixture.getDefault().build()), "$.totalElements");
       SearchPaginationInput notEqInput =
           buildSearchInputForActionPlatformsEq(List.of("Windows"), Filters.FilterMode.and);
       notEqInput
@@ -702,9 +706,9 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           .setOperator(Filters.FilterOperator.not_eq);
       response = searchWith(notEqInput);
       assertEquals(
-          4,
+          unfilteredTotal - 1,
           (int) JsonPath.read(response, "$.totalElements"),
-          "not_eq Windows should keep the four contracts without platforms");
+          "not_eq Windows should keep every contract except the Windows one");
 
       // The facet count endpoints receive the same filter group and must not fail either
       SearchPaginationInput input =

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -710,6 +710,34 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           (int) JsonPath.read(response, "$.totalElements"),
           "not_eq Windows should keep every contract except the Windows one");
 
+      // starts_with exercises the symmetric array branch of startWithText (same
+      // lower()-on-array 500 failure mode as eq). It matches on the joined array string.
+      SearchPaginationInput startsWithInput =
+          buildSearchInputForActionPlatformsEq(List.of("Wind"), Filters.FilterMode.or);
+      startsWithInput
+          .getFilterGroup()
+          .getFilters()
+          .getFirst()
+          .setOperator(Filters.FilterOperator.starts_with);
+      response = searchWith(startsWithInput);
+      assertEquals(
+          1,
+          (int) JsonPath.read(response, "$.totalElements"),
+          "starts_with Wind should match the Windows contract");
+
+      SearchPaginationInput startsWithMissInput =
+          buildSearchInputForActionPlatformsEq(List.of("Sola"), Filters.FilterMode.or);
+      startsWithMissInput
+          .getFilterGroup()
+          .getFilters()
+          .getFirst()
+          .setOperator(Filters.FilterOperator.starts_with);
+      response = searchWith(startsWithMissInput);
+      assertEquals(
+          0,
+          (int) JsonPath.read(response, "$.totalElements"),
+          "starts_with Sola should match no contract");
+
       // The facet count endpoints receive the same filter group and must not fail either
       SearchPaginationInput input =
           buildSearchInputForActionPlatformsEq(List.of("Windows"), Filters.FilterMode.and);

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -650,6 +650,108 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           "No result should contain domain1");
     }
 
+    @Test
+    @DisplayName("given action_platforms eq filter should match by array membership")
+    void given_actionPlatformsEqFilter_should_returnMatchingContracts() throws Exception {
+      // Arrange — eq on a text[] column (platforms) used to fail with a 500
+      // because lower() cannot be applied to an array expression.
+      injectorContractComposer
+          .forInjectorContract(
+              InjectorContractFixture.createInjectorContractWithPlatforms(
+                  new Endpoint.PLATFORM_TYPE[] {
+                    Endpoint.PLATFORM_TYPE.Windows, Endpoint.PLATFORM_TYPE.Linux
+                  }))
+          .withInjector(injectorFixture.getWellKnownEmailInjector(false))
+          .withDomain(domain1)
+          .persist();
+
+      // Act & Assert — single value (or mode) matches only the Windows contract
+      String response =
+          searchWith(
+              buildSearchInputForActionPlatformsEq(List.of("Windows"), Filters.FilterMode.or));
+      assertEquals(
+          1, (int) JsonPath.read(response, "$.totalElements"), "Windows should match one contract");
+
+      // and mode requires every value to be present in the array
+      response =
+          searchWith(
+              buildSearchInputForActionPlatformsEq(
+                  List.of("Windows", "Linux"), Filters.FilterMode.and));
+      assertEquals(
+          1,
+          (int) JsonPath.read(response, "$.totalElements"),
+          "Windows and Linux should match one contract");
+
+      response =
+          searchWith(
+              buildSearchInputForActionPlatformsEq(
+                  List.of("Windows", "MacOS"), Filters.FilterMode.and));
+      assertEquals(
+          0,
+          (int) JsonPath.read(response, "$.totalElements"),
+          "Windows and MacOS should match no contract");
+
+      // not_eq is the negation of the membership predicate: contracts without the
+      // value — including those with an empty platforms array — are kept.
+      SearchPaginationInput notEqInput =
+          buildSearchInputForActionPlatformsEq(List.of("Windows"), Filters.FilterMode.and);
+      notEqInput
+          .getFilterGroup()
+          .getFilters()
+          .getFirst()
+          .setOperator(Filters.FilterOperator.not_eq);
+      response = searchWith(notEqInput);
+      assertEquals(
+          4,
+          (int) JsonPath.read(response, "$.totalElements"),
+          "not_eq Windows should keep the four contracts without platforms");
+
+      // The facet count endpoints receive the same filter group and must not fail either
+      SearchPaginationInput input =
+          buildSearchInputForActionPlatformsEq(List.of("Windows"), Filters.FilterMode.and);
+      mvc.perform(
+              post(THREAT_ARSENAL_URI + "/domain-counts")
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isOk());
+      mvc.perform(
+              post(THREAT_ARSENAL_URI + "/author-counts")
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isOk());
+    }
+
+    private String searchWith(SearchPaginationInput input) throws Exception {
+      return mvc.perform(
+              post(THREAT_ARSENAL_URI + "/search")
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isOk())
+          .andReturn()
+          .getResponse()
+          .getContentAsString();
+    }
+
+    private SearchPaginationInput buildSearchInputForActionPlatformsEq(
+        List<String> platforms, Filters.FilterMode mode) {
+      Filters.Filter filter = new Filters.Filter();
+      filter.setKey("action_platforms");
+      filter.setOperator(Filters.FilterOperator.eq);
+      filter.setMode(mode);
+      filter.setValues(platforms);
+
+      Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+      filterGroup.setMode(Filters.FilterMode.and);
+      filterGroup.setFilters(new ArrayList<>(List.of(filter)));
+
+      SearchPaginationInput input = PaginationFixture.getDefault().build();
+      input.setFilterGroup(filterGroup);
+      return input;
+    }
+
     private SearchPaginationInput buildSearchInputForActionDomainsNotEqAnd(List<String> domainIds) {
       Filters.Filter filter = new Filters.Filter();
       filter.setKey("action_domains");

--- a/openaev-framework/src/main/java/io/openaev/utils/OperationUtilsJpa.java
+++ b/openaev-framework/src/main/java/io/openaev/utils/OperationUtilsJpa.java
@@ -463,9 +463,11 @@ public final class OperationUtilsJpa {
 
   // -- BASE FUNCTION --
 
-  private static Expression<Boolean> arrayPosition(
+  // array_position_wrapper RETURNS INT (V3_50__Adding_wrapper_functions): declare the matching
+  // Java type; membership call sites only wrap the result in isNotNull().
+  private static Expression<Integer> arrayPosition(
       Expression<String[]> paths, CriteriaBuilder cb, Expression<String> text) {
-    return cb.function("array_position_wrapper", Boolean.class, paths, text);
+    return cb.function("array_position_wrapper", Integer.class, paths, text);
   }
 
   private static Expression<String> lower(Expression<String> paths, CriteriaBuilder cb) {

--- a/openaev-framework/src/main/java/io/openaev/utils/OperationUtilsJpa.java
+++ b/openaev-framework/src/main/java/io/openaev/utils/OperationUtilsJpa.java
@@ -253,6 +253,12 @@ public final class OperationUtilsJpa {
       Expression<String[]> values = lowerArray(avals(paths, cb), cb);
       return cb.isNotNull(arrayPosition(values, cb, cb.literal(text.toLowerCase())));
     }
+    if (isArray(type)) {
+      // Array columns (e.g. text[] platforms): equality means membership, and
+      // lower() cannot be applied to the array expression directly.
+      Expression<String[]> values = lowerArray(paths, cb);
+      return cb.isNotNull(arrayPosition(values, cb, cb.literal(text.toLowerCase())));
+    }
     if (text.equalsIgnoreCase("true") || text.equalsIgnoreCase("false")) {
       return cb.equal(paths, Boolean.valueOf(text));
     } else {
@@ -307,6 +313,11 @@ public final class OperationUtilsJpa {
 
     if (isCollection(type)) {
       Expression<String> values = lower(arrayToString(avals(paths, cb), cb), cb);
+      return cb.like(values, text.toLowerCase() + "%");
+    }
+    if (isArray(type)) {
+      // Array columns: lower() cannot be applied to the array expression directly.
+      Expression<String> values = lower(arrayToString(paths, cb), cb);
       return cb.like(values, text.toLowerCase() + "%");
     }
 
@@ -440,6 +451,12 @@ public final class OperationUtilsJpa {
 
   // -- CUSTOM FUNCTION --
 
+  /**
+   * Lowercases every element of an array expression by round-tripping through {@code
+   * array_to_string}/{@code string_to_array} with the {@code " && "} separator. Assumes no array
+   * element contains the separator — true today for every queryable array column (enum- or
+   * IP-constrained values).
+   */
   private static Expression<String[]> lowerArray(Expression<?> paths, CriteriaBuilder cb) {
     return stringToArray(lower(arrayToString(paths, cb), cb), cb);
   }


### PR DESCRIPTION
## Summary

Fixes #6884 - filtering the Threat Arsenal page by platform returned a 500 (*Internal error* toast): `search`, `domain-counts` and `author-counts` all failed as soon as the facet sidebar's `eq` filter on `action_platforms` was applied.

**Root cause**: `OperationUtilsJpa.equalsText` has no branch for array-typed columns. For a `text[]` queryable column (platforms, mapped with `StringArrayType`) it fell through to `cb.equal(cb.lower(paths), ...)`, and Hibernate rejects `lower()` on an array (`FunctionArgumentException`). The `contains` operator already handled arrays - legacy pages send `contains`, the Threat Arsenal sidebar sends `eq`, which is why only that page surfaced the bug. Reproduced with the same filter on `/injector_contracts/search` and `/payloads/search` too.

## Fix

- `equalsText`: new `isArray` branch - `eq` on an array column means **membership** (`array_position` on the lowercased array), mirroring the existing hstore (`isCollection`) branch. `not_eq` is fixed transitively (`equalsText(...).not()`): rows without the value - including empty arrays - match, consistent with `not_contains`.
- `startWithText`: symmetric `isArray` branch (same `lower()`-on-array failure mode for `starts_with`/`not_starts_with`).
- `arrayPosition()` now declares `Integer` to match the `RETURNS INT` signature of `array_position_wrapper` (`V3_50__Adding_wrapper_functions`); the previous `Boolean` declaration predated this PR but this PR adds a second consumer (review follow-up, call sites only wrap the expression in `isNotNull`).
- Javadoc on `lowerArray` documenting the `" && "` separator assumption (all queryable array columns are enum- or IP-constrained today).

This fixes the class of bug for every array column consumer (threat arsenal, injector contracts, payloads, assets), not just the reporting page.

## Test

Regression test in `ThreatArsenalApiTest > SearchThreatArsenalActions`:

- `eq` single value (or mode) -> matches the contract containing the platform
- `eq` two values (and mode) -> membership of both required
- `eq` with a missing value (and mode) -> no match
- `not_eq` -> keeps contracts without the value (empty arrays included); exact delta is deterministic since the class is `@Transactional` (single rolled-back transaction per test)
- `starts_with` -> matching prefix returns the contract, non-matching prefix returns none (exercises the array branch of `startWithText`)
- `domain-counts` / `author-counts` with the same filter group -> 200

Also reproduced/verified manually against a local instance (500 before, 200 with correct results after).
