### PR TITLE
fix(expectations): keep AI defense collectors off endpoint parent expectations and protect children-derived verdicts (#6961)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260727080000000__Repair_parent_expectations_clobbered_by_mismatched_collector_results.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260727080000000__Repair_parent_expectations_clobbered_by_mismatched_collector_results.java
@@ -1,0 +1,149 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Repairs parent detection/prevention expectations clobbered by collectors of a mismatched security
+ * platform type.
+ *
+ * <p>Bug: the AI-defense feed ({@code GET /api/injects/expectations/ai/{sourceId}}, backed by
+ * {@code findAgentlessExpectationsNotFilledForSource}) returned every expectation with {@code
+ * agent_id IS NULL AND asset_id IS NOT NULL} - which is also the exact shape of a PARENT
+ * expectation of an endpoint with agents - and ignored {@code
+ * inject_expectation_expected_security_platforms}. An LLM firewall collector (XTM One) therefore
+ * received EDR-only endpoint parents, found no matching AI security event, and after its expiration
+ * window wrote {@code score 0 / "Not Detected"} directly on the parent rows. The write path
+ * recomputed the parent score from its own results only, clobbering the verdict rolled up from the
+ * agents (e.g. Microsoft Defender green), and the failure then propagated to the asset group rows.
+ * The bogus result was additionally invisible in the UI, whose asset view is built from the agents'
+ * results.
+ *
+ * <p>The feed and the write path are fixed in code; this migration repairs the corrupted rows:
+ *
+ * <ol>
+ *   <li>strips, from asset-level parents that have agent children, direct results written by a
+ *       collector whose security platform type is not among the expectation's expected types;
+ *   <li>restores the score of asset-level parents whose agent children verdict is green (any child
+ *       for group expectations, all children for non-group);
+ *   <li>restores the score of asset-group parents whose (possibly just repaired) asset children
+ *       verdict is green.
+ * </ol>
+ *
+ * <p>Every repaired row gets {@code inject_expectation_updated_at = now()} so the incremental
+ * Elasticsearch engine (which cursors on {@code updated_at}) re-feeds the documents and the
+ * ES-backed statistics converge on their own within its polling interval.
+ *
+ * <p>Idempotent: step 1 only matches rows still carrying a mismatched result, steps 2 and 3 only
+ * match rows whose score is still below the expected score; re-runs match nothing.
+ */
+@Component
+public
+class V6_20260727080000000__Repair_parent_expectations_clobbered_by_mismatched_collector_results
+    extends BaseJavaMigration {
+
+  /** An answered child that reached its expected score. */
+  private static final String CHILD_SUCCESS =
+      "child.inject_expectation_score IS NOT NULL"
+          + " AND child.inject_expectation_score >= child.inject_expectation_expected_score";
+
+  /**
+   * A result element written by a collector whose security platform type is NOT among the
+   * expectation's expected platform types. Collectors without a security platform (e.g. the
+   * expectations expiration manager) never match: only positively identified mismatches are
+   * stripped.
+   */
+  private static final String MISMATCHED_RESULT_SOURCE =
+      "EXISTS (SELECT 1 FROM collectors c"
+          + " JOIN assets sp ON sp.asset_id = c.collector_security_platform"
+          + " WHERE c.collector_id = elem->>'sourceId'"
+          + " AND sp.security_platform_type IS NOT NULL"
+          + " AND NOT jsonb_exists("
+          + "parent.inject_expectation_expected_security_platforms::jsonb,"
+          + " sp.security_platform_type))";
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // 1) Strip mismatched-platform direct results from asset-level parents with agent children
+      statement.execute(
+          "UPDATE injects_expectations parent SET"
+              + " inject_expectation_results = COALESCE((SELECT jsonb_agg(elem)"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE NOT "
+              + MISMATCHED_RESULT_SOURCE
+              + "), '[]'::jsonb)::json,"
+              + " inject_expectation_updated_at = now()"
+              + " WHERE parent.agent_id IS NULL AND parent.asset_id IS NOT NULL"
+              + " AND parent.inject_expectation_type IN ('DETECTION', 'PREVENTION')"
+              + " AND parent.inject_expectation_expected_security_platforms IS NOT NULL"
+              + " AND jsonb_typeof(parent.inject_expectation_expected_security_platforms::jsonb)"
+              + "   = 'array'"
+              + " AND jsonb_array_length("
+              + "parent.inject_expectation_expected_security_platforms::jsonb) > 0"
+              + " AND parent.inject_expectation_results IS NOT NULL"
+              + " AND jsonb_typeof(parent.inject_expectation_results::jsonb) = 'array'"
+              + " AND EXISTS (SELECT 1 FROM injects_expectations child"
+              + "   WHERE child.inject_id = parent.inject_id"
+              + "   AND child.asset_id = parent.asset_id"
+              + "   AND child.inject_expectation_type = parent.inject_expectation_type"
+              + "   AND child.agent_id IS NOT NULL)"
+              + " AND EXISTS (SELECT 1"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE "
+              + MISMATCHED_RESULT_SOURCE
+              + ")");
+      // 2) Asset-level parents: restore the score when their agent children verdict is green
+      statement.execute(
+          repairScoreSql(
+              /* parentScope= */ "parent.asset_id IS NOT NULL AND parent.agent_id IS NULL",
+              /* childJoin= */ "child.inject_id = parent.inject_id"
+                  + " AND child.inject_expectation_type = parent.inject_expectation_type"
+                  + " AND child.asset_id = parent.asset_id"
+                  + " AND child.agent_id IS NOT NULL"));
+      // 3) Asset-group parents: restore the score when their (possibly just repaired) asset
+      // children verdict is green
+      statement.execute(
+          repairScoreSql(
+              /* parentScope= */ "parent.asset_group_id IS NOT NULL AND parent.asset_id IS NULL"
+                  + " AND parent.agent_id IS NULL",
+              /* childJoin= */ "child.inject_id = parent.inject_id"
+                  + " AND child.inject_expectation_type = parent.inject_expectation_type"
+                  + " AND child.asset_group_id = parent.asset_group_id"
+                  + " AND child.asset_id IS NOT NULL"
+                  + " AND child.agent_id IS NULL"));
+    }
+  }
+
+  private static String repairScoreSql(String parentScope, String childJoin) {
+    return "UPDATE injects_expectations parent SET"
+        + " inject_expectation_score = parent.inject_expectation_expected_score,"
+        + " inject_expectation_updated_at = now()"
+        + " WHERE "
+        + parentScope
+        + " AND parent.inject_expectation_type IN ('DETECTION', 'PREVENTION')"
+        + " AND parent.inject_expectation_expected_score IS NOT NULL"
+        + " AND parent.inject_expectation_score IS NOT NULL"
+        + " AND parent.inject_expectation_score < parent.inject_expectation_expected_score"
+        // At least one child exists (a parent with no children is a genuine leaf, keep it)
+        + " AND EXISTS (SELECT 1 FROM injects_expectations child WHERE "
+        + childJoin
+        + ")"
+        // Children verdict: group expectations succeed when ANY child is green, non-group
+        // expectations require ALL children green
+        + " AND ((parent.inject_expectation_group = true"
+        + "   AND EXISTS (SELECT 1 FROM injects_expectations child WHERE "
+        + childJoin
+        + "     AND "
+        + CHILD_SUCCESS
+        + "))"
+        + "  OR (parent.inject_expectation_group = false"
+        + "   AND NOT EXISTS (SELECT 1 FROM injects_expectations child WHERE "
+        + childJoin
+        + "     AND NOT ("
+        + CHILD_SUCCESS
+        + "))))";
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -781,8 +781,42 @@ public class InjectExpectationService {
     addResult(technicalInjectExpectation, input, collector);
     final Double score =
         computeScore(technicalInjectExpectation.getResults(), technicalInjectExpectation);
-    technicalInjectExpectation.setScore(score);
+    technicalInjectExpectation.setScore(
+        combineWithChildrenVerdict(technicalInjectExpectation, score));
     return technicalInjectExpectation;
+  }
+
+  /**
+   * Guards a direct (collector-written) score against clobbering a PARENT expectation's
+   * children-derived verdict. An asset-level expectation whose asset has agent children carries a
+   * score rolled up from those agents (e.g. Microsoft Defender answered the agents green); a
+   * collector answering the parent row directly (e.g. an LLM firewall expiring its own pending
+   * check with "Not Detected") must never overwrite that rollup with a score computed from the
+   * parent's own results only.
+   *
+   * <p>Combination rule: a direct success is definitive (any security platform succeeding counts);
+   * otherwise the children verdict wins - including staying pending (null) while the agents are
+   * still unanswered, so a direct failure never cements a wrong verdict early.
+   *
+   * @param expectation the expectation whose score was just computed from its own results
+   * @param ownScore the score computed from the expectation's own results
+   * @return the score to persist
+   */
+  private Double combineWithChildrenVerdict(
+      @NotNull final TechnicalInjectExpectation expectation, @Nullable final Double ownScore) {
+    if (expectation.getAgent() != null || expectation.getAsset() == null) {
+      return ownScore; // agent leaf or asset-group level: no children rollup to protect
+    }
+    List<TechnicalInjectExpectation> agentChildren = getAgentsExpectationsForAsset(expectation);
+    if (agentChildren.isEmpty()) {
+      return ownScore; // true agentless leaf (AI target, agentless endpoint)
+    }
+    Double expectedScore = expectation.getExpectedScore();
+    if (expectedScore == null || (ownScore != null && ownScore >= expectedScore)) {
+      return ownScore;
+    }
+    return InjectExpectationUtils.computeChildrenScore(
+        expectation.isExpectationGroup(), expectedScore, agentChildren);
   }
 
   // -- FINAL UPDATE --
@@ -1195,14 +1229,25 @@ public class InjectExpectationService {
               }
               BaseInjectExpectation clone = expectation.clone();
               Map<String, InjectExpectationResult> bySource = new LinkedHashMap<>();
-              platformResults.forEach(
-                  r ->
-                      bySource.merge(
-                          r.getSourceId() == null ? r.getSourceName() : r.getSourceId(),
-                          r,
-                          (existing, candidate) ->
-                              // Prefer an answered result over a pending one for the same source.
-                              existing.getResult() != null ? existing : candidate));
+              // Agents' results first, then the asset expectation's OWN direct results (e.g. a
+              // security platform that answered the asset level directly): a result persisted on
+              // the row must stay visible, silently dropping it would hide what drove the score.
+              Stream.concat(
+                      platformResults.stream(),
+                      expectation.getResults().stream()
+                          .filter(
+                              r ->
+                                  COLLECTOR.equals(r.getSourceType())
+                                      || SECURITY_PLATFORM.equals(r.getSourceType())))
+                  .forEach(
+                      r ->
+                          bySource.merge(
+                              r.getSourceId() == null ? r.getSourceName() : r.getSourceId(),
+                              r,
+                              (existing, candidate) ->
+                                  // Prefer an answered result over a pending one for the same
+                                  // source.
+                                  existing.getResult() != null ? existing : candidate));
               clone.setResults(new ArrayList<>(bySource.values()));
               return clone;
             })

