### PR TITLE
fix(expectations): create asset-level expectations when all agents are inactive for agentless injectors (#7000)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
@@ -741,11 +741,16 @@ public class ExpectationUtils {
       // On an endpoint a payload runs through an OAEV agent, so the expectation
       // is created at the agent level. An asset-level (agentless) expectation is
       // therefore only needed for a non-executor injector (Nuclei, Nmap, HTTP...)
-      // targeting an endpoint that carries no agent.
+      // targeting an endpoint whose agents produce no agent-level expectations.
       if (injectRunsThroughAgents(inject)) {
         return false;
       }
-      return endpoint.getAgents().isEmpty();
+      // Judge on USABLE agents, not the mere presence of agent rows: a network
+      // scanner reaches the endpoint regardless of agent health, so an endpoint
+      // whose only agents are inactive (or invalid for this inject) must still
+      // get its asset-level expectation - otherwise it silently gets none at all
+      // (no active agent children, no agentless parent).
+      return AgentUtils.getActiveAgents(endpoint, inject).isEmpty();
     }
     // Non-endpoint assets (AI targets, ...) never run an agent: the asset itself
     // is the validation target, fulfilled by an external collector (e.g. the XTM

--- a/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
@@ -281,6 +281,25 @@ class ExpectationUtilsTest extends IntegrationTest {
   }
 
   @Test
+  @DisplayName(
+      "Endpoint whose only agent is inactive still needs an agentless expectation for a non-payload"
+          + " injector")
+  void given_endpointWithOnlyInactiveAgentAndNonPayloadInjector_should_needAgentlessExpectation() {
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    // A network scanner (Nuclei, Nmap...) reaches the endpoint regardless of agent health: a dead
+    // agent must not swallow the asset-level expectation (the endpoint would otherwise get no
+    // expectation at all - no active agent children, no agentless parent).
+    Agent inactiveAgent = AgentFixture.createInactiveAgent();
+    inactiveAgent.setId("inactiveAgentId");
+    inactiveAgent.setAsset(endpoint);
+    endpoint.setAgents(List.of(inactiveAgent));
+    Inject inject =
+        injectWithInjector(InjectorFixture.createInjector("injectorId", "manual", "manual"));
+
+    assertTrue(isAgentlessAssetExpectationNecessary(endpoint, inject));
+  }
+
+  @Test
   @DisplayName("AI target asset always needs an agentless expectation, even for a payload injector")
   void given_aiTargetAssetWithPayloadInjector_should_needAgentlessExpectation() {
     Asset aiTarget = new Asset();


### PR DESCRIPTION
## Summary

- Fixes #7000
- When an agentless injector (Nuclei, Nmap, HTTP...) targets an endpoint whose agents are ALL inactive, the endpoint silently got zero expectations: agent-level children are only created for active agents, and the asset-level (agentless) parent was only created when the endpoint carried no agent row at all ('endpoint.getAgents().isEmpty()').
- 'ExpectationUtils.isAgentlessAssetExpectationNecessary' now judges on USABLE agents ('AgentUtils.getActiveAgents(endpoint, inject).isEmpty()') instead of the mere presence of agent rows: a dead agent no longer swallows the asset-level expectation, since a network scanner reaches the endpoint regardless of agent health.
- Behavior is unchanged for agentless endpoints (parent only), endpoints with live agents (parent + agent children), payload injectors (agent level only), and AI targets (always asset level).

## Test

- New regression test in 'ExpectationUtilsTest': endpoint whose only agent is inactive + non-payload injector -> agentless asset-level expectation required.
- Full 'ExpectationUtilsTest' class passes (9/9).
- Reproduced in staging (main-ff): Nuclei CVE scan against an asset group where 'oaev-test-linux-x64-01' (agent last seen 3 days earlier) got execution traces but zero expectation rows, while agentless and live-agent assets got theirs.