### PR TITLE
fix(expectations): per-asset vulnerability verdicts, group attribution and reset-simulation expectations (#6987)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/output_processor/CVEOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/CVEOutputProcessor.java
@@ -15,10 +15,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class CVEOutputProcessor extends FindingCapableOutputProcessor {
 
-  private static final String ASSET_ID = "asset_id";
-  private static final String ID = "id";
-  private static final String HOST = "host";
-  private static final String SEVERITY = "severity";
+  // Public: InjectExpectationService reads the same fields to attribute vulnerability
+  // verdicts per asset, so the expectation matching can never drift from the findings.
+  public static final String ASSET_ID = "asset_id";
+  public static final String ID = "id";
+  public static final String HOST = "host";
+  public static final String SEVERITY = "severity";
 
   private final InjectExpectationService injectExpectationService;
 

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1,5 +1,6 @@
 package io.openaev.service;
 
+import static io.openaev.collectors.expectations_vulnerability_manager.ExpectationsVulnerabilityManagerCollector.EXPECTATIONS_VULNERABILITY_COLLECTOR_ID;
 import static io.openaev.database.model.BaseInjectExpectation.EXPECTATION_TYPE.*;
 import static io.openaev.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
 import static io.openaev.expectation.ExpectationType.VULNERABILITY;
@@ -38,6 +39,7 @@ import io.openaev.expectation.ManualExpectation;
 import io.openaev.expectation.PreventionExpectation;
 import io.openaev.expectation.VulnerabilityExpectation;
 import io.openaev.injectors.common.model.BaseInjectContent;
+import io.openaev.output_processor.CVEOutputProcessor;
 import io.openaev.rest.atomic_testing.form.InjectExpectationAgentOutput;
 import io.openaev.rest.collector.service.CollectorService;
 import io.openaev.rest.exception.ElementNotFoundException;
@@ -48,6 +50,7 @@ import io.openaev.rest.inject.service.ExecutionProcessingContext;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.service.expectation.ExpectationBehavior;
 import io.openaev.utils.TargetType;
+import io.openaev.utils.injector_contract.InjectorContractContentUtils;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
@@ -57,6 +60,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -90,6 +94,7 @@ public class InjectExpectationService {
   private final InjectExpectationLockService injectExpectationLockService;
   private final AssetGroupService assetGroupService;
   private final InjectService injectService;
+  private final InjectorContractContentUtils injectorContractContentUtils;
 
   @Resource protected ObjectMapper mapper;
 
@@ -1844,11 +1849,21 @@ public class InjectExpectationService {
    * Function used to check if the output contains vulnerabilities and update the related inject
    * expectations with the result.
    *
+   * <p>For implant executions (agent != null), the fetched expectations are all scoped to the
+   * executing agent — a single asset — so the global "any CVE found" verdict is that asset's
+   * verdict.
+   *
+   * <p>For injector executions (agent == null, e.g. Nuclei scanning several assets at once), the
+   * structured output covers ALL scanned assets: a CVE found on one asset must NOT mark the sibling
+   * assets vulnerable. Each asset-level expectation gets its own verdict from the CVE items
+   * attributed to it (via {@code asset_id}, falling back to {@code host} matching), and asset-group
+   * expectations roll up from those per-asset verdicts.
+   *
    * @param ctx the execution processing context containing the inject and agent information
    * @param jsonNode the JSON node containing the output to check for vulnerabilities
    */
   public void matchesVulnerabilityExpectations(ExecutionProcessingContext ctx, JsonNode jsonNode) {
-    boolean vulnerable =
+    boolean anyVulnerable =
         jsonNode != null
             && !jsonNode.isMissingNode()
             && jsonNode.isContainerNode()
@@ -1869,21 +1884,164 @@ public class InjectExpectationService {
     // per-platform row, like detection/prevention. Injectors without a platform keep the legacy
     // attribution to the generic Expectations Vulnerability Manager.
     Optional<SecurityPlatform> securityPlatform = resolveInjectorSecurityPlatform(inject);
-    InjectExpectationResult result =
-        securityPlatform
-            .map(sp -> buildForSecurityPlatformInFailed(sp))
-            .orElseGet(() -> buildForVulnerabilityManagerInFailed());
 
-    String label = vulnerable ? VULNERABILITY.failureLabel : VULNERABILITY.successLabel;
-
-    setResultExpectationVulnerable(expectations, result, label);
-
-    if (securityPlatform.isPresent()) {
-      validateResultForAssetFromSecurityPlatform(expectations, result, securityPlatform.get());
-    } else {
-      validateResultForAsset(expectations, result);
+    if (agent != null) {
+      // Implant execution: every fetched expectation is bound to this agent, hence to a single
+      // asset — the global verdict IS this asset's verdict.
+      expectations.forEach(
+          expectation -> applyVulnerabilityVerdict(expectation, anyVulnerable, securityPlatform));
+      return;
     }
-    injectExpectationRepository.saveAll(expectations);
+
+    Set<String> vulnerableAssetIds = resolveVulnerableAssetIds(jsonNode, inject);
+    // Older injector outputs may carry findings without any per-asset attribution: fall back to
+    // the legacy blanket verdict, since a false positive on a sibling asset beats silently losing
+    // the finding.
+    boolean blanketVulnerable = anyVulnerable && vulnerableAssetIds.isEmpty();
+
+    List<VulnerabilityInjectExpectation> assetExpectations =
+        expectations.stream().filter(expectation -> expectation.getAsset() != null).toList();
+    List<VulnerabilityInjectExpectation> assetGroupExpectations =
+        expectations.stream()
+            .filter(
+                expectation ->
+                    expectation.getAsset() == null && expectation.getAssetGroup() != null)
+            .toList();
+
+    // The verdict of an asset-level expectation is a pure function of its asset: vulnerable when
+    // at least one CVE item is attributed to it.
+    Predicate<VulnerabilityInjectExpectation> isAssetVulnerable =
+        expectation ->
+            blanketVulnerable || vulnerableAssetIds.contains(expectation.getAsset().getId());
+
+    for (VulnerabilityInjectExpectation expectation : assetExpectations) {
+      applyVulnerabilityVerdict(expectation, isAssetVulnerable.test(expectation), securityPlatform);
+    }
+
+    // Group verdict rolls up from the children verdicts (same rule as score propagation in
+    // computeScores) and is written with the same source attribution, so the group row
+    // immediately shows WHO assessed it instead of staying an unattributed "Vulnerable".
+    for (VulnerabilityInjectExpectation groupExpectation : assetGroupExpectations) {
+      List<Boolean> childVerdicts =
+          assetExpectations.stream()
+              .filter(
+                  expectation ->
+                      expectation.getAssetGroup() != null
+                          && expectation
+                              .getAssetGroup()
+                              .getId()
+                              .equals(groupExpectation.getAssetGroup().getId()))
+              .map(isAssetVulnerable::test)
+              .toList();
+      boolean groupVulnerable;
+      if (childVerdicts.isEmpty()) {
+        groupVulnerable = anyVulnerable;
+      } else if (groupExpectation.isExpectationGroup()) {
+        // "At least one asset must succeed": the group stays clean unless ALL assets are
+        // vulnerable.
+        groupVulnerable = childVerdicts.stream().allMatch(Boolean::booleanValue);
+      } else {
+        // Default "all assets must succeed": one vulnerable asset makes the group vulnerable.
+        groupVulnerable = childVerdicts.stream().anyMatch(Boolean::booleanValue);
+      }
+      applyVulnerabilityVerdict(groupExpectation, groupVulnerable, securityPlatform);
+    }
+  }
+
+  /**
+   * Writes a vulnerability verdict on a single expectation, attributed either to the injector's
+   * security platform (assessment injectors such as Nuclei) or to the generic Expectations
+   * Vulnerability Manager collector, then lets the standard update path recompute the score and
+   * propagate up the asset / asset group chain.
+   *
+   * @param expectation the vulnerability expectation to conclude
+   * @param vulnerable whether the target of this expectation was found vulnerable
+   * @param securityPlatform the injector's security platform, when one is declared
+   */
+  private void applyVulnerabilityVerdict(
+      VulnerabilityInjectExpectation expectation,
+      boolean vulnerable,
+      Optional<SecurityPlatform> securityPlatform) {
+    InjectExpectationUpdateInput.InjectExpectationUpdateInputBuilder input =
+        InjectExpectationUpdateInput.builder()
+            .result(vulnerable ? VULNERABILITY.failureLabel : VULNERABILITY.successLabel)
+            .isSuccess(!vulnerable);
+    if (securityPlatform.isPresent()) {
+      updateInjectExpectationFromSecurityPlatform(
+          expectation.getId(), input.build(), securityPlatform.get());
+    } else {
+      updateInjectExpectation(
+          expectation.getId(), input.collectorId(EXPECTATIONS_VULNERABILITY_COLLECTOR_ID).build());
+    }
+  }
+
+  /**
+   * Resolves which targeted assets the CVE items of the structured output are attributed to.
+   *
+   * <p>Attribution mirrors finding attribution ({@link
+   * io.openaev.output_processor.CVEOutputProcessor}): the {@code asset_id} field is authoritative;
+   * when absent, the {@code host} values are matched against the inject's targeted assets (the host
+   * string containing a targeted hostname/IP counts as a match, like {@code
+   * FindingService#resolveAssetFromStructuredOutput}).
+   *
+   * @param cveNode the structured output node (array of CVE items)
+   * @param inject the inject being processed
+   * @return the ids of the assets found vulnerable
+   */
+  private Set<String> resolveVulnerableAssetIds(@Nullable JsonNode cveNode, Inject inject) {
+    if (cveNode == null || !cveNode.isArray()) {
+      return Set.of();
+    }
+    Set<String> vulnerableAssetIds = new HashSet<>();
+    Map<String, Endpoint> valueTargetedAssetsMap = null;
+    for (JsonNode cveItem : cveNode) {
+      boolean attributed =
+          collectTextValues(cveItem.get(CVEOutputProcessor.ASSET_ID), vulnerableAssetIds);
+      if (attributed) {
+        continue;
+      }
+      Set<String> hosts = new HashSet<>();
+      collectTextValues(cveItem.get(CVEOutputProcessor.HOST), hosts);
+      if (hosts.isEmpty()) {
+        continue;
+      }
+      if (valueTargetedAssetsMap == null) {
+        valueTargetedAssetsMap = injectService.getValueTargetedAssetMap(inject);
+      }
+      for (Map.Entry<String, Endpoint> entry : valueTargetedAssetsMap.entrySet()) {
+        if (hosts.stream().anyMatch(host -> host.contains(entry.getKey()))) {
+          vulnerableAssetIds.add(entry.getValue().getId());
+        }
+      }
+    }
+    return vulnerableAssetIds;
+  }
+
+  /**
+   * Collects the non-blank text value(s) of a JSON node (plain text or array of texts) into the
+   * given set.
+   *
+   * @param node the JSON node to read (may be null)
+   * @param into the set collecting the values
+   * @return true when at least one value was collected
+   */
+  private static boolean collectTextValues(@Nullable JsonNode node, Set<String> into) {
+    if (node == null || node.isNull()) {
+      return false;
+    }
+    boolean collected = false;
+    if (node.isArray()) {
+      for (JsonNode item : node) {
+        collected |= collectTextValues(item, into);
+      }
+      return collected;
+    }
+    String text = node.asText(null);
+    if (text != null && !text.isBlank()) {
+      into.add(text);
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -1928,50 +2086,6 @@ public class InjectExpectationService {
   }
 
   /**
-   * Function used to set the result of inject expectations of type VULNERABILITY with a label and a
-   * score.
-   *
-   * @param injectExpectations the list of inject expectations to update
-   * @param injectExpectationResult the result to set for the inject expectations
-   */
-  public void validateResultForAsset(
-      List<? extends TechnicalInjectExpectation> injectExpectations,
-      InjectExpectationResult injectExpectationResult) {
-    injectExpectations.forEach(
-        baseInjectExpectation ->
-            updateInjectExpectation(
-                baseInjectExpectation.getId(),
-                InjectExpectationUpdateInput.builder()
-                    .collectorId(injectExpectationResult.getSourceId())
-                    .result(injectExpectationResult.getResult())
-                    .isSuccess(injectExpectationResult.getScore() != 0.0)
-                    .build()));
-  }
-
-  /**
-   * Same as {@link #validateResultForAsset} but attributes the verdict to a security platform entry
-   * (assessment injectors such as Nuclei) instead of a collector.
-   *
-   * @param injectExpectations the list of inject expectations to update
-   * @param injectExpectationResult the result to set for the inject expectations
-   * @param securityPlatform the platform the verdict is attributed to
-   */
-  public void validateResultForAssetFromSecurityPlatform(
-      List<? extends TechnicalInjectExpectation> injectExpectations,
-      InjectExpectationResult injectExpectationResult,
-      SecurityPlatform securityPlatform) {
-    injectExpectations.forEach(
-        baseInjectExpectation ->
-            updateInjectExpectationFromSecurityPlatform(
-                baseInjectExpectation.getId(),
-                InjectExpectationUpdateInput.builder()
-                    .result(injectExpectationResult.getResult())
-                    .isSuccess(injectExpectationResult.getScore() != 0.0)
-                    .build(),
-                securityPlatform));
-  }
-
-  /**
    * Converts the inject content payload to a typed object.
    *
    * <p>The content is read from {@link Inject#getContent()} and deserialized with Jackson using the
@@ -2000,16 +2114,34 @@ public class InjectExpectationService {
       throws JsonProcessingException {
     BaseInjectContent content = contentConvert(injection, BaseInjectContent.class);
 
+    // Execution-time fallback: injects created before their contract declared predefined
+    // expectations (e.g. Nuclei injects in existing simulations) carry no expectations in their
+    // stored content, so resetting and relaunching the simulation would silently create none.
+    // Read the predefined expectations from the injector contract instead, exactly like inject
+    // creation and the chaining engine do.
+    if (content.getExpectations().isEmpty() && inject.getInjectorContract().isPresent()) {
+      ObjectNode storedContent = inject.getContent();
+      ObjectNode enrichedContent =
+          injectorContractContentUtils.setExpectations(
+              inject.getInjectorContract().get(),
+              storedContent != null ? storedContent.deepCopy() : null);
+      if (enrichedContent != null) {
+        content = this.mapper.treeToValue(enrichedContent, BaseInjectContent.class);
+      }
+    }
+    final BaseInjectContent resolvedContent = content;
+
     List<Expectation> expectations = new ArrayList<>();
 
     assetToExecutes.forEach(
         assetToExecute ->
             computeExpectationsForAssetAndAgents(
-                expectations, content, assetToExecute, inject, implantType));
+                expectations, resolvedContent, assetToExecute, inject, implantType));
 
     List<AssetGroup> assetGroups = injection.getAssetGroups();
     assetGroups.forEach(
-        (assetGroup -> computeExpectationsForAssetGroup(expectations, content, assetGroup)));
+        (assetGroup ->
+            computeExpectationsForAssetGroup(expectations, resolvedContent, assetGroup)));
 
     doBuildAndSaveInjectExpectations(injection, expectations);
   }

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1893,11 +1893,14 @@ public class InjectExpectationService {
       return;
     }
 
-    Set<String> vulnerableAssetIds = resolveVulnerableAssetIds(jsonNode, inject);
-    // Older injector outputs may carry findings without any per-asset attribution: fall back to
-    // the legacy blanket verdict, since a false positive on a sibling asset beats silently losing
-    // the finding.
-    boolean blanketVulnerable = anyVulnerable && vulnerableAssetIds.isEmpty();
+    VulnerableAssetResolution resolution = resolveVulnerableAssetIds(jsonNode, inject);
+    Set<String> vulnerableAssetIds = resolution.assetIds();
+    // Injector outputs may carry findings without any per-asset attribution (legacy formats, or a
+    // CVE item whose host matches no targeted asset): fall back to the legacy blanket verdict for
+    // those, even when sibling items are attributed, since a false positive on a sibling asset
+    // beats silently losing the finding.
+    boolean blanketVulnerable =
+        anyVulnerable && (vulnerableAssetIds.isEmpty() || resolution.hasUnattributedFinding());
 
     List<VulnerabilityInjectExpectation> assetExpectations =
         expectations.stream().filter(expectation -> expectation.getAsset() != null).toList();
@@ -1986,13 +1989,16 @@ public class InjectExpectationService {
    *
    * @param cveNode the structured output node (array of CVE items)
    * @param inject the inject being processed
-   * @return the ids of the assets found vulnerable
+   * @return the ids of the assets found vulnerable, and whether any CVE item could not be
+   *     attributed to any targeted asset at all
    */
-  private Set<String> resolveVulnerableAssetIds(@Nullable JsonNode cveNode, Inject inject) {
+  private VulnerableAssetResolution resolveVulnerableAssetIds(
+      @Nullable JsonNode cveNode, Inject inject) {
     if (cveNode == null || !cveNode.isArray()) {
-      return Set.of();
+      return new VulnerableAssetResolution(Set.of(), false);
     }
     Set<String> vulnerableAssetIds = new HashSet<>();
+    boolean hasUnattributedFinding = false;
     Map<String, Endpoint> valueTargetedAssetsMap = null;
     for (JsonNode cveItem : cveNode) {
       boolean attributed =
@@ -2003,19 +2009,34 @@ public class InjectExpectationService {
       Set<String> hosts = new HashSet<>();
       collectTextValues(cveItem.get(CVEOutputProcessor.HOST), hosts);
       if (hosts.isEmpty()) {
+        hasUnattributedFinding = true;
         continue;
       }
       if (valueTargetedAssetsMap == null) {
         valueTargetedAssetsMap = injectService.getValueTargetedAssetMap(inject);
       }
+      boolean hostMatched = false;
       for (Map.Entry<String, Endpoint> entry : valueTargetedAssetsMap.entrySet()) {
         if (hosts.stream().anyMatch(host -> host.contains(entry.getKey()))) {
           vulnerableAssetIds.add(entry.getValue().getId());
+          hostMatched = true;
         }
       }
+      if (!hostMatched) {
+        hasUnattributedFinding = true;
+      }
     }
-    return vulnerableAssetIds;
+    return new VulnerableAssetResolution(vulnerableAssetIds, hasUnattributedFinding);
   }
+
+  /**
+   * Result of the per-asset attribution of the CVE items of a structured output.
+   *
+   * @param assetIds the ids of the targeted assets attributed at least one CVE item
+   * @param hasUnattributedFinding true when at least one CVE item carries no usable attribution (no
+   *     {@code asset_id}, and no {@code host} matching a targeted asset)
+   */
+  private record VulnerableAssetResolution(Set<String> assetIds, boolean hasUnattributedFinding) {}
 
   /**
    * Collects the non-blank text value(s) of a JSON node (plain text or array of texts) into the

--- a/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
@@ -3,7 +3,6 @@ package io.openaev.utils;
 import static io.openaev.database.model.BaseInjectExpectation.EXPECTATION_TYPE.*;
 import static io.openaev.expectation.DetectionExpectation.detectionExpectationForAgent;
 import static io.openaev.expectation.DetectionExpectation.detectionExpectationForAsset;
-import static io.openaev.expectation.ExpectationType.VULNERABILITY;
 import static io.openaev.expectation.ManualExpectation.manualExpectationForAgent;
 import static io.openaev.expectation.ManualExpectation.manualExpectationForAsset;
 import static io.openaev.expectation.PreventionExpectation.preventionExpectationForAgent;
@@ -439,34 +438,6 @@ public class ExpectationUtils {
           .toList();
     }
     return Collections.emptyList();
-  }
-
-  /**
-   * Sets the result for vulnerability expectations based on the vulnerability assessment outcome.
-   *
-   * <p>Updates all provided expectations with the vulnerability result, setting the score to the
-   * expected score if the vulnerability was successfully exploited, or 0.0 otherwise.
-   *
-   * @param expectations the vulnerability expectations to update
-   * @param result the result object to populate with outcome details
-   * @param vulnerabilityResult the vulnerability assessment result string
-   */
-  public static void setResultExpectationVulnerable(
-      List<VulnerabilityInjectExpectation> expectations,
-      InjectExpectationResult result,
-      String vulnerabilityResult) {
-
-    for (BaseInjectExpectation expectation : expectations) {
-      double score =
-          VULNERABILITY.successLabel.equals(vulnerabilityResult)
-              ? expectation.getExpectedScore()
-              : 0.0;
-
-      result.setResult(vulnerabilityResult);
-      result.setScore(score);
-      expectation.setScore(score);
-      expectation.setResults(List.of(result));
-    }
   }
 
   public static List<ExpectationSignature> computeSignatures(

--- a/openaev-api/src/main/java/io/openaev/utils/inject_expectation_result/ExpectationResultBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/utils/inject_expectation_result/ExpectationResultBuilder.java
@@ -1,7 +1,6 @@
 package io.openaev.utils.inject_expectation_result;
 
 import static io.openaev.collectors.expectations_vulnerability_manager.ExpectationsVulnerabilityManagerCollector.*;
-import static io.openaev.expectation.ExpectationType.VULNERABILITY;
 import static io.openaev.service.InjectExpectationService.COLLECTOR;
 import static io.openaev.service.InjectExpectationService.SECURITY_PLATFORM;
 import static java.time.Instant.now;
@@ -321,10 +320,6 @@ public final class ExpectationResultBuilder {
         .build();
   }
 
-  public static InjectExpectationResult buildForVulnerabilityManagerInFailed() {
-    return buildForVulnerabilityManager(VULNERABILITY.failureLabel, 0.0);
-  }
-
   public static InjectExpectationResult buildDefaultForVulnerabilityManagerInFailed() {
     return buildForVulnerabilityManager(NO_RESULT, NO_SCORE);
   }
@@ -351,11 +346,6 @@ public final class ExpectationResultBuilder {
         .result(result)
         .date(String.valueOf(Instant.now()))
         .build();
-  }
-
-  public static InjectExpectationResult buildForSecurityPlatformInFailed(
-      @NotNull final SecurityPlatform securityPlatform) {
-    return buildForSecurityPlatform(securityPlatform, VULNERABILITY.failureLabel, 0.0);
   }
 
   public static InjectExpectationResult buildDefaultForSecurityPlatform(

--- a/openaev-api/src/test/java/io/openaev/output_processor/SignatureOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/SignatureOutputProcessorTest.java
@@ -15,6 +15,7 @@ import io.openaev.rest.inject.service.ExecutionProcessingContext;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.*;
+import io.openaev.utils.injector_contract.InjectorContractContentUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +35,8 @@ class SignatureOutputProcessorTest {
       mock(SecurityCoverageSendJobService.class);
   private final AssetGroupService assetGroupService = mock(AssetGroupService.class);
   private final InjectService injectService = mock(InjectService.class);
+  private final InjectorContractContentUtils injectorContractContentUtils =
+      mock(InjectorContractContentUtils.class);
 
   private final InjectExpectationLockService injectExpectationLockService =
       new InjectExpectationLockService(injectExpectationRepository);
@@ -47,6 +50,7 @@ class SignatureOutputProcessorTest {
           injectExpectationLockService,
           assetGroupService,
           injectService,
+          injectorContractContentUtils,
           new ArrayList<>(List.of()));
   private final PreviewFeatureService previewFeatureService = mock(PreviewFeatureService.class);
   private final SignatureOutputProcessor processor =

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -737,6 +737,35 @@ class InjectExpectationServiceTest {
 
     @Test
     @DisplayName(
+        "Mixed attribution: an unattributable finding triggers the blanket verdict for all assets")
+    void shouldFallBackToBlanketVerdictOnMixedAttribution() {
+      when(injectService.getValueTargetedAssetMap(inject)).thenReturn(Map.of());
+
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      ObjectNode attributedCve = structuredOutput.addObject();
+      attributedCve
+          .put("id", "CVE-2025-0006")
+          .put("host", "https://vulnerable-host")
+          .put("severity", "7.5");
+      attributedCve.putArray("asset_id").add("asset-1");
+      structuredOutput
+          .addObject()
+          .put("id", "CVE-2025-0007")
+          .put("host", "https://unknown-host")
+          .put("severity", "6.1");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      // The second finding cannot be attributed to any targeted asset: rather than silently
+      // dropping it, every asset falls back to the legacy blanket verdict.
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-1").getIsSuccess());
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-2").getIsSuccess());
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-group").getIsSuccess());
+    }
+
+    @Test
+    @DisplayName(
         "Expectation-group semantics keep the group clean while at least one asset is clean")
     void shouldKeepExpectationGroupCleanWhenOneAssetIsClean() {
       expectationGroup.setExpectationGroup(true);

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -641,7 +641,10 @@ class InjectExpectationServiceTest {
       expectationGroup.setAssetGroup(assetGroup);
 
       inject.setExpectations(List.of(expectationAssetOne, expectationAssetTwo, expectationGroup));
-      doReturn(expectationAssetOne)
+      // Lenient: the security-platform attribution test routes the verdicts through
+      // updateInjectExpectationFromSecurityPlatform instead and never hits this stub.
+      lenient()
+          .doReturn(expectationAssetOne)
           .when(injectExpectationService)
           .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
     }
@@ -733,6 +736,57 @@ class InjectExpectationServiceTest {
       assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-1").getIsSuccess());
       assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-2").getIsSuccess());
       assertEquals(Boolean.FALSE, capturedVerdict("exp-group").getIsSuccess());
+    }
+
+    @Test
+    @DisplayName(
+        "Verdicts are attributed to the injector's security platform for assets AND their group")
+    void shouldAttributeVerdictsToInjectorSecurityPlatform() {
+      Injector injector = new Injector();
+      injector.setType("openaev_nuclei");
+      inject.setInjector(injector);
+      SecurityPlatform securityPlatform =
+          SecurityPlatformFixture.createDefault("Nuclei", "VULNERABILITY_SCANNER");
+      securityPlatform.setId("nuclei-platform");
+      when(securityPlatformRepository.findByExternalReference("openaev_nuclei"))
+          .thenReturn(Optional.of(securityPlatform));
+      doReturn(expectationAssetOne)
+          .when(injectExpectationService)
+          .updateInjectExpectationFromSecurityPlatform(
+              any(), any(InjectExpectationUpdateInput.class), any(SecurityPlatform.class));
+
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      ObjectNode cve = structuredOutput.addObject();
+      cve.put("id", "CVE-2025-0008").put("host", "https://vulnerable-host").put("severity", "7.5");
+      cve.putArray("asset_id").add("asset-1");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      // The vulnerable asset AND its group are both concluded through the security platform
+      // path, so the group row is immediately attributed to the Nuclei platform.
+      ArgumentCaptor<InjectExpectationUpdateInput> assetInput =
+          ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
+      verify(injectExpectationService)
+          .updateInjectExpectationFromSecurityPlatform(
+              eq("exp-asset-1"), assetInput.capture(), eq(securityPlatform));
+      assertEquals(Boolean.FALSE, assetInput.getValue().getIsSuccess());
+      assertNull(assetInput.getValue().getCollectorId());
+
+      ArgumentCaptor<InjectExpectationUpdateInput> groupInput =
+          ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
+      verify(injectExpectationService)
+          .updateInjectExpectationFromSecurityPlatform(
+              eq("exp-group"), groupInput.capture(), eq(securityPlatform));
+      assertEquals(Boolean.FALSE, groupInput.getValue().getIsSuccess());
+      assertNull(groupInput.getValue().getCollectorId());
+
+      verify(injectExpectationService)
+          .updateInjectExpectationFromSecurityPlatform(
+              eq("exp-asset-2"), any(InjectExpectationUpdateInput.class), eq(securityPlatform));
+      // No verdict falls back to the generic Expectations Vulnerability Manager collector.
+      verify(injectExpectationService, never())
+          .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -22,6 +22,7 @@ import io.openaev.expectation.ManualExpectation;
 import io.openaev.expectation.PreventionExpectation;
 import io.openaev.expectation.VulnerabilityExpectation;
 import io.openaev.injectors.common.model.BaseInjectContent;
+import io.openaev.rest.collector.service.CollectorService;
 import io.openaev.rest.inject.form.InjectExecutionAction;
 import io.openaev.rest.inject.form.InjectExecutionInput;
 import io.openaev.rest.inject.form.InjectExpectationUpdateInput;
@@ -29,6 +30,8 @@ import io.openaev.rest.inject.service.AssetToExecute;
 import io.openaev.rest.inject.service.ExecutionProcessingContext;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.utils.fixtures.*;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.injector_contract.InjectorContractContentUtils;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Stream;
@@ -42,6 +45,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class InjectExpectationServiceTest {
@@ -52,6 +56,8 @@ class InjectExpectationServiceTest {
   @Mock private AssetGroupService assetGroupService;
   @Mock private InjectService injectService;
   @Mock private InjectExpectationLockService injectExpectationLockService;
+  @Mock private CollectorService collectorService;
+  @Mock private InjectorContractContentUtils injectorContractContentUtils;
 
   // Unstubbed: findByExternalReference defaults to Optional.empty(), so vulnerability verdicts
   // keep the legacy Expectations Vulnerability Manager attribution in these tests.
@@ -377,6 +383,63 @@ class InjectExpectationServiceTest {
     // Assert
     assertNotNull(expectations);
     verify(injectService).getValueTargetedAssetMap(inject);
+  }
+
+  @Test
+  @DisplayName(
+      "Reset/relaunch fallback: contract expectations are used when the inject content has none")
+  void given_contentWithoutExpectations_should_fallBackToContractExpectations() throws Exception {
+    // Inject created before its contract declared predefined expectations: stored content has no
+    // "expectations" field, so resetting + relaunching the simulation used to create none.
+    ObjectNode storedContent = mapper.createObjectNode();
+    inject.setContent(storedContent);
+    InjectorContract contract = mock(InjectorContract.class);
+    // Agentless injector (Nuclei-like): asset-level expectations are created without agents.
+    when(contract.getNeedsExecutorEffective()).thenReturn(false);
+    inject.setInjectorContract(contract);
+    ReflectionTestUtils.setField(inject, "tenant", TenantFixture.getTenant());
+    // @Resource field, not constructor-injected: provide the default expiration configuration.
+    ReflectionTestUtils.setField(
+        injectExpectationService,
+        "expectationPropertiesConfig",
+        new io.openaev.expectation.ExpectationPropertiesConfig());
+
+    BaseInjectContent contractContent = new BaseInjectContent();
+    contractContent.setExpectations(
+        List.of(createFormExpectation(BaseInjectExpectation.EXPECTATION_TYPE.VULNERABILITY)));
+    ObjectNode enrichedContent = mapper.valueToTree(contractContent);
+    when(injectorContractContentUtils.setExpectations(eq(contract), any(ObjectNode.class)))
+        .thenReturn(enrichedContent);
+
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    endpoint.setId("asset-id");
+    endpoint.setAgents(List.of());
+    when(injectService.getValueTargetedAssetMap(inject)).thenReturn(Map.of());
+    when(collectorService.securityPlatformCollectors(any())).thenReturn(List.of());
+
+    ExecutableInject executableInject = mock(ExecutableInject.class);
+    Injection injection = mock(Injection.class);
+    when(executableInject.getInjection()).thenReturn(injection);
+    when(injection.getInject()).thenReturn(inject);
+    when(executableInject.isDirect()).thenReturn(false);
+    when(executableInject.getTeams()).thenReturn(List.of());
+    when(executableInject.getAssets()).thenReturn(List.of(endpoint));
+    when(executableInject.getAssetGroups()).thenReturn(List.of());
+
+    injectExpectationService.computeAndSaveExpectations(
+        executableInject, inject, "implant", List.of(new AssetToExecute(endpoint)));
+
+    // The contract's predefined expectations were resolved and materialized as a persisted
+    // asset-level vulnerability expectation.
+    verify(injectorContractContentUtils).setExpectations(eq(contract), any(ObjectNode.class));
+    ArgumentCaptor<List<BaseInjectExpectation>> savedCaptor = ArgumentCaptor.captor();
+    verify(injectExpectationRepository).saveAll(savedCaptor.capture());
+    List<BaseInjectExpectation> saved = savedCaptor.getValue();
+    assertEquals(1, saved.size());
+    VulnerabilityInjectExpectation savedExpectation =
+        assertInstanceOf(VulnerabilityInjectExpectation.class, saved.get(0));
+    assertEquals("asset-id", savedExpectation.getAsset().getId());
+    assertNull(savedExpectation.getAgent());
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -1,11 +1,12 @@
 package io.openaev.service;
 
+import static io.openaev.collectors.expectations_vulnerability_manager.ExpectationsVulnerabilityManagerCollector.EXPECTATIONS_VULNERABILITY_COLLECTOR_ID;
 import static io.openaev.utils.fixtures.InjectExpectationFixture.createVulnerabilityInjectExpectation;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -16,6 +17,7 @@ import io.openaev.execution.ExecutableInject;
 import io.openaev.expectation.DetectionExpectation;
 import io.openaev.expectation.Expectation;
 import io.openaev.expectation.ExpectationSignature;
+import io.openaev.expectation.ExpectationType;
 import io.openaev.expectation.ManualExpectation;
 import io.openaev.expectation.PreventionExpectation;
 import io.openaev.expectation.VulnerabilityExpectation;
@@ -26,7 +28,6 @@ import io.openaev.rest.inject.form.InjectExpectationUpdateInput;
 import io.openaev.rest.inject.service.AssetToExecute;
 import io.openaev.rest.inject.service.ExecutionProcessingContext;
 import io.openaev.rest.inject.service.InjectService;
-import io.openaev.utils.ExpectationUtils;
 import io.openaev.utils.fixtures.*;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -73,14 +74,13 @@ class InjectExpectationServiceTest {
     doReturn(expectation)
         .when(injectExpectationService)
         .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
-    when(injectExpectationRepository.saveAll(any())).thenReturn(List.of(expectation));
   }
 
   private ExecutionProcessingContext createContext(InjectExecutionInput input) {
     return new ExecutionProcessingContext(inject, agent, input, Map.of());
   }
 
-  private InjectExecutionInput buildDefaultInput(ObjectNode structuredOutput) {
+  private InjectExecutionInput buildDefaultInput(JsonNode structuredOutput) {
     InjectExecutionInput input = new InjectExecutionInput();
     input.setMessage("message");
     input.setOutputStructured(structuredOutput != null ? String.valueOf(structuredOutput) : null);
@@ -91,26 +91,18 @@ class InjectExpectationServiceTest {
     return input;
   }
 
-  private void setupInjectWithOutputParser(OutputParser outputParser)
-      throws JsonProcessingException {
-    Injector injector = InjectorFixture.createDefaultInjector("InjectorName");
-    Payload payload = PayloadFixture.createDefaultCommand();
-    payload.setOutputParsers(outputParser != null ? Set.of(outputParser) : Set.of());
-    InjectorContract contract =
-        InjectorContractFixture.createPayloadInjectorContractWithDefaultDomain(injector, payload);
-    inject.setInjectorContract(contract);
-  }
-
   private void setupVulnerabilityExpectation() {
     BaseInjectExpectation expectation = createVulnerabilityInjectExpectation(inject, agent);
     inject.setExpectations(List.of(expectation));
     mockExpectation(expectation);
   }
 
-  private void verifySetResultExpectationVulnerableCalledOnce(
-      MockedStatic<ExpectationUtils> mocked) {
-    mocked.verify(
-        () -> ExpectationUtils.setResultExpectationVulnerable(any(), any(), any()), times(1));
+  /** Verifies a single verdict was written and returns its update input. */
+  private InjectExpectationUpdateInput captureSingleVerdict() {
+    ArgumentCaptor<InjectExpectationUpdateInput> captor =
+        ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
+    verify(injectExpectationService, times(1)).updateInjectExpectation(any(), captor.capture());
+    return captor.getValue();
   }
 
   private static io.openaev.model.inject.form.Expectation createFormExpectation(
@@ -213,60 +205,6 @@ class InjectExpectationServiceTest {
         executableInject, List.of(mock(Expectation.class)));
 
     verify(executableInject, atLeastOnce()).getTeams();
-  }
-
-  @Test
-  @DisplayName(
-      "Should map zero score to unsuccessful collector result when validating asset result")
-  void given_zeroScoreResult_should_setIsSuccessToFalseInCollectorUpdate() {
-    // Arrange
-    DetectionInjectExpectation expectation =
-        InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
-    InjectExpectationResult result = new InjectExpectationResult();
-    result.setSourceId("collector-id");
-    result.setResult("detected");
-    result.setScore(0.0);
-
-    ArgumentCaptor<InjectExpectationUpdateInput> captor =
-        ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
-    doReturn(expectation)
-        .when(injectExpectationService)
-        .updateInjectExpectation(eq(expectation.getId()), any(InjectExpectationUpdateInput.class));
-
-    // Act
-    injectExpectationService.validateResultForAsset(List.of(expectation), result);
-
-    // Assert
-    verify(injectExpectationService)
-        .updateInjectExpectation(eq(expectation.getId()), captor.capture());
-    assertEquals(Boolean.FALSE, captor.getValue().getIsSuccess());
-  }
-
-  @Test
-  @DisplayName(
-      "Should map positive score to successful collector result when validating asset result")
-  void given_positiveScoreResult_should_setIsSuccessToTrueInCollectorUpdate() {
-    // Arrange
-    DetectionInjectExpectation expectation =
-        InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
-    InjectExpectationResult result = new InjectExpectationResult();
-    result.setSourceId("collector-id");
-    result.setResult("detected");
-    result.setScore(42.0);
-
-    ArgumentCaptor<InjectExpectationUpdateInput> captor =
-        ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
-    doReturn(expectation)
-        .when(injectExpectationService)
-        .updateInjectExpectation(eq(expectation.getId()), any(InjectExpectationUpdateInput.class));
-
-    // Act
-    injectExpectationService.validateResultForAsset(List.of(expectation), result);
-
-    // Assert
-    verify(injectExpectationService)
-        .updateInjectExpectation(eq(expectation.getId()), captor.capture());
-    assertEquals(Boolean.TRUE, captor.getValue().getIsSuccess());
   }
 
   @Test
@@ -550,113 +488,45 @@ class InjectExpectationServiceTest {
   }
 
   @Test
-  @DisplayName("Should set not vulnerable when no output parsers")
-  void shouldSetNotVulnerableWhenNoOutputParsers() throws JsonProcessingException {
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      setupInjectWithOutputParser(null);
-      setupVulnerabilityExpectation();
-
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(new InjectExecutionInput()), mapper.createObjectNode());
-
-      verifySetResultExpectationVulnerableCalledOnce(mocked);
-    }
-  }
-
-  @Test
-  @DisplayName("Should set not vulnerable when structured output is empty")
+  @DisplayName("Agent path: empty structured output concludes not vulnerable")
   void shouldSetNotVulnerableWhenEmptyStructuredOutput() {
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      setupVulnerabilityExpectation();
+    setupVulnerabilityExpectation();
 
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createObjectNode());
 
-      verifySetResultExpectationVulnerableCalledOnce(mocked);
-    }
+    InjectExpectationUpdateInput input = captureSingleVerdict();
+    assertEquals(Boolean.TRUE, input.getIsSuccess());
+    assertEquals(ExpectationType.VULNERABILITY.successLabel, input.getResult());
   }
 
   @Test
-  @DisplayName("Should set not vulnerable when structured output has no CVE type")
-  void shouldSetNotVulnerableWhenNoCveType() throws JsonProcessingException {
-    ObjectNode structuredOutput = mapper.createObjectNode();
-    structuredOutput
-        .putArray("no-cve-key")
-        .addObject()
-        .put("id", "no-cve-id")
-        .put("host", "savanna28")
-        .put("severity", "7.1");
-
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      setupInjectWithOutputParser(
-          OutputParserFixture.getOutputParser(
-              Set.of(OutputParserFixture.getContractOutputElementTypeIPv6())));
-      setupVulnerabilityExpectation();
-
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(structuredOutput)), structuredOutput);
-
-      verifySetResultExpectationVulnerableCalledOnce(mocked);
-    }
-  }
-
-  @Test
-  @DisplayName("Should set vulnerable when structured output has CVE type and CVE data")
-  void shouldSetVulnerableWhenHasCveTypeAndCveData() {
-    ObjectNode structuredOutput = mapper.createObjectNode();
-    structuredOutput
-        .putArray("cve-key")
-        .addObject()
-        .put("id", "CVE-2025-0234")
-        .put("host", "savacano28")
-        .put("severity", "7.1");
-
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      setupInjectWithOutputParser(
-          OutputParserFixture.getOutputParser(
-              Set.of(OutputParserFixture.getContractOutputElementTypeIPv6())));
-      setupVulnerabilityExpectation();
-
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(structuredOutput)), structuredOutput);
-
-      verifySetResultExpectationVulnerableCalledOnce(mocked);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @Test
-  @DisplayName("Should set not vulnerable when structured output is an empty array")
+  @DisplayName("Agent path: empty CVE array concludes not vulnerable")
   void shouldSetNotVulnerableWhenStructuredOutputIsEmptyArray() {
     // isArray()=true but size()=0 -> not vulnerable
-    ArrayNode structuredOutput = mapper.createArrayNode();
+    setupVulnerabilityExpectation();
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      setupVulnerabilityExpectation();
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createArrayNode());
 
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), structuredOutput);
-
-      verifySetResultExpectationVulnerableCalledOnce(mocked);
-    }
+    assertEquals(Boolean.TRUE, captureSingleVerdict().getIsSuccess());
   }
 
   @Test
-  @DisplayName("Should set vulnerable when structured output is a non-empty array")
+  @DisplayName("Agent path: non-empty CVE array concludes vulnerable for the agent's asset")
   void shouldSetVulnerableWhenStructuredOutputIsNonEmptyArray() {
     // isArray()=true and size()>0 -> vulnerable
     ArrayNode structuredOutput = mapper.createArrayNode();
     structuredOutput.addObject().put("id", "CVE-2025-9999");
+    setupVulnerabilityExpectation();
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      setupVulnerabilityExpectation();
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), structuredOutput);
 
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), structuredOutput);
-
-      verifySetResultExpectationVulnerableCalledOnce(mocked);
-    }
+    InjectExpectationUpdateInput input = captureSingleVerdict();
+    assertEquals(Boolean.FALSE, input.getIsSuccess());
+    assertEquals(ExpectationType.VULNERABILITY.failureLabel, input.getResult());
+    assertEquals(EXPECTATIONS_VULNERABILITY_COLLECTOR_ID, input.getCollectorId());
   }
 
   @Test
@@ -668,15 +538,11 @@ class InjectExpectationServiceTest {
         createVulnerabilityInjectExpectation(inject, otherAgent);
     inject.setExpectations(List.of(expectationForOtherAgent));
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createObjectNode());
 
-      // early return: nothing should be called
-      mocked.verify(
-          () -> ExpectationUtils.setResultExpectationVulnerable(any(), any(), any()), never());
-      verify(injectExpectationRepository, never()).saveAll(any());
-    }
+    verify(injectExpectationService, never())
+        .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
   }
 
   @Test
@@ -689,32 +555,27 @@ class InjectExpectationServiceTest {
         InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
     inject.setExpectations(List.of(prevention, detection));
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createObjectNode());
 
-      mocked.verify(
-          () -> ExpectationUtils.setResultExpectationVulnerable(any(), any(), any()), never());
-      verify(injectExpectationRepository, never()).saveAll(any());
-    }
+    verify(injectExpectationService, never())
+        .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
   }
 
   @Test
-  @DisplayName("Should do nothing when expectation has a null agent")
+  @DisplayName(
+      "Should do nothing for an agent execution when the expectation is not bound to an agent")
   void shouldDoNothingWhenExpectationHasNullAgent() {
-    // exp.getAgent() == null -> filtered out -> early return
+    // exp.getAgent() == null while ctx.agent() != null -> filtered out -> early return
     BaseInjectExpectation expectationWithNullAgent =
         createVulnerabilityInjectExpectation(inject, null);
     inject.setExpectations(List.of(expectationWithNullAgent));
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createObjectNode());
 
-      mocked.verify(
-          () -> ExpectationUtils.setResultExpectationVulnerable(any(), any(), any()), never());
-      verify(injectExpectationRepository, never()).saveAll(any());
-    }
+    verify(injectExpectationService, never())
+        .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
   }
 
   @Test
