### PR TITLE
feat(attack-path): chain/chokepoint UI follow-ups — clustering, fullscreen, shared score dialog (#6647)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -654,6 +654,93 @@ describe('buildCausalChainFlow', () => {
     expect(causal.filter(e => e.data?.label).length).toBe(1);
   });
 
+  it('collapses more than 4 same-type findings into one cluster and routes the causal edge through it', () => {
+    const fids = ['a', 'b', 'c', 'd', 'e']; // 5 files > cap of 4
+    const collapsed: AttackPathDTO = {
+      ...chainDto,
+      attackPathNodes: [
+        {
+          id: 'inj-A',
+          type: 'INJECTOR',
+          label: 'A',
+        },
+        {
+          id: 'inj-C',
+          type: 'INJECTOR',
+          label: 'C',
+        },
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'EP1',
+          ip: '10.0.0.1',
+        },
+        ...fids.map(v => ({
+          id: `NODE_FINDING|file|${v}`,
+          type: 'FINDING' as const,
+          typeFindings: 'file',
+          value: v,
+          label: v,
+        })),
+      ],
+      attackPathExecutions: [
+        {
+          id: 'xA',
+          type: 'EXECUTION',
+          ref: 'exec-A',
+          stepTemplateId: 'step-A',
+          findingsNodeIds: fids.map(v => `NODE_FINDING|file|${v}`),
+          dependsOn: [],
+        },
+        {
+          id: 'xC',
+          type: 'EXECUTION',
+          ref: 'exec-C',
+          stepTemplateId: 'step-C',
+          consumedFindingKeys: [{
+            keyType: 'share_name',
+            operator: 'IS_NOT_NULL',
+            value: null as unknown as string,
+            eventName: 'SHARE',
+          }],
+          dependsOn: ['step-A'],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-A',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-A'],
+        },
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-C',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-C'],
+        },
+      ],
+    };
+    // Collapsed (default): one cluster node, no individual file leaves, and ONE causal edge from the cluster.
+    const collapsedFlow = buildCausalChainFlow(collapsed, tt);
+    const clusterNodes = collapsedFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.findingCluster);
+    expect(clusterNodes).toHaveLength(1);
+    expect(clusterNodes[0].data.count).toBe(5);
+    expect(collapsedFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.finding)).toHaveLength(0);
+    const collapsedCausal = collapsedFlow.edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE && e.data?.causalKind === 'finding');
+    expect(collapsedCausal).toHaveLength(1);
+    expect(collapsedCausal[0].source).toBe(clusterNodes[0].id);
+    expect(collapsedCausal[0].target).toBe('inj-C');
+
+    // Expanded: the 5 findings render individually (no cluster) and the fan-in has 5 edges, one labelled.
+    const expandedFlow = buildCausalChainFlow(collapsed, tt, new Set([clusterNodes[0].id]));
+    expect(expandedFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.findingCluster)).toHaveLength(0);
+    expect(expandedFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.finding)).toHaveLength(5);
+    const expandedCausal = expandedFlow.edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE && e.data?.causalKind === 'finding');
+    expect(expandedCausal).toHaveLength(5);
+    expect(expandedCausal.filter(e => e.data?.label).length).toBe(1);
+  });
+
   it('anchors the causal edge on the finding of the resolved producer, not another injector sharing the type', () => {
     // Two injectors each produce a `file` finding; a consumer whose event `share_name IS_NOT_NULL` matches
     // BOTH depends (dependsOn, #6985) only on producer A. The edge must anchor on A's finding, never B's.

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from 'react-router';
 import { fetchAttackPathGraph, fetchAttackPathSimulations, fetchEndpointFindings, fetchEndpointRelations, fetchExecutionDetail, fetchFindingsByCategory, fetchSimulationsMetaById } from '../../../../../actions/attack-path/attack-path-actions';
 import { createRunningExerciseFromScenario } from '../../../../../actions/scenarios/scenario-actions';
 import Drawer from '../../../../../components/common/Drawer';
+import { criticalityColor } from '../../../../../components/criticalityColor';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
 import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
@@ -2469,8 +2470,8 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                         width: 18,
                         height: 18,
                         borderRadius: '50%',
-                        background: chokepointColor,
-                        color: theme.palette.getContrastText(chokepointColor),
+                        background: criticalityColor(c.criticality),
+                        color: theme.palette.getContrastText(criticalityColor(c.criticality)),
                         fontSize: 10,
                         fontWeight: 700,
                         display: 'flex',
@@ -2495,7 +2496,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                         variant="body2"
                         sx={{
                           fontWeight: 700,
-                          color: chokepointColor,
+                          color: criticalityColor(c.criticality),
                         }}
                       >
                         {c.score}
@@ -2517,7 +2518,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                         <Box sx={{
                           width: `${Math.min(100, Math.max(6, ((c.score ?? 0) / (chokepoints[0]?.score || 1)) * 100))}%`,
                           height: '100%',
-                          background: chokepointColor,
+                          background: criticalityColor(c.criticality),
                         }}
                         />
                       </Box>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1,5 +1,5 @@
-import { AccountTreeOutlined, BugReportOutlined, DnsOutlined, GroupOutlined, HelpOutline, InsertDriveFileOutlined, LabelOutlined, LocalFireDepartment, PlayArrowOutlined, SearchOutlined, TableRowsOutlined, VpnKeyOutlined } from '@mui/icons-material';
-import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, Paper, Popover, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
+import { AccountTreeOutlined, BugReportOutlined, DnsOutlined, FullscreenExitOutlined, FullscreenOutlined, GroupOutlined, HelpOutline, InsertDriveFileOutlined, LabelOutlined, LocalFireDepartment, PlayArrowOutlined, SearchOutlined, TableRowsOutlined, VpnKeyOutlined } from '@mui/icons-material';
+import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, IconButton, Paper, Popover, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { ReactFlowProvider } from '@xyflow/react';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -1486,11 +1486,24 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     // Highlight a path: walk UP from a clicked finding to its actions, or DOWN from a clicked
     // injector (action) to its reach. Same visual, mirrored direction, so both feel consistent.
     const pathSet = new Set<string>();
-    if (selectedInjectorId) {
-      // An injector's downstream highlight shows its REACH — the endpoints it targeted — not the findings.
-      // In the clustered view findings hang off the SHARED endpoint hub and aggregate every injector, so
-      // walking into them would wrongly credit one injector with another's findings (e.g. NetExec lighting
-      // Nmap's portscans). Stop the walk at endpoint/hub nodes: never propagate into finding-type nodes.
+    if (selectedInjectorId && chainMode) {
+      // Chain view: clicking an action lights the WHOLE chain that led to it. Walk UPSTREAM from the action
+      // through BOTH production and causal ("Triggered …") edges (target in set → add source), so the path
+      // from the first action to the one clicked — findings, endpoints and the actions between — is shown.
+      pathSet.add(selectedInjectorId);
+      for (let pass = 0; pass < 8; pass += 1) {
+        for (const e of baseFlow.edges) {
+          if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
+            pathSet.add(e.source);
+          }
+        }
+      }
+    } else if (selectedInjectorId) {
+      // Clustered view: an injector's downstream highlight shows its REACH — the endpoints it targeted — not
+      // the findings. In the clustered view findings hang off the SHARED endpoint hub and aggregate every
+      // injector, so walking into them would wrongly credit one injector with another's findings (e.g.
+      // NetExec lighting Nmap's portscans). Stop the walk at endpoint/hub nodes: never propagate into
+      // finding-type nodes.
       const findingNodeIds = new Set(
         baseFlow.nodes
           .filter(n => n.type === AP_FLOW_NODE_TYPE.finding
@@ -1564,7 +1577,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     return applyFindingFilter(withSelection.nodes, withSelection.edges, focus);
   }, [
     baseFlow, pathFinding, producingInjectorIds, selectedNodeId, selectedFindingId, selectedInjectorId,
-    focus, dto?.attackPathEdges, fullDto?.attackPathEdges, highlightedExecutionIds,
+    focus, dto?.attackPathEdges, fullDto?.attackPathEdges, highlightedExecutionIds, chainMode,
   ]);
 
   // Additive kill-chain causal edges (issue 6647) for the AGGREGATED view, merged on top of the status
@@ -1819,6 +1832,22 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // Graph (node-link) vs Table (sortable/exportable list of exposed endpoints) view of the same data.
   const [view, setView] = useState<'graph' | 'table'>('graph');
 
+  // Fullscreen: expand the whole view (cards strip + graph) over the viewport for room to navigate a large
+  // chain, keeping the finding cards for context. Escape leaves it.
+  const [fullscreen, setFullscreen] = useState(false);
+  useEffect(() => {
+    if (!fullscreen) {
+      return undefined;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setFullscreen(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [fullscreen]);
+
   // Free-text search input (endpoint / injector / finding type), used by the search autocomplete.
   const [searchInput, setSearchInput] = useState('');
 
@@ -1977,9 +2006,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       display: 'flex',
       flexDirection: 'column',
       // Give the graph as much vertical room as possible (it grows with the endpoint count); the offset
-      // only reserves the page chrome above (header + tabs + the picker/cards strip).
-      height: 'calc(100vh - 200px)',
+      // only reserves the page chrome above (header + tabs + the picker/cards strip). Fullscreen lifts it
+      // out of the page flow to cover the viewport (cards strip included) for room to navigate.
       gap: theme.spacing(1),
+      ...(fullscreen
+        ? {
+            position: 'fixed' as const,
+            inset: 0,
+            zIndex: theme.zIndex.drawer + 2,
+            height: '100vh',
+            padding: theme.spacing(2),
+            background: theme.palette.background.default,
+          }
+        : { height: 'calc(100vh - 200px)' }),
     }}
     >
       <div style={{
@@ -2071,6 +2110,15 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               <Tooltip title={t('Table')}><TableRowsOutlined fontSize="small" /></Tooltip>
             </ToggleButton>
           </ToggleButtonGroup>
+          <Tooltip title={fullscreen ? t('Exit fullscreen') : t('Fullscreen')}>
+            <IconButton
+              size="small"
+              aria-label={fullscreen ? t('Exit fullscreen') : t('Fullscreen')}
+              onClick={() => setFullscreen(f => !f)}
+            >
+              {fullscreen ? <FullscreenExitOutlined fontSize="small" /> : <FullscreenOutlined fontSize="small" />}
+            </IconButton>
+          </Tooltip>
           <Autocomplete<SearchOption>
             size="small"
             options={searchOptions}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1,5 +1,5 @@
 import { AccountTreeOutlined, BugReportOutlined, DnsOutlined, FullscreenExitOutlined, FullscreenOutlined, GroupOutlined, HelpOutline, InsertDriveFileOutlined, LabelOutlined, LocalFireDepartment, PlayArrowOutlined, SearchOutlined, TableRowsOutlined, VpnKeyOutlined } from '@mui/icons-material';
-import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, IconButton, Pagination, Paper, Popover, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
+import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, IconButton, Pagination, Paper, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { ReactFlowProvider } from '@xyflow/react';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -11,6 +11,7 @@ import Drawer from '../../../../../components/common/Drawer';
 import { criticalityColor } from '../../../../../components/criticalityColor';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
+import ScoreExplainerDialog, { type ScoreBreakdownRow } from '../../../../../components/ScoreExplainerDialog';
 import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathDTO, AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
@@ -1907,7 +1908,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   };
 
   // "Top chokepoints" card popover: the ranked list of the most-exposed endpoints.
-  const [chokepointsAnchor, setChokepointsAnchor] = useState<HTMLElement | null>(null);
+  const [chokepointExplainOpen, setChokepointExplainOpen] = useState(false);
 
   // Graph (node-link) vs Table (sortable/exportable list of exposed endpoints) view of the same data.
   const [view, setView] = useState<'graph' | 'table'>('graph');
@@ -1942,7 +1943,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     // Ensure the graph is showing: the strip chip and the popover card are reachable from the table
     // view too, and the focused path only renders in the graph view.
     setView('graph');
-    setChokepointsAnchor(null);
+    setChokepointExplainOpen(false);
     setActiveCard(null);
     setDrawerCategory(null);
     setSelectedFindingId(null);
@@ -2313,9 +2314,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         {!pathFinding && chokepoints.length > 0 && (
           <>
             <ButtonBase
-              onClick={e => setChokepointsAnchor(e.currentTarget)}
-              aria-haspopup="true"
-              aria-expanded={Boolean(chokepointsAnchor)}
+              onClick={() => setChokepointExplainOpen(true)}
+              aria-haspopup="dialog"
+              aria-expanded={chokepointExplainOpen}
               focusRipple
               sx={{
                 'flex': '1 1 0',
@@ -2325,7 +2326,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 'gap': 1.5,
                 'padding': theme.spacing(1.5),
                 'borderRadius': 1,
-                'border': `1px solid ${chokepointsAnchor ? chokepointColor : theme.palette.divider}`,
+                'border': `1px solid ${chokepointExplainOpen ? chokepointColor : theme.palette.divider}`,
                 'backgroundColor': theme.palette.background.paper,
                 'transition': theme.transitions.create(['border-color', 'background-color']),
                 '&:hover': { borderColor: chokepointColor },
@@ -2364,175 +2365,47 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 </Typography>
               </div>
             </ButtonBase>
-            <Popover
-              open={Boolean(chokepointsAnchor)}
-              anchorEl={chokepointsAnchor}
-              onClose={() => setChokepointsAnchor(null)}
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'left',
-              }}
-            >
-              <Box sx={{
-                p: 1,
-                minWidth: 340,
-                maxWidth: 400,
-              }}
-              >
-                {/* Transparent formula, mirroring the exposure-score explanation: what it measures, the
-                    exact formula, and the criticality weights it uses. */}
-                <Box sx={{
-                  px: 1,
-                  pb: 1,
-                  mb: 0.5,
-                  borderBottom: `1px solid ${theme.palette.divider}`,
-                }}
-                >
-                  <Typography variant="subtitle2">{t('How chokepoints are scored')}</Typography>
-                  <Typography variant="caption" color="text.secondary" component="p" sx={{ mt: 0.5 }}>
-                    {t('A chokepoint is the endpoint where fixing findings closes the most attack paths. The score weights an endpoint\'s findings by its business criticality, so a critical host outranks a noisier but less important one.')}
-                  </Typography>
-                  {/* Formula box styled like the asset posture-score explainer for a consistent look. */}
-                  <Box sx={{
-                    mt: 1,
-                    p: 1,
-                    borderRadius: 1,
-                    background: theme.palette.action.hover,
-                    border: `1px solid ${theme.palette.divider}`,
-                    fontFamily: 'monospace',
-                    fontSize: 13,
-                    textAlign: 'center',
-                    color: 'text.primary',
-                  }}
-                  >
-                    {t('score')}
-                    {' = '}
-                    <Box component="span">{t('findings')}</Box>
-                    {' × '}
-                    <Box component="span">{t('criticality weight')}</Box>
-                  </Box>
-                  <Typography variant="caption" color="text.secondary" component="p" sx={{ mt: 1 }}>
-                    {t('Criticality weight')}
-                    {': '}
-                    {Object.entries(CRITICALITY_WEIGHT)
-                      .filter(([k]) => k !== 'UNKNOWN')
-                      .map(([k, w]) => `${t(CRITICALITY_LABEL[k])} ×${w}`)
-                      .join(' · ')}
-                    {` · ${t(CRITICALITY_LABEL.UNKNOWN)} ×${CRITICALITY_WEIGHT.UNKNOWN}`}
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="subtitle2"
-                  sx={{
-                    px: 1,
-                    pb: 0.5,
-                  }}
-                >
-                  {t('Most exposed assets')}
-                </Typography>
-                {chokepoints.map((c, i) => (
-                  <Box
-                    key={c.nodeId}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => focusChokepoint(c)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        focusChokepoint(c);
-                      }
-                    }}
-                    sx={{
-                      'display': 'flex',
-                      'flexDirection': 'column',
-                      'gap': 0.5,
-                      'px': 1,
-                      'py': 0.75,
-                      'borderRadius': 1,
-                      'cursor': 'pointer',
-                      '&:hover': { backgroundColor: 'action.hover' },
-                      '&:focus-visible': {
-                        outline: `2px solid ${theme.palette.primary.main}`,
-                        outlineOffset: -2,
-                      },
-                    }}
-                  >
-                    {/* Rank + name + score, then a horizontal exposure bar (fill = this endpoint's score
-                        relative to the top chokepoint) — the posture-score "breakdown by pillar" bar style. */}
-                    <Box sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                    }}
-                    >
-                      <span style={{
-                        flex: '0 0 auto',
-                        width: 18,
-                        height: 18,
-                        borderRadius: '50%',
-                        background: criticalityColor(c.criticality),
-                        color: theme.palette.getContrastText(criticalityColor(c.criticality)),
-                        fontSize: 10,
-                        fontWeight: 700,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                      >
-                        {i + 1}
-                      </span>
-                      <Typography
-                        variant="body2"
-                        noWrap
-                        title={c.label}
-                        sx={{
-                          flex: 1,
-                          fontWeight: 600,
-                        }}
-                      >
-                        {c.label}
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          fontWeight: 700,
-                          color: criticalityColor(c.criticality),
-                        }}
-                      >
-                        {c.score}
-                      </Typography>
-                    </Box>
-                    <Tooltip title={t('{findings} findings × {weight} ({criticality})', {
-                      findings: `${c.findings}`,
-                      weight: `${c.weight}`,
-                      criticality: t(CRITICALITY_LABEL[c.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN),
-                    })}
-                    >
-                      <Box sx={{
-                        height: 8,
-                        borderRadius: 999,
-                        overflow: 'hidden',
-                        background: theme.palette.action.hover,
-                      }}
-                      >
-                        <Box sx={{
-                          width: `${Math.min(100, Math.max(6, ((c.score ?? 0) / (chokepoints[0]?.score || 1)) * 100))}%`,
-                          height: '100%',
-                          background: criticalityColor(c.criticality),
-                        }}
-                        />
-                      </Box>
-                    </Tooltip>
-                    <Typography variant="caption" color="text.secondary" noWrap>
-                      {[
-                        c.ip,
-                        `${c.findings} × ${c.weight} (${t(CRITICALITY_LABEL[c.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN)})`,
-                      ].filter(Boolean).join(' · ')}
-                    </Typography>
-                  </Box>
-                ))}
-              </Box>
-            </Popover>
+            <ScoreExplainerDialog
+              open={chokepointExplainOpen}
+              onClose={() => setChokepointExplainOpen(false)}
+              title={t('How chokepoints are scored')}
+              score={chokepoints[0]?.score ?? null}
+              scoreColor={criticalityColor(chokepoints[0]?.criticality)}
+              bandLabel={t(CRITICALITY_LABEL[chokepoints[0]?.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN)}
+              verdict={t('{label} is the most exposed endpoint — fixing its findings closes the most attack paths.', { label: chokepoints[0]?.label ?? '' })}
+              measures={t('A chokepoint is the endpoint where fixing findings closes the most attack paths. The score weights an endpoint\'s findings by its business criticality, so a critical host outranks a noisier but less important one.')}
+              formula={(
+                <>
+                  {t('score')}
+                  {' = '}
+                  {t('findings')}
+                  {' × '}
+                  {t('criticality weight')}
+                </>
+              )}
+              breakdownTitle={t('Most exposed assets')}
+              breakdown={chokepoints.map((c, i): ScoreBreakdownRow => ({
+                key: c.nodeId,
+                label: `${i + 1}. ${c.label}`,
+                valueLabel: `${c.score}`,
+                segments: [{
+                  widthPct: Math.min(100, Math.max(6, ((c.score ?? 0) / (chokepoints[0]?.score || 1)) * 100)),
+                  color: criticalityColor(c.criticality),
+                }],
+                sublabel: [
+                  c.ip,
+                  `${c.findings} × ${c.weight} (${t(CRITICALITY_LABEL[c.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN)})`,
+                ].filter(Boolean).join(' · '),
+                onClick: () => focusChokepoint(c),
+              }))}
+              bandsTitle={t('Criticality weights')}
+              bands={(['VERY_HIGH', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN']).map(k => ({
+                range: `×${CRITICALITY_WEIGHT[k]}`,
+                label: t(CRITICALITY_LABEL[k]),
+                color: criticalityColor(k),
+                desc: t('Weighs this endpoint\'s findings ×{weight} in the score.', { weight: `${CRITICALITY_WEIGHT[k]}` }),
+              }))}
+            />
           </>
         )}
       </div>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1026,7 +1026,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           batch: findingBatch,
         });
       } else if (chainMode && fullDto) {
-        raw = buildCausalChainFlow(fullDto, t);
+        raw = buildCausalChainFlow(fullDto, t, expandedFindingClusters);
       } else {
         raw = buildClusteredAttackPathFlow(dto, endpointBatch, t, {
           expanded: expandedFindingClusters,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2443,8 +2443,8 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                     }}
                     sx={{
                       'display': 'flex',
-                      'alignItems': 'center',
-                      'gap': 1,
+                      'flexDirection': 'column',
+                      'gap': 0.5,
                       'px': 1,
                       'py': 0.75,
                       'borderRadius': 1,
@@ -2456,65 +2456,78 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                       },
                     }}
                   >
