### PR TITLE
feat(attack-path): chained-only exposure, unified drawer, live refresh, endpoint dedup, injector traces (#6647)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -246,9 +246,11 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     });
 
     // The injector panel lists this injector's own executions (scoped via the endpoint-relations edges),
-    // under an "Executions" section — same component as the endpoint panel, findings section omitted.
+    // under an "Executions" section — same component as the endpoint panel.
     expect(await screen.findByText('Executions (1)')).toBeTruthy();
-    expect(screen.queryByText('Findings')).toBeNull();
+    // Its Findings section shows only findings attributed to this injector's executions (exec-1), via the
+    // category endpoint's executionIds — here the captured credential.
+    expect(await screen.findByText('admin : ••••••')).toBeTruthy();
 
     // Clicking the listed execution opens its Result / Execution details / Remediation detail (fetched by
     // its raw ref), showing the global command it ran.

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -10,6 +10,7 @@ type FlowProps = {
   focusRequest?: { nodeId: string };
   fitRequest?: number;
   onEndpointClick?: (nodeId: string, ref?: string, label?: string) => void;
+  onInjectorSelect?: (injectorId: string, label?: string) => void;
 };
 
 // Capture the props AttackPathFlow receives (mocked so ReactFlow is not instantiated), and stub the
@@ -140,7 +141,13 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
           payloadName: 'nmap',
           status: 'RED',
         }],
