### PR TITLE
feat(attack-path): order the kill chain by event-consumption dependencies (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -36,6 +36,7 @@ import io.openaev.service.attackpath.dto.AttackPathFindingItemDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingVerdictsDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
+import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
 import io.openaev.utils.mapper.PayloadMapper;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -561,6 +562,7 @@ public class AttackPathGraphService {
       feedByExecutionId.put(e.id(), executionFeedNode(e));
     }
     applyKillChain(executions, feedByExecutionId);
+    applyEventDependencies(executions, findings, feedByExecutionId);
     Map<String, String> contractNames = applyContractNames(executions, feedByExecutionId);
     applyInjectorNodeLabels(nodes, contractsByInjectorNode, contractNames);
 
@@ -1021,6 +1023,70 @@ public class AttackPathGraphService {
       }
       if (!meta.consumedFindingKeys().isEmpty()) {
         node.setConsumedFindingKeys(meta.consumedFindingKeys());
+      }
+    }
+  }
+
+  /**
+   * Adds event-consumption dependencies to each consumer's {@code dependsOn}: when a step consumes
+   * a finding key, the step templates of the executions that produced a matching finding (mirroring
+   * the front matcher) are added, so the front places the consumer after its producer. A producer
+   * counts only when its execution ran strictly before the consumer's — a finding is produced
+   * before it is consumed, which also keeps {@code dependsOn} acyclic — and never the consumer's
+   * own step. Resolved in memory from the executions and findings already read, so no extra query;
+   * full mode only.
+   */
+  private void applyEventDependencies(
+      List<AttackPathExecutionRow> executions,
+      List<AttackPathFindingRow> findings,
+      Map<String, AttackPathNodeDTO> feedByExecutionId) {
+    if (findings.isEmpty()) {
+      return;
+    }
+    Map<String, AttackPathExecutionRow> executionById = new HashMap<>();
+    for (AttackPathExecutionRow e : executions) {
+      executionById.putIfAbsent(e.id(), e);
+    }
+    // Findings indexed by presented type, so a consumed key scans only its reconciled type.
+    Map<String, List<AttackPathFindingRow>> findingsByType = new HashMap<>();
+    for (AttackPathFindingRow f : findings) {
+      findingsByType.computeIfAbsent(f.type(), k -> new ArrayList<>()).add(f);
+    }
+    for (AttackPathExecutionRow consumer : executions) {
+      AttackPathNodeDTO node = feedByExecutionId.get(consumer.id());
+      if (node == null
+          || node.getConsumedFindingKeys() == null
+          || node.getConsumedFindingKeys().isEmpty()
+          || consumer.executedAt() == null) {
+        continue;
+      }
+      Set<String> producerSteps = new LinkedHashSet<>();
+      for (ConsumedFindingKeyDTO key : node.getConsumedFindingKeys()) {
+        for (AttackPathFindingRow f :
+            findingsByType.getOrDefault(
+                AttackPathKeyMatcher.reconciledType(key.keyType()), List.of())) {
+          if (!AttackPathKeyMatcher.matches(f, key)) {
+            continue;
+          }
+          AttackPathExecutionRow producer = executionById.get(f.executionId());
+          if (producer != null
+              && producer.stepTemplateId() != null
+              && producer.executedAt() != null
+              && producer.executedAt().isBefore(consumer.executedAt())
+              && !producer.stepTemplateId().equals(consumer.stepTemplateId())) {
+            producerSteps.add(producer.stepTemplateId());
+          }
+        }
+      }
+      if (!producerSteps.isEmpty()) {
+        List<String> dependsOn =
+            new ArrayList<>(node.getDependsOn() == null ? List.of() : node.getDependsOn());
+        for (String s : producerSteps) {
+          if (!dependsOn.contains(s)) {
+            dependsOn.add(s);
+          }
+        }
+        node.setDependsOn(dependsOn);
       }
     }
   }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathKeyMatcher.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathKeyMatcher.java