-                    {/* Ring gauge (posture-score style): fills with this endpoint's exposure relative to the
-                        top chokepoint, coloured by the chokepoint hue, with its rank inside. */}
-                    {(() => {
-                      const maxScore = chokepoints[0]?.score || 1;
-                      const fill = Math.min(1, Math.max(0.08, (c.score ?? 0) / maxScore));
-                      const size = 26;
-                      const r = 10;
-                      const circ = 2 * Math.PI * r;
-                      return (
-                        <span style={{
-                          position: 'relative',
-                          flex: '0 0 auto',
-                          width: size,
-                          height: size,
-                        }}
-                        >
-                          <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ transform: 'rotate(-90deg)' }}>
-                            <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={theme.palette.divider} strokeWidth={2.5} />
-                            <circle
-                              cx={size / 2}
-                              cy={size / 2}
-                              r={r}
-                              fill="none"
-                              stroke={chokepointColor}
-                              strokeWidth={2.5}
-                              strokeLinecap="round"
-                              strokeDasharray={circ}
-                              strokeDashoffset={circ * (1 - fill)}
-                            />
-                          </svg>
-                          <span style={{
-                            position: 'absolute',
-                            inset: 0,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            fontSize: 10,
-                            fontWeight: 700,
-                            color: chokepointColor,
-                          }}
-                          >
-                            {i + 1}
-                          </span>
-                        </span>
-                      );
-                    })()}
-                    <div style={{
-                      minWidth: 0,
-                      flex: 1,
+                    {/* Rank + name + score, then a horizontal exposure bar (fill = this endpoint's score
+                        relative to the top chokepoint) — the posture-score "breakdown by pillar" bar style. */}
+                    <Box sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
                     }}
                     >
