### PR TITLE
feat(chaining): Findings tab and endpoint map tooltip for chaining simulations (#6647)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, friendlyNodeId, maskFindingValue } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, friendlyNodeId, maskFindingValue, pivotEndpointIds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -172,6 +172,44 @@ describe('friendlyNodeId', () => {
 
   it('returns an empty string for an undefined id', () => {
     expect(friendlyNodeId(undefined)).toBe('');
+  });
+});
+
+describe('pivotEndpointIds', () => {
+  it('flags an endpoint that is both an EDGE_EXECUTIONS source and target as a pivot', () => {
+    const pivots = pivotEndpointIds([
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_INJECTOR|nmap',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_ENDPOINT|a',
+        edgeTargetId: 'NODE_ENDPOINT|b',
+      },
+    ]);
+    expect([...pivots]).toEqual(['NODE_ENDPOINT|a']);
+  });
+
+  it('never flags a plain target or a source-only endpoint (injector→asset only)', () => {
+    expect(pivotEndpointIds([
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_INJECTOR|nmap',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+    ]).size).toBe(0);
+  });
+
+  it('ignores non-EDGE_EXECUTIONS edges', () => {
+    expect(pivotEndpointIds([
+      {
+        type: 'EDGE_FINDINGS_TYPE_FINDING',
+        edgeSourceId: 'NODE_ENDPOINT|a',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+    ]).size).toBe(0);
   });
 });
 

--- a/openaev-front/src/admin/components/simulations/simulation/SimulationShell.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/SimulationShell.tsx
@@ -45,6 +45,7 @@ const SimulationShell: FunctionComponent<{
         ['/logic', t('Logic')],
         ['/execution', t('Execution')],
         ...(isAttackPathEnabled ? [['/attack-path', t('Attack path')] as [string, string]] : []),
+        ['/findings', t('Findings')],
         ['/statistics', t('Statistics')],
       ]
     : [

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathFlow.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathFlow.tsx
@@ -13,6 +13,7 @@ import {
 import { useEffect } from 'react';
 
 import { AP_FLOW_NODE_TYPE, type AttackPathFlowEdge, type AttackPathFlowNode, type AttackPathFlowNodeData } from './attack-path-flow-helpers';
+import EndpointActionContext from './attack-path-node-context';
 import edgeTypes from './edges';
 import nodeTypes from './nodes';
 
@@ -94,57 +95,59 @@ const AttackPathFlow = ({
   }, [fitRequest, reactFlow]);
 
   return (
-    <ReactFlow
-      nodes={flowNodes}
-      edges={flowEdges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onNodeClick={(_, node) => {
-        const data = node.data as AttackPathFlowNodeData;
-        if (node.type === AP_FLOW_NODE_TYPE.asset) {
-          onEndpointClick?.(node.id, data.ref, data.label);
-        } else if (node.type === AP_FLOW_NODE_TYPE.endpointCluster && data.injectorId) {
-          onClusterClick?.(data.injectorId, data.clusterKind === 'overflow' ? 'overflow' : 'header');
-        } else if (node.type === AP_FLOW_NODE_TYPE.findingCluster && data.clusterId) {
-          onFindingClusterClick?.(data.clusterId, data.typeFindings, data.injectorId, data.endpointRef, data.clusterKind === 'overflow' ? 'overflow' : 'header');
-        } else if (node.type === AP_FLOW_NODE_TYPE.finding) {
-          onFindingSelect?.(node.id, data.typeFindings, data.label, data.assetNodeId);
-        } else if (node.type === AP_FLOW_NODE_TYPE.injector) {
-          onInjectorSelect?.(node.id, data.label);
-        }
-      }}
-      nodeTypes={nodeTypes}
-      edgeTypes={edgeTypes}
-      proOptions={proOptions}
-      fitView
-      minZoom={0.05}
-      // Follow the app theme so the canvas is not the default white; dark theme gives the dark
-      // navy background the graph is designed for.
-      colorMode={theme.palette.mode}
-      // Cull off-screen nodes: a large collapsed graph is hundreds of endpoints, so only paint the
-      // ones in the viewport to keep pan/zoom responsive.
-      onlyRenderVisibleElements
-      style={{ background: 'transparent' }}
-      defaultEdgeOptions={{ type: 'apGrouped' }}
-    >
-      <Background bgColor={theme.palette.background.default} color={theme.palette.divider} gap={24} />
-      <Controls position="top-left" />
-      {showMiniMap && (
-        <MiniMap
-          position="bottom-right"
-          pannable
-          zoomable
-          style={{
-            width: 130,
-            height: 90,
-            background: theme.palette.background.paper,
-            border: `1px solid ${theme.palette.divider}`,
-          }}
-          maskColor={`${theme.palette.background.default}80`}
-          nodeColor={theme.palette.primary.main}
-        />
-      )}
-    </ReactFlow>
+    <EndpointActionContext.Provider value={onEndpointClick}>
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={(_, node) => {
+          const data = node.data as AttackPathFlowNodeData;
+          if (node.type === AP_FLOW_NODE_TYPE.asset) {
+            onEndpointClick?.(node.id, data.ref, data.label);
+          } else if (node.type === AP_FLOW_NODE_TYPE.endpointCluster && data.injectorId) {
+            onClusterClick?.(data.injectorId, data.clusterKind === 'overflow' ? 'overflow' : 'header');
+          } else if (node.type === AP_FLOW_NODE_TYPE.findingCluster && data.clusterId) {
+            onFindingClusterClick?.(data.clusterId, data.typeFindings, data.injectorId, data.endpointRef, data.clusterKind === 'overflow' ? 'overflow' : 'header');
+          } else if (node.type === AP_FLOW_NODE_TYPE.finding) {
+            onFindingSelect?.(node.id, data.typeFindings, data.label, data.assetNodeId);
+          } else if (node.type === AP_FLOW_NODE_TYPE.injector) {
+            onInjectorSelect?.(node.id, data.label);
+          }
+        }}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        proOptions={proOptions}
+        fitView
+        minZoom={0.05}
+        // Follow the app theme so the canvas is not the default white; dark theme gives the dark
+        // navy background the graph is designed for.
+        colorMode={theme.palette.mode}
+        // Cull off-screen nodes: a large collapsed graph is hundreds of endpoints, so only paint the
+        // ones in the viewport to keep pan/zoom responsive.
+        onlyRenderVisibleElements
+        style={{ background: 'transparent' }}
+        defaultEdgeOptions={{ type: 'apGrouped' }}
+      >
+        <Background bgColor={theme.palette.background.default} color={theme.palette.divider} gap={24} />
+        <Controls position="top-left" />
+        {showMiniMap && (
+          <MiniMap
+            position="bottom-right"
+            pannable
+            zoomable
+            style={{
+              width: 130,
+              height: 90,
+              background: theme.palette.background.paper,
+              border: `1px solid ${theme.palette.divider}`,
+            }}
+            maskColor={`${theme.palette.background.default}80`}
+            nodeColor={theme.palette.primary.main}
+          />
+        )}
+      </ReactFlow>
+    </EndpointActionContext.Provider>
   );
 };
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -14,7 +14,7 @@ import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathDTO, AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import attackPathStatusColor, { attackPathChokepointColor } from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, type PathFinding } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, type PathFinding, pivotEndpointIds } from './attack-path-flow-helpers';
 import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
@@ -947,6 +947,12 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     return m;
   }, [chokepoints]);
 
+  // Pivot endpoints (an ASSET both attacked and used as an attack source) get a tooltip flag.
+  const pivotNodeIds = useMemo(
+    () => pivotEndpointIds(dto?.attackPathEdges ?? []),
+    [dto?.attackPathEdges],
+  );
+
   // All exposed endpoints (not just the top-N) for the table view; same source as chokepoints, no
   // extra fetch. Type columns are the union of finding types present, in a stable order.
   const endpointRows = useMemo<AttackPathEndpointRow[]>(
@@ -1034,23 +1040,27 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           batch: findingBatch,
         });
       }
