### PR TITLE
feat(attackpath): expose per-finding verdicts on the read side (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathFindingVerdicts.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathFindingVerdicts.java
@@ -4,9 +4,9 @@ import io.openaev.expectation.ExpectationType;
 import java.util.Collection;
 
 /**
- * The verdict semantics of a finding, in one place. A finding's verdict for each
- * bucket (prevention, detection, vulnerability) is derived from the status of its producing
- * execution rows.
+ * The verdict semantics of a finding, in one place. A finding's verdict for each bucket
+ * (prevention, detection, vulnerability) is derived from the status of its producing execution
+ * rows.
  *
  * <p>Mapping is done against the {@link ExpectationType} labels of the SAME bucket
  * (case-insensitive), not a global string list: the definitive failure labels ({@code Not

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathFindingVerdicts.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathFindingVerdicts.java
@@ -1,0 +1,111 @@
+package io.openaev.service.attackpath;
+
+import io.openaev.expectation.ExpectationType;
+import java.util.Collection;
+
+/**
+ * The verdict semantics of a finding, in one place. A finding's verdict for each
+ * bucket (prevention, detection, vulnerability) is derived from the status of its producing
+ * execution rows.
+ *
+ * <p>Mapping is done against the {@link ExpectationType} labels of the SAME bucket
+ * (case-insensitive), not a global string list: the definitive failure labels ({@code Not
+ * Prevented} / {@code Not Detected} / {@code Vulnerable}) must map to {@code failed}, or a
+ * confirmed-exploitable finding would render as {@code unknown}. The status vocabulary is open
+ * (collectors post raw strings), so anything unrecognized maps to {@code unknown} as a fail-safe.
+ *
+ * <p>Aggregation across several producers is worst-of: a finding is never greener than its
+ * producers. The {@code prevented => detected} rule is applied per execution, before aggregation.
+ */
+public final class AttackPathFindingVerdicts {
+
+  /**
+   * Legacy result string of the expectations expiration manager, duplicated here as a literal to
+   * avoid coupling the verdict mapper to the collector package. Keep in sync with {@code
+   * ExpectationsExpirationManagerService.EXPIRED}.
+   */
+  private static final String EXPIRED = "Expired";
+
+  /** A finding's verdict for one bucket, in the front's vocabulary. */
+  public enum Verdict {
+    SUCCESS("success", 0),
+    UNKNOWN("unknown", 1),
+    FAILED("failed", 2);
+
+    public final String label;
+    private final int rank;
+
+    Verdict(String label, int rank) {
+      this.label = label;
+      this.rank = rank;
+    }
+  }
+
+  /** The three per-finding verdicts. */
+  public record Verdicts(Verdict prevention, Verdict detection, Verdict vulnerability) {
+    public static final Verdicts UNKNOWN =
+        new Verdicts(Verdict.UNKNOWN, Verdict.UNKNOWN, Verdict.UNKNOWN);
+  }
+
+  private AttackPathFindingVerdicts() {}
+
+  /**
+   * The verdicts of a single producing execution, from its three status strings. Applies {@code
+   * prevented => detected} (a prevented execution is at least detected, overriding an explicit
+   * failed).
+   */
+  public static Verdicts ofExecution(
+      String preventionStatus, String detectionStatus, String vulnerabilityStatus) {
+    Verdict prevention = map(ExpectationType.PREVENTION, preventionStatus);
+    Verdict detection = map(ExpectationType.DETECTION, detectionStatus);
+    Verdict vulnerability = map(ExpectationType.VULNERABILITY, vulnerabilityStatus);
+    if (prevention == Verdict.SUCCESS) {
+      detection = Verdict.SUCCESS; // prevented => detected
+    }
+    return new Verdicts(prevention, detection, vulnerability);
+  }
+
+  /** Worst-of over a finding's producers, per bucket. Empty producers = all unknown. */
+  public static Verdicts aggregate(Collection<Verdicts> producers) {
+    Verdict prevention = Verdict.SUCCESS;
+    Verdict detection = Verdict.SUCCESS;
+    Verdict vulnerability = Verdict.SUCCESS;
+    if (producers.isEmpty()) {
+      return Verdicts.UNKNOWN;
+    }
+    for (Verdicts p : producers) {
+      prevention = worst(prevention, p.prevention());
+      detection = worst(detection, p.detection());
+      vulnerability = worst(vulnerability, p.vulnerability());
+    }
+    return new Verdicts(prevention, detection, vulnerability);
+  }
+
+  private static Verdict worst(Verdict a, Verdict b) {
+    return a.rank >= b.rank ? a : b;
+  }
+
+  private static Verdict map(ExpectationType type, String raw) {
+    if (raw == null) {
+      return Verdict.UNKNOWN;
+    }
+    String value = raw.trim();
+    if (eq(value, type.successLabel)
+        || eq(value, ExpectationType.HUMAN_RESPONSE.successLabel) // "Successful"
+        || eq(value, ExpectationType.SUCCESS_ID)) { // legacy "SUCCESS"
+      return Verdict.SUCCESS;
+    }
+    if (eq(value, type.failureLabel)
+        || eq(value, type.partialLabel)
+        || eq(value, ExpectationType.HUMAN_RESPONSE.partialLabel) // "Partial"
+        || eq(value, ExpectationType.FAILED_ID) // legacy "FAILED" / "Failed" (case-insensitive)
+        || eq(value, EXPIRED)) {
+      return Verdict.FAILED;
+    }
+    return Verdict.UNKNOWN; // pendingLabel, null already handled, and any unrecognized string
+  }
+
+  private static boolean eq(String a, String b) {
+    return a.equalsIgnoreCase(b);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -3,6 +3,7 @@ package io.openaev.service.attackpath;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.projection.AttackPathEdgeGroupRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingRow;
+import io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingVerdictRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointGroupRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointTypeCountRow;
 import io.openaev.database.model.attackpath.projection.AttackPathExecutionRow;
@@ -32,6 +33,7 @@ import io.openaev.service.attackpath.dto.AttackPathExecutionFindingItemDTO;
 import io.openaev.service.attackpath.dto.AttackPathExpandDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingItemDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
+import io.openaev.service.attackpath.dto.AttackPathFindingVerdictsDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
 import io.openaev.utils.mapper.PayloadMapper;
 import java.time.Instant;
@@ -164,7 +166,7 @@ public class AttackPathGraphService {
     Page<AttackPathFindingListRow> page =
         findingRepository.findPageByTypes(simulationId, types, pageable);
     List<AttackPathFindingListRow> rows = page.getContent();
-    Map<String, List<String>> executionIdsByFinding = executionIdsByFinding(rows);
+    FindingLinkData links = findingLinks(rows);
     boolean maskValue = CATEGORY_CREDENTIALS.equalsIgnoreCase(category);
     List<AttackPathFindingItemDTO> items =
         rows.stream()
@@ -175,7 +177,8 @@ public class AttackPathGraphService {
                         maskValue ? maskCredential(r.value()) : r.value(),
                         r.endpointKey(),
                         AttackPathIds.endpointNode(r.endpointKey()),
-                        executionIdsByFinding.getOrDefault(r.id(), List.of())))
+                        links.executionIds().getOrDefault(r.id(), List.of()),
+                        links.verdicts().get(r.id())))
             .toList();
     return new AttackPathFindingPageDTO(items, page.getTotalElements());
   }