-        edges: [],
+        // The injector's execution edge, so the injector panel can scope to its own executions.
+        edges: [{
+          edgeSourceId: 'NODE_INJECTOR|nmap',
+          edgeTargetId: ENDPOINT_NODE,
+          type: 'EDGE_EXECUTIONS',
+          executionIds: ['exec-1'],
+        }],
       },
     });
     mocks.fetchFindingsByCategory.mockResolvedValue({
@@ -227,6 +234,27 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Terminal view' }));
     expect(await screen.findByText('$ nmap -p 445 host-x -u admin -p ••••')).toBeTruthy();
     expect(screen.getByText('open')).toBeTruthy();
+  });
+
+  it('opens the injector panel listing its own executions, one click from the execution detail', async () => {
+    setup();
+    await screen.findByTestId('attack-path-flow');
+
+    // Click the injector (action) node on the map.
+    await act(async () => {
+      mocks.flowProps.current?.onInjectorSelect?.('NODE_INJECTOR|nmap', 'nmap');
+    });
+
+    // The injector panel lists this injector's own executions (scoped via the endpoint-relations edges),
+    // under an "Executions" section — same component as the endpoint panel, findings section omitted.
+    expect(await screen.findByText('Executions (1)')).toBeTruthy();
+    expect(screen.queryByText('Findings')).toBeNull();
+
+    // Clicking the listed execution opens its Result / Execution details / Remediation detail (fetched by
+    // its raw ref), showing the global command it ran.
+    const execRow = screen.getAllByRole('button').find(b => /nmap/i.test(b.textContent ?? '') && /button/i.test(b.getAttribute('role') ?? 'button'));
+    fireEvent.click(execRow as HTMLElement);
+    await waitFor(() => expect(mocks.fetchExecutionDetail).toHaveBeenCalledWith('sim-1', 'exec-1'));
   });
 
   it('switches to the table view, lists the exposed endpoint and exposes CSV export', async () => {

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -244,8 +244,10 @@ describe('buildClusteredAttackPathFlow', () => {
     expect(byId['cl-ft-cve'].data.count).toBe(1);
     // no real endpoint nodes while collapsed
     expect(byId['ep1']).toBeUndefined();
-    // edges: injector -> shared hub (labelled with the injector's reached-endpoint count) -> findings
-    expect(edges.find(e => e.id === 'inj-cl-ep-all')?.data?.count).toBe(2);
+    // edges: injector -> shared hub carries no count badge (the reached-endpoint count is shown on the
+    // hub itself, so repeating it on the injector edge is redundant) -> findings
+    expect(edges.find(e => e.id === 'inj-cl-ep-all')?.data?.count).toBe(1);
+    expect(edges.find(e => e.id === 'inj-cl-ep-all')?.data?.label).toBeUndefined();
     expect(edges.filter(e => e.source === 'cl-ep-all')).toHaveLength(2);
     expect(edges[0].type).toBe(AP_FLOW_EDGE_TYPE);
   });

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -480,9 +480,10 @@ describe('buildCausalChainFlow', () => {
 
     // The producer (nmap) sits upstream (left) of the consumer (netexec).
     expect(byId['inj-nmap'].position.x).toBeLessThan(byId['inj-smb'].position.x);
-    // Each step renders its own endpoint node (suffixed id, shared endpoint shown per hop).
-    expect(byId['chain-ep|inj-nmap|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
-    expect(byId['chain-ep|inj-smb|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
+    // Endpoint nodes are keyed by DEPTH+asset: the producer (depth 0) and consumer (depth 1) are at
+    // different depths, so the shared asset ep-1 renders once per depth (the causal chain is preserved).
+    expect(byId['chain-ep|0|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
+    expect(byId['chain-ep|1|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
     // The produced finding is placed on its producer step, upstream of the consuming injector.
     expect(byId['NODE_FINDING|port|445'].type).toBe(AP_FLOW_NODE_TYPE.finding);
     expect(byId['NODE_FINDING|port|445'].position.x).toBeLessThan(byId['inj-smb'].position.x);
@@ -528,5 +529,43 @@ describe('buildCausalChainFlow', () => {
     expect(causal[0].source).toBe('inj-nmap');
     expect(causal[0].target).toBe('inj-smb');
     expect(causal[0].data?.causalKind).toBe('depend');
+  });
+
+  it('merges same-depth injectors hitting the same asset onto one shared endpoint node', () => {
+    // Arrange: two INDEPENDENT injectors (no dependsOn → both at depth 0) target the SAME asset ep-1.
+    const parallel: AttackPathDTO = {
+      ...chainDto,
+      attackPathExecutions: [
+        {
+          id: 'x1',
+          type: 'EXECUTION',
+          ref: 'exec-1',
+          stepTemplateId: 'step-A',
+          findingsNodeIds: [],
+          dependsOn: [],
+        },
+        {
+          id: 'x2',
+          type: 'EXECUTION',
+          ref: 'exec-2',
+          stepTemplateId: 'step-B',
+          findingsNodeIds: [],
+          dependsOn: [],
+        },
+      ],
+    };
+
+    // Act
+    const { nodes, edges } = buildCausalChainFlow(parallel, tt);
+
+    // Assert: a single endpoint node for ep-1 (keyed by depth 0 + asset), not one per injector.
+    const epNodes = nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.asset);
+    expect(epNodes).toHaveLength(1);
+    expect(epNodes[0].id).toBe('chain-ep|0|ep-1');
+    // Both injectors point their own labelled edge at that shared endpoint.
+    const toEp = edges.filter(e => e.target === 'chain-ep|0|ep-1');
+    expect(toEp.map(e => e.source).sort()).toEqual(['inj-nmap', 'inj-smb']);
+    // No causal edge: independent injectors share the asset but form no kill chain.
+    expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE)).toHaveLength(0);
   });
 });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -26,6 +26,9 @@ interface Props {
   // Translated status label for an execution status (prevented / detected / ...).
   execStatusLabel: (status?: string) => string;
   onClose: () => void;
+  // When true, the Findings section is omitted — used for the injector panel, which lists the
+  // injector's contracts under "Executions" but has no findings of its own.
+  hideFindings?: boolean;
 }
 
 // Right-side panel for one endpoint selected in the attack-path graph: its findings grouped by type
@@ -43,6 +46,7 @@ const EndpointDetailPanel = ({
   onSelectExecution,
   execStatusLabel,
   onClose,
+  hideFindings = false,
 }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
@@ -78,49 +82,53 @@ const EndpointDetailPanel = ({
       </div>
 
       <div style={{ padding: theme.spacing(0, 2.5, 2) }}>
-        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          {t('Findings')}
-        </Typography>
-        {findingsLoading && (
-          <Box sx={{ minHeight: 60 }}>
-            <Loader variant="inElement" size="sm" />
-          </Box>
-        )}
-        {!findingsLoading && findingGroups.length === 0 && (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{
-              display: 'block',
-              mb: 1,
-            }}
-          >
-            {t('No findings on this endpoint')}
-          </Typography>
-        )}
-        {!findingsLoading && findingGroups.map(g => (
-          <Box key={g.type} sx={{ mb: 1 }}>
-            <Typography
-              variant="caption"
-              sx={{
-                display: 'block',
-                fontWeight: 600,
-                color: 'text.secondary',
-                textTransform: 'uppercase',
-                letterSpacing: 0.4,
-              }}
-            >
-              {`${g.type} (${g.values.length})`}
+        {!hideFindings && (
+          <>
+            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+              {t('Findings')}
             </Typography>
-            {g.values.map((v, i) => (
-              <Typography key={`${g.type}-${i}`} variant="body2" noWrap title={v}>
-                {v}
+            {findingsLoading && (
+              <Box sx={{ minHeight: 60 }}>
+                <Loader variant="inElement" size="sm" />
+              </Box>
+            )}
+            {!findingsLoading && findingGroups.length === 0 && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{
+                  display: 'block',
+                  mb: 1,
+                }}
+              >
+                {t('No findings on this endpoint')}
               </Typography>
+            )}
+            {!findingsLoading && findingGroups.map(g => (
+              <Box key={g.type} sx={{ mb: 1 }}>
+                <Typography
+                  variant="caption"
+                  sx={{
+                    display: 'block',
+                    fontWeight: 600,
+                    color: 'text.secondary',
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.4,
+                  }}
+                >
+                  {`${g.type} (${g.values.length})`}
+                </Typography>
+                {g.values.map((v, i) => (
+                  <Typography key={`${g.type}-${i}`} variant="body2" noWrap title={v}>
+                    {v}
+                  </Typography>
+                ))}
+              </Box>
             ))}
-          </Box>
-        ))}
+          </>
+        )}
 
-        <Typography variant="subtitle2" color="text.secondary" gutterBottom sx={{ mt: 1 }}>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom sx={{ mt: hideFindings ? 0 : 1 }}>
           {`${t('Executions')} (${executions.length})`}
         </Typography>
         {executions.slice(0, execDisplayCap).map((e) => {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -55,7 +55,7 @@ const EndpointDetailPanel = ({
     <Paper
       variant="outlined"
       style={{
-        width: 340,
+        flex: 1,
         minWidth: 0,
         overflow: 'auto',
         display: 'flex',

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -368,9 +368,8 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
     <Paper
       variant="outlined"
       style={{
-        // Wider than the endpoint/finding master panel it replaces: this is the sole panel while open, so
-        // the terminal has room to read without wrapping every line.
-        width: 560,
+        // Fills the resizable drawer container (drag the handle to widen when traces overflow).
+        flex: 1,
         minWidth: 0,
         display: 'flex',
         flexDirection: 'column',

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -29,6 +29,9 @@ interface Props {
   onBack?: () => void;
   // Open the originating inject (pending backend: needs the inject id on the execution detail).
   onOpenInject?: () => void;
+  // Friendly endpoint name (e.g. "kingslanding"), resolved by the caller from the graph node — the
+  // execution DTO only carries the raw endpoint key (a UUID) and the IP, neither of which reads well.
+  endpointLabel?: string;
 }
 
 const RESULT_TAB = 'result';
@@ -234,7 +237,7 @@ const InjectorExecutionTraces = ({ injectId }: { injectId: string }) => {
 // feed and the map (product mockup), not an overlay. Reuses the platform's shared `Terminal` renderer,
 // fed by the frozen snapshot's masked command and output. The Result tab shows the target and the
 // security platforms that prevented/detected the action (with their linked alerts on click).
-const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpenInject }: Props) => {
+const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpenInject, endpointLabel }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
   const { currentTab, handleChangeTab } = useTabs(RESULT_TAB);
@@ -486,10 +489,9 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
               }}
               >
                 <div>
-                  <Typography variant="subtitle2">{detail.targetHostname || detail.endpointKey}</Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {[detail.targetIp, detail.targetPlatform].filter(Boolean).join(' · ')}
-                  </Typography>
+                  {/* The friendly endpoint name (kingslanding), not the raw endpoint key/UUID, to stay
+                      consistent with the graph node; fall back to the IP only when no name is known. */}
+                  <Typography variant="subtitle2">{endpointLabel || detail.targetHostname || detail.targetIp || detail.endpointKey}</Typography>
                 </div>
                 {renderExpectationRow('prevention', t('Prevented by'), t('Not Prevented'), preventedBy)}
                 {renderExpectationRow('detection', t('Detected by'), t('Not Detected'), detectedBy)}
@@ -516,7 +518,7 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
                 return <Terminal lines={terminalLines} maxHeight={terminalMaxHeight} />;
               }
               return detail.payloadId
-                ? <LiveExecutionTerminal injectId={detail.injectId} endpointName={detail.targetHostname || detail.endpointKey} />
+                ? <LiveExecutionTerminal injectId={detail.injectId} endpointName={endpointLabel || detail.targetHostname || detail.endpointKey} />
                 : <InjectorExecutionTraces injectId={detail.injectId} />;
             })()}
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -268,6 +268,10 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
   // Seeded runs carry a frozen command/output snapshot on the DTO; a real inject leaves them empty and
   // is rendered live from execution traces instead (see hasSnapshot below).
   const hasSnapshot = Boolean(detail?.command || detail?.terminalOutput);
+  // On the terminal tab a network injector shows its execution traces (a plain list that grows), unlike
+  // the snapshot/payload `Terminal` which is sized to fill and scrolls internally. The list needs the
+  // outer box to scroll, otherwise long traces are clipped.
+  const injectorTracesView = !hasSnapshot && !!detail?.injectId && !detail?.payloadId;
   const terminalLines: TerminalLine[] = [];
   if (detail?.command) {
     terminalLines.push({
@@ -475,9 +479,10 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
             style={{
               flex: 1,
               minHeight: 0,
-              // The Result tab owns its scroll; the Terminal tab is sized to fill this box and scrolls
-              // internally, so the outer box must not add a second scrollbar.
-              overflow: currentTab === TERMINAL_TAB ? 'hidden' : 'auto',
+              // The Result tab owns its scroll; the snapshot/payload Terminal scrolls internally so its
+              // outer box must not add a second scrollbar. The injector traces list, however, needs this
+              // box to scroll or long output is clipped.
+              overflow: currentTab === TERMINAL_TAB && !injectorTracesView ? 'hidden' : 'auto',
               paddingTop: theme.spacing(2),
             }}
           >

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import DOMPurify from 'dompurify';
 import { useEffect, useRef, useState } from 'react';
 
-import { searchTargets } from '../../../../../actions/injects/inject-action';
+import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
 import AttackPatternChip from '../../../../../components/AttackPatternChip';
 import Tabs from '../../../../../components/common/tabs/Tabs';
 import useTabs from '../../../../../components/common/tabs/useTabs';
@@ -13,9 +13,10 @@ import Terminal, { type TerminalLine } from '../../../../../components/common/te
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
 import { CROWDSTRIKE, SPLUNK } from '../../../../../constants/Entities';
-import type { AttackPathExecutionDetailDTO, InjectTarget } from '../../../../../utils/api-types';
+import type { AttackPathExecutionDetailDTO, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
 import { buildTenantApiPath } from '../../../../../utils/url-helper';
 import expectationIconByType from '../../../common/ExpectationIconByType';
+import GlobalExecutionTraces from '../../../common/injects/status/traces/GlobalExecutionTraces';
 import TerminalViewTab from '../../../common/injects/status/traces/TerminalViewTab';
 import ImageWithFallback from './ImageWithFallback';
 
@@ -201,6 +202,34 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
   return <TerminalViewTab injectId={injectId} target={target} />;
 };
 
+// Terminal for a network injector's execution (NetExec, Nmap…): these have no per-agent terminal, so the
+// per-target `TerminalViewTab` above shows nothing. Instead render the inject's global execution traces —
+// the very same "Traces" the inject execution-details page shows (the "<tool> succeeded: …" output).
+const InjectorExecutionTraces = ({ injectId }: { injectId: string }) => {
+  const { t } = useFormatter();
+  const [injectStatus, setInjectStatus] = useState<InjectStatusOutput | null>(null);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    getInjectStatusWithGlobalExecutionTraces(injectId)
+      .then((response: { data: InjectStatusOutput }) => active && setInjectStatus(response.data))
+      .catch(() => active && setInjectStatus(null))
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [injectId]);
+
+  if (loading) {
+    return <Loader variant="inElement" size="sm" />;
+  }
+  if (!injectStatus) {
+    return <Typography variant="body2" color="text.secondary">{t('No data available')}</Typography>;
+  }
+  return <GlobalExecutionTraces injectStatus={injectStatus} />;
+};
+
 // The Result & Terminal panel for one execution (issue 5048): an in-flow panel between the execution
 // feed and the map (product mockup), not an overlay. Reuses the platform's shared `Terminal` renderer,
 // fed by the frozen snapshot's masked command and output. The Result tab shows the target and the
@@ -373,29 +402,6 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
           <Typography variant="caption" color="text.secondary">
             {[detail?.agentName, detail?.agentPrivilege].filter(Boolean).join(' · ')}
           </Typography>
-          {/* Path story: injector -> endpoint -> finding type, resolved for this execution. Finding
-              values are omitted here (they can be secrets); only the type is shown. */}
-          {(() => {
-            const crumb = [
-              detail?.payloadName,
-              detail?.targetHostname || detail?.endpointKey,
-              detail?.findings?.[0]?.type,
-            ].filter(Boolean);
-            return crumb.length > 1 && (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{
-                  display: 'block',
-                  mt: 0.25,
-                }}
-                title={crumb.join(' › ')}
-                noWrap
-              >
-                {crumb.join('  ›  ')}
-              </Typography>
-            );
-          })()}
           {/* MITRE ATT&CK technique(s) this action maps to, resolved server-side from the
               execution's injector contract (AttackPathExecutionDetailDTO.attackPatterns). */}
           {(detail?.attackPatterns?.length ?? 0) > 0 && (
@@ -447,7 +453,9 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
               },
               {
                 key: TERMINAL_TAB,
-                label: t('Terminal view'),
+                // A payload-backed inject shows a real per-target terminal; a network injector shows its
+                // execution traces instead, so the tab reads "Execution details" rather than "Terminal view".
+                label: detail.payloadId ? t('Terminal view') : t('Execution details'),
               },
               {
                 key: REMEDIATION_TAB,
@@ -499,11 +507,17 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
               </div>
             )}
 
-            {currentTab === TERMINAL_TAB && (
-              hasSnapshot || !detail.injectId
-                ? <Terminal lines={terminalLines} maxHeight={terminalMaxHeight} />
-                : <LiveExecutionTerminal injectId={detail.injectId} endpointName={detail.targetHostname || detail.endpointKey} />
-            )}
+            {currentTab === TERMINAL_TAB && (() => {
+              // Seeded runs show their frozen snapshot. For a real inject: a payload-backed execution runs
+              // on an agent and has a per-target terminal (keep it); a network injector (NetExec, Nmap…)
+              // has none, so show its global execution traces instead.
+              if (hasSnapshot || !detail.injectId) {
+                return <Terminal lines={terminalLines} maxHeight={terminalMaxHeight} />;
+              }
+              return detail.payloadId
+                ? <LiveExecutionTerminal injectId={detail.injectId} endpointName={detail.targetHostname || detail.endpointKey} />
+                : <InjectorExecutionTraces injectId={detail.injectId} />;
+            })()}
 
             {currentTab === REMEDIATION_TAB && (
               <div style={{

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -453,9 +453,10 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
               },
               {
                 key: TERMINAL_TAB,
-                // A payload-backed inject shows a real per-target terminal; a network injector shows its
-                // execution traces instead, so the tab reads "Execution details" rather than "Terminal view".
-                label: detail.payloadId ? t('Terminal view') : t('Execution details'),
+                // The tab label follows its content: a seeded snapshot or a payload-backed inject shows a
+                // real terminal ("Terminal view"); a network injector shows its execution traces instead
+                // ("Execution details").
+                label: hasSnapshot || detail.payloadId ? t('Terminal view') : t('Execution details'),
               },
               {
                 key: REMEDIATION_TAB,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
@@ -62,7 +62,7 @@ const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectati
     <Paper
       variant="outlined"
       style={{
-        width: 340,
+        flex: 1,
         minWidth: 0,
         overflow: 'auto',
         display: 'flex',

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -384,11 +384,12 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     };
   }, [simulationId]);
 
-  // Causal overlay data source (issue 6647). The rendered graph is collapsed, which omits the
-  // per-execution kill-chain fields, so we fetch the full graph once — only to derive the per-injector
-  // meta — and gate it on the simulation's execution count (mirrors the backend collapse-threshold) so a
-  // large run never pulls a full payload just for the overlay. When the size is unknown or above the
-  // ceiling, the overlay is simply absent (additive: the graph is unchanged).
+  // Causal overlay data source (issue 6647) + live refresh. The collapsed graph omits the per-execution
+  // kill-chain fields, so we fetch the full graph (to derive the per-injector meta AND to drive the
+  // causal-chain layout), gated on the execution count (mirrors the backend collapse-threshold) so a
+  // large run never pulls a full payload. Within the gate we also POLL it, so a running chained run
+  // (which renders from fullDto, not dto) live-updates like the collapsed graph does. The gate uses the
+  // initial summary-row count; a run that grows past the ceiling mid-view keeps its overlay until reselect.
   useEffect(() => {
     if (!simulationId) {
       setKillChainMeta(new Map());
@@ -396,34 +397,44 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       return undefined;
     }
     const row = simulations.find(s => s.simulationId === simulationId);
-    // No summary row (rows still loading, or a simulation with no attack-path data): no overlay, and
-    // clear any state carried over from a previously viewed simulation so it never leaks onto this one.
-    if (!row) {
-      setKillChainMeta(new Map());
-      setFullDto(null);
-      return undefined;
-    }
-    if ((row.executionCount ?? 0) > CAUSAL_META_MAX_EXECUTIONS) {
+    // No summary row yet, or above the ceiling: no overlay. Clear any state from a previous simulation.
+    if (!row || (row.executionCount ?? 0) > CAUSAL_META_MAX_EXECUTIONS) {
       setKillChainMeta(new Map());
       setFullDto(null);
       return undefined;
     }
     let cancelled = false;
-    fetchAttackPathGraph(simulationId, 'full')
-      .then((r) => {
-        if (!cancelled) {
-          setKillChainMeta(buildKillChainMeta(r.data));
+    let lastJson = '';
+    const REFRESH_MS = 10000;
+    const applyFull = () =>
+      fetchAttackPathGraph(simulationId, 'full')
+        .then((r) => {
+          if (cancelled) {
+            return;
+          }
+          // Skip the swap when nothing changed, so an open drawer / pan-zoom and a stable graph never
+          // churn (same discipline as the collapsed poll).
+          const json = JSON.stringify(r.data);
+          if (json === lastJson) {
+            return;
+          }
+          lastJson = json;
           setFullDto(r.data);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setKillChainMeta(new Map());
-          setFullDto(null);
-        }
-      });
+          setKillChainMeta(buildKillChainMeta(r.data));
+        })
+        .catch(() => {
+          // Initial fetch failed: show no overlay (never leak the previous simulation's). After a first
+          // success, keep the last good overlay on a transient failure; the next tick retries.
+          if (!cancelled && lastJson === '') {
+            setFullDto(null);
+            setKillChainMeta(new Map());
+          }
+        });
+    applyFull();
+    const timer = setInterval(applyFull, REFRESH_MS);
     return () => {
       cancelled = true;
+      clearInterval(timer);
     };
   }, [simulationId, simulations]);
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1740,9 +1740,16 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
 
   // Scenario context has runs to pick from; when it has none yet, the empty-state offers to launch one.
   const scenarioHasNoSims = showPicker && simulations.length === 0;
+  // A run still in progress hasn't produced anything yet — say so (and the graph live-refreshes), rather
+  // than showing the "no data" message that suggests something is wrong.
+  const selectedRunStatus = metaById.get(simulationId)?.exercise_status;
+  const runInProgress = selectedRunStatus === 'RUNNING' || selectedRunStatus === 'PAUSED';
   const emptyStateMessage = (() => {
     if (scenarioHasNoSims) {
       return t('This scenario has no simulation with attack-path data yet. Launch one to reveal its attack path.');
+    }
+    if (runInProgress) {
+      return t('Simulation running — waiting for the first inject executions…');
     }
     if (showPicker) {
       return t('No attack-path data for this simulation. Select a simulation with attack-path data above.');

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -339,6 +339,37 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     load();
   }, [load]);
 
+  // Live refresh: an on-going run keeps discovering endpoints/findings, so poll the graph on an interval
+  // and update it in place. Deliberately silent — no spinner, no selection/drawer reset (unlike `load`),
+  // and it only swaps state when the payload actually changed, so an open drawer and the current pan/zoom
+  // survive a refresh and a stable graph never churns. A transient error is swallowed (keep last good
+  // graph); the seq guard drops ticks from a previous simulation. Stops on unmount / simulation switch.
+  useEffect(() => {
+    if (!simulationId) {
+      return undefined;
+    }
+    let cancelled = false;
+    const REFRESH_MS = 10000;
+    const timer = setInterval(() => {
+      fetchAttackPathGraph(simulationId, 'collapsed')
+        .then((r) => {
+          // `cancelled` (set on unmount / simulation switch) drops a response that resolves after this
+          // run is no longer current, so a stale simulation's data never lands.
+          if (cancelled) {
+            return;
+          }
+          setDto(prev => (JSON.stringify(prev) === JSON.stringify(r.data) ? prev : r.data));
+        })
+        .catch(() => {
+          // Keep the last good graph on a transient failure; the next tick retries.
+        });
+    }, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [simulationId]);
+
   // Causal overlay data source (issue 6647). The rendered graph is collapsed, which omits the
   // per-execution kill-chain fields, so we fetch the full graph once — only to derive the per-injector
   // meta — and gate it on the simulation's execution count (mirrors the backend collapse-threshold) so a

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -75,6 +75,9 @@ const isSeedId = (id?: string) => !!id && id.startsWith('ap-seed-');
 // Every OTHER type present in the data gets an auto-generated card, so a new finding type needs no code.
 const COVERED_FINDING_TYPES = new Set(['share', 'credentials', 'username', 'admin_username', 'cve']);
 
+// Finding categories fetched (with per-finding executionIds) to attribute findings to an injector.
+const INJECTOR_FINDING_CATEGORIES = ['credentials', 'users', 'cves', 'files'];
+
 // Backend prevention/detection status -> a human label (also used for accessibility, so status is
 // never conveyed by colour alone). GREEN = prevented, ORANGE = detected, RED = neither.
 const statusLabelKey = (status?: string): string => {
@@ -241,6 +244,13 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // the injector panel — the action-side mirror of the endpoint panel. Label = the injector's name.
   const [injectorExecutions, setInjectorExecutions] = useState<AttackPathNodeDTO[]>([]);
   const [injectorPanelLabel, setInjectorPanelLabel] = useState<string>('');
+  // The clicked injector's findings, grouped by type — attributed to THIS injector (findings produced by
+  // its own executions), shown in the injector panel's Findings section like an endpoint's.
+  const [injectorFindingGroups, setInjectorFindingGroups] = useState<{
+    type: string;
+    values: string[];
+  }[]>([]);
+  const [injectorFindingsLoading, setInjectorFindingsLoading] = useState(false);
   const [endpointRelationEdges, setEndpointRelationEdges] = useState<AttackPathEdges[]>([]);
   // The clicked endpoint's own findings (deduplicated by type+value), shown in the side panel.
   const [endpointFindings, setEndpointFindings] = useState<AttackPathNodeDTO[]>([]);
@@ -581,6 +591,22 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           arr.push(ref);
         }
         map.set(e.edgeSourceId, arr);
+      }
+    }
+    return map;
+  }, [dto]);
+
+  // Endpoint ref (the raw key an execution carries) -> its friendly name, so the execution panel shows
+  // "kingslanding" instead of the raw UUID/IP the execution DTO carries.
+  const endpointLabelByRef = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const n of dto?.attackPathNodes ?? []) {
+      if (n.type === 'ASSET') {
+        const ref = n.ref ?? n.id;
+        const name = n.hostname || n.label;
+        if (ref && name) {
+          map.set(ref, name);
+        }
       }
     }
     return map;
@@ -1119,6 +1145,42 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     setSelectedFindingId(prev => (prev === nodeId ? null : nodeId));
   }, [pathFinding, highlightGraphFinding, openFindingFromGraph]);
 
+  // An injector's own findings, grouped by type: attributed to this injector by keeping only category
+  // findings produced by one of ITS execution refs (the category endpoint carries executionIds; the raw
+  // endpoint-findings endpoint does not), so a shared endpoint's findings are not wrongly credited here.
+  const loadInjectorFindings = useCallback((ownedRefs: Set<string>) => {
+    setInjectorFindingGroups([]);
+    if (ownedRefs.size === 0) {
+      return;
+    }
+    setInjectorFindingsLoading(true);
+    Promise.all(
+      INJECTOR_FINDING_CATEGORIES.map(cat => fetchFindingsByCategory(simulationId, cat, 0, DRAWER_FETCH_SIZE)
+        .then(r => (r.data.items ?? []).filter(it => (it.executionIds ?? []).some(id => ownedRefs.has(id))))
+        .catch(() => [] as AttackPathFindingItemDTO[])),
+    )
+      .then((lists) => {
+        const byType = new Map<string, string[]>();
+        for (const it of lists.flat()) {
+          const type = it.type ?? '';
+          const value = maskFindingValue(type, it.value);
+          if (!type || !value) {
+            continue;
+          }
+          const arr = byType.get(type) ?? [];
+          if (!arr.includes(value)) {
+            arr.push(value);
+          }
+          byType.set(type, arr);
+        }
+        setInjectorFindingGroups([...byType.entries()].map(([type, values]) => ({
+          type,
+          values,
+        })));
+      })
+      .finally(() => setInjectorFindingsLoading(false));
+  }, [simulationId]);
+
   // Load an injector's own executions (its contracts) across every endpoint it reached, for the injector
   // panel — the action-side mirror of the endpoint panel. Executions are gathered from the injector's
   // reached endpoints and filtered to the injector's own execution refs (from the graph edges), so the
@@ -1126,6 +1188,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   const loadInjectorExecutions = useCallback((injectorId: string, label?: string) => {
     setInjectorPanelLabel(label || friendlyNodeId(injectorId));
     setInjectorExecutions([]);
+    setInjectorFindingGroups([]);
     const refs = injectorEndpointRefs.get(injectorId) ?? [];
     if (refs.length === 0) {
       return;
@@ -1154,8 +1217,10 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           }
         }
         setInjectorExecutions(execs);
+        // Attribute findings to this injector via its own execution refs.
+        loadInjectorFindings(new Set(execs.map(e => e.ref).filter((r): r is string => !!r)));
       });
-  }, [injectorEndpointRefs, simulationId]);
+  }, [injectorEndpointRefs, simulationId, loadInjectorFindings]);
 
   // Click an injector (action) node. In the focused view it reverse-highlights on the focused
   // endpoint; in the clustered view it toggles a downstream highlight of the action's reach AND opens
@@ -1189,6 +1254,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     } else {
       // Toggling the same injector off also clears its panel.
       setInjectorExecutions([]);
+      setInjectorFindingGroups([]);
     }
   }, [pathFinding, highlightGraphInjector, endpointRelationEdges, openExecutionDetail, selectedInjectorId, loadInjectorExecutions]);
 
@@ -2222,15 +2288,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               />
             )}
 
-            {/* Injector master panel: the same component as the endpoint panel, but listing this
-                injector's own contracts/executions (findings section hidden). One click opens their
+            {/* Injector master panel: the same component as the endpoint panel — its findings (attributed
+                to this injector's executions) and its contracts/executions. One click opens their
                 Result / Execution details / Remediation detail (the global command it ran). */}
             {!pathFinding && !findingDetail && !selectedNodeId && selectedInjectorId && !detailExecutionId && (
               <EndpointDetailPanel
                 endpointLabel={injectorPanelLabel || t('Injector')}
-                hideFindings
-                findingsLoading={false}
-                findingGroups={[]}
+                findingsLoading={injectorFindingsLoading}
+                findingGroups={injectorFindingGroups}
                 executions={injectorExecutions}
                 execDisplayCap={EXEC_DISPLAY_CAP}
                 highlightedExecutionIds={highlightedExecutionIds}
@@ -2240,6 +2305,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 onClose={() => {
                   setSelectedInjectorId(null);
                   setInjectorExecutions([]);
+                  setInjectorFindingGroups([]);
                   setDetailExecutionId(null);
                 }}
               />
@@ -2249,6 +2315,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               <ExecutionResultTerminalPanel
                 loading={detailLoading}
                 detail={detail}
+                endpointLabel={detail?.endpointKey ? endpointLabelByRef.get(detail.endpointKey) : undefined}
                 // Back returns to the master panel (endpoint/finding/injector) it was opened from; close
                 // dismisses the whole drawer.
                 onBack={() => setDetailExecutionId(null)}
@@ -2257,6 +2324,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                   setSelectedNodeId(null);
                   setSelectedInjectorId(null);
                   setInjectorExecutions([]);
+                  setInjectorFindingGroups([]);
                   setFindingDetail(null);
                 }}
                 onOpenInject={(detail as { injectId?: string } | null)?.injectId

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -14,7 +14,7 @@ import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathDTO, AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import attackPathStatusColor, { attackPathChokepointColor } from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, type PathFinding } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, type PathFinding } from './attack-path-flow-helpers';
 import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
@@ -1394,6 +1394,17 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           }
         }
       }
