### PR TITLE
feat(attack-path): enforce resource RBAC on reads and scenario-scope the picker (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
@@ -9,6 +9,7 @@ import io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.PreviewFeatureService;
+import io.openaev.service.attackpath.AttackPathAccessControl;
 import io.openaev.service.attackpath.AttackPathGraphService;
 import io.openaev.service.attackpath.AttackPathSeedService;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
@@ -57,6 +58,7 @@ public class AttackPathApi extends RestBehavior {
   private final AttackPathGraphService graphService;
   private final AttackPathSeedService seedService;
   private final PreviewFeatureService previewFeatureService;
+  private final AttackPathAccessControl attackPathAccessControl;
 
   /** Runtime feature gate: return 404 unless the {@code ATTACK_PATH} preview feature is enabled. */
   private void requireAttackPathFeature() {
@@ -66,12 +68,13 @@ public class AttackPathApi extends RestBehavior {
   }
 
   /**
-   * Full graph of a simulation, built from two flat reads plus one in-memory pass. {@code
-   * skipRBAC}: synthetic seeded simulations are not real {@code exercises}, so resource-level RBAC
-   * cannot resolve them; tenant isolation is still enforced by the statement inspector.
+   * Full graph of a simulation, built from two flat reads plus one in-memory pass.
    *
-   * <p>TODO(#6647): {@code skipRBAC} is a concession while the store is fed by the synthetic seed.
-   * Once these tables are fed from real simulations, resource-level RBAC must apply on every read.
+   * <p>RBAC: the annotation stays {@code skipRBAC = true} because it cannot express the seed
+   * exception; resource-level {@code SIMULATION READ} is enforced in-method by {@link
+   * AttackPathAccessControl#assertCanReadSimulation}, which lets synthetic seed ids through (they
+   * are not real {@code exercises}). Every per-simulation read below does the same. Tenant
+   * isolation is still enforced by the statement inspector.
    */
   @GetMapping("/simulations/{simulationId}/graph")
   @Transactional(readOnly = true)
@@ -79,19 +82,26 @@ public class AttackPathApi extends RestBehavior {
   public AttackPathDTO graph(
       TxCtx ctx, @PathVariable String simulationId, @RequestParam(required = false) String mode) {
     requireAttackPathFeature();
+    attackPathAccessControl.assertCanReadSimulation(simulationId);
     return graphService.buildGraph(simulationId, mode);
   }
 
   /**
-   * Simulations that have attack-path data in the caller's tenant (id, endpoint count, execution
-   * count), for the front's picker. Tenant-scoped through the {@link TxCtx} like every other read.
+   * Simulations that have attack-path data (id, endpoint count, execution count), for the front's
+   * picker. Tenant-scoped through the {@link TxCtx}. When {@code scenarioId} is given (scenario
+   * context, #6647 B0), the query is restricted to that scenario's simulations server-side. The
+   * rows are then grant-filtered to the ones the caller can READ (seed rows kept), so the picker
+   * never leaks a simulation the user is not granted on.
    */
   @GetMapping("/simulations")
   @Transactional(readOnly = true)
   @AccessControl(skipRBAC = true)
-  public List<AttackPathSimSummaryRow> simulations(TxCtx ctx) {
+  public List<AttackPathSimSummaryRow> simulations(
+      TxCtx ctx, @RequestParam(required = false) String scenarioId) {
     requireAttackPathFeature();
-    return graphService.listSimulations();
+    return graphService.listSimulations(scenarioId).stream()
+        .filter(row -> attackPathAccessControl.canReadSimulation(row.simulationId()))
+        .toList();
   }
 
   /**
@@ -104,6 +114,7 @@ public class AttackPathApi extends RestBehavior {
   public AttackPathExpandDTO expandEndpointFindings(
       TxCtx ctx, @PathVariable String simulationId, @RequestParam String ref) {
     requireAttackPathFeature();
+    attackPathAccessControl.assertCanReadSimulation(simulationId);
     return graphService.expandEndpoint(simulationId, ref);
   }
 
@@ -117,6 +128,7 @@ public class AttackPathApi extends RestBehavior {
   public AttackPathEndpointRelationsDTO relations(
       TxCtx ctx, @PathVariable String simulationId, @RequestParam String ref) {
     requireAttackPathFeature();
+    attackPathAccessControl.assertCanReadSimulation(simulationId);
     return graphService.endpointRelations(simulationId, ref);
   }
 
@@ -137,6 +149,7 @@ public class AttackPathApi extends RestBehavior {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "50") int size) {
     requireAttackPathFeature();
+    attackPathAccessControl.assertCanReadSimulation(simulationId);
     int safePage = Math.max(page, 0);
     int safeSize = Math.min(Math.max(size, 1), MAX_FINDINGS_PAGE_SIZE);
     return graphService.listFindings(simulationId, category, PageRequest.of(safePage, safeSize));
@@ -159,6 +172,7 @@ public class AttackPathApi extends RestBehavior {
   public AttackPathExecutionDetailDTO executionDetail(
       TxCtx ctx, @PathVariable String simulationId, @RequestParam("ref") String executionId) {
     requireAttackPathFeature();
+    attackPathAccessControl.assertCanReadSimulation(simulationId);
     AttackPathExecutionDetailDTO detail = graphService.executionDetail(simulationId, executionId);
     if (detail == null) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);

--- a/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
@@ -99,9 +99,7 @@ public class AttackPathApi extends RestBehavior {
   public List<AttackPathSimSummaryRow> simulations(
       TxCtx ctx, @RequestParam(required = false) String scenarioId) {
     requireAttackPathFeature();
-    return graphService.listSimulations(scenarioId).stream()
-        .filter(row -> attackPathAccessControl.canReadSimulation(row.simulationId()))
-        .toList();
+    return attackPathAccessControl.retainReadable(graphService.listSimulations(scenarioId));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathAccessControl.java
@@ -3,8 +3,10 @@ package io.openaev.service.attackpath;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.model.User;
+import io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow;
 import io.openaev.service.PermissionService;
 import io.openaev.service.UserService;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,18 +33,26 @@ public class AttackPathAccessControl {
 
   /** Throws 403 unless the caller can READ the simulation; a seed id is always allowed. */
   public void assertCanReadSimulation(String simulationId) {
-    if (!canReadSimulation(simulationId)) {
+    if (!canRead(userService.currentUser(), simulationId)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied on simulation");
     }
   }
 
-  /** Whether the caller can READ the simulation; seed ids are always readable. */
-  public boolean canReadSimulation(String simulationId) {
-    if (AttackPathIds.isSeedId(simulationId)) {
-      return true;
-    }
+  /**
+   * Keeps only the picker rows the caller can READ (seed rows always kept). Resolves the current
+   * user ONCE, not per row: {@link UserService#currentUser()} is DB-backed for non-admins, so a
+   * per-row call would be an N+1 on tenants with many simulations. The remaining per-row check is
+   * capability-first (in memory on the user) and only falls back to a grant lookup for a user that
+   * relies on resource grants.
+   */
+  public List<AttackPathSimSummaryRow> retainReadable(List<AttackPathSimSummaryRow> rows) {
     User user = userService.currentUser();
-    return permissionService.hasPermission(
-        user, Optional.empty(), simulationId, ResourceType.SIMULATION, Action.READ);
+    return rows.stream().filter(row -> canRead(user, row.simulationId())).toList();
+  }
+
+  private boolean canRead(User user, String simulationId) {
+    return AttackPathIds.isSeedId(simulationId)
+        || permissionService.hasPermission(
+            user, Optional.empty(), simulationId, ResourceType.SIMULATION, Action.READ);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathAccessControl.java
@@ -1,0 +1,48 @@
+package io.openaev.service.attackpath;
+
+import io.openaev.database.model.Action;
+import io.openaev.database.model.ResourceType;
+import io.openaev.database.model.User;
+import io.openaev.service.PermissionService;
+import io.openaev.service.UserService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Resource-level RBAC for the attack-path read endpoints (#6647 hardening), seed-tolerant.
+ *
+ * <p>The endpoints keep {@code @AccessControl(skipRBAC = true)} because the declarative aspect
+ * cannot express the seed exception: a synthetic seed simulation ({@code ap-seed-…}) is not a real
+ * {@code exercise}, so a grant check would 403 it. This guard is the real gate — it enforces {@code
+ * SIMULATION READ} on real simulations and lets seed ids through. The same current-user source as
+ * {@link io.openaev.aop.AccessControlAspect} ({@link UserService#currentUser()}); {@code
+ * SIMULATION} is grant-managed so {@link PermissionService#hasPermission} ignores the (empty)
+ * mapping info.
+ */
+@Component
+@RequiredArgsConstructor
+public class AttackPathAccessControl {
+
+  private final UserService userService;
+  private final PermissionService permissionService;
+
+  /** Throws 403 unless the caller can READ the simulation; a seed id is always allowed. */
+  public void assertCanReadSimulation(String simulationId) {
+    if (!canReadSimulation(simulationId)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied on simulation");
+    }
+  }
+
+  /** Whether the caller can READ the simulation; seed ids are always readable. */
+  public boolean canReadSimulation(String simulationId) {
+    if (AttackPathIds.isSeedId(simulationId)) {
+      return true;
+    }
+    User user = userService.currentUser();
+    return permissionService.hasPermission(
+        user, Optional.empty(), simulationId, ResourceType.SIMULATION, Action.READ);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -136,10 +136,14 @@ public class AttackPathGraphService {
 
   /**
    * Summaries of the simulations that have attack-path data in the caller's tenant, for the picker.
+   * When {@code scenarioId} is given (scenario context, #6647 B0), the list is restricted to that
+   * scenario's simulations; otherwise every simulation with attack-path data in the tenant.
    */
   @Transactional(readOnly = true)
-  public List<AttackPathSimSummaryRow> listSimulations() {
-    return executionRepository.findSimulationSummaries();
+  public List<AttackPathSimSummaryRow> listSimulations(String scenarioId) {
+    return (scenarioId == null || scenarioId.isBlank())
+        ? executionRepository.findSimulationSummaries()
+        : executionRepository.findSimulationSummariesByScenario(scenarioId);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
@@ -16,6 +16,19 @@ public final class AttackPathIds {
   private static final char DELIMITER = '|';
 
   /**
+   * Prefix of a synthetic seed simulation id ({@code AttackPathSeedService} builds ids as {@code
+   * <prefix><seed>-sim-<n>}). Seed simulations are not real {@code exercises}, so resource-level
+   * RBAC cannot resolve them; callers use {@link #isSeedId} to keep them reachable (see {@code
+   * AttackPathAccessControl}).
+   */
+  public static final String SEED_ID_PREFIX = "ap-seed-";
+
+  /** Whether {@code id} is a synthetic seed simulation id (not a real exercise). */
+  public static boolean isSeedId(String id) {
+    return id != null && id.startsWith(SEED_ID_PREFIX);
+  }
+
+  /**
    * Marker for a {@code null} component. The two chars {@code \0} can never occur in an escaped
    * non-null component (there, a {@code \} is always followed by {@code \} or {@code |}), so a null
    * component never collides with a real value.

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathSeedService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathSeedService.java
@@ -66,7 +66,6 @@ public class AttackPathSeedService {
   private static final int BATCH_ROWS = 200;
   private static final int EXECUTION_BATCH_ROWS = 50;
   private static final int EXECS_PER_ENDPOINT = 250;
-  private static final String SEED_ID_PREFIX = "ap-seed-";
   private static final Instant BASE_TIME = Instant.parse("2026-01-01T00:00:00Z");
 
   private static final String[] FINDING_TYPES = {"credentials", "username", "cve", "port"};
@@ -166,7 +165,7 @@ public class AttackPathSeedService {
     long executionCount = 0;
     long findingCount = 0;
     for (int s = 0; s < params.simulations(); s++) {
-      String simulationId = SEED_ID_PREFIX + params.seed() + "-sim-" + s;
+      String simulationId = AttackPathIds.SEED_ID_PREFIX + params.seed() + "-sim-" + s;
       String simTenantId = tenants.get(s % tenants.size());
       int size = sizeForSimulation(s, params, random);
       long[] simCounts =
@@ -194,7 +193,7 @@ public class AttackPathSeedService {
             "INSERT INTO tenants (tenant_id, tenant_name) VALUES (?, ?)"
                 + " ON CONFLICT (tenant_id) DO NOTHING")) {
       for (int t = 0; t < params.tenants(); t++) {
-        String id = SEED_ID_PREFIX + params.seed() + "-tenant-" + t;
+        String id = AttackPathIds.SEED_ID_PREFIX + params.seed() + "-tenant-" + t;
         statement.setString(1, id);
         statement.setString(2, id);
         statement.executeUpdate();

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiRbacIT.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiRbacIT.java
@@ -68,10 +68,15 @@ class AttackPathApiRbacIT extends IntegrationTest {
   private String simulationId;
   private Authentication withGrant;
   private Authentication withoutGrant;
+  private String originalDevFeatures;
 
   @BeforeEach
   void setUp() {
-    setAttackPathFeature(true);
+    // Store and restore the dev-feature flag around the test (the Spring context is shared), so
+    // this
+    // class never wipes another test's configured dev features.
+    originalDevFeatures = openAEVConfig.getEnabledDevFeatures();
+    setDevFeatures(PreviewFeature.ATTACK_PATH.getValue());
     Exercise simulation =
         exerciseComposer.forExercise(ExerciseFixture.createDefaultExercise()).persist().get();
     simulationId = simulation.getId();
@@ -81,7 +86,7 @@ class AttackPathApiRbacIT extends IntegrationTest {
 
   @AfterEach
   void tearDown() {
-    setAttackPathFeature(false);
+    setDevFeatures(originalDevFeatures);
     userComposer.reset();
     grantComposer.reset();
     tenantGroupComposer.reset();
@@ -327,8 +332,10 @@ class AttackPathApiRbacIT extends IntegrationTest {
         .get();
   }
 
-  private void setAttackPathFeature(boolean enabled) {
-    openAEVConfig.setEnabledDevFeatures(enabled ? PreviewFeature.ATTACK_PATH.getValue() : null);
+  // Sets the raw dev-features value (may be the stored original, which can be null) and evicts the
+  // @Cacheable("global") isFeatureEnabled cache so the change is observed.
+  private void setDevFeatures(String value) {
+    openAEVConfig.setEnabledDevFeatures(value);
     if (cacheManager.getCache("global") != null) {
       cacheManager.getCache("global").clear();
     }

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiRbacIT.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiRbacIT.java
@@ -1,0 +1,336 @@
+package io.openaev.api.attackpath;
+
+import static io.openaev.service.UserService.buildAuthenticationToken;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Exercise;
+import io.openaev.database.model.Grant;
+import io.openaev.database.model.Scenario;
+import io.openaev.database.model.User;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.rest.settings.PreviewFeature;
+import io.openaev.service.attackpath.AttackPathIds;
+import io.openaev.utils.fixtures.ExerciseFixture;
+import io.openaev.utils.fixtures.ScenarioFixture;
+import io.openaev.utils.fixtures.TenantGroupFixture;
+import io.openaev.utils.fixtures.TenantRoleFixture;
+import io.openaev.utils.fixtures.UserFixture;
+import io.openaev.utils.fixtures.composers.ExerciseComposer;
+import io.openaev.utils.fixtures.composers.GrantComposer;
+import io.openaev.utils.fixtures.composers.ScenarioComposer;
+import io.openaev.utils.fixtures.composers.TenantGroupComposer;
+import io.openaev.utils.fixtures.composers.TenantRoleComposer;
+import io.openaev.utils.fixtures.composers.UserComposer;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+/**
+ * B1 (#6647 hardening): the attack-path read endpoints must enforce resource-level RBAC on real
+ * simulations, while a synthetic seed id ({@code ap-seed-…}, no real exercise) stays reachable.
+ * Real stack (MockMvc + real PG + real grants), no mocked RBAC.
+ */
+@DisplayName("attack path: read endpoints enforce SIMULATION READ (seed-tolerant)")
+class AttackPathApiRbacIT extends IntegrationTest {
+
+  private static final String BASE = "/api/attack-path/simulations/";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private io.openaev.config.OpenAEVConfig openAEVConfig;
+  @Autowired private CacheManager cacheManager;
+  @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private UserComposer userComposer;
+  @Autowired private GrantComposer grantComposer;
+  @Autowired private TenantGroupComposer tenantGroupComposer;
+  @Autowired private TenantRoleComposer tenantRoleComposer;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+
+  private String simulationId;
+  private Authentication withGrant;
+  private Authentication withoutGrant;
+
+  @BeforeEach
+  void setUp() {
+    setAttackPathFeature(true);
+    Exercise simulation =
+        exerciseComposer.forExercise(ExerciseFixture.createDefaultExercise()).persist().get();
+    simulationId = simulation.getId();
+    withGrant = buildAuthenticationToken(userGrantedReadOn(simulationId));
+    withoutGrant = buildAuthenticationToken(plainUser());
+  }
+
+  @AfterEach
+  void tearDown() {
+    setAttackPathFeature(false);
+    userComposer.reset();
+    grantComposer.reset();
+    tenantGroupComposer.reset();
+    tenantRoleComposer.reset();
+    exerciseComposer.reset();
+    scenarioComposer.reset();
+  }
+
+  // -- the 5 reads, keyed by simulationId, with the params each requires so the request reaches the
+  // controller body (a missing required param would 400 before RBAC). --
+  private MockHttpServletRequestBuilder graph(String simId) {
+    return get(BASE + simId + "/graph");
+  }
+
+  private MockHttpServletRequestBuilder endpointFindings(String simId) {
+    return get(BASE + simId + "/endpoint/findings").param("ref", "any");
+  }
+
+  private MockHttpServletRequestBuilder endpointRelations(String simId) {
+    return get(BASE + simId + "/endpoint/relations").param("ref", "any");
+  }
+
+  private MockHttpServletRequestBuilder findings(String simId) {
+    return get(BASE + simId + "/findings").param("category", "credentials");
+  }
+
+  private MockHttpServletRequestBuilder execution(String simId) {
+    return get(BASE + simId + "/execution").param("ref", "any");
+  }
+
+  // The 5 per-simulation reads, all guarded by the same assertCanReadSimulation.
+  private List<MockHttpServletRequestBuilder> reads(String simId) {
+    return List.of(
+        graph(simId),
+        endpointFindings(simId),
+        endpointRelations(simId),
+        findings(simId),
+        execution(simId));
+  }
+
+  @Test
+  @DisplayName("Without a READ grant on the simulation, every read is 403")
+  void noGrant_allReadsForbidden() throws Exception {
+    for (MockHttpServletRequestBuilder read : reads(simulationId)) {
+      mvc.perform(read.with(authentication(withoutGrant)).with(csrf()))
+          .andExpect(status().isForbidden());
+    }
+  }
+
+  @Test
+  @DisplayName(
+      "With a READ grant, no read is forbidden (the guard is wired on every read, not just one)")
+  void withGrant_noReadForbidden() throws Exception {
+    // The guard passed on each read: the status is whatever the read returns (200, or 404 for a
+    // ref/category with no data), never 403. Asserting NOT-403 on all 5 catches a mis-wired
+    // endpoint
+    // that would wrongly deny a granted user; a status-200 on graph (below) pins the real allow
+    // path.
+    for (MockHttpServletRequestBuilder read : reads(simulationId)) {
+      mvc.perform(read.with(authentication(withGrant)).with(csrf()))
+          .andExpect(r -> assertNotEquals(403, r.getResponse().getStatus()));
+    }
+  }
+
+  @Test
+  @DisplayName("With a READ grant on the simulation, the graph read is allowed (real allow path)")
+  void withGrant_graphAllowed() throws Exception {
+    mvc.perform(graph(simulationId).with(authentication(withGrant)).with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("A synthetic seed id stays reachable without a grant")
+  void seedId_reachableWithoutGrant() throws Exception {
+    String seedId = AttackPathIds.SEED_ID_PREFIX + "1-sim-0";
+    mvc.perform(graph(seedId).with(authentication(withoutGrant)).with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("Picker with a scenarioId returns only that scenario's simulations (B0)")
+  void picker_scopedToScenario() throws Exception {
+    Scenario s1 = scenario();
+    Scenario s2 = scenario();
+    String sim1 = simWithAttackDataInScenario(s1);
+    String sim2 = simWithAttackDataInScenario(s2);
+    // Granted on BOTH, so what filters the list is the scenario scope, not the grants.
+    Authentication user = grantedReadOn(sim1, sim2);
+
+    List<String> ids =
+        pickerSimulationIds(
+            get("/api/attack-path/simulations").param("scenarioId", s1.getId()), user);
+
+    assertThat(ids).contains(sim1).doesNotContain(sim2);
+  }
+
+  @Test
+  @DisplayName("Picker grant-filters: a user sees only the simulations it can read (B0)")
+  void picker_grantFiltered() throws Exception {
+    String sim1 = simWithAttackDataInScenario(scenario());
+    String sim2 = simWithAttackDataInScenario(scenario());
+    Authentication user = grantedReadOn(sim1); // granted on sim1 only
+
+    List<String> ids = pickerSimulationIds(get("/api/attack-path/simulations"), user);
+
+    assertThat(ids).contains(sim1).doesNotContain(sim2);
+  }
+
+  @Test
+  @DisplayName("Picker keeps synthetic seed rows for any caller (FR3)")
+  void picker_keepsSeedRows() throws Exception {
+    String seedSim = AttackPathIds.SEED_ID_PREFIX + "9-sim-0";
+    saveExecutionRow(seedSim);
+    // A caller with no grant: the seed row is kept (seed-tolerant), even though it is granted
+    // nothing.
+    List<String> ids = pickerSimulationIds(get("/api/attack-path/simulations"), withoutGrant);
+    assertThat(ids).contains(seedSim);
+  }
+
+  @Test
+  @DisplayName(
+      "An admin is unchanged: reads not forbidden and the picker is not grant-filtered (FR5/FR6f)")
+  void admin_unchanged() throws Exception {
+    String sim1 = simWithAttackDataInScenario(scenario());
+    String sim2 = simWithAttackDataInScenario(scenario());
+    Authentication admin = buildAuthenticationToken(adminUser());
+
+    // Reads: an admin bypasses grants, so none of the 5 is forbidden.
+    for (MockHttpServletRequestBuilder read : reads(simulationId)) {
+      mvc.perform(read.with(authentication(admin)).with(csrf()))
+          .andExpect(r -> assertNotEquals(403, r.getResponse().getStatus()));
+    }
+    // Picker: an admin sees every simulation, not a grant-filtered subset.
+    List<String> ids = pickerSimulationIds(get("/api/attack-path/simulations"), admin);
+    assertThat(ids).contains(sim1, sim2);
+  }
+
+  private List<String> pickerSimulationIds(MockHttpServletRequestBuilder request, Authentication as)
+      throws Exception {
+    String body =
+        mvc.perform(request.with(authentication(as)).with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    return JsonPath.read(body, "$..simulationId");
+  }
+
+  // -- fixtures --
+
+  private Scenario scenario() {
+    return scenarioComposer
+        .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+        .persist()
+        .get();
+  }
+
+  // A committed simulation (exercise) attached to the scenario, with one attack-path execution row
+  // so
+  // it shows up in the picker summary.
+  private String simWithAttackDataInScenario(Scenario scenario) {
+    Exercise exercise = ExerciseFixture.createDefaultExercise();
+    exercise.setScenario(scenario);
+    String simId = exerciseComposer.forExercise(exercise).persist().get().getId();
+    saveExecutionRow(simId);
+    return simId;
+  }
+
+  // One attack-path execution row for a simulation id (a real exercise or a seed id), so it
+  // surfaces
+  // in the picker summary.
+  private void saveExecutionRow(String simulationId) {
+    AttackPathExecution row = new AttackPathExecution();
+    row.setId(UUID.randomUUID().toString());
+    row.setSimulationId(simulationId);
+    row.setSourceKind("AGENT_ASSET");
+    row.setTargetKind("ASSET");
+    row.setTargetKey("target-" + simulationId);
+    row.setExecutedAt(Instant.now());
+    executionRepository.save(row);
+  }
+
+  private User adminUser() {
+    return userComposer
+        .forUser(UserFixture.getAdminUser("Ap", "Admin", UUID.randomUUID() + "@unittests.invalid"))
+        .persist()
+        .get();
+  }
+
+  // A user granted READ on each given simulation through resource grants only (empty-capability
+  // role),
+  // so the picker rows it sees come from grants, not a capability.
+  private Authentication grantedReadOn(String... exerciseIds) {
+    TenantGroupComposer.Composer group =
+        tenantGroupComposer
+            .forGroup(TenantGroupFixture.getGroup())
+            .withRole(
+                tenantRoleComposer.forRole(TenantRoleFixture.getRole(new HashSet<>(Set.of()))));
+    for (String exerciseId : exerciseIds) {
+      Grant grant = new Grant();
+      grant.setGrantResourceType(Grant.GRANT_RESOURCE_TYPE.SIMULATION);
+      grant.setName(Grant.GRANT_TYPE.OBSERVER);
+      grant.setResourceId(exerciseId);
+      group = group.withGrant(grantComposer.forGrant(grant));
+    }
+    User user =
+        userComposer
+            .forUser(UserFixture.getUser("Ap", "Picker", UUID.randomUUID() + "@unittests.invalid"))
+            .withGroup(group)
+            .persist()
+            .get();
+    return buildAuthenticationToken(user);
+  }
+
+  private User plainUser() {
+    return userComposer
+        .forUser(UserFixture.getUser("Ap", "NoGrant", UUID.randomUUID() + "@unittests.invalid"))
+        .persist()
+        .get();
+  }
+
+  // A user granted READ on the simulation ONLY through a resource grant — deliberately NO
+  // assessment
+  // capability (empty-capability role), so a 200 proves the resource grant is what grants access,
+  // not
+  // a capability. PermissionService checks the capability first, then the grant, so the capability
+  // would otherwise mask the grant path this test must exercise.
+  private User userGrantedReadOn(String exerciseId) {
+    Grant grant = new Grant();
+    grant.setGrantResourceType(Grant.GRANT_RESOURCE_TYPE.SIMULATION);
+    grant.setName(Grant.GRANT_TYPE.OBSERVER);
+    grant.setResourceId(exerciseId);
+    TenantGroupComposer.Composer group =
+        tenantGroupComposer
+            .forGroup(TenantGroupFixture.getGroup())
+            .withRole(
+                tenantRoleComposer.forRole(TenantRoleFixture.getRole(new HashSet<>(Set.of()))))
+            .withGrant(grantComposer.forGrant(grant));
+    return userComposer
+        .forUser(UserFixture.getUser("Ap", "Granted", UUID.randomUUID() + "@unittests.invalid"))
+        .withGroup(group)
+        .persist()
+        .get();
+  }
+
+  private void setAttackPathFeature(boolean enabled) {
+    openAEVConfig.setEnabledDevFeatures(enabled ? PreviewFeature.ATTACK_PATH.getValue() : null);
+    if (cacheManager.getCache("global") != null) {
+      cacheManager.getCache("global").clear();
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
@@ -88,4 +88,15 @@ class AttackPathIdsTest {
     assertThat(AttackPathIds.findingNode("credentials", "admin"))
         .isEqualTo("NODE_FINDING|credentials|admin");
   }
+
+  @Test
+  @DisplayName("isSeedId recognises synthetic seed simulation ids, and only those")
+  void is_seed_id() {
+    // A synthetic seed simulation id (the shape AttackPathSeedService builds) is a seed.
+    assertThat(AttackPathIds.isSeedId(AttackPathIds.SEED_ID_PREFIX + "42-sim-0")).isTrue();
+    // A real simulation id (a UUID) and null/blank are not seeds.
+    assertThat(AttackPathIds.isSeedId("02d737db-d12f-40bf-b427-c70ef8bac6e0")).isFalse();
+    assertThat(AttackPathIds.isSeedId(null)).isFalse();
+    assertThat(AttackPathIds.isSeedId("")).isFalse();
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
@@ -180,6 +180,22 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
   List<AttackPathSimSummaryRow> findSimulationSummaries();
 
   /**
+   * Same summary, restricted to one scenario's simulations (the picker's scenario context, #6647
+   * B0). The subquery maps each {@code simulation_id} back to its {@code exercise} and keeps only
+   * those whose scenario is the requested one; ad-hoc simulations (no scenario) and seed rows (no
+   * real exercise) are naturally excluded.
+   */
+  @Query(
+      "SELECT new io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow("
+          + "e.simulationId, count(distinct e.targetKey), count(e)) "
+          + "FROM AttackPathExecution e "
+          + "WHERE e.simulationId IN "
+          + "(SELECT ex.id FROM Exercise ex WHERE ex.scenario.id = :scenarioId) "
+          + "GROUP BY e.simulationId ORDER BY count(e) DESC")
+  List<AttackPathSimSummaryRow> findSimulationSummariesByScenario(
+      @Param("scenarioId") String scenarioId);
+
+  /**
    * Collapsed mode: one endpoint per {@code target_key}, with a representative of its frozen
    * display attributes ({@code max} per column, which is the constant value within one simulation)
    * and its per-endpoint RED (neither prevented nor detected) and ORANGE (detected but not


### PR DESCRIPTION
## What

Hardens the attack-path API on two fronts (tracked internally as B1 + B0):

- **B1 — resource-level RBAC on the reads.** The 5 per-simulation reads (`graph`,
  `endpoint/findings`, `endpoint/relations`, `findings`, `execution`) now enforce
  `SIMULATION READ` per resource, instead of being open to any authenticated user in
  the tenant.
- **B0 — scenario-scoped, grant-filtered picker.** `GET /simulations` accepts an optional
  `scenarioId` and, when given, returns only that scenario's simulations (server-side);
  the rows are then grant-filtered to the ones the caller can read.

## Why

All 7 attack-path endpoints were `@AccessControl(skipRBAC = true)`: any authenticated user
in the tenant could read any simulation's attack path, and the picker returned every
simulation with attack-path data in the tenant, regardless of scenario or the caller's
grants (e.g. one scenario's runs showing up under another). That was a POC concession while
the store was fed by synthetic seed data (seed ids are not real exercises, so resource RBAC
would 403 them). Real data now flows, so enforce real RBAC while keeping seed ids reachable.

## How

- New `AttackPathAccessControl` guard: `SIMULATION READ` via the platform `PermissionService`
  (capability-or-grant, same as every other simulation resource), **seed-tolerant** — a seed
  id (`ap-seed-…`) is allowed without a grant. The `@AccessControl(skipRBAC = true)` annotation
  stays because it cannot express the seed exception; the guard is the real gate, and one helper
  backs both the reads and the picker filter.
- `GET /simulations` gains an optional `scenarioId` -> `findSimulationSummariesByScenario`
  (JPQL subquery `simulation_id IN (SELECT ex.id FROM Exercise ex WHERE ex.scenario.id = :scenarioId)`),
  plus a per-row grant filter (`canReadSimulation`, seed rows kept).

## Scope / not in this PR

- The 5 per-simulation reads enforce READ (403 without access); `GET /simulations` grant-filters its
  rows (never 403); only `POST /seed` is left `skipRBAC` (a dev-only data generator). So 6 of the 7
  endpoints are now access-controlled.
- **Accepted pre-GA risk:** seed ids bypass RBAC (the data is synthetic). To revisit at GA / when the
  seed generator is removed.
- No payload/DTO change on the reads; the picker only gains an optional query param. Admins and
  capability users are unchanged; the front keeps working (the client-side scenario filter is now
  backed by the server). No migration.

## Tests

`AttackPathApiRbacIT` — real stack (MockMvc + real PG + real grants, no mocked RBAC), 8/8:
- no grant -> 403 on each of the 5 reads;
- a resource grant (no capability) -> not forbidden on all 5, 200 on graph (proves grant-level, not capability);
- seed id -> reachable without a grant (read and picker);
- picker scoped to a scenario returns only that scenario's sims;
- picker grant-filters (hides a simulation the caller cannot read);
- admin unchanged (reads not forbidden, picker not grant-filtered).