@@ -194,19 +197,25 @@ public class AttackPathGraphService {
     if (e == null) {
       return null;
     }
-    // Result tab: the findings this execution produced (credential values masked).
+    // Result tab: the findings this execution produced (credential values masked). Each carries
+    // this
+    // execution's own verdict triple (single producer, so no cross-execution aggregation here).
+    AttackPathFindingVerdictsDTO executionVerdicts =
+        toVerdictsDto(
+            AttackPathFindingVerdicts.ofExecution(
+                e.getPreventionStatus(), e.getDetectionStatus(), e.getVulnerabilityStatus()));
     List<AttackPathExecutionFindingItemDTO> findings = new ArrayList<>();
     for (AttackPathEndpointFindingRow f : findingRepository.findByExecutionId(executionId)) {
       boolean credential = CATEGORY_CREDENTIALS.equals(f.type());
       findings.add(
           new AttackPathExecutionFindingItemDTO(
-              f.type(), credential ? maskCredential(f.value()) : f.value()));
+              f.type(), credential ? maskCredential(f.value()) : f.value(), executionVerdicts));
     }
     // Mask, in the free-text command and output, the secrets of every credential discovered on this
     // endpoint: an execution's command references its endpoint's credentials, not only the ones it
     // links to, so endpoint-scoped masking never leaves a known secret in the clear.
     Set<String> secrets = new HashSet<>();
