### PR TITLE
test(attackpath): run the attack-path integration tests in CI

### DIFF
--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiRbacTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiRbacTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
  * Real stack (MockMvc + real PG + real grants), no mocked RBAC.
  */
 @DisplayName("attack path: read endpoints enforce SIMULATION READ (seed-tolerant)")
-class AttackPathApiRbacIT extends IntegrationTest {
+class AttackPathApiRbacTest extends IntegrationTest {
 
   private static final String BASE = "/api/attack-path/simulations/";
 

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathSecurityPlatformsTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathSecurityPlatformsTest.java
@@ -60,7 +60,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @WithMockUser(isAdmin = true)
 @DisplayName("attack path execution detail — security platforms (A1)")
-class AttackPathSecurityPlatformsIT extends IntegrationTest {
+class AttackPathSecurityPlatformsTest extends IntegrationTest {
 
   private static final String SIM = "SIM-SP";
 

--- a/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringTest.java
@@ -91,7 +91,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 // endpoint/contract). The run then executes under that tenant scope, as the worker does.
 @io.openaev.utils.mockUser.WithMockUser(isAdmin = true)
 @DisplayName("attack path: a chaining run drives the ingestion (run-level wiring)")
-class AttackPathRunWiringIT extends IntegrationTest {
+class AttackPathRunWiringTest extends IntegrationTest {
 
   // Spy, not mock: tenant provisioning (createTenantWithCurrentUser) uses the real injectorContract
   // resolution; a full mock returns null and NPEs on getPayload() during provisioning.
@@ -107,7 +107,7 @@ class AttackPathRunWiringIT extends IntegrationTest {
   @MockitoSpyBean private AttackPathExecutionIngestionService attackPathIngestion;
 
   // Mocked: this test only checks that update() drives the copy, gated by the flag; the copy itself
-  // is covered by AttackPathFindingIngestionServiceIT.
+  // is covered by AttackPathFindingIngestionServiceTest.
   @MockitoBean private AttackPathFindingIngestionService attackPathFindingIngestion;
 
   @Autowired private InjectExecutionStep injectExecutionStep;

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
@@ -183,7 +183,7 @@ class TenantActiveTableAccessArchTest {
               AttackPathExecutionIngestionService.class,
               // Scoped reader: reads the step's execution rows inside its own executeNew (the
               // inject's tenant) with an explicit tenantId predicate, to attribute copied findings.
-              // Pinned by AttackPathFindingIngestionServiceIT:
+              // Pinned by AttackPathFindingIngestionServiceTest:
               AttackPathFindingIngestionService.class)
           .should()
           .dependOnClassesThat()

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathFindingIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathFindingIngestionServiceTest.java
@@ -52,7 +52,7 @@ import org.springframework.transaction.support.TransactionTemplate;
     })
 @WithMockUser(isAdmin = true)
 @DisplayName("attack path: copyFindings copies findings onto the snapshot per endpoint")
-class AttackPathFindingIngestionServiceIT extends IntegrationTest {
+class AttackPathFindingIngestionServiceTest extends IntegrationTest {
 
   private static final String STEP_ID = "step-phaseb";
 

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathFindingWriterTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathFindingWriterTest.java
@@ -33,7 +33,7 @@ import org.springframework.test.context.TestPropertySource;
     })
 @WithMockUser(isAdmin = true)
 @DisplayName("attack path: the batched snapshot inserts are idempotent")
-class AttackPathFindingWriterIT extends IntegrationTest {
+class AttackPathFindingWriterTest extends IntegrationTest {
 
   private static final String SIM = "SIM-WRITER-IDEMPOTENT";
 


### PR DESCRIPTION
The 5 attack-path integration tests were named *IT.java, which no CI shard runs (shards match *Test.java, there is no failsafe plugin). Renaming them to *Test makes CI execute them. Pure rename, no logic change; all 30 tests pass locally. This also restores the W7 wiring guard (AttackPathRunWiringTest) as a real CI gate for the findings-copy call