### PR TITLE
fix(front): redirect chained scenario launch now to simulation attack path (#6977)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -513,7 +513,15 @@ const ScenarioHeader = ({
             onClick={async () => {
               setOpenInstantiateSimulationAndStart(false);
               const exercise: Exercise = (await createRunningExerciseFromScenario(scenarioId)).data;
-              navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}`);
+              // A chained simulation is best followed live on its attack path
+              // graph; time-based ones land on the overview as before. The
+              // route only exists when ATTACK_PATH is enabled (see
+              // simulation/Index.tsx route gating).
+              if (isScenarioChaining && isFeatureEnabled('ATTACK_PATH')) {
+                navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}/attack-path`);
+              } else {
+                navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}`);
+              }
               MESSAGING$.notifySuccess(t('New simulation successfully created and started'));
             }}
           >


### PR DESCRIPTION
## Description

When launching a **chained** scenario via "Launch now", the user is now redirected to the new simulation's **Attack path** view (`/admin/simulations/{id}/attack-path`) instead of the overview — that's where a workflow-backed run is best followed live.

- Time-based (non-chained) scenarios keep the current behavior (redirect to overview).
- The redirect is gated on the `ATTACK_PATH` feature flag, matching the route gating in `simulation/Index.tsx` (the attack-path route only exists when the flag is enabled).

## Changes
- `ScenarioHeader.tsx`: branch the post-`createRunningExerciseFromScenario` navigation on `isScenarioChaining && isFeatureEnabled('ATTACK_PATH')`.

## Checks
- `yarn eslint` and `yarn tsc --noEmit` pass.