--- a/openaev-api/src/test/java/io/openaev/rest/ExpectationApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ExpectationApiTest.java
@@ -63,6 +63,7 @@ class ExpectationApiTest extends IntegrationTest {
   @Autowired private InjectorRepository injectorRepository;
   @Autowired private CollectorTypeRepository collectorTypeRepository;
   @Autowired private CollectorRepository collectorRepository;
+  @Autowired private SecurityPlatformRepository securityPlatformRepository;
   @Autowired private InjectorContractRepository injectorContractRepository;
   @Autowired private InjectExpectationRepository injectExpectationRepository;
   @Autowired private InjectExpectationService injectExpectationService;
@@ -981,6 +982,218 @@ class ExpectationApiTest extends IntegrationTest {
           injectExpectationRepository.findAllByInjectAndAssetGroup(
               savedInject.getId(), savedAssetGroup.getId());
       assertEquals(0.0, getScore(injectExpectations));
+    }
+  }
+
+  @Nested
+  @Transactional
+  @WithMockUser(isAdmin = true)
+  @DisplayName("AI defense feed scoping and parent expectation protection")
+  class AiDefenseFeedAndParentProtection {
+
+    /**
+     * Regression test (parent asset wrongly "Not Detected" while its agent was green): the AI
+     * defense feed must never hand out PARENT asset expectations - rows with agent children whose
+     * score is derived from the agents. An LLM firewall collector receiving such a parent would
+     * later expire it with a direct failed result, clobbering the agents' green verdict.
+     */
+    @Test
+    @DisplayName("AI defense feed excludes endpoint parents with agent children")
+    void aiDefenseFeedExcludesParentsWithAgentChildren() throws Exception {
+      // -- PREPARE --
+      Collector llmCollector = createCollectorWithSecurityPlatform("LLM_FIREWALL");
+      ExecutableInject executableInject = newExecutableInjectWithTargets(true);
+      List<Expectation> detectionExpectations =
+          createDetectionExpectations(
+              List.of(savedAgent1),
+              savedEndpoint,
+              savedAssetGroup,
+              DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME);
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject, detectionExpectations);
+      em.flush();
+      em.clear();
+
+      // -- EXECUTE --
+      String response = callGetAiDefenseExpectations(llmCollector);
+
+      // -- ASSERT: the asset-level PARENT (agent child exists) must not be handed out --
+      assertEquals(0, ((List<?>) JsonPath.read(response, "$")).size());
+    }
+
+    /**
+     * Regression test: the AI defense feed must respect the expectation's expected security
+     * platform types - an expectation restricted to EDR must never reach an LLM firewall collector,
+     * even when it is a genuine agentless leaf.
+     */
+    @Test
+    @DisplayName("AI defense feed respects expected security platform types")
+    void aiDefenseFeedRespectsExpectedSecurityPlatforms() throws Exception {
+      // -- PREPARE --
+      Collector llmCollector = createCollectorWithSecurityPlatform("LLM_FIREWALL");
+      Endpoint agentlessEndpoint =
+          endpointRepository.save(EndpointFixture.createEndpoint("agentless-endpoint"));
+      ExecutableInject executableInject = newExecutableInjectWithTargets(false);
+      List<Expectation> detectionExpectations =
+          createDetectionExpectations(
+              emptyList(), agentlessEndpoint, null, DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME);
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject, detectionExpectations);
+      em.flush();
+      em.clear();
+
+      // Empty expected platforms means "any security platform": the leaf is handed out
+      String response = callGetAiDefenseExpectations(llmCollector);
+      assertEquals(1, ((List<?>) JsonPath.read(response, "$")).size());
+
+      // Restrict the expectation to EDR: it must no longer reach an LLM firewall collector
+      TechnicalInjectExpectation leaf =
+          (TechnicalInjectExpectation)
+              injectExpectationRepository
+                  .findAllByInjectAndAsset(savedInject.getId(), agentlessEndpoint.getId())
+                  .getFirst();
+      leaf.setExpectedSecurityPlatforms(List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.EDR));
+      injectExpectationRepository.save(leaf);
+      em.flush();
+      em.clear();
+
+      response = callGetAiDefenseExpectations(llmCollector);
+      assertEquals(0, ((List<?>) JsonPath.read(response, "$")).size());
+
+      // Restrict it to LLM_FIREWALL: the LLM firewall collector receives it again
+      leaf =
+          (TechnicalInjectExpectation)
+              injectExpectationRepository
+                  .findAllByInjectAndAsset(savedInject.getId(), agentlessEndpoint.getId())
+                  .getFirst();
+      leaf.setExpectedSecurityPlatforms(
+          List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.LLM_FIREWALL));
+      injectExpectationRepository.save(leaf);
+      em.flush();
+      em.clear();
+
+      response = callGetAiDefenseExpectations(llmCollector);
+      assertEquals(1, ((List<?>) JsonPath.read(response, "$")).size());
+    }
+
+    /**
+     * Regression test: a collector writing a failed result DIRECTLY on an asset-level parent
+     * expectation (asset with agent children) must not clobber the score derived from the agents.
+     * The green verdict rolled up from the agents stays, the direct result is only recorded.
+     */
+    @Test
+    @DisplayName("Direct collector failure cannot clobber a parent whose agents are green")
+    void directFailureOnParentKeepsChildrenVerdict() throws Exception {
+      // -- PREPARE --
+      ExecutableInject executableInject = newExecutableInjectWithTargets(true);
+      List<Expectation> detectionExpectations =
+          createDetectionExpectations(
+              List.of(savedAgent1),
+              savedEndpoint,
+              savedAssetGroup,
+              DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME);
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject, detectionExpectations);
+      em.flush();
+      em.clear();
+
+      // Agent answered green by the EDR collector: asset and asset group roll up to green
+      List<BaseInjectExpectation> agentExpectations =
+          injectExpectationRepository.findAllByInjectAndAgent(
+              savedInject.getId(), savedAgent1.getId());
+      callUpdateInjectExpectation(
+          agentExpectations.getFirst(),
+          getInjectExpectationUpdateInput(savedCollector.getId(), DETECTION.successLabel, true));
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(100.0, getScore(assetExpectations));
+
+      // -- EXECUTE: another collector writes a failure DIRECTLY on the asset-level parent --
+      callUpdateInjectExpectation(
+          assetExpectations.getFirst(),
+          getInjectExpectationUpdateInput(savedCollector2.getId(), DETECTION.failureLabel, false));
+
+      // -- ASSERT --
+      // The direct result is recorded on the parent row...
+      assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(0.0, getResultScoreForCollector(assetExpectations, savedCollector2).get());
+      // ...but the children-derived verdict is untouched
+      assertEquals(100.0, getScore(assetExpectations));
+      List<BaseInjectExpectation> assetGroupExpectations =
+          injectExpectationRepository.findAllByInjectAndAssetGroup(
+              savedInject.getId(), savedAssetGroup.getId());
+      assertEquals(100.0, getScore(assetGroupExpectations));
+    }
+
+    /**
+     * Regression test: a direct failure on a parent whose agents are still unanswered must keep the
+     * parent PENDING (null score) - the agents' security platform may still answer green.
+     */
+    @Test
+    @DisplayName("Direct collector failure keeps parent pending while agents are unanswered")
+    void directFailureOnParentKeepsPendingChildren() throws Exception {
+      // -- PREPARE --
+      ExecutableInject executableInject = newExecutableInjectWithTargets(true);
+      List<Expectation> detectionExpectations =
+          createDetectionExpectations(
+              List.of(savedAgent1),
+              savedEndpoint,
+              savedAssetGroup,
+              DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME);
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject, detectionExpectations);
+      em.flush();
+      em.clear();
+
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+
+      // -- EXECUTE: a collector writes a failure DIRECTLY on the asset-level parent --
+      callUpdateInjectExpectation(
+          assetExpectations.getFirst(),
+          getInjectExpectationUpdateInput(savedCollector2.getId(), DETECTION.failureLabel, false));
+
+      // -- ASSERT: the parent stays pending, waiting for its agents --
+      assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(null, getScore(assetExpectations));
+      List<BaseInjectExpectation> assetGroupExpectations =
+          injectExpectationRepository.findAllByInjectAndAssetGroup(
+              savedInject.getId(), savedAssetGroup.getId());
+      assertEquals(null, getScore(assetGroupExpectations));
+    }
+
+    private Collector createCollectorWithSecurityPlatform(String platformType) {
+      SecurityPlatform securityPlatform =
+          securityPlatformRepository.save(
+              SecurityPlatformFixture.createDefault(
+                  platformType + "-platform-" + UUID.randomUUID(), platformType));
+      CollectorType collectorType = new CollectorType(UUID.randomUUID().toString());
+      collectorTypeRepository.save(collectorType);
+      Collector collector = new Collector();
+      collector.setId(UUID.randomUUID().toString());
+      collector.setName(platformType + "-collector");
+      collector.setType(collectorType.getName());
+      collector.setCollectorType(collectorType);
+      collector.setExternal(true);
+      collector.setSecurityPlatform(securityPlatform);
+      return collectorRepository.save(collector);
+    }
+
+    private String callGetAiDefenseExpectations(Collector collector) throws Exception {
+      return mvc.perform(
+              get(INJECTS_EXPECTATIONS_URI + "/ai/" + collector.getId())
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().is2xxSuccessful())
+          .andReturn()
+          .getResponse()
+          .getContentAsString();
     }
   }
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -128,6 +128,13 @@ public interface InjectExpectationRepository
   // Only LEAF asset expectations are returned (asset_id IS NOT NULL): asset-group parents
   // (asset_id NULL, asset_group_id set) are never fulfilled directly - their score is recomputed by
   // propagation from the asset leaves - and updating them directly would dereference a null asset.