+    } else if (selectedNodeId) {
+      // Clustered endpoint click: injectors converge on the shared hub, so walking the rendered edges up
+      // would light EVERY injector. Instead resolve the injectors that actually target this endpoint from
+      // the raw execution edges, and light them + the hub so the whole path to the endpoint is shown.
+      pathSet.add(selectedNodeId);
+      pathSet.add(AP_SHARED_EP_CLUSTER_ID);
+      for (const e of dto?.attackPathEdges ?? []) {
+        if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === selectedNodeId && e.edgeSourceId) {
+          pathSet.add(e.edgeSourceId);
+        }
+      }
     }
     const withSelection = {
       nodes: baseFlow.nodes.map(n => ({
@@ -1407,7 +1418,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       })),
     };
     return applyFindingFilter(withSelection.nodes, withSelection.edges, focus);
-  }, [baseFlow, pathFinding, producingInjectorIds, selectedNodeId, selectedFindingId, selectedInjectorId, focus]);
+  }, [baseFlow, pathFinding, producingInjectorIds, selectedNodeId, selectedFindingId, selectedInjectorId, focus, dto?.attackPathEdges]);
 
   // Additive kill-chain causal edges (issue 6647) for the AGGREGATED view, merged on top of the status
   // graph. Drawn only when a consumed key matches a produced finding (or a dependsOn resolves). In chain
