### PR TITLE
fix(attack-path): align the chain view with per-contract nodes and event-dependency ordering (#6647)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -588,10 +588,11 @@ describe('buildCausalChainFlow', () => {
     expect(causal[0].data?.causalKind).toBe('finding');
   });
 
-  it('collapses N findings matching one consumed key into a single causal edge (legibility on hub endpoints)', () => {
+  it('converges N matching findings into the consumer with a single label (Option A grouping)', () => {
     // A hub endpoint yields THREE shares (native "file" type since #6972); NetExec's event consumes
-    // `share_name IS_NOT_NULL`, which reconciles to `file` and matches every one of them. Without dedup that
-    // stacks three identical "Triggered …" labels over the consumer. We must draw exactly ONE causal edge.
+    // `share_name IS_NOT_NULL`, which reconciles to `file` and matches every one of them. We draw the fan-in
+    // (one grey edge per finding, so the grouping is visible) but label only ONE — three stacked "Triggered …"
+    // labels over the consumer was the original illegibility.
     const hub: AttackPathDTO = {
       ...chainDto,
       attackPathNodes: [
@@ -644,10 +645,13 @@ describe('buildCausalChainFlow', () => {
     };
     const { edges } = buildCausalChainFlow(hub, tt);
     const causal = edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE);
-    expect(causal).toHaveLength(1);
-    expect(causal[0].target).toBe('inj-smb');
-    expect(causal[0].source).toMatch(/^NODE_FINDING\|file\|/);
-    expect(causal[0].data?.causalKind).toBe('finding');
+    // One grey edge per produced file (the fan-in), all targeting the consumer.
+    expect(causal).toHaveLength(3);
+    expect(causal.every(e => e.target === 'inj-smb')).toBe(true);
+    expect(causal.every(e => /^NODE_FINDING\|file\|/.test(e.source ?? ''))).toBe(true);
+    expect(causal.every(e => e.data?.causalKind === 'finding')).toBe(true);
+    // …but only ONE of them carries the "Triggered …" label.
+    expect(causal.filter(e => e.data?.label).length).toBe(1);
   });
 
   it('anchors the causal edge on the finding of the resolved producer, not another injector sharing the type', () => {

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -650,6 +650,113 @@ describe('buildCausalChainFlow', () => {
     expect(causal[0].data?.causalKind).toBe('finding');
   });
 
+  it('anchors the causal edge on the finding of the resolved producer, not another injector sharing the type', () => {
+    // Two injectors each produce a `file` finding; a consumer whose event `share_name IS_NOT_NULL` matches
+    // BOTH depends (dependsOn, #6985) only on producer A. The edge must anchor on A's finding, never B's.
+    const twoProducers: AttackPathDTO = {
+      ...chainDto,
+      attackPathNodes: [
+        {
+          id: 'inj-A',
+          type: 'INJECTOR',
+          label: 'A',
+        },
+        {
+          id: 'inj-B',
+          type: 'INJECTOR',
+          label: 'B',
+        },
+        {
+          id: 'inj-C',
+          type: 'INJECTOR',
+          label: 'C',
+        },
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'EP1',
+          ip: '10.0.0.1',
+        },
+        {
+          id: 'ep-2',
+          type: 'ASSET',
+          label: 'EP2',
+          ip: '10.0.0.2',
+        },
+        {
+          id: 'NODE_FINDING|file|shareA',
+          type: 'FINDING',
+          typeFindings: 'file',
+          value: 'shareA',
+          label: 'shareA',
+        },
+        {
+          id: 'NODE_FINDING|file|shareB',
+          type: 'FINDING',
+          typeFindings: 'file',
+          value: 'shareB',
+          label: 'shareB',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'xA',
+          type: 'EXECUTION',
+          ref: 'exec-A',
+          stepTemplateId: 'step-A',
+          findingsNodeIds: ['NODE_FINDING|file|shareA'],
+          dependsOn: [],
+        },
+        {
+          id: 'xB',
+          type: 'EXECUTION',
+          ref: 'exec-B',
+          stepTemplateId: 'step-B',
+          findingsNodeIds: ['NODE_FINDING|file|shareB'],
+          dependsOn: [],
+        },
+        {
+          id: 'xC',
+          type: 'EXECUTION',
+          ref: 'exec-C',
+          stepTemplateId: 'step-C',
+          consumedFindingKeys: [{
+            keyType: 'share_name',
+            operator: 'IS_NOT_NULL',
+            value: null as unknown as string,
+            eventName: 'SHARE',
+          }],
+          dependsOn: ['step-A'],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-A',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-A'],
+        },
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-B',
+          edgeTargetId: 'ep-2',
+          executionIds: ['exec-B'],
+        },
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-C',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-C'],
+        },
+      ],
+    };
+    const { edges } = buildCausalChainFlow(twoProducers, tt);
+    const causal = edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE && e.data?.causalKind === 'finding');
+    expect(causal).toHaveLength(1);
+    expect(causal[0].target).toBe('inj-C');
+    expect(causal[0].source).toBe('NODE_FINDING|file|shareA');
+  });
+
   it('merges same-depth injectors hitting the same asset onto one shared endpoint node', () => {
     // Arrange: two INDEPENDENT injectors (no dependsOn → both at depth 0) target the SAME asset ep-1.
     const parallel: AttackPathDTO = {

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, maskFindingValue } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, friendlyNodeId, maskFindingValue } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -154,6 +154,24 @@ describe('applyFindingFilter', () => {
   it('dims every node when no node matches the filter', () => {
     const { nodes } = applyFindingFilter(base.nodes, base.edges, ['cve']);
     expect(nodes.every(n => n.data.dimmed === true)).toBe(true);
+  });
+});
+
+describe('friendlyNodeId', () => {
+  it('shows just the injector name for a per-contract injector id (drops the contract uuid)', () => {
+    expect(friendlyNodeId('NODE_INJECTOR|NetExec|8f3c-contract-uuid')).toBe('NetExec');
+  });
+
+  it('keeps the plain injector name for a contractless (2-segment) injector id', () => {
+    expect(friendlyNodeId('NODE_INJECTOR|Nmap')).toBe('Nmap');
+  });
+
+  it('keeps the full key for non-injector nodes (endpoints)', () => {
+    expect(friendlyNodeId('NODE_ENDPOINT|10.0.0.1')).toBe('10.0.0.1');
+  });
+
+  it('returns an empty string for an undefined id', () => {
+    expect(friendlyNodeId(undefined)).toBe('');
   });
 });
 

--- a/openaev-front/src/admin/components/findings/FindingList.tsx
+++ b/openaev-front/src/admin/components/findings/FindingList.tsx
@@ -174,6 +174,22 @@ const FindingList = ({ searchDistinctFindings, filterLocalStorageKey, contextId,
   ];
 
   const visibleHeaders = headers.filter(h => !hiddenFields.includes(h.field));
+  // Hiding columns (e.g. the compact drawer) leaves the fixed per-column widths summing to < 100%, which
+  // squeezes and truncates the last columns (Assets). Rescale the visible columns proportionally so they
+  // fill the row; a no-op in full mode where the widths already total 100%.
+  const visibleWidthTotal = visibleHeaders.reduce(
+    (sum, h) => sum + (parseFloat(String(inlineStyles[h.field]?.width ?? '0')) || 0),
+    0,
+  );
+  const visibleStyles: Record<string, CSSProperties> = Object.fromEntries(
+    visibleHeaders.map((h) => {
+      const w = parseFloat(String(inlineStyles[h.field]?.width ?? '0')) || 0;
+      return [h.field, {
+        ...inlineStyles[h.field],
+        ...(visibleWidthTotal > 0 && w > 0 ? { width: `${((w / visibleWidthTotal) * 100).toFixed(2)}%` } : {}),
+      }];
+    }),
+  );
 
   return (
     <>
@@ -201,14 +217,14 @@ const FindingList = ({ searchDistinctFindings, filterLocalStorageKey, contextId,
             primary={(
               <SortHeadersComponentV2
                 headers={visibleHeaders}
-                inlineStylesHeaders={inlineStyles}
+                inlineStylesHeaders={visibleStyles}
                 sortHelpers={queryableHelpers.sortHelpers}
               />
             )}
           />
         </ListItem>
         {loading
-          ? <PaginatedListLoader Icon={Binoculars} headers={visibleHeaders} headerStyles={inlineStyles} />
+          ? <PaginatedListLoader Icon={Binoculars} headers={visibleHeaders} headerStyles={visibleStyles} />
           : findings.map(finding => (
               <ListItem
                 key={finding.finding_id}
@@ -233,7 +249,7 @@ const FindingList = ({ searchDistinctFindings, filterLocalStorageKey, contextId,
                             key={header.field}
                             style={{
                               ...bodyItemsStyles.bodyItem,
-                              ...inlineStyles[header.field],
+                              ...visibleStyles[header.field],
                             }}
                           >
                             {header.value && header.value(finding)}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -216,6 +216,10 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // Full-mode graph (executions + produced findings), fetched only for small runs (see the gated effect).
   // Drives the causal execution-chain layout; null for large runs (fall back to the aggregated view).
   const [fullDto, setFullDto] = useState<AttackPathDTO | null>(null);
+  // True from the first full-graph fetch until it resolves (once), so a chained run shows a loader while the
+  // causal chain is still loading instead of flashing the misleading aggregated view. Bounded to the first
+  // attempt so a persistent fetch error falls back to the aggregated view rather than a stuck spinner.
+  const [fullLoading, setFullLoading] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [forbidden, setForbidden] = useState(false);
@@ -434,6 +438,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     if (!simulationId) {
       setKillChainMeta(new Map());
       setFullDto(null);
+      setFullLoading(false);
       return undefined;
     }
     const row = simulations.find(s => s.simulationId === simulationId);
@@ -441,17 +446,20 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     if (!row || (row.executionCount ?? 0) > CAUSAL_META_MAX_EXECUTIONS) {
       setKillChainMeta(new Map());
       setFullDto(null);
+      setFullLoading(false);
       return undefined;
     }
     let cancelled = false;
     let lastJson = '';
     const REFRESH_MS = 10000;
+    setFullLoading(true);
     const applyFull = () =>
       fetchAttackPathGraph(simulationId, 'full')
         .then((r) => {
           if (cancelled) {
             return;
           }
+          setFullLoading(false);
           // Skip the swap when nothing changed, so an open drawer / pan-zoom and a stable graph never
           // churn (same discipline as the collapsed poll).
           const json = JSON.stringify(r.data);
@@ -468,6 +476,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           if (!cancelled && lastJson === '') {
             setFullDto(null);
             setKillChainMeta(new Map());
+          }
+          if (!cancelled) {
+            setFullLoading(false);
           }
         });
     applyFull();
@@ -977,6 +988,18 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // Render the causal execution-chain layout whenever the size-gated full graph is available and carries
   // executions (small runs). Large runs never fetch it (fullDto stays null) and keep the aggregated view.
   const chainMode = !!fullDto && (fullDto.attackPathExecutions?.length ?? 0) > 0;
+
+  // A run that HAS executions will render the causal chain, so while its full graph is still loading show a
+  // loader instead of the aggregated view (which reads as "no links yet"). Scoped to the first fetch
+  // (fullLoading) and to runs within the causal ceiling, so non-chained/large runs never wait on it.
+  const chainLoading = useMemo(() => {
+    if (fullDto) {
+      return false;
+    }
+    const row = simulations.find(s => s.simulationId === simulationId);
+    const count = row?.executionCount ?? 0;
+    return fullLoading && count > 0 && count <= CAUSAL_META_MAX_EXECUTIONS;
+  }, [fullDto, fullLoading, simulations, simulationId]);
 
   const baseFlow = useMemo(
     () => {
@@ -2371,7 +2394,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 position: 'relative',
               }}
             >
-              {loading && <Loader />}
+              {(loading || chainLoading) && <Loader />}
               {!loading && forbidden && (
                 <Alert severity="warning" sx={{ m: 2 }}>
                   {t('You do not have access to this simulation\'s attack path.')}
@@ -2382,7 +2405,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                   {t('Failed to load the attack-path graph. Check the simulation or reload the page.')}
                 </Alert>
               )}
-              {!loading && !forbidden && !error && !graphHasContent && (
+              {!loading && !chainLoading && !forbidden && !error && !graphHasContent && (
                 <Box sx={{
                   // Fill the (relative) graph Paper and centre both ways so the empty-state is the focal point.
                   position: 'absolute',
@@ -2423,7 +2446,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                   )}
                 </Box>
               )}
-              {!loading && !forbidden && !error && graphHasContent && (
+              {!loading && !chainLoading && !forbidden && !error && graphHasContent && (
                 <ReactFlowProvider>
                   <AttackPathFlow
                     nodes={nodes}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -694,7 +694,16 @@ export interface PathFinding {
 // A node's internal id (e.g. "NODE_ENDPOINT|<uuid>") must never surface as a user-facing label. When a
 // node can't be resolved to a real name, strip the "NODE_*|" prefix so the worst case is a bare ref,
 // not the internal id the analyst has no use for.
-export const friendlyNodeId = (raw?: string): string => (raw ?? '').replace(/^NODE_[A-Z_]+\|/, '');
+export const friendlyNodeId = (raw?: string): string => {
+  const stripped = (raw ?? '').replace(/^NODE_[A-Z_]+\|/, '');
+  // A per-contract injector id (#6981) is `NODE_INJECTOR|<injector>|<contractExternalId>`, where the
+  // trailing segment is a non-human-readable uuid. This is only a fallback label (the node normally
+  // carries the contract name), so show just the injector name; other node kinds keep their full key.
+  if ((raw ?? '').startsWith('NODE_INJECTOR|')) {
+    return stripped.split('|')[0];
+  }
+  return stripped;
+};
 
 // Human-readable plural noun for a finding type, used to give contextual cluster edges a label with
 // meaning (e.g. "6 credentials" instead of a bare "6+"). Mixed clusters fall back to "findings".

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1739,6 +1739,16 @@ export const buildCausalChainFlow = (
   // back to a dashed dependsOn edge so the sequencing is still shown.
   const findingNodes = nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.finding);
   const nodeById = new Map(nodes.map(n => [n.id, n]));
+  // Which injector(s) produced each finding node, so a causal edge can be anchored on the finding of the
+  // consumer's REAL producer rather than any finding that merely shares the value from another injector.
+  const producersByFinding = new Map<string, Set<string>>();
+  for (const [prodInjId, ps] of steps) {
+    for (const findingIds of ps.endpoints.values()) {
+      for (const fid of findingIds) {
+        (producersByFinding.get(fid) ?? producersByFinding.set(fid, new Set()).get(fid)!).add(prodInjId);
+      }
+    }
+  }
   // One causal edge per (consumer, label): a key like `share_name IS_NOT_NULL` matches EVERY produced
   // share, but drawing one "Triggered SHARE" edge per matching finding stacks N identical labels over the
   // consumer node — illegible as soon as an endpoint yields several findings of the type. Collapse them to
@@ -1750,7 +1760,14 @@ export const buildCausalChainFlow = (
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
-      const matches = findingNodes.filter(fn => findingMatchesKey(fn, key));
+      const allMatches = findingNodes.filter(fn => findingMatchesKey(fn, key));
+      // Prefer findings produced by this consumer's resolved dependency (#6985 populates dependsOn with the
+      // real producer step), so the event edge never points at a same-typed finding from an unrelated
+      // injector. Fall back to every match when no dependency resolved (e.g. a complex-type key).
+      const fromDeps = s.deps.size > 0
+        ? allMatches.filter(fn => [...(producersByFinding.get(fn.id) ?? [])].some(p => s.deps.has(p)))
+        : [];
+      const matches = fromDeps.length > 0 ? fromDeps : allMatches;
       if (matches.length === 0) {
         continue;
       }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1749,21 +1749,21 @@ export const buildCausalChainFlow = (
       }
     }
   }
-  // One causal edge per (consumer, label): a key like `share_name IS_NOT_NULL` matches EVERY produced
-  // share, but drawing one "Triggered SHARE" edge per matching finding stacks N identical labels over the
-  // consumer node — illegible as soon as an endpoint yields several findings of the type. Collapse them to
-  // a single edge, anchored to the matching finding nearest (vertically) to the consumer so the line stays
-  // short and crosses the least. This keeps a hub endpoint (1 asset, many findings) as readable as a
-  // linear multi-endpoint chain.
-  const drawnCausal = new Set<string>();
+  // Convergence with ONE label: a key like `share_name IS_NOT_NULL` matches every produced share, so draw a
+  // grey edge from EACH producing finding to the consumer — the fan-in that reads as "all these findings
+  // triggered it" (the Option A grouping) — but label only the nearest edge. N identical "Triggered …"
+  // labels stacked over the node was the original illegibility; a single label on a fan-in is clean.
+  const drawnCausalEdges = new Set<string>();
+  const labelledCausal = new Set<string>();
   for (const [injId, s] of steps) {
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
       const allMatches = findingNodes.filter(fn => findingMatchesKey(fn, key));
       // Prefer findings produced by this consumer's resolved dependency (#6985 populates dependsOn with the
-      // real producer step), so the event edge never points at a same-typed finding from an unrelated
-      // injector. Fall back to every match when no dependency resolved (e.g. a complex-type key).
+      // real producer step), so the fan-in stays on the real producer's findings and never reaches a
+      // same-typed finding from an unrelated injector. Fall back to every match when no dependency
+      // resolved (e.g. a complex-type key).
       const fromDeps = s.deps.size > 0
         ? allMatches.filter(fn => [...(producersByFinding.get(fn.id) ?? [])].some(p => s.deps.has(p)))
         : [];
@@ -1773,24 +1773,31 @@ export const buildCausalChainFlow = (
       }
       matched = true;
       const label = causalKeyLabel(key, t);
-      const dedupKey = `${injId}|${label}`;
-      if (drawnCausal.has(dedupKey)) {
-        continue;
+      // Nearest first, so the single label sits on the shortest edge of the fan-in.
+      const ordered = [...matches].sort((a, b) =>
+        Math.abs(a.position.y - injY) - Math.abs(b.position.y - injY));
+      for (const fn of ordered) {
+        const edgeId = `${AP_FLOW_CAUSAL_EDGE_TYPE}-finding-${fn.id}-${injId}`;
+        if (drawnCausalEdges.has(edgeId)) {
+          continue;
+        }
+        drawnCausalEdges.add(edgeId);
+        const showLabel = !labelledCausal.has(`${injId}|${label}`);
+        if (showLabel) {
+          labelledCausal.add(`${injId}|${label}`);
+        }
+        edges.push({
+          id: edgeId,
+          source: fn.id,
+          target: injId,
+          type: AP_FLOW_CAUSAL_EDGE_TYPE,
+          data: {
+            count: 1,
+            causalKind: 'finding',
+            label: showLabel ? label : undefined,
+          },
+        });
       }
-      drawnCausal.add(dedupKey);
-      const fn = matches.reduce((best, cur) =>
-        Math.abs(cur.position.y - injY) < Math.abs(best.position.y - injY) ? cur : best, matches[0]);
-      edges.push({
-        id: `${AP_FLOW_CAUSAL_EDGE_TYPE}-finding-${fn.id}-${injId}`,
-        source: fn.id,
-        target: injId,
-        type: AP_FLOW_CAUSAL_EDGE_TYPE,
-        data: {
-          count: 1,
-          causalKind: 'finding',
-          label,
-        },
-      });
     }
     if (!matched) {
       for (const dep of s.deps) {


### PR DESCRIPTION
## Summary

Front follow-ups that build on Laurent's two backend PRs, so the causal-chain view reads the way the Option A mockup intended — the action an event triggers renders as a node to the RIGHT of the findings that triggered it, with no backward-crossing edge.

- **#6981** (`render one injector node per contract`) — the injector node id is now `NODE_INJECTOR|<injector>|<contractExternalId>`, so a single injector that runs several contracts (e.g. NetExec *SMB Share Listing* and *LDAP Kerberoasting*) renders as distinct nodes.
- **#6985** (`order the kill chain by event-consumption dependencies`) — `dependsOn` now carries the real producer step of a consumed event, resolved per-row via the finding's `executionId`.

### What this PR does

- **Left→right placement now works with zero front code.** Our depth = longest `dependsOn` chain, so once the consumer's `dependsOn` includes the producer step, the consuming contract lands one column to the right. Verified live: NetExec *Kerberoasting* now sits to the right of the `file` findings it consumes, and the "Triggered SHARE" edge points forward.
- **`friendlyNodeId` handles the per-contract id.** The fallback label stripped only the `NODE_INJECTOR|` prefix, leaving the contract uuid visible (`NetExec|<uuid>`). Show just the injector name for an injector id; other node kinds keep their full key. (The node normally carries the contract name, so this is only a last-resort label.)
- **Causal edge anchors on the resolved producer, not any type match.** A key like `share_name IS_NOT_NULL` matches every produced finding of the type, including ones from an unrelated injector. Restrict the anchor to findings produced by the consumer's `dependsOn` producer; fall back to every match only when no dependency resolved (a complex-type key still out of the primitive scope). Adds a two-producer regression test.

### Verification

- Verified live against a backend carrying #6981 + #6985: three per-contract injector nodes, `Kerberoasting` placed at depth 1, a single "Triggered SHARE" forward edge.
- `check-ts` + eslint clean; attack-path unit tests green (28), incl. new `friendlyNodeId` and two-producer causal-anchor tests.

Related issue: #6647

### Follow-up polish

- **Causal convergence (Option A grouping).** With the consumer now placed to the right, draw the full fan-in — one grey edge from each producing finding to the consumer, so "all these shares triggered it" reads visually — while labelling only the nearest edge (the N stacked "Triggered …" labels never return).
- **Findings drawer column widths.** With columns hidden in the compact drawer, the fixed per-column widths summed to <100% and truncated Assets. Rescale the visible columns proportionally to fill the row (a no-op in full mode).