-                      <Typography variant="body2" noWrap title={c.label}>{c.label}</Typography>
-                      <Typography variant="caption" color="text.secondary" noWrap>
-                        {[
-                          c.ip,
-                          `${c.findings} ${t('findings')} × ${c.weight} (${t(CRITICALITY_LABEL[c.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN)}) = ${c.score}`,
-                        ].filter(Boolean).join(' · ')}
+                      <span style={{
+                        flex: '0 0 auto',
+                        width: 18,
+                        height: 18,
+                        borderRadius: '50%',
+                        background: chokepointColor,
+                        color: theme.palette.getContrastText(chokepointColor),
+                        fontSize: 10,
+                        fontWeight: 700,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                      >
+                        {i + 1}
+                      </span>
+                      <Typography
+                        variant="body2"
+                        noWrap
+                        title={c.label}
+                        sx={{
+                          flex: 1,
+                          fontWeight: 600,
+                        }}
+                      >
+                        {c.label}
                       </Typography>
-                    </div>
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontWeight: 700,
+                          color: chokepointColor,
+                        }}
+                      >
+                        {c.score}
+                      </Typography>
+                    </Box>
+                    <Tooltip title={t('{findings} findings × {weight} ({criticality})', {
+                      findings: `${c.findings}`,
+                      weight: `${c.weight}`,
+                      criticality: t(CRITICALITY_LABEL[c.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN),
+                    })}
+                    >
+                      <Box sx={{
+                        height: 8,
+                        borderRadius: 999,
+                        overflow: 'hidden',
+                        background: theme.palette.action.hover,
+                      }}
+                      >
+                        <Box sx={{
+                          width: `${Math.min(100, Math.max(6, ((c.score ?? 0) / (chokepoints[0]?.score || 1)) * 100))}%`,
+                          height: '100%',
+                          background: chokepointColor,
+                        }}
+                        />
+                      </Box>
+                    </Tooltip>
+                    <Typography variant="caption" color="text.secondary" noWrap>
+                      {[
+                        c.ip,
+                        `${c.findings} × ${c.weight} (${t(CRITICALITY_LABEL[c.criticality ?? 'UNKNOWN'] ?? CRITICALITY_LABEL.UNKNOWN)})`,
+                      ].filter(Boolean).join(' · ')}
+                    </Typography>
                   </Box>
                 ))}
               </Box>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1,5 +1,5 @@
 import { AccountTreeOutlined, BugReportOutlined, DnsOutlined, FullscreenExitOutlined, FullscreenOutlined, GroupOutlined, HelpOutline, InsertDriveFileOutlined, LabelOutlined, LocalFireDepartment, PlayArrowOutlined, SearchOutlined, TableRowsOutlined, VpnKeyOutlined } from '@mui/icons-material';
