### PR TITLE
fix(expectations): serialize signatures on collector polling endpoints (#6948)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/expectations/mapper/InjectExpectationMapper.java
+++ b/openaev-api/src/main/java/io/openaev/api/expectations/mapper/InjectExpectationMapper.java
@@ -24,8 +24,12 @@ public final class InjectExpectationMapper {
         expectation.getResponse(),
         expectation.getCreatedAt(),
         expectation.getUpdatedAt(),
-        expectation.getSignatures(),
-        expectation.getResults(),
+        // Signatures are a LAZY collection since they moved to a dedicated table: copy it while
+        // the session is still open, otherwise Hibernate6Module serializes the uninitialized
+        // PersistentBag as null and collectors can never match any expectation.
+        List.copyOf(expectation.getSignatures()),
+        // The results JSONB column can be SQL NULL on legacy rows: normalize to an empty list.
+        expectation.getResults() != null ? expectation.getResults() : List.of(),
         expectation.getTraces(),
         expectation.getExercise() != null ? expectation.getExercise().getId() : null,
         expectation.getInject() != null ? expectation.getInject().getId() : null,

--- a/openaev-api/src/test/java/io/openaev/rest/ExpectationApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ExpectationApiTest.java
@@ -448,6 +448,78 @@ class ExpectationApiTest extends IntegrationTest {
     }
 
     /**
+     * Regression test: signatures live in a dedicated table behind a LAZY collection since #5151.
+     * The collector polling endpoint must serialize them as a real array, not null, otherwise
+     * collectors (Defender, Sentinel, Tanium...) can never match any expectation.
+     */
+    @Test
+    @DisplayName("Serialize signatures for collector polling endpoint")
+    void getInjectExpectationsForSourceReturnsSignatures() throws Exception {
+      // -- PREPARE --
+      ExecutableInject executableInject = newExecutableInjectWithTargets(false);
+      List<Expectation> detectionExpectations =
+          createDetectionExpectations(
+              List.of(savedAgent1),
+              savedEndpoint,
+              savedAssetGroup,
+              DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME);
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject, detectionExpectations);
+      em.flush();
+      em.clear();
+
+      // Attach a signature to the agent expectation, as SignatureOutputProcessor does after the
+      // implant reports its execution traces.
+      BaseInjectExpectation agentExpectation =
+          injectExpectationRepository
+              .findAllByInjectAndAgent(savedInject.getId(), savedAgent1.getId())
+              .getFirst();
+      agentExpectation
+          .getSignatures()
+          .add(
+              new InjectExpectationSignature(
+                  agentExpectation, "process_name", "obfuscated.exe", java.time.Instant.now()));
+      injectExpectationRepository.save(agentExpectation);
+      // Detach everything so the endpoint reloads entities with an UNINITIALIZED lazy signatures
+      // collection, exactly like a real collector poll on a fresh session.
+      em.flush();
+      em.clear();
+
+      // -- EXECUTE --
+      String response =
+          mvc.perform(
+                  get(INJECTS_EXPECTATIONS_URI + "/assets/" + savedCollector.getId())
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -- ASSERT: the agent expectation carries its signatures, and no expectation in the
+      // payload has null signatures or null results --
+      List<Map<String, Object>> expectations = JsonPath.read(response, "$");
+      assertTrue(expectations.size() >= 1);
+      for (Map<String, Object> expectation : expectations) {
+        Assertions.assertNotNull(
+            expectation.get("inject_expectation_signatures"),
+            "inject_expectation_signatures must never be serialized as null");
+        Assertions.assertNotNull(
+            expectation.get("inject_expectation_results"),
+            "inject_expectation_results must never be serialized as null");
+      }
+      List<Map<String, String>> signatures =
+          JsonPath.read(
+              response,
+              "$.[?(@.inject_expectation_agent == '"
+                  + savedAgent1.getId()
+                  + "')].inject_expectation_signatures[*]");
+      assertEquals(1, signatures.size());
+      assertEquals("process_name", signatures.getFirst().get("type"));
+      assertEquals("obfuscated.exe", signatures.getFirst().get("value"));
+    }
+
+    /**
      * Lists PREVENTION expectations for a source, then fills one expectation (agent2) so that the
      * second query returns only remaining unfilled (agent1).
      */

--- a/openaev-model/src/main/java/io/openaev/database/model/BaseInjectExpectation.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/BaseInjectExpectation.java
@@ -21,9 +21,8 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
@@ -142,7 +141,11 @@ public class BaseInjectExpectation implements Base, Cloneable {
       cascade = CascadeType.ALL,
       orphanRemoval = true,
       fetch = FetchType.LAZY)
-  @Fetch(FetchMode.SUBSELECT)
+  // Batch fetching instead of @Fetch(SUBSELECT): the collector polling endpoints load up to 10k
+  // expectations with a NATIVE query (subselect fetching does not apply to those owners) and then
+  // initialize this collection for serialization. Batching keeps that to one IN-clause query per
+  // 1000 expectations instead of one query per expectation.
+  @BatchSize(size = 1000)
   @JsonProperty("inject_expectation_signatures")
   private List<InjectExpectationSignature> signatures = new ArrayList<>();
 


### PR DESCRIPTION
## Summary

- Fixes #6948: since the signatures refactor (#5151), the collector polling endpoints (`GET /api/injects/expectations/assets/{sourceId}` and siblings) serialized `inject_expectation_signatures` as `null` for every expectation, because the LAZY signatures collection was never initialized before Jackson's `Hibernate6Module` serialized the DTO. The Defender collector crashed on it (OpenAEV-Platform/collectors#537) and every other collector silently matched nothing.
- `InjectExpectationMapper.toOutput()` now copies the signatures collection while the Hibernate session is still open (all call sites are `@Transactional`), and normalizes SQL-NULL `inject_expectation_results` to an empty list.
- `BaseInjectExpectation.signatures` now uses `@BatchSize(size = 1000)` instead of `@Fetch(SUBSELECT)`: subselect fetching does not apply to owners loaded via the native polling queries, so initialization would otherwise cost one query per expectation (the polling endpoints fetch up to 10,000 rows).

## Test plan

- [x] New regression test `ExpectationApiTest#getInjectExpectationsForSourceReturnsSignatures`: persists a detection expectation with a signature, clears the persistence context, calls the collector polling endpoint, and asserts signatures and results are serialized as real arrays. Verified it FAILS without the fix (`inject_expectation_signatures` is null) and passes with it.
- [x] `mvn spotless:apply` clean.

Related: collector-side hardening in OpenAEV-Platform/collectors#538 (guards against null/empty signatures, which remain legitimately possible while async signature initialization is pending).