-      if (chokepointRankById.size === 0) {
+      if (chokepointRankById.size === 0 && pivotNodeIds.size === 0) {
         return raw;
       }
       return {
-        nodes: raw.nodes.map(n => (n.type === AP_FLOW_NODE_TYPE.asset && chokepointRankById.has(n.id)
+        nodes: raw.nodes.map(n => (n.type === AP_FLOW_NODE_TYPE.asset && (chokepointRankById.has(n.id) || pivotNodeIds.has(n.id))
           ? {
               ...n,
               data: {
                 ...n.data,
                 chokepointRank: chokepointRankById.get(n.id),
+                isPivot: pivotNodeIds.has(n.id),
               },
             }
           : n)),
         edges: raw.edges,
       };
     },
-    [dto, chainMode, fullDto, pathFinding, pathContractLabelByInjector, endpointBatch, expandedFindingClusters, findingsByCluster, findingBatch, chokepointRankById, t],
+    [
+      dto, chainMode, fullDto, pathFinding, pathContractLabelByInjector, endpointBatch,
+      expandedFindingClusters, findingsByCluster, findingBatch, chokepointRankById, pivotNodeIds, t,
+    ],
   );
 
   // Highlight, in place, a finding clicked directly in the focused graph: keep it where it is and

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -721,7 +721,7 @@ export const pivotEndpointIds = (
   const sources = new Set<string>();
   const targets = new Set<string>();
   for (const e of edges) {
-    if (e.type !== 'EDGE_EXECUTIONS') {
+    if (e.type !== EDGE_EXECUTIONS) {
       continue;
     }
     if (e.edgeSourceId) {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -79,6 +79,9 @@ export interface AttackPathFlowNodeData {
   // For an endpoint (ASSET) node: its 1-based rank among the top chokepoints (most findings), used to
   // badge the most-exposed endpoints. Absent when the endpoint is not a top chokepoint.
   chokepointRank?: number;
+  // For an endpoint (ASSET) node: it is a pivot (both attacked and used as an attack source, i.e. an
+  // AGENT_ASSET source that is also a target), so the tooltip flags lateral movement through it.
+  isPivot?: boolean;
   dimmed?: boolean;
   // Aggregate cluster nodes: the endpoint count (endpoint cluster) or finding count (finding cluster).
   count?: number;
@@ -703,6 +706,38 @@ export const friendlyNodeId = (raw?: string): string => {
     return stripped.split('|')[0];
   }
   return stripped;
+};
+
+// A pivot endpoint is an ASSET both attacked and used as an attack source (an AGENT_ASSET source that is
+// also a target), so its node id is BOTH an EDGE_EXECUTIONS source and target. Injector sources are never
+// targets, so the source∩target intersection is exactly the pivot assets.
+export const pivotEndpointIds = (
+  edges: {
+    type?: string;
+    edgeSourceId?: string;
+    edgeTargetId?: string;
+  }[],
+): Set<string> => {
+  const sources = new Set<string>();
+  const targets = new Set<string>();
+  for (const e of edges) {
+    if (e.type !== 'EDGE_EXECUTIONS') {
+      continue;
+    }
+    if (e.edgeSourceId) {
+      sources.add(e.edgeSourceId);
+    }
+    if (e.edgeTargetId) {
+      targets.add(e.edgeTargetId);
+    }
+  }
+  const pivots = new Set<string>();
+  sources.forEach((s) => {
+    if (targets.has(s)) {
+      pivots.add(s);
+    }
+  });
+  return pivots;
 };
 
 // Human-readable plural noun for a finding type, used to give contextual cluster edges a label with

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-node-context.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-node-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+// Provides the endpoint-detail action to attack-path node components. ReactFlow renders custom nodes
+// without direct props, and a node's MUI Tooltip renders in a portal, so a "Details" button inside it
+// cannot bubble to ReactFlow's onNodeClick; AttackPathFlow sets this from its onEndpointClick prop and
+// AssetNode consumes it. Undefined outside a provider (the button is then simply inert).
+const EndpointActionContext = createContext<
+  ((nodeId: string, ref?: string, label?: string) => void) | undefined
+>(undefined);
+
+export default EndpointActionContext;

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/nodes/AssetNode.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/nodes/AssetNode.tsx
@@ -113,7 +113,13 @@ const AssetNode = ({ id, data, selected }: NodeProps<AttackPathFlowNode>) => {
       aria-label={`${data.label}, ${statusText}${isChokepoint ? `, ${t('chokepoint')}` : ''}`}
     >
       <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
-      <Tooltip title={tooltipTitle} arrow>
+      <Tooltip
+        title={tooltipTitle}
+        arrow
+        // Interactive tooltip with a Details button: give the pointer time to travel the gap from
+        // the circle to the tooltip so it does not close unless you cross exactly through the centre.
+        leaveDelay={200}
+      >
         <div
           style={{
             width: AP_ENDPOINT_SIZE,
@@ -154,61 +160,61 @@ const AssetNode = ({ id, data, selected }: NodeProps<AttackPathFlowNode>) => {
           )}
         </div>
       </Tooltip>
-        {data.chokepointRank !== undefined && (
-          <Tooltip title={t('Chokepoint #{rank} — most exposed endpoint ({count} findings)', {
-            rank: String(data.chokepointRank),
-            count: String(total),
-          })}
-          >
-            <div
-              style={{
-                position: 'absolute',
-                top: -12,
-                left: -12,
-                minWidth: 34,
-                height: 30,
-                padding: '0 9px',
-                borderRadius: 15,
-                background: chokepointColor,
-                color: theme.palette.getContrastText(chokepointColor),
-                fontSize: 15,
-                fontWeight: 800,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 3,
-                justifyContent: 'center',
-                boxShadow: `0 0 0 3px ${theme.palette.background.paper}, 0 2px 6px ${alpha(theme.palette.common.black, 0.4)}`,
-              }}
-            >
-              <LocalFireDepartment sx={{ fontSize: 19 }} />
-              {data.chokepointRank}
-            </div>
-          </Tooltip>
-        )}
-        {total > 0 && (
+      {data.chokepointRank !== undefined && (
+        <Tooltip title={t('Chokepoint #{rank} — most exposed endpoint ({count} findings)', {
+          rank: String(data.chokepointRank),
+          count: String(total),
+        })}
+        >
           <div
             style={{
               position: 'absolute',
-              top: -6,
-              right: -6,
-              minWidth: 22,
-              height: 22,
-              padding: '0 6px',
-              borderRadius: 11,
-              background: color,
-              color: theme.palette.getContrastText(color),
-              fontSize: 11,
-              fontWeight: 700,
+              top: -12,
+              left: -12,
+              minWidth: 34,
+              height: 30,
+              padding: '0 9px',
+              borderRadius: 15,
+              background: chokepointColor,
+              color: theme.palette.getContrastText(chokepointColor),
+              fontSize: 15,
+              fontWeight: 800,
               display: 'flex',
               alignItems: 'center',
+              gap: 3,
               justifyContent: 'center',
+              boxShadow: `0 0 0 3px ${theme.palette.background.paper}, 0 2px 6px ${alpha(theme.palette.common.black, 0.4)}`,
             }}
           >
-            {`+${total}`}
+            <LocalFireDepartment sx={{ fontSize: 19 }} />
+            {data.chokepointRank}
           </div>
-        )}
-        <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
-      </div>
+        </Tooltip>
+      )}
+      {total > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            top: -6,
+            right: -6,
+            minWidth: 22,
+            height: 22,
+            padding: '0 6px',
+            borderRadius: 11,
+            background: color,
+            color: theme.palette.getContrastText(color),
+            fontSize: 11,
+            fontWeight: 700,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {`+${total}`}
+        </div>
+      )}
+      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+    </div>
   );
 };
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/nodes/AssetNode.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/nodes/AssetNode.tsx
@@ -1,20 +1,22 @@
-import { LocalFireDepartment } from '@mui/icons-material';
-import { Tooltip, Typography } from '@mui/material';
+import { LocalFireDepartment, SwapHoriz } from '@mui/icons-material';
+import { Button, Chip, Tooltip, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { Handle, type NodeProps, Position } from '@xyflow/react';
-import { memo } from 'react';
+import { memo, useContext } from 'react';
 
 import { useFormatter } from '../../../../../../components/i18n';
 import attackPathStatusColor, { attackPathChokepointColor, attackPathStatusLabel } from '../attack-path-colors';
 import { type AttackPathFlowNode } from '../attack-path-flow-helpers';
+import EndpointActionContext from '../attack-path-node-context';
 import { AP_ENDPOINT_SIZE } from './node-sizes';
 
 // The endpoint (target) node: a circle whose ring is the prevention/detection colour. An endpoint
 // with no findings is a faint dashed grey circle; one with findings carries a coloured "+N" badge of
 // its distinct-finding count (collapsed mode). Mirrors the product mockup's endpoint node.
-const AssetNode = ({ data, selected }: NodeProps<AttackPathFlowNode>) => {
+const AssetNode = ({ id, data, selected }: NodeProps<AttackPathFlowNode>) => {
   const theme = useTheme();
   const { t } = useFormatter();
+  const onDetails = useContext(EndpointActionContext);
   // findingCounts is only set in collapsed mode; when it is present and empty the endpoint is known
   // to have no findings (faint dashed grey). Otherwise the ring follows the prevention status.
   const counts = data.findingCounts;
@@ -32,6 +34,75 @@ const AssetNode = ({ data, selected }: NodeProps<AttackPathFlowNode>) => {
   } else if (selected) {
     nodeShadow = `0 0 0 4px ${alpha(color, 0.45)}`;
   }
+  const agents = data.agents ?? [];
+  const tooltipTitle = (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 6,
+      padding: 2,
+      minWidth: 170,
+    }}
+    >
+      <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>{data.hostname || data.label}</Typography>
+      {data.ip && (
+        <Typography variant="caption" color="text.secondary">
+          {t('IP')}
+          :
+          {' '}
+          {data.ip}
+        </Typography>
+      )}
+      {data.platform && (
+        <Typography variant="caption" color="text.secondary">
+          {t('Platform')}
+          :
+          {' '}
+          {data.platform}
+        </Typography>
+      )}
+      {data.isPivot && (
+        <Typography
+          variant="caption"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            color: 'warning.main',
+          }}
+        >
+          <SwapHoriz sx={{ fontSize: 16 }} />
+          {t('Pivot node')}
+        </Typography>
+      )}
+      {agents.length > 0 && (
+        <div style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 4,
+          marginTop: 2,
+        }}
+        >
+          {agents.map(a => <Chip key={a} label={a} size="small" variant="outlined" />)}
+        </div>
+      )}
+      {onDetails && (
+        <Button
+          size="small"
+          variant="outlined"
+          sx={{
+            alignSelf: 'flex-end',
+            mt: 0.5,
+          }}
+          onClick={() => onDetails(id, data.ref, data.label)}
+        >
+          {t('Details')}
+          {' '}
+          →
+        </Button>
+      )}
+    </div>
+  );
   return (
     <div
       style={{
@@ -39,104 +110,105 @@ const AssetNode = ({ data, selected }: NodeProps<AttackPathFlowNode>) => {
         width: AP_ENDPOINT_SIZE,
         height: AP_ENDPOINT_SIZE,
       }}
-      title={`${data.label} — ${statusText}`}
       aria-label={`${data.label}, ${statusText}${isChokepoint ? `, ${t('chokepoint')}` : ''}`}
     >
       <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
-      <div
-        style={{
-          width: AP_ENDPOINT_SIZE,
-          height: AP_ENDPOINT_SIZE,
-          borderRadius: '50%',
-          border: `${selected || isChokepoint ? 3 : 2}px ${knownNoFindings ? 'dashed' : 'solid'} ${color}`,
-          // Keep the dark node fill (readable white label); show selection with a halo ring, not a
-          // pale fill that would wash the text out. A chokepoint gets a violet halo so it stands out
-          // without overriding the verdict-coloured ring.
-          background: theme.palette.background.paper,
-          boxShadow: nodeShadow,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: 4,
-          boxSizing: 'border-box',
-        }}
-      >
-        <Typography
-          variant="caption"
-          fontWeight={700}
-          sx={{
-            maxWidth: AP_ENDPOINT_SIZE - 12,
-            textAlign: 'center',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            lineHeight: 1.1,
+      <Tooltip title={tooltipTitle} arrow>
+        <div
+          style={{
+            width: AP_ENDPOINT_SIZE,
+            height: AP_ENDPOINT_SIZE,
+            borderRadius: '50%',
+            border: `${selected || isChokepoint ? 3 : 2}px ${knownNoFindings ? 'dashed' : 'solid'} ${color}`,
+            // Keep the dark node fill (readable white label); show selection with a halo ring, not a
+            // pale fill that would wash the text out. A chokepoint gets a violet halo so it stands out
+            // without overriding the verdict-coloured ring.
+            background: theme.palette.background.paper,
+            boxShadow: nodeShadow,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 4,
+            boxSizing: 'border-box',
           }}
         >
-          {data.label}
-        </Typography>
-        {data.ip && (
-          <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10 }}>
-            {data.ip}
+          <Typography
+            variant="caption"
+            fontWeight={700}
+            sx={{
+              maxWidth: AP_ENDPOINT_SIZE - 12,
+              textAlign: 'center',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              lineHeight: 1.1,
+            }}
+          >
+            {data.label}
           </Typography>
+          {data.ip && (
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: 10 }}>
+              {data.ip}
+            </Typography>
+          )}
+        </div>
+      </Tooltip>
+        {data.chokepointRank !== undefined && (
+          <Tooltip title={t('Chokepoint #{rank} — most exposed endpoint ({count} findings)', {
+            rank: String(data.chokepointRank),
+            count: String(total),
+          })}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: -12,
+                left: -12,
+                minWidth: 34,
+                height: 30,
+                padding: '0 9px',
+                borderRadius: 15,
+                background: chokepointColor,
+                color: theme.palette.getContrastText(chokepointColor),
+                fontSize: 15,
+                fontWeight: 800,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 3,
+                justifyContent: 'center',
+                boxShadow: `0 0 0 3px ${theme.palette.background.paper}, 0 2px 6px ${alpha(theme.palette.common.black, 0.4)}`,
+              }}
+            >
+              <LocalFireDepartment sx={{ fontSize: 19 }} />
+              {data.chokepointRank}
+            </div>
+          </Tooltip>
         )}
-      </div>
-      {data.chokepointRank !== undefined && (
-        <Tooltip title={t('Chokepoint #{rank} — most exposed endpoint ({count} findings)', {
-          rank: String(data.chokepointRank),
-          count: String(total),
-        })}
-        >
+        {total > 0 && (
           <div
             style={{
               position: 'absolute',
-              top: -12,
-              left: -12,
-              minWidth: 34,
-              height: 30,
-              padding: '0 9px',
-              borderRadius: 15,
-              background: chokepointColor,
-              color: theme.palette.getContrastText(chokepointColor),
-              fontSize: 15,
-              fontWeight: 800,
+              top: -6,
+              right: -6,
+              minWidth: 22,
+              height: 22,
+              padding: '0 6px',
+              borderRadius: 11,
+              background: color,
+              color: theme.palette.getContrastText(color),
+              fontSize: 11,
+              fontWeight: 700,
               display: 'flex',
               alignItems: 'center',
-              gap: 3,
               justifyContent: 'center',
-              boxShadow: `0 0 0 3px ${theme.palette.background.paper}, 0 2px 6px ${alpha(theme.palette.common.black, 0.4)}`,
             }}
           >
-            <LocalFireDepartment sx={{ fontSize: 19 }} />
-            {data.chokepointRank}
+            {`+${total}`}
           </div>
-        </Tooltip>
-      )}
-      {total > 0 && (
-        <div
-          style={{
-            position: 'absolute',
-            top: -6,
-            right: -6,
-            minWidth: 22,
-            height: 22,
-            padding: '0 6px',
-            borderRadius: 11,
-            background: color,
-            color: theme.palette.getContrastText(color),
-            fontSize: 11,
-            fontWeight: 700,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          {`+${total}`}
-        </div>
-      )}
-      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
-    </div>
+        )}
+        <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+      </div>
   );
 };
 

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "Die Telefonnummer muss mit + beginnen und darf nur Ziffern enthalten",
   "phone_number_tooltip": "Die Rufnummer sollte mit einem Pluszeichen ( + ) beginnen. Sie kann Leerzeichen oder Bindestriche ( - ) oder Klammern enthalten.",
   "Pipe": "Rohrleitung",
+  "Pivot node": "Pivot node",
   "Planning": "Planung",
   "Platform": "Plattform",
   "Platform connected": "Plattform verbunden",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "Phone number must start with + and contain only digits",
   "phone_number_tooltip": "Phone number should start with a plus sign ( + ). It may contain white spaces or hyphens ( – ) or parenthesis.",
   "Pipe": "Pipe",
+  "Pivot node": "Pivot node",
   "Planning": "Planning",
   "Platform": "Platform",
   "Platform connected": "Platform connected",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "El número de teléfono debe empezar por + y contener sólo dígitos",
   "phone_number_tooltip": "El número de teléfono debe empezar por el signo más ( + ). Puede contener espacios en blanco o guiones ( - ) o paréntesis.",
   "Pipe": "Canal",
+  "Pivot node": "Pivot node",
   "Planning": "Planificación",
   "Platform": "Plataforma",
   "Platform connected": "Plataforma conectada",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -2379,6 +2379,7 @@
   "Phone number must start with + and contain only digits": "Le numéro de téléphone doit commencer par + et ne contenir que des chiffres",
   "phone_number_tooltip": "Le numéro de téléphone devrait commencer par un signe plus ( + ). Il peut contenir des espaces ou des tirets ( – ) ou des parenthèses.",
   "Pipe": "Tuyau",
+  "Pivot node": "Nœud pivot",
   "Planning": "Planification",
   "Platform": "Plateforme",
   "Platform connected": "Plateforme connectée",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "Il numero di telefono deve iniziare con + e deve contenere solo cifre",
   "phone_number_tooltip": "Il numero di telefono deve iniziare con un segno più ( + ). Può contenere spazi bianchi, trattini ( - ) o parentesi.",
   "Pipe": "Tubo",
+  "Pivot node": "Pivot node",
   "Planning": "Pianificazione",
   "Platform": "Piattaforma",
   "Platform connected": "Piattaforma collegata",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "電話番号は+で始まり、数字のみであること",
   "phone_number_tooltip": "電話番号はプラス記号（+）で始まります。空白やハイフン（-）、括弧が含まれていても構いません。",
   "Pipe": "パイプ",
+  "Pivot node": "Pivot node",
   "Planning": "プランニング",
   "Platform": "プラットフォーム",
   "Platform connected": "プラットフォーム接続",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "전화 번호는 +로 시작하고 숫자만 포함해야 합니다",
   "phone_number_tooltip": "전화번호는 더하기 기호(+)로 시작해야 합니다. 공백이나 하이픈( - ) 또는 괄호를 포함할 수 있습니다.",
   "Pipe": "파이프",
+  "Pivot node": "Pivot node",
   "Planning": "계획",
   "Platform": "플랫폼",
   "Platform connected": "플랫폼 연결",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "Номер телефона должен начинаться с + и содержать только цифры",
   "phone_number_tooltip": "Номер телефона должен начинаться со знака плюс ( + ). Он может содержать пробелы, дефисы ( - ) или круглые скобки.",
   "Pipe": "Труба",
+  "Pivot node": "Pivot node",
   "Planning": "Планирование",
   "Platform": "Платформа",
   "Platform connected": "Платформа подключена",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -2372,6 +2372,7 @@
   "Phone number must start with + and contain only digits": "电话号码必须以 + 开头，且只包含数字",
   "phone_number_tooltip": "电话号码应以加号 ( + )开头. 它可以包含空格、连字符( - ) 或括号.",
   "Pipe": "管道",
+  "Pivot node": "Pivot node",
   "Planning": "计划",
   "Platform": "平台",
   "Platform connected": "平台已连接",


### PR DESCRIPTION
## What

Two front-end additions to the chaining attack-path experience.

**Findings tab on chaining simulations.** The chaining simulation shell now exposes a Findings tab, between Attack path and Statistics, so a chained simulation lists its findings the same way a time-based one does.

**Endpoint map tooltip.** Hovering an endpoint on the attack-path map now shows a tooltip with its hostname, IP, platform and agents, a pivot marker when the endpoint is both a source and a target of the graph, and a Details button that opens the endpoint drawer.

Front-only. No API or schema change.

## Implementation notes

- The Details action reaches the map through a small React context, because a MUI tooltip renders in a portal and cannot bubble through ReactFlow's node click.
- The tooltip has a short leave delay so the cursor can travel from the node onto the tooltip without it closing.
- The pivot marker appears only where the graph has an endpoint that is both source and target of an execution edge.

## Test plan

- Open a chaining simulation: the Findings tab is present and lists its findings.
- On the Attack path tab, hover an endpoint: the tooltip shows host, IP, platform and agents, plus a Details button that opens the drawer.