-import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, IconButton, Paper, Popover, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
+import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, IconButton, Pagination, Paper, Popover, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { ReactFlowProvider } from '@xyflow/react';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -2728,30 +2728,21 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
               </Box>
             );
           })}
-          {!findingsLoading && drawerFilteredItems.length > DRAWER_PAGE_SIZE && (
+          {!findingsLoading && drawerPageCount > 1 && (
             <Box sx={{
               display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
+              justifyContent: 'center',
               pt: 1.5,
             }}
             >
-              <Chip
+              {/* Standard MUI pagination (clickable page numbers), consistent with the rest of the app —
+                  replaces the previous custom Prev/Next chips whose page number was not clickable. */}
+              <Pagination
+                count={drawerPageCount}
+                page={drawerSafePage + 1}
+                onChange={(_, p) => setDrawerPage(p - 1)}
                 size="small"
-                variant="outlined"
-                label={t('Previous')}
-                disabled={drawerSafePage <= 0}
-                onClick={() => setDrawerPage(p => Math.max(0, p - 1))}
-              />
-              <Typography variant="caption" color="text.secondary">
-                {`${drawerSafePage + 1} / ${drawerPageCount}`}
-              </Typography>
-              <Chip
-                size="small"
-                variant="outlined"
-                label={t('Next')}
-                disabled={drawerSafePage >= drawerPageCount - 1}
-                onClick={() => setDrawerPage(p => Math.min(drawerPageCount - 1, p + 1))}
+                color="primary"
               />
             </Box>
           )}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1,6 +1,6 @@
 import { AccountTreeOutlined, BugReportOutlined, DnsOutlined, FullscreenExitOutlined, FullscreenOutlined, GroupOutlined, HelpOutline, InsertDriveFileOutlined, LabelOutlined, LocalFireDepartment, PlayArrowOutlined, SearchOutlined, TableRowsOutlined, VpnKeyOutlined } from '@mui/icons-material';
 import { Alert, Autocomplete, Box, Button, ButtonBase, Chip, IconButton, Pagination, Paper, Popover, TextField, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
-import { alpha, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import { ReactFlowProvider } from '@xyflow/react';
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -2391,17 +2391,24 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                   <Typography variant="caption" color="text.secondary" component="p" sx={{ mt: 0.5 }}>
                     {t('A chokepoint is the endpoint where fixing findings closes the most attack paths. The score weights an endpoint\'s findings by its business criticality, so a critical host outranks a noisier but less important one.')}
                   </Typography>
+                  {/* Formula box styled like the asset posture-score explainer for a consistent look. */}
                   <Box sx={{
                     mt: 1,
-                    p: 0.75,
+                    p: 1,
                     borderRadius: 1,
-                    backgroundColor: alpha(chokepointColor, 0.12),
+                    background: theme.palette.action.hover,
+                    border: `1px solid ${theme.palette.divider}`,
                     fontFamily: 'monospace',
-                    fontSize: 12,
+                    fontSize: 13,
                     textAlign: 'center',
+                    color: 'text.primary',
                   }}
                   >
-                    {t('score = findings × criticality weight')}
+                    {t('score')}
+                    {' = '}
+                    <Box component="span">{t('findings')}</Box>
+                    {' × '}
+                    <Box component="span">{t('criticality weight')}</Box>
                   </Box>
                   <Typography variant="caption" color="text.secondary" component="p" sx={{ mt: 1 }}>
                     {t('Criticality weight')}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -613,6 +613,56 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       });
   }, [simulationId]);
 
+  // Focused view: expand the endpoint's finding clusters BY DEFAULT so the analyst sees the actual findings
+  // without a click. The endpoint's findings are already loaded (endpointFindings), and the focus layout
+  // keys a type's cluster deterministically as `path-cl-type|<type>|<endpointKey>`, so we pre-seed those
+  // clusters (findings + expanded flag + first batch). A type with many findings (> the cap) stays a
+  // collapsed "+N" cluster to keep the view readable; the user can still expand it.
+  const AUTO_EXPAND_MAX = 5;
+  useEffect(() => {
+    if (!pathFinding || endpointFindings.length === 0) {
+      return;
+    }
+    const epKey = pathFinding.endpointKey;
+    const byType = new Map<string, typeof endpointFindings>();
+    for (const f of endpointFindings) {
+      const type = f.typeFindings ?? '';
+      (byType.get(type) ?? byType.set(type, []).get(type)!).push(f);
+    }
+    const clusterData = new Map<string, typeof endpointFindings>();
+    for (const [type, list] of byType) {
+      if (type && list.length > 0 && list.length <= AUTO_EXPAND_MAX) {
+        clusterData.set(`path-cl-type|${type}|${epKey}`, list);
+      }
+    }
+    if (clusterData.size === 0) {
+      return;
+    }
+    setFindingsByCluster((prev) => {
+      const next = new Map(prev);
+      clusterData.forEach((v, k) => {
+        if (!next.has(k)) {
+          next.set(k, v);
+        }
+      });
+      return next;
+    });
+    setFindingBatch((prev) => {
+      const next = new Map(prev);
+      clusterData.forEach((_, k) => {
+        if (!next.has(k)) {
+          next.set(k, FINDING_BATCH_SIZE);
+        }
+      });
+      return next;
+    });
+    setExpandedFindingClusters((prev) => {
+      const next = new Set(prev);
+      clusterData.forEach((_, k) => next.add(k));
+      return next;
+    });
+  }, [pathFinding, endpointFindings]);
+
   // Progressive endpoint reveal: the "+N" header toggles expand/collapse; an "+rest" overflow reveals
   // the next batch.
   const onClusterClick = useCallback((injectorId: string, kind: 'header' | 'overflow') => {
@@ -1453,6 +1503,20 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                 continue;
               }
               pathSet.add(e.source);
+            }
+          }
+        }
+      }
+      // A selected finding CLUSTER sits upstream of its expanded children (cluster → finding). The up-walk
+      // above never reaches them, so they'd render dimmed once expanded. Add a scoped DOWNSTREAM pass from
+      // the selection so its own expanded findings (and their edges) stay lit.
+      if (selectedFindingId && pathSet.has(selectedFindingId)) {
+        const down = new Set<string>([selectedFindingId]);
+        for (let pass = 0; pass < 3; pass += 1) {
+          for (const e of baseFlow.edges) {
+            if (e.source && e.target && down.has(e.source) && !down.has(e.target)) {
+              down.add(e.target);
+              pathSet.add(e.target);
             }
           }
         }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2456,22 +2456,52 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                       },
                     }}
                   >
