### PR TITLE
fix(chaining): feed agentless (network injector) structured output into the workflow state (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -1100,9 +1100,12 @@ public class InjectExecutionStep implements ActionStep {
     for (ExecutionTrace trace : traces) {
       Map<String, JsonElement> map = new HashMap<>();
       if (trace.getAgent() == null) {
-        // Network injectors (nmap, netexec, …) execute without an on-host agent, so their traces carry no
-        // agent — but they DO carry the structured output the chaining engine decomposes into primitives
-        // to drive events. Only the agent_id enrichment is agent-specific. Dropping the whole trace here
+        // Network injectors (nmap, netexec, …) execute without an on-host agent, so their traces
+        // carry no
+        // agent — but they DO carry the structured output the chaining engine decomposes into
+        // primitives
+        // to drive events. Only the agent_id enrichment is agent-specific. Dropping the whole trace
+        // here
         // meant no port/share/… event could ever fire from a network injector's findings; keep the
         // structured output so it still feeds the workflow state.
         if (trace.getStructuredOutput() != null) {

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -1100,7 +1100,15 @@ public class InjectExecutionStep implements ActionStep {
     for (ExecutionTrace trace : traces) {
       Map<String, JsonElement> map = new HashMap<>();
       if (trace.getAgent() == null) {
-        log.info("[Chaining] Trace skipped: agent is null");
+        // Network injectors (nmap, netexec, …) execute without an on-host agent, so their traces carry no
+        // agent — but they DO carry the structured output the chaining engine decomposes into primitives
+        // to drive events. Only the agent_id enrichment is agent-specific. Dropping the whole trace here
+        // meant no port/share/… event could ever fire from a network injector's findings; keep the
+        // structured output so it still feeds the workflow state.
+        if (trace.getStructuredOutput() != null) {
+          map.put("parsed", JsonParser.parseString(trace.getStructuredOutput().toString()));
+          output.add(map);
+        }
         continue;
       }
       map.put("agent_id", gson.toJsonTree(trace.getAgent().getId()));


### PR DESCRIPTION
## Summary

Network injectors (nmap, netexec, …) execute **without an on-host agent**, so their execution traces carry no agent. `InjectExecutionStep.formatExecutionTracesToOutput` dropped every agentless trace outright (`if (trace.getAgent() == null) continue;`), which also dropped the **structured output** those traces carry. As a result the chaining engine never received a network injector's parsed output, so it never decomposed it into workflow-state primitives (`Port`, `ShareName`, `Host`, …) — and no event based on those findings (e.g. `port = 445`, `share_name IS_NOT_NULL`) could ever fire. Payload-based injects run via an agent, so they were unaffected: that's why "it works for payloads but not injectors".

## Fix

For an agentless trace, still process its `structuredOutput` into the step output (only the `agent_id` enrichment is agent-specific). Message-only agentless traces stay skipped, so nothing else changes.

## Evidence

- DB: 100% of nmap/netexec traces have `execution_agent_id IS NULL`, including every trace carrying structured output (60 nmap, 28 netexec).
- Their structured output is well-formed for decomposition, e.g. nmap: `{"scan_results":[{"port":445,"service":"microsoft-ds","host":"…","asset_id":"…"}], "ports":[445,3389]}`.
- After the fix (validated locally): the workflow-state pool gets `Port`/`Host`/`ShareName`, the `SHARE` event fired and triggered a downstream `NetExec LDAP - Kerberoasting` action, and the attack-path draws the causal "Triggered SHARE" edge.

Related issue: #6647