### PR TITLE
fix(expectations): aggregate endpoint alerts from child agent expectations (#6978)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
@@ -6,9 +6,10 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.BaseInjectExpectation;
 import io.openaev.database.model.Collector;
 import io.openaev.database.model.InjectExpectationTrace;
-import io.openaev.database.model.SecurityPlatform;
+import io.openaev.database.model.TechnicalInjectExpectation;
 import io.openaev.database.raw.impl.SimpleRawExpectationTrace;
 import io.openaev.database.repository.CollectorRepository;
+import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.InjectExpectationTraceRepository;
 import io.openaev.database.repository.SecurityPlatformRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
@@ -29,28 +30,68 @@ public class InjectExpectationTraceService {
   private final InjectExpectationTraceRepository injectExpectationTraceRepository;
   private final SecurityPlatformRepository securityPlatformRepository;
   private final CollectorRepository collectorRepository;
+  private final InjectExpectationRepository injectExpectationRepository;
   private final ResultsMetricCollector resultsMetricCollector;
 
   public List<InjectExpectationTrace> getInjectExpectationTracesFromCollector(
       @NotNull String injectExpectationId, @NotNull String sourceId) {
-    return this.injectExpectationTraceRepository.findByExpectationAndSecurityPlatform(
-        injectExpectationId, sourceId);
+    return this.injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+        resolveAlertExpectationIds(injectExpectationId), sourceId);
   }
 
   public long getAlertLinksNumber(
       @NotNull String injectExpectationId,
       @NotNull String sourceId,
       String expectationResultSourceType) {
+    String securityPlatformId;
     if (expectationResultSourceType.equalsIgnoreCase(COLLECTOR)) {
-      SecurityPlatform securityPlatform =
+      securityPlatformId =
           securityPlatformRepository
               .findByExternalReference(sourceId)
-              .orElseThrow(() -> new ElementNotFoundException("Security platform not found"));
-      return this.injectExpectationTraceRepository.countAlerts(
-          injectExpectationId, securityPlatform.getId());
+              .orElseThrow(() -> new ElementNotFoundException("Security platform not found"))
+              .getId();
     } else {
-      return this.injectExpectationTraceRepository.countAlerts(injectExpectationId, sourceId);
+      securityPlatformId = sourceId;
     }
+    return this.injectExpectationTraceRepository.countAlertsForExpectations(
+        resolveAlertExpectationIds(injectExpectationId), securityPlatformId);
+  }
+
+  /**
+   * Alerts (traces) are attached by the collector to the AGENT-level expectations. The asset
+   * (endpoint) target-results row shows the asset-level expectation, which carries none of its own,
+   * so its alert count would always read 0. When the given expectation is an asset-level technical
+   * expectation (asset set, no agent), we roll its alerts up from its child agent expectations of
+   * the same type, plus the asset expectation itself (agentless endpoints and any result written
+   * directly at the asset level). Any other expectation resolves to itself.
+   *
+   * @param injectExpectationId the expectation whose alerts are requested
+   * @return the set of expectation ids whose traces must be aggregated
+   */
+  private List<String> resolveAlertExpectationIds(@NotNull final String injectExpectationId) {
+    return injectExpectationRepository
+        .findById(injectExpectationId)
+        .filter(TechnicalInjectExpectation.class::isInstance)
+        .map(TechnicalInjectExpectation.class::cast)
+        .filter(
+            expectation ->
+                expectation.getAsset() != null
+                    && expectation.getAgent() == null
+                    && expectation.getInject() != null)
+        .map(
+            assetExpectation -> {
+              List<String> expectationIds = new ArrayList<>();
+              expectationIds.add(injectExpectationId);
+              injectExpectationRepository
+                  .findAllAgentExpectationsByInjectAndAsset(
+                      assetExpectation.getInject().getId(), assetExpectation.getAsset().getId())
+                  .stream()
+                  .filter(child -> child.getType() == assetExpectation.getType())
+                  .map(BaseInjectExpectation::getId)
+                  .forEach(expectationIds::add);
+              return expectationIds;
+            })
+        .orElseGet(() -> List.of(injectExpectationId));
   }
 
   @Transactional(rollbackFor = Exception.class)

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
@@ -83,10 +83,11 @@ public class InjectExpectationTraceService {
               List<String> expectationIds = new ArrayList<>();
               expectationIds.add(injectExpectationId);
               injectExpectationRepository
-                  .findAllAgentExpectationsByInjectAndAsset(
-                      assetExpectation.getInject().getId(), assetExpectation.getAsset().getId())
+                  .findAllWithAgentsByInjectAndAsset(
+                      assetExpectation.getInject().getId(),
+                      assetExpectation.getAsset().getId(),
+                      assetExpectation.getType())
                   .stream()
-                  .filter(child -> child.getType() == assetExpectation.getType())
                   .map(BaseInjectExpectation::getId)
                   .forEach(expectationIds::add);
               return expectationIds;

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
@@ -35,8 +35,9 @@ public class InjectExpectationTraceService {
 
   public List<InjectExpectationTrace> getInjectExpectationTracesFromCollector(
       @NotNull String injectExpectationId, @NotNull String sourceId) {
-    return this.injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
-        resolveAlertExpectationIds(injectExpectationId), sourceId);
+    return deduplicateByAlertIdentity(
+        this.injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            resolveAlertExpectationIds(injectExpectationId), sourceId));
   }
 
   public long getAlertLinksNumber(
@@ -53,8 +54,33 @@ public class InjectExpectationTraceService {
     } else {
       securityPlatformId = sourceId;
     }
-    return this.injectExpectationTraceRepository.countAlertsForExpectations(
-        resolveAlertExpectationIds(injectExpectationId), securityPlatformId);
+    return deduplicateByAlertIdentity(
+            this.injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+                resolveAlertExpectationIds(injectExpectationId), securityPlatformId))
+        .size();
+  }
+
+  /**
+   * A trace belongs to exactly one expectation, and the collector stores the same physical alert
+   * once per matching agent expectation (unique per expectation + source + name + link). When
+   * several expectations are rolled up onto the endpoint row, that alert would therefore be listed
+   * and counted once per agent; keep only the first occurrence of each (name, link) pair so the
+   * aggregated view reflects distinct alerts. Single-expectation lookups are unaffected (the
+   * uniqueness constraint already forbids duplicates there).
+   *
+   * @param traces the traces returned for the resolved expectation ids
+   * @return the traces with per-agent duplicates of the same alert removed, original order kept
+   */
+  private List<InjectExpectationTrace> deduplicateByAlertIdentity(
+      final List<InjectExpectationTrace> traces) {
+    Set<String> seenAlerts = new HashSet<>();
+    List<InjectExpectationTrace> distinctTraces = new ArrayList<>();
+    for (InjectExpectationTrace trace : traces) {
+      if (seenAlerts.add(trace.getAlertName() + "|" + trace.getAlertLink())) {
+        distinctTraces.add(trace);
+      }
+    }
+    return distinctTraces;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
@@ -62,20 +62,33 @@ public class InjectExpectationTraceService {
 
   /**
    * A trace belongs to exactly one expectation, and the collector stores the same physical alert
-   * once per matching agent expectation (unique per expectation + source + name + link). When
-   * several expectations are rolled up onto the endpoint row, that alert would therefore be listed
-   * and counted once per agent; keep only the first occurrence of each (name, link) pair so the
-   * aggregated view reflects distinct alerts. Single-expectation lookups are unaffected (the
-   * uniqueness constraint already forbids duplicates there).
+   * once per matching agent expectation. When several expectations are rolled up onto the endpoint
+   * row, that alert would therefore be listed and counted once per agent; keep a single
+   * representative per (name, link) pair so the aggregated view reflects distinct alerts. The DB
+   * query has no ORDER BY, so the traces are first sorted (newest alert first, id as the final
+   * tie-break) to make the chosen representative - and the date it displays - deterministic.
+   * Single-expectation lookups also go through here: the uniqueness constraint on (expectation,
+   * source, name, link) treats NULLs as distinct, so duplicate rows remain possible when the alert
+   * name or link is NULL.
    *
    * @param traces the traces returned for the resolved expectation ids
-   * @return the traces with per-agent duplicates of the same alert removed, original order kept
+   * @return the distinct alerts, newest first, per-agent duplicates removed
    */
   private List<InjectExpectationTrace> deduplicateByAlertIdentity(
       final List<InjectExpectationTrace> traces) {
+    List<InjectExpectationTrace> sortedTraces = new ArrayList<>(traces);
+    sortedTraces.sort(
+        Comparator.comparing(
+                InjectExpectationTrace::getAlertDate,
+                Comparator.nullsLast(Comparator.reverseOrder()))
+            .thenComparing(
+                InjectExpectationTrace::getCreatedAt,
+                Comparator.nullsLast(Comparator.reverseOrder()))
+            .thenComparing(
+                InjectExpectationTrace::getId, Comparator.nullsLast(Comparator.naturalOrder())));
     Set<AlertIdentity> seenAlerts = new HashSet<>();
     List<InjectExpectationTrace> distinctTraces = new ArrayList<>();
-    for (InjectExpectationTrace trace : traces) {
+    for (InjectExpectationTrace trace : sortedTraces) {
       if (seenAlerts.add(new AlertIdentity(trace.getAlertName(), trace.getAlertLink()))) {
         distinctTraces.add(trace);
       }

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationTraceService.java
@@ -73,15 +73,25 @@ public class InjectExpectationTraceService {
    */
   private List<InjectExpectationTrace> deduplicateByAlertIdentity(
       final List<InjectExpectationTrace> traces) {
-    Set<String> seenAlerts = new HashSet<>();
+    Set<AlertIdentity> seenAlerts = new HashSet<>();
     List<InjectExpectationTrace> distinctTraces = new ArrayList<>();
     for (InjectExpectationTrace trace : traces) {
-      if (seenAlerts.add(trace.getAlertName() + "|" + trace.getAlertLink())) {
+      if (seenAlerts.add(new AlertIdentity(trace.getAlertName(), trace.getAlertLink()))) {
         distinctTraces.add(trace);
       }
     }
     return distinctTraces;
   }
+
+  /**
+   * Identity of a physical alert as reported by the security platform. A dedicated key type (not a
+   * string concatenation) so values containing any separator, or null fields, can never make two
+   * different alerts collide or the same alert count twice.
+   *
+   * @param name the alert name
+   * @param link the alert link
+   */
+  private record AlertIdentity(String name, String link) {}
 
   /**
    * Alerts (traces) are attached by the collector to the AGENT-level expectations. The asset
@@ -92,7 +102,7 @@ public class InjectExpectationTraceService {
    * directly at the asset level). Any other expectation resolves to itself.
    *
    * @param injectExpectationId the expectation whose alerts are requested
-   * @return the set of expectation ids whose traces must be aggregated
+   * @return the list of expectation ids whose traces must be aggregated
    */
   private List<String> resolveAlertExpectationIds(@NotNull final String injectExpectationId) {
     return injectExpectationRepository

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
@@ -255,6 +255,31 @@ class InjectExpectationTraceServiceTest {
         .findAllWithAgentsByInjectAndAsset(anyString(), anyString(), any());
   }
 
+  @Test
+  void getInjectExpectationTracesFromCollector_DuplicateAlerts_KeepsNewestDeterministically() {
+    // Arrange: the same physical alert stored on two agent expectations, returned by the DB in
+    // arbitrary order (oldest first here since the query has no ORDER BY); the aggregated view
+    // must always keep the newest occurrence as the representative
+    Instant now = Instant.now();
+    InjectExpectationTrace olderTrace = buildTrace("Shared Alert", "http://shared-link.com");
+    olderTrace.setAlertDate(now.minusSeconds(3600));
+    InjectExpectationTrace newerTrace = buildTrace("Shared Alert", "http://shared-link.com");
+    newerTrace.setAlertDate(now);
+    when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(List.of(olderTrace, newerTrace));
+
+    // Act
+    List<InjectExpectationTrace> result =
+        injectExpectationTraceService.getInjectExpectationTracesFromCollector(
+            injectExpectationId, securityPlatformId);
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals(newerTrace, result.get(0));
+  }
+
   private DetectionInjectExpectation buildAssetLevelExpectation(final String expectationId) {
     Inject inject = new Inject();
     inject.setId(UUID.randomUUID().toString());

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
@@ -3,7 +3,11 @@ package io.openaev.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.Asset;
 import io.openaev.database.model.BaseInjectExpectation;
+import io.openaev.database.model.DetectionInjectExpectation;
+import io.openaev.database.model.Inject;
 import io.openaev.database.model.InjectExpectationTrace;
 import io.openaev.database.model.SecurityPlatform;
 import io.openaev.database.repository.CollectorRepository;
@@ -134,6 +138,107 @@ class InjectExpectationTraceServiceTest {
     assertEquals(0L, result);
     verify(injectExpectationTraceRepository)
         .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
+  }
+
+  @Test
+  void getAlertLinksNumber_AssetLevelExpectation_AggregatesChildAgentExpectations() {
+    // Arrange: an asset-level detection expectation (asset set, no agent) whose alerts live on
+    // its two child agent expectations of the same type
+    DetectionInjectExpectation assetExpectation = buildAssetLevelExpectation(injectExpectationId);
+    when(injectExpectationRepository.findById(injectExpectationId))
+        .thenReturn(Optional.of(assetExpectation));
+    when(injectExpectationRepository.findAllWithAgentsByInjectAndAsset(
+            assetExpectation.getInject().getId(),
+            assetExpectation.getAsset().getId(),
+            assetExpectation.getType()))
+        .thenReturn(
+            List.of(
+                buildAgentLevelExpectation("agent-expectation-1"),
+                buildAgentLevelExpectation("agent-expectation-2")));
+    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
+        .thenReturn(3L);
+
+    // Act
+    long result =
+        injectExpectationTraceService.getAlertLinksNumber(
+            injectExpectationId, securityPlatformId, expectationResultSourceType);
+
+    // Assert: the count query receives the asset expectation id plus both child agent ids
+    assertEquals(3L, result);
+    verify(injectExpectationTraceRepository)
+        .countAlertsForExpectations(
+            List.of(injectExpectationId, "agent-expectation-1", "agent-expectation-2"),
+            securityPlatformId);
+  }
+
+  @Test
+  void getInjectExpectationTracesFromCollector_AssetLevelExpectation_AggregatesChildAgents() {
+    // Arrange
+    DetectionInjectExpectation assetExpectation = buildAssetLevelExpectation(injectExpectationId);
+    when(injectExpectationRepository.findById(injectExpectationId))
+        .thenReturn(Optional.of(assetExpectation));
+    when(injectExpectationRepository.findAllWithAgentsByInjectAndAsset(
+            assetExpectation.getInject().getId(),
+            assetExpectation.getAsset().getId(),
+            assetExpectation.getType()))
+        .thenReturn(List.of(buildAgentLevelExpectation("agent-expectation-1")));
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(List.of(injectExpectationTrace));
+
+    // Act
+    List<InjectExpectationTrace> result =
+        injectExpectationTraceService.getInjectExpectationTracesFromCollector(
+            injectExpectationId, securityPlatformId);
+
+    // Assert: the list query receives the asset expectation id plus the child agent id
+    assertEquals(1, result.size());
+    verify(injectExpectationTraceRepository)
+        .findByExpectationsAndSecurityPlatform(
+            List.of(injectExpectationId, "agent-expectation-1"), securityPlatformId);
+  }
+
+  @Test
+  void getAlertLinksNumber_AgentLevelExpectation_ResolvesToItself() {
+    // Arrange: an agent-level expectation must never trigger the aggregation lookup
+    DetectionInjectExpectation agentExpectation = buildAgentLevelExpectation(injectExpectationId);
+    when(injectExpectationRepository.findById(injectExpectationId))
+        .thenReturn(Optional.of(agentExpectation));
+    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
+        .thenReturn(1L);
+
+    // Act
+    long result =
+        injectExpectationTraceService.getAlertLinksNumber(
+            injectExpectationId, securityPlatformId, expectationResultSourceType);
+
+    // Assert
+    assertEquals(1L, result);
+    verify(injectExpectationTraceRepository)
+        .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
+    verify(injectExpectationRepository, never())
+        .findAllWithAgentsByInjectAndAsset(anyString(), anyString(), any());
+  }
+
+  private DetectionInjectExpectation buildAssetLevelExpectation(final String expectationId) {
+    Inject inject = new Inject();
+    inject.setId(UUID.randomUUID().toString());
+    Asset asset = new Asset();
+    asset.setId(UUID.randomUUID().toString());
+    DetectionInjectExpectation assetExpectation = new DetectionInjectExpectation();
+    assetExpectation.setId(expectationId);
+    assetExpectation.setInject(inject);
+    assetExpectation.setAsset(asset);
+    return assetExpectation;
+  }
+
+  private DetectionInjectExpectation buildAgentLevelExpectation(final String expectationId) {
+    Agent agent = new Agent();
+    agent.setId(UUID.randomUUID().toString());
+    DetectionInjectExpectation agentExpectation = new DetectionInjectExpectation();
+    agentExpectation.setId(expectationId);
+    agentExpectation.setAgent(agent);
+    return agentExpectation;
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
@@ -7,10 +7,12 @@ import io.openaev.database.model.BaseInjectExpectation;
 import io.openaev.database.model.InjectExpectationTrace;
 import io.openaev.database.model.SecurityPlatform;
 import io.openaev.database.repository.CollectorRepository;
+import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.InjectExpectationTraceRepository;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ class InjectExpectationTraceServiceTest {
 
   @Mock private InjectExpectationTraceRepository injectExpectationTraceRepository;
   @Mock private CollectorRepository collectorRepository;
+  @Mock private InjectExpectationRepository injectExpectationRepository;
 
   @InjectMocks private InjectExpectationTraceService injectExpectationTraceService;
 
@@ -58,8 +61,9 @@ class InjectExpectationTraceServiceTest {
   void getInjectExpectationTracesFromCollector_Success() {
     // Arrange
     List<InjectExpectationTrace> expectedTraces = Collections.singletonList(injectExpectationTrace);
-    when(injectExpectationTraceRepository.findByExpectationAndSecurityPlatform(
-            anyString(), anyString()))
+    when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
         .thenReturn(expectedTraces);
 
     // Act
@@ -72,14 +76,15 @@ class InjectExpectationTraceServiceTest {
     assertEquals(1, result.size());
     assertEquals(injectExpectationTrace, result.get(0));
     verify(injectExpectationTraceRepository)
-        .findByExpectationAndSecurityPlatform(injectExpectationId, securityPlatformId);
+        .findByExpectationsAndSecurityPlatform(List.of(injectExpectationId), securityPlatformId);
   }
 
   @Test
   void getInjectExpectationTracesFromCollector_EmptyResult() {
     // Arrange
-    when(injectExpectationTraceRepository.findByExpectationAndSecurityPlatform(
-            anyString(), anyString()))
+    when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
         .thenReturn(Collections.emptyList());
 
     // Act
@@ -91,14 +96,15 @@ class InjectExpectationTraceServiceTest {
     assertNotNull(result);
     assertTrue(result.isEmpty());
     verify(injectExpectationTraceRepository)
-        .findByExpectationAndSecurityPlatform(injectExpectationId, securityPlatformId);
+        .findByExpectationsAndSecurityPlatform(List.of(injectExpectationId), securityPlatformId);
   }
 
   @Test
   void getAlertLinksNumber_Success() {
     // Arrange
     long expectedCount = 5L;
-    when(injectExpectationTraceRepository.countAlerts(anyString(), anyString()))
+    when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
+    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
         .thenReturn(expectedCount);
 
     // Act
@@ -108,13 +114,16 @@ class InjectExpectationTraceServiceTest {
 
     // Assert
     assertEquals(expectedCount, result);
-    verify(injectExpectationTraceRepository).countAlerts(injectExpectationId, securityPlatformId);
+    verify(injectExpectationTraceRepository)
+        .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
   }
 
   @Test
   void getAlertLinksNumber_ZeroCount() {
     // Arrange
-    when(injectExpectationTraceRepository.countAlerts(anyString(), anyString())).thenReturn(0L);
+    when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
+    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
+        .thenReturn(0L);
 
     // Act
     long result =
@@ -123,7 +132,8 @@ class InjectExpectationTraceServiceTest {
 
     // Assert
     assertEquals(0L, result);
-    verify(injectExpectationTraceRepository).countAlerts(injectExpectationId, securityPlatformId);
+    verify(injectExpectationTraceRepository)
+        .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationTraceServiceTest.java
@@ -13,6 +13,7 @@ import io.openaev.database.model.SecurityPlatform;
 import io.openaev.database.repository.CollectorRepository;
 import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.InjectExpectationTraceRepository;
+import io.openaev.database.repository.SecurityPlatformRepository;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class InjectExpectationTraceServiceTest {
 
   @Mock private InjectExpectationTraceRepository injectExpectationTraceRepository;
+  @Mock private SecurityPlatformRepository securityPlatformRepository;
   @Mock private CollectorRepository collectorRepository;
   @Mock private InjectExpectationRepository injectExpectationRepository;
 
@@ -106,10 +108,11 @@ class InjectExpectationTraceServiceTest {
   @Test
   void getAlertLinksNumber_Success() {
     // Arrange
-    long expectedCount = 5L;
     when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
-    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
-        .thenReturn(expectedCount);
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(
+            List.of(injectExpectationTrace, buildTrace("Other Alert", "http://other-link.com")));
 
     // Act
     long result =
@@ -117,17 +120,18 @@ class InjectExpectationTraceServiceTest {
             injectExpectationId, securityPlatformId, expectationResultSourceType);
 
     // Assert
-    assertEquals(expectedCount, result);
+    assertEquals(2L, result);
     verify(injectExpectationTraceRepository)
-        .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
+        .findByExpectationsAndSecurityPlatform(List.of(injectExpectationId), securityPlatformId);
   }
 
   @Test
   void getAlertLinksNumber_ZeroCount() {
     // Arrange
     when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
-    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
-        .thenReturn(0L);
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(Collections.emptyList());
 
     // Act
     long result =
@@ -137,13 +141,37 @@ class InjectExpectationTraceServiceTest {
     // Assert
     assertEquals(0L, result);
     verify(injectExpectationTraceRepository)
-        .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
+        .findByExpectationsAndSecurityPlatform(List.of(injectExpectationId), securityPlatformId);
+  }
+
+  @Test
+  void getAlertLinksNumber_CollectorSource_ResolvesSecurityPlatformFromExternalReference() {
+    // Arrange: security-platform results carry the collector id; the service must resolve it
+    // to the backing security platform before querying the traces
+    String collectorId = UUID.randomUUID().toString();
+    when(securityPlatformRepository.findByExternalReference(collectorId))
+        .thenReturn(Optional.of(securityPlatform));
+    when(injectExpectationRepository.findById(injectExpectationId)).thenReturn(Optional.empty());
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(List.of(injectExpectationTrace));
+
+    // Act
+    long result =
+        injectExpectationTraceService.getAlertLinksNumber(
+            injectExpectationId, collectorId, "collector");
+
+    // Assert: the trace query receives the resolved security platform id, not the collector id
+    assertEquals(1L, result);
+    verify(injectExpectationTraceRepository)
+        .findByExpectationsAndSecurityPlatform(List.of(injectExpectationId), securityPlatformId);
   }
 
   @Test
   void getAlertLinksNumber_AssetLevelExpectation_AggregatesChildAgentExpectations() {
     // Arrange: an asset-level detection expectation (asset set, no agent) whose alerts live on
-    // its two child agent expectations of the same type
+    // its two child agent expectations of the same type; both agents matched the same physical
+    // alert, so the roll-up must count it once
     DetectionInjectExpectation assetExpectation = buildAssetLevelExpectation(injectExpectationId);
     when(injectExpectationRepository.findById(injectExpectationId))
         .thenReturn(Optional.of(assetExpectation));
@@ -155,18 +183,24 @@ class InjectExpectationTraceServiceTest {
             List.of(
                 buildAgentLevelExpectation("agent-expectation-1"),
                 buildAgentLevelExpectation("agent-expectation-2")));
-    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
-        .thenReturn(3L);
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(
+            List.of(
+                buildTrace("Shared Alert", "http://shared-link.com"),
+                buildTrace("Shared Alert", "http://shared-link.com"),
+                buildTrace("Other Alert", "http://other-link.com")));
 
     // Act
     long result =
         injectExpectationTraceService.getAlertLinksNumber(
             injectExpectationId, securityPlatformId, expectationResultSourceType);
 
-    // Assert: the count query receives the asset expectation id plus both child agent ids
-    assertEquals(3L, result);
+    // Assert: the trace query receives the asset expectation id plus both child agent ids,
+    // and the per-agent duplicate of the shared alert is counted once
+    assertEquals(2L, result);
     verify(injectExpectationTraceRepository)
-        .countAlertsForExpectations(
+        .findByExpectationsAndSecurityPlatform(
             List.of(injectExpectationId, "agent-expectation-1", "agent-expectation-2"),
             securityPlatformId);
   }
@@ -204,8 +238,9 @@ class InjectExpectationTraceServiceTest {
     DetectionInjectExpectation agentExpectation = buildAgentLevelExpectation(injectExpectationId);
     when(injectExpectationRepository.findById(injectExpectationId))
         .thenReturn(Optional.of(agentExpectation));
-    when(injectExpectationTraceRepository.countAlertsForExpectations(anyCollection(), anyString()))
-        .thenReturn(1L);
+    when(injectExpectationTraceRepository.findByExpectationsAndSecurityPlatform(
+            anyCollection(), anyString()))
+        .thenReturn(List.of(injectExpectationTrace));
 
     // Act
     long result =
@@ -215,7 +250,7 @@ class InjectExpectationTraceServiceTest {
     // Assert
     assertEquals(1L, result);
     verify(injectExpectationTraceRepository)
-        .countAlertsForExpectations(List.of(injectExpectationId), securityPlatformId);
+        .findByExpectationsAndSecurityPlatform(List.of(injectExpectationId), securityPlatformId);
     verify(injectExpectationRepository, never())
         .findAllWithAgentsByInjectAndAsset(anyString(), anyString(), any());
   }
@@ -239,6 +274,16 @@ class InjectExpectationTraceServiceTest {
     agentExpectation.setId(expectationId);
     agentExpectation.setAgent(agent);
     return agentExpectation;
+  }
+
+  private InjectExpectationTrace buildTrace(final String alertName, final String alertLink) {
+    InjectExpectationTrace trace = new InjectExpectationTrace();
+    trace.setId(UUID.randomUUID().toString());
+    trace.setSecurityPlatform(securityPlatform);
+    trace.setAlertDate(Instant.now());
+    trace.setAlertName(alertName);
+    trace.setAlertLink(alertLink);
+    return trace;
   }
 
   @Test

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationAggregatedAgentsView.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationAggregatedAgentsView.tsx
@@ -72,6 +72,7 @@ const InjectExpectationAggregatedAgentsView = ({ inject, injectExpectation, expe
       injectorContractPayload={inject.inject_injector_contract?.injector_contract_payload}
       injectType={inject.inject_type}
       agentBreakdownBySource={agentBreakdownBySource}
+      aggregateAgentAlerts
     />
   );
 };

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -200,16 +200,20 @@ const InjectExpectationResultList = ({
         </Box>
 
         {injectExpectationResults.map((expectationResult, index) => {
-          const showDetectionTime = expectationResult.result === 'Prevented' || expectationResult.result === 'Detected' || expectationResult.result === 'SUCCESS'
+          // Result labels are written with inconsistent casing across producers (backend
+          // ExpectationType says "Partially vulnerable", the frontend status map "Partially
+          // Vulnerable"), so match them case-insensitively.
+          const resultLabel = expectationResult.result?.toLowerCase();
+          const showDetectionTime = resultLabel === 'prevented' || resultLabel === 'detected' || resultLabel === 'success'
             // Vulnerability verdicts (e.g. written by a scanner platform like Nuclei) carry the scan time.
-            || expectationResult.result === 'Not vulnerable' || expectationResult.result === 'Vulnerable' || expectationResult.result === 'Partially vulnerable';
+            || resultLabel === 'not vulnerable' || resultLabel === 'vulnerable' || resultLabel === 'partially vulnerable';
           // Alerts apply to a collector result that detected/prevented. They render either
           // for a per-agent row (injectExpectationAgent set) or for the aggregated endpoint
           // row, where the backend rolls the child agents' traces up onto the asset
           // expectation id. Anything else (no collector match, non-collector source) shows a dash.
           const alertsApplicable = !!expectationResult.sourceId
             && expectationResult.sourceType === 'collector'
-            && (expectationResult.result === 'Prevented' || expectationResult.result === 'Detected');
+            && (resultLabel === 'prevented' || resultLabel === 'detected');
           const alertsInScope = !!injectExpectationAgent || aggregateAgentAlerts;
           const showAlerts = alertsApplicable && alertsInScope;
           const showAlertsDash = !showAlerts;

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationResultList.tsx
@@ -43,6 +43,10 @@ interface Props {
   // When set (endpoint aggregation), each source id/name maps to the per-agent
   // results that rolled up into the aggregated row, shown in an "i" tooltip.
   agentBreakdownBySource?: Record<string, AgentResultBreakdownEntry[]>;
+  // Endpoint (asset) aggregated view: alerts live on the child agent expectations,
+  // so there is no per-line agent, but the count/dialog endpoints roll them up from
+  // the asset expectation id. Let the Alerts column render without an agent scope.
+  aggregateAgentAlerts?: boolean;
 }
 
 const GRID_TEMPLATE_COLUMNS = 'minmax(180px, 2fr) 150px 140px 160px 80px 40px';
@@ -58,6 +62,7 @@ const InjectExpectationResultList = ({
   injectorContractPayload,
   injectType,
   agentBreakdownBySource,
+  aggregateAgentAlerts = false,
 }: Props) => {
   const { nsdt, t } = useFormatter();
   const theme = useTheme();
@@ -195,15 +200,19 @@ const InjectExpectationResultList = ({
         </Box>
 
         {injectExpectationResults.map((expectationResult, index) => {
-          const showDetectionTime = expectationResult.result === 'Prevented' || expectationResult.result === 'Detected' || expectationResult.result === 'SUCCESS';
-          const showAlerts = !!(expectationResult.sourceId
-            && injectExpectationAgent
+          const showDetectionTime = expectationResult.result === 'Prevented' || expectationResult.result === 'Detected' || expectationResult.result === 'SUCCESS'
+            // Vulnerability verdicts (e.g. written by a scanner platform like Nuclei) carry the scan time.
+            || expectationResult.result === 'Not vulnerable' || expectationResult.result === 'Vulnerable' || expectationResult.result === 'Partially vulnerable';
+          // Alerts apply to a collector result that detected/prevented. They render either
+          // for a per-agent row (injectExpectationAgent set) or for the aggregated endpoint
+          // row, where the backend rolls the child agents' traces up onto the asset
+          // expectation id. Anything else (no collector match, non-collector source) shows a dash.
+          const alertsApplicable = !!expectationResult.sourceId
             && expectationResult.sourceType === 'collector'
-            && (expectationResult.result === 'Prevented' || expectationResult.result === 'Detected'));
-          const showAlertsDash = (!injectExpectationAgent
-            || (injectExpectationAgent && (expectationResult.result === 'Not Detected' || expectationResult.result === 'Not Prevented'))
-            || (injectExpectationAgent && expectationResult.sourceType !== 'collector' && (expectationResult.result === 'Prevented' || expectationResult.result === 'Detected'))
-          );
+            && (expectationResult.result === 'Prevented' || expectationResult.result === 'Detected');
+          const alertsInScope = !!injectExpectationAgent || aggregateAgentAlerts;
+          const showAlerts = alertsApplicable && alertsInScope;
+          const showAlertsDash = !showAlerts;
 
           const sourceName = expectationResult.sourceName?.trim() || '-';
           const breakdownKey = expectationResult.sourceId ?? expectationResult.sourceName ?? '';

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationTraceRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationTraceRepository.java
@@ -16,14 +16,10 @@ public interface InjectExpectationTraceRepository
     extends CrudRepository<InjectExpectationTrace, String>,
         JpaSpecificationExecutor<InjectExpectationTrace> {
 
-  @Query(
-      "select t from InjectExpectationTrace t where t.injectExpectation.id = :expectationId and t.securityPlatform.id = :sourceId")
-  List<InjectExpectationTrace> findByExpectationAndSecurityPlatform(
-      @Param("expectationId") final String expectationId, @Param("sourceId") final String sourceId);
-
-  // Same as above but across several expectations: used to roll an asset (endpoint)
-  // expectation's alerts up from its child agent expectations, which is where the
-  // collector actually attaches the traces (the asset row carries none of its own).
+  // Accepts several expectation ids: used to roll an asset (endpoint) expectation's
+  // alerts up from its child agent expectations, which is where the collector actually
+  // attaches the traces (the asset row carries none of its own). Single-expectation
+  // lookups simply pass a singleton collection.
   @Query(
       "select t from InjectExpectationTrace t where t.injectExpectation.id in :expectationIds and t.securityPlatform.id = :sourceId")
   List<InjectExpectationTrace> findByExpectationsAndSecurityPlatform(

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationTraceRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationTraceRepository.java
@@ -35,20 +35,6 @@ public interface InjectExpectationTraceRepository
       @Param("expectationIds") final Collection<String> expectationIds);
 
   @Query(
-      "select count(distinct t) from InjectExpectationTrace t where t.injectExpectation.id = :expectationId and t.securityPlatform.id = :sourceId")
-  long countAlerts(
-      @Param("expectationId") final String expectationId, @Param("sourceId") final String sourceId);
-
-  // Aggregated variant of countAlerts across several expectations (asset row rolling
-  // up its child agent expectations' alerts). Distinct so a trace shared across the
-  // provided ids is never double-counted.
-  @Query(
-      "select count(distinct t) from InjectExpectationTrace t where t.injectExpectation.id in :expectationIds and t.securityPlatform.id = :sourceId")
-  long countAlertsForExpectations(
-      @Param("expectationIds") final Collection<String> expectationIds,
-      @Param("sourceId") final String sourceId);
-
-  @Query(
       "select t from InjectExpectationTrace t where t.injectExpectation.id = :expectationId and t.securityPlatform.id = :sourceId and t.alertName = :alertName and t.alertLink = :alertLink")
   InjectExpectationTrace findByAlertLinkAndAlertNameAndSecurityPlatformAndInjectExpectation(
       @Param("alertLink") final String alertLink,

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationTraceRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationTraceRepository.java
@@ -21,6 +21,15 @@ public interface InjectExpectationTraceRepository
   List<InjectExpectationTrace> findByExpectationAndSecurityPlatform(
       @Param("expectationId") final String expectationId, @Param("sourceId") final String sourceId);
 
+  // Same as above but across several expectations: used to roll an asset (endpoint)
+  // expectation's alerts up from its child agent expectations, which is where the
+  // collector actually attaches the traces (the asset row carries none of its own).
+  @Query(
+      "select t from InjectExpectationTrace t where t.injectExpectation.id in :expectationIds and t.securityPlatform.id = :sourceId")
+  List<InjectExpectationTrace> findByExpectationsAndSecurityPlatform(
+      @Param("expectationIds") final Collection<String> expectationIds,
+      @Param("sourceId") final String sourceId);
+
   @Query("select t from InjectExpectationTrace t where t.injectExpectation.id in :expectationIds")
   List<InjectExpectationTrace> findByInjectExpectationIdIn(
       @Param("expectationIds") final Collection<String> expectationIds);
@@ -29,6 +38,15 @@ public interface InjectExpectationTraceRepository
       "select count(distinct t) from InjectExpectationTrace t where t.injectExpectation.id = :expectationId and t.securityPlatform.id = :sourceId")
   long countAlerts(
       @Param("expectationId") final String expectationId, @Param("sourceId") final String sourceId);
+
+  // Aggregated variant of countAlerts across several expectations (asset row rolling
+  // up its child agent expectations' alerts). Distinct so a trace shared across the
+  // provided ids is never double-counted.
+  @Query(
+      "select count(distinct t) from InjectExpectationTrace t where t.injectExpectation.id in :expectationIds and t.securityPlatform.id = :sourceId")
+  long countAlertsForExpectations(
+      @Param("expectationIds") final Collection<String> expectationIds,
+      @Param("sourceId") final String sourceId);
 
   @Query(
       "select t from InjectExpectationTrace t where t.injectExpectation.id = :expectationId and t.securityPlatform.id = :sourceId and t.alertName = :alertName and t.alertLink = :alertLink")


### PR DESCRIPTION
## Summary

- Fixes the endpoint (asset) "Results by target" tab showing `0` alerts even when the collector reported them on the agents (the Agents tab shows them and the status is correctly Prevented/Detected).
- Backend rolls an asset-level expectation's alerts up from its child agent expectations; agent-level and all other expectations are unchanged.
- Frontend lets the aggregated endpoint view render the Alerts column; the count and the alerts dialog resolve against the asset expectation id, now aggregated server-side.

## Root cause

For an endpoint that has agents, the platform stores one asset-level expectation (aggregated status) plus one expectation per agent. Collectors attach alert traces (`injects_expectations_traces`) to the agent-level expectations, so the asset row carries none of its own:

- `GET /api/inject-expectations-traces/count` and `GET /api/inject-expectations-traces` looked up traces by the exact expectation id -> `0` for the asset row.
- The aggregated endpoint view passed no agent scope, forcing the Alerts column to a dash.

## Changes

- `InjectExpectationTraceRepository`: add distinct aggregated `countAlertsForExpectations(ids, sourceId)` and `findByExpectationsAndSecurityPlatform(ids, sourceId)`.
- `InjectExpectationTraceService`: `resolveAlertExpectationIds()` detects an asset-level technical expectation (asset set, no agent) and aggregates its child agent expectations of the same type plus the asset row itself; everything else resolves to itself.
- `InjectExpectationTraceServiceTest`: updated to the aggregated repository methods.
- `InjectExpectationResultList` / `InjectExpectationAggregatedAgentsView`: new `aggregateAgentAlerts` prop enables the Alerts column on the aggregated endpoint view.

## Test plan

- [x] `InjectExpectationTraceServiceTest` passes locally
- [x] `yarn eslint` + `yarn check-ts` green
- [ ] CI green
- [ ] Verify on staging: endpoint (asset) tab shows the aggregated Defender alert count and the alerts dialog lists the child agents' alerts

Closes #6978