-                    <span style={{
-                      flex: '0 0 auto',
-                      width: 20,
-                      height: 20,
-                      borderRadius: '50%',
-                      background: chokepointColor,
-                      color: theme.palette.getContrastText(chokepointColor),
-                      fontSize: 11,
-                      fontWeight: 700,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                    >
-                      {i + 1}
-                    </span>
+                    {/* Ring gauge (posture-score style): fills with this endpoint's exposure relative to the
+                        top chokepoint, coloured by the chokepoint hue, with its rank inside. */}
+                    {(() => {
+                      const maxScore = chokepoints[0]?.score || 1;
+                      const fill = Math.min(1, Math.max(0.08, (c.score ?? 0) / maxScore));
+                      const size = 26;
+                      const r = 10;
+                      const circ = 2 * Math.PI * r;
+                      return (
+                        <span style={{
+                          position: 'relative',
+                          flex: '0 0 auto',
+                          width: size,
+                          height: size,
+                        }}
+                        >
+                          <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ transform: 'rotate(-90deg)' }}>
+                            <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={theme.palette.divider} strokeWidth={2.5} />
+                            <circle
+                              cx={size / 2}
+                              cy={size / 2}
+                              r={r}
+                              fill="none"
+                              stroke={chokepointColor}
+                              strokeWidth={2.5}
+                              strokeLinecap="round"
+                              strokeDasharray={circ}
+                              strokeDashoffset={circ * (1 - fill)}
+                            />
+                          </svg>
+                          <span style={{
+                            position: 'absolute',
+                            inset: 0,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            fontSize: 10,
+                            fontWeight: 700,
+                            color: chokepointColor,
+                          }}
+                          >
+                            {i + 1}
+                          </span>
+                        </span>
+                      );
+                    })()}
                     <div style={{
                       minWidth: 0,
                       flex: 1,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -794,6 +794,21 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       setFindingBatch(prev => new Map(prev).set(clusterId, FINDING_BATCH_SIZE));
       setSelectedFindingId(clusterId);
       setFindingDetail(null);
+      // In the focused view, scope the highlight to the action(s) that PRODUCED this finding type — so
+      // clicking the portscan cluster lights Nmap (its producer), not another injector that merely reached
+      // the endpoint. Mirrors a leaf-finding click, aggregated over every finding of the type.
+      if (pathFinding && typeFindings) {
+        const typeFindingIds = new Set(
+          (fullDto?.attackPathNodes ?? [])
+            .filter(n => n.type === 'FINDING' && (n.typeFindings ?? '') === typeFindings)
+            .map(n => n.id),
+        );
+        const refs = (fullDto?.attackPathExecutions ?? [])
+          .filter(e => (e.findingsNodeIds ?? []).some(id => typeFindingIds.has(id)))
+          .map(e => e.ref)
+          .filter((r): r is string => !!r);
+        setHighlightedExecutionIds(new Set(refs));
+      }
       if (!findingsByCluster.has(clusterId)) {
         if (endpointRef) {
           fetchEndpointFindings(simulationId, endpointRef)
@@ -832,7 +847,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         }
       }
     },
-    [expandedFindingClusters, findingsByCluster, fetchClusterFindings, simulationId, pathFinding],
+    [expandedFindingClusters, findingsByCluster, fetchClusterFindings, simulationId, pathFinding, fullDto],
   );
 
   // Open the findings drawer for a summary category and load the whole category once (bounded); the

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1230,26 +1230,22 @@ const causalKeyLabel = (key: CausalConsumedKey, t: ApTranslate): string =>
 //   - IS_NOT_NULL => any produced finding of the reconciled type matches (presence, not value).
 // EQ, IN and IS_NOT_NULL are handled. SKIPPED operators (no edge emitted, no silent cap): NEQ, GT, GTE,
 // LT, LTE, CONTAINS, REGEX, and any other — add them here when the backend needs them.
