### PR TITLE
fix(ui): disable burger button when all menu entries are disabled (#6336)

### DIFF
--- a/openaev-front/src/admin/components/threat_arsenal/ThreatArsenalActionPopover.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/ThreatArsenalActionPopover.tsx
@@ -28,7 +28,7 @@ import {
   type ThreatArsenalActionUpdateInput,
 } from '../../../utils/api-types';
 import { type ThreatArsenalActionCreateCustomInput } from '../../../utils/api-types-custom';
-import { AbilityContext, Can } from '../../../utils/permissions/permissionsContext';
+import { AbilityContext } from '../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
 import { download } from '../../../utils/utils';
 import InjectorContractForm, { type InjectorContractFormValues } from '../integrations/injectors/injector_contracts/InjectorContractForm';
@@ -213,8 +213,14 @@ const ThreatArsenalActionPopover = ({
     handleCloseDuplicate();
   };
 
-  const hasUpdateCapability = ability.can(ACTIONS.MANAGE, SUBJECTS.THREAT_ARSENALS) || ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, payloadId);
+  const hasDuplicateCapability = ability.can(ACTIONS.MANAGE, SUBJECTS.THREAT_ARSENALS);
+  const hasUpdateCapability = hasDuplicateCapability || ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, payloadId);
   const hasDeleteCapability = ability.can(ACTIONS.DELETE, SUBJECTS.THREAT_ARSENALS) || ability.can(ACTIONS.DELETE, SUBJECTS.RESOURCE, payloadId);
+
+  const duplicateOff = !hasDuplicateCapability || !!disableDuplicate;
+  const updateOff = !hasUpdateCapability || !!disableUpdate;
+  const deleteOff = !hasDeleteCapability || !!disableDelete;
+  const allDisabled = duplicateOff && !!disableJsonExport && updateOff && deleteOff;
 
   // -- Export --
   const handleExportJsonSingle = async () => {
@@ -227,17 +233,17 @@ const ThreatArsenalActionPopover = ({
 
   return (
     <>
-      <IconButton color="primary" onClick={handlePopoverOpen} aria-haspopup="true" size="small" sx={{ borderRadius: 1 }}>
-        <MoreVert fontSize="small" />
+      <IconButton color="primary" onClick={handlePopoverOpen} aria-haspopup="true" size="small" disabled={allDisabled} sx={{ borderRadius: 1 }}>
+        <MoreVert fontSize="small" color={allDisabled ? 'disabled' : 'primary'} />
       </IconButton>
       <Menu
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handlePopoverClose}
       >
-        <Can I={ACTIONS.MANAGE} a={SUBJECTS.THREAT_ARSENALS}>
+        {hasDuplicateCapability && (
           <MenuItem onClick={handleOpenDuplicate} disabled={disableDuplicate}>{t('Duplicate')}</MenuItem>
-        </Can>
+        )}
         <MenuItem onClick={handleExportJsonSingle} disabled={disableJsonExport}>{t('Export')}</MenuItem>
         {hasUpdateCapability && (
           <MenuItem onClick={handleOpenEdit} disabled={disableUpdate}>{t('Update')}</MenuItem>

--- a/openaev-front/src/components/common/ButtonPopover.tsx
+++ b/openaev-front/src/components/common/ButtonPopover.tsx
@@ -40,13 +40,16 @@ const ButtonPopover: FunctionComponent<Props> = ({
 
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
+  const visibleEntries = entries.filter(entry => entry.userRight);
+  const allDisabled = disabled || visibleEntries.every(entry => entry.disabled);
+
   return (
     <>
       {/* The ONE kebab trigger, aligned with OpenCTI and identical everywhere
           (list rows, detail heroes, drawers): a small squared (4px radius)
           transparent primary button - never a large round IconButton, never a
           bordered ToggleButton. */}
-      {!entries.every(entry => !entry.userRight)
+      {visibleEntries.length > 0
         && (
           <IconButton
             className={className}
@@ -64,10 +67,10 @@ const ButtonPopover: FunctionComponent<Props> = ({
               setAnchorEl(ev.currentTarget);
             }}
             style={{ ...style }}
-            disabled={disabled}
+            disabled={allDisabled}
             sx={{ borderRadius: 1 }}
           >
-            <MoreVert fontSize="small" color={disabled ? 'disabled' : 'primary'} />
+            <MoreVert fontSize="small" color={allDisabled ? 'disabled' : 'primary'} />
           </IconButton>
         )}
       <Menu


### PR DESCRIPTION
## Summary
- When all visible entries in a kebab (burger) menu are disabled, the trigger button itself is now automatically disabled, preventing users from opening an entirely greyed-out menu.
- Applied to `ButtonPopover` (shared component used across the app) and `ThreatArsenalActionPopover` (custom implementation).

## Changes
- **`ButtonPopover.tsx`**: compute `allDisabled` from visible entries; disable `IconButton` when all are disabled.
- **`ThreatArsenalActionPopover.tsx`**: compute `allDisabled` from permission + `disable*` props; disable `IconButton` accordingly. Replaced `<Can>` wrapper with conditional render for consistency.

## Test plan
- [ ] Open a page with a burger menu where all entries are disabled (e.g. an inject with no available actions) — the burger button should appear greyed out and not be clickable.
- [ ] Open a page with a burger menu where at least one entry is enabled — the burger button should remain active as before.
- [ ] Verify Threat Arsenal action popover behaves the same way when all actions are disabled vs. when some are available.

Closes #6336