### PR TITLE
fix(attack-path): restrict the graph to chained scenarios and fix the inject link (#6647)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -48,7 +48,11 @@ const IndexScenarioComponent: FunctionComponent<{ scenario: ScenarioOutput }> = 
   const { t } = useFormatter();
   const location = useLocation();
   const isChainingFeatureEnabled = isFeatureEnabled('INJECT_CHAINING');
-  const isAttackPathEnabled = isFeatureEnabled('ATTACK_PATH');
+  // Attack path only exists for chained scenarios (workflow-backed), never for time-based ones — mirror
+  // the simulation gating so the tab and route are hidden unless the scenario has a workflow.
+  const isAttackPathEnabled = isFeatureEnabled('ATTACK_PATH')
+    && isChainingFeatureEnabled
+    && !!scenario.scenario_workflow_id;
   const permissions = useScenarioPermissions(scenario.scenario_id);
   // The Tests tab only exists for email/SMS injects that have actually been
   // tested; hide it entirely otherwise.

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -1,4 +1,4 @@
-import { Close, OpenInNew, ShieldOutlined } from '@mui/icons-material';
+import { ArrowBack, Close, OpenInNew, ShieldOutlined } from '@mui/icons-material';
 import { Button, IconButton, Paper, Popover, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 // eslint-disable-next-line import/no-named-as-default
@@ -23,6 +23,9 @@ interface Props {
   loading: boolean;
   detail: AttackPathExecutionDetailDTO | null;
   onClose: () => void;
+  // Return to the endpoint/finding panel this execution was opened from (master→detail navigation). When
+  // set, a back arrow replaces nothing and sits left of the title; `onClose` still fully closes the panel.
+  onBack?: () => void;
   // Open the originating inject (pending backend: needs the inject id on the execution detail).
   onOpenInject?: () => void;
 }
@@ -202,7 +205,7 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
 // feed and the map (product mockup), not an overlay. Reuses the platform's shared `Terminal` renderer,
 // fed by the frozen snapshot's masked command and output. The Result tab shows the target and the
 // security platforms that prevented/detected the action (with their linked alerts on click).
-const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onOpenInject }: Props) => {
+const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpenInject }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
   const { currentTab, handleChangeTab } = useTabs(RESULT_TAB);
@@ -329,7 +332,9 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onOpenInject }
     <Paper
       variant="outlined"
       style={{
-        width: 400,
+        // Wider than the endpoint/finding master panel it replaces: this is the sole panel while open, so
+        // the terminal has room to read without wrapping every line.
+        width: 560,
         minWidth: 0,
         display: 'flex',
         flexDirection: 'column',
@@ -340,11 +345,30 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onOpenInject }
         display: 'flex',
         alignItems: 'flex-start',
         justifyContent: 'space-between',
+        gap: theme.spacing(1),
         padding: theme.spacing(2, 2.5, 1),
         flexShrink: 0,
       }}
       >
-        <div style={{ minWidth: 0 }}>
+        {/* Back to the endpoint/finding panel this execution was opened from. */}
+        {onBack && (
+          <IconButton
+            size="small"
+            aria-label={t('Back')}
+            onClick={onBack}
+            sx={{
+              flexShrink: 0,
+              mt: 0.25,
+            }}
+          >
+            <ArrowBack fontSize="small" />
+          </IconButton>
+        )}
+        <div style={{
+          minWidth: 0,
+          flex: 1,
+        }}
+        >
           <Typography variant="h6" noWrap>{detail?.payloadName || t('Execution')}</Typography>
           <Typography variant="caption" color="text.secondary">
             {[detail?.agentName, detail?.agentPrivilege].filter(Boolean).join(' · ')}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2172,7 +2172,10 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 detail={detail}
                 onClose={() => setDetailExecutionId(null)}
                 onOpenInject={(detail as { injectId?: string } | null)?.injectId
-                  ? () => navigate(`../injects/${(detail as { injectId?: string }).injectId}`)
+                  // The inject belongs to the run, not the scenario: a relative `../injects/…` would point
+                  // at the scenario in scenario context (which has no such inject → 404). Always target the
+                  // selected simulation so both contexts resolve to the real inject.
+                  ? () => navigate(`${SIMULATION_BASE_URL}/${simulationId}/injects/${(detail as { injectId?: string }).injectId}`)
                   : undefined}
               />
             )}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2121,7 +2121,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               )}
             </Paper>
 
-            {findingDetail && (
+            {/* Master→detail in a single drawer: while an execution detail is open it REPLACES the
+                endpoint/finding master panel (below), and its back arrow returns here. */}
+            {findingDetail && !detailExecutionId && (
               <FindingDetailPanel
                 value={maskFindingValue(findingDetail.type, findingDetail.value)}
                 type={findingDetail.type}
@@ -2142,7 +2144,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               />
             )}
 
-            {!findingDetail && selectedNodeId && (
+            {!findingDetail && selectedNodeId && !detailExecutionId && (
               <EndpointDetailPanel
                 endpointLabel={selectedLabel || t('Endpoint')}
                 findingsLoading={endpointFindingsLoading}
@@ -2170,7 +2172,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               <ExecutionResultTerminalPanel
                 loading={detailLoading}
                 detail={detail}
-                onClose={() => setDetailExecutionId(null)}
+                // Back returns to the master panel (endpoint/finding) it was opened from; close dismisses
+                // the whole drawer.
+                onBack={() => setDetailExecutionId(null)}
+                onClose={() => {
+                  setDetailExecutionId(null);
+                  setSelectedNodeId(null);
+                  setFindingDetail(null);
+                }}
                 onOpenInject={(detail as { injectId?: string } | null)?.injectId
                   // The inject belongs to the run, not the scenario: a relative `../injects/…` would point
                   // at the scenario in scenario context (which has no such inject → 404). Always target the


### PR DESCRIPTION
## Summary

Two fixes on the Attack Path view (behind the `ATTACK_PATH` flag):

- **Chained-only exposure**: the attack-path tab and route were shown on time-based scenarios. They are now gated to chained scenarios (`INJECT_CHAINING` + `scenario_workflow_id`), mirroring the existing simulation gating. Time-based scenarios no longer show the tab, and the route is not registered.
- **"Action details" link**: from the scenario attack-path view the link used a relative `../injects/<id>`, resolving to the scenario (which has no such inject → 404). It now targets the selected simulation: `/admin/simulations/<simulationId>/injects/<injectId>`, so it resolves in both scenario and simulation contexts.

`check-ts` and eslint clean; verified live that a chained scenario still shows the tab.

Related issue: #6647