### PR TITLE
fix(connectors): return Output DTO from single-connector GET endpoints (#6980)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/execution/ExecutionExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/execution/ExecutionExecutorService.java
@@ -106,9 +106,10 @@ public class ExecutionExecutorService {
         Manager manager = managerFactory.getManager(inject.getTenant().getId());
         ExecutorContextService executorContextService;
         if (executor.isExternal()) {
-          // Resolve the ConnectorInstance that owns this executor
+          // Resolve the ConnectorInstance that owns this executor, scoped to the inject's tenant
           ConnectorInstancePersisted instance =
-              connectorInstanceService.findByExecutorId(executor.getId());
+              connectorInstanceService.findByExecutorId(
+                  executor.getId(), inject.getTenant().getId());
           executorContextService =
               manager.requestForInstance(instance, ExecutorContextService.class);
         } else {

--- a/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
@@ -94,6 +94,10 @@ public class ExecutorService extends AbstractConnectorService<Executor, Executor
     return new Executor();
   }
 
+  public ExecutorOutput executorOutput(String id) {
+    return getConnectorOutput(id);
+  }
+
   /**
    * Retrieve all executors.
    *

--- a/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
@@ -98,17 +98,16 @@ public class CollectorApi extends RestBehavior {
   }
 
   @GetMapping({COLLECTOR_URI + "/{collectorId}", TENANT_COLLECTOR_URI + "/{collectorId}"})
-  @Transactional
+  @Transactional(readOnly = true)
   @AccessControl(
       resourceId = "#collectorId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.COLLECTOR)
   // Collector uses a composite PK (collector_id, tenant_id); the same ID exists per tenant.
   // Require a selector so findByCollectorId never returns multiple rows under a multi-tenant scope.
-  public Collector getCollector(
+  public CollectorOutput getCollector(
       @RequireTenantSelector TxCtx ctx, @PathVariable String collectorId) {
-    String tenantId = writeScopeResolver.tenantForWrite(ctx, null);
-    return collectorService.collector(collectorId, tenantId);
+    return collectorService.collectorOutput(collectorId);
   }
 
   @GetMapping({

--- a/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
@@ -127,6 +127,10 @@ public class CollectorService extends AbstractConnectorService<Collector, Collec
     return collectorRepository.findAll();
   }
 
+  public CollectorOutput collectorOutput(String id) {
+    return getConnectorOutput(id);
+  }
+
   /**
    * Retrieve all collectors.
    *

--- a/openaev-api/src/main/java/io/openaev/rest/executor/ExecutorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/executor/ExecutorApi.java
@@ -100,14 +100,14 @@ public class ExecutorApi extends RestBehavior {
   }
 
   @GetMapping({EXECUTOR_URI + "/{executorId}", TENANT_EXECUTOR_URI + "/{executorId}"})
-  @Transactional
+  @Transactional(readOnly = true)
   @AccessControl(
       resourceId = "#executorId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.ASSET)
-  public Executor getExecutor(@PathVariable String executorId) {
+  public ExecutorOutput getExecutor(@PathVariable String executorId) {
     try {
-      return executorService.executor(executorId);
+      return executorService.executorOutput(executorId);
     } catch (ElementNotFoundException e) {
       log.warn(
           "Executor with id {} not found - This may be because the executor has never been started yet",

--- a/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector/InjectorApi.java
@@ -152,15 +152,13 @@ public class InjectorApi extends RestBehavior {
   }
 
   @GetMapping({INJECT0R_URI + "/{injectorId}", TENANT_INJECTOR_URI + "/{injectorId}"})
-  @Transactional
+  @Transactional(readOnly = true)
   @AccessControl(
       resourceId = "#injectorId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.INJECTOR)
-  public Injector injector(@PathVariable String injectorId) {
-    return injectorRepository
-        .findByIdAndTenantId(injectorId, TenantContext.getCurrentTenant())
-        .orElseThrow(ElementNotFoundException::new);
+  public InjectorOutput injector(@PathVariable String injectorId) {
+    return injectorService.injectorOutput(injectorId);
   }
 
   @GetMapping({

--- a/openaev-api/src/main/java/io/openaev/service/InjectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectorService.java
@@ -192,6 +192,10 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
     return injectorRepository.findAllById(compositeIds);
   }
 
+  public InjectorOutput injectorOutput(String id) {
+    return getConnectorOutput(id);
+  }
+
   /**
    * Retrieve all injectors.
    *

--- a/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
@@ -174,31 +174,24 @@ public class ConnectorInstanceService {
     }
   }
 
-  /**
-   * Resolves the {@link ConnectorInstance} that owns the given executor entity.
-   *
-   * <p>Looks up the connector instance configuration where the key is {@code EXECUTOR_ID} and the
-   * value matches the provided executor ID.
-   *
-   * @param executorId the executor entity ID
-   * @return the owning connector instance
-   * @throws EntityNotFoundException if no connector instance is found for the executor ID
-   */
-  @Transactional(readOnly = true)
-  public ConnectorInstancePersisted findByExecutorId(String executorId) {
+  public Optional<ConnectorInstancePersisted> findPersistedByConnectorId(
+      ConnectorType connectorType, String connectorId) {
     ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase persistedId =
         this.connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValue(
-            ConnectorType.EXECUTOR.getIdKeyName(), executorId);
-    if (persistedId == null) {
-      throw new EntityNotFoundException(
-          "No connector instance found for executor ID: " + executorId);
+            connectorType.getIdKeyName(), connectorId);
+    if (persistedId == null || persistedId.getConnectorInstanceId() == null) {
+      return Optional.empty();
     }
-    return this.connectorInstanceRepository
-        .findById(persistedId.getConnectorInstanceId())
+    return this.connectorInstanceRepository.findById(persistedId.getConnectorInstanceId());
+  }
+
+  @Transactional(readOnly = true)
+  public ConnectorInstancePersisted findByExecutorId(String executorId) {
+    return findPersistedByConnectorId(ConnectorType.EXECUTOR, executorId)
         .orElseThrow(
             () ->
                 new EntityNotFoundException(
-                    "Connector instance not found: " + persistedId.getConnectorInstanceId()));
+                    "No connector instance found for executor ID: " + executorId));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
@@ -174,20 +174,43 @@ public class ConnectorInstanceService {
     }
   }
 
+  /**
+   * Resolves the persisted {@link ConnectorInstancePersisted} that owns the given connector
+   * (collector / injector / executor), scoped to the connector's tenant.
+   *
+   * <p>The lookup relies on a native query which bypasses the Hibernate tenant filter, and the same
+   * connector ID can exist in several tenants (collectors use a composite PK), so the tenant
+   * predicate must be carried explicitly to avoid resolving another tenant's instance.
+   *
+   * @param connectorType the connector type whose ID key is matched in the instance configuration
+   * @param connectorId the connector entity ID
+   * @param tenantId the tenant owning the connector
+   * @return the owning connector instance, or empty if none is found for this tenant
+   */
   public Optional<ConnectorInstancePersisted> findPersistedByConnectorId(
-      ConnectorType connectorType, String connectorId) {
+      ConnectorType connectorType, String connectorId, String tenantId) {
     ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase persistedId =
-        this.connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValue(
-            connectorType.getIdKeyName(), connectorId);
+        this.connectorInstanceConfigurationRepository
+            .findInstanceAndCatalogIdsByKeyValueAndTenantId(
+                connectorType.getIdKeyName(), connectorId, tenantId);
     if (persistedId == null || persistedId.getConnectorInstanceId() == null) {
       return Optional.empty();
     }
     return this.connectorInstanceRepository.findById(persistedId.getConnectorInstanceId());
   }
 
+  /**
+   * Resolves the {@link ConnectorInstancePersisted} that owns the given executor entity, scoped to
+   * the executor's tenant.
+   *
+   * @param executorId the executor entity ID
+   * @param tenantId the tenant owning the executor
+   * @return the owning connector instance
+   * @throws EntityNotFoundException if no connector instance is found for the executor ID
+   */
   @Transactional(readOnly = true)
-  public ConnectorInstancePersisted findByExecutorId(String executorId) {
-    return findPersistedByConnectorId(ConnectorType.EXECUTOR, executorId)
+  public ConnectorInstancePersisted findByExecutorId(String executorId, String tenantId) {
+    return findPersistedByConnectorId(ConnectorType.EXECUTOR, executorId, tenantId)
         .orElseThrow(
             () ->
                 new EntityNotFoundException(

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -127,23 +127,35 @@ public abstract class AbstractConnectorService<
             .collect(Collectors.toList()));
   }
 
+  /**
+   * Builds the Output DTO for a single connector, including its instance context (in-memory
+   * auto-start instance or persisted instance), so single-resource GET endpoints expose the same
+   * status information as the list endpoints.
+   *
+   * @param id the connector entity ID
+   * @return the connector output
+   * @throws ElementNotFoundException if the connector is not visible in the current tenant scope
+   */
   public Output getConnectorOutput(String id) {
     T connector = getConnectorById(id);
     if (connector == null) {
       throw new ElementNotFoundException("Connector not found with id: " + id);
     }
-    return toConnectorOutput(connector, findInstanceForConnector(id));
+    return toConnectorOutput(connector, findInstanceForConnector(id, connector.getTenantId()));
   }
 
-  private ConnectorInstance findInstanceForConnector(String connectorId) {
+  private ConnectorInstance findInstanceForConnector(String connectorId, String tenantId) {
     for (ConnectorInstanceInMemory instance :
         connectorInstanceService.getConnectorInstancesInMemoryByConnectorType(connectorType)) {
       if (connectorId.equals(getConnectorIdFromInstance(instance))) {
         return instance;
       }
     }
+    // The persisted lookup uses a native query that bypasses the Hibernate tenant filter, so it
+    // must be scoped to the connector's tenant explicitly (the same connector ID can exist in
+    // several tenants).
     return connectorInstanceService
-        .findPersistedByConnectorId(connectorType, connectorId)
+        .findPersistedByConnectorId(connectorType, connectorId, tenantId)
         .orElse(null);
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -3,6 +3,7 @@ package io.openaev.service.connectors;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ConnectorInstanceConfigurationRepository;
 import io.openaev.rest.catalog_connector.dto.ConnectorIds;
+import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
 import io.openaev.service.exception.ConnectorStatusException;
@@ -65,9 +66,7 @@ public abstract class AbstractConnectorService<
     return map;
   }
 
-  private Output toExistingConnectorOutput(
-      T connector, Map<String, ConnectorInstance> instanceMap) {
-    ConnectorInstance instance = instanceMap.get(connector.getId());
+  private Output toConnectorOutput(T connector, ConnectorInstance instance) {
     boolean isVerified = instance != null;
     CatalogConnector catalogConnector =
         isVerified && instance instanceof ConnectorInstancePersisted
@@ -77,6 +76,11 @@ public abstract class AbstractConnectorService<
       getConfiguredConnectorName(persistedInstance).ifPresent(connector::setName);
     }
     return mapToOutput(connector, catalogConnector, instance, true);
+  }
+
+  private Output toExistingConnectorOutput(
+      T connector, Map<String, ConnectorInstance> instanceMap) {
+    return toConnectorOutput(connector, instanceMap.get(connector.getId()));
   }
 
   private T createExternalConnector(String collectorId, ConnectorInstancePersisted instance) {
@@ -112,6 +116,37 @@ public abstract class AbstractConnectorService<
         .findFirst();
   }
 
+  private Map<String, ConnectorInstance> buildInstanceMap() {
+    List<ConnectorInstancePersisted> instancesPersisted =
+        this.connectorInstanceService.getAllConnectorInstancesPersistedByConnectorType(
+            connectorType);
+    List<ConnectorInstanceInMemory> instancesInMemory =
+        this.connectorInstanceService.getConnectorInstancesInMemoryByConnectorType(connectorType);
+    return mapInstancesByConnectorId(
+        Stream.concat(instancesPersisted.stream(), instancesInMemory.stream())
+            .collect(Collectors.toList()));
+  }
+
+  public Output getConnectorOutput(String id) {
+    T connector = getConnectorById(id);
+    if (connector == null) {
+      throw new ElementNotFoundException("Connector not found with id: " + id);
+    }
+    return toConnectorOutput(connector, findInstanceForConnector(id));
+  }
+
+  private ConnectorInstance findInstanceForConnector(String connectorId) {
+    for (ConnectorInstanceInMemory instance :
+        connectorInstanceService.getConnectorInstancesInMemoryByConnectorType(connectorType)) {
+      if (connectorId.equals(getConnectorIdFromInstance(instance))) {
+        return instance;
+      }
+    }
+    return connectorInstanceService
+        .findPersistedByConnectorId(connectorType, connectorId)
+        .orElse(null);
+  }
+
   /**
    * Retrieves all connectors including those pending deployment. Pending collectors are identified
    * through their connector instances that exist but haven't yet been registered in the
@@ -124,16 +159,7 @@ public abstract class AbstractConnectorService<
    */
   public Iterable<Output> getConnectorsOutput(boolean includeNext) {
     List<T> connectors = getAllConnectors();
-    List<ConnectorInstancePersisted> instancesPersisted =
-        this.connectorInstanceService.getAllConnectorInstancesPersistedByConnectorType(
-            connectorType);
-    List<ConnectorInstanceInMemory> instancesInMemory =
-        this.connectorInstanceService.getConnectorInstancesInMemoryByConnectorType(connectorType);
-
-    Map<String, ConnectorInstance> instancesByConnectorIdMap =
-        mapInstancesByConnectorId(
-            Stream.concat(instancesPersisted.stream(), instancesInMemory.stream())
-                .collect(Collectors.toList()));
+    Map<String, ConnectorInstance> instancesByConnectorIdMap = buildInstanceMap();
 
     List<Output> result = new ArrayList<>();
 

--- a/openaev-api/src/test/java/io/openaev/executors/execution/service/ExecutionExecutorServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/execution/service/ExecutionExecutorServiceTest.java
@@ -314,8 +314,8 @@ public class ExecutionExecutorServiceTest {
       ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase ids =
           mock(ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase.class);
       when(ids.getConnectorInstanceId()).thenReturn(instance.getId());
-      when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValue(
-              "EXECUTOR_ID", executorId))
+      when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+              eq("EXECUTOR_ID"), eq(executorId), anyString()))
           .thenReturn(ids);
       when(connectorInstanceRepository.findById(instance.getId()))
           .thenReturn(Optional.of(instance));
@@ -354,7 +354,8 @@ public class ExecutionExecutorServiceTest {
 
       // Assert
       verify(connectorInstanceConfigurationRepository)
-          .findInstanceAndCatalogIdsByKeyValue("EXECUTOR_ID", executor.getId());
+          .findInstanceAndCatalogIdsByKeyValueAndTenantId(
+              eq("EXECUTOR_ID"), eq(executor.getId()), anyString());
       verify(manager).requestForInstance(eq(connectorInstance), eq(ExecutorContextService.class));
       verify(mockContextService)
           .launchBatchExecutorSubprocess(eq(inject), any(), any(), anyString());

--- a/openaev-api/src/test/java/io/openaev/rest/CollectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/CollectorApiTest.java
@@ -21,6 +21,7 @@ import io.openaev.database.model.*;
 import io.openaev.database.repository.CollectorRepository;
 import io.openaev.rest.collector.form.CollectorCreateInput;
 import io.openaev.service.FileService;
+import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.CollectorFixture;
 import io.openaev.utils.fixtures.SecurityPlatformFixture;
 import io.openaev.utils.fixtures.composers.*;
@@ -54,6 +55,7 @@ public class CollectorApiTest extends IntegrationTest {
   @Autowired private ConnectorInstanceConfigurationComposer connectorInstanceConfigurationComposer;
   @Autowired private SecurityPlatformComposer securityPlatformComposer;
   @Autowired private CollectorTypeComposer collectorTypeComposer;
+  @Autowired private TenantIsolationTestHelper tenantHelper;
 
   private MockMultipartFile buildInputPart(CollectorCreateInput input) {
     return new MockMultipartFile(
@@ -173,6 +175,101 @@ public class CollectorApiTest extends IntegrationTest {
           .containsExactly(pendingCollectorInstance.getCatalogConnector().getId());
 
       assertThatJson(response).inPath(path + ".is_verified").isArray().containsExactly(true);
+    }
+  }
+
+  @Nested
+  @DisplayName("Retrieve collector by id")
+  class GetCollectorById {
+
+    private String performSingleGet(String collectorId) throws Exception {
+      return mvc.perform(
+              get(tenantUri(TENANT_COLLECTOR_URI + "/" + collectorId))
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().is2xxSuccessful())
+          .andReturn()
+          .getResponse()
+          .getContentAsString();
+    }
+
+    @Test
+    @DisplayName("Should return the collector output with its linked connector instance")
+    void shouldReturnCollectorOutputWithLinkedInstance() throws Exception {
+      Collector collector = getCollector("single-get-linked");
+      ConnectorInstancePersisted instance =
+          getCollectorInstance(collector.getId(), collector.getName());
+
+      String response = performSingleGet(collector.getId());
+
+      assertThatJson(response).inPath("collector_id").isEqualTo(collector.getId());
+      assertThatJson(response).inPath("is_verified").isEqualTo(true);
+      assertThatJson(response)
+          .inPath("connector_instance.connector_instance_id")
+          .isEqualTo(instance.getId());
+      assertThatJson(response)
+          .inPath("catalog.catalog_connector_id")
+          .isEqualTo(instance.getCatalogConnector().getId());
+    }
+
+    @Test
+    @DisplayName("Should return the collector output as unverified when no instance is linked")
+    void shouldReturnCollectorOutputWithoutInstance() throws Exception {
+      Collector collector = getCollector("single-get-unlinked");
+
+      String response = performSingleGet(collector.getId());
+
+      assertThatJson(response).inPath("collector_id").isEqualTo(collector.getId());
+      assertThatJson(response).inPath("is_verified").isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("Should return 404 for an unknown collector id")
+    void shouldReturn404ForUnknownCollector() throws Exception {
+      mvc.perform(
+              get(tenantUri(TENANT_COLLECTOR_URI + "/unknown-collector-id"))
+                  .with(csrf())
+                  .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should not resolve a connector instance belonging to another tenant")
+    void shouldNotResolveInstanceFromAnotherTenant() throws Exception {
+      Collector collector = getCollector("single-get-cross-tenant");
+      ConnectorInstancePersisted instance =
+          getCollectorInstance(collector.getId(), collector.getName());
+      // Resolve the tenant-scoped URI before creating the second tenant: tenantUri() picks the
+      // user's first tenant, which is no longer deterministic once the user belongs to two.
+      String uri = tenantUri(TENANT_COLLECTOR_URI + "/" + collector.getId());
+      Tenant otherTenant = tenantHelper.createTenantWithCurrentUser("collector-single-get-b");
+
+      // Move the instance to another tenant while keeping its COLLECTOR_ID pointing at the
+      // current tenant's collector: the instance lookup is a native query bypassing the Hibernate
+      // tenant filter, so it must not resolve a foreign tenant's instance.
+      entityManager.flush();
+      entityManager
+          .createNativeQuery(
+              "UPDATE connector_instances SET tenant_id = :tenant"
+                  + " WHERE connector_instance_id = :id")
+          .setParameter("tenant", otherTenant.getId())
+          .setParameter("id", instance.getId())
+          .executeUpdate();
+
+      String response =
+          mvc.perform(
+                  get(uri)
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      assertThatJson(response).inPath("collector_id").isEqualTo(collector.getId());
+      assertThatJson(response).inPath("is_verified").isEqualTo(false);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a regression where the detail page of an auto-start built-in connector (e.g. Challenge, Email) showed the status as **stopped** after a browser refresh, even though the connector was still running.

The list endpoints (`GET /api/collectors`, `/api/injectors`, `/api/executors`) already return `*Output` DTOs that include the connector-instance context (in-memory auto-start instances and persisted instances), but the single-resource GET endpoints returned the bare JPA entity, so the frontend lost the instance status on reload.

## Changes

- `AbstractConnectorService.getConnectorOutput(id)`: shared path building a single connector's Output DTO, resolving the owning instance (in-memory first, then persisted) with the same precedence as the list path.
- `InjectorApi`, `ExecutorApi`, `CollectorApi` single GET endpoints now return `InjectorOutput` / `ExecutorOutput` / `CollectorOutput` and use `@Transactional(readOnly = true)`.
- `ConnectorInstanceService.findPersistedByConnectorId(type, id, tenantId)`: the persisted-instance lookup is scoped to the connector's tenant. The underlying native query bypasses the Hibernate tenant filter and the same connector id can exist in several tenants (collectors use a composite PK), so the tenant predicate is carried explicitly to avoid resolving another tenant's instance. `findByExecutorId` now takes the tenant as well and `ExecutionExecutorService` passes the inject's tenant.

## Tests

- New API tests on `GET /api/tenants/{tenantId}/collectors/{collectorId}`: Output shape with a linked persisted instance, unverified output without instance, 404 on unknown id, and a cross-tenant isolation case proving a foreign tenant's instance is not resolved.
- `ExecutionExecutorServiceTest` updated to stub the tenant-scoped repository query.

Closes #6980