-const findingMatchesKey = (node: AttackPathFlowNode, key: CausalConsumedKey): boolean => {
-  if (node.type !== AP_FLOW_NODE_TYPE.finding) {
-    return false;
-  }
+// The type/value core of the match, shared by the flow-node matcher and the logical-finding matcher used
+// by the chain layout (where a finding may be collapsed into a cluster and so has no leaf flow node).
+const matchesKeyValue = (typeFindings: string, value: string, key: CausalConsumedKey): boolean => {
   const reconciledType = KEYTYPE_TO_FINDING_TYPE[key.keyType] ?? key.keyType;
-  if ((node.data.typeFindings ?? '') !== reconciledType) {
+  if (typeFindings !== reconciledType) {
     return false;
   }
-  // IS_NOT_NULL matches on presence, not value: any produced finding of the reconciled type satisfies it
-  // (e.g. an event "triggered when any share is found"). Its key.value is null, so this must be handled
-  // before the string guard below.
+  // IS_NOT_NULL matches on presence, not value (e.g. "triggered when any share is found"); its key.value is
+  // null, so handle it before the string guard below.
   if (key.operator === 'IS_NOT_NULL') {
-    return findingNodeValue(node).length > 0;
+    return value.length > 0;
   }
-  // Guard the real DTO field (the mock is always a string, but the backend value may be null/undefined):
-  // a non-string key value can never match and must not reach key.value.split() below.
+  // Guard the real DTO field (the mock is always a string, but the backend value may be null/undefined).
   if (typeof key.value !== 'string') {
     return false;
   }
-  const value = findingNodeValue(node);
   if (key.operator === 'EQ') {
     return value === key.value;
   }
@@ -1263,6 +1259,10 @@ const findingMatchesKey = (node: AttackPathFlowNode, key: CausalConsumedKey): bo
   // Unsupported operator (see list above): ignore, emit nothing.
   return false;
 };
+
+const findingMatchesKey = (node: AttackPathFlowNode, key: CausalConsumedKey): boolean =>
+  node.type === AP_FLOW_NODE_TYPE.finding
+  && matchesKeyValue(node.data.typeFindings ?? '', findingNodeValue(node), key);
 
 /**
  * Build the additive kill-chain causal edges for a set of flow nodes (issue 6647).
@@ -1389,6 +1389,8 @@ const CHAIN_STEP_GAP = 80; // vertical gap between two asset blocks sharing a de
 const CHAIN_INJECTOR_ROW = 110; // vertical slot per injector when several share one endpoint block
 const CHAIN_EP_BLOCK_MIN = 120; // minimum height of one endpoint block (endpoint node + breathing room)
 const CHAIN_FIND_HALF = 28; // half of AP_FINDING_SIZE (56), to centre a finding node on its row
+const CHAIN_FINDINGS_MAX_PER_TYPE = 4; // a type with more than this on an endpoint collapses into a "+N"
+// cluster (click to expand), so a heavy endpoint (e.g. 24 portscans) stays a few rows tall, not a column.
 
 interface ChainStep {
   injectorId: string;
@@ -1405,6 +1407,9 @@ interface ChainStep {
 export const buildCausalChainFlow = (
   dto: AttackPathDTO,
   t: ApTranslate,
+  // Cluster ids (chain-fc|<depth>|<endpoint>|<type>) the user expanded, so their findings render
+  // individually instead of collapsed into a "+N" cluster row.
+  expandedChainClusters: Set<string> = new Set(),
 ): {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
@@ -1600,6 +1605,10 @@ export const buildCausalChainFlow = (
   // A finding is placed once (unique React Flow id) on the first endpoint that produced it; any other
   // endpoint that also produced it just gets an edge to the same node.
   const placedFindings = new Set<string>();
+  const placedClusters = new Set<string>();
+  // Finding node id -> the flow node that REPRESENTS it in the graph: itself when rendered individually, or
+  // the cluster node when collapsed. Lets a causal edge point at the cluster when its findings are hidden.
+  const causalSourceByFinding = new Map<string, string>();
 
   for (const [d, ids] of sortedDepths) {
     const x = depthX.get(d) as number;
@@ -1637,9 +1646,38 @@ export const buildCausalChainFlow = (
     for (const epId of assetOrder) {
       const injectors = assetInjectors.get(epId) as string[];
       const findingIds = assetFindings.get(epId) as string[];
+      // Group the endpoint's findings by type; a type with more than the cap collapses into ONE "+N"
+      // cluster row (unless the user expanded it), so a heavy endpoint stays a handful of rows tall.
+      const findingsByType = new Map<string, string[]>();
+      for (const fid of findingIds) {
+        const ftype = findingById.get(fid)?.typeFindings ?? '';
+        (findingsByType.get(ftype) ?? findingsByType.set(ftype, []).get(ftype)!).push(fid);
+      }
+      const findRows: {
+        type: string;
+        fids: string[];
+        clusterId?: string;
+      }[] = [];
+      for (const [ftype, fids] of findingsByType) {
+        const clusterId = `chain-fc|${d}|${epId}|${ftype}`;
+        if (fids.length > CHAIN_FINDINGS_MAX_PER_TYPE && !expandedChainClusters.has(clusterId)) {
+          findRows.push({
+            type: ftype,
+            fids,
+            clusterId,
+          });
+        } else {
+          for (const fid of fids) {
+            findRows.push({
+              type: ftype,
+              fids: [fid],
+            });
+          }
+        }
+      }
       const h = Math.max(
         CHAIN_EP_BLOCK_MIN,
-        findingIds.length * CHAIN_FIND_ROW,
+        findRows.length * CHAIN_FIND_ROW,
         injectors.length * CHAIN_INJECTOR_ROW,
       );
       const blockTop = cursorY;
@@ -1695,10 +1733,57 @@ export const buildCausalChainFlow = (
         });
       });
 
-      // Findings discovered on this asset (union across the injectors), stacked and centred on the block.
-      findingIds.forEach((fid, k) => {
+      // Findings on this asset (union across the injectors), stacked and centred — each row is either a
+      // single finding or a collapsed "+N" cluster for its type.
+      findRows.forEach((row, k) => {
+        const fY = blockCenter + (k - (findRows.length - 1) / 2) * CHAIN_FIND_ROW;
+        if (row.clusterId) {
+          // Worst-of status across the collapsed findings (a missing status is treated as the worst, RED).
+          let clusterStatus = 'GREEN';
+          if (row.fids.some(f => findingById.get(f)?.status === 'ORANGE')) {
+            clusterStatus = 'ORANGE';
+          }
+          if (row.fids.some(f => (findingById.get(f)?.status ?? 'RED') === 'RED')) {
+            clusterStatus = 'RED';
+          }
+          if (!placedClusters.has(row.clusterId)) {
+            placedClusters.add(row.clusterId);
+            nodes.push({
+              id: row.clusterId,
+              type: AP_FLOW_NODE_TYPE.findingCluster,
+              position: {
+                x: x + chainFindDx,
+                y: fY - CHAIN_FIND_HALF,
+              },
+              data: {
+                typeFindings: row.type,
+                count: row.fids.length,
+                label: row.type,
+                clusterId: row.clusterId,
+                clusterKind: 'header',
+                expanded: false,
+                status: clusterStatus,
+              },
+            });
+          }
+          edges.push({
+            id: `${epNodeId}-${row.clusterId}`,
+            source: epNodeId,
+            target: row.clusterId,
+            type: AP_FLOW_EDGE_TYPE,
+            data: {
+              count: row.fids.length,
+              status: clusterStatus,
+              label: t('{type} found', { type: row.type }),
+            },
+          });
+          // The hidden findings are represented by the cluster for causal routing.
+          row.fids.forEach(fid => causalSourceByFinding.set(fid, row.clusterId as string));
+          return;
+        }
+        const fid = row.fids[0];
         const fDto = findingById.get(fid);
-        const fY = blockCenter + (k - (findingIds.length - 1) / 2) * CHAIN_FIND_ROW;
+        causalSourceByFinding.set(fid, fid);
         if (!placedFindings.has(fid)) {
           placedFindings.add(fid);
           nodes.push({
@@ -1737,9 +1822,8 @@ export const buildCausalChainFlow = (
   // Forward causal links: a produced finding → the downstream inject that consumes a matching key. When a
   // step consumes but no produced finding matches (value not surfaced, or a pure ordering dependency), fall
   // back to a dashed dependsOn edge so the sequencing is still shown.
-  const findingNodes = nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.finding);
   const nodeById = new Map(nodes.map(n => [n.id, n]));
-  // Which injector(s) produced each finding node, so a causal edge can be anchored on the finding of the
+  // Which injector(s) produced each finding, so a causal edge can be anchored on the finding of the
   // consumer's REAL producer rather than any finding that merely shares the value from another injector.
   const producersByFinding = new Map<string, Set<string>>();
   for (const [prodInjId, ps] of steps) {
@@ -1751,33 +1835,44 @@ export const buildCausalChainFlow = (
   }
   // Convergence with ONE label: a key like `share_name IS_NOT_NULL` matches every produced share, so draw a
   // grey edge from EACH producing finding to the consumer — the fan-in that reads as "all these findings
-  // triggered it" (the Option A grouping) — but label only the nearest edge. N identical "Triggered …"
-  // labels stacked over the node was the original illegibility; a single label on a fan-in is clean.
+  // triggered it" (the Option A grouping) — but label only the nearest edge. A collapsed cluster routes the
+  // fan-in through its single cluster node (so N hidden findings share one edge). Match against LOGICAL
+  // findings, since a collapsed finding has no leaf flow node.
   const drawnCausalEdges = new Set<string>();
   const labelledCausal = new Set<string>();
   for (const [injId, s] of steps) {
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
-      const allMatches = findingNodes.filter(fn => findingMatchesKey(fn, key));
+      const allFids = [...producersByFinding.keys()].filter((fid) => {
+        const f = findingById.get(fid);
+        return !!f && matchesKeyValue(f.typeFindings ?? '', (f.value ?? f.label ?? ''), key);
+      });
       // Prefer findings produced by this consumer's resolved dependency (#6985 populates dependsOn with the
       // real producer step), so the fan-in stays on the real producer's findings and never reaches a
-      // same-typed finding from an unrelated injector. Fall back to every match when no dependency
-      // resolved (e.g. a complex-type key).
+      // same-typed finding from an unrelated injector. Fall back to every match when no dependency resolved.
       const fromDeps = s.deps.size > 0
-        ? allMatches.filter(fn => [...(producersByFinding.get(fn.id) ?? [])].some(p => s.deps.has(p)))
+        ? allFids.filter(fid => [...(producersByFinding.get(fid) ?? [])].some(p => s.deps.has(p)))
         : [];
-      const matches = fromDeps.length > 0 ? fromDeps : allMatches;
-      if (matches.length === 0) {
+      const fids = fromDeps.length > 0 ? fromDeps : allFids;
+      if (fids.length === 0) {
         continue;
       }
       matched = true;
       const label = causalKeyLabel(key, t);
+      // Resolve each finding to the flow node that represents it (itself or its cluster) and de-dup, so a
+      // collapsed cluster gets ONE causal edge for all its findings.
+      const sourceIds = new Set<string>();
+      for (const fid of fids) {
+        sourceIds.add(causalSourceByFinding.get(fid) ?? fid);
+      }
       // Nearest first, so the single label sits on the shortest edge of the fan-in.
-      const ordered = [...matches].sort((a, b) =>
-        Math.abs(a.position.y - injY) - Math.abs(b.position.y - injY));
-      for (const fn of ordered) {
-        const edgeId = `${AP_FLOW_CAUSAL_EDGE_TYPE}-finding-${fn.id}-${injId}`;
+      const ordered = [...sourceIds]
+        .map(id => nodeById.get(id))
+        .filter((n): n is AttackPathFlowNode => !!n)
+        .sort((a, b) => Math.abs(a.position.y - injY) - Math.abs(b.position.y - injY));
+      for (const src of ordered) {
+        const edgeId = `${AP_FLOW_CAUSAL_EDGE_TYPE}-finding-${src.id}-${injId}`;
         if (drawnCausalEdges.has(edgeId)) {
           continue;
         }
@@ -1788,7 +1883,7 @@ export const buildCausalChainFlow = (
         }
         edges.push({
           id: edgeId,
-          source: fn.id,
+          source: src.id,
           target: injId,
           type: AP_FLOW_CAUSAL_EDGE_TYPE,
           data: {

--- a/openaev-front/src/components/ItemCriticality.tsx
+++ b/openaev-front/src/components/ItemCriticality.tsx
@@ -1,8 +1,9 @@
 import { Chip } from '@mui/material';
-import { type CSSProperties, type FunctionComponent } from 'react';
+import { type FunctionComponent } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import { humanizeEnum } from '../admin/components/assets/asset-categories';
+import { criticalityStyle } from './criticalityColor';
 import { useFormatter } from './i18n';
 
 const useStyles = makeStyles()(() => ({
@@ -14,47 +15,6 @@ const useStyles = makeStyles()(() => ({
     width: 100,
   },
 }));
-
-// Aligns with the severity palette used across the app (see ItemSeverity) so criticality reads the
-// same everywhere: green = low risk, escalating to red for the most critical assets.
-const inlineStyles: Record<string, CSSProperties> = {
-  green: {
-    backgroundColor: 'rgba(76, 175, 80, 0.08)',
-    color: '#4caf50',
-  },
-  blue: {
-    backgroundColor: 'rgba(92, 123, 245, 0.08)',
-    color: '#5c7bf5',
-  },
-  orange: {
-    backgroundColor: 'rgba(255, 152, 0, 0.08)',
-    color: '#ff9800',
-  },
-  red: {
-    backgroundColor: 'rgba(244, 67, 54, 0.08)',
-    color: '#f44336',
-  },
-  blueGrey: {
-    backgroundColor: 'rgba(96, 125, 139, 0.08)',
-    color: '#607d8b',
-    fontStyle: 'italic',
-  },
-};
-
-const computeCriticalityStyle = (criticality: string | undefined | null): CSSProperties => {
-  switch (criticality) {
-    case 'LOW':
-      return inlineStyles.green;
-    case 'MEDIUM':
-      return inlineStyles.blue;
-    case 'HIGH':
-      return inlineStyles.orange;
-    case 'VERY_HIGH':
-      return inlineStyles.red;
-    default:
-      return inlineStyles.blueGrey;
-  }
-};
 
 interface ItemCriticalityProps {
   criticality?: string | null;
@@ -71,7 +31,7 @@ const ItemCriticality: FunctionComponent<ItemCriticalityProps> = ({ criticality,
   return (
     <Chip
       classes={{ root: cx(classes.chip, className) }}
-      style={computeCriticalityStyle(criticality)}
+      style={criticalityStyle(criticality)}
       label={t(humanizeEnum(criticality))}
     />
   );

--- a/openaev-front/src/components/ScoreExplainerDialog.tsx
+++ b/openaev-front/src/components/ScoreExplainerDialog.tsx
@@ -1,0 +1,326 @@
+import { InfoOutlined } from '@mui/icons-material';
+import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, Tooltip, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import { type FunctionComponent, type ReactNode } from 'react';
+
+import { useFormatter } from './i18n';
+
+// Shared score-explainer dialog (posture score + attack-path chokepoints).
+// One coloured segment of a breakdown bar (e.g. met=green / missed=red, or a single exposure fill).
+export interface ScoreBarSegment {
+  widthPct: number;
+  color: string;
+}
+
+// One row of the "breakdown" section: a label, a right-aligned value, and a segmented bar. Optionally
+// clickable (the chokepoints use this to focus an endpoint).
+export interface ScoreBreakdownRow {
+  key: string;
+  label: string;
+  valueLabel: string;
+  segments: ScoreBarSegment[];
+  sublabel?: string;
+  tooltip?: string;
+  onClick?: () => void;
+}
+
+export interface ScoreBand {
+  range: string;
+  label: string;
+  color: string;
+  desc: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  /** Hero number (or '-' when not applicable). */
+  score: number | string | null;
+  scoreColor: string;
+  bandLabel: string;
+  verdict: string;
+  measures: string;
+  /** Formula box content (already composed with any coloured spans). */
+  formula: ReactNode;
+  footnote?: string;
+  breakdownTitle?: string;
+  breakdown?: ScoreBreakdownRow[];
+  bandsTitle?: string;
+  bands?: ScoreBand[];
+  /** Legend chips under the breakdown bars (e.g. Met / Missed). */
+  legend?: {
+    color: string;
+    label: string;
+  }[];
+}
+
+/**
+ * Shared "explain this score" dialog: a hero (score + band + verdict), a plain-language "what it
+ * measures", the exact formula, an optional per-item breakdown of segmented bars, and an optional
+ * severity-band scale. Used by the asset posture score and the attack-path chokepoints so every score in
+ * the app is explained with the same layout — only the numbers, formula and wording differ.
+ */
+const ScoreExplainerDialog: FunctionComponent<Props> = ({
+  open,
+  onClose,
+  title,
+  score,
+  scoreColor,
+  bandLabel,
+  verdict,
+  measures,
+  formula,
+  footnote,
+  breakdownTitle,
+  breakdown = [],
+  bandsTitle,
+  bands = [],
+  legend = [],
+}) => {
+  const theme = useTheme();
+  const { t } = useFormatter();
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { borderRadius: 1 } }}
+    >
+      <DialogTitle sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+      }}
+      >
+        <InfoOutlined color="primary" />
+        {title}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          padding: 2,
+          borderRadius: 1,
+          marginBottom: 2,
+          border: `1px solid ${alpha(scoreColor, 0.3)}`,
+          background: alpha(scoreColor, 0.08),
+        }}
+        >
+          <Typography sx={{
+            fontFamily: '"Geologica", sans-serif',
+            fontSize: 44,
+            fontWeight: 500,
+            lineHeight: 1,
+            color: scoreColor,
+          }}
+          >
+            {score === null ? '-' : score}
+          </Typography>
+          <Box>
+            <Typography sx={{
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              color: scoreColor,
+            }}
+            >
+              {bandLabel}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {verdict}
+            </Typography>
+          </Box>
+        </Box>
+
+        <Typography variant="h4" gutterBottom>{t('What it measures')}</Typography>
+        <Typography variant="body2" color="text.secondary" paragraph>
+          {measures}
+        </Typography>
+        <Box sx={{
+          padding: 1.5,
+          borderRadius: 1,
+          marginBottom: 2,
+          fontFamily: 'monospace',
+          fontSize: 13,
+          textAlign: 'center',
+          color: 'text.primary',
+          background: theme.palette.action.hover,
+          border: `1px solid ${theme.palette.divider}`,
+        }}
+        >
+          {formula}
+        </Box>
+        {footnote && (
+          <Typography variant="body2" color="text.secondary" paragraph>
+            {footnote}
+          </Typography>
+        )}
+
+        {breakdown.length > 0 && (
+          <>
+            <Typography variant="h4" gutterBottom sx={{ marginTop: 2 }}>{breakdownTitle}</Typography>
+            {breakdown.map((row) => {
+              const bar = (
+                <Box sx={{
+                  display: 'flex',
+                  height: 8,
+                  borderRadius: 999,
+                  overflow: 'hidden',
+                  background: theme.palette.action.hover,
+                }}
+                >
+                  {row.segments.map((seg, i) => (
+                    <Box
+                      key={i}
+                      sx={{
+                        width: `${seg.widthPct}%`,
+                        background: seg.color,
+                      }}
+                    />
+                  ))}
+                </Box>
+              );
+              return (
+                <Box
+                  key={row.key}
+                  {...(row.onClick
+                    ? {
+                        role: 'button',
+                        tabIndex: 0,
+                        onClick: row.onClick,
+                        onKeyDown: (e: React.KeyboardEvent) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            row.onClick?.();
+                          }
+                        },
+                      }
+                    : {})}
+                  sx={{
+                    'marginBottom': 1.5,
+                    'borderRadius': 1,
+                    'p': row.onClick ? 0.5 : 0,
+                    'cursor': row.onClick ? 'pointer' : 'default',
+                    '&:hover': row.onClick ? { backgroundColor: 'action.hover' } : undefined,
+                    '&:focus-visible': row.onClick
+                      ? {
+                          outline: `2px solid ${theme.palette.primary.main}`,
+                          outlineOffset: -2,
+                        }
+                      : undefined,
+                  }}
+                >
+                  <Box sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    marginBottom: 0.5,
+                  }}
+                  >
+                    <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap title={row.label}>
+                      {row.label}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {row.valueLabel}
+                    </Typography>
+                  </Box>
+                  {row.tooltip ? <Tooltip title={row.tooltip}>{bar}</Tooltip> : bar}
+                  {row.sublabel && (
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      sx={{
+                        display: 'block',
+                        mt: 0.25,
+                      }}
+                    >
+                      {row.sublabel}
+                    </Typography>
+                  )}
+                </Box>
+              );
+            })}
+            {legend.length > 0 && (
+              <Box sx={{
+                display: 'flex',
+                gap: 2,
+                marginTop: 1,
+              }}
+              >
+                {legend.map(l => (
+                  <Box
+                    key={l.label}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                    }}
+                  >
+                    <Box sx={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      background: l.color,
+                    }}
+                    />
+                    <Typography variant="body2" color="text.secondary">{l.label}</Typography>
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </>
+        )}
+
+        {bands.length > 0 && (
+          <>
+            <Typography variant="h4" gutterBottom sx={{ marginTop: 2 }}>{bandsTitle}</Typography>
+            {bands.map((entry) => {
+              const isCurrent = entry.label === bandLabel;
+              return (
+                <Box
+                  key={entry.range}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 1.5,
+                    paddingBlock: 0.75,
+                    paddingInline: 1,
+                    borderRadius: 1,
+                    background: isCurrent ? alpha(entry.color, 0.1) : 'transparent',
+                    border: `1px solid ${isCurrent ? alpha(entry.color, 0.4) : 'transparent'}`,
+                  }}
+                >
+                  <Box sx={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: '50%',
+                    marginTop: 0.5,
+                    flexShrink: 0,
+                    background: entry.color,
+                    boxShadow: `0 0 6px ${alpha(entry.color, 0.7)}`,
+                  }}
+                  />
+                  <Box>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {`${entry.range} - ${entry.label}`}
+                      {isCurrent ? ` - ${t('current')}` : ''}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">{entry.desc}</Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" color="primary" onClick={onClose}>{t('Close')}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ScoreExplainerDialog;

--- a/openaev-front/src/components/criticalityColor.ts
+++ b/openaev-front/src/components/criticalityColor.ts
@@ -1,0 +1,36 @@
+import { type CSSProperties } from 'react';
+
+// Single source of truth for the asset-criticality palette, so criticality reads the SAME everywhere it is
+// shown — the ItemCriticality chip, the attack-path chokepoint bars, etc. Aligns with the app severity
+// palette: green = low risk, escalating to red for the most critical assets (UNKNOWN is a neutral grey).
+const CRITICALITY_STYLE: Record<string, CSSProperties> = {
+  LOW: {
+    backgroundColor: 'rgba(76, 175, 80, 0.08)',
+    color: '#4caf50',
+  },
+  MEDIUM: {
+    backgroundColor: 'rgba(92, 123, 245, 0.08)',
+    color: '#5c7bf5',
+  },
+  HIGH: {
+    backgroundColor: 'rgba(255, 152, 0, 0.08)',
+    color: '#ff9800',
+  },
+  VERY_HIGH: {
+    backgroundColor: 'rgba(244, 67, 54, 0.08)',
+    color: '#f44336',
+  },
+  UNKNOWN: {
+    backgroundColor: 'rgba(96, 125, 139, 0.08)',
+    color: '#607d8b',
+    fontStyle: 'italic',
+  },
+};
+
+// The full chip style (background + accent) for a criticality; unknown/absent falls back to neutral grey.
+export const criticalityStyle = (criticality: string | undefined | null): CSSProperties =>
+  CRITICALITY_STYLE[criticality ?? 'UNKNOWN'] ?? CRITICALITY_STYLE.UNKNOWN;
+
+// The accent colour alone, for callers that colour their own elements (e.g. the chokepoint exposure bars).
+export const criticalityColor = (criticality: string | undefined | null): string =>
+  (criticalityStyle(criticality).color as string);

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "Verkleinern",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3459,5 +3459,7 @@
   "YYYY": "JJJJ",
   "Zoom in": "Vergrößern",
   "Zoom out": "Verkleinern",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "Zoom out",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3459,5 +3459,7 @@
   "YYYY": "YYYY",
   "Zoom in": "Zoom in",
   "Zoom out": "Zoom out",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "Alejar",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3459,5 +3459,7 @@
   "YYYY": "AAAA",
   "Zoom in": "Acercar",
   "Zoom out": "Alejar",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3472,5 +3472,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Affichage de {shown} sur {total} findings — ouvrez l’inject pour tous les voir.",
   "Fullscreen": "Plein écran",
   "Exit fullscreen": "Quitter le plein écran",
-  "criticality weight": "poids de criticité"
+  "criticality weight": "poids de criticité",
+  "Criticality weights": "Poids de criticité",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} est l’endpoint le plus exposé — corriger ses findings ferme le plus de chemins d’attaque.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Pondère les findings de cet endpoint ×{weight} dans le score."
 }

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3469,5 +3469,7 @@
   "YYYY": "AAAA",
   "Zoom in": "Zoom avant",
   "Zoom out": "Zoom arriere",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Affichage de {shown} sur {total} findings — ouvrez l’inject pour tous les voir."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Affichage de {shown} sur {total} findings — ouvrez l’inject pour tous les voir.",
+  "Fullscreen": "Plein écran",
+  "Exit fullscreen": "Quitter le plein écran"
 }

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3471,5 +3471,6 @@
   "Zoom out": "Zoom arriere",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Affichage de {shown} sur {total} findings — ouvrez l’inject pour tous les voir.",
   "Fullscreen": "Plein écran",
