### PR TITLE
feat(catalog): display catalog connector version in integration detail page (#6938)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/catalog_connector/dto/CatalogConnectorOutput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/catalog_connector/dto/CatalogConnectorOutput.java
@@ -2,6 +2,7 @@ package io.openaev.rest.catalog_connector.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.database.model.ConnectorType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
@@ -51,6 +52,10 @@ public class CatalogConnectorOutput {
   @JsonProperty("catalog_connector_type")
   @NotNull
   private ConnectorType containerType;
+
+  @JsonProperty("catalog_connector_container_version")
+  @Schema(description = "Connector container version referenced in the catalog")
+  private String containerVersion;
 
   @JsonProperty("catalog_connector_last_verified_date")
   private Instant lastVerifiedDate;

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/CatalogConnectorMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/CatalogConnectorMapper.java
@@ -31,6 +31,7 @@ public class CatalogConnectorMapper {
         .useCases(catalogConnector.getUseCases())
         .isManagerSupported(catalogConnector.isManagerSupported())
         .instanceDeployedCount(instanceDeployedCount)
+        .containerVersion(catalogConnector.getContainerVersion())
         .build();
   }
 

--- a/openaev-front/src/admin/components/integrations/common/ConnectorCatalogInfo.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorCatalogInfo.tsx
@@ -1,5 +1,5 @@
-import { LibraryBooksOutlined, OpenInNewOutlined, VerifiedOutlined } from '@mui/icons-material';
-import { Box, Paper, Typography } from '@mui/material';
+import { InfoOutlined, LibraryBooksOutlined, OpenInNewOutlined, VerifiedOutlined } from '@mui/icons-material';
+import { Box, Paper, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { type ComponentType, type ReactNode } from 'react';
 
@@ -19,11 +19,12 @@ const SECTION_LABEL_SX = {
 };
 
 // A resource row: framed icon + title + caption, optionally acting as a link.
-const ResourceRow = ({ icon: Icon, title, caption, href }: {
+const ResourceRow = ({ icon: Icon, title, caption, href, endAdornment }: {
   icon: ComponentType<{ sx?: object }>;
   title: ReactNode;
   caption?: ReactNode;
   href?: string;
+  endAdornment?: ReactNode;
 }) => {
   const theme = useTheme();
   const content = (
@@ -50,22 +51,31 @@ const ResourceRow = ({ icon: Icon, title, caption, href }: {
         minWidth: 0,
         display: 'flex',
         flexDirection: 'column',
+        flex: 1,
       }}
       >
-        <Typography sx={{
-          fontSize: 13,
-          fontWeight: 600,
-          lineHeight: 1.4,
+        <Box sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
         }}
         >
-          {title}
-        </Typography>
+          <Typography sx={{
+            fontSize: theme.typography.h3.fontSize,
+            fontWeight: 600,
+            lineHeight: 1.4,
+          }}
+          >
+            {title}
+          </Typography>
+          {endAdornment}
+        </Box>
         {caption && (
           <Typography
             variant="body2"
             sx={{
               color: 'text.secondary',
-              fontSize: 12,
+              fontSize: theme.typography.h4.fontSize,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
             }}
@@ -167,6 +177,26 @@ const ConnectorCatalogInfo = ({ catalogConnector }: Props) => {
             gap: 2.5,
           }}
         >
+          {catalogConnector.catalog_connector_container_version && (
+            <ResourceRow
+              icon={VerifiedOutlined}
+              title={t('Catalog version')}
+              caption={catalogConnector.catalog_connector_container_version}
+              endAdornment={(
+                <Tooltip title={t('Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.')}>
+                  {/* tabIndex makes the icon keyboard-focusable; the Tooltip
+                      title doubles as its accessible name (MUI default). */}
+                  <InfoOutlined
+                    tabIndex={0}
+                    sx={{
+                      fontSize: theme.typography.h6.fontSize,
+                      color: 'text.secondary',
+                    }}
+                  />
+                </Tooltip>
+              )}
+            />
+          )}
           {catalogConnector.catalog_connector_source_code && (
             <ResourceRow
               icon={LibraryBooksOutlined}

--- a/openaev-front/src/admin/components/integrations/common/ConnectorCatalogInfo.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorCatalogInfo.tsx
@@ -78,6 +78,7 @@ const ResourceRow = ({ icon: Icon, title, caption, href, endAdornment }: {
               fontSize: theme.typography.h4.fontSize,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
           >
             {caption}

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1539,6 +1539,8 @@ export interface CatalogConnectorConfiguration {
 }
 
 export interface CatalogConnectorOutput {
+  /** Connector container version referenced in the catalog */
+  catalog_connector_container_version?: string;
   catalog_connector_description?: string;
   /** @minLength 1 */
   catalog_connector_id: string;

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "Groß-/Kleinschreibung wird nicht berücksichtigt",
   "Case-sensitive": "Groß-/Kleinschreibung wird berücksichtigt",
   "Catalog": "Katalog",
+  "Catalog version": "Katalogversion",
   "Categories": "Kategorien",
   "Categories and questions": "Kategorien und Fragen",
   "Category": "Kategorie",
@@ -2370,6 +2371,7 @@
   "Reset filters": "Filter zurücksetzen",
   "Reset to default values": "Auf Standardwerte zurücksetzen",
   "Resilience": "Resilienz",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "Grenze der Simulationsrate",
   "Simulation results": "Ergebnisse der Simulation",
   "Simulation results statistics": "Statistik der Simulationsergebnisse",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "Zeitüberschreitung der Simulation",
   "simulation-plural": "simulationen",
   "simulation-singular": "simulation",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "Geprüft",
   "Verified and tested by OpenAEV": "Verifiziert und getestet von OpenAEV",
   "Version": "Version",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "Im Integrationskatalog referenzierte Version. Die laufende Instanz kann eine andere Version verwenden, wenn sie manuell überschrieben wurde.",
   "Very_high": "Very High",
   "View": "Ansicht",
   "view custom variables": "benutzerdefinierte Variablen anzeigen",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "Ihre Gesamteinschätzung zu dieser Frage.",
   "Your threat arsenal is empty": "Dein Threat Arsenal ist leer",
   "your trial license online": "ihre Testlizenz online",
-  "YYYY": "JJJJ",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "JJJJ"
 }

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "Case-insensitive",
   "Case-sensitive": "Case-sensitive",
   "Catalog": "Catalog",
+  "Catalog version": "Catalog version",
   "Categories": "Categories",
   "Categories and questions": "Categories and questions",
   "Category": "Category",
@@ -2370,6 +2371,7 @@
   "Reset filters": "Reset filters",
   "Reset to default values": "Reset to default values",
   "Resilience": "Resilience",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "Simulation rate limit",
   "Simulation results": "Simulation results",
   "Simulation results statistics": "Simulation results statistics",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "Simulation time out",
   "simulation-plural": "simulations",
   "simulation-singular": "simulation",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "Verified",
   "Verified and tested by OpenAEV": "Verified and tested by OpenAEV",
   "Version": "Version",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.",
   "Very_high": "Very High",
   "View": "View",
   "view custom variables": "view custom variables",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "Your overall evaluation about this question.",
   "Your threat arsenal is empty": "Your threat arsenal is empty",
   "your trial license online": "your trial license online",
-  "YYYY": "YYYY",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "YYYY"
 }

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "Sin distinción entre mayúsculas y minúsculas",
   "Case-sensitive": "Con distinción entre mayúsculas y minúsculas",
   "Catalog": "Catálogo",
+  "Catalog version": "Versión del catálogo",
   "Categories": "Categorías",
   "Categories and questions": "Categorías y preguntas",
   "Category": "Categoría",
@@ -2370,6 +2371,7 @@
   "Reset filters": "Restablecer filtros",
   "Reset to default values": "Restablecer valores por defecto",
   "Resilience": "Resiliencia",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "Límite de tasa de simulación",
   "Simulation results": "Resultados de la simulación",
   "Simulation results statistics": "Estadísticas de los resultados de la simulación",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "Tiempo de simulación agotado",
   "simulation-plural": "simulaciones",
   "simulation-singular": "simulación",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "Verificado",
   "Verified and tested by OpenAEV": "Verificado y probado por OpenAEV",
   "Version": "Versión",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "Versión referenciada en el catálogo de integraciones. La instancia en ejecución puede usar una versión diferente si se ha sobrescrito manualmente.",
   "Very_high": "Very High",
   "View": "Vista",
   "view custom variables": "ver variables personalizadas",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "Su evaluación general sobre esta pregunta.",
   "Your threat arsenal is empty": "Tu arsenal está vacío",
   "your trial license online": "su licencia de prueba en línea",
-  "YYYY": "AAAA",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "AAAA"
 }

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -449,6 +449,7 @@
   "Case-insensitive": "Sans distinction de majuscules/minuscules",
   "Case-sensitive": "Avec distinction de majuscules/minuscules",
   "Catalog": "Catalogue",
+  "Catalog version": "Version du catalogue",
   "Categories": "Catégories",
   "Categories and questions": "Catégories et questions",
   "Category": "Catégorie",
@@ -2377,6 +2378,7 @@
   "Reset filters": "Réinitialiser les filtres",
   "Reset to default values": "Réinitialiser les valeurs par défaut",
   "Resilience": "Résilience",
+  "Resize panel": "Redimensionner le panneau",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2605,6 +2607,7 @@
   "Simulation rate limit": "Limite du taux de simulation",
   "Simulation results": "Résultats de la simulation",
   "Simulation results statistics": "Statistiques des résultats de la simulation",
+  "Simulation running — waiting for the first inject executions…": "Simulation en cours — en attente des premières exécutions d’injects…",
   "Simulation time out": "Temps d'attente de la simulation",
   "simulation-plural": "simulations",
   "simulation-singular": "simulation",
@@ -3102,6 +3105,7 @@
   "VERIFIED": "Verified",
   "Verified and tested by OpenAEV": "Vérifié et testé par OpenAEV",
   "Version": "Version",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "Version référencée dans le catalogue d'intégrations. L'instance en cours d'exécution peut utiliser une version différente si elle a été remplacée manuellement.",
   "Very high": "Très élevé",
   "Very_high": "Very High",
   "View": "Voir",
@@ -3226,7 +3230,5 @@
   "Your overall evaluation about this question.": "Votre évaluation globale de cette question.",
   "Your threat arsenal is empty": "Votre arsenal est vide",
   "your trial license online": "votre licence d'essai en ligne",
-  "YYYY": "AAAA",
-  "Simulation running — waiting for the first inject executions…": "Simulation en cours — en attente des premières exécutions d’injects…",
-  "Resize panel": "Redimensionner le panneau"
+  "YYYY": "AAAA"
 }

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "Senza distinzione tra maiuscole e minuscole",
   "Case-sensitive": "Con distinzione tra maiuscole e minuscole",
   "Catalog": "Catalogo",
+  "Catalog version": "Versione del catalogo",
   "Categories": "Categorie",
   "Categories and questions": "Categorie e domande",
   "Category": "Categoria",
@@ -2370,6 +2371,7 @@
   "Reset filters": "Reimposta filtri",
   "Reset to default values": "Ripristina i valori predefiniti",
   "Resilience": "Resilienza",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "Limite del tasso di simulazione",
   "Simulation results": "Risultati della simulazione",
   "Simulation results statistics": "Statistiche dei risultati della simulazione",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "Time out della simulazione",
   "simulation-plural": "simulazioni",
   "simulation-singular": "simulazione",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "Verificato",
   "Verified and tested by OpenAEV": "Verificato e testato da OpenAEV",
   "Version": "Versione",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "Versione indicata nel catalogo delle integrazioni. L'istanza in esecuzione può utilizzare una versione diversa se è stata sostituita manualmente.",
   "Very_high": "Very High",
   "View": "Vista",
   "view custom variables": "visualizza le variabili personalizzate",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "La vostra valutazione complessiva su questa domanda.",
   "Your threat arsenal is empty": "Il tuo arsenale è vuoto",
   "your trial license online": "la vostra licenza di prova online",
-  "YYYY": "AAAA",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "AAAA"
 }

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "大文字小文字を区別しない",
   "Case-sensitive": "大文字小文字を区別する",
   "Catalog": "カタログ",
+  "Catalog version": "カタログバージョン",
   "Categories": "カテゴリ",
   "Categories and questions": "カテゴリーと質問",
   "Category": "カテゴリー",
@@ -2370,6 +2371,7 @@
   "Reset filters": "フィルターをリセット",
   "Reset to default values": "初期値に戻す",
   "Resilience": "レジリエンス",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "シミュレーション速度制限",
   "Simulation results": "シミュレーション結果",
   "Simulation results statistics": "シミュレーション結果統計",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "シミュレーションタイムアウト",
   "simulation-plural": "シミュレーション",
   "simulation-singular": "シミュレーション",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "検証済み",
   "Verified and tested by OpenAEV": "OpenAEVで検証・テスト済み",
   "Version": "バージョン",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "統合カタログで参照されているバージョンです。手動で上書きされた場合、実行中のインスタンスは異なるバージョンを使用している可能性があります。",
   "Very_high": "Very High",
   "View": "表示",
   "view custom variables": "カスタム変数を表示",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "この質問に対するあなたの総合評価",
   "Your threat arsenal is empty": "兵器庫は空です",
   "your trial license online": "オンライン試用ライセンス",
-  "YYYY": "年",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "年"
 }

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "대소문자 구분 없음",
   "Case-sensitive": "대소문자 구분 있음",
   "Catalog": "카탈로그",
+  "Catalog version": "카탈로그 버전",
   "Categories": "카테고리",
   "Categories and questions": "카테고리 및 질문",
   "Category": "카테고리",
@@ -2370,6 +2371,7 @@
   "Reset filters": "필터 초기화",
   "Reset to default values": "기본값으로 재설정",
   "Resilience": "회복력",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "시뮬레이션 속도 제한",
   "Simulation results": "시뮬레이션 결과",
   "Simulation results statistics": "시뮬레이션 결과 통계",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "시뮬레이션 시간 초과",
   "simulation-plural": "시뮬레이션",
   "simulation-singular": "시뮬레이션",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "확인 완료",
   "Verified and tested by OpenAEV": "OpenAEV에서 검증 및 테스트 완료",
   "Version": "버전",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "통합 카탈로그에서 참조되는 버전입니다. 수동으로 재정의된 경우 실행 중인 인스턴스는 다른 버전을 사용할 수 있습니다.",
   "Very_high": "Very High",
   "View": "보기",
   "view custom variables": "사용자 지정 변수 보기",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "이 질문에 대한 전반적인 평가입니다.",
   "Your threat arsenal is empty": "무기고가 비어 있습니다",
   "your trial license online": "온라인 평가판 라이선스",
-  "YYYY": "YYYY",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "YYYY"
 }

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "Без учета регистра",
   "Case-sensitive": "С учетом регистра",
   "Catalog": "Каталог",
+  "Catalog version": "Версия каталога",
   "Categories": "Категории",
   "Categories and questions": "Категории и вопросы",
   "Category": "Категория",
@@ -2370,6 +2371,7 @@
   "Reset filters": "Сбросить фильтры",
   "Reset to default values": "Сбросить значения по умолчанию",
   "Resilience": "Устойчивость",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "Предел скорости симуляции",
   "Simulation results": "Результаты моделирования",
   "Simulation results statistics": "Статистика результатов моделирования",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "Время отключения симуляции",
   "simulation-plural": "симуляции",
   "simulation-singular": "симуляция",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "Проверено",
   "Verified and tested by OpenAEV": "Проверено и протестировано OpenAEV",
   "Version": "Версия",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "Версия, указанная в каталоге интеграций. Запущенный экземпляр может использовать другую версию, если она была переопределена вручную.",
   "Very_high": "Very High",
   "View": "Вид",
   "view custom variables": "просмотр пользовательских переменных",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "Ваша общая оценка этого вопроса.",
   "Your threat arsenal is empty": "Ваш арсенал пуст",
   "your trial license online": "ваша пробная лицензия онлайн",
-  "YYYY": "ГГГГ",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "ГГГГ"
 }

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -448,6 +448,7 @@
   "Case-insensitive": "不区分大小写",
   "Case-sensitive": "区分大小写",
   "Catalog": "目录",
+  "Catalog version": "目录版本",
   "Categories": "类别",
   "Categories and questions": "分类和问题",
   "Category": "分类",
@@ -2370,6 +2371,7 @@
   "Reset filters": "重置筛选器",
   "Reset to default values": "恢复默认值",
   "Resilience": "韧性",
+  "Resize panel": "Resize panel",
   "Resolve": "Resolve",
   "Resolve IP from hostname": "Resolve IP from hostname",
   "Resource ID / ARN": "Resource ID / ARN",
@@ -2597,6 +2599,7 @@
   "Simulation rate limit": "模拟速率限制",
   "Simulation results": "模拟结果",
   "Simulation results statistics": "模拟结果统计",
+  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
   "Simulation time out": "模拟超时",
   "simulation-plural": "模拟",
   "simulation-singular": "模拟",
@@ -3092,6 +3095,7 @@
   "VERIFIED": "已验证",
   "Verified and tested by OpenAEV": "由 OpenAEV 验证和测试",
   "Version": "版本",
+  "Version referenced in the integration catalog. The running instance may use a different version if it was manually overridden.": "集成目录中引用的版本。如果被手动覆盖，正在运行的实例可能使用不同的版本。",
   "Very_high": "Very High",
   "View": "视图",
   "view custom variables": "查看自定义变量",
@@ -3215,7 +3219,5 @@
   "Your overall evaluation about this question.": "您对此问题的总体评价。",
   "Your threat arsenal is empty": "您的武器库为空",
   "your trial license online": "在线试用许可证",
-  "YYYY": "YYYY",
-  "Simulation running — waiting for the first inject executions…": "Simulation running — waiting for the first inject executions…",
-  "Resize panel": "Resize panel"
+  "YYYY": "YYYY"
 }


### PR DESCRIPTION
## Summary

Closes #6938

Displays the container version referenced by the integration catalog on the integration detail page, so users can tell which version the catalog currently points to (as opposed to the version the running instance may actually use).

- Backend: expose `catalog_connector_container_version` in `CatalogConnectorOutput` (with an OpenAPI `@Schema` description) and map it from the `CatalogConnector` entity in `CatalogConnectorMapper`.
- Frontend: new "Catalog version" row in the Basic Information panel of `ConnectorCatalogInfo`, with an info tooltip clarifying that the running instance may use a different version if it was manually overridden. The tooltip icon is keyboard-focusable (`tabIndex`) and the tooltip title doubles as its accessible name. Row captions now truncate on a single line (`whiteSpace: nowrap` completing the existing `overflow: hidden` + `textOverflow: ellipsis` pair), so long versions/URLs render with an ellipsis instead of wrapping.
- Generated types: `api-types.d.ts` regenerated for the new DTO field.
- i18n: the two new UI strings added to all 9 supported language files.

## Notes for reviewers

- Font sizes in the new row deliberately reference theme typography tokens (`theme.typography.h3/h4/h6.fontSize`) instead of `variant` props: the heading variants in this theme also apply Geologica, lowercase text-transform, and margins, which would break the row layout. Borrowing only the size token keeps the visual design while removing hardcoded values.
- The branch was squashed into a single signed commit (the repository enforces signed commits and the original commits were unsigned); original authorship is preserved via `Co-authored-by` trailers.

## Test plan

- `yarn check-ts`, `yarn lint` (changed file), and `yarn i18n-checker` pass locally.
- `mvn spotless:check` passes on `openaev-api`.
- CI quality gates (API types check, frontend quality, API tests, E2E) on this PR.