@@ -1,0 +1,63 @@
+package io.openaev.service.attackpath;
+
+import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
+import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Matches a produced finding against a consumed finding key, mirroring the front's finding matcher
+ * so the producer the backend resolves is the finding the front would match. The key type is
+ * reconciled to the finding-type vocabulary, then the operator is applied: {@code EQ} (value
+ * equals), {@code IN} (comma-separated membership, single token falls back to substring), and
+ * {@code IS_NOT_NULL} (presence). Every other operator matches nothing. Primitive keys only;
+ * reaching into a complex finding's sub-field is deferred.
+ */
+public final class AttackPathKeyMatcher {
+
+  // The complex sub-field keys whose vocabulary differs from the finding type; every other key type
+  // maps to a finding type 1:1 (identity).
+  private static final Map<String, String> KEYTYPE_TO_FINDING_TYPE =
+      Map.of("share_name", "file", "password", "credentials");
+
+  private AttackPathKeyMatcher() {}
+
+  /** The finding type a consumed key type reconciles to (identity when there is no mapping). */
+  public static String reconciledType(String keyType) {
+    // Map.of() rejects a null lookup (NPE), and a null key type never matches a finding anyway.
+    if (keyType == null) {
+      return null;
+    }
+    return KEYTYPE_TO_FINDING_TYPE.getOrDefault(keyType, keyType);
+  }
+
+  public static boolean matches(AttackPathFindingRow finding, ConsumedFindingKeyDTO key) {
+    if (finding == null || key == null) {
+      return false;
+    }
+    String reconciledType = reconciledType(key.keyType());
+    if (reconciledType == null || !reconciledType.equals(finding.type())) {
+      return false;
+    }
+    String value = finding.value();
+    return switch (key.operator() == null ? "" : key.operator()) {
+      case "IS_NOT_NULL" -> value != null && !value.isBlank();
+      case "EQ" -> key.value() != null && key.value().equals(value);
+      case "IN" -> matchesIn(value, key.value());
+      default -> false;
+    };
+  }
+
+  private static boolean matchesIn(String value, String keyValue) {
+    if (value == null || keyValue == null) {
+      return false;
+    }
+    List<String> members =
+        Arrays.stream(keyValue.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
+    if (members.size() > 1) {
+      return members.contains(value);
+    }
+    return value.contains(keyValue);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathKillChainGraphTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathKillChainGraphTest.java
@@ -8,7 +8,10 @@ import io.openaev.database.model.ConditionType;
 import io.openaev.database.model.PrimitiveType;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
+import io.openaev.database.model.attackpath.AttackPathFinding;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
 import io.openaev.service.attackpath.AttackPathGraphService;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
@@ -41,6 +44,7 @@ class AttackPathKillChainGraphTest extends IntegrationTest {
 
   @Autowired private AttackPathGraphService graphService;
   @Autowired private AttackPathExecutionRepository executionRepository;
+  @Autowired private AttackPathFindingRepository findingRepository;
   @Autowired private ConditionComposer conditionComposer;
   @Autowired private StepComposer stepComposer;
   @Autowired private WorkflowComposer workflowComposer;
@@ -92,5 +96,171 @@ class AttackPathKillChainGraphTest extends IntegrationTest {
     assertThat(node.getDependsOn()).containsExactly("prereq-step-tpl");
     assertThat(node.getConsumedFindingKeys())
         .containsExactly(new ConsumedFindingKeyDTO("port", "EQ", "445", null));
+  }
+
+  @Test
+  @DisplayName("a step that consumes an event gets its finding's producer added to dependsOn")
+  void consumerGetsProducerInDependsOn() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-tenant"));
+
+    // Consumer step B: a filter condition on share_name IS_NOT_NULL (the SMB "share found" event).
+    StepComposer.Composer stepB = stepComposer.forStep(StepFixture.getDefaultStepTemplate());
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withSimulation(exerciseComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+        .withStep(stepB)
+        .persist();
+    Condition consumed = ConditionFixture.getDefaultCondition(PrimitiveType.ShareName, null);
+    consumed.setType(ConditionType.IS_NOT_NULL);
+    conditionComposer.forCondition(consumed).withStep(stepB).persist();
+
+    // The producer ran earlier and produced a share (presented as file); the consumer ran later.
+    AttackPathExecution producer =
+        saveExecution(tenant, "nmap", "producer-step-tpl", Instant.parse("2026-06-18T08:00:00Z"));
+    saveFinding(tenant, "share", "\\\\host\\NETLOGON", producer.getId());
+    saveExecution(tenant, "netexec", stepB.get().getId(), Instant.parse("2026-06-18T08:05:00Z"));
+    entityManager.flush();
+
+    AttackPathNodeDTO consumerNode =
+        graphService.buildGraph(SIM, "full").attackPathExecutions().stream()
+            .filter(n -> stepB.get().getId().equals(n.getStepTemplateId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(consumerNode.getDependsOn()).contains("producer-step-tpl");
+  }
+
+  @Test
+  @DisplayName("explicit DEPEND_ON is preserved and every matching producer is merged in")
+  void mergesExplicitDependOnAndMultipleProducers() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-merge"));
+    StepComposer.Composer stepB =
+        consumerStep(PrimitiveType.ShareName, ConditionType.IS_NOT_NULL, null);
+    Condition dependOn = new Condition();
+    dependOn.setType(ConditionType.DEPEND_ON);
+    dependOn.setValue("explicit-prereq");
+    conditionComposer.forCondition(dependOn).withStep(stepB).persist();
+
+    // Two earlier producers of a share (presented file), each on its own step.
+    AttackPathExecution p1 =
+        saveExecution(tenant, "nmap", "prod-1", Instant.parse("2026-06-18T08:00:00Z"));
+    saveFinding(tenant, "share", "\\\\host\\NETLOGON", p1.getId());
+    AttackPathExecution p2 =
+        saveExecution(tenant, "smb", "prod-2", Instant.parse("2026-06-18T08:01:00Z"));
+    saveFinding(tenant, "share", "\\\\host\\SYSVOL", p2.getId());
+    saveExecution(tenant, "netexec", stepB.get().getId(), Instant.parse("2026-06-18T08:05:00Z"));
+    entityManager.flush();
+
+    assertThat(nodeForStep(stepB.get().getId()).getDependsOn())
+        .containsExactlyInAnyOrder("explicit-prereq", "prod-1", "prod-2");
+  }
+
+  @Test
+  @DisplayName("a step that produces and consumes the same event does not depend on itself")
+  void guardsSelfDependency() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-self"));
+    StepComposer.Composer selfStep =
+        consumerStep(PrimitiveType.ShareName, ConditionType.IS_NOT_NULL, null);
+    AttackPathExecution selfExec =
+        saveExecution(
+            tenant, "netexec", selfStep.get().getId(), Instant.parse("2026-06-18T08:00:00Z"));
+    saveFinding(tenant, "share", "\\\\host\\NETLOGON", selfExec.getId());
+    entityManager.flush();
+
+    assertThat(nodeForStep(selfStep.get().getId()).getDependsOn()).isNullOrEmpty();
+  }
+
+  @Test
+  @DisplayName("a producer that ran after the consumer is excluded (causality)")
+  void guardsCausality() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-causality"));
+    StepComposer.Composer stepB =
+        consumerStep(PrimitiveType.ShareName, ConditionType.IS_NOT_NULL, null);
+    saveExecution(tenant, "netexec", stepB.get().getId(), Instant.parse("2026-06-18T08:00:00Z"));
+    AttackPathExecution later =
+        saveExecution(tenant, "nmap", "later-prod", Instant.parse("2026-06-18T09:00:00Z"));
+    saveFinding(tenant, "share", "\\\\host\\NETLOGON", later.getId());
+    entityManager.flush();
+
+    assertThat(nodeForStep(stepB.get().getId()).getDependsOn()).isNullOrEmpty();
+  }
+
+  @Test
+  @DisplayName("EQ matches the exact producer value; IN matches a member; a non-match adds nothing")
+  void operatorCoverageEqAndIn() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-ops"));
+    AttackPathExecution hit =
+        saveExecution(tenant, "nmap", "port-445", Instant.parse("2026-06-18T08:00:00Z"));
+    saveFinding(tenant, "port", "445", hit.getId());
+    AttackPathExecution miss =
+        saveExecution(tenant, "nmap", "port-443", Instant.parse("2026-06-18T08:01:00Z"));
+    saveFinding(tenant, "port", "443", miss.getId());
+
+    StepComposer.Composer eqStep = consumerStep(PrimitiveType.Port, ConditionType.EQ, "445");
+    saveExecution(tenant, "netexec", eqStep.get().getId(), Instant.parse("2026-06-18T08:05:00Z"));
+    StepComposer.Composer inStep =
+        consumerStep(PrimitiveType.Port, ConditionType.IN, "139,445,3389");
+    saveExecution(
+        tenant, "crackmapexec", inStep.get().getId(), Instant.parse("2026-06-18T08:06:00Z"));
+    entityManager.flush();
+
+    // EQ 445 → only the 445 producer, not 443.
+    assertThat(nodeForStep(eqStep.get().getId()).getDependsOn()).containsExactly("port-445");
+    // IN {139,445,3389} → the 445 producer matches.
+    assertThat(nodeForStep(inStep.get().getId()).getDependsOn()).contains("port-445");
+  }
+
+  private AttackPathExecution saveExecution(
+      Tenant tenant, String injector, String stepTemplateId, Instant executedAt) {
+    AttackPathExecution e = new AttackPathExecution();
+    e.setTenant(tenant);
+    e.setSimulationId(SIM);
+    e.setSourceKind("INJECTOR");
+    e.setSourceInjector(injector);
+    e.setTargetKind("ASSET");
+    e.setTargetAssetId("host-x");
+    e.setTargetKey("host-x");
+    e.setTargetHostname("host-x");
+    e.setExecutedAt(executedAt);
+    e.setStepTemplateId(stepTemplateId);
+    return executionRepository.save(e);
+  }
+
+  private void saveFinding(Tenant tenant, String type, String value, String executionId) {
+    AttackPathFinding f = new AttackPathFinding();
+    f.setTenant(tenant);
+    f.setSimulationId(SIM);
+    f.setType(type); // a "share" is presented as the native "file" type at the read boundary
+    f.setValue(value);
+    f.setEndpointId("host-x");
+    f.setEndpointKey("host-x");
+    String findingId = findingRepository.save(f).getId();
+    AttackPathExecutionFinding link = new AttackPathExecutionFinding();
+    link.setExecutionId(executionId);
+    link.setFindingId(findingId);
+    entityManager.persist(link);
+  }
+
+  /**
+   * A persisted consumer step template whose filter consumes {@code keyType} with {@code operator}.
+   */
+  private StepComposer.Composer consumerStep(
+      PrimitiveType keyType, ConditionType operator, String value) {
+    StepComposer.Composer step = stepComposer.forStep(StepFixture.getDefaultStepTemplate());
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withSimulation(exerciseComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+        .withStep(step)
+        .persist();
+    Condition consumed = ConditionFixture.getDefaultCondition(keyType, value);
+    consumed.setType(operator);
+    conditionComposer.forCondition(consumed).withStep(step).persist();
+    return step;
+  }
+
+  private AttackPathNodeDTO nodeForStep(String stepTemplateId) {
+    return graphService.buildGraph(SIM, "full").attackPathExecutions().stream()
+        .filter(n -> stepTemplateId.equals(n.getStepTemplateId()))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathKeyMatcherTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathKeyMatcherTest.java
@@ -1,0 +1,109 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
+import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the consumed-key ↔ produced-finding matcher (mirror of the front matcher). */
+class AttackPathKeyMatcherTest {
+
+  private static AttackPathFindingRow finding(String type, String value) {
+    return new AttackPathFindingRow("f-id", type, value, null, null, "ep", "exec");
+  }
+
+  private static ConsumedFindingKeyDTO key(String keyType, String operator, String value) {
+    return new ConsumedFindingKeyDTO(keyType, operator, value, null);
+  }
+
+  @Test
+  @DisplayName(
+      "the key type is reconciled to the finding type (share_name -> file, password -> credentials)")
+  void reconciles_key_type_to_finding_type() {
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", "\\\\host\\NETLOGON"), key("share_name", "IS_NOT_NULL", null)))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("credentials", "admin:secret"), key("password", "IS_NOT_NULL", null)))
+        .isTrue();
+    // A key type with no mapping matches its own finding type 1:1 (identity).
+    assertThat(
+            AttackPathKeyMatcher.matches(finding("port", "445"), key("port", "IS_NOT_NULL", null)))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("a type mismatch never matches")
+  void type_mismatch_never_matches() {
+    // share_name reconciles to file, which is not the port finding's type.
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("port", "445"), key("share_name", "IS_NOT_NULL", null)))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("IS_NOT_NULL matches on presence of a non-blank value")
+  void is_not_null_is_presence() {
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", "\\\\host\\NETLOGON"), key("share_name", "IS_NOT_NULL", null)))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", ""), key("share_name", "IS_NOT_NULL", null)))
+        .isFalse();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", null), key("share_name", "IS_NOT_NULL", null)))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("EQ matches the exact value; a null key value never matches")
+  void eq_matches_exact_value() {
+    assertThat(AttackPathKeyMatcher.matches(finding("port", "445"), key("port", "EQ", "445")))
+        .isTrue();
+    assertThat(AttackPathKeyMatcher.matches(finding("port", "443"), key("port", "EQ", "445")))
+        .isFalse();
+    assertThat(AttackPathKeyMatcher.matches(finding("port", "445"), key("port", "EQ", null)))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("IN matches a comma-separated member; a single token falls back to substring")
+  void in_matches_member_or_substring() {
+    assertThat(
+            AttackPathKeyMatcher.matches(finding("port", "445"), key("port", "IN", "139,445,3389")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(finding("port", "22"), key("port", "IN", "139,445,3389")))
+        .isFalse();
+    // Single token: substring containment (mirrors the front).
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", "\\\\host\\NETLOGON"), key("share_name", "IN", "NETLOGON")))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("a null key type reconciles to null and never matches (no NPE from Map.of)")
+  void null_key_type_is_safe() {
+    assertThat(AttackPathKeyMatcher.reconciledType(null)).isNull();
+    assertThat(AttackPathKeyMatcher.matches(finding("file", "x"), key(null, "IS_NOT_NULL", null)))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("an unsupported operator matches nothing")
+  void unsupported_operator_matches_nothing() {
+    assertThat(AttackPathKeyMatcher.matches(finding("port", "445"), key("port", "GT", "400")))
+        .isFalse();
+    assertThat(AttackPathKeyMatcher.matches(finding("port", "445"), key("port", null, "445")))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

The causal chain's left→right placement is derived from `dependsOn` alone (depth = the longest
`dependsOn` chain). But an event-consuming step carries no automatic `DEPEND_ON` on its producer:
`DEPEND_ON` conditions and filter (event) conditions are independent. So a step that fires on another
step's finding (e.g. NetExec Kerberoasting on the SMB `share_name` event) had an empty `dependsOn` and
was not placed after its producer.

This resolves the true producer of each consumed finding key and adds its step to the consumer's
`dependsOn`, so the front's existing placement orders the chain with no front change.

## Changes (backend only, full mode)

- New `AttackPathKeyMatcher`: matches a produced finding against a consumed key, mirroring the front
  matcher so the producer resolved here is the finding the front matches. Reconciles the key type
  (`share_name` -> `file`, `password` -> `credentials`, identity otherwise), then applies the operator
  (`EQ`, `IN`, `IS_NOT_NULL`); every other operator matches nothing.
- `applyEventDependencies` (after `applyKillChain`): for each consumer, finds the executions that
  produced a matching finding, resolves their step templates, and merges them into `dependsOn`. All in
  memory from the executions and findings already read, so no new query.
- Causality guard: a producer counts only when its execution ran strictly before the consumer's (a
  finding is produced before it is consumed), which also keeps `dependsOn` acyclic; the consumer's own
  step is never added. All matching producers are added and deduped; explicit `DEPEND_ON` is preserved.

## Not changed

No new query (full-mode statement count unchanged), no migration, no api-types change, no front change.
The front consumes `dependsOn` for placement as-is; anchoring the causal edge to the resolved producer
is a front follow-up. `IS_NOT_NULL` matching mirrors the front's #6964.

## Tests

TDD, real stack, no mocks: matcher unit (reconcile + EQ/IN/IS_NOT_NULL + skips); event producer added
to `dependsOn`; explicit `DEPEND_ON` preserved + multiple producers merged; self-dependency and
causality guards; EQ/IN coverage. Broad AttackPath suite + arch 197 green, query pins held.

Related: #6647