### PR TITLE
fix(model): remove duplicate @Id from ConnectorInstance

### DIFF
--- a/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstance.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstance.java
@@ -1,7 +1,5 @@
 package io.openaev.database.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.persistence.Id;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -11,10 +9,6 @@ import lombok.Setter;
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public abstract class ConnectorInstance {
-
-  @Id
-  @JsonProperty("connector_instance_id")
-  private String id;
 
   public enum CURRENT_STATUS_TYPE {
     started,

--- a/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstance.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstance.java
@@ -29,6 +29,8 @@ public abstract class ConnectorInstance {
   @EqualsAndHashCode.Include
   public abstract String getId();
 
+  public abstract void setId(String newId);
+
   public abstract CURRENT_STATUS_TYPE getCurrentStatus();
 
   public abstract void setCurrentStatus(CURRENT_STATUS_TYPE newStatus);

--- a/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstancePersisted.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstancePersisted.java
@@ -20,7 +20,7 @@ import org.hibernate.type.SqlTypes;
 
 @Getter
 @Setter
-@Entity
+@Entity(name = "ConnectorInstance")
 @Table(name = "connector_instances")
 @EntityListeners({ModelBaseListener.class, TenantBaseListener.class})
 @Filter(name = "tenantFilter", condition = "tenant_id = :tenantId")


### PR DESCRIPTION
Remove unused `@Id`, `@JsonProperty` and shadowed `id` field from the abstract `ConnectorInstance` class — both concrete subclasses already declare their own. Eliminates the recurring WARN log from `BaseEvent`.