+  // Two additional guards keep collectors away from expectations that are not theirs to answer:
+  // 1. PARENT asset expectations (same shape: asset set, agent null) whose asset has agent-level
+  //    children are excluded - their score is derived from the agents, and a collector answering
+  //    the parent directly would clobber that derived verdict (e.g. an LLM firewall stamping
+  //    "Not Detected" on an endpoint parent whose EDR agents were already green).
+  // 2. When the expectation restricts its expected security platform types, only collectors whose
+  //    security platform matches one of those types receive it (empty/null means any platform).
   @Query(
       value =
           "SELECT e.* FROM injects_expectations e "
@@ -136,6 +143,19 @@ public interface InjectExpectationRepository
               + "AND e.inject_expectation_type = :type "
               + "AND e.agent_id IS NULL "
               + "AND e.asset_id IS NOT NULL "
+              + "AND NOT EXISTS (SELECT 1 FROM injects_expectations child "
+              + "  WHERE child.inject_id = e.inject_id "
+              + "  AND child.asset_id = e.asset_id "
+              + "  AND child.inject_expectation_type = e.inject_expectation_type "
+              + "  AND child.agent_id IS NOT NULL) "
+              + "AND (e.inject_expectation_expected_security_platforms IS NULL "
+              + "  OR jsonb_typeof(e.inject_expectation_expected_security_platforms::jsonb) <> 'array' "
+              + "  OR jsonb_array_length(e.inject_expectation_expected_security_platforms::jsonb) = 0 "
+              + "  OR EXISTS (SELECT 1 FROM collectors c "
+              + "    JOIN assets sp ON sp.asset_id = c.collector_security_platform "
+              + "    WHERE c.collector_id = :sourceId "
+              + "    AND sp.security_platform_type IS NOT NULL "
+              + "    AND jsonb_exists(e.inject_expectation_expected_security_platforms::jsonb, sp.security_platform_type))) "
               + "AND "
               + RESULTS_HAS_NO_RESULT_FOR_SOURCE
               + "ORDER BY e.inject_expectation_created_at ASC LIMIT :limit",


### PR DESCRIPTION
## Summary

Fixes #6961 - an asset showed "Not Detected" / "Not Prevented" hours after execution while its agent showed the green Microsoft Defender verdict. The XTM One (LLM firewall) collector was handed EDR-only endpoint PARENT expectations by the AI defense feed, expired them with a direct failed result, and that write clobbered the score rolled up from the green agents (invisibly - the UI discards parent-row results for assets with agents).

- Feed guard (InjectExpectationRepository.findAgentlessExpectationsNotFilledForSource): exclude asset parents that have agent children, and only hand an expectation to collectors whose security platform type is among inject_expectation_expected_security_platforms (empty means any platform).
- Write guard (InjectExpectationService.computeInjectExpectationForAgentOrAssetAgentless): a direct collector result on a parent with agent children is combined with the children verdict - a direct success is definitive, otherwise the children verdict wins, including staying pending while agents are unanswered - instead of overwriting the derived score.
- Display (enrichAssetExpectationsWithAgentSecurityPlatforms): merge the parent row's own collector results into the asset security-platform rows instead of silently discarding them.
- Repair migration V6_20260727080000000: strips mismatched-platform direct results from endpoint parents, restores asset parents whose agent children verdict is green (any child for group expectations, all children for non-group), then asset group parents from the repaired assets. Every repaired row bumps inject_expectation_updated_at so the incremental ES engine re-feeds the documents and the statistics converge. Idempotent.

## Test plan

- [x] ExpectationApiTest: AI defense feed excludes endpoint parents with agent children
- [x] ExpectationApiTest: AI defense feed respects expected security platform types (EDR-only never reaches an LLM firewall collector; empty means any)
- [x] ExpectationApiTest: direct collector failure on a parent whose agents are green keeps the green verdict at asset and asset group level while recording the result
- [x] ExpectationApiTest: direct collector failure keeps the parent pending while agents are unanswered
- [x] mvn compile + test-compile green locally; full suite via CI
- [ ] Verify on prod data: migration repairs the Bloodhound run parents (asset 57640428) and ES stats converge
