### PR TITLE
docs(api): document bulk delete endpoints on players and organizations (#6887)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/organization/OrganizationApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/organization/OrganizationApi.java
@@ -19,6 +19,9 @@ import io.openaev.rest.organization.form.OrganizationUpdateInput;
 import io.openaev.service.organization.OrganizationService;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.pagination.SearchPaginationInput;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -112,6 +115,14 @@ public class OrganizationApi extends RestBehavior {
     organizationRepository.deleteById(organizationId);
   }
 
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "The ids of the deleted organizations")
+      })
+  @Operation(
+      summary = "Bulk delete organizations",
+      description =
+          "Deletes the organizations matching the given ids (organization_ids). Organizations from other tenants are silently skipped.")
   @DeleteMapping({ORGANIZATION_URI, TENANT_ORGANIZATION_URI})
   @Transactional(rollbackFor = Exception.class)
   @AccessControl(actionPerformed = Action.DELETE, resourceType = ResourceType.ORGANIZATION)

--- a/openaev-api/src/main/java/io/openaev/rest/user/PlayerApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/PlayerApi.java
@@ -20,6 +20,9 @@ import io.openaev.service.UserService;
 import io.openaev.service.account.ReservedKeyValidator;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.pagination.SearchPaginationInput;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import java.util.Comparator;
@@ -104,6 +107,12 @@ public class PlayerApi extends RestBehavior {
     userService.delete(userId);
   }
 
+  @ApiResponses(
+      value = {@ApiResponse(responseCode = "200", description = "The ids of the deleted players")})
+  @Operation(
+      summary = "Bulk delete players",
+      description =
+          "Deletes players either from an explicit id list (user_ids_to_process) or from a select-all search scope (search_pagination_input) - the two are mutually exclusive. user_ids_to_ignore removes ids from a select-all scope. The current user, admin users and reserved service accounts are always excluded server-side.")
   @LogExecutionTime
   @DeleteMapping({PLAYER_URI, TENANT_PLAYER_URI})
   @Transactional(rollbackFor = Exception.class)


### PR DESCRIPTION
## Summary

Follow-up to #6888 (merged): adds the Swagger `@Operation` / `@ApiResponses` documentation requested by the Copilot review on the two bulk delete endpoints that were still undocumented - `DELETE /api/players` (request shape, mutually exclusive `user_ids_to_process` / `search_pagination_input` select-all semantics, `user_ids_to_ignore`, and the server-side exclusions: current user, admins, reserved service accounts) and `DELETE /api/organizations` (id-list semantics, cross-tenant rows silently skipped). The teams, scenarios, simulations and atomic testings endpoints were already documented.

Relates to #6887.

## Test plan

- [x] `mvn compile` + spotless green locally
- [x] Annotation-only change: no behavior or generated `api-types.d.ts` impact (operation-level annotations do not affect schema types)
