### PR TITLE
fix(platform): real-time inject updates, expectation verdicts, tenant scoping, findings visibility and vulnerability UI (#6997)

### DIFF
--- a/.github/agents/multi-tenancy-reviewer.agent.md
+++ b/.github/agents/multi-tenancy-reviewer.agent.md
@@ -47,7 +47,8 @@ When the Test Specialist writes isolation tests, flag this agent to verify the p
 | 🟠 **HIGH** | Single service handling both platform and tenant scope for dual-scope entity | `issue (blocking):` — cross-scope data leak risk |
 | 🟠 **HIGH** | Unscoped `findAll()` / `findById()` on dual-scope entity (no `tenant_id` filter) | `issue (blocking):` — returns mixed platform + tenant data |
 | 🟡 **MEDIUM** | Service calling `TenantContext.getCurrentTenant()` directly (should receive tenant as argument from API layer) | `suggestion (blocking):` — hidden coupling, breaks testability and async safety |
-| 🟡 **MEDIUM** | Background job / async without `TenantContext.setCurrentTenant()` | `suggestion (non-blocking):` — potential leak in async context |
+| 🔴 **CRITICAL** | Background job / queue consumer / async task reading or writing tenant rows without `TenantContext.setCurrentTenant()` (even when it sets `TxCtx`) | `issue (blocking):` — silently resolves the DEFAULT tenant, see `multi-tenancy.instructions.md` > Background Threads Carry Both Scopes |
+| 🟠 **HIGH** | `TenantContext.setCurrentTenant()` on a pooled thread without a `finally` restore | `issue (blocking):` — leaks the scope into the next task on that thread |
 | 🟡 **MEDIUM** | Cache key without `tenant_id` | `suggestion (non-blocking):` — cross-tenant cache poisoning risk |
 | 🟢 **LOW** | Entity could be tenant-scoped but isn't yet (tech debt tracking) | `note:` — informational |
 
@@ -90,6 +91,19 @@ For tenant-scoped tables:
 - ✅ FK to `tenants(tenant_id) ON DELETE CASCADE`
 - ✅ Index on `tenant_id`
 - ✅ Unique constraints are composite with `tenant_id`
+
+### Step 5 — Audit background entry points
+
+```bash
+# Every off-request entry point: Quartz jobs, queue consumers, @Async, parallelStream workers
+grep -rn "tenantTx.execute\|forEachTenant\|implements Job\|@Async" --include="*.java" openaev-api/src/main/java/
+```
+
+Each hit that reads or writes tenant rows MUST also set the thread-local `TenantContext`, cleared
+in a `finally`. Setting only `TxCtx` is 🔴 CRITICAL: the v1 `@Filter` then resolves the DEFAULT
+tenant instead of failing, so the leak is silent and invisible in single-tenant deployments. Model:
+`InjectsExecutionJob#executeInTenant`. Note that `findById` is *not* filtered by Hibernate, so it
+never reveals this class of bug — check JPQL / Criteria reads and `TenantBaseListener` inserts.
 
 ## What NOT to Flag
 

--- a/.github/instructions/multi-tenancy.instructions.md
+++ b/.github/instructions/multi-tenancy.instructions.md
@@ -26,6 +26,34 @@ description: "Multi-tenancy conventions: tenant isolation, dual-scope, anti-patt
 1. Native `@Query` **bypasses** Hibernate filter → always add `WHERE tenant_id = :tenantId`
 2. Never return `tenant_id` in API responses → `@JsonIgnore` on tenant relation
 3. Unique constraints on tenant-scoped entities → composite `(field, tenant_id)`
+4. Off the request thread, **both** tenant scopes must be set — see below
+
+## Background Threads Carry Both Scopes
+
+On an HTTP request `TenantInterceptor` sets the thread-local `TenantContext`, and
+`TxCtxArgumentResolver` resolves the v2 `TxCtx`. Nothing does either on a Quartz job, a queue
+consumer, an `@Async` task or a `parallelStream` worker, so a background entry point must set them
+itself:
+
+```java
+TenantContext.setCurrentTenant(tenantId);   // v1: HibernateFilterTransactionAspect -> @Filter
+try {
+  tenantTx.execute(TxCtx.forTenant(tenantId), work);  // v2: transaction GUC -> inspector
+} finally {
+  TenantContext.clearCurrentTenant();       // restore the previous value on a shared pool
+}
+```
+
+Setting only the v2 primitive is **not** enough while entities still carry `@Filter`, and it fails
+silently: `TenantContext.getCurrentTenant()` falls back to `Tenant.DEFAULT_TENANT_UUID`, so every
+JPQL / Criteria read resolves the DEFAULT tenant's rows and every `TenantBaseListener` insert is
+attributed there. Single-tenant deployments never see it, because the fallback is the right tenant.
+This shipped once: scheduled inject execution resolved another tenant's endpoints and created a
+customer simulation's expectations against them (`InjectsExecutionJob#executeInTenant`).
+
+Two details that are easy to miss: Hibernate `@Filter` does **not** apply to `find()` by primary
+key, so a green `findById` proves nothing about scoping; and a deliberately cross-tenant sweep
+(`session.disableFilter("tenantFilter")`) must set the tenant explicitly on anything it writes.
 
 ## Anti-Patterns
 
@@ -35,3 +63,5 @@ description: "Multi-tenancy conventions: tenant isolation, dual-scope, anti-patt
 | `@Column(unique = true)` on tenant-scoped field | Composite `UNIQUE (field, tenant_id)` |
 | Single service for dual-scope entity | Split `PlatformXxxService` / `TenantXxxService` |
 | `tenant_id` in API response | `@JsonIgnore` on tenant relation |
+| Background job setting only `TxCtx` | Set `TenantContext` too, cleared in a `finally` |
+| Relying on the `TenantContext` default fallback | Pass the owning row's tenant explicitly |

--- a/openaev-api/src/main/java/io/openaev/api/expectations/ExpectationsDriftService.java
+++ b/openaev-api/src/main/java/io/openaev/api/expectations/ExpectationsDriftService.java
@@ -43,9 +43,12 @@ import org.springframework.stereotype.Service;
  * name, description, expiration time) are deliberately ignored - users legitimately adjust those
  * per inject, and such adjustments are not a posture change.
  *
