### PR TITLE
feat(attack-path): render one injector node per contract (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -1,5 +1,6 @@
 package io.openaev.service.attackpath;
 
+import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.projection.AttackPathEdgeGroupRow;
 import io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingRow;
@@ -1084,22 +1085,24 @@ public class AttackPathGraphService {
   }
 
   /**
-   * Resolves the {@code externalId → contract name} map for a set of injector-contract external
-   * ids, one read per distinct id (a run uses a handful of contracts). Shared by the feed-node
-   * contract names and the injector node labels so neither pays for a second read.
+   * Resolves the {@code externalId → contract name} map for a set of injector-contract external ids
+   * in a single batched read. Shared by the feed-node contract names and the injector node labels
+   * so neither pays for a second read, and constant in the number of contracts.
    */
   private Map<String, String> resolveContractNames(Set<String> externalIds) {
+    if (externalIds.isEmpty()) {
+      return Map.of();
+    }
+    List<InjectorContract> contracts =
+        injectorContractRepository.findAllByIdOrExternalIdIn(externalIds);
     Map<String, String> nameByExternalId = new HashMap<>();
     for (String externalId : externalIds) {
-      injectorContractRepository
-          .findByIdOrExternalId(externalId, externalId)
-          .ifPresent(
-              contract -> {
-                String name = contractLabel(contract.getLabels());
-                if (name != null) {
-                  nameByExternalId.put(externalId, name);
-                }
-              });
+      contracts.stream()
+          .filter(c -> externalId.equals(c.getExternalId()) || externalId.equals(c.getId()))
+          .findFirst()
+          .map(c -> contractLabel(c.getLabels()))
+          .filter(Objects::nonNull)
+          .ifPresent(name -> nameByExternalId.put(externalId, name));
     }
     return nameByExternalId;
   }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -560,7 +560,8 @@ public class AttackPathGraphService {
       feedByExecutionId.put(e.id(), executionFeedNode(e));
     }
     applyKillChain(executions, feedByExecutionId);
-    applyContractNames(executions, feedByExecutionId);
+    Map<String, String> contractNames = applyContractNames(executions, feedByExecutionId);
+    applyInjectorNodeLabels(nodes, contractsByInjectorNode, contractNames);
 
     // Endpoint (ASSET) nodes, with attributes and colour from the executions targeting them.
     for (Map.Entry<String, List<AttackPathExecutionRow>> entry : byTarget.entrySet()) {
@@ -682,8 +683,9 @@ public class AttackPathGraphService {
    */
   private void enrichCollapsedInjectors(String simulationId, Map<String, AttackPathNodeDTO> nodes) {
     Map<String, Set<String>> contractsByInjectorNode = new LinkedHashMap<>();
+    Set<String> externalIds = new HashSet<>();
     for (AttackPathInjectorMetaRow meta : executionRepository.findInjectorMetadata(simulationId)) {
-      String nodeId = AttackPathIds.injectorNode(meta.sourceInjector());
+      String nodeId = AttackPathIds.injectorNode(meta.sourceInjector(), meta.contractExternalId());
       AttackPathNodeDTO injectorNode = nodes.get(nodeId);
       if (injectorNode == null) {
         continue;
@@ -695,8 +697,10 @@ public class AttackPathGraphService {
         contractsByInjectorNode
             .computeIfAbsent(nodeId, k -> new LinkedHashSet<>())
             .add(meta.contractExternalId());
+        externalIds.add(meta.contractExternalId());
       }
     }
+    applyInjectorNodeLabels(nodes, contractsByInjectorNode, resolveContractNames(externalIds));
     resolveInjectorAttackPatterns(nodes, contractsByInjectorNode);
   }
 
@@ -847,7 +851,7 @@ public class AttackPathGraphService {
 
   private String collapsedSourceNodeId(AttackPathEdgeGroupRow g) {
     return SOURCE_INJECTOR.equals(g.sourceKind())
-        ? AttackPathIds.injectorNode(g.sourceInjector())
+        ? AttackPathIds.injectorNode(g.sourceInjector(), g.contractExternalId())
         : AttackPathIds.endpointNode(g.sourceAssetId());
   }
 
@@ -871,7 +875,7 @@ public class AttackPathGraphService {
 
   private String sourceNodeId(AttackPathExecutionRow e) {
     return SOURCE_INJECTOR.equals(e.sourceKind())
-        ? AttackPathIds.injectorNode(e.sourceInjector())
+        ? AttackPathIds.injectorNode(e.sourceInjector(), e.contractExternalId())
         : AttackPathIds.endpointNode(e.sourceAssetId());
   }
 
@@ -1025,9 +1029,10 @@ public class AttackPathGraphService {
    * external id and sets it on the execution feed node, so the front can name WHAT was launched on
    * the inject→endpoint edge. Batched over the DISTINCT external ids (a run uses a handful of
    * contracts, not one per execution), so this is a few reads regardless of the execution count.
-   * No-op when no execution carries a contract.
+   * No-op when no execution carries a contract. Returns the resolved {@code externalId → name} map
+   * so the injector node labels can reuse it without a second read.
    */
-  private void applyContractNames(
+  private Map<String, String> applyContractNames(
       List<AttackPathExecutionRow> executions, Map<String, AttackPathNodeDTO> feedByExecutionId) {
     Set<String> externalIds =
         executions.stream()
@@ -1035,8 +1040,55 @@ public class AttackPathGraphService {
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
     if (externalIds.isEmpty()) {
-      return;
+      return Map.of();
     }
+    Map<String, String> nameByExternalId = resolveContractNames(externalIds);
+    if (nameByExternalId.isEmpty()) {
+      return nameByExternalId;
+    }
+    for (AttackPathExecutionRow e : executions) {
+      String externalId = e.contractExternalId();
+      if (externalId == null) {
+        continue;
+      }
+      AttackPathNodeDTO node = feedByExecutionId.get(e.id());
+      if (node != null) {
+        node.setContractName(nameByExternalId.get(externalId));
+      }
+    }
+    return nameByExternalId;
+  }
+
+  /**
+   * Labels each per-contract injector node with its contract's name, so two nodes of the same
+   * injector are distinguishable on the map. Reuses the names already resolved for the feed nodes,
+   * so no extra query; a node whose contract name did not resolve keeps its injector-name label.
+   */
+  private void applyInjectorNodeLabels(
+      Map<String, AttackPathNodeDTO> nodes,
+      Map<String, Set<String>> contractsByInjectorNode,
+      Map<String, String> nameByExternalId) {
+    contractsByInjectorNode.forEach(
+        (nodeId, contractIds) -> {
+          AttackPathNodeDTO node = nodes.get(nodeId);
+          if (node == null) {
+            return;
+          }
+          // A per-contract injector node maps to exactly one contract.
+          contractIds.stream()
+              .map(nameByExternalId::get)
+              .filter(Objects::nonNull)
+              .findFirst()
+              .ifPresent(node::setLabel);
+        });
+  }
+
+  /**
+   * Resolves the {@code externalId → contract name} map for a set of injector-contract external
+   * ids, one read per distinct id (a run uses a handful of contracts). Shared by the feed-node
+   * contract names and the injector node labels so neither pays for a second read.
+   */
+  private Map<String, String> resolveContractNames(Set<String> externalIds) {
     Map<String, String> nameByExternalId = new HashMap<>();
     for (String externalId : externalIds) {
       injectorContractRepository
@@ -1049,19 +1101,7 @@ public class AttackPathGraphService {
                 }
               });
     }
-    if (nameByExternalId.isEmpty()) {
-      return;
-    }
-    for (AttackPathExecutionRow e : executions) {
-      String externalId = e.contractExternalId();
-      if (externalId == null) {
-        continue;
-      }
-      AttackPathNodeDTO node = feedByExecutionId.get(e.id());
-      if (node != null) {
-        node.setContractName(nameByExternalId.get(externalId));
-      }
-    }
+    return nameByExternalId;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
@@ -42,6 +42,18 @@ public final class AttackPathIds {
     return encode("NODE_INJECTOR", injector);
   }
 
+  /**
+   * {@code NODE_INJECTOR} per contract: the injector name plus the frozen contract external id, so
+   * an injector that ran several contracts renders one node per contract. A {@code null} contract
+   * falls back to the per-injector id, byte-identical, so contractless sources (seed, legacy,
+   * agents) keep the same id.
+   */
+  public static String injectorNode(String injector, String contractExternalId) {
+    return contractExternalId == null
+        ? injectorNode(injector)
+        : encode("NODE_INJECTOR", injector, contractExternalId);
+  }
+
   /** {@code NODE_ENDPOINT}: the unified endpoint key (asset id or raw value). DTO type = ASSET. */
   public static String endpointNode(String endpointKey) {
     return encode("NODE_ENDPOINT", endpointKey);

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
@@ -3,6 +3,7 @@ package io.openaev.service.attackpath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openaev.IntegrationTest;
+import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
@@ -21,6 +22,7 @@ import io.openaev.utils.fixtures.composers.InjectorContractComposer;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
 import java.time.Instant;
+import java.util.Map;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
@@ -289,8 +291,51 @@ class AttackPathGraphServiceTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("An injector running several contracts shows the union of their techniques")
-  void injector_node_unions_techniques_across_contracts() {
+  @DisplayName(
+      "Collapsed mode splits the injector node per contract, with its own techniques, label and edges")
+  void collapsed_injector_node_splits_per_contract() {
+    seedContractWithPattern("C-CA", "T1003");
+    // A second contract with BOTH an attack pattern and a resolvable label (FR4 in collapsed).
+    InjectorContract cb =
+        InjectorContractFixture.createDefaultInjectorContractWithExternalId("C-CB");
+    cb.setLabels(Map.of("en", "Kerberoasting"));
+    injectorContractComposer
+        .forInjectorContract(cb)
+        .withAttackPattern(
+            attackPatternComposer.forAttackPattern(
+                AttackPatternFixture.createAttackPatternsWithExternalId("T1004")))
+        .persist();
+    // Same injector "COLLSPLIT", two contracts on two targets.
+    seedInjectorRun("COLLSPLIT", "cg-a", "CG-A", "C-CA", "openaev_impl", at(41));
+    seedInjectorRun("COLLSPLIT", "cg-b", "CG-B", "C-CB", "openaev_impl", at(42));
+    entityManager.flush();
+
+    AttackPathDTO dto = service.buildGraph(SIM, "collapsed");
+    AttackPathNodeDTO nodeA = nodeById(dto, AttackPathIds.injectorNode("COLLSPLIT", "C-CA"));
+    AttackPathNodeDTO nodeB = nodeById(dto, AttackPathIds.injectorNode("COLLSPLIT", "C-CB"));
+    // Each per-contract node shows only its own contract's technique.
+    assertThat(nodeA.getAttackPatterns())
+        .extracting(AttackPathAttackPatternDTO::externalId)
+        .containsExactly("T1003");
+    assertThat(nodeB.getAttackPatterns())
+        .extracting(AttackPathAttackPatternDTO::externalId)
+        .containsExactly("T1004");
+    // FR4 label in collapsed: the labelled contract's name; the label-less one falls back.
+    assertThat(nodeB.getLabel()).isEqualTo("Kerberoasting");
+    assertThat(nodeA.getLabel()).isEqualTo("COLLSPLIT");
+    // The grouped edges attach to the per-contract sources.
+    assertThat(dto.attackPathEdges())
+        .extracting(AttackPathEdges::getEdgeSourceId)
+        .contains(
+            AttackPathIds.injectorNode("COLLSPLIT", "C-CA"),
+            AttackPathIds.injectorNode("COLLSPLIT", "C-CB"));
+  }
+
+  @Test
+  @DisplayName(
+      "An injector running several contracts renders one node per contract, each with its own"
+          + " technique")
+  void injector_node_splits_per_contract() {
     seedContractWithPattern("C-A", "T1001");
     seedContractWithPattern("C-B", "T1002");
     // Same injector "SPRAY", two runs under two different contracts.
@@ -298,15 +343,76 @@ class AttackPathGraphServiceTest extends IntegrationTest {
     seedInjectorRun("SPRAY", "h-b", "H-B", "C-B", "openaev_impl", at(13));
     entityManager.flush();
 
-    AttackPathNodeDTO injectorNode =
-        service.buildGraph(SIM).attackPathNodes().stream()
-            .filter(n -> "INJECTOR".equals(n.getType()) && "SPRAY".equals(n.getLabel()))
-            .findFirst()
-            .orElseThrow();
-
-    assertThat(injectorNode.getAttackPatterns())
+    AttackPathDTO dto = service.buildGraph(SIM);
+    // Two distinct injector nodes, one per contract (not one merged node). Selected by id, since
+    // the
+    // label-less fixture contracts make both nodes fall back to the injector name "SPRAY".
+    AttackPathNodeDTO nodeA = nodeById(dto, AttackPathIds.injectorNode("SPRAY", "C-A"));
+    AttackPathNodeDTO nodeB = nodeById(dto, AttackPathIds.injectorNode("SPRAY", "C-B"));
+    assertThat(nodeA.getType()).isEqualTo("INJECTOR");
+    assertThat(nodeB.getType()).isEqualTo("INJECTOR");
+    // Each node shows only its own contract's technique, not the union across the injector.
+    assertThat(nodeA.getAttackPatterns())
         .extracting(AttackPathAttackPatternDTO::externalId)
-        .containsExactlyInAnyOrder("T1001", "T1002");
+        .containsExactly("T1001");
+    assertThat(nodeB.getAttackPatterns())
+        .extracting(AttackPathAttackPatternDTO::externalId)
+        .containsExactly("T1002");
+  }
+
+  @Test
+  @DisplayName("The injector node label is its contract's name (fallback to the injector name)")
+  void injector_node_label_is_contract_name() {
+    // The default fixture contract carries no labels; set one so the node can present the contract
+    // name instead of the injector name.
+    InjectorContract labelled =
+        InjectorContractFixture.createDefaultInjectorContractWithExternalId("C-LABEL");
+    labelled.setLabels(Map.of("en", "Share Listing"));
+    injectorContractComposer.forInjectorContract(labelled).persist();
+    seedInjectorRun("NETEXEC", "srv-9", "SRV-9", "C-LABEL", "openaev_netexec", at(14));
+    entityManager.flush();
+
+    AttackPathNodeDTO node =
+        nodeById(service.buildGraph(SIM), AttackPathIds.injectorNode("NETEXEC", "C-LABEL"));
+    assertThat(node.getLabel()).isEqualTo("Share Listing");
+  }
+
+  @Test
+  @DisplayName(
+      "A contractless injector keeps the 2-segment per-injector id and injector-name label, full and"
+          + " collapsed")
+  void contractless_injector_falls_back_to_per_injector_id() {
+    // The @BeforeEach NMAP runs carry no contract, so their node is the 2-segment per-injector id,
+    // byte-identical to the pre-split form, and its label falls back to the injector name.
+    String id = AttackPathIds.injectorNode("NMAP");
+    assertThat(id).isEqualTo("NODE_INJECTOR|NMAP");
+
+    AttackPathNodeDTO full = nodeById(service.buildGraph(SIM), id);
+    assertThat(full.getType()).isEqualTo("INJECTOR");
+    assertThat(full.getLabel()).isEqualTo("NMAP");
+
+    AttackPathNodeDTO collapsed = nodeById(service.buildGraph(SIM, "collapsed"), id);
+    assertThat(collapsed.getType()).isEqualTo("INJECTOR");
+    assertThat(collapsed.getLabel()).isEqualTo("NMAP");
+  }
+
+  @Test
+  @DisplayName(
+      "An injector with both a contract run and a contractless run renders both a per-contract and a"
+          + " per-injector node")
+  void injector_with_mixed_contract_renders_both_nodes() {
+    seedContractWithPattern("C-MIX", "T1005");
+    // Same injector "MIXED": one run under a contract, one run with no contract.
+    seedInjectorRun("MIXED", "mx-a", "MX-A", "C-MIX", "openaev_impl", at(43));
+    injectorExecution("MIXED", "mx-b", "MX-B", "Prevented", "Not Detected", "Scan", at(44));
+    entityManager.flush();
+
+    AttackPathDTO dto = service.buildGraph(SIM);
+    // The contract run is a 3-segment per-contract node; the contractless run is the 2-segment
+    // node.
+    assertThat(nodeById(dto, AttackPathIds.injectorNode("MIXED", "C-MIX")).getType())
+        .isEqualTo("INJECTOR");
+    assertThat(nodeById(dto, AttackPathIds.injectorNode("MIXED")).getType()).isEqualTo("INJECTOR");
   }
 
   @Test
@@ -423,6 +529,24 @@ class AttackPathGraphServiceTest extends IntegrationTest {
     AttackPathEdges edge = dto.edges().get(0);
     assertThat(edge.getCount()).isEqualTo(2);
     assertThat(edge.getExecutionIds()).containsExactlyInAnyOrder(exec1Id, exec2Id);
+  }
+
+  @Test
+  @DisplayName(
+      "Endpoint relations expose the same per-contract injector source id as the full graph")
+  void relations_use_per_contract_injector_source_id() {
+    // The front correlates /graph and /endpoint/relations by edgeSourceId string-equality, so both
+    // must emit the SAME per-contract id for a given (injector, contract).
+    seedContractWithPattern("C-REL", "T1210");
+    seedInjectorRun("WINRM", "ep-rel", "EP-REL", "C-REL", "openaev_impl", at(40));
+    entityManager.flush();
+
+    String expectedSource = AttackPathIds.injectorNode("WINRM", "C-REL");
+    AttackPathEndpointRelationsDTO relations = service.endpointRelations(SIM, "ep-rel");
+    assertThat(relations.edges())
+        .singleElement()
+        .satisfies(e -> assertThat(e.getEdgeSourceId()).isEqualTo(expectedSource));
+    assertThat(nodeById(service.buildGraph(SIM), expectedSource).getType()).isEqualTo("INJECTOR");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
@@ -110,6 +110,25 @@ class AttackPathIdsTest {
   }
 
   @Test
+  @DisplayName(
+      "An injector node id is per (injector, contract); a null contract falls back to the per-injector"
+          + " id")
+  void injector_node_per_contract() {
+    // A contract-bearing injector node is a distinct, 3-segment id.
+    assertThat(AttackPathIds.injectorNode("NMAP", "C-1")).isEqualTo("NODE_INJECTOR|NMAP|C-1");
+    // A null contract falls back to the per-injector id (byte-identical to the 1-arg form), so
+    // contractless/seed/legacy injectors keep their current id.
+    assertThat(AttackPathIds.injectorNode("NMAP", null))
+        .isEqualTo(AttackPathIds.injectorNode("NMAP"))
+        .isEqualTo("NODE_INJECTOR|NMAP");
+    // Two contracts of the same injector never collide, and neither collides with the per-injector
+    // id.
+    assertThat(AttackPathIds.injectorNode("NMAP", "C-1"))
+        .isNotEqualTo(AttackPathIds.injectorNode("NMAP", "C-2"))
+        .isNotEqualTo(AttackPathIds.injectorNode("NMAP"));
+  }
+
+  @Test
   @DisplayName("isSeedId recognises synthetic seed simulation ids, and only those")
   void is_seed_id() {
     // A synthetic seed simulation id (the shape AttackPathSeedService builds) is a seed.

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEdgeGroupRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEdgeGroupRow.java
@@ -10,6 +10,9 @@ public record AttackPathEdgeGroupRow(
     String sourceKind,
     String sourceInjector,
     String sourceAssetId,
+    // The injector's frozen contract external id (null for agent/asset sources), so the collapsed
+    // injector node is per contract, matching the full graph.
+    String contractExternalId,
     // Frozen source endpoint attributes, constant per source asset within a simulation, so a
     // source-only endpoint renders them in collapsed mode too rather than a bare id.
     String sourceHostname,

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEdgeGroupRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEdgeGroupRow.java
@@ -2,9 +2,9 @@ package io.openaev.database.model.attackpath.projection;
 
 /**
  * One grouped source-to-target edge for the collapsed graph mode (issue 6647): the source identity
- * (an injector name or a source asset id) and the target key, with how many executions it groups.
- * Produced by a {@code GROUP BY} on the source and target, so the per-execution rows are never
- * materialized.
+ * (an injector name plus its contract external id, or a source asset id) and the target key, with
+ * how many executions it groups. Produced by a {@code GROUP BY} on the source and target, so the
+ * per-execution rows are never materialized.
  */
 public record AttackPathEdgeGroupRow(
     String sourceKind,

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -110,6 +110,14 @@ public interface InjectorContractRepository
       @Param("id") String id, @Param("externalId") String externalId);
 
   /**
+   * Batched form of {@link #findByIdOrExternalId}: every contract whose id OR external id is in the
+   * set.
+   */
+  @Query(
+      "SELECT ic FROM InjectorContract ic WHERE ic.compositeId.id IN :ids OR ic.externalId IN :ids")
+  List<InjectorContract> findAllByIdOrExternalIdIn(@Param("ids") Collection<String> ids);
+
+  /**
    * Batched ATT&CK techniques for the attack-path injector nodes: one flat query returning the
    * (contract external id, pattern) pairs for a set of contracts. A flat projection, not the
    * entity, so it never pulls the contract's other eager collections into secondary selects.

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
@@ -139,11 +139,11 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathEdgeGroupRow("
-          + "e.sourceKind, e.sourceInjector, e.sourceAssetId, "
+          + "e.sourceKind, e.sourceInjector, e.sourceAssetId, e.contractExternalId, "
           + "max(e.sourceHostname), max(e.sourceIp), max(e.sourcePlatform), "
           + "e.targetKey, count(e)) "
           + "FROM AttackPathExecution e WHERE e.simulationId = :simulationId "
-          + "GROUP BY e.sourceKind, e.sourceInjector, e.sourceAssetId, e.targetKey")
+          + "GROUP BY e.sourceKind, e.sourceInjector, e.sourceAssetId, e.contractExternalId, e.targetKey")
   List<AttackPathEdgeGroupRow> findEdgeGroups(@Param("simulationId") String simulationId);
 
   /**


### PR DESCRIPTION
## Summary

The injector map node was keyed per injector, so every contract an injector ran in a simulation
collapsed onto one node. When one contract produced a finding and another contract of the same
injector consumed it (e.g. NetExec Share Listing then Kerberoasting on the shared SMB event),
producer and consumer were the same node and the causal edge folded back into a cycle. This keys the
injector node per (injector, contract), so producer and consumer are distinct nodes and the fold-back
is gone.

## Changes (backend only)

- `AttackPathIds.injectorNode(injector, contractExternalId)` overload. A null contract falls back to
  the current 2-segment id, byte-identical, so contractless sources (seed, legacy, agents) are
  unchanged.
- The per-contract id is emitted identically on the full `/graph` (nodes and
  `EDGE_EXECUTIONS.edgeSourceId`), on `/endpoint/relations`, and in collapsed mode, so the front's
  `edgeSourceId` correlation holds across all three (one `sourceNodeId()` serves full and relations).
- Collapsed: `findEdgeGroups` and `AttackPathEdgeGroupRow` gain `contractExternalId` in the GROUP BY;
  agent/asset sources are unaffected.
- The injector node label is now its contract name (fallback: injector name when the contract is null
  or unnamed), so two nodes of the same injector are distinguishable. Names are resolved once and
  shared: no extra query in full mode, one bounded read in collapsed.
- Each per-contract node shows only its own contract's ATT&CK techniques, no longer the union.

## Not changed

- No migration, no ingestion change, no api-types change, no front change. The current front matches
  injector nodes by opaque `edgeSourceId` and renders `node.label`; the follow-up front PR is
  compatible. Two dependent steps of the same contract still merge (accepted); causal-edge
  over-matching is a separate front follow-up.

## Tests

TDD, real stack, no mocks. Per-contract split (full and collapsed, selected by id), endpoint-relations
shares the id, contract-name label, null-contract fallback byte-identical, mixed contract; query-count
pins held. Broad AttackPath suite 172 green, arch 14 green.

Related: #6647