### PR TITLE
feat(chaining): highlight the dataflow (#6921)

### DIFF
--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/LogicFlow.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/LogicFlow.tsx
@@ -57,6 +57,9 @@ const proOptions = {
   hideAttribution: true,
 };
 
+/** Opacity applied to nodes/edges outside the selected event's flow (spotlight backdrop). */
+const DIMMED_OPACITY = 0.24;
+
 /**
  * Main logic flow part that displays actions and events as a ReactFlow graph,
  * grouped into MITRE tactic columns. Supports connecting events to actions, editing,
@@ -351,26 +354,42 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
      * Recomputed whenever nodes or callbacks change.
      */
   const nodesWithCallbacks = useMemo(
-    () => nodes.map(node => ({
-      ...node,
-      data: {
-        ...node.data,
-        onEdit: editNode,
-        onDelete: requestDeleteNode,
-        ...(node.type === 'event'
-          ? {
-              isSelected: node.id === selectedEventId,
-              pathIndex: node.id === selectedEventId ? eventPathIndex : undefined,
-            }
-          : {}),
-        ...(node.type === 'action'
-          ? {
-              isHighlighted: highlightedStepIds.has(node.id),
-              pathIndex: stepPathIndex[node.id],
-            }
-          : {}),
-      },
-    })),
+    () => nodes.map((node) => {
+      // When an event is selected, everything outside its data-flow is dimmed
+      // to create a spotlight ("backdrop") effect on the highlighted flow.
+      let inFlow = false;
+      if (node.type === 'event') {
+        inFlow = node.id === selectedEventId;
+      } else if (node.type === 'action') {
+        inFlow = highlightedStepIds.has(node.id);
+      }
+      const dimmed = !!selectedEventId && !inFlow;
+      return {
+        ...node,
+        style: {
+          ...node.style,
+          opacity: dimmed ? DIMMED_OPACITY : 1,
+          transition: 'opacity 0.2s ease',
+        },
+        data: {
+          ...node.data,
+          onEdit: editNode,
+          onDelete: requestDeleteNode,
+          ...(node.type === 'event'
+            ? {
+                isSelected: node.id === selectedEventId,
+                pathIndex: node.id === selectedEventId ? eventPathIndex : undefined,
+              }
+            : {}),
+          ...(node.type === 'action'
+            ? {
+                isHighlighted: highlightedStepIds.has(node.id),
+                pathIndex: stepPathIndex[node.id],
+              }
+            : {}),
+        },
+      };
+    }),
     [nodes, editNode, requestDeleteNode, selectedEventId, highlightedStepIds, stepPathIndex, eventPathIndex],
   );
 
@@ -379,15 +398,22 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
      * Recomputed whenever edges or the delete handler changes.
      */
   const edgesWithCallbacks = useMemo(
-    () => edges.map(edge => ({
-      ...edge,
-      data: {
-        ...edge.data,
-        onDelete: onDeleteEdgeClick,
-        // Real event → step links are emphasized in blue while their event is selected.
-        isHighlighted: !!selectedEventId && edge.source === selectedEventId,
-      },
-    })),
+    () => edges.map((edge) => {
+      // Real event → step link belonging to the selected event's flow.
+      const inFlow = !!selectedEventId && edge.source === selectedEventId;
+      const dimmed = !!selectedEventId && !inFlow;
+      return {
+        ...edge,
+        data: {
+          ...edge.data,
+          onDelete: onDeleteEdgeClick,
+          // Real event → step links are emphasized in blue while their event is selected.
+          isHighlighted: inFlow,
+          // Faded out when outside the selected event's flow (spotlight backdrop).
+          dimmed,
+        },
+      };
+    }),
     [edges, onDeleteEdgeClick, selectedEventId],
   );
 

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/LogicFlow.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/LogicFlow.tsx
@@ -8,9 +8,10 @@ import {
   type Node,
   ReactFlow,
   useEdgesState,
+  useKeyPress,
   useNodesState,
 } from '@xyflow/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   deleteCondition,
@@ -29,6 +30,8 @@ import {
   buildActionMetas,
   buildEdges,
   buildEventData,
+  buildEventPath,
+  buildInformationalEdges,
   buildOutputProvidersMap,
   buildTacticForStep,
   buildTacticNodes,
@@ -92,6 +95,9 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
 
   // Delete confirmation dialog state
   const [pendingDeleteNodeId, setPendingDeleteNodeId] = useState<string | null>(null);
+
+  // Event currently selected to reveal its informational (data-flow) arrows.
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
 
   /**
      * Build the step for updateStep API calls.
@@ -244,6 +250,8 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
   const onEdgesDelete = useCallback(
     (deletedEdges: Edge[]) => {
       for (const edge of deletedEdges) {
+        // Informational edges are read-only visualizations — never unlink steps for them.
+        if (edge.type !== 'deletable') continue;
         removeEdge(edge.source, edge.target);
       }
     },
@@ -321,6 +329,24 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
   }, [actionMetas, eventMetas, onEditStep, onEditEvent]);
 
   /**
+     * Invert action metas into an "output type → provider actions" map so we can
+     * resolve which actions feed a given event condition field.
+     */
+  const outputProviders = useMemo(() => buildOutputProvidersMap(actionMetas), [actionMetas]);
+
+  // Read-only dotted arrows from provider actions into the selected event (see helper).
+  const informationalEdges = useMemo<Edge[]>(
+    () => buildInformationalEdges(selectedEventId, eventMetas, outputProviders, theme.palette.warning.main),
+    [selectedEventId, eventMetas, outputProviders, theme.palette.warning.main],
+  );
+
+  // Numbered path (provider = 1, event = 2, consumer = 3) + highlighted steps
+  const { highlightedStepIds, stepPathIndex, eventPathIndex } = useMemo(
+    () => buildEventPath(selectedEventId, informationalEdges, actionMetas),
+    [selectedEventId, informationalEdges, actionMetas],
+  );
+
+  /**
      * Enrich all nodes with edit/delete callbacks so custom node components can trigger actions.
      * Recomputed whenever nodes or callbacks change.
      */
@@ -331,9 +357,21 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
         ...node.data,
         onEdit: editNode,
         onDelete: requestDeleteNode,
+        ...(node.type === 'event'
+          ? {
+              isSelected: node.id === selectedEventId,
+              pathIndex: node.id === selectedEventId ? eventPathIndex : undefined,
+            }
+          : {}),
+        ...(node.type === 'action'
+          ? {
+              isHighlighted: highlightedStepIds.has(node.id),
+              pathIndex: stepPathIndex[node.id],
+            }
+          : {}),
       },
     })),
