### PR TITLE
feat(fds): add theme-mode class hook and plan Navbar in roadmap

### DIFF
--- a/fds-migration/IMPLEMENTATION-ROADMAP.md
+++ b/fds-migration/IMPLEMENTATION-ROADMAP.md
@@ -24,3 +24,10 @@ Not scoped yet. See fds-migration/AGENTS.md rule 5 — do not start component
 migration under this phase without an explicit go-ahead. When it starts,
 order by filigran-design-system `ROADMAP.json` `priority`; readiness for
 this product is COMPONENT-MAPPING.md's "Product status" column.
+
+### Planned steps
+
+- [ ] Navbar — planned. Coverage audit already done: see COMPONENT-MAPPING.md
+  ("Navbar" row — MUI identifiers, occurrences, lib/product status). No
+  implementation started; this is a scoping placeholder only, rule 5 above
+  still applies.

--- a/openaev-front/src/__tests__/utils/hooks/UseThemeModeClass.test.tsx
+++ b/openaev-front/src/__tests__/utils/hooks/UseThemeModeClass.test.tsx
@@ -1,0 +1,170 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { type Theme } from '@mui/material/styles';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import useThemeModeClass from '../../../utils/hooks/useThemeModeClass';
+
+// -- TEST DATA --
+
+const darkTheme = createTheme({ palette: { mode: 'dark' } });
+const lightTheme = createTheme({ palette: { mode: 'light' } });
+
+// -- HELPERS --
+
+/**
+ * Wrapper factory. `getTheme` is read at every render (including on
+ * `rerender`), so mutating the value it returns between renders lets tests
+ * simulate the app toggling theme mode.
+ */
+const createWrapper = (getTheme: () => Theme) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <ThemeProvider theme={getTheme()}>{children}</ThemeProvider>;
+  };
+
+// -- TESTS --
+
+describe('useThemeModeClass', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('Applying the class', () => {
+    it('given_darkTheme_should_applyDarkClassAndReturnDark', () => {
+      // Arrange
+      const container = document.createElement('div');
+
+      // Act
+      const { result } = renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => darkTheme) });
+
+      // Assert
+      expect(result.current).toBe('dark');
+      expect(container.classList.contains('dark')).toBe(true);
+      expect(container.classList.contains('light')).toBe(false);
+    });
+
+    it('given_lightTheme_should_applyLightClassAndReturnLight', () => {
+      // Arrange
+      const container = document.createElement('div');
+
+      // Act
+      const { result } = renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => lightTheme) });
+
+      // Assert
+      expect(result.current).toBe('light');
+      expect(container.classList.contains('light')).toBe(true);
+      expect(container.classList.contains('dark')).toBe(false);
+    });
+
+    it('given_nullContainer_should_notThrowAndStillReturnMode', () => {
+      // Act
+      const { result } = renderHook(() => useThemeModeClass(null), { wrapper: createWrapper(() => darkTheme) });
+
+      // Assert — no container to apply a class to, but the mode is still resolved
+      expect(result.current).toBe('dark');
+    });
+  });
+
+  describe('Reactivity to mode changes', () => {
+    it('given_themeModeChangesFromDarkToLight_should_swapClassesAndReturnValue', async () => {
+      // Arrange — starts in dark mode
+      const container = document.createElement('div');
+      let currentTheme = darkTheme;
+      const { result, rerender } = renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => currentTheme) });
+      expect(result.current).toBe('dark');
+      expect(container.classList.contains('dark')).toBe(true);
+
+      // Act — theme switches to light
+      currentTheme = lightTheme;
+      rerender();
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current).toBe('light');
+      });
+      expect(container.classList.contains('light')).toBe(true);
+      expect(container.classList.contains('dark')).toBe(false);
+    });
+
+    it('given_themeModeChangesFromLightToDark_should_swapClassesAndReturnValue', async () => {
+      // Arrange — starts in light mode
+      const container = document.createElement('div');
+      let currentTheme = lightTheme;
+      const { result, rerender } = renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => currentTheme) });
+      expect(result.current).toBe('light');
+
+      // Act — theme switches to dark
+      currentTheme = darkTheme;
+      rerender();
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current).toBe('dark');
+      });
+      expect(container.classList.contains('dark')).toBe(true);
+      expect(container.classList.contains('light')).toBe(false);
+    });
+
+    it('given_containerChanges_should_removeClassFromPreviousContainerAndApplyToNewOne', () => {
+      // Arrange
+      const firstContainer = document.createElement('div');
+      let currentContainer: HTMLElement | null = firstContainer;
+      const { rerender } = renderHook(() => useThemeModeClass(currentContainer), { wrapper: createWrapper(() => darkTheme) });
+      expect(firstContainer.classList.contains('dark')).toBe(true);
+
+      // Act — hook is now given a different container
+      const secondContainer = document.createElement('div');
+      currentContainer = secondContainer;
+      rerender();
+
+      // Assert — previous container is cleaned up, new one carries the class
+      expect(firstContainer.classList.contains('dark')).toBe(false);
+      expect(secondContainer.classList.contains('dark')).toBe(true);
+    });
+  });
+
+  describe('Non-clobbering and scoping', () => {
+    it('given_containerHasPreexistingClasses_should_preserveThemAndOnlyToggleModeClass', () => {
+      // Arrange — container already used by other code (e.g. layout classes)
+      const container = document.createElement('div');
+      container.classList.add('some-other-widget-class', 'another-class');
+
+      // Act
+      renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => darkTheme) });
+
+      // Assert — pre-existing classes survive, only the mode class was added
+      expect(container.classList.contains('some-other-widget-class')).toBe(true);
+      expect(container.classList.contains('another-class')).toBe(true);
+      expect(container.classList.contains('dark')).toBe(true);
+    });
+
+    it('given_hookApplied_should_neverTouchDocumentBodyOrDocumentElement', () => {
+      // Arrange
+      const container = document.createElement('div');
+      const bodyClassesBefore = document.body.className;
+      const htmlClassesBefore = document.documentElement.className;
+
+      // Act
+      renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => darkTheme) });
+
+      // Assert — strictly scoped to the given container
+      expect(document.body.className).toBe(bodyClassesBefore);
+      expect(document.documentElement.className).toBe(htmlClassesBefore);
+    });
+
+    it('given_hookUnmounts_should_removeModeClassFromContainer', () => {
+      // Arrange
+      const container = document.createElement('div');
+      const { unmount } = renderHook(() => useThemeModeClass(container), { wrapper: createWrapper(() => darkTheme) });
+      expect(container.classList.contains('dark')).toBe(true);
+
+      // Act
+      unmount();
+
+      // Assert — no dangling class left on a container that outlives the hook
+      expect(container.classList.contains('dark')).toBe(false);
+      expect(container.classList.contains('light')).toBe(false);
+    });
+  });
+});