@@ -1737,6 +1748,15 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       onCardClick(opt.card);
     }
   };
+
+  // The clustered builder always emits the endpoint-cluster hub, so `nodes` is never empty even with no
+  // real data; treat the graph as empty unless it has an actual injector/endpoint/finding to show (so the
+  // empty-state — including the "run in progress" message — appears instead of a lone "+0" hub).
+  const graphHasContent = nodes.some(n =>
+    n.type === AP_FLOW_NODE_TYPE.injector
+    || n.type === AP_FLOW_NODE_TYPE.asset
+    || n.type === AP_FLOW_NODE_TYPE.finding,
+  );
 
   // Scenario context has runs to pick from; when it has none yet, the empty-state offers to launch one.
   const scenarioHasNoSims = showPicker && simulations.length === 0;
@@ -2208,7 +2228,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                   {t('Failed to load the attack-path graph. Check the simulation or reload the page.')}
                 </Alert>
               )}
-              {!loading && !forbidden && !error && nodes.length === 0 && (
+              {!loading && !forbidden && !error && !graphHasContent && (
                 <Box sx={{
                   m: 'auto',
                   p: 4,
@@ -2240,7 +2260,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                   )}
                 </Box>
               )}
-              {!loading && !forbidden && !error && nodes.length > 0 && (
+              {!loading && !forbidden && !error && graphHasContent && (
                 <ReactFlowProvider>
                   <AttackPathFlow
                     nodes={nodes}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -14,7 +14,7 @@ import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathDTO, AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import attackPathStatusColor, { attackPathChokepointColor } from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, maskFindingValue, type PathFinding } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, type PathFinding } from './attack-path-flow-helpers';
 import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
@@ -237,6 +237,10 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     value: string;
   } | null>(null);
   const [executions, setExecutions] = useState<AttackPathNodeDTO[]>([]);
+  // The clicked injector's own executions (its contracts across every endpoint it reached), listed in
+  // the injector panel — the action-side mirror of the endpoint panel. Label = the injector's name.
+  const [injectorExecutions, setInjectorExecutions] = useState<AttackPathNodeDTO[]>([]);
+  const [injectorPanelLabel, setInjectorPanelLabel] = useState<string>('');
   const [endpointRelationEdges, setEndpointRelationEdges] = useState<AttackPathEdges[]>([]);
   // The clicked endpoint's own findings (deduplicated by type+value), shown in the side panel.
   const [endpointFindings, setEndpointFindings] = useState<AttackPathNodeDTO[]>([]);
@@ -1115,28 +1119,43 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     setSelectedFindingId(prev => (prev === nodeId ? null : nodeId));
   }, [pathFinding, highlightGraphFinding, openFindingFromGraph]);
 
-  // Open the Result & Terminal drawer for a representative execution of an injector (action): its
-  // executed command (Terminal tab), prevention/detection verdicts (Result tab) and ATT&CK techniques
-  // (header) — the action-side mirror of the finding panel. The representative execution is resolved
-  // from one of the injector's reached endpoints, matched to the injector by payload/step template.
-  const openInjectorExecution = useCallback((injectorId: string, label?: string) => {
+  // Load an injector's own executions (its contracts) across every endpoint it reached, for the injector
+  // panel — the action-side mirror of the endpoint panel. Executions are gathered from the injector's
+  // reached endpoints and filtered to the injector's own execution refs (from the graph edges), so the
+  // list is exactly what this injector ran (potentially the same contract against several endpoints).
+  const loadInjectorExecutions = useCallback((injectorId: string, label?: string) => {
+    setInjectorPanelLabel(label || friendlyNodeId(injectorId));
+    setInjectorExecutions([]);
     const refs = injectorEndpointRefs.get(injectorId) ?? [];
     if (refs.length === 0) {
       return;
     }
-    const base = (label ?? '').toLowerCase();
-    const matchesInjector = (e: AttackPathNodeDTO) =>
-      (e.payloadName ?? '').toLowerCase().replace(/-payload$/, '') === base
-      || (e.stepTemplateId ?? '').toLowerCase() === `step-tpl-${base}`;
-    fetchEndpointRelations(simulationId, refs[0])
-      .then((r) => {
-        const exec = (r.data.executions ?? []).find(e => !!e.ref && matchesInjector(e));
-        if (exec?.ref) {
-          openExecutionDetail(exec.ref);
+    // The collapsed graph edges carry no executionIds, so scope per endpoint using the endpoint-relations
+    // edges (which do): keep only the executions this injector ran on each endpoint.
+    Promise.all(
+      refs.map(ref => fetchEndpointRelations(simulationId, ref)
+        .then((r) => {
+          const owned = new Set(
+            (r.data.edges ?? [])
+              .filter(e => e.edgeSourceId === injectorId)
+              .flatMap(e => e.executionIds ?? []),
+          );
+          return (r.data.executions ?? []).filter(e => !!e.ref && owned.has(e.ref));
+        })
+        .catch(() => [] as AttackPathNodeDTO[])),
+    )
+      .then((lists) => {
+        const seen = new Set<string>();
+        const execs: AttackPathNodeDTO[] = [];
+        for (const e of lists.flat()) {
+          if (e.ref && !seen.has(e.ref)) {
+            seen.add(e.ref);
+            execs.push(e);
+          }
         }
-      })
-      .catch(() => undefined);
-  }, [injectorEndpointRefs, simulationId, openExecutionDetail]);
+        setInjectorExecutions(execs);
+      });
+  }, [injectorEndpointRefs, simulationId]);
 
   // Click an injector (action) node. In the focused view it reverse-highlights on the focused
   // endpoint; in the clustered view it toggles a downstream highlight of the action's reach AND opens
@@ -1158,16 +1177,20 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     setSelectedNodeId(null);
     setFindingDetail(null);
     setSelectedFindingId(null);
+    // Any execution detail from a previous selection is closed, so the injector panel opens as master.
+    setDetailExecutionId(null);
+    setDetail(null);
     const willSelect = selectedInjectorId !== injectorId;
     setSelectedInjectorId(willSelect ? injectorId : null);
     if (willSelect) {
-      openInjectorExecution(injectorId, label);
+      // Open the injector panel: its contracts/executions listed like an endpoint's, one click away from
+      // the Result / Execution details / Remediation detail (the global command it ran).
+      loadInjectorExecutions(injectorId, label);
     } else {
-      // Toggling the same injector off also closes its inject drawer.
-      setDetailExecutionId(null);
-      setDetail(null);
+      // Toggling the same injector off also clears its panel.
+      setInjectorExecutions([]);
     }
-  }, [pathFinding, highlightGraphInjector, endpointRelationEdges, openExecutionDetail, selectedInjectorId, openInjectorExecution]);
+  }, [pathFinding, highlightGraphInjector, endpointRelationEdges, openExecutionDetail, selectedInjectorId, loadInjectorExecutions]);
 
   // The active card focus, as finding types (or the endpoints backbone).
   const focus = useMemo((): readonly string[] | 'endpoints' | null => {
@@ -2199,16 +2222,41 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               />
             )}
 