-    [nodes, editNode, requestDeleteNode],
+    [nodes, editNode, requestDeleteNode, selectedEventId, highlightedStepIds, stepPathIndex, eventPathIndex],
   );
 
   /**
@@ -346,10 +384,37 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
       data: {
         ...edge.data,
         onDelete: onDeleteEdgeClick,
+        // Real event → step links are emphasized in blue while their event is selected.
+        isHighlighted: !!selectedEventId && edge.source === selectedEventId,
       },
     })),
-    [edges, onDeleteEdgeClick],
+    [edges, onDeleteEdgeClick, selectedEventId],
   );
+
+  const allEdges = useMemo(
+    () => [...edgesWithCallbacks, ...informationalEdges],
+    [edgesWithCallbacks, informationalEdges],
+  );
+
+  /**
+     * Select an event when clicked, or clear the
+     * selection when any other node is clicked.
+     */
+  const onNodeClick = useCallback(
+    (_: ReactMouseEvent, node: Node) => {
+      setSelectedEventId(node.type === 'event' ? node.id : null);
+    },
+    [],
+  );
+
+  /** Dismiss the informational visualization when clicking on the empty canvas. */
+  const onPaneClick = useCallback(() => setSelectedEventId(null), []);
+
+  // Dismiss the informational visualization when pressing Escape (ReactFlow's key hook).
+  const escapePressed = useKeyPress('Escape');
+  useEffect(() => {
+    if (escapePressed) setSelectedEventId(null);
+  }, [escapePressed]);
 
   return (
     <>
@@ -358,11 +423,13 @@ const LogicFlow = ({ workflowId, reloadTrigger, onEditStep, onEditEvent, onEvent
         <>
           <ReactFlow
             nodes={nodesWithCallbacks}
-            edges={edgesWithCallbacks}
+            edges={allEdges}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onEdgesDelete={onEdgesDelete}
             onConnect={onConnect}
+            onNodeClick={onNodeClick}
+            onPaneClick={onPaneClick}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
             proOptions={proOptions}

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/DeletableEdge.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/DeletableEdge.tsx
@@ -11,6 +11,8 @@ import {
 
 interface DeletableEdgeData {
   onDelete?: (edgeId: string, source: string, target: string) => void;
+  /** Emphasized in blue when its event is the currently selected one. */
+  isHighlighted?: boolean;
 
   [key: string]: unknown;
 }
@@ -48,7 +50,17 @@ const DeletableEdge = ({
 
   return (
     <>
-      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} />
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        markerEnd={markerEnd}
+        style={data?.isHighlighted
+          ? {
+              stroke: theme.palette.primary.main,
+              strokeWidth: 2,
+            }
+          : undefined}
+      />
       <EdgeLabelRenderer>
         <div
           style={{

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/DeletableEdge.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/DeletableEdge.tsx
@@ -13,11 +13,16 @@ interface DeletableEdgeData {
   onDelete?: (edgeId: string, source: string, target: string) => void;
   /** Emphasized in blue when its event is the currently selected one. */
   isHighlighted?: boolean;
+  /** Faded out when outside the selected event's flow (spotlight backdrop). */
+  dimmed?: boolean;
 
   [key: string]: unknown;
 }
 
 type DeletableEdgeType = Edge<DeletableEdgeData, 'deletable'>;
+
+/** Opacity applied to edges outside the selected event's flow (spotlight backdrop). */
+const DIMMED_OPACITY = 0.24;
 
 const DeletableEdge = ({
   id,
@@ -48,19 +53,26 @@ const DeletableEdge = ({
     }
   };
 
+  const dimmed = !!data?.dimmed;
+
   return (
     <>
       <BaseEdge
         id={id}
         path={edgePath}
         markerEnd={markerEnd}
-        style={data?.isHighlighted
-          ? {
-              stroke: theme.palette.primary.main,
-              strokeWidth: 2,
-            }
-          : undefined}
+        style={{
+          ...(data?.isHighlighted
+            ? {
+                stroke: theme.palette.primary.main,
+                strokeWidth: 2,
+              }
+            : {}),
+          ...(dimmed ? { opacity: DIMMED_OPACITY } : {}),
+          transition: 'opacity 0.2s ease',
+        }}
       />
+
       <EdgeLabelRenderer>
         <div
           style={{

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/InformationalEdge.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/InformationalEdge.tsx
@@ -1,0 +1,59 @@
+import { useTheme } from '@mui/material/styles';
+import {
+  BaseEdge,
+  type Edge,
+  type EdgeProps,
+  getSmoothStepPath,
+} from '@xyflow/react';
+
+interface InformationalEdgeData {
+  outputLabel?: string;
+
+  [key: string]: unknown;
+}
+
+type InformationalEdgeType = Edge<InformationalEdgeData, 'informational'>;
+
+/**
+ * Dotted orange edge used to visualize the data flow between a provider
+ * action and a selected event. It does NOT represent a real execution link and is
+ * never persisted, it only helps the user understand which action outputs can feed
+ * the event's conditions. Unlike {@link DeletableEdge}, it exposes no delete control.
+ */
+const InformationalEdge = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+}: EdgeProps<InformationalEdgeType>) => {
+  const theme = useTheme();
+  const [edgePath] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  const color = theme.palette.warning.main;
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      markerEnd={markerEnd}
+      style={{
+        stroke: color,
+        strokeWidth: 2,
+        strokeDasharray: '6 4',
+      }}
+    />
+  );
+};
+
+export default InformationalEdge;

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/index.ts
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/edges/index.ts
@@ -1,7 +1,11 @@
 import { type EdgeTypes } from '@xyflow/react';
 
 import DeletableEdge from './DeletableEdge';
+import InformationalEdge from './InformationalEdge';
 
-const edgeTypes: EdgeTypes = { deletable: DeletableEdge };
+const edgeTypes: EdgeTypes = {
+  deletable: DeletableEdge,
+  informational: InformationalEdge,
+};
 
 export default edgeTypes;

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/ActionNode.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/ActionNode.tsx
@@ -14,6 +14,10 @@ export type ActionNodeData = Node<{
   payloadType?: string;
   isPayload?: boolean;
   injectorContract?: string;
+  /** Highlighted in blue when it produces or consumes the currently selected event. */
+  isHighlighted?: boolean;
+  /** 1-based position of this step in the selected event's data-flow path (badge). */
+  pathIndex?: number;
   onEdit?: (id: string, type: string) => void;
   onDelete?: (id: string) => void;
 }>;
@@ -49,11 +53,45 @@ const ActionNode = ({ id, data }: NodeProps<ActionNodeData>) => {
         background: theme.palette.background.default,
         width: ACTION_WIDTH,
         position: 'relative',
+        boxShadow: data.isHighlighted ? `0 0 0 2px ${theme.palette.primary.main}` : 'none',
       }}
     >
+      {data.pathIndex !== undefined && (
+        <div
+          style={{
+            position: 'absolute',
+            top: -10,
+            left: -10,
+            width: 20,
+            height: 20,
+            borderRadius: '50%',
+            background: theme.palette.primary.main,
+            color: theme.palette.primary.contrastText,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 12,
+            fontWeight: 700,
+            zIndex: 2,
+          }}
+        >
+          {data.pathIndex}
+        </div>
+      )}
       <Handle
         type="target"
         position={Position.Left}
+        style={{
+          background: 'transparent',
+          border: 'none',
+        }}
+      />
+      {/* Hidden source handle used as the origin of informational (data-flow) arrows toward events. */}
+      <Handle
+        id="action-source-left"
+        type="source"
+        position={Position.Left}
+        isConnectable={false}
         style={{
           background: 'transparent',
           border: 'none',

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/ActionNode.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/ActionNode.tsx
@@ -88,9 +88,9 @@ const ActionNode = ({ id, data }: NodeProps<ActionNodeData>) => {
       />
       {/* Hidden source handle used as the origin of informational (data-flow) arrows toward events. */}
       <Handle
-        id="action-source-left"
+        id="action-source-right"
         type="source"
-        position={Position.Left}
+        position={Position.Right}
         isConnectable={false}
         style={{
           background: 'transparent',

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/EventNode.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/EventNode.tsx
@@ -9,6 +9,10 @@ import NodePopover from './NodePopover';
 export type EventNodeData = Node<{
   label: string;
   conditions?: string[];
+  /** Whether this event is currently selected to reveal its informational data-flow arrows. */
+  isSelected?: boolean;
+  /** 1-based position of this event in the selected data-flow path (badge). */
+  pathIndex?: number;
   onEdit?: (id: string, type: string) => void;
   onDelete?: (id: string) => void;
 }>;
@@ -41,6 +45,27 @@ const EventNode = ({ id, data }: NodeProps<EventNodeData>) => {
       paddingTop: 2,
     }}
     >
+      {data.pathIndex !== undefined && (
+        <Box sx={{
+          position: 'absolute',
+          top: 8,
+          left: -10,
+          width: 20,
+          height: 20,
+          borderRadius: '50%',
+          background: theme.palette.warning.main,
+          color: theme.palette.warning.contrastText,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 12,
+          fontWeight: 700,
+          zIndex: 2,
+        }}
+        >
+          {data.pathIndex}
+        </Box>
+      )}
       <Box
         sx={{
           position: 'absolute',
@@ -74,6 +99,7 @@ const EventNode = ({ id, data }: NodeProps<EventNodeData>) => {
           justifyContent: 'space-between',
           alignItems: 'center',
           position: 'relative',
+          boxShadow: data.isSelected ? `0 0 0 2px ${theme.palette.warning.main}` : 'none',
         }}
       >
         <Typography
@@ -104,6 +130,17 @@ const EventNode = ({ id, data }: NodeProps<EventNodeData>) => {
           position={Position.Right}
           style={{
             background: theme.palette.primary.main,
+            border: 'none',
+          }}
+        />
+        {/* Hidden target handle used to receive informational (data-flow) arrows from provider actions. */}
+        <Handle
+          id="event-target"
+          type="target"
+          position={Position.Right}
+          isConnectable={false}
+          style={{
+            background: 'transparent',
             border: 'none',
           }}
         />

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/EventNode.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/EventNode.tsx
@@ -137,7 +137,7 @@ const EventNode = ({ id, data }: NodeProps<EventNodeData>) => {
         <Handle
           id="event-target"
           type="target"
-          position={Position.Right}
+          position={Position.Left}
           isConnectable={false}
           style={{
             background: 'transparent',

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/NodePopover.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/nodes/NodePopover.tsx
@@ -15,11 +15,19 @@ const NodePopover = ({ anchorEl, onClose, onEdit, onDelete }: NodePopoverProps) 
 
   return (
     <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={onClose}>
-      <MenuItem onClick={onEdit}>
+      <MenuItem onClick={(e) => {
+        e.stopPropagation();
+        onEdit();
+      }}
+      >
         <ListItemIcon><EditOutlined fontSize="small" /></ListItemIcon>
         <ListItemText>{t('Edit')}</ListItemText>
       </MenuItem>
-      <MenuItem onClick={onDelete}>
+      <MenuItem onClick={(e) => {
+        e.stopPropagation();
+        onDelete();
+      }}
+      >
         <ListItemIcon><DeleteOutlined fontSize="small" /></ListItemIcon>
         <ListItemText>{t('Delete')}</ListItemText>
       </MenuItem>

--- a/openaev-front/src/admin/components/chaining/logic/logic-flow-helpers.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-flow-helpers.ts
@@ -541,7 +541,7 @@ export const buildInformationalEdges = (
   return Array.from(typesByAction.entries()).map(([stepId, types]) => ({
     id: `info-${stepId}-${selectedEventId}`,
     source: stepId,
-    sourceHandle: 'action-source-left',
+    sourceHandle: 'action-source-right',
     target: selectedEventId,
     targetHandle: 'event-target',
     type: 'informational',

--- a/openaev-front/src/admin/components/chaining/logic/logic-flow-helpers.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-flow-helpers.ts
@@ -9,7 +9,9 @@ import {
   type ConditionKeyType,
   createEmptyCondition,
   createEmptyGroup,
-  type EventCondition, generateId,
+  type EventCondition,
+  formatConditionKeyLabel,
+  generateId,
   type LogicalOperator,
 } from './events/event-types';
 import type { ActionMeta, EventMeta } from './types';
@@ -493,4 +495,122 @@ export const buildEdges = (
     }
   }
   return edges;
+};
+
+// -- Informational data-flow visualization (selected event) --
+
+/** Recursively collect every leaf-condition field referenced by an event's condition tree. */
+export const collectEventFields = (group: ConditionGroup): string[] => [
+  ...group.conditions.map(c => c.field),
+  ...group.subGroups.flatMap(collectEventFields),
+];
+
+/**
+ * Build the read-only dotted arrows from every provider action into the currently selected
+ * event. One arrow per provider action, carrying the matching output type(s) as label data.
+ * These are informational only — they are never persisted and do not represent a real link.
+ *
+ * @param selectedEventId the currently selected event id (or null → no arrows)
+ * @param eventMetas all events keyed by id
+ * @param outputProviders inverted map "output type → provider actions"
+ * @param arrowColor the stroke/marker color (resolved from the theme by the caller)
+ */
+export const buildInformationalEdges = (
+  selectedEventId: string | null,
+  eventMetas: Record<string, EventMeta>,
+  outputProviders: Record<string, OutputProviderEntry[]>,
+  arrowColor: string,
+): Edge[] => {
+  if (!selectedEventId) return [];
+  const meta = eventMetas[selectedEventId];
+  if (!meta) return [];
+
+  // All distinct condition fields referenced by the event.
+  const fields = new Set(meta.formData.conditionGroups.flatMap(collectEventFields).filter(Boolean));
+
+  // Aggregate, per provider action, the set of matching output types it feeds.
+  const typesByAction = new Map<string, Set<string>>();
+  for (const field of fields) {
+    for (const provider of outputProviders[field] ?? []) {
+      const current = typesByAction.get(provider.stepId) ?? new Set<string>();
+      current.add(field);
+      typesByAction.set(provider.stepId, current);
+    }
+  }
+
+  return Array.from(typesByAction.entries()).map(([stepId, types]) => ({
+    id: `info-${stepId}-${selectedEventId}`,
+    source: stepId,
+    sourceHandle: 'action-source-left',
+    target: selectedEventId,
+    targetHandle: 'event-target',
+    type: 'informational',
+    selectable: false,
+    deletable: false,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      color: arrowColor,
+    },
+    data: { outputLabel: Array.from(types).map(formatConditionKeyLabel).join(', ') },
+  }));
+};
+
+export interface EventPath {
+  /** Ids of every step (provider or consumer) involved in the selected event's data flow. */
+  highlightedStepIds: Set<string>;
+  /** 1-based badge index per step id. */
+  stepPathIndex: Record<string, number>;
+  /** 1-based badge index of the event itself (sits between providers and consumers). */
+  eventPathIndex: number | undefined;
+}
+
+/**
+ * Compute the data-flow path for the selected event: provider steps (which produce outputs
+ * feeding the event) first, then the event itself, then consumer steps (which use the event
+ * as an execution condition). Each element gets a 1-based index rendered as a numbered badge
+ * (e.g. provider = 1, event = 2, consumer step = 3).
+ *
+ * @param selectedEventId the currently selected event id (or null → empty path)
+ * @param informationalEdges the informational edges produced by {@link buildInformationalEdges}
+ * @param actionMetas all steps keyed by id
+ */
+export const buildEventPath = (
+  selectedEventId: string | null,
+  informationalEdges: Edge[],
+  actionMetas: Record<string, ActionMeta>,
+): EventPath => {
+  if (!selectedEventId) {
+    return {
+      highlightedStepIds: new Set<string>(),
+      stepPathIndex: {},
+      eventPathIndex: undefined,
+    };
+  }
+
+  // Provider steps: actions producing an output matching one of the event's condition fields.
+  const providerIds = Array.from(new Set(informationalEdges.map(e => e.source)));
+  // Consumer steps: actions using this event as an execution condition (real link).
+  const consumerIds = Object.entries(actionMetas)
+    .filter(([, meta]) => meta.step_condition_ids.includes(selectedEventId))
+    .map(([stepId]) => stepId);
+
+  const index: Record<string, number> = {};
+  let counter = 0;
+
+  // 1..n — provider steps come first.
+  for (const id of providerIds) {
+    if (!(id in index)) index[id] = ++counter;
+  }
+  // n+1 — the event sits between producers and consumers.
+  const eventPathIndex = ++counter;
+  // n+2.. — consumer steps (skip any already counted as a provider).
+  for (const id of consumerIds) {
+    if (!(id in index)) index[id] = ++counter;
+  }
+
+  return {
+    highlightedStepIds: new Set(Object.keys(index)),
+    stepPathIndex: index,
+    eventPathIndex,
+  };
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Highlight the data flow when clicking on an event to show which actions produce the data type and which actions consume it.


### Testing Instructions

1. Create a chaining simulation 
2. Add an action which produce text (for example) 
3. Add an event (text=blabla)
4. Link the event to an other action
5. Click on the event 
<img width="1913" height="344" alt="Capture d’écran 2026-07-28 à 16 16 05" src="https://github.com/user-attachments/assets/b89989b0-fc98-4b50-9072-0d58f30985bb" />


### Related issues

* Closes #6921 
