### PR TITLE
feat(attackpath): present SMB share findings as the native file type (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -94,6 +94,14 @@ public class AttackPathGraphService {
   private static final String CATEGORY_CREDENTIALS = "credentials";
   private static final String CREDENTIAL_MASK = "••••";
 
+  // Interim stand-in: SMB `share` findings are presented as captured files until a native `file`
+  // finding type exists. presentType is applied once at each finding-read boundary, so every
+  // downstream node id / counter / DTO presents `file`. To drop the stand-in later, remove the
+  // `share` source from FILE_SOURCE_TYPES and presentType.
+  private static final String SHARE_TYPE = "share";
+  private static final String FILE_TYPE = "file";
+  private static final Set<String> FILE_SOURCE_TYPES = Set.of(SHARE_TYPE, FILE_TYPE);
+
   private final AttackPathExecutionRepository executionRepository;
   private final AttackPathFindingRepository findingRepository;
   private final InjectorContractRepository injectorContractRepository;
@@ -165,7 +173,7 @@ public class AttackPathGraphService {
     }
     Page<AttackPathFindingListRow> page =
         findingRepository.findPageByTypes(simulationId, types, pageable);
-    List<AttackPathFindingListRow> rows = page.getContent();
+    List<AttackPathFindingListRow> rows = presentListRows(page.getContent());
     FindingLinkData links = findingLinks(rows);
     boolean maskValue = CATEGORY_CREDENTIALS.equalsIgnoreCase(category);
     List<AttackPathFindingItemDTO> items =
@@ -205,7 +213,8 @@ public class AttackPathGraphService {
             AttackPathFindingVerdicts.ofExecution(
                 e.getPreventionStatus(), e.getDetectionStatus(), e.getVulnerabilityStatus()));
     List<AttackPathExecutionFindingItemDTO> findings = new ArrayList<>();
-    for (AttackPathEndpointFindingRow f : findingRepository.findByExecutionId(executionId)) {
+    for (AttackPathEndpointFindingRow f :
+        presentEndpointFindingRows(findingRepository.findByExecutionId(executionId))) {
       boolean credential = CATEGORY_CREDENTIALS.equals(f.type());
       findings.add(
           new AttackPathExecutionFindingItemDTO(
@@ -343,8 +352,9 @@ public class AttackPathGraphService {
    * The finding types each product widget aggregates (spec 5048 section 2:
    * Files/Credentials/Users/CVEs; Endpoints is a separate endpoint-group read, not a finding type).
    * {@code port} is a graph finding type but not a product widget, so it has no category here;
-   * {@code file} has no seed finding type yet (an open question), so the files drawer is empty
-   * until ingestion produces one. An unknown category yields no types (an empty page).
+   * {@code files} aggregates the SMB {@code share} source type (presented as {@code file}), an
+   * interim stand-in until a native {@code file} finding type exists. An unknown category yields no
+   * types (an empty page).
    */
   private static Set<String> categoryTypes(String category) {
     if (category == null) {
@@ -354,9 +364,81 @@ public class AttackPathGraphService {
       case CATEGORY_CREDENTIALS -> Set.of("credentials");
       case "users" -> Set.of("username", "admin_username");
       case "cves" -> Set.of("cve");
-      case "files" -> Set.of("file");
+      case "files" -> FILE_SOURCE_TYPES;
       default -> Set.of();
     };
+  }
+
+  /**
+   * Interim stand-in: present a stored SMB {@code share} finding as the native {@code file} type.
+   */
+  private static String presentType(String rawType) {
+    return SHARE_TYPE.equals(rawType) ? FILE_TYPE : rawType;
+  }
+
+  // Relabel the finding type once at each repository-read boundary, so every downstream id / node /
+  // counter / DTO derives from the presented type (single choke point). Records are immutable and
+  // List overloads would clash on erasure, so each read has a distinctly-named mapper.
+  private static List<AttackPathFindingRow> presentGraphRows(List<AttackPathFindingRow> rows) {
+    return rows.stream()
+        .map(
+            r ->
+                new AttackPathFindingRow(
+                    r.id(),
+                    presentType(r.type()),
+                    r.value(),
+                    r.endpointId(),
+                    r.endpointRaw(),
+                    r.endpointKey(),
+                    r.executionId()))
+        .toList();
+  }
+
+  private static List<AttackPathEndpointFindingVerdictRow> presentVerdictRows(
+      List<AttackPathEndpointFindingVerdictRow> rows) {
+    return rows.stream()
+        .map(
+            r ->
+                new AttackPathEndpointFindingVerdictRow(
+                    presentType(r.type()),
+                    r.value(),
+                    r.preventionStatus(),
+                    r.detectionStatus(),
+                    r.vulnerabilityStatus()))
+        .toList();
+  }
+
+  private static List<AttackPathEndpointFindingRow> presentEndpointFindingRows(
+      List<AttackPathEndpointFindingRow> rows) {
+    return rows.stream()
+        .map(r -> new AttackPathEndpointFindingRow(presentType(r.type()), r.value()))
+        .toList();
+  }
+
+  private static List<AttackPathFindingListRow> presentListRows(
+      List<AttackPathFindingListRow> rows) {
+    return rows.stream()
+        .map(
+            r ->
+                new AttackPathFindingListRow(
+                    r.id(), presentType(r.type()), r.value(), r.endpointKey()))
+        .toList();
+  }
+
+  private static List<AttackPathTypeCountRow> presentTypeCounts(List<AttackPathTypeCountRow> rows) {
+    return rows.stream()
+        .map(r -> new AttackPathTypeCountRow(presentType(r.type()), r.distinctValues()))
+        .toList();
+  }
+
+  private static List<AttackPathEndpointTypeCountRow> presentEndpointTypeCounts(
+      List<AttackPathEndpointTypeCountRow> rows) {
+    return rows.stream()
+        .map(
+            r ->
+                new AttackPathEndpointTypeCountRow(
+                    r.endpointKey(), presentType(r.type()), r.distinctValues()))
+        .toList();
   }
 
   /**
@@ -382,7 +464,8 @@ public class AttackPathGraphService {
 
   private AttackPathDTO fullGraph(String simulationId) {
     List<AttackPathExecutionRow> executions = executionRepository.findGraphRows(simulationId);
-    List<AttackPathFindingRow> findings = findingRepository.findGraphRows(simulationId);
+    List<AttackPathFindingRow> findings =
+        presentGraphRows(findingRepository.findGraphRows(simulationId));
     return assemble(executions, findings);
   }
 
@@ -393,7 +476,7 @@ public class AttackPathGraphService {
   @Transactional(readOnly = true)
   public AttackPathExpandDTO expandEndpoint(String simulationId, String endpointKey) {
     List<AttackPathEndpointFindingVerdictRow> findings =
-        findingRepository.findByEndpoint(simulationId, endpointKey);
+        presentVerdictRows(findingRepository.findByEndpoint(simulationId, endpointKey));
     String assetNodeId = AttackPathIds.endpointNode(endpointKey);
     Map<String, AttackPathNodeDTO> typeNodes = new LinkedHashMap<>();
     Map<String, AttackPathNodeDTO> findingNodes = new LinkedHashMap<>();
@@ -497,6 +580,7 @@ public class AttackPathGraphService {
     Set<String> userKeys = new HashSet<>();
     Set<String> cveKeys = new HashSet<>();
     Set<String> portKeys = new HashSet<>();
+    Set<String> fileKeys = new HashSet<>();
     for (AttackPathFindingRow f : findings) {
       String assetNodeId = AttackPathIds.endpointNode(f.endpointKey());
       String typeNodeId = AttackPathIds.findingTypeNode(f.type(), f.endpointKey());
@@ -544,6 +628,7 @@ public class AttackPathGraphService {
         case "username", "admin_username" -> userKeys.add(counterKey);
         case "cve" -> cveKeys.add(counterKey);
         case "port" -> portKeys.add(counterKey);
+        case "file" -> fileKeys.add(counterKey);
         default -> {
           // other finding types do not feed a top-bar counter
         }
@@ -576,7 +661,8 @@ public class AttackPathGraphService {
             credentialKeys.size(),
             userKeys.size(),
             cveKeys.size(),
-            portKeys.size());
+            portKeys.size(),
+            fileKeys.size());
     return new AttackPathDTO(
         staticFindings,
         new ArrayList<>(feedByExecutionId.values()),
@@ -665,9 +751,10 @@ public class AttackPathGraphService {
     List<AttackPathEndpointGroupRow> endpoints =
         executionRepository.findEndpointGroups(simulationId);
     List<AttackPathEdgeGroupRow> edges = executionRepository.findEdgeGroups(simulationId);
-    List<AttackPathTypeCountRow> typeCounts = findingRepository.findTypeCounts(simulationId);
+    List<AttackPathTypeCountRow> typeCounts =
+        presentTypeCounts(findingRepository.findTypeCounts(simulationId));
     List<AttackPathEndpointTypeCountRow> endpointTypeCounts =
-        findingRepository.findEndpointTypeCounts(simulationId);
+        presentEndpointTypeCounts(findingRepository.findEndpointTypeCounts(simulationId));
 
     Map<String, Map<String, Long>> findingCountsByEndpoint = new LinkedHashMap<>();
     for (AttackPathEndpointTypeCountRow row : endpointTypeCounts) {
@@ -728,18 +815,20 @@ public class AttackPathGraphService {
     long users = 0;
     long cves = 0;
     long ports = 0;
+    long files = 0;
     for (AttackPathTypeCountRow t : typeCounts) {
       switch (t.type()) {
         case "credentials" -> credentials += t.distinctValues();
         case "username", "admin_username" -> users += t.distinctValues();
         case "cve" -> cves += t.distinctValues();
         case "port" -> ports += t.distinctValues();
+        case "file" -> files += t.distinctValues();
         default -> {
           // other finding types do not feed a top-bar counter
         }
       }
     }
-    return new AttackPathCounters(endpoints, credentials, users, cves, ports);
+    return new AttackPathCounters(endpoints, credentials, users, cves, ports, files);
   }
 
   /** Worst-case severity of an endpoint's executions from the aggregated red/orange counts. */

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -225,7 +225,7 @@ public class AttackPathGraphService {
     // links to, so endpoint-scoped masking never leaves a known secret in the clear.
     Set<String> secrets = new HashSet<>();
     for (AttackPathEndpointFindingVerdictRow f :
-        findingRepository.findByEndpoint(simulationId, e.getTargetKey())) {
+        presentVerdictRows(findingRepository.findByEndpoint(simulationId, e.getTargetKey()))) {
       if (CATEGORY_CREDENTIALS.equals(f.type())) {
         String secret = credentialSecret(f.value());
         if (secret != null && !secret.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathCounters.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathCounters.java
@@ -3,7 +3,9 @@ package io.openaev.service.attackpath.dto;
 /**
  * Top-bar counters, derived in the rebuild pass (issue 6647). {@code endpoints} is the number of
  * distinct execution targets (from Read A); the rest are distinct findings by type (from Read B).
- * There is no files counter: no {@code ContractOutputType} value maps to it.
+ * {@code files} counts distinct {@code file} findings. As an interim stand-in, SMB {@code share}
+ * findings are presented as {@code file}, so today this is the distinct-share count, surfaced as a
+ * real backend counter instead of the front's former {@code findingCounts.share} approximation.
  */
 public record AttackPathCounters(
-    long endpoints, long credentials, long users, long cves, long ports) {}
+    long endpoints, long credentials, long users, long cves, long ports, long files) {}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFileTypeApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFileTypeApiTest.java
@@ -1,0 +1,171 @@
+package io.openaev.api.attackpath;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
+import io.openaev.database.model.attackpath.AttackPathFinding;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * SMB {@code share} findings present as the native {@code file} type across the attack-path reads,
+ * via the interim {@code share -> file} stand-in. A persisted {@code share} finding reads {@code
+ * typeFindings == "file"} on the endpoint expand, the graph node, the drawer, the execution detail,
+ * and the {@code files} counter.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@TestPropertySource(properties = "openaev.enabled-dev-features=INJECT_CHAINING,ATTACK_PATH")
+@DisplayName("attack path: share findings present as the native file type")
+class AttackPathFileTypeApiTest extends IntegrationTest {
+
+  private static final String SIM = "SIM-FILE";
+  private static final String ENDPOINT = "dc-01";
+  private static final String SHARE_VALUE = "public-share-01";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+  @Autowired private AttackPathFindingRepository findingRepository;
+
+  private Tenant tenant;
+
+  @BeforeEach
+  void setUp() {
+    tenant = tenantRepository.save(TenantFixture.getTenant("ap-file-type"));
+  }
+
+  @Test
+  @DisplayName("expand: a share finding reads type 'file'")
+  void expandPresentsShareAsFile() throws Exception {
+    seedShare(SHARE_VALUE);
+
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/endpoint/findings")
+                .param("ref", ENDPOINT))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.findings[?(@.value=='" + SHARE_VALUE + "')].typeFindings")
+                .value(hasItem("file")));
+  }
+
+  @Test
+  @DisplayName(
+      "file appears consistently on graph node, counter, collapsed, drawer, execution detail")
+  void fileAppearsOnEveryRead() throws Exception {
+    String executionId = seedShare(SHARE_VALUE);
+
+    // Full graph: the FINDING node presents file, and the real files counter is populated.
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/graph")
+                .param("mode", "full"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.counters.files").value(1))
+        .andExpect(
+            jsonPath("$.attackPathNodes[?(@.value=='" + SHARE_VALUE + "')].typeFindings")
+                .value(hasItem("file")));
+
+    // Collapsed (default view): the top-bar files counter AND the per-endpoint findingCounts.file
+    // (what the front's focused count reads) are populated — second counter switch +
+    // presentEndpointTypeCounts.
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/graph")
+                .param("mode", "collapsed"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.counters.files").value(1))
+        .andExpect(
+            jsonPath("$.attackPathNodes[?(@.type=='ASSET')].findingCounts.file").value(hasItem(1)));
+
+    // Drawer: the files category lists the finding as file.
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/findings")
+                .param("category", "files"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.items[0].type").value("file"))
+        .andExpect(jsonPath("$.items[0].value").value(SHARE_VALUE));
+
+    // Execution detail: the produced finding reads file (attack-path store).
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/execution")
+                .param("ref", executionId))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.findings[?(@.value=='" + SHARE_VALUE + "')].type").value(hasItem("file")));
+  }
+
+  @Test
+  @DisplayName("day one: no shares -> files counter is 0, no file nodes")
+  void dayOneNoShares() throws Exception {
+    // A CVE finding only: the files counter stays 0 and nothing presents as file.
+    AttackPathExecution execution = execution();
+    AttackPathFinding cve = new AttackPathFinding();
+    cve.setTenant(tenant);
+    cve.setSimulationId(SIM);
+    cve.setType("cve");
+    cve.setValue("CVE-2026-1");
+    cve.setEndpointId(ENDPOINT);
+    cve.setEndpointKey(ENDPOINT);
+    cve = findingRepository.save(cve);
+    link(execution, cve);
+    entityManager.flush();
+
+    mvc.perform(
+            get(AttackPathApi.ATTACK_PATH_URI + "/simulations/" + SIM + "/graph")
+                .param("mode", "full"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.counters.files").value(0));
+  }
+
+  /** A share finding needs a producing execution + link to appear on any read (graph invariant). */
+  private String seedShare(String value) {
+    AttackPathExecution execution = execution();
+    AttackPathFinding finding = new AttackPathFinding();
+    finding.setTenant(tenant);
+    finding.setSimulationId(SIM);
+    finding.setType("share");
+    finding.setValue(value);
+    finding.setEndpointId(ENDPOINT);
+    finding.setEndpointKey(ENDPOINT);
+    finding = findingRepository.save(finding);
+    link(execution, finding);
+    entityManager.flush();
+    return execution.getId();
+  }
+
+  private AttackPathExecution execution() {
+    AttackPathExecution execution = new AttackPathExecution();
+    execution.setTenant(tenant);
+    execution.setSimulationId(SIM);
+    execution.setSourceKind("INJECTOR");
+    execution.setSourceInjector("nmap");
+    execution.setTargetKind("ASSET");
+    execution.setTargetAssetId(ENDPOINT);
+    execution.setTargetKey(ENDPOINT);
+    execution.setTargetHostname("CORP-DC-01");
+    execution.setExecutedAt(Instant.parse("2026-06-18T08:00:00Z"));
+    execution.setPreventionStatus("Prevented");
+    return executionRepository.save(execution);
+  }
+
+  private void link(AttackPathExecution execution, AttackPathFinding finding) {
+    AttackPathExecutionFinding link = new AttackPathExecutionFinding();
+    link.setExecutionId(execution.getId());
+    link.setFindingId(finding.getId());
+    entityManager.persist(link);
+  }
+}

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -384,10 +384,10 @@ describe('buildKillChainMeta', () => {
 });
 
 describe('buildCausalEdges', () => {
-  it('draws a solid finding edge, reconciling the primitive key type (share_name -> share)', () => {
+  it('draws a solid finding edge, reconciling the primitive key type (share_name -> file)', () => {
     // Arrange
     const meta = buildKillChainMeta(killChainDto);
-    const nodes = [injectorNode('inj-smb'), findingNode('find-share', 'share', 'ADMIN$')];
+    const nodes = [injectorNode('inj-smb'), findingNode('find-share', 'file', 'ADMIN$')];
     // Act
     const edges = buildCausalEdges(nodes, id => (id ? meta.get(id) : undefined), tt);
     // Assert

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -73,7 +73,7 @@ const isSeedId = (id?: string) => !!id && id.startsWith('ap-seed-');
 
 // Finding types already surfaced by the curated summary cards (endpoints/files/credentials/users/cves).
 // Every OTHER type present in the data gets an auto-generated card, so a new finding type needs no code.
-const COVERED_FINDING_TYPES = new Set(['share', 'credentials', 'username', 'admin_username', 'cve']);
+const COVERED_FINDING_TYPES = new Set(['file', 'credentials', 'username', 'admin_username', 'cve']);
 
 // Finding categories fetched (with per-finding executionIds) to attribute findings to an injector.
 const INJECTOR_FINDING_CATEGORIES = ['credentials', 'users', 'cves', 'files'];
@@ -139,7 +139,7 @@ const CATEGORY_OF_TYPE: Record<string, string> = {
   username: 'users',
   admin_username: 'users',
   cve: 'cves',
-  share: 'files',
+  file: 'files',
 };
 
 // Match a drawer finding value to a graph finding value. Credentials are masked server-side in the
@@ -1555,19 +1555,11 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     [drawerFilteredItems, drawerSafePage],
   );
 
-  // "Captured Files" has no backend counter: derive an approximate share count from the collapsed
-  // endpoints' per-type finding counts (temporary until a native "file" finding type exists).
-  const filesCount = useMemo(() => {
-    let sum = 0;
-    for (const n of dto?.attackPathNodes ?? []) {
-      if (n.type === 'ASSET') {
-        sum += n.findingCounts?.share ?? 0;
-      }
-    }
-    return sum;
-  }, [dto]);
+  // "Captured Files" reads the real backend files counter. SMB share findings are presented as file
+  // (an interim stand-in), so this is the distinct-share count today, but wired properly.
+  const filesCount = counters?.files ?? 0;
 
-  const focusedFilesCount = focusedEndpoint?.findingCounts?.share ?? 0;
+  const focusedFilesCount = focusedEndpoint?.findingCounts?.file ?? 0;
   const effectiveCounters = pathFinding
     ? {
         endpoints: 1,
@@ -1595,7 +1587,6 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         label: t('Captured Files'),
         icon: <InsertDriveFileOutlined fontSize="small" />,
         count: pathFinding ? focusedFilesCount : filesCount,
-        hint: t('Temporarily mapped to "share" findings'),
       },
       {
         key: 'credentials',

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -706,7 +706,7 @@ export const findingCategoryNoun = (typeFindings?: string): string => {
       return 'open ports';
     case 'hash':
       return 'hashes';
-    case 'share':
+    case 'file':
       return 'files';
     case 'password_policy':
       return 'password policies';
@@ -969,11 +969,11 @@ export const maskFindingValue = (typeFindings?: string, value?: string): string 
   return value;
 };
 
-// Card filter -> the ContractOutputType finding-type values it focuses (issue 6647). "files" maps to
-// `share` as a temporary stand-in until a native file finding type exists; "users" also includes
-// admin usernames per product decision.
+// Card filter -> the finding-type values it focuses (issue 6647). "files" maps to `file` (the backend
+// presents SMB `share` findings as `file`, an interim stand-in until a native file finding type
+// exists); "users" also includes admin usernames per product decision.
 export const FILTER_TO_FINDING_TYPES: Record<Exclude<AttackPathFindingFilter, 'endpoints'>, string[]> = {
-  files: ['share'],
+  files: ['file'],
   credentials: ['credentials'],
   users: ['username', 'admin_username'],
   cves: ['cve'],
@@ -1189,14 +1189,14 @@ const findingNodeValue = (node: AttackPathFlowNode): string => {
 };
 
 // A consumed key uses the raw PrimitiveType vocabulary (e.g. `share_name`, `password`) while finding
-// nodes use the finding-type vocabulary (`share`, `credentials`). Reconcile the known complex sub-field
+// nodes use the finding-type vocabulary (`file`, `credentials`). Reconcile the known complex sub-field
 // keys to their finding type here. Primitives that already match a finding type 1:1 (`port`, `cve`,
 // `ipv4`, `username`, `hostname`, `hash`…) are left untouched (identity). NOTE: reconciling the VALUE of
 // a complex finding (reaching into its sub-field, e.g. a share's `share_name`) is the front-side complex
 // matching still to come — today only the TYPE is reconciled and value comparison stays direct, which is
 // correct for primitives; complex value-matching is a follow-up (see backend requirements topo).
 const KEYTYPE_TO_FINDING_TYPE: Record<string, string> = {
-  share_name: 'share',
+  share_name: 'file',
   password: 'credentials',
 };
 

--- a/openaev-front/src/components/FindingIcon.tsx
+++ b/openaev-front/src/components/FindingIcon.tsx
@@ -1,4 +1,4 @@
-import { ReportProblemOutlined } from '@mui/icons-material';
+import { InsertDriveFileOutlined, ReportProblemOutlined } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 import {
   AccountAlertOutline,
@@ -47,6 +47,8 @@ const renderIcon = (findingType: string) => {
       return <AccountOutline color="primary" />;
     case 'share':
       return <FolderNetworkOutline color="primary" />;
+    case 'file':
+      return <InsertDriveFileOutlined color="primary" />;
     case 'group':
       return <AccountGroupOutline color="primary" />;
     case 'computer':

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -959,6 +959,8 @@ export interface AttackPathCounters {
   /** @format int64 */
   endpoints?: number;
   /** @format int64 */
+  files?: number;
+  /** @format int64 */
   ports?: number;
   /** @format int64 */
   users?: number;


### PR DESCRIPTION
## What

The attack-path "Captured Files" widget now reads a real, native `file` finding type instead of a
front-side stand-in. SMB `share` findings are presented as `file` across every attack-path read, and a
real `AttackPathCounters.files` replaces the front's former `findingCounts.share` approximation.

## How

A single interim stand-in, entirely in the attack-path layer:

- `presentType("share") = "file"`, applied **once at each finding repository-read boundary** in
  `AttackPathGraphService` (six relabel helpers), so every downstream node id, edge, counter and DTO
  presents `file` with no id divergence.
- `categoryTypes("files")` returns the file-source types so the drawer lists the underlying findings.
- Both counter switches (`assemble` and `collapsedCounters`) gain a `file` case, so `counters.files`
  is populated in full **and** collapsed (the default) modes; `AttackPathCounters` gains a `files` field.
- Front: `CATEGORY_OF_TYPE`, `FILTER_TO_FINDING_TYPES`, `COVERED_FINDING_TYPES`,
  `KEYTYPE_TO_FINDING_TYPE.share_name` and `findingCategoryNoun` all map `file`; the global `FindingIcon`
  gains an additive `case 'file'`; the "Captured Files" card reads `counters.files`; the existing
  kill-chain vitest is updated to the `file` node.

## Scope

- Attack-path layer only. No `ContractOutputType.File`, no `FileOutputProcessor`, no migration, no
  arsenal / XTM-Hub change, no other finding feature touched (the `FindingIcon` case is additive).
- The source `share` finding in the main store is untouched.
- Real captured-file data (exfil modelling) stays a content/arsenal follow-up. When it lands, drop the
  `share` source from `presentType` / `FILE_SOURCE_TYPES` and everything else is already correct.

## Notes

- **Interim divergence**: in the attack-path a share finding reads `file`; in the main findings store
  (and the execution-drawer Findings tab that reads it) the same finding still reads `share`.
- **Counter caveat (post-MVP)**: while only `share` feeds `files`, full and collapsed agree. If a native
  `file` later coexists with a `share` of the same value, the collapsed top-bar would sum while
  per-endpoint `findingCounts` overwrites; the un-bridge step switches `findingCounts` to a merge-sum.

## Tests

- `AttackPathFileTypeApiTest` (real stack): a `share` finding reads `file` on expand, the graph FINDING
  node, the drawer, the execution detail and per-endpoint `findingCounts`; `counters.files` in both
  modes; a day-one case (no shares -> 0). Statement-count pins unchanged (no new query).
- Front `check-ts` + `eslint` + `vitest` green (incl. the updated kill-chain causal-edge test).
