### PR TITLE
fix(expectations): carry the tenant scope on the AI defense feed endpoint (#7014)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/expectation/ExpectationApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/expectation/ExpectationApi.java
@@ -248,8 +248,11 @@ public class ExpectationApi extends RestBehavior {
   })
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.SIMULATION)
   @Transactional
+  // TxCtx scopes the transaction so the collectors table (v2-activated) is visible: the feed's
+  // expected-security-platforms guard reads collectors natively, and without a scope the guard is
+  // fail-closed empty, silently dropping every platform-restricted expectation (#7014).
   public List<InjectExpectationOutput> getAiDefenseExpectationsNotFilledForSource(
-      @PathVariable String sourceId) {
+      TxCtx ctx, @PathVariable String sourceId) {
     String tenantId = TenantContext.getCurrentTenant();
     return toOutputs(injectExpectationService.aiDefenseExpectationsNotFill(tenantId, sourceId));
   }

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
@@ -104,7 +104,12 @@ class TenantScopedEntrypointsTxCtxArchTest {
           "io.openaev.rest.inject.ScenarioInjectApi#updateInjectForScenario",
           // health-check streams: runChecks -> securityPlatformCollectors
           "io.openaev.rest.scenario.ScenarioApi#streamHealthChecks",
-          "io.openaev.rest.exercise.ExerciseApi#streamHealthChecks");
+          "io.openaev.rest.exercise.ExerciseApi#streamHealthChecks",
+          // expectations: the AI feed reads collectors natively (expected-security-platforms
+          // guard, #7014); the update endpoints attach collector-sourced results. Both overloads
+          // of updateInjectExpectation are covered by the single name entry.
+          "io.openaev.rest.expectation.ExpectationApi#getAiDefenseExpectationsNotFilledForSource",
+          "io.openaev.rest.expectation.ExpectationApi#updateInjectExpectation");
 
   @ArchTest
   static final ArchRule tx_scoped_entrypoints_must_declare_tx_ctx =

