### PR TITLE
fix(front): stop calling the feature-flag hook inside the launch handler (#6977)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -133,6 +133,9 @@ const ScenarioHeader = ({
   const hasChallenges = challenges.length > 0;
 
   const isChainingFeatureEnabled = isFeatureEnabled('INJECT_CHAINING');
+  // isFeatureEnabled reads the store through a hook, so it must stay at render scope: calling it
+  // from an event handler throws and silently aborts the handler mid-way.
+  const isAttackPathEnabled = isFeatureEnabled('ATTACK_PATH');
   const scenarioWorkflowId = (scenario as unknown as Record<string, unknown>).scenario_workflow_id as string | undefined;
   const isScenarioChaining = isChainingFeatureEnabled && !!scenarioWorkflowId;
   const isScopeMissing = isScenarioChaining
@@ -525,7 +528,7 @@ const ScenarioHeader = ({
               // graph; time-based ones land on the overview as before. The
               // route only exists when ATTACK_PATH is enabled (see
               // simulation/Index.tsx route gating).
-              if (isScenarioChaining && isFeatureEnabled('ATTACK_PATH')) {
+              if (isScenarioChaining && isAttackPathEnabled) {
                 navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}/attack-path`);
               } else {
                 navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}`);


### PR DESCRIPTION
## Problem

On a chained scenario, clicking **Launch now → Confirm** created the simulation but the UI never moved: no navigation, no success toast, no `GET /exercises/{id}`. Reproduced on staging — the `POST /scenarios/{id}/exercise/running` returns 200 with a valid `exercise_id` and the simulation runs, but the page stays on the scenario.

## Cause

Regression from #6977. `isFeatureEnabled` is a hook in disguise — it reads the store via `useHelper` (`utils/utils.ts:132`). #6977 called it from the Confirm `onClick` handler, so React throws an invalid-hook-call at click time: the handler aborts right after the POST, before `navigate()` and before the notification.

## Fix

Resolve the flag at render scope (next to the existing `isChainingFeatureEnabled`) and read the resulting boolean in the handler. The redirect behaviour itself is unchanged: chained scenarios land on the simulation's attack path, time-based ones on the overview.

Checked the rest of the codebase for the same mistake — every other `isFeatureEnabled` call site is already at render scope.

## Checks
- `yarn eslint`, `yarn tsc --noEmit` clean.
- Direct navigation to `/admin/simulations/{id}/attack-path` was verified working on staging, confirming the target route is fine and only the handler was at fault.