-  "Exit fullscreen": "Quitter le plein écran"
+  "Exit fullscreen": "Quitter le plein écran",
+  "criticality weight": "poids de criticité"
 }

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3459,5 +3459,7 @@
   "YYYY": "AAAA",
   "Zoom in": "Ingrandisci",
   "Zoom out": "Riduci",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "Riduci",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3459,5 +3459,7 @@
   "YYYY": "年",
   "Zoom in": "ズームイン",
   "Zoom out": "ズームアウト",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "ズームアウト",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "축소",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3459,5 +3459,7 @@
   "YYYY": "YYYY",
   "Zoom in": "확대",
   "Zoom out": "축소",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "Отдалить",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3459,5 +3459,7 @@
   "YYYY": "ГГГГ",
   "Zoom in": "Приблизить",
   "Zoom out": "Отдалить",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3462,5 +3462,8 @@
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
   "Exit fullscreen": "Exit fullscreen",
-  "criticality weight": "criticality weight"
+  "criticality weight": "criticality weight",
+  "Criticality weights": "Criticality weights",
+  "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.": "{label} is the most exposed endpoint — fixing its findings closes the most attack paths.",
+  "Weighs this endpoint's findings ×{weight} in the score.": "Weighs this endpoint's findings ×{weight} in the score."
 }

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3459,5 +3459,7 @@
   "YYYY": "YYYY",
   "Zoom in": "放大",
   "Zoom out": "缩小",