--- a/openaev-api/src/test/java/io/openaev/rest/expectation/AiDefenseFeedTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/expectation/AiDefenseFeedTenantScopeTest.java
@@ -1,0 +1,183 @@
+package io.openaev.rest.expectation;
+
+import static io.openaev.expectation.ExpectationPropertiesConfig.DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME;
+import static io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegration.OPENAEV_INJECTOR_NAME;
+import static io.openaev.rest.expectation.ExpectationApi.INJECTS_EXPECTATIONS_URI;
+import static io.openaev.utils.fixtures.ExpectationFixture.createDetectionExpectations;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.AssetGroup;
+import io.openaev.database.model.Collector;
+import io.openaev.database.model.CollectorType;
+import io.openaev.database.model.Endpoint;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Injector;
+import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.SecurityPlatform;
+import io.openaev.database.model.TechnicalInjectExpectation;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.AssetGroupRepository;
+import io.openaev.database.repository.CollectorRepository;
+import io.openaev.database.repository.CollectorTypeRepository;
+import io.openaev.database.repository.EndpointRepository;
+import io.openaev.database.repository.InjectExpectationRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.database.repository.InjectorContractRepository;
+import io.openaev.database.repository.InjectorRepository;
+import io.openaev.database.repository.SecurityPlatformRepository;
+import io.openaev.execution.ExecutableInject;
+import io.openaev.expectation.Expectation;
+import io.openaev.service.InjectExpectationService;
+import io.openaev.utils.fixtures.AssetGroupFixture;
+import io.openaev.utils.fixtures.EndpointFixture;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.InjectorFixture;
+import io.openaev.utils.fixtures.SecurityPlatformFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression test for #7014: with {@code collectors} on v2 tenant isolation, the AI defense feed
+ * endpoint must carry a {@link io.openaev.context.TxCtx} tenant scope. Its native query reads the
+ * collectors table inside the expected-security-platforms guard; without a scope the guard is
+ * fail-closed EMPTY (no error), so every platform-restricted AI adversarial expectation silently
+ * disappears from the feed and is never validated. This runs the real HTTP endpoint with the table
+ * active - the production configuration that {@code ExpectationApiTest} does not exercise (the test
+ * properties leave {@code openaev.tenant.active-tables} empty).
+ */
+@Transactional
+@TestPropertySource(properties = "openaev.tenant.active-tables=collectors")
+@WithMockUser(isAdmin = true)
+@DisplayName("AI defense feed carries the tenant scope with collectors v2-activated")
+class AiDefenseFeedTenantScopeTest extends IntegrationTest {
+
+  private static final String INJECTION_NAME = "AI adversarial - direct prompt injection";
+  private static final String INJECTOR_TYPE = "openaev_ai_feed_scope_test";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private EntityManager em;
+  @Autowired private AssetGroupRepository assetGroupRepository;
+  @Autowired private EndpointRepository endpointRepository;
+  @Autowired private InjectRepository injectRepository;
+  @Autowired private InjectorRepository injectorRepository;
+  @Autowired private InjectorContractRepository injectorContractRepository;
+  @Autowired private CollectorTypeRepository collectorTypeRepository;
+  @Autowired private CollectorRepository collectorRepository;
+  @Autowired private SecurityPlatformRepository securityPlatformRepository;
+  @Autowired private InjectExpectationRepository injectExpectationRepository;
+  @Autowired private InjectExpectationService injectExpectationService;
+
+  private Inject savedInject;
+  private Endpoint agentlessEndpoint;
+  private Collector llmCollector;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // The TxCtx scope is the caller's authorized tenants: the mock user must be a member of the
+    // default tenant (where the collector and the inject live) for the scope to cover them.
+    String userId = testUserHolder.get().getId();
+    tenantRepository.addUserToTenant(userId, Tenant.DEFAULT_TENANT_UUID);
+    tenantMembershipCacheManager.evict(userId, Tenant.DEFAULT_TENANT_UUID);
+
+    InjectorContract injectorContract =
+        InjectorContractFixture.createInjectorContract(Map.of("en", INJECTION_NAME));
+    injectorContract.setCustom(true);
+    Injector savedInjector =
+        injectorRepository.save(
+            InjectorFixture.createInjector(
+                UUID.randomUUID().toString(), OPENAEV_INJECTOR_NAME + "-ai-scope", INJECTOR_TYPE));
+    injectorContract.addInjector(savedInjector);
+    InjectorContract savedInjectorContract = injectorContractRepository.save(injectorContract);
+    em.flush();
+    savedInjector.linkContract(savedInjectorContract);
+    injectorRepository.save(savedInjector);
+
+    agentlessEndpoint =
+        endpointRepository.save(EndpointFixture.createEndpoint("ai-agentless-endpoint"));
+    AssetGroup savedAssetGroup =
+        assetGroupRepository.save(
+            AssetGroupFixture.createAssetGroupWithAssets(
+                "ai-scope-asset-group", List.of(agentlessEndpoint)));
+    savedInject =
+        injectRepository.save(
+            InjectFixture.createTechnicalInjectWithAssetGroup(
+                savedInjectorContract, INJECTION_NAME, savedAssetGroup));
+
+    // An LLM firewall collector in the default tenant, and an agentless DETECTION expectation
+    // restricted to that platform type - the production AI red team shape.
+    SecurityPlatform securityPlatform =
+        securityPlatformRepository.save(
+            SecurityPlatformFixture.createDefault(
+                "LLM_FIREWALL-platform-" + UUID.randomUUID(), "LLM_FIREWALL"));
+    CollectorType collectorType = new CollectorType(UUID.randomUUID().toString());
+    collectorTypeRepository.save(collectorType);
+    Collector collector = new Collector();
+    collector.setId(UUID.randomUUID().toString());
+    collector.setTenantId(Tenant.DEFAULT_TENANT_UUID);
+    collector.setName("llm-firewall-collector");
+    collector.setType(collectorType.getName());
+    collector.setCollectorType(collectorType);
+    collector.setExternal(true);
+    collector.setSecurityPlatform(securityPlatform);
+    llmCollector = collectorRepository.save(collector);
+
+    ExecutableInject executableInject =
+        new ExecutableInject(
+            false,
+            true,
+            savedInject,
+            emptyList(),
+            List.of(agentlessEndpoint),
+            emptyList(),
+            emptyList());
+    List<Expectation> detectionExpectations =
+        createDetectionExpectations(
+            emptyList(), agentlessEndpoint, null, DEFAULT_TECHNICAL_EXPECTATION_EXPIRATION_TIME);
+    injectExpectationService.buildAndSaveInjectExpectations(
+        executableInject, detectionExpectations);
+
+    TechnicalInjectExpectation leaf =
+        (TechnicalInjectExpectation)
+            injectExpectationRepository
+                .findAllByInjectAndAsset(savedInject.getId(), agentlessEndpoint.getId())
+                .getFirst();
+    leaf.setExpectedSecurityPlatforms(
+        List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.LLM_FIREWALL));
+    injectExpectationRepository.save(leaf);
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("a platform-restricted agentless expectation reaches its matching collector")
+  void platformRestrictedExpectationReachesMatchingCollector() throws Exception {
+    String response =
+        mvc.perform(
+                get(INJECTS_EXPECTATIONS_URI + "/ai/" + llmCollector.getId())
+                    .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    // Without the TxCtx scope the collectors read is fail-closed empty and the feed silently
+    // returns [] - the #7014 production regression.
+    assertEquals(1, ((List<?>) JsonPath.read(response, "$")).size());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #7014. Second production regression from #6751: after #7008 removed the 500, `GET /api/injects/expectations/ai/{sourceId}` returned an EMPTY list instead - AI defense collectors (XTM One) had nothing to validate and DETECTION / PREVENTION expectations stayed Pending forever.

Root cause: the v2 tenant scope is parameter-driven. `TenantScopeTransactionAspect` writes `app.current_tenants` only when the `@Transactional` method declares a `TxCtx` parameter; without it the GUC stays empty and `can_access_tenant()` is false for every row (fail-closed by design, even for platform rows). #6751 added `TxCtx` to the expectation WRITE endpoints but not to the AI feed endpoint, whose native query reads the v2-activated `collectors` table inside its expected-security-platforms guard:

```sql
OR EXISTS (SELECT 1 FROM collectors c JOIN assets sp ... WHERE c.collector_id = :sourceId ...)
```

With no scope, the rewritten collectors sub-query yields zero rows, the EXISTS is always false, and every expectation carrying `inject_expectation_expected_security_platforms` (all AI red team expectations) silently disappears from the feed. No error, no log - the worst failure mode of fail-closed reads.

## Changes

- `ExpectationApi#getAiDefenseExpectationsNotFilledForSource` now declares `TxCtx ctx`, exactly like the expectation write endpoints fixed in #6751, so the transaction carries the caller's tenant scope.
- `TenantScopedEntrypointsTxCtxArchTest` now pins the AI feed endpoint and the two expectation write endpoints (they carried `TxCtx` but were never pinned), so a refactor cannot silently drop the parameter again.
- New `AiDefenseFeedTenantScopeTest`: runs the real HTTP endpoint with `openaev.tenant.active-tables=collectors` (the production configuration that the existing `ExpectationApiTest` never exercises, since test properties leave the active-tables list empty), seeding an agentless DETECTION expectation restricted to LLM_FIREWALL plus a matching collector in the default tenant, and asserting the feed hands it out.

## Test plan

- [x] `AiDefenseFeedTenantScopeTest` is RED without the fix (feed silently returns `[]`, reproducing production) and GREEN with it
- [x] `TenantScopedEntrypointsTxCtxArchTest` passes with the new pins
- [x] `mvn spotless:apply` clean