- * <p>Injects whose content carries no expectations are never drifted: they inherit the contract's
- * predefined expectations dynamically at execution time (see {@link
- * InjectorContractContentUtils#setExpectations}), so they always follow the current template.
+ * <p>Injects whose content carries no expectations field at all are never drifted: they inherit the
+ * contract's predefined expectations dynamically at execution time (see {@link
+ * InjectorContractContentUtils#setExpectations}), so they always follow the current template. An
+ * explicit empty expectations array is different: the user deliberately removed every expectation,
+ * which is a customization like any other - it is reported as drift (realignment being the opt-in
+ * way to restore the template) but never overridden at execution time.
  *
  * <p>Realignment overwrites the drifted injects' stored expectations with the contract's current
  * predefined expectations, chunk by chunk in short independent transactions, tracked as a massive
@@ -164,7 +167,7 @@ public class ExpectationsDriftService {
     }
     List<String> injectSignatures = injectExpectationSignatures(inject);
     if (injectSignatures == null) {
-      // No stored expectations: the inject inherits the contract's predefined expectations
+      // No stored expectations field: the inject inherits the contract's predefined expectations
       // dynamically at execution time, so it always follows the current template.
       return false;
     }
@@ -193,7 +196,9 @@ public class ExpectationsDriftService {
 
   /**
    * Canonical signatures of the expectations stored in the inject content, or {@code null} when the
-   * content carries no expectations (the inject then follows the contract dynamically).
+   * content carries no expectations field (the inject then follows the contract dynamically). An
+   * explicit empty array yields an empty signature list: the user deliberately removed every
+   * expectation, which counts as drift against a contract that declares predefined ones.
    */
   private List<String> injectExpectationSignatures(Inject inject) {
     ObjectNode content = inject.getContent();
@@ -201,7 +206,7 @@ public class ExpectationsDriftService {
       return null;
     }
     JsonNode expectations = content.get(CONTRACT_ELEMENT_CONTENT_KEY_EXPECTATIONS);
-    if (expectations == null || !expectations.isArray() || expectations.isEmpty()) {
+    if (expectations == null || expectations.isNull() || !expectations.isArray()) {
       return null;
     }
     List<String> signatures = new ArrayList<>();

--- a/openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/service/ExpectationsExpirationManagerService.java
+++ b/openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/service/ExpectationsExpirationManagerService.java
@@ -67,16 +67,7 @@ public class ExpectationsExpirationManagerService {
           || !ExpectationUtils.isAgentExpectation(technicalExpectation)) {
         continue;
       }
-      InjectExpectationUpdateInput input = new InjectExpectationUpdateInput();
-      if (ExpectationType.VULNERABILITY.toString().equals(expectation.getType().toString())) {
-        input.setIsSuccess(true);
-        input.setResult(computeSuccessMessage(expectation.getType()));
-        expireEmptyResults(expectation.getResults(), expectation.getExpectedScore(), EXPIRED);
-      } else {
-        input.setIsSuccess(false);
-        input.setResult(computeFailedMessage(expectation.getType()));
-        expireEmptyResults(expectation.getResults(), FAILED_SCORE_VALUE, EXPIRED);
-      }
+      InjectExpectationUpdateInput input = buildExpirationInput(expectation);
       expiredExpectations.add(technicalExpectation);
       inputsById.put(expectation.getId(), input);
     }
@@ -115,15 +106,13 @@ public class ExpectationsExpirationManagerService {
         directlyAnswerable.add(expectation);
       }
     }
-    // Genuine leaves (human expectations, agentless assets / AI targets) are answered directly:
-    // unanswered and expired means failed. Processed FIRST so parent recomputation below reads
-    // the final leaf scores (an asset group may aggregate agentless asset leaves).
+    // Genuine leaves (human expectations, agentless assets / AI targets) are answered directly
+    // with the type's default verdict (failed, except VULNERABILITY where silence means "Not
+    // vulnerable"). Processed FIRST so parent recomputation below reads the final leaf scores
+    // (an asset group may aggregate agentless asset leaves).
     directlyAnswerable.forEach(
         expectation -> {
-          InjectExpectationUpdateInput input = new InjectExpectationUpdateInput();
-          input.setIsSuccess(false);
-          input.setResult(computeFailedMessage(expectation.getType()));
-          expireEmptyResults(expectation.getResults(), FAILED_SCORE_VALUE, EXPIRED);
+          InjectExpectationUpdateInput input = buildExpirationInput(expectation);
           if (HUMAN_EXPECTATION.contains(expectation.getType())) {
             updated.add(
                 injectExpectationService.computeInjectExpectationForHumanResponse(
@@ -141,5 +130,30 @@ public class ExpectationsExpirationManagerService {
     assetGroupParents.forEach(
         parent ->
             updated.addAll(injectExpectationService.recomputeParentTechnicalExpectation(parent)));
+  }
+
+  /**
+   * Builds the expiration verdict for an unanswered expectation, honoring the type's signal
+   * polarity: silence means FAILURE for detection/prevention/human expectations (nothing was
+   * prevented, detected or validated within the window), but SUCCESS for VULNERABILITY (no scanner
+   * reported a finding, so the target defaults to "Not vulnerable"). Empty per-source result rows
+   * are expired with the matching score.
+   *
+   * @param expectation the expired, unanswered expectation
+   * @return the update input carrying the expiration verdict
+   */
+  private InjectExpectationUpdateInput buildExpirationInput(
+      @NotNull final BaseInjectExpectation expectation) {
+    InjectExpectationUpdateInput input = new InjectExpectationUpdateInput();
+    if (ExpectationType.VULNERABILITY.toString().equals(expectation.getType().toString())) {
+      input.setIsSuccess(true);
+      input.setResult(computeSuccessMessage(expectation.getType()));
+      expireEmptyResults(expectation.getResults(), expectation.getExpectedScore(), EXPIRED);
+    } else {
+      input.setIsSuccess(false);
+      input.setResult(computeFailedMessage(expectation.getType()));
+      expireEmptyResults(expectation.getResults(), FAILED_SCORE_VALUE, EXPIRED);
+    }
+    return input;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/collectors/expectations_expiration_manager/utils/ExpectationUtils.java
@@ -37,6 +37,7 @@ public class ExpectationUtils {
     return switch (expectationType) {
       case DETECTION -> ExpectationType.DETECTION.failureLabel;
       case PREVENTION -> ExpectationType.PREVENTION.failureLabel;
+      case VULNERABILITY -> ExpectationType.VULNERABILITY.failureLabel;
       default -> ExpectationType.HUMAN_RESPONSE.failureLabel;
     };
   }

--- a/openaev-api/src/main/java/io/openaev/config/RequireTenantSelector.java
+++ b/openaev-api/src/main/java/io/openaev/config/RequireTenantSelector.java
@@ -6,12 +6,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a {@code TxCtx} controller parameter as requiring an explicit tenant selector on the
- * request: a {@code /{tenantId}} path or an {@code X-Tenant-Ids} header. Without one, the request
- * is refused (400) instead of falling back to the caller's full set of allowed tenants. Use it on
- * endpoints where operating across every tenant of the caller by accident would be wrong, typically
- * writes or single-tenant operations. The default (no annotation) keeps the composable semantics
- * where an absent selector means the full allowed set.
+ * Marks a {@code TxCtx} controller parameter as needing a single-tenant scope: the endpoint
+ * performs a composite-PK lookup or attributes rows, so operating across every tenant of the caller
+ * by accident would be wrong. The scope is taken from the explicit selector when present (a {@code
+ * /{tenantId}} path or an {@code X-Tenant-Ids} header); without one the request is NOT refused but
+ * falls back: a single-tenant caller (every Community Edition deployment, single-tenant users in
+ * EE) resolves to its own tenant, a multi-tenant caller falls back to the default tenant (the
+ * platform-wide convention for requests without an explicit tenant context). Only a multi-tenant
+ * caller without access to the default tenant is refused (400), the one case where no fallback is
+ * safe. The default (no annotation) keeps the composable semantics where an absent selector means
+ * the full allowed set.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
+++ b/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
@@ -51,14 +51,37 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
     Set<String> selector = extractSelector(webRequest);
-    if (selector.isEmpty() && parameter.hasParameterAnnotation(RequireTenantSelector.class)) {
-      throw new TenantSelectorRequiredException();
-    }
     Set<String> authorized =
         tenantService.findTenantsByUserId(SessionHelper.currentUser().getId()).stream()
             .map(Tenant::getId)
             .collect(Collectors.toSet());
+    if (selector.isEmpty() && parameter.hasParameterAnnotation(RequireTenantSelector.class)) {
+      selector = fallbackSelector(authorized);
+    }
     return scopeResolver.resolve(selector, authorized);
+  }
+
+  /**
+   * Fallback scope for single-tenant endpoints (composite-PK lookups, row attribution) when the
+   * request carries no selector. An explicit selector is never mandatory: tenant-unaware API
+   * clients (collectors, injectors, plain scripts) must keep working. A caller authorized on a
+   * single tenant (every Community Edition deployment, single-tenant users in EE) is unambiguous
+   * as-is; a multi-tenant caller falls back to the default tenant, mirroring the platform-wide
+   * convention for requests without an explicit tenant context (see {@link
+   * io.openaev.context.TenantContext#getCurrentTenant()}, issues #6331 / #6332). Only a
+   * multi-tenant caller without access to the default tenant remains genuinely ambiguous and is
+   * refused (400), since silently picking one of its tenants could read or write the wrong one.
+   */
+  private static Set<String> fallbackSelector(Set<String> authorized) {
+    if (authorized.size() <= 1) {
+      // resolve() maps an empty selector to the caller's full allowed set, which is already a
+      // single-tenant (or fail-closed empty) scope here.
+      return Set.of();
+    }
+    if (authorized.contains(Tenant.DEFAULT_TENANT_UUID)) {
+      return Set.of(Tenant.DEFAULT_TENANT_UUID);
+    }
+    throw new TenantSelectorRequiredException();
   }
 
   private Set<String> extractSelector(NativeWebRequest webRequest) {

--- a/openaev-api/src/main/java/io/openaev/executors/Executor.java
+++ b/openaev-api/src/main/java/io/openaev/executors/Executor.java
@@ -84,7 +84,9 @@ public class Executor {
     InjectStatus injectStatus =
         this.injectStatusRepository.findByInjectId(inject.getId()).orElseThrow();
     InjectStatus completeStatus = injectStatusService.fromExecution(execution, injectStatus);
-    return injectStatusRepository.save(completeStatus);
+    // Save + stream: internal injectors reach their terminal status here without any listened
+    // entity update, so the execution board would otherwise only move on a page reload.
+    return injectStatusService.saveAndStreamInject(completeStatus);
   }
 
   public InjectStatus execute(ExecutableInject executableInject) throws Exception {

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260728100000000__Fix_execution_tracking_timestamp_columns.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260728100000000__Fix_execution_tracking_timestamp_columns.java
@@ -1,0 +1,45 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converts the execution-tracking timestamp columns from {@code timestamp without time zone} to
+ * {@code timestamp with time zone}.
+ *
+ * <p>Bug: the Java entities map these columns as {@link java.time.Instant}, which Hibernate binds
+ * as a {@code timestamptz} parameter. When the target column is a naive {@code timestamp},
+ * PostgreSQL converts the parameter to the JDBC session's time zone (the JVM default) before
+ * storing it, while reads interpret the stored literal as UTC. On any server not running in UTC
+ * this skews the stored value by the zone offset: e.g. {@code tracking_end_date} lands 2 hours
+ * ahead of {@code tracking_sent_date} (already {@code timestamptz}), producing absurd execution
+ * durations after a reload even though live SSE updates show the correct value.
+ *
+ * <p>Fix: align the columns with their siblings as {@code timestamptz}. The session time zone is
+ * pinned to UTC for the ALTERs so PostgreSQL interprets existing naive literals as UTC — exactly
+ * how the application reads them today, so the visible values of existing rows are unchanged — and
+ * so the conversion is a metadata-only change (no table rewrite, PostgreSQL 12+).
+ */
+@Component
+public class V6_20260728100000000__Fix_execution_tracking_timestamp_columns
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute("SET LOCAL TimeZone = 'UTC'");
+      statement.execute(
+          "ALTER TABLE injects_statuses"
+              + " ALTER COLUMN tracking_end_date TYPE timestamp with time zone");
+      statement.execute(
+          "ALTER TABLE injects_tests_statuses"
+              + " ALTER COLUMN tracking_sent_date TYPE timestamp with time zone,"
+              + " ALTER COLUMN tracking_end_date TYPE timestamp with time zone");
+      statement.execute(
+          "ALTER TABLE execution_traces"
+              + " ALTER COLUMN execution_time TYPE timestamp with time zone");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260728100000000__Fix_execution_tracking_timestamp_columns.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260728100000000__Fix_execution_tracking_timestamp_columns.java
@@ -30,16 +30,34 @@ public class V6_20260728100000000__Fix_execution_tracking_timestamp_columns
   public void migrate(Context context) throws Exception {
     try (Statement statement = context.getConnection().createStatement()) {
       statement.execute("SET LOCAL TimeZone = 'UTC'");
-      statement.execute(
-          "ALTER TABLE injects_statuses"
-              + " ALTER COLUMN tracking_end_date TYPE timestamp with time zone");
-      statement.execute(
-          "ALTER TABLE injects_tests_statuses"
-              + " ALTER COLUMN tracking_sent_date TYPE timestamp with time zone,"
-              + " ALTER COLUMN tracking_end_date TYPE timestamp with time zone");
-      statement.execute(
-          "ALTER TABLE execution_traces"
-              + " ALTER COLUMN execution_time TYPE timestamp with time zone");
+      convertToTimestamptz(statement, "injects_statuses", "tracking_end_date");
+      convertToTimestamptz(statement, "injects_tests_statuses", "tracking_sent_date");
+      convertToTimestamptz(statement, "injects_tests_statuses", "tracking_end_date");
+      convertToTimestamptz(statement, "execution_traces", "execution_time");
     }
+  }
+
+  /**
+   * Converts the column to {@code timestamptz} only when it is still a naive {@code timestamp}, so
+   * the migration is idempotent / re-runnable (already-converted databases skip the ALTER
+   * entirely).
+   */
+  private void convertToTimestamptz(Statement statement, String table, String column)
+      throws Exception {
+    statement.execute(
+        "DO $$ BEGIN "
+            + "IF EXISTS (SELECT 1 FROM information_schema.columns "
+            + "WHERE table_name = '"
+            + table
+            + "' AND column_name = '"
+            + column
+            + "' AND data_type = 'timestamp without time zone') THEN "
+            + "ALTER TABLE "
+            + table
+            + " ALTER COLUMN "
+            + column
+            + " TYPE timestamp with time zone; "
+            + "END IF; "
+            + "END $$;");
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/EndpointApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/EndpointApi.java
@@ -22,12 +22,14 @@ import io.openaev.rest.atomic_testing.form.InjectResultOutput;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.inject.service.InjectStatusService;
+import io.openaev.service.AssetGroupService;
 import io.openaev.service.AssetService;
 import io.openaev.service.EndpointService;
 import io.openaev.service.InjectSearchService;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.HttpReqRespUtils;
 import io.openaev.utils.InputFilterOptions;
+import io.openaev.utils.mapper.AssetGroupMapper;
 import io.openaev.utils.mapper.EndpointMapper;
 import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.validation.Valid;
@@ -57,12 +59,26 @@ public class EndpointApi extends RestBehavior {
 
   private final EndpointService endpointService;
   private final AssetService assetService;
+  private final AssetGroupService assetGroupService;
   private final InjectSearchService injectSearchService;
   private final InjectStatusService injectStatusService;
   private final EndpointRepository endpointRepository;
   private final AssetAgentJobRepository assetAgentJobRepository;
 
   private final EndpointMapper endpointMapper;
+  private final AssetGroupMapper assetGroupMapper;
+
+  /**
+   * Complete an overview output with the asset groups the asset belongs to (static or dynamic
+   * membership), so the asset detail page can show its group memberships.
+   */
+  private EndpointOverviewOutput withAssetGroups(EndpointOverviewOutput output, Asset asset) {
+    output.setAssetGroups(
+        this.assetGroupService.assetGroupsOfAsset(asset).stream()
+            .map(assetGroupMapper::toAssetGroupSimple)
+            .toList());
+    return output;
+  }
 
   @PostMapping({ENDPOINT_URI + "/agentless", TENANT_ENDPOINT_URI + "/agentless"})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.ASSET)
@@ -153,8 +169,9 @@ public class EndpointApi extends RestBehavior {
       actionPerformed = Action.READ,
       resourceType = ResourceType.ASSET)
   public EndpointOverviewOutput endpoint(@PathVariable @NotBlank final String endpointId) {
-    return endpointMapper.toEndpointOverviewOutput(
-        this.endpointService.getEndpoint(endpointId, TenantContext.getCurrentTenant()));
+    Endpoint endpoint =
+        this.endpointService.getEndpoint(endpointId, TenantContext.getCurrentTenant());
+    return withAssetGroups(endpointMapper.toEndpointOverviewOutput(endpoint), endpoint);
   }
 
   @LogExecutionTime
@@ -220,8 +237,9 @@ public class EndpointApi extends RestBehavior {
   public EndpointOverviewOutput updateEndpoint(
       @PathVariable @NotBlank final String endpointId,
       @Valid @RequestBody final EndpointInput input) {
-    return endpointMapper.toEndpointOverviewOutput(
-        this.endpointService.updateEndpoint(endpointId, input, TenantContext.getCurrentTenant()));
+    Endpoint endpoint =
+        this.endpointService.updateEndpoint(endpointId, input, TenantContext.getCurrentTenant());
+    return withAssetGroups(endpointMapper.toEndpointOverviewOutput(endpoint), endpoint);
   }
 
   @DeleteMapping({ENDPOINT_URI + "/{endpointId}", TENANT_ENDPOINT_URI + "/{endpointId}"})
@@ -246,7 +264,8 @@ public class EndpointApi extends RestBehavior {
       actionPerformed = Action.READ,
       resourceType = ResourceType.ASSET)
   public EndpointOverviewOutput asset(@PathVariable @NotBlank final String assetId) {
-    return endpointMapper.toAssetOverviewOutput(assetService.asset(assetId));
+    Asset asset = assetService.asset(assetId);
+    return withAssetGroups(endpointMapper.toAssetOverviewOutput(asset), asset);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/form/EndpointOverviewOutput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/endpoint/form/EndpointOverviewOutput.java
@@ -10,9 +10,11 @@ import io.openaev.database.model.AssetCriticality;
 import io.openaev.database.model.AssetSubCategory;
 import io.openaev.database.model.CloudProvider;
 import io.openaev.database.model.Endpoint;
+import io.openaev.rest.asset_group.form.AssetGroupSimple;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.Builder;
@@ -75,6 +77,10 @@ public class EndpointOverviewOutput {
   @Schema(description = "Tags")
   @JsonProperty("asset_tags")
   private Set<String> tags;
+
+  @Schema(description = "Asset groups the asset belongs to (static or dynamic membership)")
+  @JsonProperty("asset_asset_groups")
+  private List<AssetGroupSimple> assetGroups;
 
   @Schema(description = "Asset category")
   @JsonProperty("asset_category")

--- a/openaev-api/src/main/java/io/openaev/rest/finding/FindingDistinctSearchService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/finding/FindingDistinctSearchService.java
@@ -37,13 +37,11 @@ public class FindingDistinctSearchService {
         buildPaginationJPA(
             (specification, pageable) ->
                 findingRepository.findAll(
-                    FindingSpecification.distinctTypeValueWithFilter(
-                        FindingSpecification.forLatestSimulations().and(specification)),
-                    pageable),
+                    FindingSpecification.distinctTypeValueWithFilter(specification), pageable),
             searchPaginationInput,
             Finding.class);
 
-    return searchDistinctBySpecification(FindingSpecification.forLatestSimulations(), page);
+    return searchDistinctBySpecification(Specification.unrestricted(), page);
   }
 
   public Page<AggregatedFindingOutput> searchDistinctFindingsByInject(
@@ -87,16 +85,13 @@ public class FindingDistinctSearchService {
                 this.findingRepository.findAll(
                     FindingSpecification.distinctTypeValueWithFilter(
                         FindingSpecification.findFindingsForScenario(scenarioId)
-                            .and(FindingSpecification.forLatestSimulations())
                             .and(specification)),
                     pageable),
             searchPaginationInput,
             Finding.class);
 
     return searchDistinctBySpecification(
-        FindingSpecification.findFindingsForScenario(scenarioId)
-            .and(FindingSpecification.forLatestSimulations()),
-        page);
+        FindingSpecification.findFindingsForScenario(scenarioId), page);
   }
 
   public Page<AggregatedFindingOutput> searchDistinctFindingsByEndpoint(
@@ -107,16 +102,13 @@ public class FindingDistinctSearchService {
                 this.findingRepository.findAll(
                     FindingSpecification.distinctTypeValueWithFilter(
                         FindingSpecification.findFindingsForEndpoint(endpointId)
-                            .and(FindingSpecification.forLatestSimulations())
                             .and(specification)),
                     pageable),
             searchPaginationInput,
             Finding.class);
 
     return searchDistinctBySpecification(
-        FindingSpecification.findFindingsForEndpoint(endpointId)
-            .and(FindingSpecification.forLatestSimulations()),
-        page);
+        FindingSpecification.findFindingsForEndpoint(endpointId), page);
   }
 
   public Page<AggregatedFindingOutput> searchDistinctBySpecification(

--- a/openaev-api/src/main/java/io/openaev/rest/finding/FindingSearchApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/finding/FindingSearchApi.java
@@ -57,9 +57,7 @@ public class FindingSearchApi extends RestBehavior {
       return findingDistinctSearchService.searchDistinctFindings(searchPaginationInput);
     }
     return buildPaginationJPA(
-            (specification, pageable) ->
-                this.findingRepository.findAll(
-                    FindingSpecification.forLatestSimulations().and(specification), pageable),
+            (specification, pageable) -> this.findingRepository.findAll(specification, pageable),
             searchPaginationInput,
             Finding.class)
         .map(findingMapper::toRelatedFindingOutput);
@@ -166,9 +164,7 @@ public class FindingSearchApi extends RestBehavior {
     return buildPaginationJPA(
             (Specification<Finding> specification, Pageable pageable) ->
                 this.findingRepository.findAll(
-                    FindingSpecification.findFindingsForScenario(scenarioId)
-                        .and(FindingSpecification.forLatestSimulations())
-                        .and(specification),
+                    FindingSpecification.findFindingsForScenario(scenarioId).and(specification),
                     pageable),
             searchPaginationInput,
             Finding.class)
@@ -204,9 +200,7 @@ public class FindingSearchApi extends RestBehavior {
     return buildPaginationJPA(
             (Specification<Finding> specification, Pageable pageable) ->
                 this.findingRepository.findAll(
-                    FindingSpecification.findFindingsForEndpoint(endpointId)
-                        .and(FindingSpecification.forLatestSimulations())
-                        .and(specification),
+                    FindingSpecification.findFindingsForEndpoint(endpointId).and(specification),
                     pageable),
             searchPaginationInput,
             Finding.class)

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectStatusService.java
@@ -3,9 +3,12 @@ package io.openaev.rest.inject.service;
 import static io.openaev.utils.ExecutionTraceUtils.convertExecutionAction;
 import static org.springframework.util.StringUtils.hasText;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.aop.lock.Lock;
 import io.openaev.aop.lock.LockResourceType;
+import io.openaev.database.audit.BaseEvent;
+import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.helper.ExecutionTraceRepositoryHelper;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.AgentRepository;
@@ -25,6 +28,7 @@ import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,8 +43,27 @@ public class InjectStatusService {
   private final InjectUtils injectUtils;
   private final InjectStatusRepository injectStatusRepository;
   private final ExecutionTraceRepositoryHelper executionTraceRepositoryHelper;
+  private final ApplicationEventPublisher eventPublisher;
+  private final ObjectMapper mapper;
 
   private final EntityManager entityManager;
+
+  /**
+   * Streams the parent inject (with its embedded status) to the SSE consumers.
+   *
+   * <p>Inject status transitions persist only the {@link InjectStatus} entity, which carries no
+   * entity listener and no id the frontend can map back to an inject ({@code inject} is
+   * {@code @JsonIgnore}d): without this explicit event, the execution screens never see the
+   * QUEUING/EXECUTING/PENDING/terminal transitions in real time and the live board only moves on a
+   * full page reload. Must be called within an active transaction: {@link
+   * io.openaev.rest.stream.StreamApi} listens with {@code @TransactionalEventListener} and delivers
+   * after commit.
+   *
+   * @param inject the inject whose status just changed, with the fresh status attached
+   */
+  private void publishInjectStatusUpdate(Inject inject) {
+    eventPublisher.publishEvent(new BaseEvent(ModelBaseListener.DATA_UPDATE, inject, mapper));
+  }
 
   public InjectStatus findInjectStatusByInjectId(final String injectId) {
     if (!hasText(injectId)) {
@@ -217,6 +240,10 @@ public class InjectStatusService {
           injectStatus.getInject().getId(), injectStatus.getInject().getUpdatedAt());
       executionTraceRepositoryHelper.updateInjectStatus(
           injectStatus.getId(), injectStatus.getName().name(), injectStatus.getTrackingEndDate());
+      // updateUpdatedAt is a bulk JPQL update: it bypasses the entity listeners, so no SSE event
+      // is emitted. Stream the terminal transition explicitly so the execution board moves the
+      // inject from "in flight" to "completed" without a page reload.
+      publishInjectStatusUpdate(inject);
       log.debug("Successfully updated inject final status: {}", inject.getId());
     }
 
@@ -279,6 +306,7 @@ public class InjectStatusService {
     return injectUtils.getStatusPayloadFromInject(inject);
   }
 
+  @Transactional
   public InjectStatus failInjectStatus(@NotNull String injectId, @Nullable String message) {
     Inject inject = this.injectRepository.findById(injectId).orElseThrow();
     InjectStatus injectStatus = getOrInitializeInjectStatus(inject);
@@ -288,7 +316,11 @@ public class InjectStatusService {
     injectStatus.setName(ExecutionStatus.ERROR);
     injectStatus.setTrackingEndDate(Instant.now());
     injectStatus.setPayloadOutput(getPayloadOutput(inject));
-    return injectStatusRepository.save(injectStatus);
+    InjectStatus saved = injectStatusRepository.save(injectStatus);
+    // Stream the ERROR transition so the execution board moves the inject to "completed" live.
+    inject.setStatus(saved);
+    publishInjectStatusUpdate(inject);
+    return saved;
   }
 
   @Transactional
@@ -299,11 +331,36 @@ public class InjectStatusService {
     injectStatus.setName(status);
     injectStatus.setTrackingSentDate(Instant.now());
     injectStatus.setPayloadOutput(getPayloadOutput(inject));
-    return injectStatusRepository.save(injectStatus);
+    InjectStatus saved = injectStatusRepository.save(injectStatus);
+    // Stream the transition (typically -> EXECUTING) so the execution board moves the inject
+    // from "up next" to "in flight" without a page reload.
+    inject.setStatus(saved);
+    publishInjectStatusUpdate(inject);
+    return saved;
   }
 
   public Iterable<InjectStatus> saveAll(@NotNull List<InjectStatus> injectStatuses) {
     return this.injectStatusRepository.saveAll(injectStatuses);
+  }
+
+  /**
+   * Persists a status transition and streams the parent inject to the SSE consumers, so the
+   * execution screens reflect the transition in real time. Used by execution paths that save the
+   * status without any listened entity update (internal injector completion, pending-inject timeout
+   * finalization).
+   *
+   * @param injectStatus the inject status to persist
+   * @return the persisted status
+   */
+  @Transactional
+  public InjectStatus saveAndStreamInject(@NotNull InjectStatus injectStatus) {
+    InjectStatus saved = this.injectStatusRepository.save(injectStatus);
+    // Reload the inject inside this transaction: callers typically hold a detached inject (Quartz
+    // job threads) whose lazy relations cannot be serialized into the stream event payload.
+    Inject inject = this.injectRepository.findById(saved.getInject().getId()).orElseThrow();
+    inject.setStatus(saved);
+    publishInjectStatusUpdate(inject);
+    return saved;
   }
 
   public InjectStatus save(@NotNull InjectStatus injectStatus) {

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -8,6 +8,7 @@ import static java.util.stream.Collectors.groupingBy;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.openaev.aop.LogExecutionTime;
+import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
@@ -189,12 +190,10 @@ public class InjectsExecutionJob implements Job {
         }
       }
       injectStatusService.updateFinalInjectStatus(status);
+      // Save + stream one by one: the timeout finalization must reach the execution screens in
+      // real time (an inject stuck PENDING would otherwise stay "in flight" until a reload).
+      injectStatusService.saveAndStreamInject(status);
     }
-
-    injectStatusService.saveAll(
-        pendingInjects.stream()
-            .map(inject -> inject.getStatus().orElseThrow(ElementNotFoundException::new))
-            .collect(Collectors.toList()));
   }
 
   private void executeInject(ExecutableInject executableInject) throws Exception {
@@ -391,6 +390,41 @@ public class InjectsExecutionJob implements Job {
     exerciseRepository.save(exercise);
   }
 
+  /**
+   * Runs an inject execution under BOTH tenant scopes of the platform, set to the inject's tenant:
+   * the v2 primitive (transaction GUC, read by the inspector for activated tables such as
+   * collectors) and the v1 thread-local {@link TenantContext}, which {@link
+   * io.openaev.aop.HibernateFilterTransactionAspect} turns into the Hibernate {@code tenantFilter}
+   * on every {@code @Transactional} method it enters.
+   *
+   * <p>The v1 bridge is not optional: executing an inject resolves asset groups, endpoints and
+   * agents through Criteria queries, all still {@code @Filter} entities. {@link
+   * TenantContext#getCurrentTenant()} falls back to the DEFAULT tenant when the thread-local is
+   * unset, so without this a customer's simulation resolved the default tenant's endpoints and
+   * created its expectations against them - cross-tenant rows, and none for the real targets. It
+   * stayed invisible in single-tenant deployments, where that fallback happens to be the right
+   * tenant. Every other background executor (ScenarioExecutionJob, AtomicTestingExecutionJob,
+   * ExpectationsExpirationManagerJob, StepEventService...) already carries the same bridge.
+   *
+   * <p>Unlike those, this job runs on the shared {@code ForkJoinPool.commonPool} (nested {@code
+   * parallelStream}), which also borrows the calling thread: restore the previous value instead of
+   * clearing, so the scope of whatever else runs on that thread survives.
+   */
+  private void executeInTenant(@NotNull final String tenantId, @NotNull final Runnable work) {
+    String previousTenant =
+        TenantContext.hasCurrentTenant() ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(tenantId);
+    try {
+      tenantTx.execute(TxCtx.forTenant(tenantId), work);
+    } finally {
+      if (previousTenant == null) {
+        TenantContext.clearCurrentTenant();
+      } else {
+        TenantContext.setCurrentTenant(previousTenant);
+      }
+    }
+  }
+
   @Override
   @LogExecutionTime
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
@@ -447,10 +481,8 @@ public class InjectsExecutionJob implements Job {
                           try {
                             String tenantId =
                                 executableInject.getInjection().getInject().getTenant().getId();
-                            // Scope the transaction so the v2 inspector can resolve
-                            // can_access_tenant for activated tables (e.g. collectors)
-                            tenantTx.execute(
-                                TxCtx.forTenant(tenantId),
+                            executeInTenant(
+                                tenantId,
                                 () -> {
                                   try {
                                     this.executeInject(executableInject);

--- a/openaev-api/src/main/java/io/openaev/service/AssetGroupService.java
+++ b/openaev-api/src/main/java/io/openaev/service/AssetGroupService.java
@@ -205,6 +205,47 @@ public class AssetGroupService {
     return assets;
   }
 
+  /**
+   * Resolve every asset group the given asset belongs to: static membership (the asset is
+   * explicitly listed in the group) plus dynamic membership (the group's dynamic filter matches the
+   * asset). Dynamic membership is checked with an id-constrained query per dynamic group so the
+   * potentially large dynamic member lists are never materialized.
+   */
+  @Transactional(readOnly = true)
+  public List<AssetGroup> assetGroupsOfAsset(@NotNull final Asset asset) {
+    Map<String, AssetGroup> assetGroupsById = new LinkedHashMap<>();
+    asset.getAssetGroups().forEach(group -> assetGroupsById.putIfAbsent(group.getId(), group));
+    fromIterable(this.assetGroupRepository.findAll()).stream()
+        .filter(group -> !assetGroupsById.containsKey(group.getId()))
+        .filter(group -> !isEmptyFilterGroup(group.getDynamicFilter()))
+        .filter(group -> isAssetInDynamicGroup(asset, group))
+        .forEach(group -> assetGroupsById.putIfAbsent(group.getId(), group));
+    return new ArrayList<>(assetGroupsById.values());
+  }
+
+  /** True when the group's dynamic filter matches the given asset (id-constrained query). */
+  private boolean isAssetInDynamicGroup(
+      @NotNull final Asset asset, @NotNull final AssetGroup assetGroup) {
+    if (Hibernate.unproxy(asset) instanceof Endpoint) {
+      Specification<Endpoint> filterSpecification =
+          computeFilterGroupJpa(assetGroup.getDynamicFilter());
+      Specification<Endpoint> specification =
+          filterSpecification
+              .and(EndpointSpecification.findEndpointsForInjectionOrAgentlessEndpoints())
+              .and((root, query, cb) -> cb.equal(root.get("id"), asset.getId()));
+      return !this.endpointService.endpoints(specification).isEmpty();
+    }
+    // Same eager key validation as resolveDynamicNonEndpointAssets: endpoint-only filter keys
+    // cannot match non-endpoint assets and would fail the base-Asset query.
+    if (!isFilterResolvableForBaseAssets(assetGroup.getDynamicFilter())) {
+      return false;
+    }
+    Specification<Asset> filterSpecification = computeFilterGroupJpa(assetGroup.getDynamicFilter());
+    Specification<Asset> specification =
+        filterSpecification.and((root, query, cb) -> cb.equal(root.get("id"), asset.getId()));
+    return !this.assetService.assets(specification).isEmpty();
+  }
+
   private List<AssetGroup> computeDynamicAssets(@NotNull final List<AssetGroup> assetGroups) {
     if (assetGroups.stream()
         .allMatch(assetGroup -> isEmptyFilterGroup(assetGroup.getDynamicFilter()))) {

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -641,8 +641,13 @@ public class InjectExpectationService {
       throw new IllegalArgumentException("Updates are only supported for technical expectations");
     }
     addResult(technicalExpectation, input, securityPlatform);
+    // Same combination contract as the collector path (computeInjectExpectationForAgentOrAsset
+    // Agentless): a direct write on a parent row must not clobber - nor be clobbered by - the
+    // children-derived verdict.
     technicalExpectation.setScore(
-        computeScore(technicalExpectation.getResults(), technicalExpectation));
+        combineWithChildrenVerdict(
+            technicalExpectation,
+            computeScore(technicalExpectation.getResults(), technicalExpectation)));
     TechnicalInjectExpectation updated =
         this.injectExpectationRepository.save(technicalExpectation);
     // Same propagation contract as computeTechnicalExpectation: agentless expectations only
@@ -844,9 +849,19 @@ public class InjectExpectationService {
    * check with "Not Detected") must never overwrite that rollup with a score computed from the
    * parent's own results only.
    *
-   * <p>Combination rule: a direct success is definitive (any security platform succeeding counts);
-   * otherwise the children verdict wins - including staying pending (null) while the agents are
-   * still unanswered, so a direct failure never cements a wrong verdict early.
+   * <p>For DETECTION / PREVENTION a direct SUCCESS wins (any security platform proving
+   * prevention/detection counts) and anything else defers to the children - including staying
+   * pending (null) while the agents are unanswered, so a direct absence-of-signal answer never
+   * cements a wrong verdict early.
+   *
+   * <p>VULNERABILITY is decided on its own row instead, in BOTH directions, because the verdict
+   * comes from scanning the asset itself: "Not vulnerable" is a real answer there, not the absence
+   * of one. Deferring it to the children would hang the row until expiry, since an agentless
+   * injector never fills the agent expectations - those exist only because the endpoint happens to
+   * run an agent. A proven VULNERABLE result still wins over a "Not vulnerable" one from another
+   * source (worst case wins, hence {@code reconcileWithDirectVulnerableVerdict} rather than the
+   * max-based own score), and a child that reports a finding later still overrides the row through
+   * the rollup path, which only pins direct VULNERABLE verdicts.
    *
    * @param expectation the expectation whose score was just computed from its own results
    * @param ownScore the score computed from the expectation's own results
@@ -862,7 +877,24 @@ public class InjectExpectationService {
       return ownScore; // true agentless leaf (AI target, agentless endpoint)
     }
     Double expectedScore = expectation.getExpectedScore();
-    if (expectedScore == null || (ownScore != null && ownScore >= expectedScore)) {
+    if (expectedScore == null) {
+      return ownScore;
+    }
+    if (BaseInjectExpectation.EXPECTATION_TYPE.VULNERABILITY.equals(expectation.getType())) {
+      Double directVulnerable =
+          InjectExpectationUtils.reconcileWithDirectVulnerableVerdict(expectation, null);
+      if (directVulnerable != null) {
+        return directVulnerable;
+      }
+      // No finding: conclude only once every expected source has answered - ownScore is null while
+      // one is still missing, which is exactly the pending state to keep.
+      if (ownScore != null) {
+        return ownScore;
+      }
+      return InjectExpectationUtils.computeChildrenScore(
+          expectation.isExpectationGroup(), expectedScore, agentChildren);
+    }
+    if (ownScore != null && ownScore >= expectedScore) {
       return ownScore;
     }
     return InjectExpectationUtils.computeChildrenScore(
@@ -2136,11 +2168,16 @@ public class InjectExpectationService {
     BaseInjectContent content = contentConvert(injection, BaseInjectContent.class);
 
     // Execution-time fallback: injects created before their contract declared predefined
-    // expectations (e.g. Nuclei injects in existing simulations) carry no expectations in their
-    // stored content, so resetting and relaunching the simulation would silently create none.
-    // Read the predefined expectations from the injector contract instead, exactly like inject
-    // creation and the chaining engine do.
-    if (content.getExpectations().isEmpty() && inject.getInjectorContract().isPresent()) {
+    // expectations (e.g. Nuclei injects in existing simulations) carry no expectations FIELD in
+    // their stored content, so resetting and relaunching the simulation would silently create
+    // none. Read the predefined expectations from the injector contract instead, exactly like
+    // inject creation and the chaining engine do. An EXPLICIT empty list is a different thing:
+    // it means the user deliberately removed every expectation from the inject, and that choice
+    // is never overridden here - expectation drift realignment is the opt-in way to restore the
+    // contract template.
+    if (content.getExpectations().isEmpty()
+        && contentNeverCarriedExpectations(inject)
+        && inject.getInjectorContract().isPresent()) {
       ObjectNode storedContent = inject.getContent();
       ObjectNode enrichedContent =
           injectorContractContentUtils.setExpectations(
@@ -2165,6 +2202,23 @@ public class InjectExpectationService {
             computeExpectationsForAssetGroup(expectations, resolvedContent, assetGroup)));
 
     doBuildAndSaveInjectExpectations(injection, expectations);
+  }
+
+  /**
+   * Whether the stored inject content never carried the expectations field at all: the inject was
+   * created before its injector contract declared predefined expectations, so it follows the
+   * contract template dynamically at execution time (same semantics as the expectation drift
+   * detection). An explicit empty array is NOT "never carried": it means the user deliberately
+   * removed every expectation from the inject, and that customization must be respected.
+   */
+  private static boolean contentNeverCarriedExpectations(@NotNull final Inject inject) {
+    ObjectNode storedContent = inject.getContent();
+    if (storedContent == null) {
+      return true;
+    }
+    JsonNode expectationsNode =
+        storedContent.get(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_EXPECTATIONS);
+    return expectationsNode == null || expectationsNode.isNull();
   }
 
   /** In case of direct assetToExecute, we have an individual expectation for the assetToExecute */

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
@@ -170,6 +170,44 @@ public class InjectExpectationUtils {
     return success ? expectedScore : FAILED_SCORE_VALUE;
   }
 
+  /**
+   * Guards a children-derived rollup score against clobbering a definitive direct VULNERABLE
+   * verdict carried by the parent expectation's own results.
+   *
+   * <p>VULNERABILITY has an inverted signal polarity compared to detection/prevention: the
+   * meaningful signal is a FAILURE (a scanner proved the target vulnerable), while a success ("Not
+   * vulnerable") is merely the absence of a finding. Assessment injectors such as Nuclei write
+   * their verdict directly on the asset/asset-group row (agent == null execution), so when the
+   * untouched agent children later expire to the default "Not vulnerable", the children rollup must
+   * not overwrite the proven vulnerable verdict with an absence-of-signal default.
+   *
+   * <p>Rows attributed to the expiration manager and rows expired to "Expired" are defaults, not
+   * signals, and are ignored.
+   *
+   * @param expectation the parent expectation whose score is being recomputed from children
+   * @param childrenScore the score derived from the children rollup
+   * @return the score to persist: the worst direct vulnerable score when one exists, otherwise the
+   *     children score
+   */
+  public static Double reconcileWithDirectVulnerableVerdict(
+      @NotNull final BaseInjectExpectation expectation, @Nullable final Double childrenScore) {
+    Double expectedScore = expectation.getExpectedScore();
+    List<InjectExpectationResult> results = expectation.getResults();
+    if (expectedScore == null || results == null || !VULNERABILITY.equals(expectation.getType())) {
+      return childrenScore;
+    }
+    return results.stream()
+        .filter(
+            result ->
+                !ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(result.getSourceId()))
+        .filter(result -> !EXPIRED.equals(result.getResult()))
+        .map(InjectExpectationResult::getScore)
+        .filter(Objects::nonNull)
+        .filter(score -> score < expectedScore)
+        .reduce(Math::min)
+        .orElse(childrenScore);
+  }
+
   public static Double computeChildrenScore(
       boolean isGroupExpectation,
       @NotNull Double expectedScore,
@@ -227,7 +265,9 @@ public class InjectExpectationUtils {
     parentExpectations.forEach(
         expectation -> {
           if (noExpectationScore) {
-            expectation.setScore(null);
+            // Children still pending: keep a definitive direct vulnerable verdict (e.g. Nuclei
+            // answered the asset row itself) instead of resetting the parent to pending.
+            expectation.setScore(reconcileWithDirectVulnerableVerdict(expectation, null));
             return;
           }
 
@@ -245,8 +285,12 @@ public class InjectExpectationUtils {
               score = InjectExpectationUtils.computeScore(expectation, false);
             }
           }
-          expectation.setScore(score);
-          if (addResult != null) {
+          Double reconciledScore = reconcileWithDirectVulnerableVerdict(expectation, score);
+          expectation.setScore(reconciledScore);
+          // When the direct vulnerable verdict overrode the children rollup, stamping the
+          // triggering result (an expiration "Not vulnerable") would contradict the verdict the
+          // parent just kept: skip it, the genuine platform row already explains the score.
+          if (addResult != null && Objects.equals(reconciledScore, score)) {
             InjectExpectationResult newResultToAdd = addResult.apply(score);
             Optional<InjectExpectationResult> existingResult =
                 expectation.getResults().stream()
@@ -258,10 +302,15 @@ public class InjectExpectationUtils {
             expectation.getResults().add(newResultToAdd);
 
             // IF RESULT TO ADD IS EXPIRATION MANAGER => SO I EXPIRE ALL the inject expectation with
-            // no result to expired
+            // no result to expired, using the type's default polarity (silence means "Not
+            // vulnerable" for VULNERABILITY, failure for the other types)
             if (ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(
                 newResultToAdd.getSourceId())) {
-              expireEmptyResults(expectation.getResults(), FAILED_SCORE_VALUE, EXPIRED);
+              Double expiredScore =
+                  VULNERABILITY.equals(expectation.getType())
+                      ? expectation.getExpectedScore()
+                      : Double.valueOf(FAILED_SCORE_VALUE);
+              expireEmptyResults(expectation.getResults(), expiredScore, EXPIRED);
             }
           }
         });

--- a/openaev-api/src/main/java/io/openaev/service/expectation/AbstractTechnicalBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/service/expectation/AbstractTechnicalBehavior.java
@@ -1,6 +1,7 @@
 package io.openaev.service.expectation;
 
 import static io.openaev.service.InjectExpectationUtils.computeChildrenScore;
+import static io.openaev.service.InjectExpectationUtils.reconcileWithDirectVulnerableVerdict;
 import static io.openaev.utils.AgentUtils.getActiveAgents;
 import static io.openaev.utils.ExpectationSignatureUtils.convertToInjectExpectationSignatures;
 import static io.openaev.utils.ExpectationUtils.*;
@@ -212,7 +213,9 @@ public abstract class AbstractTechnicalBehavior implements ExpectationBehavior {
       if (!children.isEmpty()) {
         Double score =
             computeChildrenScore(parent.isExpectationGroup(), parent.getExpectedScore(), children);
-        parent.setScore(score);
+        // A definitive direct VULNERABLE verdict written on the parent row (e.g. by an assessment
+        // injector such as Nuclei) must survive the children rollup.
+        parent.setScore(reconcileWithDirectVulnerableVerdict(parent, score));
         updated.add(parent);
       }
     }

--- a/openaev-api/src/test/java/io/openaev/api/expectations/ExpectationsDriftServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/expectations/ExpectationsDriftServiceTest.java
@@ -236,6 +236,27 @@ class ExpectationsDriftServiceTest {
   }
 
   @Test
+  @DisplayName("An explicitly emptied expectations list is a customization - drift")
+  void explicitlyEmptiedExpectationsListIsDrift() {
+    // The user deliberately removed every expectation from the inject (the form persists an
+    // explicit empty array). Execution respects that choice, so drift is how the divergence from
+    // the contract template is surfaced - realignment being the opt-in way to restore it.
+    InjectorContract contract =
+        contractWithExpectations(expectationNode("PREVENTION", false, 100, true));
+    Inject inject = injectWith(contract);
+    ObjectNode content = MAPPER.createObjectNode();
+    content.set("expectations", MAPPER.createArrayNode());
+    inject.setContent(content);
+    stubScenarioInjects(inject);
+
+    ExpectationsDriftOutput output = service.scenarioDrift(SCENARIO_ID);
+
+    assertThat(output.driftDetected()).isTrue();
+    assertThat(output.driftedInjectCount()).isEqualTo(1);
+    assertThat(output.totalInjectCount()).isEqualTo(1);
+  }
+
+  @Test
   @DisplayName("Injects whose contract has no expectations field are excluded from the report")
   void injectWithoutExpectationsContractIsExcluded() {
     Inject inject =

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverIntegrationTest.java
@@ -131,6 +131,9 @@ class TxCtxArgumentResolverIntegrationTest extends IntegrationTest {
   @DisplayName(
       "a selector-requiring endpoint without one falls back to the default tenant for a"
           + " multi-tenant caller authorized on it")
+  // Transactional so the native membership INSERT runs inside a transaction (a @Modifying query
+  // cannot flush without one) and rolls back, keeping the sibling refusal test's premise intact.
+  @Transactional
   void requiredSelectorMissingFallsBackToDefaultTenant() throws Exception {
     // Tenant-unaware API clients (collectors, injectors) never send a selector; the platform-wide
     // convention for requests without an explicit tenant context is the default tenant.

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverIntegrationTest.java
@@ -7,8 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.openaev.IntegrationTest;
 import io.openaev.aop.AccessControl;
+import io.openaev.config.cache.TenantMembershipCacheManager;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.TenantRepository;
 import io.openaev.service.tenants.TenantService;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.mockUser.WithMockUser;
@@ -28,8 +30,11 @@ import org.springframework.web.bind.annotation.RestController;
  * End-to-end proof, through a real controller and MockMvc, that a {@code TxCtx} method parameter is
  * resolved from the request within the caller's rights: the selector (path or {@code X-Tenant-Ids}
  * header) is intersected with the user's tenants, the path wins when present, a selector outside
- * the rights is refused, and no selector yields the full allowed set. No mocks: a real user with
- * real tenant memberships hits a real endpoint that returns the resolved scope.
+ * the rights is refused, and no selector yields the full allowed set. On selector-requiring
+ * endpoints, a missing selector falls back (single-tenant caller, then default tenant) rather than
+ * being refused, so tenant-unaware API clients keep working; only a multi-tenant caller without
+ * default-tenant access is refused. No mocks: a real user with real tenant memberships hits a real
+ * endpoint that returns the resolved scope.
  */
 @WithMockUser
 @DisplayName("TxCtx is resolved from the request within the caller's rights (HTTP)")
@@ -41,6 +46,8 @@ class TxCtxArgumentResolverIntegrationTest extends IntegrationTest {
   @Autowired private MockMvc mvc;
   @Autowired private TenantService tenantService;
   @Autowired private TenantIsolationTestHelper tenantHelper;
+  @Autowired private TenantRepository tenantRepository;
+  @Autowired private TenantMembershipCacheManager tenantMembershipCacheManager;
 
   private String tenantA;
   private String tenantB;
@@ -111,9 +118,29 @@ class TxCtxArgumentResolverIntegrationTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("an endpoint requiring a selector refuses a request without one (400)")
+  @DisplayName(
+      "a selector-requiring endpoint without one: a multi-tenant caller not on the default tenant"
+          + " is the only refused case (400)")
   void requiredSelectorMissingIsRejected() throws Exception {
+    // The mock user is a member of tenants A and B but NOT of the default tenant: no fallback is
+    // safe (any silent pick could read or write the wrong tenant), so the request is refused.
     mvc.perform(get("/api/test/txctx/required/scope")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName(
+      "a selector-requiring endpoint without one falls back to the default tenant for a"
+          + " multi-tenant caller authorized on it")
+  void requiredSelectorMissingFallsBackToDefaultTenant() throws Exception {
+    // Tenant-unaware API clients (collectors, injectors) never send a selector; the platform-wide
+    // convention for requests without an explicit tenant context is the default tenant.
+    String userId = SessionHelper.currentUser().getId();
+    tenantRepository.addUserToTenant(userId, Tenant.DEFAULT_TENANT_UUID);
+    tenantMembershipCacheManager.evict(userId, Tenant.DEFAULT_TENANT_UUID);
+
+    mvc.perform(get("/api/test/txctx/required/scope"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(Tenant.DEFAULT_TENANT_UUID));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
@@ -1,0 +1,107 @@
+package io.openaev.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TxCtx;
+import io.openaev.database.model.Tenant;
+import io.openaev.rest.exception.TenantSelectorRequiredException;
+import io.openaev.service.tenants.TenantService;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.NativeWebRequest;
+
+/**
+ * Unit coverage for the no-selector fallback on selector-requiring endpoints. A selector is never
+ * mandatory: tenant-unaware API clients (collectors, injectors, plain scripts) must keep working.
+ * The Community Edition case (a caller authorized on a single tenant) cannot be reached by the
+ * MockMvc integration test, whose seed always creates extra tenant memberships, so it is proven
+ * here.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TxCtx no-selector fallback on selector-requiring endpoints")
+class TxCtxArgumentResolverTest {
+
+  private static final String USER_ID = "user-id";
+
+  @Mock private TenantService tenantService;
+  @Mock private MethodParameter parameter;
+  @Mock private NativeWebRequest webRequest;
+
+  private TxCtxArgumentResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new TxCtxArgumentResolver(new TenantScopeResolver(), tenantService);
+    OpenAEVPrincipal principal = mock(OpenAEVPrincipal.class);
+    when(principal.getId()).thenReturn(USER_ID);
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.getPrincipal()).thenReturn(principal);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private void authorizeTenants(String... tenantIds) {
+    List<Tenant> tenants = Arrays.stream(tenantIds).map(Tenant::new).toList();
+    when(tenantService.findTenantsByUserId(USER_ID)).thenReturn(tenants);
+  }
+
+  private void requireSelector() {
+    when(parameter.hasParameterAnnotation(RequireTenantSelector.class)).thenReturn(true);
+  }
+
+  private TxCtx resolve() {
+    return (TxCtx) resolver.resolveArgument(parameter, null, webRequest, null);
+  }
+
+  @Test
+  @DisplayName("a single-tenant caller (Community Edition) resolves to its own tenant")
+  void singleTenantCallerResolvesWithoutSelector() {
+    authorizeTenants("tenant-1");
+    requireSelector();
+
+    assertThat(resolve().toGuc()).isEqualTo("tenant-1");
+  }
+
+  @Test
+  @DisplayName("a multi-tenant caller authorized on the default tenant falls back to it")
+  void multiTenantCallerFallsBackToDefaultTenant() {
+    authorizeTenants("tenant-1", Tenant.DEFAULT_TENANT_UUID, "tenant-2");
+    requireSelector();
+
+    assertThat(resolve().toGuc()).isEqualTo(Tenant.DEFAULT_TENANT_UUID);
+  }
+
+  @Test
+  @DisplayName("a multi-tenant caller without default-tenant access is the only refused case")
+  void multiTenantCallerWithoutDefaultTenantIsRefused() {
+    authorizeTenants("tenant-1", "tenant-2");
+    requireSelector();
+
+    assertThatThrownBy(this::resolve).isInstanceOf(TenantSelectorRequiredException.class);
+  }
+
+  @Test
+  @DisplayName("without the annotation, no selector still yields the full allowed set")
+  void withoutAnnotationNoSelectorYieldsFullSet() {
+    authorizeTenants("tenant-1", "tenant-2");
+
+    assertThat(resolve().toGuc()).isEqualTo("tenant-1,tenant-2");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/finding/FindingApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/finding/FindingApiTest.java
@@ -170,41 +170,34 @@ class FindingApiTest extends IntegrationTest {
     @DisplayName("When searching globally for findings")
     class WhenSearchingGloballyForFindings {
       @Test
-      @DisplayName("Returns only findings for latest simulation of each scenario")
-      public void ReturnsOnlyFindingsForLatestSimulationOfEachScenario() throws Exception {
+      @DisplayName("Returns findings from all simulations of each scenario")
+      public void ReturnsFindingsFromAllSimulationsOfEachScenario() throws Exception {
         List<ScenarioComposer.Composer> scenarioWrappers =
             List.of(getScenarioWithSimulationsWrapper(), getScenarioWithSimulationsWrapper());
 
-        // latest findings
-        List<FindingComposer.Composer> latestFindingWrappers = new ArrayList<>();
-
-        // add latest simulation to each scenario
+        // add one more simulation with findings to each scenario
         for (ScenarioComposer.Composer scenarioWrapper : scenarioWrappers) {
           Hashtable<String, InjectComposer.Composer> latestSimulationInjectWrappers =
               attachSimulationToScenario(
                   scenarioWrapper, ExerciseFixture.createFinishedAttackExercise());
           for (Map.Entry<String, InjectComposer.Composer> entry :
               latestSimulationInjectWrappers.entrySet()) {
-            FindingComposer.Composer findingWrapper =
-                findingComposer.forFinding(createDefaultTextFindingWithRandomValue());
-            latestFindingWrappers.add(findingWrapper);
-            entry.getValue().withFinding(findingWrapper);
+            entry
+                .getValue()
+                .withFinding(findingComposer.forFinding(createDefaultTextFindingWithRandomValue()));
           }
           scenarioWrapper.persist();
         }
 
         // add injects (atomic testing) with findings too
         for (int i = 0; i < 2; i++) {
-          FindingComposer.Composer findingWrapper =
-              findingComposer.forFinding(createDefaultTextFindingWithRandomValue());
-          latestFindingWrappers.add(findingWrapper);
           injectComposer
               .forInject(InjectFixture.getDefaultInject())
-              .withFinding(findingWrapper)
+              .withFinding(findingComposer.forFinding(createDefaultTextFindingWithRandomValue()))
               .persist();
         }
 
-        SearchPaginationInput input = PaginationFixture.getDefault().build();
+        SearchPaginationInput input = PaginationFixture.getDefault().size(500).build();
 
         entityManager.flush();
         entityManager.clear();
@@ -215,15 +208,10 @@ class FindingApiTest extends IntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
+        // every finding is visible, whatever the simulation it comes from
         List<RelatedFindingOutput> expectedFindings =
-            fromIterable(
-                    findingRepository.findAllById(
-                        latestFindingWrappers.stream()
-                            .map(wrapper -> wrapper.get().getId())
-                            .toList()))
-                .stream()
+            fromIterable(findingRepository.findAll()).stream()
                 .map(findingMapper::toRelatedFindingOutput)
-                .limit(input.getSize())
                 .toList();
 
         assertThatJson(response)
@@ -233,46 +221,45 @@ class FindingApiTest extends IntegrationTest {
       }
 
       @Test
-      @DisplayName("Returns only findings for latest finished simulation of each scenario")
-      public void ReturnsOnlyFindingsForLatestFinishedSimulationOfEachScenario() throws Exception {
+      @DisplayName("Returns findings from running simulations as well as finished ones")
+      public void ReturnsFindingsFromRunningSimulationsAsWellAsFinishedOnes() throws Exception {
         List<ScenarioComposer.Composer> scenarioWrappers =
             List.of(getScenarioWithSimulationsWrapper(), getScenarioWithSimulationsWrapper());
 
-        // latest findings
-        List<FindingComposer.Composer> latestFindingWrappers = new ArrayList<>();
-
-        // add latest simulations to each scenario
         for (ScenarioComposer.Composer scenarioWrapper : scenarioWrappers) {
-          ///  FINISHED simulation
-          Hashtable<String, InjectComposer.Composer> latestSimulationInjectWrappers =
+          ///  FINISHED simulation with findings
+          Hashtable<String, InjectComposer.Composer> finishedSimulationInjectWrappers =
               attachSimulationToScenario(
                   scenarioWrapper, ExerciseFixture.createFinishedAttackExercise());
           for (Map.Entry<String, InjectComposer.Composer> entry :
-              latestSimulationInjectWrappers.entrySet()) {
-            FindingComposer.Composer findingWrapper =
-                findingComposer.forFinding(createDefaultTextFindingWithRandomValue());
-            latestFindingWrappers.add(findingWrapper);
-            entry.getValue().withFinding(findingWrapper);
+              finishedSimulationInjectWrappers.entrySet()) {
+            entry
+                .getValue()
+                .withFinding(findingComposer.forFinding(createDefaultTextFindingWithRandomValue()));
           }
 
-          /// RUNNING simulation with no findings
-          attachSimulationToScenario(
-              scenarioWrapper, ExerciseFixture.createRunningAttackExercise());
+          /// RUNNING simulation with findings - visible while the simulation is still running
+          Hashtable<String, InjectComposer.Composer> runningSimulationInjectWrappers =
+              attachSimulationToScenario(
+                  scenarioWrapper, ExerciseFixture.createRunningAttackExercise());
+          for (Map.Entry<String, InjectComposer.Composer> entry :
+              runningSimulationInjectWrappers.entrySet()) {
+            entry
+                .getValue()
+                .withFinding(findingComposer.forFinding(createDefaultTextFindingWithRandomValue()));
+          }
           scenarioWrapper.persist();
         }
 
         // add injects (atomic testing) with findings too
         for (int i = 0; i < 2; i++) {
-          FindingComposer.Composer findingWrapper =
-              findingComposer.forFinding(createDefaultTextFindingWithRandomValue());
-          latestFindingWrappers.add(findingWrapper);
           injectComposer
               .forInject(InjectFixture.getDefaultInject())
-              .withFinding(findingWrapper)
+              .withFinding(findingComposer.forFinding(createDefaultTextFindingWithRandomValue()))
               .persist();
         }
 
-        SearchPaginationInput input = PaginationFixture.getDefault().build();
+        SearchPaginationInput input = PaginationFixture.getDefault().size(500).build();
 
         entityManager.flush();
         entityManager.clear();
@@ -283,15 +270,10 @@ class FindingApiTest extends IntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
+        // every finding is visible, including those of the running simulations
         List<RelatedFindingOutput> expectedFindings =
-            fromIterable(
-                    findingRepository.findAllById(
-                        latestFindingWrappers.stream()
-                            .map(wrapper -> wrapper.get().getId())
-                            .toList()))
-                .stream()
+            fromIterable(findingRepository.findAll()).stream()
                 .map(findingMapper::toRelatedFindingOutput)
-                .limit(input.getSize())
                 .toList();
 
         assertThatJson(response)
@@ -305,27 +287,31 @@ class FindingApiTest extends IntegrationTest {
     @DisplayName("When searching for findings on scenario")
     class WhenSearchingForFindingsOnScenario {
       @Test
-      @DisplayName("Returns only findings for latest simulation")
-      public void ReturnsOnlyFindingsForLatestSimulation() throws Exception {
+      @DisplayName("Returns findings from all simulations of the scenario")
+      public void ReturnsFindingsFromAllSimulationsOfScenario() throws Exception {
         ScenarioComposer.Composer scenarioWrapper = getScenarioWithSimulationsWrapper();
 
-        // latest findings
-        List<FindingComposer.Composer> latestFindingWrappers = new ArrayList<>();
-
-        // add latest simulation to scenario
+        // add one more simulation with findings to the scenario
         Hashtable<String, InjectComposer.Composer> latestSimulationInjectWrappers =
             attachSimulationToScenario(
                 scenarioWrapper, ExerciseFixture.createFinishedAttackExercise());
         for (Map.Entry<String, InjectComposer.Composer> entry :
             latestSimulationInjectWrappers.entrySet()) {
-          FindingComposer.Composer findingWrapper =
-              findingComposer.forFinding(createDefaultTextFindingWithRandomValue());
-          latestFindingWrappers.add(findingWrapper);
-          entry.getValue().withFinding(findingWrapper);
+          entry
+              .getValue()
+              .withFinding(findingComposer.forFinding(createDefaultTextFindingWithRandomValue()));
         }
         scenarioWrapper.persist();
 
-        SearchPaginationInput input = PaginationFixture.getDefault().build();
+        // every finding of every simulation of the scenario is expected
+        List<String> expectedFindingIds =
+            scenarioWrapper.get().getExercises().stream()
+                .flatMap(exercise -> exercise.getInjects().stream())
+                .flatMap(inject -> inject.getFindings().stream())
+                .map(Finding::getId)
+                .toList();
+
+        SearchPaginationInput input = PaginationFixture.getDefault().size(500).build();
 
         entityManager.flush();
         entityManager.clear();
@@ -338,14 +324,8 @@ class FindingApiTest extends IntegrationTest {
                 .getContentAsString();
 
         List<RelatedFindingOutput> expectedFindings =
-            fromIterable(
-                    findingRepository.findAllById(
-                        latestFindingWrappers.stream()
-                            .map(wrapper -> wrapper.get().getId())
-                            .toList()))
-                .stream()
+            fromIterable(findingRepository.findAllById(expectedFindingIds)).stream()
                 .map(findingMapper::toRelatedFindingOutput)
-                .limit(input.getSize())
                 .toList();
 
         assertThatJson(response)
@@ -448,17 +428,19 @@ class FindingApiTest extends IntegrationTest {
     @DisplayName("When searching for findings on Endpoint")
     class WhenSearchingForFindingsOnEndpoint {
       @Test
-      @DisplayName("Returns all findings for latest simulations involving endpoint")
-      public void ReturnsAllFindingsForLatestSimulationsInvolvingEndpoint() throws Exception {
+      @DisplayName("Returns findings from all simulations involving endpoint")
+      public void ReturnsFindingsFromAllSimulationsInvolvingEndpoint() throws Exception {
         EndpointComposer.Composer endpointWrapper =
             endpointComposer.forEndpoint(EndpointFixture.createEndpoint()).persist();
         ScenarioComposer.Composer scenarioWrapper = getScenarioWithSimulationsWrapper();
 
         // hack findings to attach to endpoint
+        List<Finding> previousSimulationFindings = new ArrayList<>();
         for (Exercise ex : scenarioWrapper.get().getExercises()) {
           for (Inject inject : ex.getInjects()) {
             for (Finding finding : inject.getFindings()) {
               finding.setAssets(new ArrayList<>(List.of(endpointWrapper.get())));
+              previousSimulationFindings.add(finding);
             }
           }
         }
@@ -490,7 +472,7 @@ class FindingApiTest extends IntegrationTest {
               .persist();
         }
 
-        SearchPaginationInput input = PaginationFixture.getDefault().build();
+        SearchPaginationInput input = PaginationFixture.getDefault().size(500).build();
 
         entityManager.flush();
         entityManager.clear();
@@ -502,15 +484,14 @@ class FindingApiTest extends IntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
+        // previous simulations' findings are visible too
+        List<String> expectedFindingIds = new ArrayList<>();
+        previousSimulationFindings.forEach(finding -> expectedFindingIds.add(finding.getId()));
+        latestFindingWrappers.forEach(wrapper -> expectedFindingIds.add(wrapper.get().getId()));
+
         List<RelatedFindingOutput> expectedFindings =
-            fromIterable(
-                    findingRepository.findAllById(
-                        latestFindingWrappers.stream()
-                            .map(wrapper -> wrapper.get().getId())
-                            .toList()))
-                .stream()
+            fromIterable(findingRepository.findAllById(expectedFindingIds)).stream()
                 .map(findingMapper::toRelatedFindingOutput)
-                .limit(input.getSize())
                 .toList();
 
         assertThatJson(response)
@@ -520,25 +501,26 @@ class FindingApiTest extends IntegrationTest {
       }
 
       @Test
-      @DisplayName(
-          "Returns all unsolved findings for latest finished simulations involving endpoint")
-      public void ReturnsAllUnsolvedFindingsForLatestFinishedSimulationsInvolvingEndpoint()
+      @DisplayName("Returns previous simulations findings even when latest simulation reports none")
+      public void ReturnsPreviousSimulationsFindingsEvenWhenLatestSimulationReportsNone()
           throws Exception {
         EndpointComposer.Composer endpointWrapper =
             endpointComposer.forEndpoint(EndpointFixture.createEndpoint()).persist();
         ScenarioComposer.Composer scenarioWrapper = getScenarioWithSimulationsWrapper();
 
         // hack findings to attach to endpoint
+        List<Finding> previousSimulationFindings = new ArrayList<>();
         for (Exercise ex : scenarioWrapper.get().getExercises()) {
           for (Inject inject : ex.getInjects()) {
             for (Finding finding : inject.getFindings()) {
               finding.setAssets(new ArrayList<>(List.of(endpointWrapper.get())));
+              previousSimulationFindings.add(finding);
             }
           }
         }
 
-        List<FindingComposer.Composer> latestFindingWrappers = new ArrayList<>();
-        // add finished simulation to scenario with no findings (= all previous findings solved)
+        List<FindingComposer.Composer> atomicFindingWrappers = new ArrayList<>();
+        // add finished simulation to scenario with no findings
         attachSimulationToScenario(scenarioWrapper, ExerciseFixture.createFinishedAttackExercise());
 
         scenarioWrapper.persist();
@@ -547,14 +529,14 @@ class FindingApiTest extends IntegrationTest {
         for (int i = 0; i < 2; i++) {
           FindingComposer.Composer findingWrapper =
               findingComposer.forFinding(createDefaultTextFindingWithRandomValue());
-          latestFindingWrappers.add(findingWrapper);
+          atomicFindingWrappers.add(findingWrapper);
           injectComposer
               .forInject(InjectFixture.getDefaultInject())
               .withFinding(findingWrapper.withEndpoint(endpointWrapper))
               .persist();
         }
 
-        SearchPaginationInput input = PaginationFixture.getDefault().build();
+        SearchPaginationInput input = PaginationFixture.getDefault().size(500).build();
 
         entityManager.flush();
         entityManager.clear();
@@ -566,15 +548,14 @@ class FindingApiTest extends IntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
+        // findings of previous simulations remain visible even though the latest one has none
+        List<String> expectedFindingIds = new ArrayList<>();
+        previousSimulationFindings.forEach(finding -> expectedFindingIds.add(finding.getId()));
+        atomicFindingWrappers.forEach(wrapper -> expectedFindingIds.add(wrapper.get().getId()));
+
         List<RelatedFindingOutput> expectedFindings =
-            fromIterable(
-                    findingRepository.findAllById(
-                        latestFindingWrappers.stream()
-                            .map(wrapper -> wrapper.get().getId())
-                            .toList()))
-                .stream()
+            fromIterable(findingRepository.findAllById(expectedFindingIds)).stream()
                 .map(findingMapper::toRelatedFindingOutput)
-                .limit(input.getSize())
                 .toList();
 
         assertThatJson(response)
@@ -584,29 +565,30 @@ class FindingApiTest extends IntegrationTest {
       }
 
       @Test
-      @DisplayName("Returns all findings for latest finished simulations involving endpoint")
-      public void ReturnsAllFindingsForLatestFinishedSimulationsInvolvingEndpoint()
-          throws Exception {
+      @DisplayName("Returns findings from running simulations involving endpoint")
+      public void ReturnsFindingsFromRunningSimulationsInvolvingEndpoint() throws Exception {
         EndpointComposer.Composer endpointWrapper =
             endpointComposer.forEndpoint(EndpointFixture.createEndpoint()).persist();
         ScenarioComposer.Composer scenarioWrapper = getScenarioWithSimulationsWrapper();
 
         // hack findings to attach to endpoint
+        List<Finding> previousSimulationFindings = new ArrayList<>();
         for (Exercise ex : scenarioWrapper.get().getExercises()) {
           for (Inject inject : ex.getInjects()) {
             for (Finding finding : inject.getFindings()) {
               finding.setAssets(new ArrayList<>(List.of(endpointWrapper.get())));
+              previousSimulationFindings.add(finding);
             }
           }
         }
 
         List<FindingComposer.Composer> latestFindingWrappers = new ArrayList<>();
-        // add latest simulation to scenario
-        Hashtable<String, InjectComposer.Composer> latestSimulationInjectWrappers =
+        // add finished simulation to scenario
+        Hashtable<String, InjectComposer.Composer> finishedSimulationInjectWrappers =
             attachSimulationToScenario(
                 scenarioWrapper, ExerciseFixture.createFinishedAttackExercise());
         for (Map.Entry<String, InjectComposer.Composer> entry :
-            latestSimulationInjectWrappers.entrySet()) {
+            finishedSimulationInjectWrappers.entrySet()) {
           FindingComposer.Composer findingWrapper =
               findingComposer
                   .forFinding(createDefaultTextFindingWithRandomValue())
@@ -615,7 +597,19 @@ class FindingApiTest extends IntegrationTest {
           latestFindingWrappers.add(findingWrapper);
         }
 
-        attachSimulationToScenario(scenarioWrapper, ExerciseFixture.createRunningAttackExercise());
+        // add RUNNING simulation with findings - visible while still running
+        Hashtable<String, InjectComposer.Composer> runningSimulationInjectWrappers =
+            attachSimulationToScenario(
+                scenarioWrapper, ExerciseFixture.createRunningAttackExercise());
+        for (Map.Entry<String, InjectComposer.Composer> entry :
+            runningSimulationInjectWrappers.entrySet()) {
+          FindingComposer.Composer findingWrapper =
+              findingComposer
+                  .forFinding(createDefaultTextFindingWithRandomValue())
+                  .withEndpoint(endpointWrapper);
+          entry.getValue().withFinding(findingWrapper);
+          latestFindingWrappers.add(findingWrapper);
+        }
 
         scenarioWrapper.persist();
 
@@ -630,7 +624,7 @@ class FindingApiTest extends IntegrationTest {
               .persist();
         }
 
-        SearchPaginationInput input = PaginationFixture.getDefault().build();
+        SearchPaginationInput input = PaginationFixture.getDefault().size(500).build();
 
         entityManager.flush();
         entityManager.clear();
@@ -642,15 +636,14 @@ class FindingApiTest extends IntegrationTest {
                 .getResponse()
                 .getContentAsString();
 
+        // every finding involving the endpoint is visible, including the running simulation's
+        List<String> expectedFindingIds = new ArrayList<>();
+        previousSimulationFindings.forEach(finding -> expectedFindingIds.add(finding.getId()));
+        latestFindingWrappers.forEach(wrapper -> expectedFindingIds.add(wrapper.get().getId()));
+
         List<RelatedFindingOutput> expectedFindings =
-            fromIterable(
-                    findingRepository.findAllById(
-                        latestFindingWrappers.stream()
-                            .map(wrapper -> wrapper.get().getId())
-                            .toList()))
-                .stream()
+            fromIterable(findingRepository.findAllById(expectedFindingIds)).stream()
                 .map(findingMapper::toRelatedFindingOutput)
-                .limit(input.getSize())
                 .toList();
 
         assertThatJson(response)

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectServiceTest.java
@@ -141,8 +141,11 @@ class InjectServiceTest {
 
   @BeforeEach
   void setUp() {
-    mapper = new ObjectMapper();
+    // InjectStatusService serializes the inject (Instant / Optional fields) into the SSE
+    // BaseEvent payload on status transitions, so the mapper needs the JSR-310/JDK8 modules.
+    mapper = new ObjectMapper().findAndRegisterModules();
     ReflectionTestUtils.setField(injectService, "mapper", mapper);
+    ReflectionTestUtils.setField(injectStatusService, "mapper", mapper);
     ReflectionTestUtils.setField(
         injectService,
         "healthCheckUtils",

--- a/openaev-api/src/test/java/io/openaev/rest/inject_expectation/ExpectationsExpirationManagerServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject_expectation/ExpectationsExpirationManagerServiceTest.java
@@ -1,9 +1,13 @@
 package io.openaev.rest.inject_expectation;
 
+import static io.openaev.collectors.expectations_expiration_manager.config.ExpectationsExpirationManagerConfig.COLLECTOR_ID;
 import static io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegration.OPENAEV_INJECTOR_ID;
+import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAsset;
 import static io.openaev.utils.fixtures.ExpectationFixture.*;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.openaev.IntegrationTest;
 import io.openaev.collectors.expectations_expiration_manager.ExpectationsExpirationManagerJob;
@@ -13,12 +17,14 @@ import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
 import io.openaev.execution.ExecutableInject;
 import io.openaev.expectation.Expectation;
+import io.openaev.rest.inject.form.InjectExpectationUpdateInput;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.*;
@@ -41,6 +47,7 @@ public class ExpectationsExpirationManagerServiceTest extends IntegrationTest {
   @Autowired private InjectorRepository injectorRepository;
   @Autowired private InjectorContractRepository injectorContractRepository;
   @Autowired private InjectExpectationRepository injectExpectationRepository;
+  @Autowired private SecurityPlatformRepository securityPlatformRepository;
   @Autowired private InjectExpectationService injectExpectationService;
   @Autowired private ExpectationsExpirationManagerService expectationsExpirationManagerService;
   @Autowired private ExpectationsExpirationManagerJob expectationsExpirationManagerJob;
@@ -576,6 +583,172 @@ public class ExpectationsExpirationManagerServiceTest extends IntegrationTest {
       assertEquals(
           BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
           injectExpectations.getFirst().getResponse());
+    }
+
+    @Test
+    @DisplayName("A direct VULNERABLE verdict on the asset survives the agent expiration rollup")
+    void directVulnerableVerdictSurvivesAgentExpiration() {
+      // Regression: an assessment injector (e.g. Nuclei, agentless execution) wrote VULNERABLE
+      // directly on the asset-level expectation, while the agent-level children stayed untouched.
+      // When the expiration manager later expired the agents to the default "Not vulnerable", the
+      // children rollup overwrote the proven vulnerable verdict with "Not vulnerable / 100" and
+      // stamped a contradicting expiration result on the asset row.
+      ExecutableInject executableInject = newExecutableInjectWithTargets();
+      List<Expectation> expectations = new ArrayList<>();
+      expectations.add(
+          createTechnicalVulnerabilityExpectationForAgent(
+              savedAgent1, savedEndpoint, null, EXPIRATION_TIME_1_s, null));
+      expectations.add(
+          vulnerabilityExpectationForAsset(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedEndpoint,
+              null,
+              EXPIRATION_TIME_1_s));
+      injectExpectationService.buildAndSaveInjectExpectations(executableInject, expectations);
+
+      em.flush();
+      em.clear();
+
+      // The assessment injector answers the ASSET row directly: proven vulnerable
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      BaseInjectExpectation assetExpectation = assetExpectations.getFirst();
+      assetExpectation.setResults(
+          List.of(
+              InjectExpectationResult.builder()
+                  .sourceId("nuclei-security-platform")
+                  .sourceName("Nuclei")
+                  .sourceType("security-platform")
+                  .sourcePlatform(
+                      SecurityPlatform.SECURITY_PLATFORM_TYPE.VULNERABILITY_SCANNER.name())
+                  .result("Vulnerable")
+                  .sourceAssetId(UUID.randomUUID().toString())
+                  .score(0.0)
+                  .build()));
+      assetExpectation.setScore(0.0);
+      injectExpectationRepository.save(assetExpectation);
+
+      // -- EXECUTE --
+      expireExpectationsInDbByInjectId(savedInject.getId());
+      expectationsExpirationManagerService.computeExpectations(savedInject.getTenant().getId());
+
+      // -- ASSERT --
+      // Agent child: expired to the vulnerability default "Not vulnerable"
+      List<BaseInjectExpectation> agentExpectations =
+          injectExpectationRepository.findAllByInjectAndAgent(
+              savedInject.getId(), savedAgent1.getId());
+      assertEquals(100.0, agentExpectations.getFirst().getScore());
+      // Asset: the proven VULNERABLE verdict survives the children rollup
+      assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(0.0, assetExpectations.getFirst().getScore());
+      assertEquals(
+          BaseInjectExpectation.EXPECTATION_STATUS.FAILED,
+          assetExpectations.getFirst().getResponse());
+      // And no contradicting "Not vulnerable" expiration row was stamped on the asset
+      assertTrue(
+          assetExpectations.getFirst().getResults().stream()
+              .noneMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
+    }
+
+    @Test
+    @DisplayName("A direct NOT VULNERABLE verdict concludes the asset without waiting for expiry")
+    void directNotVulnerableVerdictConcludesImmediately() {
+      // Regression: a scanner assessing an endpoint that happens to run an agent answered "Not
+      // vulnerable" on the asset row, but the row deferred to its agent children - which an
+      // agentless injector never fills - and stayed PENDING until the expiration manager fired
+      // minutes later, contradicting the verdict already displayed on the row.
+      ExecutableInject executableInject = newExecutableInjectWithTargets();
+      List<Expectation> expectations = new ArrayList<>();
+      expectations.add(
+          createTechnicalVulnerabilityExpectationForAgent(
+              savedAgent1, savedEndpoint, null, EXPIRATION_TIME_1_s, null));
+      expectations.add(
+          vulnerabilityExpectationForAsset(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedEndpoint,
+              null,
+              EXPIRATION_TIME_1_s));
+      injectExpectationService.buildAndSaveInjectExpectations(executableInject, expectations);
+
+      em.flush();
+      em.clear();
+
+      SecurityPlatform nuclei =
+          securityPlatformRepository.save(
+              SecurityPlatformFixture.createDefault("Nuclei", "VULNERABILITY_SCANNER"));
+      String assetExpectationId =
+          injectExpectationRepository
+              .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
+              .getFirst()
+              .getId();
+
+      // -- EXECUTE --
+      // The scanner answers the ASSET row directly: nothing found.
+      InjectExpectationUpdateInput input = new InjectExpectationUpdateInput();
+      input.setIsSuccess(true);
+      input.setResult("Not vulnerable");
+      injectExpectationService.updateInjectExpectationFromSecurityPlatform(
+          assetExpectationId, input, nuclei);
+
+      em.flush();
+      em.clear();
+
+      // -- ASSERT --
+      // Asset: concluded straight away, no expiration manager run involved.
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(100.0, assetExpectations.getFirst().getScore());
+      assertEquals(
+          BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
+          assetExpectations.getFirst().getResponse());
+      // The agent child is untouched: the scanner knows nothing about agents.
+      List<BaseInjectExpectation> agentExpectations =
+          injectExpectationRepository.findAllByInjectAndAgent(
+              savedInject.getId(), savedAgent1.getId());
+      assertNull(agentExpectations.getFirst().getScore());
+    }
+
+    @Test
+    @DisplayName("An agentless vulnerability leaf expires to Not vulnerable, not to failed")
+    void agentlessVulnerabilityLeafExpiresToNotVulnerable() {
+      // For VULNERABILITY, silence means "nothing found": an agentless asset expectation that no
+      // scanner ever answered must expire to the success default (Not vulnerable), matching the
+      // agent-level expiration behavior - not to a failed "Vulnerable" verdict.
+      ExecutableInject executableInject = newExecutableInjectWithTargets();
+      Expectation expectation =
+          vulnerabilityExpectationForAsset(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedEndpoint,
+              null,
+              EXPIRATION_TIME_1_s);
+      injectExpectationService.buildAndSaveInjectExpectations(
+          executableInject, List.of(expectation));
+
+      em.flush();
+      em.clear();
+
+      // -- EXECUTE --
+      expireExpectationsInDbByInjectId(savedInject.getId());
+      expectationsExpirationManagerService.computeExpectations(savedInject.getTenant().getId());
+
+      // -- ASSERT --
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(100.0, assetExpectations.getFirst().getScore());
+      assertEquals(
+          BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
+          assetExpectations.getFirst().getResponse());
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTenantScopeTest.java
@@ -1,0 +1,178 @@
+package io.openaev.scheduler.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TenantContext;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Injection;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.ExerciseRepository;
+import io.openaev.database.repository.InjectDependenciesRepository;
+import io.openaev.database.repository.InjectExpectationRepository;
+import io.openaev.execution.ExecutableInject;
+import io.openaev.healthcheck.utils.HealthCheckUtils;
+import io.openaev.helper.InjectHelper;
+import io.openaev.rest.inject.service.InjectService;
+import io.openaev.rest.inject.service.InjectStatusService;
+import io.openaev.service.NotificationEventService;
+import io.openaev.service.PreviewFeatureService;
+import io.openaev.service.SecurityCoverageSendJobService;
+import io.openaev.service.chaining.WorkflowService;
+import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hibernate.Session;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Scheduled inject execution must carry the inject's tenant in BOTH scopes: the v2 primitive and
+ * the v1 thread-local {@link TenantContext}, which {@code HibernateFilterTransactionAspect} turns
+ * into the Hibernate {@code tenantFilter}.
+ *
+ * <p>Regression: only the primitive was set, so {@link TenantContext#getCurrentTenant()} fell back
+ * to the DEFAULT tenant on the executor thread. Everything the execution resolves through a
+ * Criteria query - asset groups, endpoints, agents - therefore came from the default tenant, and a
+ * customer simulation created its expectations against another tenant's endpoints while its own
+ * targets got none. Invisible in single-tenant deployments, where the fallback is the right tenant:
+ * these assertions are the guard, since a unit test can name the tenant the default is not.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Scheduled inject execution runs under the inject's tenant (v1 + v2 scopes)")
+class InjectsExecutionJobTenantScopeTest {
+
+  private static final String INJECT_TENANT = "11111111-2222-3333-4444-555555555555";
+
+  @Mock private InjectHelper injectHelper;
+  @Mock private InjectService injectService;
+  @Mock private ExerciseRepository exerciseRepository;
+  @Mock private InjectDependenciesRepository injectDependenciesRepository;
+  @Mock private InjectExpectationRepository injectExpectationRepository;
+  @Mock private InjectStatusService injectStatusService;
+  @Mock private io.openaev.executors.Executor executor;
+  @Mock private ActionMetricCollector actionMetricCollector;
+  @Mock private NotificationEventService notificationEventService;
+  @Mock private SecurityCoverageSendJobService securityCoverageSendJobService;
+  @Mock private EntityManager entityManager;
+  @Mock private TenantScopedTransaction tenantTx;
+  @Mock private PreviewFeatureService previewFeatureService;
+  @Mock private WorkflowService workflowService;
+  @Mock private HealthCheckUtils healthCheckUtils;
+
+  @InjectMocks private InjectsExecutionJob job;
+
+  /** The tenant the executor saw while the inject was running. */
+  private final AtomicReference<String> tenantDuringExecution = new AtomicReference<>();
+
+  /** The scope the v2 primitive was opened with. */
+  private final AtomicReference<TxCtx> primitiveScope = new AtomicReference<>();
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ReflectionTestUtils.setField(job, "injectExecutionThreshold", 15);
+    when(entityManager.unwrap(Session.class)).thenReturn(mock(Session.class));
+
+    // Every sweep around the execution is a no-op here: this test is about the execution scope.
+    when(exerciseRepository.findAllShouldBeInRunningState(any())).thenReturn(List.of());
+    when(exerciseRepository.thatMustBeFinished()).thenReturn(List.of());
+    doReturn(List.of()).when(exerciseRepository).saveAll(any());
+    when(previewFeatureService.isFeatureEnabled(any())).thenReturn(false);
+    when(injectService.getExecutedAndNotFinished()).thenReturn(List.of());
+    when(injectHelper.getAllPendingInjectsWithThresholdMinutes(anyInt())).thenReturn(List.of());
+    when(healthCheckUtils.runContentChecks(any(Inject.class))).thenReturn(List.of());
+
+    when(injectHelper.getInjectsToRun()).thenReturn(List.of(atomicInjectOfTenant(INJECT_TENANT)));
+
+    // Stand in for the real primitive: record the scope, run the work on this thread.
+    doAnswer(
+            invocation -> {
+              primitiveScope.set(invocation.getArgument(0));
+              invocation.getArgument(1, Runnable.class).run();
+              return null;
+            })
+        .when(tenantTx)
+        .execute(any(TxCtx.class), any(Runnable.class));
+
+    when(executor.execute(any()))
+        .thenAnswer(
+            invocation -> {
+              tenantDuringExecution.set(TenantContext.getCurrentTenant());
+              return null;
+            });
+  }
+
+  @AfterEach
+  void clearScope() {
+    TenantContext.clearCurrentTenant();
+  }
+
+  /** An atomic inject (no exercise) so the run needs no dependency or exercise bookkeeping. */
+  private static ExecutableInject atomicInjectOfTenant(String tenantId) {
+    Inject inject = new Inject();
+    inject.setId(UUID.randomUUID().toString());
+    inject.setTitle("Nuclei - CVE scan");
+    inject.setTenant(new Tenant(tenantId));
+
+    Injection injection = mock(Injection.class);
+    when(injection.getInject()).thenReturn(inject);
+    when(injection.getId()).thenReturn(inject.getId());
+    when(injection.getExercise()).thenReturn(null);
+
+    ExecutableInject executableInject = mock(ExecutableInject.class);
+    when(executableInject.getInjection()).thenReturn(injection);
+    when(executableInject.getExerciseId()).thenReturn(null);
+    return executableInject;
+  }
+
+  @Test
+  @DisplayName("the v1 tenant filter scope is the inject's tenant, never the default fallback")
+  void executionRunsUnderTheInjectTenant() throws Exception {
+    job.execute(null);
+
+    assertThat(tenantDuringExecution.get())
+        .as("asset groups, endpoints and agents must resolve in the inject's tenant")
+        .isEqualTo(INJECT_TENANT);
+    assertThat(tenantDuringExecution.get())
+        .as("the default-tenant fallback is exactly the cross-tenant bug being guarded against")
+        .isNotEqualTo(Tenant.DEFAULT_TENANT_UUID);
+  }
+
+  @Test
+  @DisplayName("the v2 primitive is opened on the same tenant")
+  void primitiveIsScopedToTheInjectTenant() throws Exception {
+    job.execute(null);
+
+    assertThat(primitiveScope.get()).isNotNull();
+    assertThat(primitiveScope.get().toGuc()).isEqualTo(INJECT_TENANT);
+  }
+
+  @Test
+  @DisplayName("the thread-local scope is restored once the inject is done")
+  void scopeDoesNotLeakOntoThePooledThread() throws Exception {
+    job.execute(null);
+
+    assertThat(TenantContext.hasCurrentTenant())
+        .as("the job borrows shared ForkJoinPool threads: it must leave no scope behind")
+        .isFalse();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTenantScopeTest.java
@@ -101,7 +101,10 @@ class InjectsExecutionJobTenantScopeTest {
     when(injectHelper.getAllPendingInjectsWithThresholdMinutes(anyInt())).thenReturn(List.of());
     when(healthCheckUtils.runContentChecks(any(Inject.class))).thenReturn(List.of());
 
-    when(injectHelper.getInjectsToRun()).thenReturn(List.of(atomicInjectOfTenant(INJECT_TENANT)));
+    // Built before the when(): the helper stubs its own mocks, and nesting that inside
+    // thenReturn(...) argument evaluation trips Mockito's unfinished-stubbing detection.
+    ExecutableInject injectToRun = atomicInjectOfTenant(INJECT_TENANT);
+    when(injectHelper.getInjectsToRun()).thenReturn(List.of(injectToRun));
 
     // Stand in for the real primitive: record the scope, run the work on this thread.
     doAnswer(
@@ -169,10 +172,25 @@ class InjectsExecutionJobTenantScopeTest {
   @Test
   @DisplayName("the thread-local scope is restored once the inject is done")
   void scopeDoesNotLeakOntoThePooledThread() throws Exception {
+    // The job borrows shared ForkJoinPool threads (including this caller): a scope the thread
+    // carried before the sweep must survive it (restore semantics, not a blanket clear). Note
+    // DefaultTenantExtension pre-sets the default tenant on every test thread, so "starts empty"
+    // is not a premise this suite can rely on.
+    String preexistingScope = "99999999-8888-7777-6666-555555555555";
+    TenantContext.setCurrentTenant(preexistingScope);
+
     job.execute(null);
 
-    assertThat(TenantContext.hasCurrentTenant())
-        .as("the job borrows shared ForkJoinPool threads: it must leave no scope behind")
-        .isFalse();
+    assertThat(TenantContext.hasCurrentTenant() ? TenantContext.getCurrentTenant() : null)
+        .as("the pre-existing scope of the borrowed thread must be restored, not overwritten")
+        .isEqualTo(preexistingScope);
+
+    // And a thread that had no scope at all must end with none.
+    TenantContext.clearCurrentTenant();
+    job.execute(null);
+
+    assertThat(TenantContext.hasCurrentTenant() ? TenantContext.getCurrentTenant() : null)
+        .as("a scope-less thread must leave the sweep scope-less")
+        .isNull();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -444,6 +444,38 @@ class InjectExpectationServiceTest {
 
   @Test
   @DisplayName(
+      "Reset/relaunch fallback: an explicit empty expectations list is respected, never overridden")
+  void given_contentWithExplicitlyEmptyExpectations_should_notFallBackToContractExpectations()
+      throws Exception {
+    // The user deliberately removed every expectation from the inject: the stored content carries
+    // an explicit empty "expectations" array (that is what the inject form persists on removal).
+    // Execution must respect that customization instead of forcing the contract's predefined
+    // expectations back on every launch - drift realignment is the opt-in way to restore them.
+    ObjectNode storedContent = mapper.createObjectNode();
+    storedContent.putArray("expectations");
+    inject.setContent(storedContent);
+    inject.setInjectorContract(mock(InjectorContract.class));
+
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    endpoint.setId("asset-id");
+    endpoint.setAgents(List.of());
+
+    ExecutableInject executableInject = mock(ExecutableInject.class);
+    Injection injection = mock(Injection.class);
+    when(executableInject.getInjection()).thenReturn(injection);
+    when(injection.getInject()).thenReturn(inject);
+    when(executableInject.getAssetGroups()).thenReturn(List.of());
+
+    injectExpectationService.computeAndSaveExpectations(
+        executableInject, inject, "implant", List.of(new AssetToExecute(endpoint)));
+
+    // No contract fallback and no expectation persisted: the empty list is the user's choice.
+    verify(injectorContractContentUtils, never()).setExpectations(any(), any());
+    verify(injectExpectationRepository, never()).saveAll(any());
+  }
+
+  @Test
+  @DisplayName(
       "Should create one asset group expectation per supported type when at least one asset matches")
   void given_matchingAssetExpectations_should_createAssetGroupExpectationsForAllSupportedTypes()
       throws Exception {

--- a/openaev-front/src/admin/components/assets/asset/AssetDetail.tsx
+++ b/openaev-front/src/admin/components/assets/asset/AssetDetail.tsx
@@ -26,7 +26,6 @@ import Loader from '../../../../components/Loader';
 import PlatformIcon from '../../../../components/PlatformIcon';
 import { useHelper } from '../../../../store';
 import {
-  type AssetGroupSimple,
   type EndpointOverviewOutput,
   type InjectResultOutput,
   type SearchPaginationInput,
@@ -57,7 +56,6 @@ type AssetOverview = EndpointOverviewOutput & {
   ai_target_endpoint?: string;
   ai_target_model?: string;
   ai_target_system_prompt?: string;
-  asset_asset_groups?: AssetGroupSimple[];
 };
 
 const AssetDetail = () => {

--- a/openaev-front/src/admin/components/assets/asset/AssetDetail.tsx
+++ b/openaev-front/src/admin/components/assets/asset/AssetDetail.tsx
@@ -1,7 +1,7 @@
 import { DevicesOtherOutlined, TrackChangesOutlined } from '@mui/icons-material';
-import { Alert, AlertTitle, Box, Typography } from '@mui/material';
+import { Alert, AlertTitle, Box, Chip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { Binoculars } from 'mdi-material-ui';
+import { Binoculars, SelectGroup } from 'mdi-material-ui';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -26,6 +26,7 @@ import Loader from '../../../../components/Loader';
 import PlatformIcon from '../../../../components/PlatformIcon';
 import { useHelper } from '../../../../store';
 import {
+  type AssetGroupSimple,
   type EndpointOverviewOutput,
   type InjectResultOutput,
   type SearchPaginationInput,
@@ -56,6 +57,7 @@ type AssetOverview = EndpointOverviewOutput & {
   ai_target_endpoint?: string;
   ai_target_model?: string;
   ai_target_system_prompt?: string;
+  asset_asset_groups?: AssetGroupSimple[];
 };
 
 const AssetDetail = () => {
@@ -250,9 +252,12 @@ const AssetDetail = () => {
 
       {currentTab === 'overview' && (
         <>
-          {/* Information + the asset-kind-specific card side by side for a compact,
-          grid-based overview (Network / Cloud / AI target as the second column). */}
-          <DetailSections>
+          {/* Information + the asset-kind-specific card + asset groups side by side for a
+          compact, grid-based overview (Network / Cloud / AI target as the second column).
+          For the standard host layout (information + network + groups) the row uses an
+          explicit 40/40/20 split: the groups column only carries chips and does not need
+          an equal share. Other asset kinds keep the adaptive equal columns. */}
+          <DetailSections columns={!isAiTarget && hasNetwork && !hasCloud ? '2fr 2fr 1fr' : undefined}>
             <InformationGrid title={t('Asset Information')}>
               <Field label={t('Description')}>
                 {asset.asset_description
@@ -358,6 +363,37 @@ const AssetDetail = () => {
                 )}
               </InformationGrid>
             )}
+
+            {/* Groups the asset belongs to, whether by static membership or by matching a
+            dynamic group filter (the backend resolves both). Chips link to the group page. */}
+            <SectionBlock title={t('Asset groups')}>
+              {asset.asset_asset_groups && asset.asset_asset_groups.length > 0
+                ? (
+                    <Box sx={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 1,
+                      alignContent: 'start',
+                    }}
+                    >
+                      {asset.asset_asset_groups.map(assetGroup => (
+                        <Chip
+                          key={assetGroup.asset_group_id}
+                          icon={<SelectGroup fontSize="small" />}
+                          label={assetGroup.asset_group_name}
+                          size="small"
+                          variant="outlined"
+                          onClick={() => navigate(`/admin/asset_groups/${assetGroup.asset_group_id}`)}
+                        />
+                      ))}
+                    </Box>
+                  )
+                : (
+                    <Typography variant="body2" color="text.secondary">
+                      {t('No asset group')}
+                    </Typography>
+                  )}
+            </SectionBlock>
           </DetailSections>
 
           {hasAgents && (

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/AtomicTesting.tsx
@@ -50,6 +50,28 @@ type TabConfig = {
   entityPrefix: string;
 };
 
+// The Targets tab the user last opened, remembered per inject. An atomic testing IS an inject, and
+// this screen serves both, so keying on the inject id scopes the memory to a single atomic testing
+// or a single simulation inject - opening another one never inherits the tab. First visit has
+// nothing stored and lands on the first (broadest) tab; every later visit or reload reopens where
+// the user left off. Same per-inject key shape as the target filters stored next to it
+// (`${targetType}_${injectId}_filters` in PaginatedTargetTab).
+const targetTabStorageKey = (injectId: string) => `${injectId}_target_tab`;
+
+const readStoredTargetTab = (injectId: string): string | null => {
+  if (!injectId || typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage.getItem(targetTabStorageKey(injectId));
+};
+
+const storeTargetTab = (injectId: string, targetType: string) => {
+  if (!injectId || typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(targetTabStorageKey(injectId), targetType);
+};
+
 const AtomicTesting = () => {
   // Standard hooks
   const { classes } = useStyles();
@@ -79,6 +101,7 @@ const AtomicTesting = () => {
   // Initial tab open
   const [searchParams, setSearchParams] = useSearchParams();
   const targetType = searchParams.get('target');
+  const injectId = injectResultOverviewOutput?.inject_id || '';
 
   const navigateToTab = (tab: TabConfig | undefined) => {
     setActiveTab(tab);
@@ -153,32 +176,40 @@ const AtomicTesting = () => {
     }
 
     // tabs visibility may have changed so we reevaluate this structure;
-    // figure out which tab to display; if the previously displayed tab
-    // is still available, keep it up
-    // otherwise default to the first occurring tab (the broadest scope:
-    // asset groups, then teams, then assets, ...)
+    // figure out which tab to display, in order of precedence: an explicit
+    // ?target= deep link, the tab already open, the tab this inject was last
+    // left on, and finally the first occurring tab (the broadest scope: asset
+    // groups, then teams, then assets, ...) on a first visit.
     if (tabs.length === 0) {
       navigateToTab(undefined);
+      return tabs;
     }
 
-    if (targetType != null && tabs.map(conf => conf.type).includes(targetType)) {
+    const availableTypes = tabs.map(conf => conf.type);
+    if (targetType != null && availableTypes.includes(targetType)) {
       navigateToTab(tabs.find(tc => targetType === tc.type));
+      // The deep link is consumed from the URL, so remember it: a reload must
+      // land on the tab the user is looking at, not back on the first one.
+      storeTargetTab(injectId, targetType);
       searchParams.delete('target');
       setSearchParams(searchParams, { replace: true });
-    } else if (activeTab && tabs.map(conf => conf.type).includes(activeTab.type)) {
-      navigateToTab(tabs.find(tc => activeTab.type === tc.type));
-    } else {
-      navigateToTab(tabs[0]);
+      return tabs;
     }
+    if (activeTab && availableTypes.includes(activeTab.type)) {
+      navigateToTab(tabs.find(tc => activeTab.type === tc.type));
+      return tabs;
+    }
+    const storedType = readStoredTargetTab(injectId);
+    // A stored tab that no longer exists on this inject (targets changed since)
+    // falls back to the first one instead of leaving the pane empty.
+    navigateToTab(tabs.find(tc => tc.type === storedType) ?? tabs[0]);
 
     return tabs;
-  }, [hasAssetsGroup, hasTeams, hasEndpoints, hasAgents, hasPlayers, hasAiTargets, allTargetsChecked]);
+  }, [hasAssetsGroup, hasTeams, hasEndpoints, hasAgents, hasPlayers, hasAiTargets, allTargetsChecked, injectId]);
 
   const activeTabKey: number = useMemo(() => {
     return activeTab?.key || 0;
   }, [activeTab]);
-
-  const injectId = injectResultOverviewOutput?.inject_id || '';
 
   useEffect(() => {
     if (!injectResultOverviewOutput) return;
@@ -282,6 +313,9 @@ const AtomicTesting = () => {
   const handleTabChange = (_event: SyntheticEvent, newValue: number) => {
     const location = tabConfig.find(tc => newValue == tc.key);
     navigateToTab(location);
+    if (location) {
+      storeTargetTab(injectId, location.type);
+    }
   };
 
   const drawTabs = () => {

--- a/openaev-front/src/admin/components/settings/TaxonomiesMenu.tsx
+++ b/openaev-front/src/admin/components/settings/TaxonomiesMenu.tsx
@@ -1,4 +1,4 @@
-import { ReportProblemOutlined, RouteOutlined, StyleOutlined } from '@mui/icons-material';
+import { BugReportOutlined, RouteOutlined, StyleOutlined } from '@mui/icons-material';
 import { LockPattern } from 'mdi-material-ui';
 import { type FunctionComponent, memo } from 'react';
 
@@ -23,7 +23,7 @@ const TaxonomiesMenuComponent: FunctionComponent = () => {
     },
     {
       path: '/admin/settings/taxonomies/vulnerabilities',
-      icon: () => (<ReportProblemOutlined />),
+      icon: () => (<BugReportOutlined />),
       label: 'Vulnerabilities',
     },
   ];

--- a/openaev-front/src/admin/components/settings/vulnerabilities/GeneralVulnerabilityInfoTab.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/GeneralVulnerabilityInfoTab.tsx
@@ -1,10 +1,13 @@
-import { Divider, List, ListItem, Stack, Typography } from '@mui/material';
+import { GppMaybeOutlined, LaunchOutlined } from '@mui/icons-material';
+import { Alert, Box, Chip, Link, List, ListItem, ListItemIcon, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
+import { Field, InformationGrid, Section, SectionBlock } from '../../../../components/common/detail/EntityDetailCommon';
 import CVSSBadge from '../../../../components/CvssBadge';
 import { useFormatter } from '../../../../components/i18n';
 import type { CweOutput, VulnerabilityOutput } from '../../../../utils/api-types';
 import { emptyFilled } from '../../../../utils/String';
+import { humanizeEnum } from '../../assets/asset-categories';
 
 interface Props { vulnerability: VulnerabilityOutput }
 
@@ -12,104 +15,135 @@ const GeneralVulnerabilityInfoTab = ({ vulnerability }: Props) => {
   const { fldt, t } = useFormatter();
   const theme = useTheme();
 
+  const isKev = !!(
+    vulnerability?.vulnerability_cisa_vulnerability_name
+    || vulnerability?.vulnerability_cisa_exploit_add
+    || vulnerability?.vulnerability_cisa_action_due
+    || vulnerability?.vulnerability_cisa_required_action
+  );
+
   return (
-    <div style={{ padding: theme.spacing(2, 1, 0, 0) }}>
-      {/* VULNERABILITY ID */}
-      <Typography variant="subtitle2" gutterBottom>
-        {emptyFilled(vulnerability?.vulnerability_external_id)}
-      </Typography>
+    <Box sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 2,
+      marginTop: 2,
+    }}
+    >
+      {/* Known-exploited banner: the single most actionable signal, so it leads. */}
+      {isKev && (
+        <Alert severity="warning" variant="outlined" icon={<GppMaybeOutlined />}>
+          {t('This vulnerability is listed in CISA\'s Known Exploited Vulnerabilities catalog.')}
+        </Alert>
+      )}
+
+      {/* Information */}
+      <InformationGrid title={t('Information')}>
+        <Field label={t('CVSS Version 3.1')}>
+          <CVSSBadge score={vulnerability?.vulnerability_cvss_v31} />
+        </Field>
+        <Field label={t('Status')}>
+          {vulnerability?.vulnerability_vuln_status
+            ? (
+                <Chip
+                  size="small"
+                  variant="outlined"
+                  sx={{ borderRadius: 1 }}
+                  label={t(humanizeEnum(vulnerability.vulnerability_vuln_status))}
+                />
+              )
+            : '-'}
+        </Field>
+        <Field label={t('Published')}>{fldt(vulnerability?.vulnerability_published)}</Field>
+        <Field label={t('Source')}>{emptyFilled(vulnerability?.vulnerability_source_identifier)}</Field>
+      </InformationGrid>
 
       {/* Description */}
-      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        {t('Description')}
-      </Typography>
-      <Typography variant="body2">
-        {emptyFilled(vulnerability?.vulnerability_description)}
-      </Typography>
-      <Divider sx={{ my: theme.spacing(2) }} />
+      <Section title={t('Description')}>
+        <Typography
+          variant="body2"
+          sx={{
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {emptyFilled(vulnerability?.vulnerability_description)}
+        </Typography>
+      </Section>
 
-      {/* Quick Info */}
-      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        {t('Quick Info')}
-      </Typography>
-      <Stack spacing={1}>
-        <Typography variant="body2">
-          <strong>{`${t('Published')}: `}</strong>
-          {fldt(vulnerability?.vulnerability_published)}
-        </Typography>
-        <Typography variant="body2">
-          <strong>{`${t('Source')}: `}</strong>
-          {emptyFilled(vulnerability?.vulnerability_source_identifier)}
-        </Typography>
-      </Stack>
-      <Divider sx={{ my: theme.spacing(2) }} />
-
-      {/* Metrics */}
-      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        {t('Metrics Version 3.1')}
-      </Typography>
-      {vulnerability?.vulnerability_cvss_v31 && <CVSSBadge score={vulnerability?.vulnerability_cvss_v31} />}
-      <Divider sx={{ my: theme.spacing(2) }} />
-
-      {/* References */}
-      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        {t('References to Advisories, Solutions, and Tools')}
-      </Typography>
-      <List dense>
-        {vulnerability?.vulnerability_reference_urls?.length ? (
-          vulnerability.vulnerability_reference_urls.map((url, index) => (
-            <ListItem key={index}>
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                {url}
-              </a>
-            </ListItem>
-          ))
-        ) : (
-          <ListItem>{t('No references available.')}</ListItem>
-        )}
-      </List>
-      <Divider sx={{ my: theme.spacing(2) }} />
-
-      {/* CISA */}
-      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        {t('CISA\'s Known Exploited Vulnerabilities Catalog')}
-      </Typography>
-      <Stack spacing={1}>
-        <Typography variant="body2">
-          <strong>{`${t('Vulnerability Name')}: `}</strong>
-          {emptyFilled(vulnerability?.vulnerability_cisa_vulnerability_name)}
-        </Typography>
-        <Typography variant="body2">
-          <strong>{`${t('Date Added')}: `}</strong>
-          {fldt(vulnerability?.vulnerability_cisa_exploit_add)}
-        </Typography>
-        <Typography variant="body2">
-          <strong>{`${t('Due Date')}: `}</strong>
-          {fldt(vulnerability?.vulnerability_cisa_action_due)}
-        </Typography>
-        <Typography variant="body2">
-          <strong>{`${t('Required Action')}: `}</strong>
-          {emptyFilled(vulnerability?.vulnerability_cisa_required_action)}
-        </Typography>
-      </Stack>
-      <Divider sx={{ my: theme.spacing(2) }} />
+      {/* CISA KEV details */}
+      {isKev && (
+        <InformationGrid title={t('CISA\'s Known Exploited Vulnerabilities Catalog')}>
+          <Field label={t('Vulnerability Name')}>{emptyFilled(vulnerability?.vulnerability_cisa_vulnerability_name)}</Field>
+          <Field label={t('Date Added')}>{fldt(vulnerability?.vulnerability_cisa_exploit_add)}</Field>
+          <Field label={t('Due Date')}>{fldt(vulnerability?.vulnerability_cisa_action_due)}</Field>
+          <Field label={t('Required Action')}>{emptyFilled(vulnerability?.vulnerability_cisa_required_action)}</Field>
+        </InformationGrid>
+      )}
 
       {/* CWE */}
-      <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
-        {t('Weakness Enumeration')}
-      </Typography>
-      <Stack spacing={1}>
-        {vulnerability?.vulnerability_cwes?.length ? (
-          vulnerability.vulnerability_cwes.map((cwe: CweOutput) => (
-            <Typography key={cwe.cwe_external_id} variant="body2">
-              {cwe.cwe_external_id}
-            </Typography>
-          ))
-        ) : (
-          <Typography variant="body2">{t('No CWEs listed.')}</Typography>
-        )}
-      </Stack>
-    </div>
+      <SectionBlock title={t('Weakness Enumeration')}>
+        {vulnerability?.vulnerability_cwes?.length
+          ? (
+              <Box sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 1,
+              }}
+              >
+                {vulnerability.vulnerability_cwes.map((cwe: CweOutput) => (
+                  <Chip
+                    key={cwe.cwe_external_id}
+                    size="small"
+                    variant="outlined"
+                    color="primary"
+                    sx={{ borderRadius: 1 }}
+                    label={cwe.cwe_source ? `${cwe.cwe_external_id} (${cwe.cwe_source})` : cwe.cwe_external_id}
+                  />
+                ))}
+              </Box>
+            )
+          : (
+              <Typography variant="body2" color="textSecondary">
+                {t('No CWEs listed.')}
+              </Typography>
+            )}
+      </SectionBlock>
+
+      {/* References */}
+      <SectionBlock title={t('References to Advisories, Solutions, and Tools')} disablePadding={!!vulnerability?.vulnerability_reference_urls?.length}>
+        {vulnerability?.vulnerability_reference_urls?.length
+          ? (
+              <List dense disablePadding>
+                {vulnerability.vulnerability_reference_urls.map(url => (
+                  <ListItem
+                    key={url}
+                    divider
+                    sx={{ padding: theme.spacing(0.75, 2) }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 30 }}>
+                      <LaunchOutlined fontSize="small" color="primary" />
+                    </ListItemIcon>
+                    <Link
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      variant="body2"
+                      sx={{ wordBreak: 'break-all' }}
+                    >
+                      {url}
+                    </Link>
+                  </ListItem>
+                ))}
+              </List>
+            )
+          : (
+              <Typography variant="body2" color="textSecondary">
+                {t('No references available.')}
+              </Typography>
+            )}
+      </SectionBlock>
+    </Box>
   );
 };
 

--- a/openaev-front/src/admin/components/settings/vulnerabilities/RemediationInfoTab.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/RemediationInfoTab.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { Alert, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
 import { useFormatter } from '../../../../components/i18n';
@@ -10,16 +10,27 @@ const RemediationInfoTab = ({ vulnerability }: Props) => {
   const { t } = useFormatter();
   const theme = useTheme();
 
+  const remediation = vulnerability?.vulnerability_remediation;
+
+  if (!remediation) {
+    return (
+      <Alert severity="info" variant="outlined" style={{ marginTop: theme.spacing(2) }}>
+        {t('There is no information yet on a vulnerability remediation for this vulnerability.')}
+      </Alert>
+    );
+  }
+
   return (
     <div style={{ padding: theme.spacing(2, 1, 0, 0) }}>
-      <Typography variant="subtitle2" gutterBottom>
-        {t('Vulnerability Remediation')}
+      <Typography
+        variant="body2"
+        sx={{
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {remediation}
       </Typography>
-      <pre>
-        <Typography variant="body2" gutterBottom>
-          {vulnerability?.vulnerability_remediation ?? t('There is no information yet on a vulnerability remediation for this vulnerability.')}
-        </Typography>
-      </pre>
     </div>
   );
 };

--- a/openaev-front/src/admin/components/settings/vulnerabilities/RemediationInfoTab.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/RemediationInfoTab.tsx
@@ -14,7 +14,7 @@ const RemediationInfoTab = ({ vulnerability }: Props) => {
 
   if (!remediation) {
     return (
-      <Alert severity="info" variant="outlined" style={{ marginTop: theme.spacing(2) }}>
+      <Alert severity="info" variant="outlined" sx={{ marginTop: 2 }}>
         {t('There is no information yet on a vulnerability remediation for this vulnerability.')}
       </Alert>
     );

--- a/openaev-front/src/admin/components/settings/vulnerabilities/TabLabelWithEE.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/TabLabelWithEE.tsx
@@ -11,8 +11,19 @@ const TabLabelWithEE = ({ label }: { label: string }) => {
   const { t } = useFormatter();
 
   return (
-    <Box display="flex" alignItems="center">
-      {label}
+    <Box component="span" display="inline-flex" alignItems="center">
+      {/* The theme's MuiTab override lowercases the label and re-capitalizes it
+          with ::first-letter - a rule that does not apply to flex containers.
+          Keeping the text in an inline-block span restores the capital letter. */}
+      <Box
+        component="span"
+        sx={{
+          'display': 'inline-block',
+          '&::first-letter': { textTransform: 'uppercase' },
+        }}
+      >
+        {label}
+      </Box>
       {!isEE && (
         <EEChip
           style={{ marginLeft: theme.spacing(1) }}

--- a/openaev-front/src/admin/components/settings/vulnerabilities/Vulnerabilities.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/Vulnerabilities.tsx
@@ -1,4 +1,4 @@
-import { HubOutlined, ReportProblemOutlined } from '@mui/icons-material';
+import { BugReportOutlined } from '@mui/icons-material';
 import { List, ListItem, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import { type CSSProperties, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
@@ -75,7 +75,7 @@ const Vulnerabilities = () => {
       label: 'CVSS',
       isSortable: true,
       value: (vulnerability: VulnerabilitySimple) => (
-        <CVSSBadge score={vulnerability.vulnerability_cvss_v31}></CVSSBadge>
+        <CVSSBadge score={vulnerability.vulnerability_cvss_v31} variant="inList" />
       ),
     },
     {
@@ -129,7 +129,7 @@ const Vulnerabilities = () => {
             />
           </ListItem>
 
-          {loading ? <PaginatedListLoader Icon={HubOutlined} headers={headers} headerStyles={inlineStyles} /> : vulnerabilities.map(vulnerability => (
+          {loading ? <PaginatedListLoader Icon={BugReportOutlined} headers={headers} headerStyles={inlineStyles} /> : vulnerabilities.map(vulnerability => (
             <ListItem
               key={vulnerability.vulnerability_id}
               divider
@@ -147,7 +147,7 @@ const Vulnerabilities = () => {
                 onClick={() => setSelectedVulnerability(vulnerability)}
               >
                 <ListItemIcon>
-                  <ReportProblemOutlined />
+                  <BugReportOutlined color="primary" />
                 </ListItemIcon>
                 <ListItemText
                   primary={(
@@ -174,8 +174,8 @@ const Vulnerabilities = () => {
           open={!!selectedVulnerability}
           handleClose={() => setSelectedVulnerability(null)}
           title={selectedVulnerability?.vulnerability_external_id ?? ''}
-          additionalTitle={selectedVulnerability?.vulnerability_cvss_v31 ? 'CVSS' : undefined}
-          additionalChipLabel={selectedVulnerability?.vulnerability_cvss_v31.toFixed(1)}
+          additionalTitle={selectedVulnerability?.vulnerability_cvss_v31 != null ? 'CVSS' : undefined}
+          additionalChipLabel={selectedVulnerability?.vulnerability_cvss_v31?.toFixed(1)}
         >
           {selectedVulnerability && (
             <VulnerabilityDetail

--- a/openaev-front/src/admin/components/settings/vulnerabilities/VulnerabilityTabPanel.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/VulnerabilityTabPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material';
+import { Alert } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
 import { useFormatter } from '../../../../components/i18n';
@@ -21,11 +21,9 @@ const VulnerabilityTabPanel = ({ status, vulnerability, children }: CveTabPanelP
       return <Loader />;
     case 'notAvailable':
       return (
-        <Box padding={theme.spacing(2, 1, 0, 0)}>
-          <Typography variant="body2" gutterBottom>
-            {t('There is no information about this vulnerability yet.')}
-          </Typography>
-        </Box>
+        <Alert severity="info" variant="outlined" style={{ marginTop: theme.spacing(2) }}>
+          {t('There is no information about this vulnerability yet.')}
+        </Alert>
       );
     case 'loaded':
       return vulnerability ? <>{children}</> : null;

--- a/openaev-front/src/admin/components/settings/vulnerabilities/VulnerabilityTabPanel.tsx
+++ b/openaev-front/src/admin/components/settings/vulnerabilities/VulnerabilityTabPanel.tsx
@@ -1,5 +1,4 @@
 import { Alert } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
 
 import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
@@ -13,7 +12,6 @@ interface CveTabPanelProps {
 }
 
 const VulnerabilityTabPanel = ({ status, vulnerability, children }: CveTabPanelProps) => {
-  const theme = useTheme();
   const { t } = useFormatter();
 
   switch (status) {
@@ -21,7 +19,7 @@ const VulnerabilityTabPanel = ({ status, vulnerability, children }: CveTabPanelP
       return <Loader />;
     case 'notAvailable':
       return (
-        <Alert severity="info" variant="outlined" style={{ marginTop: theme.spacing(2) }}>
+        <Alert severity="info" variant="outlined" sx={{ marginTop: 2 }}>
           {t('There is no information about this vulnerability yet.')}
         </Alert>
       );

--- a/openaev-front/src/components/CvssBadge.tsx
+++ b/openaev-front/src/components/CvssBadge.tsx
@@ -1,21 +1,64 @@
-import type React from 'react';
+import { Chip, Tooltip } from '@mui/material';
+import { type FunctionComponent } from 'react';
+import { makeStyles } from 'tss-react/mui';
 
-import { getSeverityAndColor } from '../utils/Colors';
+import { getSeverityAndColor, hexToRGB } from '../utils/Colors';
 import { useFormatter } from './i18n';
 
-interface CvssBadgeProps { score: number }
+const useStyles = makeStyles()(() => ({
+  chip: {
+    fontSize: 12,
+    height: 25,
+    textTransform: 'uppercase',
+    borderRadius: 4,
+    width: 120,
+  },
+  chipInList: {
+    fontSize: 12,
+    height: 20,
+    float: 'left',
+    textTransform: 'uppercase',
+    borderRadius: 4,
+    width: 120,
+  },
+}));
 
-const CVSSBadge: React.FC<CvssBadgeProps> = ({ score }) => {
+// Severity enum -> translatable label (the chip style uppercases it visually).
+const SEVERITY_LABELS: Record<string, string> = {
+  CRITICAL: 'Critical',
+  HIGH: 'High',
+  MEDIUM: 'Medium',
+  LOW: 'Low',
+  NONE: 'None',
+};
+
+interface CvssBadgeProps {
+  score: number | null | undefined;
+  variant?: 'inList';
+}
+
+// CVSS score rendered as a design-system severity chip (same geometry and
+// tinted palette as ItemSeverity / ItemCriticality): "9.8 CRITICAL".
+const CVSSBadge: FunctionComponent<CvssBadgeProps> = ({ score, variant }) => {
   const { t } = useFormatter();
-  const { severity, color } = getSeverityAndColor(score);
+  const { classes } = useStyles();
 
+  if (score == null) {
+    return <>-</>;
+  }
+
+  const { severity, color } = getSeverityAndColor(score);
   return (
-    <span
-      style={{ color: color }}
-      title={t(`CVSS Score: ${score}`)}
-    >
-      {`${score.toFixed(1)} ${severity}`}
-    </span>
+    <Tooltip title={`${t('CVSS score')}: ${score.toFixed(1)}`}>
+      <Chip
+        classes={{ root: variant === 'inList' ? classes.chipInList : classes.chip }}
+        style={{
+          backgroundColor: hexToRGB(color, 0.08),
+          color,
+        }}
+        label={`${score.toFixed(1)} ${t(SEVERITY_LABELS[severity])}`}
+      />
+    </Tooltip>
   );
 };
 

--- a/openaev-front/src/components/CvssBadge.tsx
+++ b/openaev-front/src/components/CvssBadge.tsx
@@ -52,7 +52,7 @@ const CVSSBadge: FunctionComponent<CvssBadgeProps> = ({ score, variant }) => {
     <Tooltip title={`${t('CVSS score')}: ${score.toFixed(1)}`}>
       <Chip
         classes={{ root: variant === 'inList' ? classes.chipInList : classes.chip }}
-        style={{
+        sx={{
           backgroundColor: hexToRGB(color, 0.08),
           color,
         }}

--- a/openaev-front/src/components/FindingIcon.tsx
+++ b/openaev-front/src/components/FindingIcon.tsx
@@ -1,4 +1,4 @@
-import { InsertDriveFileOutlined, ReportProblemOutlined } from '@mui/icons-material';
+import { BugReportOutlined, InsertDriveFileOutlined } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 import {
   AccountAlertOutline,
@@ -40,8 +40,9 @@ const renderIcon = (findingType: string) => {
       return <IpOutline color="primary" />;
     case 'credentials':
       return <KeyOutline color="primary" />;
+    case 'cve':
     case 'vulnerability':
-      return <ReportProblemOutlined color="primary" />;
+      return <BugReportOutlined color="primary" />;
     case 'username':
     case 'admin_username':
       return <AccountOutline color="primary" />;

--- a/openaev-front/src/components/common/detail/EntityDetailCommon.tsx
+++ b/openaev-front/src/components/common/detail/EntityDetailCommon.tsx
@@ -108,11 +108,22 @@ export const InformationGrid = ({ title, action, children }: {
 
 // Lays the related-entity sections in an adaptive multi-column grid: two (or
 // more) sections sit side by side on wide screens, while a lone section spans
-// the full width (auto-fit collapses the empty track).
-export const DetailSections = ({ children }: { children: ReactNode }) => (
+// the full width (auto-fit collapses the empty track). An explicit `columns`
+// template (e.g. '2fr 2fr 1fr') overrides the equal split on large screens
+// when the sections have known, unequal content densities; smaller screens
+// keep the adaptive wrap.
+export const DetailSections = ({ children, columns }: {
+  children: ReactNode;
+  columns?: string;
+}) => (
   <Box sx={{
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))',
+    gridTemplateColumns: columns
+      ? {
+          xs: 'repeat(auto-fit, minmax(340px, 1fr))',
+          lg: columns,
+        }
+      : 'repeat(auto-fit, minmax(340px, 1fr))',
     gap: 2,
     alignItems: 'stretch',
   }}

--- a/openaev-front/src/utils/Colors.ts
+++ b/openaev-front/src/utils/Colors.ts
@@ -40,36 +40,37 @@ export interface SeverityAndColor {
   color: string;
 }
 
-// CVSS
+// CVSS - hex colors aligned with the severity chip palette used across the app
+// (see ItemSeverity / ItemCriticality) so CVSS reads the same everywhere.
 export const getSeverityAndColor = (score: number | string | null | undefined): SeverityAndColor => {
   const numScore = typeof score === 'string' ? parseFloat(score) : (score ?? 0);
 
   if (numScore >= 9.0) {
     return {
       severity: 'CRITICAL',
-      color: 'red',
+      color: '#f44336',
     };
   }
   if (numScore >= 7.0) {
     return {
       severity: 'HIGH',
-      color: 'orangered',
+      color: '#ff9800',
     };
   }
   if (numScore >= 4.0) {
     return {
       severity: 'MEDIUM',
-      color: 'orange',
+      color: '#5c7bf5',
     };
   }
   if (numScore > 0.0) {
     return {
       severity: 'LOW',
-      color: 'green',
+      color: '#4caf50',
     };
   }
   return {
     severity: 'NONE',
-    color: 'gray',
+    color: '#607d8b',
   };
 };

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -3282,6 +3282,8 @@ export interface EndpointOverviewOutput {
    * @uniqueItems true
    */
   asset_agents: AgentOutput[];
+  /** Asset groups the asset belongs to (static or dynamic membership) */
+  asset_asset_groups?: AssetGroupSimple[];
   /** Asset category */
   asset_category?:
     | "HOST"

--- a/openaev-front/src/utils/hooks/useDataLoader.js
+++ b/openaev-front/src/utils/hooks/useDataLoader.js
@@ -189,6 +189,16 @@ const useDataLoader = (loader = () => {}, refetchArg = []) => {
       if (needsResync) return;
       const data = JSON.parse(event.data);
       if (data.listened) {
+        // A malformed event (missing schema/id - e.g. a backend entity whose @Id
+        // lives deeper in its class hierarchy than the event builder inspects)
+        // must never throw out of the SSE handler: it would flood the console
+        // with uncaught errors, one per mutation, while a running simulation
+        // streams. Skip it - the initial fetch and later reloads reconcile.
+        if (!data.attribute_schema || !data.attribute_id) {
+          // eslint-disable-next-line no-console
+          console.warn('[SSE] Skipping malformed stream event (missing schema or id attribute)', data);
+          return;
+        }
         const entityId = data.instance[data.attribute_id];
         if (data.event_type === DATA_DELETE_SUCCESS) {
           batcher.addDelete(data.attribute_schema, entityId);

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3093,6 +3093,7 @@
   "This tenant": "Dieser Tenant",
   "This user could not be found.": "Dieser Benutzer wurde nicht gefunden.",
   "This user does not belong to any group.": "Dieser Benutzer gehört keiner Gruppe an.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "Diese Schwachstelle ist im CISA-Katalog der bekannten ausgenutzten Schwachstellen (KEV) aufgeführt.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "Diese Warnung wurde für alle Benutzer verworfen, aber die Erwartungen stimmen weiterhin nicht überein. Sie können sie neu ausrichten oder die vollständige Warnung wiederherstellen.",
   "Threat Arsenal": "Arsenal",
   "Threat Arsenal supports .zip file import format": "Arsenal unterstützt das .zip-Datei-Importformat",

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "Kein Alarm verknüpft",
   "No alerts have been reported by this security platform.": "Von dieser Sicherheitsplattform wurden keine Alarme gemeldet.",
   "No asset added yet.": "Noch kein Asset hinzugefügt.",
+  "No asset group": "Keine Anlagengruppe",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "Kein Asset ausgewählt. Fügen Sie manuell Assets hinzu, indem Sie IPs, CIDRs oder Hostnamen eingeben oder einige aus der Asset-Liste auswählen.",
   "No asset selected. Add asset manually or select some in the asset list.": "Kein Vermögenswert ausgewählt. Fügen Sie manuell ein Asset hinzu oder wählen Sie eines aus der Asset-Liste.",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3093,6 +3093,7 @@
   "This tenant": "This tenant",
   "This user could not be found.": "This user could not be found.",
   "This user does not belong to any group.": "This user does not belong to any group.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.",
   "Threat Arsenal": "Threat Arsenal",
   "Threat Arsenal supports .zip file import format": "Threat Arsenal supports .zip file import format",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "No alert linked",
   "No alerts have been reported by this security platform.": "No alerts have been reported by this security platform.",
   "No asset added yet.": "No asset added yet.",
+  "No asset group": "No asset group",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.",
   "No asset selected. Add asset manually or select some in the asset list.": "No asset selected. Add asset manually or select some in the asset list.",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "Ninguna alerta vinculada",
   "No alerts have been reported by this security platform.": "Esta plataforma de seguridad no ha notificado ninguna alerta.",
   "No asset added yet.": "Ningún activo añadido aún.",
+  "No asset group": "Ningún grupo de activos",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "No hay ningún activo seleccionado. Añada activos manualmente escribiendo IPs, CIDRs o nombres de host o seleccione algunos en la lista de activos.",
   "No asset selected. Add asset manually or select some in the asset list.": "No hay ningún activo seleccionado. Añadir activo manualmente o seleccionar alguno en la lista de activos.",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3093,6 +3093,7 @@
   "This tenant": "Este tenant",
   "This user could not be found.": "No se pudo encontrar este usuario.",
   "This user does not belong to any group.": "Este usuario no pertenece a ningún grupo.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "Esta vulnerabilidad está incluida en el catálogo de vulnerabilidades explotadas conocidas (KEV) de CISA.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "Esta advertencia ha sido descartada para todos los usuarios, pero las expectativas siguen sin coincidir. Puede realinearlas o restaurar la advertencia completa.",
   "Threat Arsenal": "Arsenal",
   "Threat Arsenal supports .zip file import format": "Arsenal admite el formato de importación de archivos .zip",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3101,6 +3101,7 @@
   "This tenant": "Ce tenant",
   "This user could not be found.": "Cet utilisateur est introuvable.",
   "This user does not belong to any group.": "Cet utilisateur n'appartient à aucun groupe.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "Cette vulnérabilité est répertoriée dans le catalogue des vulnérabilités exploitées connues (KEV) de la CISA.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "Cet avertissement a été ignoré pour tous les utilisateurs, mais les attentes ne correspondent toujours pas. Vous pouvez les réaligner ou restaurer l'avertissement complet.",
   "Threat Arsenal": "Arsenal",
   "Threat Arsenal supports .zip file import format": "L'arsenal prend en charge le format d'importation des fichiers .zip",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -2078,6 +2078,7 @@
   "No alert linked": "Aucune alerte liée",
   "No alerts have been reported by this security platform.": "Aucune alerte n'a été remontée par cette plateforme de sécurité.",
   "No asset added yet.": "Aucun actif n'a encore été ajouté.",
+  "No asset group": "Aucun groupe d'actifs",
   "No asset in this asset group.": "Aucun actif dans ce groupe d'actifs.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "Aucun bien n'est sélectionné. Ajoutez un poste manuellement en saisissant des IP, des CIDR ou des noms d'hôte, ou sélectionnez-en un dans la liste des postes.",
   "No asset selected. Add asset manually or select some in the asset list.": "Aucun bien n'a été sélectionné. Ajoutez un bien manuellement ou sélectionnez-en un dans la liste des biens.",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3093,6 +3093,7 @@
   "This tenant": "Questo tenant",
   "This user could not be found.": "Impossibile trovare questo utente.",
   "This user does not belong to any group.": "Questo utente non appartiene ad alcun gruppo.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "Questa vulnerabilità è elencata nel catalogo delle vulnerabilità sfruttate note (KEV) della CISA.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "Questo avviso è stato ignorato per tutti gli utenti, ma le aspettative non corrispondono ancora. Puoi riallinearle o ripristinare l'avviso completo.",
   "Threat Arsenal": "Arsenale",
   "Threat Arsenal supports .zip file import format": "Arsenal supporta il formato di importazione dei file .zip",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "Nessuna allerta collegata",
   "No alerts have been reported by this security platform.": "Nessun avviso è stato segnalato da questa piattaforma di sicurezza.",
   "No asset added yet.": "Nessuna risorsa ancora aggiunta.",
+  "No asset group": "Nessun gruppo di attività",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "Non è stato selezionato alcun asset. Aggiungere un asset manualmente digitando IP, CIDR o nomi di host o selezionarne alcuni nell'elenco degli asset.",
   "No asset selected. Add asset manually or select some in the asset list.": "Nessuna risorsa selezionata. Aggiungere una risorsa manualmente o selezionarne una nell'elenco delle risorse.",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3093,6 +3093,7 @@
   "This tenant": "このテナント",
   "This user could not be found.": "このユーザーが見つかりませんでした。",
   "This user does not belong to any group.": "このユーザーはどのグループにも属していません。",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "この脆弱性は、CISA の既知の悪用された脆弱性 (KEV) カタログに掲載されています。",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "この警告はすべてのユーザーに対して却下されましたが、期待値は依然として一致していません。再調整するか、完全な警告を復元できます。",
   "Threat Arsenal": "兵器庫",
   "Threat Arsenal supports .zip file import format": "兵器庫 は .zip ファイルのインポート形式をサポートします。",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "リンクされたアラートはありません",
   "No alerts have been reported by this security platform.": "このセキュリティプラットフォームからアラートは報告されていません。",
   "No asset added yet.": "アセット未追加",
+  "No asset group": "アセットグループなし",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "アセットが選択されていません。IP、CIDR、またはホスト名を入力して手動でアセットを追加するか、アセットリストからいくつかを選択します。",
   "No asset selected. Add asset manually or select some in the asset list.": "アセットが選択されていません。手動でアセットを追加するか、アセットリストからアセットを選択してください。",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3093,6 +3093,7 @@
   "This tenant": "현재 테넌트",
   "This user could not be found.": "이 사용자를 찾을 수 없습니다.",
   "This user does not belong to any group.": "이 사용자는 어떤 그룹에도 속해 있지 않습니다.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "이 취약점은 CISA의 알려진 악용 취약점(KEV) 카탈로그에 등재되어 있습니다.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "이 경고는 모든 사용자에 대해 무시되었지만 기대치가 여전히 일치하지 않습니다. 재정렬하거나 전체 경고를 복원할 수 있습니다.",
   "Threat Arsenal": "무기고",
   "Threat Arsenal supports .zip file import format": "도구 모음은 .zip 형식 파일 가져오기를 지원합니다",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "연결된 경고 없음",
   "No alerts have been reported by this security platform.": "이 보안 플랫폼에서 보고된 경고가 없습니다.",
   "No asset added yet.": "아직 추가된 자산이 없습니다.",
+  "No asset group": "자산 그룹 없음",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "선택한 자산이 없습니다. IP, CIDR 또는 호스트 이름을 입력하여 자산을 수동으로 추가하거나 자산 목록에서 일부를 선택하세요.",
   "No asset selected. Add asset manually or select some in the asset list.": "선택한 에셋이 없습니다. 자산을 수동으로 추가하거나 자산 목록에서 일부 자산을 선택하세요.",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3093,6 +3093,7 @@
   "This tenant": "Этот тенант",
   "This user could not be found.": "Этот пользователь не найден.",
   "This user does not belong to any group.": "Этот пользователь не входит ни в одну группу.",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "Эта уязвимость включена в каталог известных эксплуатируемых уязвимостей (KEV) CISA.",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "Это предупреждение было скрыто для всех пользователей, но ожидания по-прежнему не совпадают. Вы можете выровнять их или восстановить полное предупреждение.",
   "Threat Arsenal": "Арсенал",
   "Threat Arsenal supports .zip file import format": "Арсенал поддерживает импорт файлов в формате .zip",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "Нет связанных оповещений",
   "No alerts have been reported by this security platform.": "Эта платформа безопасности не сообщила ни об одном оповещении.",
   "No asset added yet.": "Еще не добавлены активы.",
+  "No asset group": "Нет групп активов",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "Не выбран ни один актив. Добавьте актив вручную, введя IP-адреса, CIDR или имена хостов, или выберите несколько в списке активов.",
   "No asset selected. Add asset manually or select some in the asset list.": "Не выбран ни один актив. Добавьте актив вручную или выберите его в списке активов.",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3093,6 +3093,7 @@
   "This tenant": "此租户",
   "This user could not be found.": "未找到该用户。",
   "This user does not belong to any group.": "该用户不属于任何组。",
+  "This vulnerability is listed in CISA's Known Exploited Vulnerabilities catalog.": "此漏洞已列入 CISA 已知被利用漏洞 (KEV) 目录。",
   "This warning has been dismissed for all users, but the expectations still do not match. You can realign them or restore the full warning.": "此警告已对所有用户忽略，但预期仍不匹配。您可以重新对齐或恢复完整警告。",
   "Threat Arsenal": "武器库",
   "Threat Arsenal supports .zip file import format": "工具集支持导入 .zip 格式的文件",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -2073,6 +2073,7 @@
   "No alert linked": "无关联警报",
   "No alerts have been reported by this security platform.": "此安全平台未报告任何警报。",
   "No asset added yet.": "尚未添加资产。",
+  "No asset group": "无资产组",
   "No asset in this asset group.": "No asset in this asset group.",
   "No asset selected. Add asset manually by typing IPs, CIDRs or hostnames or select some in the asset list.": "未选择资产。通过键入 IP、CIDR 或主机名手动添加资产，或在资产列表中选择某些资产。",
   "No asset selected. Add asset manually or select some in the asset list.": "未选择资产。手动添加资产或在资产列表中选择一些。",

--- a/openaev-model/src/main/java/io/openaev/database/audit/BaseEvent.java
+++ b/openaev-model/src/main/java/io/openaev/database/audit/BaseEvent.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.context.BulkOperationContext;
 import io.openaev.database.model.Base;
 import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -85,43 +86,38 @@ public class BaseEvent implements Cloneable {
     Class<?> baseClass = data.getClass();
 
     /*
-     * Inspect fields declared directly in the current class.
-     * If an @Id is found, initialize the identifier attribute and schema
-     * based on the current class name.
+     * Locate the @Id field by walking the WHOLE class hierarchy. Concrete entities can sit
+     * several levels below the class that declares the identifier (e.g. the InjectExpectation
+     * subclasses: PreventionInjectExpectation -> TechnicalInjectExpectation ->
+     * BaseInjectExpectation). The previous implementation only inspected the class and its
+     * direct superclass, so 2+ level hierarchies produced events with a null attribute_id /
+     * attribute_schema, which crashed the frontend SSE pipeline (normalizr requires a string
+     * schema key) and silently dropped every such update. The topmost declaring class wins,
+     * preserving the historical "parent overrides child" semantics.
      */
-    for (Field field : baseClass.getDeclaredFields()) {
-      if (field.isAnnotationPresent(Id.class)) {
-        JsonProperty jp = field.getAnnotation(JsonProperty.class);
-        this.attributeId = (jp != null) ? jp.value() : field.getName();
-
-        String className = baseClass.getSimpleName().toLowerCase();
-        this.schema = className + (className.endsWith("s") ? "es" : "s");
-        break;
-      }
-    }
-
-    /*
-     * If the class has a parent class, inspect its declared fields.
-     * If an @Id is found in the superclass, override the identifier attribute
-     * and schema using the parent class definition.
-     */
-    if (baseClass.getSuperclass() != Object.class) {
-      for (Field fieldSC : baseClass.getSuperclass().getDeclaredFields()) {
-        if (fieldSC.isAnnotationPresent(Id.class)) {
-          if (this.schema != null) {
+    Field idField = null;
+    Class<?> idDeclaringClass = null;
+    for (Class<?> current = baseClass;
+        current != null && current != Object.class;
+        current = current.getSuperclass()) {
+      for (Field field : current.getDeclaredFields()) {
+        if (field.isAnnotationPresent(Id.class)) {
+          if (idDeclaringClass != null) {
             log.warn(
                 "Schema already defined in child class {} but overridden by parent class {} (both define an @Id).",
-                baseClass.getSimpleName(),
-                baseClass.getSuperclass().getSimpleName());
+                idDeclaringClass.getSimpleName(),
+                current.getSimpleName());
           }
-          JsonProperty jp = fieldSC.getAnnotation(JsonProperty.class);
-          this.attributeId = (jp != null) ? jp.value() : fieldSC.getName();
-
-          String className = baseClass.getSuperclass().getSimpleName().toLowerCase();
-          this.schema = className + (className.endsWith("s") ? "es" : "s");
+          idField = field;
+          idDeclaringClass = current;
           break;
         }
       }
+    }
+    if (idField != null) {
+      JsonProperty jp = idField.getAnnotation(JsonProperty.class);
+      this.attributeId = (jp != null) ? jp.value() : idField.getName();
+      this.schema = schemaNameFor(idDeclaringClass);
     }
 
     /*
@@ -138,12 +134,30 @@ public class BaseEvent implements Cloneable {
           } catch (NoSuchMethodException e) {
             this.attributeId = "id";
           }
-          String className = baseClass.getSimpleName().toLowerCase();
-          this.schema = className + (className.endsWith("s") ? "es" : "s");
+          this.schema = schemaNameFor(baseClass);
           break;
         }
       }
     }
+  }
+
+  /**
+   * Derives the pluralized schema name from the class declaring the identifier. The explicit JPA
+   * entity name is preferred when present ({@code @Entity(name = "InjectExpectation")} on {@code
+   * BaseInjectExpectation} yields "injectexpectations"): it is the stable, functional name the
+   * frontend keys its entity store on, while the simple class name can drift through refactors
+   * (e.g. Base* prefixes introduced when adding JPA subclasses).
+   *
+   * @param declaringClass the class that declares the {@code @Id} / {@code @EmbeddedId}
+   * @return the pluralized, lowercased schema name
+   */
+  private static String schemaNameFor(Class<?> declaringClass) {
+    Entity entity = declaringClass.getAnnotation(Entity.class);
+    String className =
+        (entity != null && !entity.name().isEmpty())
+            ? entity.name().toLowerCase()
+            : declaringClass.getSimpleName().toLowerCase();
+    return className + (className.endsWith("s") ? "es" : "s");
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/database/specification/FindingSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/FindingSpecification.java
@@ -1,7 +1,6 @@
 package io.openaev.database.specification;
 
 import io.openaev.database.model.ContractOutputType;
-import io.openaev.database.model.ExerciseStatus;
 import io.openaev.database.model.Finding;
 import jakarta.persistence.criteria.*;
 import jakarta.validation.constraints.NotNull;
@@ -29,34 +28,6 @@ public class FindingSpecification {
 
   public static Specification<Finding> findFindingsForEndpoint(@NotNull final String endpointId) {
     return (root, query, cb) -> cb.equal(root.get("assets").get("id"), endpointId);
-  }
-
-  public static Specification<Finding> forLatestSimulations() {
-    return (root, query, cb) -> {
-      Join<?, ?> exerciseJoin1 =
-          root.join("inject", JoinType.INNER).join("exercise", JoinType.LEFT);
-      Join<?, ?> exerciseJoin2 =
-          exerciseJoin1.join("scenario", JoinType.LEFT).join("exercises", JoinType.LEFT);
-
-      exerciseJoin2.on(
-          cb.and(
-              cb.equal(
-                  exerciseJoin1.get("scenario").get("id"), exerciseJoin2.get("scenario").get("id")),
-              // check this column is not null for joining
-              cb.isNotNull(exerciseJoin1.get("launchOrder")),
-              cb.isNotNull(exerciseJoin2.get("launchOrder")),
-              // only consider finished simulations
-              cb.equal(exerciseJoin1.get("status"), ExerciseStatus.FINISHED),
-              cb.equal(exerciseJoin2.get("status"), ExerciseStatus.FINISHED),
-              // trim to "latest" simulation
-              cb.lessThan(exerciseJoin1.get("launchOrder"), exerciseJoin2.get("launchOrder"))));
-
-      return cb.and(
-          cb.isNull(exerciseJoin2.get("id")),
-          cb.or(
-              cb.equal(exerciseJoin1.get("status"), ExerciseStatus.FINISHED),
-              cb.isNull(exerciseJoin1.get("id"))));
-    };
   }
 
   public static Specification<Finding> distinctTypeValueWithFilter(


### PR DESCRIPTION
﻿## Summary

Fixes #6997

This PR bundles the fixes and enhancements identified while running vulnerability scenarios (Nuclei) end to end:

### Backend

- **Real-time inject status streaming**: `InjectStatusService` now publishes an SSE `BaseEvent` for the parent inject on every status transition (initialize, fail, terminal update), so the execution board moves injects between "Up Next" / "In Flight" / "Completed" without a page reload. `BaseEvent` walks the whole class hierarchy to resolve `@Id` / `@EmbeddedId` and the schema annotation, fixing the frontend normalizr crashes ("Expected a string key for Entity, but found null.").
- **Vulnerability expectation verdicts**: direct VULNERABLE verdicts written by agentless scanners (Nuclei) on asset-level expectations are preserved when agent children expire; direct "Not vulnerable" scores are now definitive instead of hanging in PENDING; expiration messages reflect the actual source.
- **Expectation fallback**: the reset-simulation fallback to injector contract expectations only triggers when the inject content never carried an expectations field, so a user explicitly clearing expectations is respected (follow-up to #6989).
- **Tenant selector fallback**: `@RequireTenantSelector` endpoints fall back to the single accessible tenant instead of returning `400 TENANT_SELECTOR_REQUIRED` (fixes the NVD NIST CVE collector on single-tenant / CE platforms).
- **Tenant scoping in inject execution**: `InjectsExecutionJob` wraps each inject execution in the inject's tenant context (v1 `TenantContext` + v2 `TxCtx`), fixing dynamic asset group resolution running against the default tenant in production (missing asset-level expectations).
- **Timezone migration**: new Flyway migration converts `injects_statuses.tracking_end_date`, `injects_tests_statuses.tracking_sent_date` / `tracking_end_date` and `execution_traces.execution_time` to `timestamp with time zone` (metadata-only change, existing values reinterpreted as UTC), fixing execution durations skewed by the server timezone offset after reload.
- **Findings visibility**: removed the "latest finished simulation" specification from all finding search paths (global, scenario, endpoint, aggregated occurrence counts). Findings are now visible while the simulation is running, consistent with the Home dashboard.

### Frontend

- `useDataLoader` skips malformed SSE events defensively instead of crashing normalizr.
- Atomic testing / inject overview remembers the selected targets tab per inject across reloads (initial load still lands on the first tab).
- Vulnerability (CVE) display redesign: CVSS score chips with severity colors and tooltip, bug icon instead of the warning triangle (list, menu, finding icons), General tab rebuilt with shared detail components (information grid, CISA KEV alert and details, weakness enumeration chips, references list), MUI info alerts for empty/not-available states, Remediation tab label capitalization fix, redundant titles removed.
- Asset overview now shows the asset groups the asset belongs to (static membership and dynamic filter matches, resolved server-side) as clickable chips linking to the group page. The standard host overview row uses a 40/40/20 information/network/groups split; other asset kinds keep the adaptive columns.
- New i18n key added to all nine language files.

## Test plan

- [x] `FindingApiTest` (19 tests) green, including new tests asserting findings from running simulations are returned globally and per endpoint
- [x] `ExpectationsExpirationManagerServiceTest`, `InjectExpectationServiceTest`, `ExpectationsDriftServiceTest` green
- [x] `TxCtxArgumentResolverTest` / `TxCtxArgumentResolverIntegrationTest` cover the single-tenant fallback
- [x] `InjectsExecutionJobTenantScopeTest` covers tenant context propagation
- [x] Manual: Nuclei simulation end to end - real-time board transitions, asset-level VULNERABLE verdicts kept after expiration, findings visible in global list while running
- [x] Manual: vulnerability drawer and settings list rendering (chips, icons, empty states)