-  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all."
+  "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
+  "Fullscreen": "Fullscreen",
+  "Exit fullscreen": "Exit fullscreen"
 }

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3461,5 +3461,6 @@
   "Zoom out": "缩小",
   "Showing {shown} of {total} findings — open the inject to see them all.": "Showing {shown} of {total} findings — open the inject to see them all.",
   "Fullscreen": "Fullscreen",
-  "Exit fullscreen": "Exit fullscreen"
+  "Exit fullscreen": "Exit fullscreen",
+  "criticality weight": "criticality weight"
 }


### PR DESCRIPTION
## Summary

UI follow-ups on the Attack Path view (behind the `ATTACK_PATH` flag), on top of #6995. Focused on legibility and interaction on the causal-chain and chokepoint views, plus consistency with the rest of the app.

### Chain / graph
- **Fullscreen toggle** — lifts the view (cards strip + graph) over the viewport for room to navigate a large chain; Escape exits.
- **Full-chain highlight on action click** — clicking an action highlights the whole chain that led to it (walks upstream through production and causal edges), not just its downstream reach.
- **Findings "+N" clustering (chain view)** — an endpoint with more than four findings of a type collapses that type into an expandable "+N" cluster (click to expand), so a heavy endpoint (e.g. 24 portscans) stays a few rows tall. The causal fan-in routes through the cluster when collapsed.
- **Loader while the causal chain loads** — a chained run shows a loader until the full graph is ready instead of flashing the aggregated view (which read as "no links").

### Focused (chokepoint) view
- **Findings expanded by default** — the focused endpoint's finding clusters open on entry (a type with ≤5 findings shows them individually; larger stays a collapsed "+N"), seeded from the already-loaded endpoint findings.
- **Expanded clusters stay lit** — a selected cluster's expanded children sit downstream of it, so the highlight walk left them dimmed; a scoped downstream pass keeps them lit.
- **Cluster click highlights the real producer** — clicking a finding-type cluster (e.g. portscan) now highlights the action that produced that type (Nmap), not a stale injector.

### Chokepoints
- **Shared score explainer** — extract the posture-score explainer into a reusable `ScoreExplainerDialog` (hero + "what it measures" + formula + segmented breakdown bars + severity bands) and use it for the chokepoints: hero shows the top chokepoint's score coloured by its criticality, the breakdown lists every exposed asset as a clickable exposure bar (click focuses it), and the bands become the criticality weights. Same visual language as the asset posture score; only the data/wording differ.
- **Shared criticality palette** — extract the asset-criticality colours into a shared `criticalityColor` module (single source of truth) consumed by `ItemCriticality` and the chokepoints, so criticality reads the same everywhere (Very high = red … Unknown = grey).

### Findings drawer / list
- **Standard MUI pagination** in the drawer (clickable page numbers), replacing the custom Prev/Next chips.

### Verification
- `check-ts` + eslint + i18n-checker clean; attack-path unit tests green (29). Each change verified live against a backend carrying the per-contract / event-dependency work (#6981, #6985, #6972).

Related issue: #6647
