### PR TITLE
fix(chaining): scope step consumers to the run tenant (#6357)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/ExternalUpdateEvent.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ExternalUpdateEvent.java
@@ -26,6 +26,14 @@ public class ExternalUpdateEvent implements Queueable {
   @JsonProperty("step_id")
   private String stepId;
 
+  /**
+   * The tenant this event's work belongs to. Carried so the consumer can restore the tenant context
+   * the producer thread had. Null on legacy/in-flight messages (pre-#6357); the consumer falls
+   * back.
+   */
+  @JsonProperty("tenant_id")
+  private String tenantId;
+
   /** The timestamp when this event was emitted, in milliseconds since epoch. */
   @JsonProperty("event_emission_date")
   private long emissionDate;

--- a/openaev-api/src/main/java/io/openaev/service/chaining/QueueChainingService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/QueueChainingService.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.database.model.Step;
 import io.openaev.database.model.Workflow;
+import io.openaev.database.repository.StepRepository;
+import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.service.RabbitmqService;
 import io.openaev.service.queue.BatchQueueService;
 import io.openaev.service.queue.QueueExecution;
@@ -28,6 +30,8 @@ public class QueueChainingService {
   private final RabbitmqService rabbitmqService;
   private final OpenAEVConfig openAEVConfig;
   private final ObjectMapper objectMapper;
+  private final StepRepository stepRepository;
+  private final WorkflowRepository workflowRepository;
 
   @Setter private BatchQueueService<StepEvent> readyQueueService;
   @Setter private BatchQueueService<ExternalUpdateEvent> updateQueueService;
@@ -92,8 +96,23 @@ public class QueueChainingService {
     StepEvent event = new StepEvent();
     event.setStepId(stepExecution.getId());
     event.setWorkflowId(workflowRun.getId());
+    event.setTenantId(tenantIdOfWorkflow(workflowRun));
     event.setEmissionDate(Instant.now().toEpochMilli());
     readyQueueService.publish(event);
+  }
+
+  /**
+   * Server-side tenant source for a ready event: the workflow's simulation's tenant, resolved with
+   * a projection query (not {@code TenantContext}, not lazy entity navigation). Correct on any
+   * thread — the request thread, the chaining worker, or a scheduler ({@code QueueChainingJob}) —
+   * none of which is guaranteed to carry the tenant or keep a Hibernate session open. Null for a
+   * standalone/atomic run with no simulation; the consumer falls back rather than failing (#6357).
+   */
+  private String tenantIdOfWorkflow(Workflow workflowRun) {
+    if (workflowRun == null || workflowRun.getId() == null) {
+      return null;
+    }
+    return workflowRepository.findTenantIdByWorkflowId(workflowRun.getId()).orElse(null);
   }
 
   /**
@@ -106,8 +125,22 @@ public class QueueChainingService {
     log.info("PUBLISH STEP UPDATE : {}", stepRunId);
     ExternalUpdateEvent event = new ExternalUpdateEvent();
     event.setStepId(stepRunId);
+    event.setTenantId(tenantIdOfStep(stepRunId));
     event.setEmissionDate(Instant.now().toEpochMilli());
     updateQueueService.publish(event);
+  }
+
+  /**
+   * Server-side tenant for update-event stamping: step -&gt; workflow -&gt; simulation -&gt;
+   * tenant, resolved with a projection query. {@code Step}/{@code Workflow} are {@code Base} (not
+   * tenant-filtered), and the query touches no lazy association, so this resolves on any thread
+   * with no ambient tenant context and no open session (the update-event producer runs on a
+   * scheduler/queue thread via {@code WorkflowUpdateEventAspect}). Null when the step or its
+   * simulation is absent; the consumer falls back (#6357). Symmetric with {@link
+   * #tenantIdOfWorkflow} used by {@link #readyStep}.
+   */
+  private String tenantIdOfStep(String stepId) {
+    return stepRepository.findTenantIdByStepId(stepId).orElse(null);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepEvent.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepEvent.java
@@ -29,6 +29,14 @@ public class StepEvent implements Queueable {
   @JsonProperty("step_id")
   private String stepId;
 
+  /**
+   * The tenant this event's work belongs to. Carried on the event so the consumer can restore the
+   * tenant context the producer thread had (the chaining worker sets none). Null on
+   * legacy/in-flight messages (pre-#6357); the consumer falls back rather than failing (#6357).
+   */
+  @JsonProperty("tenant_id")
+  private String tenantId;
+
   /** The timestamp when this event was emitted, in milliseconds since epoch. */
   @JsonProperty("event_emission_date")
   private long emissionDate;

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepEventService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepEventService.java
@@ -1,6 +1,11 @@
 package io.openaev.service.chaining;
 
+import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
+
 import io.openaev.api.chaining.ActionStep;
+import io.openaev.context.TenantContext;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
 import io.openaev.database.model.Step;
 import io.openaev.database.model.StepStatus;
 import io.openaev.database.model.Workflow;
@@ -13,8 +18,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Handles step lifecycle events consumed from the chaining queues: ready events (execute a step)
@@ -32,10 +35,21 @@ public class StepEventService implements StepEventHandler, ExternalUpdateEventHa
   private final QueueChainingService queueChainingService;
 
   /**
-   * Programmatic transaction manager used exclusively for {@link #handleReadyStepEvent}. Do NOT use
-   * it elsewhere — prefer {@code @Transactional} on public methods called from outside this class.
+   * MT v2 background transaction primitive (activate-tenant-table skill, Phase 5b). The chaining
+   * queue consumers run on worker threads that carry no tenant scope; they open a per-event
+   * tenant-scoped transaction through this primitive rather than {@code @Transactional} or a raw
+   * {@code TransactionTemplate}. This sets the v2 GUC ({@code app.current_tenants}), scoping the
+   * tenant-active tables the run writes (e.g. {@code attackpath_execution}).
+   *
+   * <p>The GUC alone is not enough here: a step run also reads v1 {@code @Filter} entities that are
+   * not yet migrated to v2 (injector contract, endpoints, assets). Those are scoped by the
+   * thread-local {@link TenantContext} via {@link io.openaev.aop.HibernateFilterTransactionAspect},
+   * not by the GUC. Each consumer therefore also sets {@link TenantContext} to the run's tenant for
+   * the duration of the event (set-then-finally-clear on the pooled worker thread), mirroring the
+   * background scheduler jobs (e.g. {@code ScenarioExecutionJob}). Both scopes carry the same
+   * tenant and cohabit: the primitive covers v2, {@link TenantContext} covers v1.
    */
-  private final TransactionTemplate transactionTemplate;
+  private final TenantScopedTransaction tenantTx;
 
   // -- READY EVENTS --
 
@@ -57,13 +71,24 @@ public class StepEventService implements StepEventHandler, ExternalUpdateEventHa
    */
   @Override
   public void handleReadyStepEvent(StepEvent stepEvent) {
+    // #6357: the chaining worker thread carries no tenant scope. Scope the event to its run's
+    // tenant
+    // on both mechanisms so run() resolves the right rows: the MT v2 primitive sets the GUC for the
+    // tenant-active tables the run writes (attackpath_execution), and TenantContext scopes the v1
+    // @Filter entities the run reads (injector contract, endpoints, assets) that are not yet
+    // migrated to v2. TenantContext is set on the pooled worker thread and cleared in finally so it
+    // never leaks to the next event (mirrors ScenarioExecutionJob). A null tenantId
+    // (legacy/in-flight
+    // message) falls back to the default tenant, today's behaviour. Per-event scoping keeps a
+    // failing
+    // event from rolling the rest of the batch back.
+    String tenantId =
+        stepEvent.getTenantId() != null ? stepEvent.getTenantId() : DEFAULT_TENANT_UUID;
+    TenantContext.setCurrentTenant(tenantId);
     try {
-      // Using TransactionTemplate instead of @Transactional because this method is called from
-      // handleReadyEvent() within the same class (self-invocation).
-      // We can't put the transactional annotation on handleReadyEvent as it would rollback the
-      // whole batch being treated instead of just the one faulty event.
-      transactionTemplate.executeWithoutResult(
-          status ->
+      tenantTx.execute(
+          TxCtx.forTenant(tenantId),
+          () ->
               stepRepository
                   .findById(stepEvent.getStepId())
                   .ifPresentOrElse(
@@ -96,6 +121,8 @@ public class StepEventService implements StepEventHandler, ExternalUpdateEventHa
             chainingConfig.getMaxRetryCount(),
             e);
       }
+    } finally {
+      TenantContext.clearCurrentTenant();
     }
   }
 
@@ -156,7 +183,15 @@ public class StepEventService implements StepEventHandler, ExternalUpdateEventHa
    * @param events list of events
    * @return consumed list of events
    */
-  @Transactional(rollbackFor = Exception.class)
+  // #6357: NOT @Transactional. A batch-level transaction would fire
+  // HibernateFilterTransactionAspect
+  // once with the (context-less) default tenant and pin the tenantFilter to it for every event in
+  // the
+  // batch, defeating the per-event tenant restore below. Each event runs in its own transaction
+  // with
+  // its tenant set first (mirrors handleReadyStepEvent), which also isolates a failing event from
+  // the
+  // rest of the batch.
   public List<ExternalUpdateEvent> handleExternalUpdateEvent(List<ExternalUpdateEvent> events) {
     events.forEach(this::handleExternalUpdateEvent);
     return events;
@@ -169,6 +204,21 @@ public class StepEventService implements StepEventHandler, ExternalUpdateEventHa
    */
   @Override
   public void handleExternalUpdateEvent(ExternalUpdateEvent stepEvent) {
+    // #6357: same dual scoping as the ready path (see handleReadyStepEvent) - the MT v2 primitive
+    // for the tenant-active writes, TenantContext for the v1 @Filter reads, both on the run's
+    // tenant, set-then-finally-clear on the pooled worker thread. Null tenantId (legacy/in-flight
+    // message) falls back to the default tenant.
+    String tenantId =
+        stepEvent.getTenantId() != null ? stepEvent.getTenantId() : DEFAULT_TENANT_UUID;
+    TenantContext.setCurrentTenant(tenantId);
+    try {
+      tenantTx.execute(TxCtx.forTenant(tenantId), () -> processExternalUpdateEvent(stepEvent));
+    } finally {
+      TenantContext.clearCurrentTenant();
+    }
+  }
+
+  private void processExternalUpdateEvent(ExternalUpdateEvent stepEvent) {
     Step stepRun;
     try {
       stepRun = stepService.findByIdAndStatus(stepEvent.getStepId(), StepStatus.RUN);

--- a/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringIT.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringIT.java
@@ -313,10 +313,14 @@ class AttackPathRunWiringIT extends IntegrationTest {
           + " any thread)")
   void tenantProjectionsResolveTheRunTenant() throws Exception {
     Step committedStep = persistCommittedReadyStep();
+    // The producers run on scheduler/queue threads with NO tenant scope: clear TenantContext so
+    // this
+    // proves the projections are context-free (not silently relying on the ambient v1
+    // tenantFilter).
+    TenantContext.clearCurrentTenant();
 
     // The producer stamps events with these projections (step/workflow -> simulation -> tenant).
-    // Assert they resolve the tenant on a real graph: they must not depend on an open session (the
-    // producers run on scheduler/queue threads), which a projection query guarantees.
+    // Assert they resolve the tenant on a real graph regardless of ambient scope.
     assertThat(stepRepository.findTenantIdByStepId(committedStep.getId()))
         .as("step -> workflow -> simulation -> tenant projection")
         .contains(tenant.getId());

--- a/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringIT.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringIT.java
@@ -27,6 +27,8 @@ import io.openaev.database.model.Workflow;
 import io.openaev.database.model.WorkflowStatus;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
+import io.openaev.database.repository.StepRepository;
+import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.executors.Executor;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.rest.inject.service.InjectService;
@@ -36,6 +38,8 @@ import io.openaev.service.UserService;
 import io.openaev.service.attackpath.AttackPathIds;
 import io.openaev.service.attackpath.ingestion.AttackPathExecutionIngestionService;
 import io.openaev.service.chaining.ConditionService;
+import io.openaev.service.chaining.StepEvent;
+import io.openaev.service.chaining.StepEventService;
 import io.openaev.utils.ConditionUtils;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.AgentFixture;
@@ -48,6 +52,7 @@ import io.openaev.utils.fixtures.PayloadFixture;
 import io.openaev.utils.fixtures.WorkflowFixture;
 import io.openaev.utils.fixtures.composers.AgentComposer;
 import io.openaev.utils.fixtures.composers.EndpointComposer;
+import io.openaev.utils.fixtures.composers.ExerciseComposer;
 import io.openaev.utils.fixtures.composers.PayloadComposer;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterEach;
@@ -100,6 +105,9 @@ class AttackPathRunWiringIT extends IntegrationTest {
   @MockitoSpyBean private AttackPathExecutionIngestionService attackPathIngestion;
 
   @Autowired private InjectExecutionStep injectExecutionStep;
+  @Autowired private StepEventService stepEventService;
+  @Autowired private StepRepository stepRepository;
+  @Autowired private WorkflowRepository workflowRepository;
   @Autowired private OpenAEVConfig openAEVConfig;
   @Autowired private CacheManager cacheManager;
   @Autowired private DataSource dataSource;
@@ -110,6 +118,7 @@ class AttackPathRunWiringIT extends IntegrationTest {
   @Autowired private InjectorRepository injectorRepository;
   @Autowired private InjectorContractRepository injectorContractRepository;
   @Autowired private PayloadComposer payloadComposer;
+  @Autowired private ExerciseComposer exerciseComposer;
 
   private JdbcTemplate jdbc;
   private Tenant tenant;
@@ -118,6 +127,7 @@ class AttackPathRunWiringIT extends IntegrationTest {
   private Inject fixtureInject;
   private Payload commandPayload;
   private String injectInputJson;
+  private String persistedWorkflowId;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -194,6 +204,10 @@ class AttackPathRunWiringIT extends IntegrationTest {
     jdbc.update(
         "DELETE FROM attackpath_execution WHERE attackpath_execution_simulation_id = ?",
         "SIM-WIRING");
+    // Remove the committed workflow_run (steps cascade on the FK) seeded by the consumer tests.
+    if (persistedWorkflowId != null) {
+      jdbc.update("DELETE FROM workflows WHERE workflow_id = ?", persistedWorkflowId);
+    }
     // The tenant-active FKs are ON DELETE CASCADE (e.g. injectors_contracts.tenant_id -> tenants,
     // migration V4_88), so deleting the tenant removes the committed contract, injector, payload,
     // agent and endpoint in one shot.
@@ -243,6 +257,74 @@ class AttackPathRunWiringIT extends IntegrationTest {
         .isZero();
   }
 
+  @Test
+  @DisplayName(
+      "W4 — #6357 consumer: handleReadyStepEvent scopes the run to the EVENT's tenant with no ambient"
+          + " scope; the v1 @Filter contract resolves and the row lands")
+  void consumerScopesRunToEventTenantWithoutAmbientScope() throws Exception {
+    setAttackPathFeature(true);
+    Step committedStep = persistCommittedReadyStep();
+    // The real chaining worker carries NO tenant scope: the fix must restore it from the event, not
+    // from an ambient ThreadLocal. Clear it so a regression that drops the propagation goes red
+    // (the
+    // v1 injector_contract read would resolve under the default tenant and find nothing).
+    TenantContext.clearCurrentTenant();
+
+    stepEventService.handleReadyStepEvent(
+        StepEvent.builder().stepId(committedStep.getId()).tenantId(tenant.getId()).build());
+
+    String rowId =
+        AttackPathIds.executionNode(fixtureInject.getId(), endpoint.getId(), agent.getId());
+    // A present row proves getInjectFromDataStep resolved the tenant-B contract under the scope the
+    // consumer set from the event (a run that could not resolve it throws before onRun and writes
+    // nothing). onRun stamps the tenant from the inject, hence == tenant.getId().
+    assertThat(rawTenantOf(rowId))
+        .as("consumer must scope run() to the event tenant so the v1 contract resolves")
+        .isEqualTo(tenant.getId());
+  }
+
+  @Test
+  @DisplayName(
+      "W5 — #6357 isolation: an event carrying the WRONG tenant cannot resolve the tenant-B contract,"
+          + " so the run writes no row")
+  void consumerWithWrongEventTenantResolvesNothing() throws Exception {
+    setAttackPathFeature(true);
+    Step committedStep = persistCommittedReadyStep();
+    TenantContext.clearCurrentTenant();
+
+    // The default tenant is not tenant B: its scope cannot see the committed injector_contract, so
+    // getInjectFromDataStep finds nothing and the run ends before onRun. Proves the scoping is a
+    // real
+    // tenant boundary, not an always-on write.
+    stepEventService.handleReadyStepEvent(
+        StepEvent.builder()
+            .stepId(committedStep.getId())
+            .tenantId(Tenant.DEFAULT_TENANT_UUID)
+            .build());
+
+    assertThat(rawRowCount())
+        .as("a wrong-tenant event must not resolve the contract nor write a row")
+        .isZero();
+  }
+
+  @Test
+  @DisplayName(
+      "W6 — #6357 producer: the tenant projections resolve the run tenant from a real graph (no lazy,"
+          + " any thread)")
+  void tenantProjectionsResolveTheRunTenant() throws Exception {
+    Step committedStep = persistCommittedReadyStep();
+
+    // The producer stamps events with these projections (step/workflow -> simulation -> tenant).
+    // Assert they resolve the tenant on a real graph: they must not depend on an open session (the
+    // producers run on scheduler/queue threads), which a projection query guarantees.
+    assertThat(stepRepository.findTenantIdByStepId(committedStep.getId()))
+        .as("step -> workflow -> simulation -> tenant projection")
+        .contains(tenant.getId());
+    assertThat(workflowRepository.findTenantIdByWorkflowId(persistedWorkflowId))
+        .as("workflow -> simulation -> tenant projection")
+        .contains(tenant.getId());
+  }
+
   // Handed to run() in memory (via the createInject stub) with contract + exercise attached. The
   // resolution then runs on the executor-backed contract; the agent's own endpoint is source and
   // target. Same shape as the onRun tenant test's fixture.
@@ -289,6 +371,40 @@ class AttackPathRunWiringIT extends IntegrationTest {
     return injectExecutionStep
         .ready(stepTemplate, "{\"input\":\"do defined\"}", workflowRun)
         .orElseThrow();
+  }
+
+  // Commits the READY step (its workflow_run and its TEMPLATE step) so the consumer's
+  // findById(stepId) resolves it - create/ready build transient steps (the production persistence
+  // is
+  // QueueChainingService's job). steps.step_workflow_id is NOT NULL, so the workflow_run is
+  // committed first; step_template_id is an FK to steps and setGlobalInformation dereferences
+  // step.getStepTemplate().getId(), so the template step is committed too. The IT is not
+  // @Transactional, so each save auto-commits and is visible to the primitive's REQUIRES_NEW tx.
+  private Step persistCommittedReadyStep() throws Exception {
+    // workflows carries a check constraint (simulation OR scenario); attach a committed simulation.
+    // It is only there to satisfy the FK/constraint - run() uses the fixture inject's own exercise.
+    Exercise simulation =
+        exerciseComposer.forExercise(ExerciseFixture.createDefaultExercise()).persist().get();
+    Workflow workflow = WorkflowFixture.getDefaultWorkflowExecution(WorkflowStatus.RUN);
+    workflow.setSimulation(simulation);
+    Workflow workflowRun = workflowRepository.save(workflow);
+    persistedWorkflowId = workflowRun.getId();
+
+    InjectInput injectInput = new ObjectMapper().readValue(injectInputJson, InjectInput.class);
+    StepsCreateInput.StepInput stepInput =
+        InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
+    Step template = injectExecutionStep.create(stepInput, workflowRun).orElseThrow();
+    template.setWorkflow(workflowRun);
+    template.setLimitExecution(0);
+    template = stepRepository.save(template);
+
+    Step ready =
+        injectExecutionStep
+            .ready(template, "{\"input\":\"do defined\"}", workflowRun)
+            .orElseThrow();
+    ready.setWorkflow(workflowRun);
+    ready.setLimitExecution(0);
+    return stepRepository.save(ready);
   }
 
   private void setAttackPathFeature(boolean enabled) {

--- a/openaev-api/src/test/java/io/openaev/service/chaining/QueueChainingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/QueueChainingServiceTest.java
@@ -7,6 +7,8 @@ import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.QueueConfig;
 import io.openaev.database.model.Step;
 import io.openaev.database.model.Workflow;
+import io.openaev.database.repository.StepRepository;
+import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.service.queue.BatchQueueService;
 import io.openaev.service.queue.QueueExecution;
 import java.io.IOException;
@@ -36,6 +38,10 @@ class QueueChainingServiceTest {
   @Mock private BatchQueueService<StepEvent> readyQueueService;
 
   @Mock private BatchQueueService<ExternalUpdateEvent> updateQueueService;
+
+  @Mock private StepRepository stepRepository;
+
+  @Mock private WorkflowRepository workflowRepository;
 
   @InjectMocks private QueueChainingService queueChainingService;
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepEventServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepEventServiceTest.java
@@ -58,6 +58,10 @@ class StepEventServiceTest {
             })
         .when(tenantTx)
         .execute(any(TxCtx.class), any(Runnable.class));
+    // Tenant-propagation tests assert the scope opened around the event, not run() itself; make the
+    // step lookup explicitly empty so the primitive's Runnable takes the (harmless) not-found
+    // branch.
+    lenient().when(stepRepository.findById(any())).thenReturn(Optional.empty());
   }
 
   @AfterEach

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepEventServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepEventServiceTest.java
@@ -1,11 +1,17 @@
 package io.openaev.service.chaining;
 
+import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.openaev.api.chaining.ActionStep;
+import io.openaev.context.TenantContext;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
 import io.openaev.database.model.Step;
 import io.openaev.database.model.StepActionClass;
 import io.openaev.database.model.StepStatus;
@@ -17,7 +23,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,8 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class StepEventServiceTest {
@@ -36,24 +41,30 @@ class StepEventServiceTest {
   @Mock private WorkflowService workflowService;
   @Mock private StepRepository stepRepository;
   @Mock private QueueChainingService queueChainingService;
-  @Mock private TransactionTemplate transactionTemplate;
+  @Mock private TenantScopedTransaction tenantTx;
   @Mock private ActionStep actionStep;
 
   @InjectMocks private StepEventService stepEventService;
 
-  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     lenient().when(chainingConfig.getMaxRetryCount()).thenReturn(3);
     lenient()
         .doAnswer(
             invocation -> {
-              Consumer<TransactionStatus> action = invocation.getArgument(0);
-              action.accept(null);
+              Runnable work = invocation.getArgument(1);
+              work.run();
               return null;
             })
-        .when(transactionTemplate)
-        .executeWithoutResult(any());
+        .when(tenantTx)
+        .execute(any(TxCtx.class), any(Runnable.class));
+  }
+
+  @AfterEach
+  void clearTenantScope() {
+    // Belt and suspenders: the consumer clears TenantContext in a finally, but the tests share the
+    // JUnit thread, so guarantee no scope leaks between them.
+    TenantContext.clearCurrentTenant();
   }
 
   // -- RUN --
@@ -266,8 +277,8 @@ class StepEventServiceTest {
               invocation -> {
                 throw new RuntimeException("DB error");
               })
-          .when(transactionTemplate)
-          .executeWithoutResult(any());
+          .when(tenantTx)
+          .execute(any(TxCtx.class), any(Runnable.class));
 
       // Act
       stepEventService.handleReadyStepEvent(event);
@@ -287,8 +298,8 @@ class StepEventServiceTest {
               invocation -> {
                 throw new RuntimeException("DB error");
               })
-          .when(transactionTemplate)
-          .executeWithoutResult(any());
+          .when(tenantTx)
+          .execute(any(TxCtx.class), any(Runnable.class));
 
       // Act
       stepEventService.handleReadyStepEvent(event);
@@ -306,8 +317,8 @@ class StepEventServiceTest {
               invocation -> {
                 throw new RuntimeException("DB error");
               })
-          .when(transactionTemplate)
-          .executeWithoutResult(any());
+          .when(tenantTx)
+          .execute(any(TxCtx.class), any(Runnable.class));
 
       doThrow(new IOException("RabbitMQ down"))
           .when(queueChainingService)
@@ -319,6 +330,82 @@ class StepEventServiceTest {
       // Assert
       assertEquals(1, event.getRetryCount());
       verify(queueChainingService).republishReadyEvent(event);
+    }
+  }
+
+  // -- TENANT PROPAGATION (#6357) --
+
+  @Nested
+  class TenantPropagation {
+
+    // The chaining worker carries no tenant; the fix restores it from the event on BOTH mechanisms:
+    // the MT v2 primitive (GUC, tenant-active writes) and the v1 TenantContext (@Filter reads).
+    // These
+    // pin the propagation: the consumer MUST open the scope under the event's tenant (and the
+    // default
+    // when absent), and must clear TenantContext after, so a regression that drops either is
+    // caught.
+
+    @Test
+    void handleReadyStepEvent_opensTheScopeUnderTheEventTenant() {
+      StepEvent event =
+          StepEvent.builder().stepId(UUID.randomUUID().toString()).tenantId("tenant-B").build();
+
+      stepEventService.handleReadyStepEvent(event);
+
+      verify(tenantTx).execute(eq(TxCtx.forTenant("tenant-B")), any(Runnable.class));
+    }
+
+    @Test
+    void handleReadyStepEvent_scopesV1TenantContextDuringWork_andClearsAfter() {
+      StepEvent event =
+          StepEvent.builder().stepId(UUID.randomUUID().toString()).tenantId("tenant-B").build();
+      // Capture the v1 @Filter scope (TenantContext) visible while the primitive's work runs: the
+      // v1
+      // entities the run reads (injector contract, endpoints, assets) resolve through it, not the
+      // GUC.
+      AtomicReference<String> seenDuringWork = new AtomicReference<>();
+      doAnswer(
+              invocation -> {
+                seenDuringWork.set(TenantContext.getCurrentTenant());
+                Runnable work = invocation.getArgument(1);
+                work.run();
+                return null;
+              })
+          .when(tenantTx)
+          .execute(any(TxCtx.class), any(Runnable.class));
+
+      stepEventService.handleReadyStepEvent(event);
+
+      assertEquals("tenant-B", seenDuringWork.get());
+      assertFalse(TenantContext.hasCurrentTenant(), "TenantContext must not leak past the event");
+    }
+
+    @Test
+    void handleReadyStepEvent_nullEventTenant_fallsBackToDefault() {
+      StepEvent event = StepEvent.builder().stepId(UUID.randomUUID().toString()).build();
+
+      stepEventService.handleReadyStepEvent(event);
+
+      verify(tenantTx).execute(eq(TxCtx.forTenant(DEFAULT_TENANT_UUID)), any(Runnable.class));
+    }
+
+    @Test
+    void handleExternalUpdateEvent_opensTheScopeUnderTheEventTenant() {
+      ExternalUpdateEvent event =
+          ExternalUpdateEvent.builder()
+              .stepId(UUID.randomUUID().toString())
+              .tenantId("tenant-B")
+              .build();
+      // Short-circuit the body: this test only asserts the tenant scope is opened, not the update
+      // logic (the setUp stub runs the primitive's Runnable, which would otherwise NPE on a null
+      // step).
+      when(stepService.findByIdAndStatus(any(), any()))
+          .thenThrow(new ElementNotFoundException("short-circuit"));
+
+      stepEventService.handleExternalUpdateEvent(event);
+
+      verify(tenantTx).execute(eq(TxCtx.forTenant("tenant-B")), any(Runnable.class));
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTimeoutGuardsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTimeoutGuardsTest.java
@@ -3,11 +3,12 @@ package io.openaev.service.chaining;
 import static org.mockito.Mockito.*;
 
 import io.openaev.api.chaining.ActionStep;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.StepRepository;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,8 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("StepService Timeout Guards Tests")
@@ -29,23 +28,22 @@ class StepServiceTimeoutGuardsTest {
   @Mock private StepService stepService;
   @Mock private WorkflowService workflowService;
   @Mock private QueueChainingService queueChainingService;
-  @Mock private TransactionTemplate transactionTemplate;
+  @Mock private TenantScopedTransaction tenantTx;
   @Mock private ActionStep actionStep;
 
   @Spy @InjectMocks private StepEventService stepEventService;
 
-  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     lenient()
         .doAnswer(
             invocation -> {
-              Consumer<TransactionStatus> action = invocation.getArgument(0);
-              action.accept(null);
+              Runnable work = invocation.getArgument(1);
+              work.run();
               return null;
             })
-        .when(transactionTemplate)
-        .executeWithoutResult(any());
+        .when(tenantTx)
+        .execute(any(TxCtx.class), any(Runnable.class));
   }
 
   // ========================================================================

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -126,13 +126,25 @@ public interface StepRepository extends JpaRepository<Step, String> {
   Optional<String> findStepIdByInjectId(@Param("injectId") String injectId);
 
   /**
-   * Resolves the tenant that owns a step, as a projection: step -&gt; workflow -&gt; simulation
-   * -&gt; tenant. Used to stamp the tenant on chaining events (#6357). A single query with no lazy
-   * association access, so it is safe on any thread with no open session (the update-event producer
-   * runs on scheduler/queue threads where open-in-view is inactive). Empty for a workflow with no
-   * simulation (standalone run); the caller falls back to the default tenant.
+   * Resolves the tenant that owns a step: step -&gt; workflow -&gt; simulation -&gt; tenant. Used
+   * to stamp the tenant on chaining events (#6357). NATIVE on purpose: {@code exercises} is a v1
+   * {@code @Filter} entity ({@code tenantFilter}), so a JPQL path through it would be re-filtered
+   * by the ambient {@code TenantContext} and, on a scheduler/queue producer thread that carries the
+   * default (or wrong) tenant, could silently return empty and stamp the event with null. A native
+   * query bypasses the Hibernate filter, so the stamp is truly context-free. Also no lazy
+   * navigation, so it is safe with no open session. Empty for a workflow with no simulation
+   * (standalone run); the caller falls back to the default tenant.
    */
-  @Query("SELECT s.workflow.simulation.tenant.id FROM Step s WHERE s.id = :stepId")
+  @Query(
+      value =
+          """
+      SELECT e.tenant_id
+      FROM steps s
+      JOIN workflows w ON w.workflow_id = s.step_workflow_id
+      JOIN exercises e ON e.exercise_id = w.workflow_simulation_id
+      WHERE s.step_id = :stepId
+      """,
+      nativeQuery = true)
   Optional<String> findTenantIdByStepId(@Param("stepId") String stepId);
 
   /**

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -126,6 +126,16 @@ public interface StepRepository extends JpaRepository<Step, String> {
   Optional<String> findStepIdByInjectId(@Param("injectId") String injectId);
 
   /**
+   * Resolves the tenant that owns a step, as a projection: step -&gt; workflow -&gt; simulation
+   * -&gt; tenant. Used to stamp the tenant on chaining events (#6357). A single query with no lazy
+   * association access, so it is safe on any thread with no open session (the update-event producer
+   * runs on scheduler/queue threads where open-in-view is inactive). Empty for a workflow with no
+   * simulation (standalone run); the caller falls back to the default tenant.
+   */
+  @Query("SELECT s.workflow.simulation.tenant.id FROM Step s WHERE s.id = :stepId")
+  Optional<String> findTenantIdByStepId(@Param("stepId") String stepId);
+
+  /**
    * Return the injectId frozen in a step's data, if present. The engine writes it into {@code
    * step_data} at run ({@code InjectExecutionStep.setInjectId}), so the attack-path read can
    * resolve the "Action details" inject link from the durable step rather than storing it on the

--- a/openaev-model/src/main/java/io/openaev/database/repository/WorkflowRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/WorkflowRepository.java
@@ -13,13 +13,24 @@ import org.springframework.stereotype.Repository;
 public interface WorkflowRepository extends JpaRepository<Workflow, String> {
 
   /**
-   * Resolves the tenant that owns a workflow, as a projection: workflow -&gt; simulation -&gt;
-   * tenant. Used to stamp the tenant on chaining ready events (#6357). A single query with no lazy
-   * association access, so it is safe on any thread with no open session (ready events are also
-   * produced from scheduler jobs where open-in-view is inactive). Empty for a workflow with no
-   * simulation (standalone run); the caller falls back to the default tenant.
+   * Resolves the tenant that owns a workflow: workflow -&gt; simulation -&gt; tenant. Used to stamp
+   * the tenant on chaining ready events (#6357). NATIVE on purpose: {@code exercises} is a v1
+   * {@code @Filter} entity ({@code tenantFilter}), so a JPQL path through it would be re-filtered
+   * by the ambient {@code TenantContext} and, on a scheduler producer thread ({@code
+   * QueueChainingJob}) that carries the default (or wrong) tenant, could silently return empty and
+   * stamp the event with null. A native query bypasses the Hibernate filter, so the stamp is truly
+   * context-free. Also no lazy navigation, so it is safe with no open session. Empty for a workflow
+   * with no simulation (standalone run); the caller falls back to the default tenant.
    */
-  @Query("SELECT w.simulation.tenant.id FROM Workflow w WHERE w.id = :workflowId")
+  @Query(
+      value =
+          """
+      SELECT e.tenant_id
+      FROM workflows w
+      JOIN exercises e ON e.exercise_id = w.workflow_simulation_id
+      WHERE w.workflow_id = :workflowId
+      """,
+      nativeQuery = true)
   Optional<String> findTenantIdByWorkflowId(@Param("workflowId") String workflowId);
 
   /**

--- a/openaev-model/src/main/java/io/openaev/database/repository/WorkflowRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/WorkflowRepository.java
@@ -6,10 +6,22 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WorkflowRepository extends JpaRepository<Workflow, String> {
+
+  /**
+   * Resolves the tenant that owns a workflow, as a projection: workflow -&gt; simulation -&gt;
+   * tenant. Used to stamp the tenant on chaining ready events (#6357). A single query with no lazy
+   * association access, so it is safe on any thread with no open session (ready events are also
+   * produced from scheduler jobs where open-in-view is inactive). Empty for a workflow with no
+   * simulation (standalone run); the caller falls back to the default tenant.
+   */
+  @Query("SELECT w.simulation.tenant.id FROM Workflow w WHERE w.id = :workflowId")
+  Optional<String> findTenantIdByWorkflowId(@Param("workflowId") String workflowId);
+
   /**
    * Retrieves all {@link Workflow} entities associated with the specified simulation ID.
    *


### PR DESCRIPTION
### What
The chaining queue consumers run on worker threads that carry no tenant scope, so a step run resolved its
data under the default tenant. On a non-default tenant this means the run's tenant-active reads find
nothing and the inject does not execute. This scopes each event's run to its tenant.

- `StepEventService` (ready + external-update) opens each event under the run's tenant on both MT
  mechanisms: the v2 primitive (`tenantTx.execute`, GUC for tenant-active writes) and v1
  `TenantContext` (the `@Filter` reads the run still needs, not yet migrated to v2), set-then-finally-clear
  on the pooled worker (mirrors `ScenarioExecutionJob`).
- The tenant travels on the event (`StepEvent`/`ExternalUpdateEvent` carry `tenant_id`), stamped
  server-side by `QueueChainingService` from the workflow/step simulation tenant via projection queries
  (no lazy navigation: the producers run on scheduler/queue threads with no open session).
- Null `tenant_id` (in-flight/legacy messages) falls back to the default tenant: no rollout break.

### Scope / not in this PR
This covers **internal injectors** (e.g. the attack-path implant, `Executor.executeInternal`). It does
**not** fix **external injectors**: `Executor.executeExternal` publishes to the static base connector
exchange (`RabbitmqService.publish`, tenant-blind), which 404s on a non-default tenant. That is a separate
change (make the external publish tenant-aware) and must not regress classic-external / the default tenant.
Do not auto-close #6357.

### Tests
`AttackPathRunWiringIT` W4 (real consumer, no ambient scope → row under the run tenant), W5 (wrong tenant →
no row), W6 (tenant projections on a real graph); unit tests for both consumers; full chaining/attackpath
suite green.