@@ -722,27 +583,11 @@ class InjectExpectationServiceTest {
   void shouldDoNothingWhenInjectHasNoExpectations() {
     inject.setExpectations(List.of());
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createObjectNode());
 
-      mocked.verify(
-          () -> ExpectationUtils.setResultExpectationVulnerable(any(), any(), any()), never());
-      verify(injectExpectationRepository, never()).saveAll(any());
-    }
-  }
-
-  @Test
-  @DisplayName("Should save all expectations after processing")
-  void shouldSaveAllExpectationsAfterProcessing() {
-    setupVulnerabilityExpectation();
-
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
-
-      verify(injectExpectationRepository, times(1)).saveAll(any());
-    }
+    verify(injectExpectationService, never())
+        .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
   }
 
   @Test
@@ -755,16 +600,158 @@ class InjectExpectationServiceTest {
     doReturn(exp1)
         .when(injectExpectationService)
         .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
-    when(injectExpectationRepository.saveAll(any())).thenReturn(List.of(exp1, exp2));
 
-    try (MockedStatic<ExpectationUtils> mocked = Mockito.mockStatic(ExpectationUtils.class)) {
-      injectExpectationService.matchesVulnerabilityExpectations(
-          createContext(buildDefaultInput(null)), mapper.createObjectNode());
+    injectExpectationService.matchesVulnerabilityExpectations(
+        createContext(buildDefaultInput(null)), mapper.createObjectNode());
 
-      // updateInjectExpectation called once per expectation
-      verify(injectExpectationService, times(2))
+    // updateInjectExpectation called once per expectation
+    verify(injectExpectationService, times(2))
+        .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
+  }
+
+  @Nested
+  @DisplayName("matchesVulnerabilityExpectations - injector path (agent == null)")
+  class MatchesVulnerabilityExpectationsInjectorPath {
+
+    private VulnerabilityInjectExpectation expectationAssetOne;
+    private VulnerabilityInjectExpectation expectationAssetTwo;
+    private VulnerabilityInjectExpectation expectationGroup;
+
+    @BeforeEach
+    void setUpInjectorPath() {
+      Asset assetOne = AssetFixture.createDefaultAsset("vulnerable-asset");
+      assetOne.setId("asset-1");
+      Asset assetTwo = AssetFixture.createDefaultAsset("clean-asset");
+      assetTwo.setId("asset-2");
+      AssetGroup assetGroup = AssetGroupFixture.createDefaultAssetGroup("group");
+      assetGroup.setId("group-1");
+
+      expectationAssetOne = createVulnerabilityInjectExpectation(inject, null);
+      expectationAssetOne.setId("exp-asset-1");
+      expectationAssetOne.setAsset(assetOne);
+      expectationAssetOne.setAssetGroup(assetGroup);
+
+      expectationAssetTwo = createVulnerabilityInjectExpectation(inject, null);
+      expectationAssetTwo.setId("exp-asset-2");
+      expectationAssetTwo.setAsset(assetTwo);
+      expectationAssetTwo.setAssetGroup(assetGroup);
+
+      expectationGroup = createVulnerabilityInjectExpectation(inject, null);
+      expectationGroup.setId("exp-group");
+      expectationGroup.setAssetGroup(assetGroup);
+
+      inject.setExpectations(List.of(expectationAssetOne, expectationAssetTwo, expectationGroup));
+      doReturn(expectationAssetOne)
+          .when(injectExpectationService)
           .updateInjectExpectation(any(), any(InjectExpectationUpdateInput.class));
-      verify(injectExpectationRepository, times(1)).saveAll(any());
+    }
+
+    private ExecutionProcessingContext injectorContext(ArrayNode structuredOutput) {
+      return new ExecutionProcessingContext(
+          inject, null, buildDefaultInput(structuredOutput), Map.of());
+    }
+
+    private InjectExpectationUpdateInput capturedVerdict(String expectationId) {
+      ArgumentCaptor<InjectExpectationUpdateInput> captor =
+          ArgumentCaptor.forClass(InjectExpectationUpdateInput.class);
+      verify(injectExpectationService).updateInjectExpectation(eq(expectationId), captor.capture());
+      return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("Only the asset carrying the CVE is marked vulnerable, siblings stay clean")
+    void shouldMarkOnlyAttributedAssetVulnerable() {
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      ObjectNode cve = structuredOutput.addObject();
+      cve.put("id", "CVE-2025-0001").put("host", "https://vulnerable-host").put("severity", "7.5");
+      cve.putArray("asset_id").add("asset-1");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-1").getIsSuccess());
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-asset-2").getIsSuccess());
+      // Default group semantics: one vulnerable asset makes the group vulnerable, and the group
+      // verdict is written with its own attributed source result.
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-group").getIsSuccess());
+    }
+
+    @Test
+    @DisplayName("All assets stay clean when the CVE is attributed to an untargeted asset")
+    void shouldKeepAllAssetsCleanWhenCveAttributedElsewhere() {
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      ObjectNode cve = structuredOutput.addObject();
+      cve.put("id", "CVE-2025-0002").put("host", "https://other-host").put("severity", "5.0");
+      cve.putArray("asset_id").add("asset-unrelated");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-asset-1").getIsSuccess());
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-asset-2").getIsSuccess());
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-group").getIsSuccess());
+    }
+
+    @Test
+    @DisplayName("Host matching attributes the CVE when asset_id is missing")
+    void shouldAttributeCveThroughHostFallback() {
+      Endpoint endpointOne = EndpointFixture.createEndpoint();
+      endpointOne.setId("asset-1");
+      when(injectService.getValueTargetedAssetMap(inject))
+          .thenReturn(Map.of("vulnerable-host", endpointOne));
+
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      structuredOutput
+          .addObject()
+          .put("id", "CVE-2025-0003")
+          .put("host", "https://vulnerable-host:8443/path")
+          .put("severity", "9.8");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-1").getIsSuccess());
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-asset-2").getIsSuccess());
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-group").getIsSuccess());
+    }
+
+    @Test
+    @DisplayName("Findings without any attribution fall back to the legacy blanket verdict")
+    void shouldFallBackToBlanketVerdictWithoutAttribution() {
+      when(injectService.getValueTargetedAssetMap(inject)).thenReturn(Map.of());
+
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      structuredOutput
+          .addObject()
+          .put("id", "CVE-2025-0004")
+          .put("host", "https://unknown-host")
+          .put("severity", "6.1");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-1").getIsSuccess());
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-2").getIsSuccess());
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-group").getIsSuccess());
+    }
+
+    @Test
+    @DisplayName(
+        "Expectation-group semantics keep the group clean while at least one asset is clean")
+    void shouldKeepExpectationGroupCleanWhenOneAssetIsClean() {
+      expectationGroup.setExpectationGroup(true);
+
+      ArrayNode structuredOutput = mapper.createArrayNode();
+      ObjectNode cve = structuredOutput.addObject();
+      cve.put("id", "CVE-2025-0005").put("host", "https://vulnerable-host").put("severity", "7.5");
+      cve.putArray("asset_id").add("asset-1");
+
+      injectExpectationService.matchesVulnerabilityExpectations(
+          injectorContext(structuredOutput), structuredOutput);
+
+      assertEquals(Boolean.FALSE, capturedVerdict("exp-asset-1").getIsSuccess());
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-asset-2").getIsSuccess());
+      assertEquals(Boolean.TRUE, capturedVerdict("exp-group").getIsSuccess());
     }
   }
 

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationCard.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/InjectExpectationCard.tsx
@@ -255,7 +255,10 @@ const InjectExpectationCard = ({ inject, injectExpectation, isAgentless, target 
             />
           )
         ) : (
-          (!isAssetGroupExpectation(injectExpectation) && ['DETECTION', 'PREVENTION', 'VULNERABILITY'].includes(injectExpectation.inject_expectation_type) && (injectExpectation.inject_expectation_results?.length ?? 0) > 0)
+          // Asset-group expectations show their result list too: their verdict carries a real
+          // source attribution (e.g. the Nuclei security platform) that must be visible at the
+          // group level, not only on the child assets.
+          (['DETECTION', 'PREVENTION', 'VULNERABILITY'].includes(injectExpectation.inject_expectation_type) && (injectExpectation.inject_expectation_results?.length ?? 0) > 0)
           && (
             <InjectExpectationResultList
               injectExpectation={injectExpectation}

--- a/openaev-front/src/admin/components/reporting/form/ReportingForm.tsx
+++ b/openaev-front/src/admin/components/reporting/form/ReportingForm.tsx
@@ -744,7 +744,6 @@ const ReportingForm: FunctionComponent<Props> = ({
         style={{
           display: 'flex',
           flexDirection: 'column',
-          minHeight: '100%',
           gap: theme.spacing(3),
         }}
         onSubmit={handleSubmit(submit)}
@@ -767,12 +766,13 @@ const ReportingForm: FunctionComponent<Props> = ({
         {activeStep === 2 && renderBrandingStep()}
         {activeStep === 3 && renderScheduleStep()}
 
+        {/* Buttons follow the form content like every other drawer form in
+            the app (no bottom-pinned footer). */}
         <Box sx={{
           display: 'flex',
           justifyContent: 'flex-end',
           gap: 1,
-          marginTop: 'auto',
-          paddingTop: 2,
+          marginBottom: 2,
         }}
         >
           <Button


### PR DESCRIPTION
## Summary

Full sweep of the Nuclei vulnerability expectation flow (closes #6987), plus a reporting drawer UI fix (closes #6988).

### Per-asset vulnerability verdicts (#6987)

`InjectExpectationService.matchesVulnerabilityExpectations` applied one blanket "any CVE found = every asset vulnerable" verdict on the injector path. The Nuclei structured output already attributes each CVE to specific assets (`asset_id` / `host` per finding); the backend now consumes it:

- Each asset expectation is marked vulnerable only from its own CVE findings.
- Findings without `asset_id` fall back to matching the finding `host` against the inject's targeted endpoints (same semantics as `FindingService.resolveAssetFromStructuredOutput`).
- Findings with no attribution at all keep the legacy blanket verdict so a finding is never silently dropped.
- The asset group verdict rolls up from its children (one vulnerable child = vulnerable group; all-children rule for "at least one asset must succeed" groups).

### Security platform attribution at the asset group level (#6987)

The group verdict is now written through the same security-platform result path as the asset verdicts, so the group row is immediately attributed to the Nuclei security platform. The frontend `InjectExpectationCard` filter that hid result details on asset-group expectations is removed.

### Expectations for reset + relaunched simulations (#6987)

Injects created before their injector contract declared predefined expectations carry no expectations in their stored content, so resetting and relaunching an existing simulation silently created none. `computeAndSaveExpectations` now falls back to reading the predefined expectations from the injector contract, exactly like inject creation and the chaining engine do.

### Reporting drawer buttons (#6988)

The create / update reporting drawer buttons were pinned to the bottom of the drawer; they now follow the form content, in line with the design system.

## Test plan

- [x] `InjectExpectationServiceTest` (35 tests, incl. new nested injector-path suite: per-asset attribution, host fallback, blanket fallback, group semantics)
- [x] `SignatureOutputProcessorTest` (24 tests)
- [x] Spring integration test `io.openaev.rest.inject_expectation.InjectExpectationServiceTest` (5 tests)
- [x] `mvn spotless:apply`, frontend `yarn check-ts` and eslint on touched files
- [ ] Manual: Nuclei atomic testing on an asset group with 1 vulnerable + 1 clean endpoint
- [ ] Manual: reset + relaunch of an existing simulation containing a Nuclei inject
