### PR TITLE
fix(attackpath): list findings for data-driven drawer categories  (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -353,8 +353,9 @@ public class AttackPathGraphService {
    * Files/Credentials/Users/CVEs; Endpoints is a separate endpoint-group read, not a finding type).
    * {@code port} is a graph finding type but not a product widget, so it has no category here;
    * {@code files} aggregates the SMB {@code share} source type (presented as {@code file}), an
-   * interim stand-in until a native {@code file} finding type exists. An unknown category yields no
-   * types (an empty page).
+   * interim stand-in until a native {@code file} finding type exists. Any other category is treated
+   * as a literal finding type (data-driven, mirroring the front's cards), so a category matching no
+   * finding type yields an empty page.
    */
   private static Set<String> categoryTypes(String category) {
     if (category == null) {
@@ -365,7 +366,9 @@ public class AttackPathGraphService {
       case "users" -> Set.of("username", "admin_username");
       case "cves" -> Set.of("cve");
       case "files" -> FILE_SOURCE_TYPES;
-      default -> Set.of();
+      // Any other category is a literal finding type (data-driven, mirroring the front's cards),
+      // so the "Text fields"/etc. cards open a populated drawer instead of an empty one.
+      default -> Set.of(category.toLowerCase(Locale.ROOT));
     };
   }
 

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathFindingsListTest.java
@@ -109,9 +109,25 @@ class AttackPathFindingsListTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("an unknown category (e.g. ports, not a product widget) yields an empty page")
-  void unknownCategoryYieldsEmptyPage() {
-    AttackPathFindingPageDTO page = graphService.listFindings(SIM, "ports", PageRequest.of(0, 10));
+  @DisplayName("a raw finding type category (e.g. text) lists its findings")
+  void rawFindingTypeCategoryListsItsFindings() {
+    // The front's data-driven cards open the drawer with the finding type itself as the category
+    // (e.g. "text" for the "Text fields" card). It must list those findings, not an empty page.
+    linkedFinding("host-x", "text", "some captured text", executionId);
+    entityManager.flush();
+
+    AttackPathFindingPageDTO page = graphService.listFindings(SIM, "text", PageRequest.of(0, 10));
+
+    assertThat(page.total()).isEqualTo(1);
+    assertThat(page.items().get(0).type()).isEqualTo("text");
+    assertThat(page.items().get(0).value()).isEqualTo("some captured text");
+  }
+
+  @Test
+  @DisplayName("a category matching no finding type yields an empty page")
+  void nonMatchingCategoryYieldsEmptyPage() {
+    AttackPathFindingPageDTO page =
+        graphService.listFindings(SIM, "not-a-type", PageRequest.of(0, 10));
 
     assertThat(page.total()).isZero();
     assertThat(page.items()).isEmpty();


### PR DESCRIPTION
The attack-path finding widgets (e.g. 'Text fields') open the right drawer with the finding type itself as the category. `categoryTypes` only mapped the curated aggregates (credentials/users/cves/files), so those drawers returned an empty page. It now treats any other category as a literal finding type (data-driven, mirroring the front's cards), so the drawer lists the findings. Backend-only; real-stack test added (RED->GREEN). 