### PR TITLE
fix(expectations): accept collector result predicates under tenant filtering (#7007)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
@@ -133,6 +133,47 @@ class TenantStatementInspectorTest {
     assertTrue(out.contains("can_access_tenant(f.tenant_id)"), out);
   }
 
+  @Test
+  @DisplayName("a LATERAL table function as the sole FROM of a sub-query is accepted")
+  void lateralTableFunctionAsSubqueryFromIsAccepted() {
+    // The collector "not filled" predicate shape: NOT EXISTS over a jsonb unnest of the current
+    // row. LATERAL is a noise word for a function-call FROM item in PostgreSQL but is what marks
+    // the shape as reviewed-safe for the rewriter (#7007).
+    String out =
+        inspect(
+            "SELECT * FROM documents d WHERE NOT EXISTS"
+                + " (SELECT 1 FROM LATERAL jsonb_array_elements(d.payload::jsonb) r"
+                + " WHERE r->>'sourceId' = :sourceId)");
+    assertTrue(out.contains("can_access_tenant(d.tenant_id)"), out);
+    assertTrue(out.contains("jsonb_array_elements"), out);
+  }
+
+  @Test
+  @DisplayName("the AI defense collector query passes with collectors active (regression #7007)")
+  void aiDefenseExpectationsQueryPassesWithCollectorsActive() throws Exception {
+    // #6751 activated collectors, which pulled findAgentlessExpectationsNotFilledForSource into
+    // rewriting; its jsonb_array_elements predicate was refused and the AI expectations endpoint
+    // returned 500 TENANT_FILTERING_REFUSED to every AI defense collector. Pin the real production
+    // SQL against an inspector with collectors active (dual-scope, tenant_id is nullable).
+    String sql =
+        io.openaev.database.repository.InjectExpectationRepository.class
+            .getMethod(
+                "findAgentlessExpectationsNotFilledForSource",
+                String.class,
+                String.class,
+                String.class,
+                int.class)
+            .getAnnotation(org.springframework.data.jpa.repository.Query.class)
+            .value();
+    TenantStatementInspector collectorsActive =
+        new TenantStatementInspector(new TenantTables(Set.of(), Set.of("collectors")));
+    String out = collectorsActive.inspect(sql).replaceAll("\\s+", " ").trim();
+    // The collectors read source is filtered (platform rows allowed: dual-scope read)...
+    assertTrue(out.contains("can_access_tenant(c.tenant_id, true)"), out);
+    // ...and the result predicate survives the rewrite instead of being refused.
+    assertTrue(out.contains("jsonb_array_elements"), out);
+  }
+
   // --- Single table --------------------------------------------------------
 
   @Test

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -24,11 +24,16 @@ public interface InjectExpectationRepository
 
   // JSON predicates over inject_expectation_results: a result "fills" the expectation when its
   // result text is non-empty. Keys are the Java property names serialized by JsonType (camelCase).
+  // LATERAL is a noise word for a function-call FROM item in PostgreSQL (same semantics and plan),
+  // but it matters for multi-tenancy v2: the fail-closed TenantStatementInspector only accepts
+  // table functions carrying the LATERAL prefix (they unnest a column of the current row, never a
+  // whole table). Without it, any query embedding these predicates that also touches a
+  // tenant-active table (e.g. collectors) is refused with TENANT_FILTERING_REFUSED (#7007).
   String RESULTS_HAS_NO_RESULT_FOR_SOURCE =
-      "NOT EXISTS (SELECT 1 FROM jsonb_array_elements(e.inject_expectation_results::jsonb) r "
+      "NOT EXISTS (SELECT 1 FROM LATERAL jsonb_array_elements(e.inject_expectation_results::jsonb) r "
           + "WHERE r->>'sourceId' = :sourceId AND COALESCE(r->>'result', '') <> '') ";
   String RESULTS_HAS_NO_RESULT_AT_ALL =
-      "NOT EXISTS (SELECT 1 FROM jsonb_array_elements(e.inject_expectation_results::jsonb) r "
+      "NOT EXISTS (SELECT 1 FROM LATERAL jsonb_array_elements(e.inject_expectation_results::jsonb) r "
           + "WHERE COALESCE(r->>'result', '') <> '') ";
 
   @NotNull


### PR DESCRIPTION
## Summary

Fixes #7007 - production regression introduced by #6751: since `collectors` was added to `openaev.tenant.active-tables`, the AI defense expectations endpoint `GET /api/injects/expectations/ai/{sourceId}` fails on every call with `500 TENANT_FILTERING_REFUSED`, so AI defense collectors (XTM One LLM firewall / guardrail) can no longer fetch or validate DETECTION / PREVENTION expectations.

## Root cause

`findAgentlessExpectationsNotFilledForSource` contains `JOIN collectors c`, so activating `collectors` pulled the whole statement into the fail-closed `TenantStatementInspector` rewrite. The shared predicate `RESULTS_HAS_NO_RESULT_FOR_SOURCE` embeds:

```sql
NOT EXISTS (SELECT 1 FROM jsonb_array_elements(e.inject_expectation_results::jsonb) r ...)
```

`FROM jsonb_array_elements(...)` is a table function WITHOUT the `LATERAL` prefix; the inspector only accepts LATERAL table functions (the shape reviewed in #6751) and refuses everything else fail-closed -> `TenantFilteringException` -> 500.

CI did not catch it because `src/test/resources/application.properties` shadows the production properties, so `openaev.tenant.active-tables` is empty in `ExpectationApiTest` and the inspector stays inert there.

## Fix

- Add the `LATERAL` prefix to the `jsonb_array_elements` FROM items in `RESULTS_HAS_NO_RESULT_FOR_SOURCE` and `RESULTS_HAS_NO_RESULT_AT_ALL`. For a function-call FROM item, `LATERAL` is a noise word in PostgreSQL (identical semantics and plan), and it is exactly the shape the inspector already accepts. No inspector / security-posture change.
- Regression tests in `TenantStatementInspectorTest`:
  - a LATERAL table function as the sole FROM of a sub-query is accepted;
  - the REAL production SQL of `findAgentlessExpectationsNotFilledForSource` (read via reflection from the `@Query` annotation) passes with `collectors` active as a dual-scope table, and the collectors read source is filtered with `can_access_tenant(c.tenant_id, true)`.

## Test plan

- [x] `TenantStatementInspectorTest`: 77 tests, 0 failures (includes the 2 new regression tests pinning the production query shape)
- [x] Verified with JSQLParser 5.3 that `FROM LATERAL jsonb_array_elements(...) r` parses as `TableFunction` with prefix `LATERAL` (the accepted shape)
- [ ] CI: `ExpectationApiTest` executes the modified native SQL against real PostgreSQL (validates the LATERAL noise word end-to-end)
