### PR TITLE
fix(attack-path): expand the focused endpoint's finding clusters and reclaim hidden columns' width (#6647)

### DIFF
--- a/openaev-front/src/admin/components/findings/FindingList.tsx
+++ b/openaev-front/src/admin/components/findings/FindingList.tsx
@@ -175,6 +175,24 @@ const FindingList = ({ searchDistinctFindings, filterLocalStorageKey, contextId,
 
   const visibleHeaders = headers.filter(h => !hiddenFields.includes(h.field));
 
+  // The column widths above are percentages of the full six-column table: hiding columns would
+  // otherwise leave the remainder crammed on the left with dead space on the right (the assets chips
+  // truncating while the row is half empty). Re-spread the hidden columns' share over the visible
+  // ones, keeping their relative proportions.
+  const visibleStyles: Record<string, CSSProperties> = (() => {
+    const widthOf = (field: string) => Number.parseFloat(String(inlineStyles[field]?.width ?? '0'));
+    const totalWidth = visibleHeaders.reduce((sum, h) => sum + widthOf(h.field), 0);
+    if (totalWidth <= 0 || totalWidth >= 100) {
+      return inlineStyles;
+    }
+    return Object.fromEntries(
+      visibleHeaders.map(h => [h.field, {
+        ...inlineStyles[h.field],
+        width: `${(widthOf(h.field) / totalWidth) * 100}%`,
+      }]),
+    );
+  })();
+
   return (
     <>
       <PaginationComponentV2
@@ -201,14 +219,14 @@ const FindingList = ({ searchDistinctFindings, filterLocalStorageKey, contextId,
             primary={(
               <SortHeadersComponentV2
                 headers={visibleHeaders}
-                inlineStylesHeaders={inlineStyles}
+                inlineStylesHeaders={visibleStyles}
                 sortHelpers={queryableHelpers.sortHelpers}
               />
             )}
           />
         </ListItem>
         {loading
-          ? <PaginatedListLoader Icon={Binoculars} headers={visibleHeaders} headerStyles={inlineStyles} />
+          ? <PaginatedListLoader Icon={Binoculars} headers={visibleHeaders} headerStyles={visibleStyles} />
           : findings.map(finding => (
               <ListItem
                 key={finding.finding_id}
@@ -233,7 +251,7 @@ const FindingList = ({ searchDistinctFindings, filterLocalStorageKey, contextId,
                             key={header.field}
                             style={{
                               ...bodyItemsStyles.bodyItem,
-                              ...inlineStyles[header.field],
+                              ...visibleStyles[header.field],
                             }}
                           >
                             {header.value && header.value(finding)}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1802,6 +1802,46 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // Focus a chokepoint endpoint: redraw the graph as the focused endpoint path (injectors -> endpoint
   // -> its finding clusters) and open its side panel (findings + executions). Uses the endpoint-focus
   // mode of buildFindingPathFlow (empty finding type/value).
+  // Entering an endpoint focus, pre-expand every finding-type cluster of that endpoint: the analyst
+  // came here to read the findings, so making them click each cluster open adds a step with no
+  // information gain. One fetch feeds every cluster (they all read the same endpoint).
+  const expandFocusedEndpointClusters = useCallback((endpointNodeId: string, ref: string) => {
+    const counts = (dto?.attackPathNodes ?? []).find(n => n.id === endpointNodeId)?.findingCounts ?? {};
+    const types = Object.entries(counts).filter(([, v]) => (v ?? 0) > 0).map(([type]) => type);
+    if (types.length === 0) {
+      return;
+    }
+    const clusterIdOf = (type: string) => `path-cl-type|${type}|${ref}`;
+    setExpandedFindingClusters(new Set(types.map(clusterIdOf)));
+    setFindingBatch((prev) => {
+      const next = new Map(prev);
+      types.forEach(type => next.set(clusterIdOf(type), FINDING_BATCH_SIZE));
+      return next;
+    });
+    fetchEndpointFindings(simulationId, ref)
+      .then((r) => {
+        const byType = new Map<string, AttackPathNodeDTO[]>();
+        const seen = new Set<string>();
+        for (const f of r.data.findings ?? []) {
+          const type = f.typeFindings ?? '';
+          const key = `${type}|${f.value ?? f.id ?? ''}`;
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          const list = byType.get(type) ?? [];
+          list.push(f);
+          byType.set(type, list);
+        }
+        setFindingsByCluster((prev) => {
+          const next = new Map(prev);
+          byType.forEach((list, type) => next.set(clusterIdOf(type), list));
+          return next;
+        });
+      })
+      .catch(() => undefined);
+  }, [dto, simulationId]);
+
   const focusChokepoint = (c: {
     nodeId: string;
     ref: string;
@@ -1824,6 +1864,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     });
     setFitNonce(n => n + 1);
     onEndpointClick(c.nodeId, c.ref, c.label);
+    expandFocusedEndpointClusters(c.nodeId, c.ref);
   };
 
   // Keep the selected value in the options so MUI does not warn when the current simulation has no


### PR DESCRIPTION
## Description

Two UX fixes on the attack path view, reported from the chokepoint drill-down flow.

**1. Focusing an endpoint now opens its findings straight away.** Clicking a chokepoint (from the "Top chokepoints" popover, the table, or the search) rebuilt the graph as the focused endpoint path but left every finding-type cluster collapsed — the analyst had to click each one (portscan, files, credentials…) to see anything. The focused view now pre-expands all of the endpoint's finding-type clusters, fed by a single `fetchEndpointFindings` call split per type (no extra round-trips versus expanding them by hand).

**2. The findings drawer no longer truncates the Assets column.** `FindingList` column widths are percentages of the full six-column table. In compact mode the drawer hides three of them, so Type/Value/Assets only used 57% of the row: the asset chips ellipsized while the right half sat empty. The hidden columns' share is now redistributed over the visible ones, keeping their relative proportions. Full-page usage (no hidden fields) is unchanged.

Follow-up to #6964.

## Checks
- `yarn eslint`, `yarn tsc --noEmit` clean.
- `yarn vitest run` on the attack-path and findings suites: 27 tests pass.