+            {/* Injector master panel: the same component as the endpoint panel, but listing this
+                injector's own contracts/executions (findings section hidden). One click opens their
+                Result / Execution details / Remediation detail (the global command it ran). */}
+            {!pathFinding && !findingDetail && !selectedNodeId && selectedInjectorId && !detailExecutionId && (
+              <EndpointDetailPanel
+                endpointLabel={injectorPanelLabel || t('Injector')}
+                hideFindings
+                findingsLoading={false}
+                findingGroups={[]}
+                executions={injectorExecutions}
+                execDisplayCap={EXEC_DISPLAY_CAP}
+                highlightedExecutionIds={highlightedExecutionIds}
+                registerRow={() => {}}
+                onSelectExecution={openExecutionDetail}
+                execStatusLabel={status => t(statusLabelKey(status))}
+                onClose={() => {
+                  setSelectedInjectorId(null);
+                  setInjectorExecutions([]);
+                  setDetailExecutionId(null);
+                }}
+              />
+            )}
+
             {detailExecutionId && (
               <ExecutionResultTerminalPanel
                 loading={detailLoading}
                 detail={detail}
-                // Back returns to the master panel (endpoint/finding) it was opened from; close dismisses
-                // the whole drawer.
+                // Back returns to the master panel (endpoint/finding/injector) it was opened from; close
+                // dismisses the whole drawer.
                 onBack={() => setDetailExecutionId(null)}
                 onClose={() => {
                   setDetailExecutionId(null);
                   setSelectedNodeId(null);
+                  setSelectedInjectorId(null);
+                  setInjectorExecutions([]);
                   setFindingDetail(null);
                 }}
                 onOpenInject={(detail as { injectId?: string } | null)?.injectId

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2214,8 +2214,16 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 onOpenInject={(detail as { injectId?: string } | null)?.injectId
                   // The inject belongs to the run, not the scenario: a relative `../injects/…` would point
                   // at the scenario in scenario context (which has no such inject → 404). Always target the
-                  // selected simulation so both contexts resolve to the real inject.
-                  ? () => navigate(`${SIMULATION_BASE_URL}/${simulationId}/injects/${(detail as { injectId?: string }).injectId}`)
+                  // selected simulation. A payload-backed inject opens on its Overview; a network injector
+                  // (no payload) opens straight on its Execution details, where its traces live.
+                  ? () => {
+                      const d = detail as {
+                        injectId?: string;
+                        payloadId?: string;
+                      };
+                      const base = `${SIMULATION_BASE_URL}/${simulationId}/injects/${d.injectId}`;
+                      navigate(d.payloadId ? base : `${base}/execution_details`);
+                    }
                   : undefined}
               />
             )}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -78,6 +78,10 @@ const COVERED_FINDING_TYPES = new Set(['share', 'credentials', 'username', 'admi
 // Finding categories fetched (with per-finding executionIds) to attribute findings to an injector.
 const INJECTOR_FINDING_CATEGORIES = ['credentials', 'users', 'cves', 'files'];
 
+// Drawer resize bounds (px).
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MAX_WIDTH = 1000;
+
 // Backend prevention/detection status -> a human label (also used for accessibility, so status is
 // never conveyed by colour alone). GREEN = prevented, ORANGE = detected, RED = neither.
 const statusLabelKey = (status?: string): string => {
@@ -294,6 +298,38 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // quickly: only the latest request may write state.
   const graphSeq = useRef(0);
   const endpointSeq = useRef(0);
+
+  // Drawer width, drag-resizable (the graph is flex:1 and reflows as this changes). Dragging the handle
+  // on the drawer's left edge leftwards widens it — useful when execution traces overflow.
+  const [panelWidth, setPanelWidth] = useState(460);
+  const resizeRef = useRef<{
+    startX: number;
+    startW: number;
+  } | null>(null);
+  const onResizeMove = useCallback((e: MouseEvent) => {
+    if (!resizeRef.current) {
+      return;
+    }
+    const next = resizeRef.current.startW + (resizeRef.current.startX - e.clientX);
+    setPanelWidth(Math.max(PANEL_MIN_WIDTH, Math.min(PANEL_MAX_WIDTH, next)));
+  }, []);
+  const onResizeEnd = useCallback(() => {
+    resizeRef.current = null;
+    document.removeEventListener('mousemove', onResizeMove);
+    document.removeEventListener('mouseup', onResizeEnd);
+    document.body.style.userSelect = '';
+  }, [onResizeMove]);
+  const onResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    resizeRef.current = {
+      startX: e.clientX,
+      startW: panelWidth,
+    };
+    document.addEventListener('mousemove', onResizeMove);
+    document.addEventListener('mouseup', onResizeEnd);
+    // Suppress text selection while dragging.
+    document.body.style.userSelect = 'none';
+  }, [panelWidth, onResizeMove, onResizeEnd]);
 
   // Always collapsed-first: the graph auto-loads on simulation change, clustered by injector.
   const load = useCallback(() => {
@@ -2279,107 +2315,141 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               )}
             </Paper>
 
-            {/* Master→detail in a single drawer: while an execution detail is open it REPLACES the
+            {/* Resizable drawer: a single panel shows at a time (mutually exclusive); the handle on its
+                left edge drags the width, and the graph (flex:1) reflows. */}
+            {(!!detailExecutionId || !!findingDetail || !!selectedNodeId || (!pathFinding && !!selectedInjectorId)) && (
+              <div style={{
+                position: 'relative',
+                display: 'flex',
+                flexShrink: 0,
+                width: panelWidth,
+                minWidth: PANEL_MIN_WIDTH,
+              }}
+              >
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label={t('Resize panel')}
+                  onMouseDown={onResizeStart}
+                  style={{
+                    flex: '0 0 auto',
+                    width: 6,
+                    cursor: 'col-resize',
+                    marginRight: theme.spacing(1),
+                    borderRadius: 3,
+                    background: theme.palette.divider,
+                  }}
+                />
+                <div style={{
+                  flex: 1,
+                  minWidth: 0,
+                  display: 'flex',
+                }}
+                >
+                  {/* Master→detail in a single drawer: while an execution detail is open it REPLACES the
                 endpoint/finding master panel (below), and its back arrow returns here. */}
-            {findingDetail && !detailExecutionId && (
-              <FindingDetailPanel
-                value={maskFindingValue(findingDetail.type, findingDetail.value)}
-                type={findingDetail.type}
-                endpointLabel={focusedEndpoint?.hostname || focusedEndpoint?.label || pathFinding?.endpointKey || t('Endpoint')}
-                endpointSub={[focusedEndpoint?.ip, focusedEndpoint?.platform].filter(Boolean).join(' · ')}
-                expectations={findingExpectations}
-                actions={producingActions}
-                activeRef={detailExecutionId}
-                onSelect={openExecutionDetail}
-                onClose={() => {
-                  // Clicking a finding in the clustered view also selects its endpoint (to load the
-                  // feed), so clear both here — otherwise closing the finding panel would just reveal
-                  // the endpoint panel and look like it never closed.
-                  setFindingDetail(null);
-                  setSelectedNodeId(null);
-                  setDetailExecutionId(null);
-                }}
-              />
-            )}
+                  {findingDetail && !detailExecutionId && (
+                    <FindingDetailPanel
+                      value={maskFindingValue(findingDetail.type, findingDetail.value)}
+                      type={findingDetail.type}
+                      endpointLabel={focusedEndpoint?.hostname || focusedEndpoint?.label || pathFinding?.endpointKey || t('Endpoint')}
+                      endpointSub={[focusedEndpoint?.ip, focusedEndpoint?.platform].filter(Boolean).join(' · ')}
+                      expectations={findingExpectations}
+                      actions={producingActions}
+                      activeRef={detailExecutionId}
+                      onSelect={openExecutionDetail}
+                      onClose={() => {
+                        // Clicking a finding in the clustered view also selects its endpoint (to load the
+                        // feed), so clear both here — otherwise closing the finding panel would just reveal
+                        // the endpoint panel and look like it never closed.
+                        setFindingDetail(null);
+                        setSelectedNodeId(null);
+                        setDetailExecutionId(null);
+                      }}
+                    />
+                  )}
 
-            {!findingDetail && selectedNodeId && !detailExecutionId && (
-              <EndpointDetailPanel
-                endpointLabel={selectedLabel || t('Endpoint')}
-                findingsLoading={endpointFindingsLoading}
-                findingGroups={endpointFindingGroups}
-                executions={executions}
-                execDisplayCap={EXEC_DISPLAY_CAP}
-                highlightedExecutionIds={highlightedExecutionIds}
-                registerRow={(id, el) => {
-                  if (el) {
-                    feedRowRefs.current.set(id, el);
-                  } else {
-                    feedRowRefs.current.delete(id);
-                  }
-                }}
-                onSelectExecution={openExecutionDetail}
-                execStatusLabel={status => t(statusLabelKey(status))}
-                onClose={() => {
-                  setSelectedNodeId(null);
-                  setDetailExecutionId(null);
-                }}
-              />
-            )}
+                  {!findingDetail && selectedNodeId && !detailExecutionId && (
+                    <EndpointDetailPanel
+                      endpointLabel={selectedLabel || t('Endpoint')}
+                      findingsLoading={endpointFindingsLoading}
+                      findingGroups={endpointFindingGroups}
+                      executions={executions}
+                      execDisplayCap={EXEC_DISPLAY_CAP}
+                      highlightedExecutionIds={highlightedExecutionIds}
+                      registerRow={(id, el) => {
+                        if (el) {
+                          feedRowRefs.current.set(id, el);
+                        } else {
+                          feedRowRefs.current.delete(id);
+                        }
+                      }}
+                      onSelectExecution={openExecutionDetail}
+                      execStatusLabel={status => t(statusLabelKey(status))}
+                      onClose={() => {
+                        setSelectedNodeId(null);
+                        setDetailExecutionId(null);
+                      }}
+                    />
+                  )}
 
-            {/* Injector master panel: the same component as the endpoint panel — its findings (attributed
+                  {/* Injector master panel: the same component as the endpoint panel — its findings (attributed
                 to this injector's executions) and its contracts/executions. One click opens their
                 Result / Execution details / Remediation detail (the global command it ran). */}
-            {!pathFinding && !findingDetail && !selectedNodeId && selectedInjectorId && !detailExecutionId && (
-              <EndpointDetailPanel
-                endpointLabel={injectorPanelLabel || t('Injector')}
-                findingsLoading={injectorFindingsLoading}
-                findingGroups={injectorFindingGroups}
-                executions={injectorExecutions}
-                execDisplayCap={EXEC_DISPLAY_CAP}
-                highlightedExecutionIds={highlightedExecutionIds}
-                registerRow={() => {}}
-                onSelectExecution={openExecutionDetail}
-                execStatusLabel={status => t(statusLabelKey(status))}
-                onClose={() => {
-                  setSelectedInjectorId(null);
-                  setInjectorExecutions([]);
-                  setInjectorFindingGroups([]);
-                  setDetailExecutionId(null);
-                }}
-              />
-            )}
+                  {!pathFinding && !findingDetail && !selectedNodeId && selectedInjectorId && !detailExecutionId && (
+                    <EndpointDetailPanel
+                      endpointLabel={injectorPanelLabel || t('Injector')}
+                      findingsLoading={injectorFindingsLoading}
+                      findingGroups={injectorFindingGroups}
+                      executions={injectorExecutions}
+                      execDisplayCap={EXEC_DISPLAY_CAP}
+                      highlightedExecutionIds={highlightedExecutionIds}
+                      registerRow={() => {}}
+                      onSelectExecution={openExecutionDetail}
+                      execStatusLabel={status => t(statusLabelKey(status))}
+                      onClose={() => {
+                        setSelectedInjectorId(null);
+                        setInjectorExecutions([]);
+                        setInjectorFindingGroups([]);
+                        setDetailExecutionId(null);
+                      }}
+                    />
+                  )}
 
-            {detailExecutionId && (
-              <ExecutionResultTerminalPanel
-                loading={detailLoading}
-                detail={detail}
-                endpointLabel={detail?.endpointKey ? endpointLabelByRef.get(detail.endpointKey) : undefined}
-                // Back returns to the master panel (endpoint/finding/injector) it was opened from; close
-                // dismisses the whole drawer.
-                onBack={() => setDetailExecutionId(null)}
-                onClose={() => {
-                  setDetailExecutionId(null);
-                  setSelectedNodeId(null);
-                  setSelectedInjectorId(null);
-                  setInjectorExecutions([]);
-                  setInjectorFindingGroups([]);
-                  setFindingDetail(null);
-                }}
-                onOpenInject={(detail as { injectId?: string } | null)?.injectId
-                  // The inject belongs to the run, not the scenario: a relative `../injects/…` would point
-                  // at the scenario in scenario context (which has no such inject → 404). Always target the
-                  // selected simulation. A payload-backed inject opens on its Overview; a network injector
-                  // (no payload) opens straight on its Execution details, where its traces live.
-                  ? () => {
-                      const d = detail as {
-                        injectId?: string;
-                        payloadId?: string;
-                      };
-                      const base = `${SIMULATION_BASE_URL}/${simulationId}/injects/${d.injectId}`;
-                      navigate(d.payloadId ? base : `${base}/execution_details`);
-                    }
-                  : undefined}
-              />
+                  {detailExecutionId && (
+                    <ExecutionResultTerminalPanel
+                      loading={detailLoading}
+                      detail={detail}
+                      endpointLabel={detail?.endpointKey ? endpointLabelByRef.get(detail.endpointKey) : undefined}
+                      // Back returns to the master panel (endpoint/finding/injector) it was opened from; close
+                      // dismisses the whole drawer.
+                      onBack={() => setDetailExecutionId(null)}
+                      onClose={() => {
+                        setDetailExecutionId(null);
+                        setSelectedNodeId(null);
+                        setSelectedInjectorId(null);
+                        setInjectorExecutions([]);
+                        setInjectorFindingGroups([]);
+                        setFindingDetail(null);
+                      }}
+                      onOpenInject={(detail as { injectId?: string } | null)?.injectId
+                      // The inject belongs to the run, not the scenario: a relative `../injects/…` would point
+                      // at the scenario in scenario context (which has no such inject → 404). Always target the
+                      // selected simulation. A payload-backed inject opens on its Overview; a network injector
+                      // (no payload) opens straight on its Execution details, where its traces live.
+                        ? () => {
+                            const d = detail as {
+                              injectId?: string;
+                              payloadId?: string;
+                            };
+                            const base = `${SIMULATION_BASE_URL}/${simulationId}/injects/${d.injectId}`;
+                            navigate(d.payloadId ? base : `${base}/execution_details`);
+                          }
+                        : undefined}
+                    />
+                  )}
+                </div>
+              </div>
             )}
           </>
         )}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -467,7 +467,6 @@ export const buildClusteredAttackPathFlow = (
   // endpoints). Endpoints are SHARED across injectors — never repeated once per injector.
   const injectorsByEndpoint = new Map<string, string[]>();
   const reachedOrder: string[] = [];
-  const reachedCountByInjector = new Map<string, number>();
   for (const e of execEdges) {
     const src = e.edgeSourceId;
     const tgt = e.edgeTargetId;
@@ -477,7 +476,6 @@ export const buildClusteredAttackPathFlow = (
     const injs = injectorsByEndpoint.get(tgt) ?? [];
     if (!injs.includes(src)) {
       injs.push(src);
-      reachedCountByInjector.set(src, (reachedCountByInjector.get(src) ?? 0) + 1);
     }
     injectorsByEndpoint.set(tgt, injs);
     if (!reachedOrder.includes(tgt)) {
@@ -580,7 +578,6 @@ export const buildClusteredAttackPathFlow = (
   });
   injectors.forEach((inj) => {
     const injId = inj.id as string;
-    const reachedCount = reachedCountByInjector.get(injId) ?? 0;
     const injStatus = aggregateStatus(
       reachedOrder
         .filter(ep => (injectorsByEndpoint.get(ep) ?? []).includes(injId))
@@ -591,9 +588,11 @@ export const buildClusteredAttackPathFlow = (
       source: injId,
       target: clusterId,
       type: AP_FLOW_EDGE_TYPE,
+      // No count badge here: the reached-endpoint count is already shown on the endpoint-cluster hub, so
+      // repeating it on the injector edge is redundant. (A distinct-contract count would need the backend
+      // to expose per-injector contract info on the collapsed graph — not available client-side.)
       data: {
-        count: reachedCount,
-        label: `+${reachedCount}`,
+        count: 1,
         status: injStatus,
       },
     });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1364,8 +1364,8 @@ const CHAIN_COL_W = 620; // horizontal span of one causal depth (inject + endpoi
 const CHAIN_EP_DX = 210; // inject → endpoint horizontal offset within a step
 const CHAIN_FIND_DX = 400; // inject → produced-finding horizontal offset within a step
 const CHAIN_FIND_ROW = 96; // vertical gap between findings stacked on the SAME endpoint
-const CHAIN_EP_GAP = 56; // vertical gap between an injector's endpoint blocks
-const CHAIN_STEP_GAP = 80; // vertical gap between two injectors sharing a depth (same column)
+const CHAIN_STEP_GAP = 80; // vertical gap between two asset blocks sharing a depth (same column)
+const CHAIN_INJECTOR_ROW = 110; // vertical slot per injector when several share one endpoint block
 const CHAIN_EP_BLOCK_MIN = 120; // minimum height of one endpoint block (endpoint node + breathing room)
 const CHAIN_FIND_HALF = 28; // half of AP_FINDING_SIZE (56), to centre a finding node on its row
 
@@ -1584,50 +1584,81 @@ export const buildCausalChainFlow = (
     const x = depthX.get(d) as number;
     const chainEpDx = depthEpDx.get(d) as number;
     const chainFindDx = depthFindDx.get(d) as number;
-    let cursorY = PADDING;
+    // Merge endpoints by ASSET within this depth: injectors sharing a depth are never causally linked (a
+    // dependency pushes the consumer into a deeper column), so several independent injectors hitting the
+    // same asset converge on ONE endpoint node instead of one copy per injector. Aggregate, per distinct
+    // asset at this depth: the injectors targeting it (first-seen order) and the union of their findings.
+    const assetOrder: string[] = [];
+    const assetInjectors = new Map<string, string[]>();
+    const assetFindings = new Map<string, string[]>();
     ids.forEach((injId) => {
       const s = steps.get(injId) as ChainStep;
-      const endpointEntries = [...s.endpoints.entries()];
-      // Each endpoint is a vertical block sized to hold the endpoint node and its stacked findings.
-      const blocks = endpointEntries.map(([epId, findingIds]) => ({
-        epId,
-        findingIds,
-        h: Math.max(CHAIN_EP_BLOCK_MIN, findingIds.length * CHAIN_FIND_ROW),
-      }));
-      const totalH = blocks.reduce((sum, b) => sum + b.h, 0) + Math.max(0, blocks.length - 1) * CHAIN_EP_GAP;
-      const stepTop = cursorY;
-      const injCenterY = stepTop + Math.max(totalH, CHAIN_EP_BLOCK_MIN) / 2;
+      for (const [epId, findingIds] of s.endpoints.entries()) {
+        if (!assetInjectors.has(epId)) {
+          assetOrder.push(epId);
+          assetInjectors.set(epId, []);
+          assetFindings.set(epId, []);
+        }
+        assetInjectors.get(epId)!.push(injId);
+        const fset = assetFindings.get(epId)!;
+        findingIds.forEach((fid) => {
+          if (!fset.includes(fid)) {
+            fset.push(fid);
+          }
+        });
+      }
+    });
 
-      // Inject node, vertically centred against its whole block (keeps its real id + data so the icon,
-      // ATT&CK and injector-click still resolve).
-      const injDto = injectorById.get(injId);
-      // The full graph may omit injector nodes; label the action from its contract name rather than the
-      // raw step id, so the node never reads "NODE_*|<uuid>".
-      const injActionLabel = [...s.contractByEndpoint.values()][0];
+    // One vertical block per distinct asset, tall enough for BOTH its stacked injectors (left) and its
+    // stacked findings (right). An injector that hits several assets is positioned once (first block).
+    let cursorY = PADDING;
+    const injectorPlaced = new Set<string>();
+    for (const epId of assetOrder) {
+      const injectors = assetInjectors.get(epId) as string[];
+      const findingIds = assetFindings.get(epId) as string[];
+      const h = Math.max(
+        CHAIN_EP_BLOCK_MIN,
+        findingIds.length * CHAIN_FIND_ROW,
+        injectors.length * CHAIN_INJECTOR_ROW,
+      );
+      const blockTop = cursorY;
+      const blockCenter = blockTop + h / 2;
+
+      const epDto = assetById.get(epId);
+      // Endpoint id keyed by depth+asset (not by injector), so injectors at this depth share this node.
+      const epNodeId = `chain-ep|${d}|${epId}`;
       nodes.push({
-        id: injId,
-        type: AP_FLOW_NODE_TYPE.injector,
+        id: epNodeId,
+        type: AP_FLOW_NODE_TYPE.asset,
         position: {
-          x,
-          y: injCenterY - CLUSTER_INJECTOR_HALF_H,
+          x: x + chainEpDx,
+          y: blockCenter - CLUSTER_EP_HALF_H,
         },
-        data: injDto ? nodeData(injDto) : { label: injActionLabel || friendlyNodeId(injId) },
+        data: epDto ? nodeData(epDto) : { label: friendlyNodeId(epId) },
       });
 
-      let blockCursor = stepTop;
-      blocks.forEach(({ epId, findingIds, h }) => {
-        const blockCenter = blockCursor + h / 2;
-        const epDto = assetById.get(epId);
-        const epNodeId = `chain-ep|${injId}|${epId}`;
-        nodes.push({
-          id: epNodeId,
-          type: AP_FLOW_NODE_TYPE.asset,
-          position: {
-            x: x + chainEpDx,
-            y: blockCenter - CLUSTER_EP_HALF_H,
-          },
-          data: epDto ? nodeData(epDto) : { label: friendlyNodeId(epId) },
-        });
+      // Injectors that hit this asset, stacked within the block, each with its own labelled edge.
+      injectors.forEach((injId, i) => {
+        const s = steps.get(injId) as ChainStep;
+        if (!injectorPlaced.has(injId)) {
+          injectorPlaced.add(injId);
+          const injCenterY = injectors.length === 1
+            ? blockCenter
+            : blockTop + (i + 0.5) * (h / injectors.length);
+          const injDto = injectorById.get(injId);
+          // The full graph may omit injector nodes; label the action from its contract name rather than
+          // the raw step id, so the node never reads "NODE_*|<uuid>".
+          const injActionLabel = [...s.contractByEndpoint.values()][0];
+          nodes.push({
+            id: injId,
+            type: AP_FLOW_NODE_TYPE.injector,
+            position: {
+              x,
+              y: injCenterY - CLUSTER_INJECTOR_HALF_H,
+            },
+            data: injDto ? nodeData(injDto) : { label: injActionLabel || friendlyNodeId(injId) },
+          });
+        }
         edges.push({
           id: `${injId}-${epNodeId}`,
           source: injId,
@@ -1641,46 +1672,45 @@ export const buildCausalChainFlow = (
             label: s.contractByEndpoint.get(epId),
           },
         });
-
-        // The findings discovered on THIS endpoint, stacked and centred against the block.
-        findingIds.forEach((fid, k) => {
-          const fDto = findingById.get(fid);
-          const fY = blockCenter + (k - (findingIds.length - 1) / 2) * CHAIN_FIND_ROW;
-          if (!placedFindings.has(fid)) {
-            placedFindings.add(fid);
-            nodes.push({
-              id: fid,
-              type: AP_FLOW_NODE_TYPE.finding,
-              position: {
-                x: x + chainFindDx,
-                y: fY - CHAIN_FIND_HALF,
-              },
-              data: {
-                label: fDto?.value ?? fDto?.label,
-                value: fDto?.value,
-                typeFindings: fDto?.typeFindings,
-                assetNodeId: fDto?.assetNodeId,
-                status: fDto?.status ?? 'RED',
-              },
-            });
-          }
-          edges.push({
-            id: `${epNodeId}-${fid}`,
-            source: epNodeId,
-            target: fid,
-            type: AP_FLOW_EDGE_TYPE,
-            data: {
-              count: 1,
-              status: fDto?.status ?? 'RED',
-              label: fDto?.typeFindings ? t('{type} found', { type: fDto.typeFindings }) : undefined,
-            },
-          });
-        });
-        blockCursor += h + CHAIN_EP_GAP;
       });
 
-      cursorY = stepTop + Math.max(totalH, CHAIN_EP_BLOCK_MIN) + CHAIN_STEP_GAP;
-    });
+      // Findings discovered on this asset (union across the injectors), stacked and centred on the block.
+      findingIds.forEach((fid, k) => {
+        const fDto = findingById.get(fid);
+        const fY = blockCenter + (k - (findingIds.length - 1) / 2) * CHAIN_FIND_ROW;
+        if (!placedFindings.has(fid)) {
+          placedFindings.add(fid);
+          nodes.push({
+            id: fid,
+            type: AP_FLOW_NODE_TYPE.finding,
+            position: {
+              x: x + chainFindDx,
+              y: fY - CHAIN_FIND_HALF,
+            },
+            data: {
+              label: fDto?.value ?? fDto?.label,
+              value: fDto?.value,
+              typeFindings: fDto?.typeFindings,
+              assetNodeId: fDto?.assetNodeId,
+              status: fDto?.status ?? 'RED',
+            },
+          });
+        }
+        edges.push({
+          id: `${epNodeId}-${fid}`,
+          source: epNodeId,
+          target: fid,
+          type: AP_FLOW_EDGE_TYPE,
+          data: {
+            count: 1,
+            status: fDto?.status ?? 'RED',
+            label: fDto?.typeFindings ? t('{type} found', { type: fDto.typeFindings }) : undefined,
+          },
+        });
+      });
+
+      cursorY = blockTop + h + CHAIN_STEP_GAP;
+    }
   }
 
   // Forward causal links: a produced finding → the downstream inject that consumes a matching key. When a

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "Ihre Gesamteinschätzung zu dieser Frage.",
   "Your threat arsenal is empty": "Dein Threat Arsenal ist leer",
   "your trial license online": "ihre Testlizenz online",
-  "YYYY": "JJJJ"
+  "YYYY": "JJJJ",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "Dein Threat Arsenal ist leer",
   "your trial license online": "ihre Testlizenz online",
   "YYYY": "JJJJ",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "Your threat arsenal is empty",
   "your trial license online": "your trial license online",
   "YYYY": "YYYY",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "Your overall evaluation about this question.",
   "Your threat arsenal is empty": "Your threat arsenal is empty",
   "your trial license online": "your trial license online",
-  "YYYY": "YYYY"
+  "YYYY": "YYYY",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "Tu arsenal está vacío",
   "your trial license online": "su licencia de prueba en línea",
   "YYYY": "AAAA",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "Su evaluación general sobre esta pregunta.",
   "Your threat arsenal is empty": "Tu arsenal está vacío",
   "your trial license online": "su licencia de prueba en línea",
-  "YYYY": "AAAA"
+  "YYYY": "AAAA",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3227,5 +3227,6 @@
   "Your threat arsenal is empty": "Votre arsenal est vide",
   "your trial license online": "votre licence d'essai en ligne",
   "YYYY": "AAAA",
-  "Simulation running — waiting for the first inject executions…": "Simulation en cours — en attente des premières exécutions d’injects…"
+  "Simulation running — waiting for the first inject executions…": "Simulation en cours — en attente des premières exécutions d’injects…",
+  "Resize panel": "Redimensionner le panneau"
 }

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3226,5 +3226,6 @@
   "Your overall evaluation about this question.": "Votre évaluation globale de cette question.",
   "Your threat arsenal is empty": "Votre arsenal est vide",
   "your trial license online": "votre licence d'essai en ligne",
-  "YYYY": "AAAA"
+  "YYYY": "AAAA",
+  "Simulation running — waiting for the first inject executions…": "Simulation en cours — en attente des premières exécutions d’injects…"
 }

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "La vostra valutazione complessiva su questa domanda.",
   "Your threat arsenal is empty": "Il tuo arsenale è vuoto",
   "your trial license online": "la vostra licenza di prova online",
-  "YYYY": "AAAA"
+  "YYYY": "AAAA",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "Il tuo arsenale è vuoto",
   "your trial license online": "la vostra licenza di prova online",
   "YYYY": "AAAA",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "兵器庫は空です",
   "your trial license online": "オンライン試用ライセンス",
   "YYYY": "年",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "この質問に対するあなたの総合評価",
   "Your threat arsenal is empty": "兵器庫は空です",
   "your trial license online": "オンライン試用ライセンス",
-  "YYYY": "年"
+  "YYYY": "年",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "무기고가 비어 있습니다",
   "your trial license online": "온라인 평가판 라이선스",
   "YYYY": "YYYY",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "이 질문에 대한 전반적인 평가입니다.",
   "Your threat arsenal is empty": "무기고가 비어 있습니다",
   "your trial license online": "온라인 평가판 라이선스",
-  "YYYY": "YYYY"
+  "YYYY": "YYYY",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "Ваша общая оценка этого вопроса.",
   "Your threat arsenal is empty": "Ваш арсенал пуст",
   "your trial license online": "ваша пробная лицензия онлайн",
-  "YYYY": "ГГГГ"
+  "YYYY": "ГГГГ",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "Ваш арсенал пуст",
   "your trial license online": "ваша пробная лицензия онлайн",
   "YYYY": "ГГГГ",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3215,5 +3215,6 @@
   "Your overall evaluation about this question.": "您对此问题的总体评价。",
   "Your threat arsenal is empty": "您的武器库为空",
   "your trial license online": "在线试用许可证",
-  "YYYY": "YYYY"
+  "YYYY": "YYYY",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
 }

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3216,5 +3216,6 @@
   "Your threat arsenal is empty": "您的武器库为空",
   "your trial license online": "在线试用许可证",
   "YYYY": "YYYY",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…"
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
+  "Resize panel": "Resize panel"
 }


### PR DESCRIPTION
## Summary

Frontend improvements to the Attack Path view (all behind the `ATTACK_PATH` flag). Supersedes #6911 (which held the first two items — that PR can be closed).

- **Chained-only exposure**: the tab/route are gated to chained scenarios (`INJECT_CHAINING` + `scenario_workflow_id`), mirroring the simulation gating. Time-based scenarios no longer show it.
- **Unified master-detail drawer**: clicking an execution replaces the endpoint/finding panel in a single, wider drawer with a back arrow (no more double drawer); close dismisses the whole thing.
- **"Action details" target**: opens the inject on its **simulation** (not the scenario → 404); a payload-backed inject lands on Overview, a network injector on Execution details.
- **Live refresh**: the graph polls every 10s while mounted and updates in place (no spinner / selection reset / churn) so a running run populates on its own.
- **Endpoint dedup in chain mode**: several independent injectors at the same depth hitting the same asset now converge on one shared endpoint node (cross-depth causal chains are preserved).
- **Injector terminal view**: a network injector (no payload) shows its global execution traces (the "<tool> succeeded: …" output) instead of an empty per-target terminal; the tab is labelled "Execution details" vs "Terminal view" accordingly. Dropped the noisy `payload › <uuid>` crumb.

Tests: extended `attack-path-flow-helpers.test.ts` (endpoint dedup + updated depth-keyed ids) and kept the component test green.

Related issue: #6647