--- a/openaev-front/src/utils/hooks/useThemeModeClass.ts
+++ b/openaev-front/src/utils/hooks/useThemeModeClass.ts
@@ -1,0 +1,51 @@
+import type { Theme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
+import { useEffect } from 'react';
+
+export type ThemeModeClassName = 'dark' | 'light';
+
+/**
+ * Reactively applies the current MUI theme mode as a class — exactly one of
+ * 'dark' or 'light' at all times — on a given DOM container, so that its
+ * subtree can rely on either selector to style itself (e.g. FDS-generated
+ * or third-party CSS bundled in mode-scoped selectors, such as the Tailwind
+ * `.dark` variant shipped by `@filigran/chatbot`).
+ *
+ * Generalizes the ad-hoc `container.className = isDarkMode ? 'dark' : ''`
+ * pattern from AskArianePanel.tsx into reusable infrastructure, with two
+ * deliberate improvements over that original pattern:
+ *  - always applies exactly one of 'dark' | 'light' (never both, never
+ *    neither), instead of 'dark' or nothing — so consumers can rely on a
+ *    '.light' selector too, not just the absence of '.dark';
+ *  - uses `classList.add`/`remove` instead of overwriting `className`, so it
+ *    never clobbers other class names already present on the container.
+ *
+ * Strictly scoped to the given `container` — never touches
+ * `document.documentElement` or `document.body` — safe to use on any
+ * FDS-consuming subtree (a portal container, a widget root, …) without
+ * affecting the rest of the app.
+ *
+ * @param container the DOM node to apply the mode class to, or `null` if not
+ * yet mounted (e.g. a container held in `useState` created by an effect).
+ * @returns the resolved mode ('dark' | 'light') matching the current theme.
+ */
+const useThemeModeClass = (container: HTMLElement | null): ThemeModeClassName => {
+  const theme = useTheme<Theme>();
+  const mode: ThemeModeClassName = theme.palette.mode === 'dark' ? 'dark' : 'light';
+
+  useEffect(() => {
+    if (!container) {
+      return undefined;
+    }
+    const opposite: ThemeModeClassName = mode === 'dark' ? 'light' : 'dark';
+    container.classList.remove(opposite);
+    container.classList.add(mode);
+    return () => {
+      container.classList.remove(mode);
+    };
+  }, [container, mode]);
+
+  return mode;
+};
+
+export default useThemeModeClass;


### PR DESCRIPTION
## Mission 1 — Generic theme-mode bridge hook

Generalizes the ad-hoc pattern already in `AskArianePanel.tsx`
(`isDarkMode = theme.palette.mode === 'dark'` → local class) into
`useThemeModeClass`, a standalone, reusable hook:
`openaev-front/src/utils/hooks/useThemeModeClass.ts`.

- Reactively applies **exactly one** of `.dark` / `.light` to a given DOM
  container — never both, never neither. This is a deliberate improvement
  over the original pattern (which only ever set `dark` or empty string),
  so that other FDS-consuming subtrees can rely on an explicit `.light`
  selector too, not just the absence of `.dark`.
- Uses `classList.add`/`remove` instead of overwriting `className`, so it
  never clobbers other classes already present on the container.
- Strictly scoped to the given container — never touches
  `document.documentElement`/`document.body`.
- **Not applied anywhere yet** — infrastructure only, per mission scope.

Tested in isolation: `openaev-front/src/__tests__/utils/hooks/UseThemeModeClass.test.tsx`
(9 cases — dark/light application, reactivity in both directions, null
container, container swap, pre-existing classes preserved, global DOM
untouched, unmount cleanup). All green; lint and full-repo `tsc --noEmit`
clean.

## Mission 2 — Navbar planned in the roadmap

Adds a "Planned steps" entry for Navbar under Phase 2 in
`fds-migration/IMPLEMENTATION-ROADMAP.md`, status `planned`, referencing
the coverage audit already done in `COMPONENT-MAPPING.md` (Navbar row).
Scoping placeholder only — **no Navbar implementation** in this PR;
`fds-migration/AGENTS.md` rule 5 (tokens-only for the current chantier)
still applies.

## CI note

This repo's workflows only run lint/test/typecheck (`core-ci.yml` calling
`_quality-gates.yml`) on PRs/pushes targeting `main` — none trigger on a
PR targeting `design-system/current` (confirmed empirically: the already
merged #6684, also based on `design-system/current`, only ran
`filigran/cla`). So GitHub checks on this PR will not validate anything
beyond the CLA — independent review is the real control here, not the
checks tab. Local verification (lint, typecheck, tests) is documented
above and was green before pushing.

No merge — for review.