-    for (AttackPathEndpointFindingRow f :
+    for (AttackPathEndpointFindingVerdictRow f :
         findingRepository.findByEndpoint(simulationId, e.getTargetKey())) {
       if (CATEGORY_CREDENTIALS.equals(f.type())) {
         String secret = credentialSecret(f.value());
@@ -267,6 +276,7 @@ public class AttackPathGraphService {
         e.getTargetPlatform(),
         e.getPreventionStatus(),
         e.getDetectionStatus(),
+        e.getVulnerabilityStatus(),
         e.getExecutedAt() == null ? null : e.getExecutedAt().toString(),
         findings,
         securityPlatformResolver.resolve(injectId, e.getAgentId(), e.getTargetAssetId()),
@@ -302,17 +312,32 @@ public class AttackPathGraphService {
    * The producing-execution ids per finding for a page of rows, from a single link read. The
    * finding ids come from a tenant-scoped page, so the read is already bounded to the tenant.
    */
-  private Map<String, List<String>> executionIdsByFinding(List<AttackPathFindingListRow> rows) {
+  private FindingLinkData findingLinks(List<AttackPathFindingListRow> rows) {
     if (rows.isEmpty()) {
-      return Map.of();
+      return new FindingLinkData(Map.of(), Map.of());
     }
     List<String> findingIds = rows.stream().map(AttackPathFindingListRow::id).toList();
-    Map<String, List<String>> byFinding = new LinkedHashMap<>();
+    Map<String, List<String>> executionIds = new LinkedHashMap<>();
+    Map<String, List<AttackPathFindingVerdicts.Verdicts>> producers = new LinkedHashMap<>();
     for (AttackPathFindingExecutionRow link : findingRepository.findExecutionLinks(findingIds)) {
-      byFinding.computeIfAbsent(link.findingId(), k -> new ArrayList<>()).add(link.executionId());
+      executionIds
+          .computeIfAbsent(link.findingId(), k -> new ArrayList<>())
+          .add(link.executionId());
+      producers
+          .computeIfAbsent(link.findingId(), k -> new ArrayList<>())
+          .add(
+              AttackPathFindingVerdicts.ofExecution(
+                  link.preventionStatus(), link.detectionStatus(), link.vulnerabilityStatus()));
     }
-    return byFinding;
+    Map<String, AttackPathFindingVerdictsDTO> verdicts = new LinkedHashMap<>();
+    producers.forEach(
+        (id, list) -> verdicts.put(id, toVerdictsDto(AttackPathFindingVerdicts.aggregate(list))));
+    return new FindingLinkData(executionIds, verdicts);
   }
+
+  /** The producing-execution ids and the worst-of verdict, per finding row of a drawer page. */
+  private record FindingLinkData(
+      Map<String, List<String>> executionIds, Map<String, AttackPathFindingVerdictsDTO> verdicts) {}
 
   /**
    * The finding types each product widget aggregates (spec 5048 section 2:
@@ -367,18 +392,29 @@ public class AttackPathGraphService {
    */
   @Transactional(readOnly = true)
   public AttackPathExpandDTO expandEndpoint(String simulationId, String endpointKey) {
-    List<AttackPathEndpointFindingRow> findings =
+    List<AttackPathEndpointFindingVerdictRow> findings =
         findingRepository.findByEndpoint(simulationId, endpointKey);
     String assetNodeId = AttackPathIds.endpointNode(endpointKey);
     Map<String, AttackPathNodeDTO> typeNodes = new LinkedHashMap<>();
     Map<String, AttackPathNodeDTO> findingNodes = new LinkedHashMap<>();
-    for (AttackPathEndpointFindingRow f : findings) {
+    Map<String, List<AttackPathFindingVerdicts.Verdicts>> producersByFinding = new HashMap<>();
+    for (AttackPathEndpointFindingVerdictRow f : findings) {
       String typeNodeId = AttackPathIds.findingTypeNode(f.type(), endpointKey);
       typeNodes.computeIfAbsent(typeNodeId, id -> findingTypeNode(id, f.type(), assetNodeId));
       String findingNodeId = AttackPathIds.findingNode(f.type(), f.value());
       findingNodes.computeIfAbsent(
           findingNodeId, id -> findingNode(id, f.type(), f.value(), typeNodeId, assetNodeId));
+      producersByFinding
+          .computeIfAbsent(findingNodeId, id -> new ArrayList<>())
+          .add(
+              AttackPathFindingVerdicts.ofExecution(
+                  f.preventionStatus(), f.detectionStatus(), f.vulnerabilityStatus()));
     }
+    // Worst-of across every producer of the (type, value) on this endpoint.
+    findingNodes.forEach(
+        (id, node) ->
+            node.setVerdicts(
+                toVerdictsDto(AttackPathFindingVerdicts.aggregate(producersByFinding.get(id)))));
     return new AttackPathExpandDTO(
         new ArrayList<>(typeNodes.values()), new ArrayList<>(findingNodes.values()));
   }
@@ -449,6 +485,11 @@ public class AttackPathGraphService {
     // Single pass over findings: finding-type nodes, finding nodes (deduped by type+value), finding
     // edges, the execution -> finding-node cross-reference, and the counters. No extra query,
     // no second walk of the findings.
+    Map<String, AttackPathExecutionRow> executionById = new HashMap<>();
+    for (AttackPathExecutionRow e : executions) {
+      executionById.putIfAbsent(e.id(), e);
+    }
+    Map<String, List<AttackPathFindingVerdicts.Verdicts>> producersByFindingNode = new HashMap<>();
     List<AttackPathNodeDTO> staticFindings = new ArrayList<>();
     Set<String> seenFindingNodes = new HashSet<>();
     Map<String, List<String>> findingNodeIdsByExecution = new LinkedHashMap<>();
@@ -471,6 +512,18 @@ public class AttackPathGraphService {
               findingNodeId, id -> findingNode(id, f.type(), f.value(), typeNodeId, assetNodeId));
       if (seenFindingNodes.add(findingNodeId)) {
         staticFindings.add(findingNode);
+      }
+
+      // Accumulate each producing execution's verdict for the cross-endpoint worst-of on the node.
+      AttackPathExecutionRow producer = executionById.get(f.executionId());
+      if (producer != null) {
+        producersByFindingNode
+            .computeIfAbsent(findingNodeId, k -> new ArrayList<>())
+            .add(
+                AttackPathFindingVerdicts.ofExecution(
+                    producer.preventionStatus(),
+                    producer.detectionStatus(),
+                    producer.vulnerabilityStatus()));
       }
 
       edges.computeIfAbsent(
@@ -496,6 +549,14 @@ public class AttackPathGraphService {
         }
       }
     }
+
+    // Worst-of verdict on each FINDING node, across all its producing executions (cross-endpoint).
+    staticFindings.forEach(
+        node ->
+            node.setVerdicts(
+                toVerdictsDto(
+                    AttackPathFindingVerdicts.aggregate(
+                        producersByFindingNode.getOrDefault(node.getId(), List.of())))));
 
     // Wire the execution -> findings cross-reference onto the feed nodes.
     findingNodeIdsByExecution.forEach(
@@ -994,6 +1055,11 @@ public class AttackPathGraphService {
     node.setFindingsTypeNodeId(typeNodeId);
     node.setAssetNodeId(assetNodeId);
     return node;
+  }
+
+  private static AttackPathFindingVerdictsDTO toVerdictsDto(AttackPathFindingVerdicts.Verdicts v) {
+    return new AttackPathFindingVerdictsDTO(
+        v.prevention().label, v.detection().label, v.vulnerability().label);
   }
 
   private AttackPathNodeDTO node(String id, String type, String label) {

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -197,9 +197,9 @@ public class AttackPathGraphService {
     if (e == null) {
       return null;
     }
-    // Result tab: the findings this execution produced (credential values masked). Each carries
-    // this
-    // execution's own verdict triple (single producer, so no cross-execution aggregation here).
+    // Result tab: the findings this execution produced (credential values masked). Each finding
+    // carries this execution's own verdict triple (single producer, no cross-execution
+    // aggregation).
     AttackPathFindingVerdictsDTO executionVerdicts =
         toVerdictsDto(
             AttackPathFindingVerdicts.ofExecution(

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -26,6 +26,7 @@ public record AttackPathExecutionDetailDTO(
     String targetPlatform,
     String preventionStatus,
     String detectionStatus,
+    String vulnerabilityStatus,
     String executedAt,
     List<AttackPathExecutionFindingItemDTO> findings,
     // the security platforms that acted (prevention/detection), resolved live from the inject's

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionFindingItemDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionFindingItemDTO.java
@@ -4,4 +4,5 @@ package io.openaev.service.attackpath.dto;
  * One finding produced by an execution, for the Result tab of the execution detail drawer (issue
  * 5048): its type and value. The value is masked server-side for the credentials category.
  */
-public record AttackPathExecutionFindingItemDTO(String type, String value) {}
+public record AttackPathExecutionFindingItemDTO(
+    String type, String value, AttackPathFindingVerdictsDTO verdicts) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingItemDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingItemDTO.java
@@ -13,4 +13,5 @@ public record AttackPathFindingItemDTO(
     String value,
     String endpointKey,
     String endpointNodeId,
-    List<String> executionIds) {}
+    List<String> executionIds,
+    AttackPathFindingVerdictsDTO verdicts) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingVerdictsDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathFindingVerdictsDTO.java
@@ -1,0 +1,9 @@
+package io.openaev.service.attackpath.dto;
+
+/**
+ * A finding's verdict triple (issue 6647), derived from its producing executions: prevention,
+ * detection and vulnerability, each {@code success | failed | unknown} (the front's vocabulary). A
+ * missing slot renders as {@code unknown} front-side.
+ */
+public record AttackPathFindingVerdictsDTO(
+    String prevention, String detection, String vulnerability) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
@@ -74,4 +74,7 @@ public class AttackPathNodeDTO {
   private String typeFindings;
   private String findingsTypeNodeId;
   private String assetNodeId;
+  // FINDING only: the per-finding verdict triple, worst-of aggregated across the producing
+  // executions. Null on every other node type (omitted from the JSON).
+  private AttackPathFindingVerdictsDTO verdicts;
 }

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingVerdictsApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingVerdictsApiTest.java
@@ -126,6 +126,28 @@ class AttackPathFindingVerdictsApiTest extends IntegrationTest {
         .andExpect(jsonPath("$.findings[0].verdicts.vulnerability").value("failed"));
   }
 
+  @Test
+  @DisplayName("fail-closed: a cross-simulation link never attaches another run's status")
+  void crossSimulationLinkIsIgnored() throws Exception {
+    AttackPathFinding cve = save(finding("host-a", CVE));
+    // Same-simulation producer: prevented.
+    link(save(execution("host-a", "Prevented")), cve);
+    // Corrupt cross-simulation link: an execution of ANOTHER simulation, not prevented. It must not
+    // leak its status into this simulation's read, on either the expand or the drawer path.
+    AttackPathExecution otherSim = execution("host-a", "Not Prevented");
+    otherSim.setSimulationId("SIM-OTHER");
+    link(save(otherSim), cve);
+    entityManager.flush();
+
+    // Only the same-simulation producer counts: prevention stays success, not failed.
+    expand("host-a").andExpect(verdict(CVE, "prevention", "success"));
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/findings")
+                .param("category", "cves"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].verdicts.prevention").value("success"));
+  }
+
   // -- helpers --
 
   private ResultActions expand(String endpointKey) throws Exception {

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingVerdictsApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingVerdictsApiTest.java
@@ -1,0 +1,182 @@
+package io.openaev.api.attackpath;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
+import io.openaev.database.model.attackpath.AttackPathFinding;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Per-finding verdicts (A2), through the real endpoints. A finding node/row carries a {@code
+ * verdicts} triple ({@code success|failed|unknown}) derived from its producing executions and
+ * worst-of aggregated. Covers the four carriers: expand (default view, per endpoint), the graph
+ * FINDING node (cross-endpoint rollup), the drawer row, and the execution detail item.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@TestPropertySource(properties = "openaev.enabled-dev-features=INJECT_CHAINING,ATTACK_PATH")
+@DisplayName("attack path: per-finding verdicts on every read")
+class AttackPathFindingVerdictsApiTest extends IntegrationTest {
+
+  private static final String SIM = "SIM-VERDICTS";
+  private static final String CVE = "CVE-2026-1";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+  @Autowired private AttackPathFindingRepository findingRepository;
+
+  private Tenant tenant;
+
+  @BeforeEach
+  void setUp() {
+    tenant = tenantRepository.save(TenantFixture.getTenant("ap-verdicts"));
+  }
+
+  @Test
+  @DisplayName(
+      "expand: worst-of across producers on one endpoint, and unknown for a status-less producer")
+  void expandWorstOfAndUnknown() throws Exception {
+    AttackPathExecution prevented = save(execution("host-a", "Prevented"));
+    AttackPathExecution notPrevented = save(execution("host-a", "Not Prevented"));
+    AttackPathFinding divergent = save(finding("host-a", CVE));
+    link(prevented, divergent);
+    link(notPrevented, divergent);
+
+    AttackPathExecution noStatus = save(execution("host-a", null));
+    AttackPathFinding unknown = save(finding("host-a", "CVE-2026-9"));
+    link(noStatus, unknown);
+    entityManager.flush();
+
+    expand("host-a")
+        .andExpect(verdict(CVE, "prevention", "failed"))
+        .andExpect(verdict("CVE-2026-9", "prevention", "unknown"));
+  }
+
+  @Test
+  @DisplayName(
+      "the same finding diverges per endpoint on expand, and the graph node is the worst-of rollup")
+  void perEndpointExpandAndCrossEndpointGraphNode() throws Exception {
+    // Same (type, value) prevented on host-a, not prevented on host-b.
+    link(save(execution("host-a", "Prevented")), save(finding("host-a", CVE)));
+    link(save(execution("host-b", "Not Prevented")), save(finding("host-b", CVE)));
+    entityManager.flush();
+
+    // Expand is per endpoint: the verdict differs by endpoint.
+    expand("host-a").andExpect(verdict(CVE, "prevention", "success"));
+    expand("host-b").andExpect(verdict(CVE, "prevention", "failed"));
+
+    // The single FINDING node of the full graph rolls up across endpoints: worst-of = failed.
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/graph")
+                .param("mode", "full"))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath(
+                    "$.attackPathNodes[?(@.type=='FINDING' && @.value=='"
+                        + CVE
+                        + "')].verdicts.prevention")
+                .value(hasItem("failed")));
+  }
+
+  @Test
+  @DisplayName(
+      "drawer rows carry the aggregated verdict; execution detail items carry the execution's own")
+  void drawerAndExecutionDetailCarryVerdicts() throws Exception {
+    AttackPathExecution exec = execution("host-a", null);
+    exec.setDetectionStatus("Detected"); // detection success label
+    exec.setVulnerabilityStatus("Vulnerable"); // vulnerability failure label
+    exec = executionRepository.save(exec);
+    link(exec, save(finding("host-a", CVE)));
+    entityManager.flush();
+
+    // Drawer: worst-of of the row's producers (here one, so its own triple).
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/findings")
+                .param("category", "cves"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].verdicts.detection").value("success"))
+        .andExpect(jsonPath("$.items[0].verdicts.vulnerability").value("failed"));
+
+    // Execution detail: this execution's own triple + the new vulnerabilityStatus field.
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/execution")
+                .param("ref", exec.getId()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.vulnerabilityStatus").value("Vulnerable"))
+        .andExpect(jsonPath("$.findings[0].verdicts.detection").value("success"))
+        .andExpect(jsonPath("$.findings[0].verdicts.vulnerability").value("failed"));
+  }
+
+  // -- helpers --
+
+  private ResultActions expand(String endpointKey) throws Exception {
+    return mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/endpoint/findings")
+                .param("ref", endpointKey))
+        .andExpect(status().isOk());
+  }
+
+  private ResultMatcher verdict(String value, String bucket, String expected) {
+    return jsonPath("$.findings[?(@.value=='" + value + "')].verdicts." + bucket)
+        .value(hasItem(expected));
+  }
+
+  private AttackPathExecution execution(String endpointKey, String preventionStatus) {
+    AttackPathExecution e = new AttackPathExecution();
+    e.setTenant(tenant);
+    e.setSimulationId(SIM);
+    e.setSourceKind("INJECTOR");
+    e.setSourceInjector("nmap");
+    e.setTargetKind("ASSET");
+    e.setTargetAssetId(endpointKey);
+    e.setTargetKey(endpointKey);
+    e.setExecutedAt(Instant.parse("2026-06-18T08:00:00Z"));
+    e.setPreventionStatus(preventionStatus);
+    return e;
+  }
+
+  private AttackPathExecution save(AttackPathExecution e) {
+    return executionRepository.save(e);
+  }
+
+  private AttackPathFinding finding(String endpointKey, String value) {
+    AttackPathFinding f = new AttackPathFinding();
+    f.setTenant(tenant);
+    f.setSimulationId(SIM);
+    f.setType("cve");
+    f.setValue(value);
+    f.setEndpointId(endpointKey);
+    f.setEndpointKey(endpointKey);
+    return f;
+  }
+
+  private AttackPathFinding save(AttackPathFinding f) {
+    return findingRepository.save(f);
+  }
+
+  private void link(AttackPathExecution execution, AttackPathFinding finding) {
+    AttackPathExecutionFinding link = new AttackPathExecutionFinding();
+    link.setExecutionId(execution.getId());
+    link.setFindingId(finding.getId());
+    entityManager.persist(link);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathFindingVerdictsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathFindingVerdictsTest.java
@@ -1,0 +1,150 @@
+package io.openaev.service.attackpath;
+
+import static io.openaev.service.attackpath.AttackPathFindingVerdicts.Verdict.FAILED;
+import static io.openaev.service.attackpath.AttackPathFindingVerdicts.Verdict.SUCCESS;
+import static io.openaev.service.attackpath.AttackPathFindingVerdicts.Verdict.UNKNOWN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.service.attackpath.AttackPathFindingVerdicts.Verdict;
+import io.openaev.service.attackpath.AttackPathFindingVerdicts.Verdicts;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the per-finding verdict semantics (label mapping, prevented=>detected, worst-of).
+ */
+class AttackPathFindingVerdictsTest {
+
+  @Test
+  @DisplayName("success labels map to success, including the vulnerability inversion")
+  void successLabels() {
+    assertThat(ofOne("Prevented", "Detected", "Not vulnerable"))
+        .isEqualTo(new Verdicts(SUCCESS, SUCCESS, SUCCESS));
+  }
+
+  @Test
+  @DisplayName("CRITICAL: the definitive failure labels map to failed, not unknown")
+  void failureLabelsMapToFailed() {
+    // A confirmed-exploitable CVE ("Vulnerable") must be red, not grey. Prevention is not success
+    // here, so the prevented=>detected rule does not mask the detection failure.
+    assertThat(ofOne("Not Prevented", "Not Detected", "Vulnerable"))
+        .isEqualTo(new Verdicts(FAILED, FAILED, FAILED));
+  }
+
+  @Test
+  @DisplayName("partial labels map to failed")
+  void partialLabels() {
+    assertThat(ofOne("Partially Prevented", "Partially Detected", "Partially vulnerable"))
+        .isEqualTo(new Verdicts(FAILED, FAILED, FAILED));
+  }
+
+  @Test
+  @DisplayName("pending, null and unrecognized strings map to unknown")
+  void unknownLabels() {
+    assertThat(ofOne("Pending", null, "Quarantined"))
+        .isEqualTo(new Verdicts(UNKNOWN, UNKNOWN, UNKNOWN));
+  }
+
+  @Test
+  @DisplayName(
+      "CRITICAL: a bucket rejects other buckets' labels (per-bucket slot matching, not a global set)")
+  void crossBucketLabelsMapToUnknown() {
+    // "Detected"/"Vulnerable"/"Prevented"/"Not Detected" are definitive verdicts in OTHER buckets;
+    // fed to the wrong bucket they are unrecognized. A global label list would wrongly turn them
+    // into success/failed here, silently making up a definitive verdict from cross-bucket data.
+    assertThat(map("prevention", "Detected")).isEqualTo(UNKNOWN);
+    assertThat(map("prevention", "Vulnerable")).isEqualTo(UNKNOWN);
+    assertThat(map("detection", "Prevented")).isEqualTo(UNKNOWN);
+    assertThat(map("vulnerability", "Not Detected")).isEqualTo(UNKNOWN);
+  }
+
+  @Test
+  @DisplayName(
+      "generic and legacy aliases: Successful/SUCCESS -> success, Failed/FAILED/Expired -> failed")
+  void aliases() {
+    assertThat(map("prevention", "success")).isEqualTo(SUCCESS);
+    assertThat(map("prevention", "SUCCESS")).isEqualTo(SUCCESS);
+    assertThat(map("prevention", "Successful")).isEqualTo(SUCCESS);
+    // the raw graph value is case-insensitive, so the front's lowercase legacy aliases match too
+    assertThat(map("detection", "detected")).isEqualTo(SUCCESS);
+    assertThat(map("detection", "Failed")).isEqualTo(FAILED);
+    assertThat(map("detection", "FAILED")).isEqualTo(FAILED);
+    assertThat(map("vulnerability", "Expired")).isEqualTo(FAILED);
+  }
+
+  @Test
+  @DisplayName(
+      "prevented => detected: a prevented execution's detection is success, overriding failed")
+  void preventedImpliesDetected() {
+    assertThat(ofOne("Prevented", "Not Detected", "Not vulnerable"))
+        .isEqualTo(new Verdicts(SUCCESS, SUCCESS, SUCCESS));
+  }
+
+  @Test
+  @DisplayName("Partially Prevented does NOT lift detection")
+  void partiallyPreventedDoesNotLiftDetection() {
+    assertThat(ofOne("Partially Prevented", "Not Detected", "Not vulnerable"))
+        .isEqualTo(new Verdicts(FAILED, FAILED, SUCCESS));
+  }
+
+  @Test
+  @DisplayName("prevented => detected is folded per execution, before aggregation (order matters)")
+  void preventedImpliesDetectedFoldedPerExecution() {
+    // Producer A is prevented (so detected) yet reports "Not Detected"; producer B is not prevented
+    // but detected. Folding per execution lifts A's detection to success, so worst-of detection is
+    // success. Folding on the aggregate instead (prevention aggregate = failed, so no lift) would
+    // wrongly give detection = failed. This pins the fold-then-aggregate order.
+    Verdicts a = ofOne("Prevented", "Not Detected", "Not vulnerable");
+    Verdicts b = ofOne("Not Prevented", "Detected", "Not vulnerable");
+    assertThat(AttackPathFindingVerdicts.aggregate(List.of(a, b)))
+        .isEqualTo(new Verdicts(FAILED, SUCCESS, SUCCESS));
+  }
+
+  @Test
+  @DisplayName(
+      "worst-of aggregation: any failed wins; success only if all success; empty is unknown")
+  void worstOfAggregation() {
+    Verdicts prevented = ofOne("Prevented", "Detected", "Not vulnerable");
+    Verdicts notPrevented = ofOne("Not Prevented", "Not Detected", "Vulnerable");
+    Verdicts noStatus = ofOne(null, null, null);
+
+    assertThat(AttackPathFindingVerdicts.aggregate(List.of(prevented, notPrevented)))
+        .as("success + failed -> failed")
+        .isEqualTo(new Verdicts(FAILED, FAILED, FAILED));
+    assertThat(AttackPathFindingVerdicts.aggregate(List.of(notPrevented, noStatus)))
+        .as("failed + unknown -> failed (failed outranks unknown)")
+        .isEqualTo(new Verdicts(FAILED, FAILED, FAILED));
+    assertThat(AttackPathFindingVerdicts.aggregate(List.of(prevented, noStatus)))
+        .as("success + unknown -> unknown (a finding is never greener than its producers)")
+        .isEqualTo(new Verdicts(UNKNOWN, UNKNOWN, UNKNOWN));
+    assertThat(AttackPathFindingVerdicts.aggregate(List.of(prevented, prevented)))
+        .as("all success -> success")
+        .isEqualTo(new Verdicts(SUCCESS, SUCCESS, SUCCESS));
+    assertThat(AttackPathFindingVerdicts.aggregate(List.of()))
+        .as("no producers -> all unknown")
+        .isEqualTo(Verdicts.UNKNOWN);
+  }
+
+  @Test
+  @DisplayName("the verdict labels are the front's lowercase vocabulary")
+  void labels() {
+    assertThat(SUCCESS.label).isEqualTo("success");
+    assertThat(FAILED.label).isEqualTo("failed");
+    assertThat(UNKNOWN.label).isEqualTo("unknown");
+  }
+
+  private static Verdicts ofOne(String prevention, String detection, String vulnerability) {
+    return AttackPathFindingVerdicts.ofExecution(prevention, detection, vulnerability);
+  }
+
+  // Maps a single bucket by routing through ofExecution and reading the matching field, so the test
+  // never re-implements the mapping.
+  private static Verdict map(String bucket, String raw) {
+    return switch (bucket) {
+      case "prevention" -> AttackPathFindingVerdicts.ofExecution(raw, null, null).prevention();
+      case "detection" -> AttackPathFindingVerdicts.ofExecution(null, raw, null).detection();
+      default -> AttackPathFindingVerdicts.ofExecution(null, null, raw).vulnerability();
+    };
+  }
+}

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1006,11 +1006,13 @@ export interface AttackPathExecutionDetailDTO {
   targetIp?: string;
   targetPlatform?: string;
   terminalOutput?: string;
+  vulnerabilityStatus?: string;
 }
 
 export interface AttackPathExecutionFindingItemDTO {
   type?: string;
   value?: string;
+  verdicts?: AttackPathFindingVerdictsDTO;
 }
 
 export interface AttackPathExpandDTO {
@@ -1024,12 +1026,19 @@ export interface AttackPathFindingItemDTO {
   executionIds?: string[];
   type?: string;
   value?: string;
+  verdicts?: AttackPathFindingVerdictsDTO;
 }
 
 export interface AttackPathFindingPageDTO {
   items?: AttackPathFindingItemDTO[];
   /** @format int64 */
   total?: number;
+}
+
+export interface AttackPathFindingVerdictsDTO {
+  detection?: string;
+  prevention?: string;
+  vulnerability?: string;
 }
 
 export interface AttackPathNodeDTO {
@@ -1063,6 +1072,7 @@ export interface AttackPathNodeDTO {
   type?: string;
   typeFindings?: string;
   value?: string;
+  verdicts?: AttackPathFindingVerdictsDTO;
 }
 
 export interface AttackPathSecurityPlatformDTO {

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEndpointFindingVerdictRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEndpointFindingVerdictRow.java
@@ -1,0 +1,14 @@
+package io.openaev.database.model.attackpath.projection;
+
+/**
+ * Flat projection for the endpoint expand read (issue 6647): a finding on one endpoint joined to
+ * one of its producing executions, carrying that execution's three status columns. One row per
+ * (finding, producer); the service groups per (type, value) and worst-of aggregates the verdicts.
+ * The {@code AttackPathFinding} join in the query is the tenant fail-closed scope.
+ */
+public record AttackPathEndpointFindingVerdictRow(
+    String type,
+    String value,
+    String preventionStatus,
+    String detectionStatus,
+    String vulnerabilityStatus) {}

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathExecutionRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathExecutionRow.java
@@ -26,6 +26,7 @@ public record AttackPathExecutionRow(
     Instant executedAt,
     String preventionStatus,
     String detectionStatus,
+    String vulnerabilityStatus,
     String stepTemplateId,
     // Injector node enrichment: the frozen contract external id resolves the ATT&CK techniques, and
     // the injector type labels the node with what actually ran.

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingExecutionRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingExecutionRow.java
@@ -5,4 +5,9 @@ package io.openaev.database.model.attackpath.projection;
  * discovered each finding to the drawer rows so the front can cross-focus the map edge and the
  * feed.
  */
-public record AttackPathFindingExecutionRow(String findingId, String executionId) {}
+public record AttackPathFindingExecutionRow(
+    String findingId,
+    String executionId,
+    String preventionStatus,
+    String detectionStatus,
+    String vulnerabilityStatus) {}

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
@@ -144,7 +144,7 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
           + "FROM AttackPathExecution e WHERE e.simulationId = :simulationId")
   List<AttackPathExecutionRow> findGraphRows(@Param("simulationId") String simulationId);
 
@@ -157,7 +157,7 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
           + "FROM AttackPathExecution e "
           + "WHERE e.simulationId = :simulationId AND e.targetKey = :targetKey")
   List<AttackPathExecutionRow> findByTarget(

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
@@ -38,7 +38,9 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    * produced it) and replaces the former {@code EXISTS} semi-join; it multiplies rows per producer,
    * which the service groups per (type, value) and worst-of aggregates. One indexed read using
    * {@code idx_ap_find_sim_endpointkey_type}; the {@code AttackPathFinding} scope is the tenant
-   * fail-closed boundary; {@code endpointKey} is the asset id or the raw value.
+   * fail-closed boundary; {@code endpointKey} is the asset id or the raw value. The joined
+   * execution is pinned to the same simulation, so a corrupt cross-simulation link cannot attach
+   * another run's status.
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingVerdictRow("
@@ -46,7 +48,8 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
           + "FROM AttackPathFinding f "
           + "JOIN AttackPathExecutionFinding ef ON ef.findingId = f.id "
           + "JOIN AttackPathExecution e ON e.id = ef.executionId "
-          + "WHERE f.simulationId = :simulationId AND f.endpointKey = :endpointKey")
+          + "WHERE f.simulationId = :simulationId AND f.endpointKey = :endpointKey "
+          + "AND e.simulationId = :simulationId")
   List<AttackPathEndpointFindingVerdictRow> findByEndpoint(
       @Param("simulationId") String simulationId, @Param("endpointKey") String endpointKey);
 
@@ -113,7 +116,9 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    * deliberately not tenant-active and the statement inspector adds no predicate to it. Read alone
    * it would return every tenant's links. Joined to its guarded parent, it inherits the parent's
    * scope. Isolation here is enforced by the mechanism rather than argued from the caller passing
-   * ids it obtained from a scoped page. Pinned by {@code linkReadWithoutScopeIsFailClosed}.
+   * ids it obtained from a scoped page. Pinned by {@code linkReadWithoutScopeIsFailClosed}. The
+   * joined execution is pinned to the finding's simulation, so a corrupt cross-simulation link
+   * cannot attach another run's status.
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow("
@@ -123,6 +128,7 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
           + "JOIN AttackPathFinding f ON f.id = ef.findingId "
           + "JOIN AttackPathExecution e ON e.id = ef.executionId "
           + "WHERE ef.findingId IN :findingIds "
+          + "AND e.simulationId = f.simulationId "
           + "ORDER BY ef.executionId")
   List<AttackPathFindingExecutionRow> findExecutionLinks(
       @Param("findingIds") Collection<String> findingIds);

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
@@ -2,6 +2,7 @@ package io.openaev.database.repository.attackpath;
 
 import io.openaev.database.model.attackpath.AttackPathFinding;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingRow;
+import io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingVerdictRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointTypeCountRow;
 import io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow;
 import io.openaev.database.model.attackpath.projection.AttackPathFindingListRow;
@@ -31,19 +32,22 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
   List<AttackPathFindingRow> findGraphRows(@Param("simulationId") String simulationId);
 
   /**
-   * Expand one endpoint: its findings' (type, value), restricted to findings a producing execution
-   * links to. That {@code EXISTS} semi-join is the graph invariant (a finding is in the graph iff
-   * an execution produced it), so expand agrees with the full rebuild (Read B, an inner join) and
-   * with the collapsed counters. One indexed read using {@code idx_ap_find_sim_endpointkey_type};
-   * {@code endpointKey} is the asset id or the raw value.
+   * Expand one endpoint: its findings' (type, value) joined to their producing executions' three
+   * status columns, so the read can carry a per-finding verdict. The inner join to {@code
+   * AttackPathExecutionFinding} is the graph invariant (a finding is in the graph iff an execution
+   * produced it) and replaces the former {@code EXISTS} semi-join; it multiplies rows per producer,
+   * which the service groups per (type, value) and worst-of aggregates. One indexed read using
+   * {@code idx_ap_find_sim_endpointkey_type}; the {@code AttackPathFinding} scope is the tenant
+   * fail-closed boundary; {@code endpointKey} is the asset id or the raw value.
    */
   @Query(
-      "SELECT new io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingRow("
-          + "f.type, f.value) "
+      "SELECT new io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingVerdictRow("
+          + "f.type, f.value, e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus) "
           + "FROM AttackPathFinding f "
-          + "WHERE f.simulationId = :simulationId AND f.endpointKey = :endpointKey "
-          + "AND EXISTS (SELECT ef FROM AttackPathExecutionFinding ef WHERE ef.findingId = f.id)")
-  List<AttackPathEndpointFindingRow> findByEndpoint(
+          + "JOIN AttackPathExecutionFinding ef ON ef.findingId = f.id "
+          + "JOIN AttackPathExecution e ON e.id = ef.executionId "
+          + "WHERE f.simulationId = :simulationId AND f.endpointKey = :endpointKey")
+  List<AttackPathEndpointFindingVerdictRow> findByEndpoint(
       @Param("simulationId") String simulationId, @Param("endpointKey") String endpointKey);
 
   /**
@@ -113,9 +117,11 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingExecutionRow("
-          + "ef.findingId, ef.executionId) "
+          + "ef.findingId, ef.executionId, e.preventionStatus, e.detectionStatus,"
+          + " e.vulnerabilityStatus) "
           + "FROM AttackPathExecutionFinding ef "
           + "JOIN AttackPathFinding f ON f.id = ef.findingId "
+          + "JOIN AttackPathExecution e ON e.id = ef.executionId "
           + "WHERE ef.findingId IN :findingIds "
           + "ORDER BY ef.executionId")
   List<AttackPathFindingExecutionRow> findExecutionLinks(


### PR DESCRIPTION
## What

Exposes a per-finding `verdicts` triple on the attack-path read side, so the front
can drop its mock `findingExpectations` and show real prevention / detection /
vulnerability outcomes on each finding.

Each bucket is one of `success | failed | unknown`:
- `success`: the control worked (prevented, detected, or not vulnerable)
- `failed`: it did not (not prevented, not detected, vulnerable; also Partial and Expired)
- `unknown`: no status yet, or an unrecognized value

## Where

`verdicts` rides every read that carries a finding, with the same shape everywhere:
- the graph `FINDING` node (full mode) via `AttackPathNodeDTO.verdicts`
- the endpoint expand rows
- the findings drawer rows via `AttackPathFindingItemDTO.verdicts`
- the execution-detail items via `AttackPathExecutionFindingItemDTO.verdicts`

Execution detail also gains `vulnerabilityStatus`, next to the existing
`preventionStatus` / `detectionStatus`.

## How the verdict is derived

- Status to verdict is per-bucket slot matching against `ExpectationType` labels
  (case-insensitive), not a global string list. This is what keeps a definitive
  failure label (`Not Prevented`, `Not Detected`, `Vulnerable`) mapping to `failed`
  rather than `unknown`, so a confirmed-exploitable finding never renders grey.
  Legacy raw aliases (`SUCCESS` / `FAILED` / `prevented` / `detected`) still map.
- Aggregation across the producing executions is worst-of per bucket
  (`failed` > `unknown` > `success`), so a finding is never greener than its producers.
- `prevented implies detected` is folded per execution, before aggregation.

## Scope and rollout

- Backend read-only, no migration. It reads the same `prevention/detection/vulnerabilityStatus`
  columns that #6912 (status write-back) fills. The hunks are disjoint, so the two merge cleanly
  in either order. On day one, before real runs populate those columns, verdicts read `unknown`.
- `@JsonInclude(NON_NULL)`: non-finding nodes omit `verdicts` entirely, so the field is additive
  and safe for an old front against this back and a new front against an old back.
- Fail-closed on simulation: the two status reads (expand, drawer) pin the joined execution to the
  finding's simulation, so a corrupt cross-simulation link can never attach another run's status.
  The existence-only counters are unchanged (they expose no status), so at worst such a link would
  be counted while its verdict reads `unknown`, never a wrong verdict.

## Tests

- Unit coverage of the mapping and aggregation, including the per-bucket rejection of
  cross-bucket labels, worst-of ordering, and the fold-before-aggregation rule.
- API coverage of all four carriers through the real endpoints (expand per endpoint,
  cross-endpoint graph rollup, drawer rows, execution detail).
- Graph statement-count pins unchanged: no extra query is introduced.

## Front follow-up

Front replaces the `findingExpectations` mock and reads `verdicts` off the finding.
Contract and lookup recipe are in the team's front API doc.
