### PR TITLE
feat(chaining): match complex-finding sub-fields for kill-chain events (#6647)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -1061,23 +1061,38 @@ public class AttackPathGraphService {
         continue;
       }
       Set<String> producerSteps = new LinkedHashSet<>();
+      List<ConsumedFindingKeyDTO> resolvedKeys = new ArrayList<>();
       for (ConsumedFindingKeyDTO key : node.getConsumedFindingKeys()) {
-        for (AttackPathFindingRow f :
-            findingsByType.getOrDefault(
-                AttackPathKeyMatcher.reconciledType(key.keyType()), List.of())) {
-          if (!AttackPathKeyMatcher.matches(f, key)) {
-            continue;
-          }
-          AttackPathExecutionRow producer = executionById.get(f.executionId());
-          if (producer != null
-              && producer.stepTemplateId() != null
-              && producer.executedAt() != null
-              && producer.executedAt().isBefore(consumer.executedAt())
-              && !producer.stepTemplateId().equals(consumer.stepTemplateId())) {
-            producerSteps.add(producer.stepTemplateId());
+        // The finding-node ids this key matched (back-authoritative, spec 011): the front anchors
+        // the
+        // causal edge on these instead of re-matching.
+        Set<String> matchedNodeIds = new LinkedHashSet<>();
+        // A primitive key can be satisfied by its own type OR by a complex finding that carries it
+        // as a sub-field (e.g. `port` by a `portscan`), so scan every candidate bucket, not just
+        // the
+        // reconciled one.
+        for (String findingType : AttackPathKeyMatcher.candidateFindingTypes(key.keyType())) {
+          for (AttackPathFindingRow f : findingsByType.getOrDefault(findingType, List.of())) {
+            if (!AttackPathKeyMatcher.matches(f, key)) {
+              continue;
+            }
+            AttackPathExecutionRow producer = executionById.get(f.executionId());
+            if (producer != null
+                && producer.stepTemplateId() != null
+                && producer.executedAt() != null
+                && producer.executedAt().isBefore(consumer.executedAt())
+                && !producer.stepTemplateId().equals(consumer.stepTemplateId())) {
+              producerSteps.add(producer.stepTemplateId());
+              matchedNodeIds.add(AttackPathIds.findingNode(f.type(), f.value()));
+            }
           }
         }
+        resolvedKeys.add(
+            matchedNodeIds.isEmpty()
+                ? key
+                : key.withMatchedFindingIds(List.copyOf(matchedNodeIds)));
       }
+      node.setConsumedFindingKeys(resolvedKeys);
       if (!producerSteps.isEmpty()) {
         List<String> dependsOn =
             new ArrayList<>(node.getDependsOn() == null ? List.of() : node.getDependsOn());

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathKeyMatcher.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathKeyMatcher.java
@@ -3,16 +3,21 @@ package io.openaev.service.attackpath;
 import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
 import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Matches a produced finding against a consumed finding key, mirroring the front's finding matcher
  * so the producer the backend resolves is the finding the front would match. The key type is
  * reconciled to the finding-type vocabulary, then the operator is applied: {@code EQ} (value
  * equals), {@code IN} (comma-separated membership, single token falls back to substring), and
- * {@code IS_NOT_NULL} (presence). Every other operator matches nothing. Primitive keys only;
- * reaching into a complex finding's sub-field is deferred.
+ * {@code IS_NOT_NULL} (presence). Every other operator matches nothing. A key whose type reconciles
+ * to the finding type tests the whole value; a key targeting a SUB-FIELD of a multi-field complex
+ * finding (e.g. {@code port} of a {@code portscan} value {@code host:port (service)}) is resolved
+ * through a per-type sub-field extractor.
  */
 public final class AttackPathKeyMatcher {
 
@@ -32,21 +37,151 @@ public final class AttackPathKeyMatcher {
     return KEYTYPE_TO_FINDING_TYPE.getOrDefault(keyType, keyType);
   }
 
+  /**
+   * The finding types a key of this type can match: its reconciled/identity type plus every complex
+   * type that carries it as a sub-field (e.g. {@code port} → {@code {port, portscan}}). Empty for a
+   * null key type. The caller uses this to pick which finding-type buckets to scan before matching,
+   * since a primitive key can reach both a primitive finding and a complex finding's sub-field.
+   */
+  public static Set<String> candidateFindingTypes(String keyType) {
+    if (keyType == null) {
+      return Set.of();
+    }
+    Set<String> types = new LinkedHashSet<>();
+    types.add(reconciledType(keyType));
+    SUBFIELDS.forEach(
+        (findingType, subfields) -> {
+          if (subfields.containsKey(keyType)) {
+            types.add(findingType);
+          }
+        });
+    return types;
+  }
+
+  // Per-type sub-field extractors, keyed by (finding type, key type): the inverse of each
+  // *OutputProcessor.toFindingValue. Only multi-field complex types whose sub-fields events consume
+  // are registered; a finding type absent here is matched on its whole value. Keyed on the
+  // PRESENTED
+  // type (a share is a file here). portscan first (T1); the other types follow.
+  private static final Map<String, Map<String, Function<String, String>>> SUBFIELDS =
+      Map.of(
+          "portscan", Map.of("port", AttackPathKeyMatcher::extractPortscanPort),
+          "credentials",
+              Map.of(
+                  "username", AttackPathKeyMatcher::extractCredentialsUsername,
+                  "password", AttackPathKeyMatcher::extractCredentialsPassword),
+          "file", Map.of("share_name", AttackPathKeyMatcher::extractShareName),
+          "username",
+              Map.of(
+                  "username", AttackPathKeyMatcher::extractUsernameFindingUser,
+                  "domain", AttackPathKeyMatcher::extractUsernameFindingDomain));
+
   public static boolean matches(AttackPathFindingRow finding, ConsumedFindingKeyDTO key) {
     if (finding == null || key == null) {
       return false;
     }
-    String reconciledType = reconciledType(key.keyType());
-    if (reconciledType == null || !reconciledType.equals(finding.type())) {
+    String candidate = resolveCandidate(finding, key.keyType());
+    if (candidate == null) {
       return false;
     }
-    String value = finding.value();
     return switch (key.operator() == null ? "" : key.operator()) {
-      case "IS_NOT_NULL" -> value != null && !value.isBlank();
-      case "EQ" -> key.value() != null && key.value().equals(value);
-      case "IN" -> matchesIn(value, key.value());
+      case "IS_NOT_NULL" -> !candidate.isBlank();
+      case "EQ" -> key.value() != null && key.value().equals(candidate);
+      case "IN" -> matchesIn(candidate, key.value());
       default -> false;
     };
+  }
+
+  /**
+   * The value tested against the key: the extracted sub-field when the finding is a multi-field
+   * complex type and the key targets one of its sub-fields, else the whole finding value when the
+   * key type reconciles to the finding type. Null when the finding cannot satisfy this key type, or
+   * the sub-field does not parse — both a non-match.
+   */
+  private static String resolveCandidate(AttackPathFindingRow finding, String keyType) {
+    String findingType = finding.type();
+    // Immutable Map.of() throws on a null lookup, and a null key/finding type can never be a
+    // registered sub-field, so guard before the sub-field lookup and fall to the whole-value path.
+    if (keyType != null && findingType != null) {
+      Function<String, String> extractor =
+          SUBFIELDS.getOrDefault(findingType, Map.of()).get(keyType);
+      if (extractor != null) {
+        return extractor.apply(finding.value());
+      }
+    }
+    String reconciledType = reconciledType(keyType);
+    return reconciledType != null && reconciledType.equals(findingType) ? finding.value() : null;
+  }
+
+  // portscan value is "host:port (service)"; the port is the token after the LAST ':' once the
+  // optional " (service)" suffix is dropped, so an IPv6 host's own ':' is never mistaken for it.
+  private static String extractPortscanPort(String value) {
+    if (value == null) {
+      return null;
+    }
+    String v = value;
+    int paren = v.indexOf(" (");
+    if (paren >= 0) {
+      v = v.substring(0, paren);
+    }
+    int lastColon = v.lastIndexOf(':');
+    if (lastColon < 0 || lastColon == v.length() - 1) {
+      return null;
+    }
+    return v.substring(lastColon + 1).trim();
+  }
+
+  // credentials value is "username:password" (CredentialsOutputProcessor); split on the FIRST ':',
+  // since a username has none but a password may.
+  private static String extractCredentialsUsername(String value) {
+    if (value == null) {
+      return null;
+    }
+    int i = value.indexOf(':');
+    return i < 0 ? null : value.substring(0, i);
+  }
+
+  private static String extractCredentialsPassword(String value) {
+    if (value == null) {
+      return null;
+    }
+    int i = value.indexOf(':');
+    return i < 0 || i == value.length() - 1 ? null : value.substring(i + 1);
+  }
+
+  // A share is presented as a file with value "\\host\shareName (permissions)"
+  // (ShareOutputProcessor);
+  // the share name is the token after the LAST '\' once the optional " (permissions)" is dropped.
+  private static String extractShareName(String value) {
+    if (value == null) {
+      return null;
+    }
+    String v = value;
+    int paren = v.indexOf(" (");
+    if (paren >= 0) {
+      v = v.substring(0, paren);
+    }
+    int lastBackslash = v.lastIndexOf('\\');
+    return lastBackslash < 0 || lastBackslash == v.length() - 1
+        ? null
+        : v.substring(lastBackslash + 1);
+  }
+
+  // username value is domain, then a backslash, then username (UsernameOutputProcessor).
+  private static String extractUsernameFindingUser(String value) {
+    if (value == null) {
+      return null;
+    }
+    int i = value.lastIndexOf('\\');
+    return i < 0 || i == value.length() - 1 ? null : value.substring(i + 1);
+  }
+
+  private static String extractUsernameFindingDomain(String value) {
+    if (value == null) {
+      return null;
+    }
+    int i = value.indexOf('\\');
+    return i <= 0 ? null : value.substring(0, i);
   }
 
   private static boolean matchesIn(String value, String keyValue) {

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/ConsumedFindingKeyDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/ConsumedFindingKeyDTO.java
@@ -1,5 +1,7 @@
 package io.openaev.service.attackpath.dto;
 
+import java.util.List;
+
 /**
  * One finding key a kill-chain step consumes as input (issue 5048).
  *
@@ -12,6 +14,27 @@ package io.openaev.service.attackpath.dto;
  * <p>{@code eventName} is the name of the root filter condition (the event) this key belongs to, so
  * the front can tell the analyst which event the consuming action was triggered by (e.g. "SMB UP")
  * rather than only the raw key match. Null when the event has no name.
+ *
+ * <p>{@code matchedFindingIds} are the finding-node ids ({@code NODE_FINDING|type|value}) this key
+ * matched, resolved by the backend (spec 011, back-authoritative). The front anchors the causal
+ * edge on these instead of re-matching. Empty until resolved, or when nothing matched.
  */
 public record ConsumedFindingKeyDTO(
-    String keyType, String operator, String value, String eventName) {}
+    String keyType,
+    String operator,
+    String value,
+    String eventName,
+    List<String> matchedFindingIds) {
+
+  /**
+   * Built from a condition; the matched producing findings are resolved later (empty until then).
+   */
+  public ConsumedFindingKeyDTO(String keyType, String operator, String value, String eventName) {
+    this(keyType, operator, value, eventName, List.of());
+  }
+
+  /** A copy carrying the finding-node ids this key matched. */
+  public ConsumedFindingKeyDTO withMatchedFindingIds(List<String> ids) {
+    return new ConsumedFindingKeyDTO(keyType, operator, value, eventName, ids);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathKillChainGraphTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathKillChainGraphTest.java
@@ -13,6 +13,7 @@ import io.openaev.database.model.attackpath.AttackPathFinding;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
 import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
 import io.openaev.service.attackpath.AttackPathGraphService;
+import io.openaev.service.attackpath.AttackPathIds;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
 import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
@@ -127,6 +128,11 @@ class AttackPathKillChainGraphTest extends IntegrationTest {
             .findFirst()
             .orElseThrow();
     assertThat(consumerNode.getDependsOn()).contains("producer-step-tpl");
+    // The share is presented as file, so the matched id uses the PRESENTED type (file), matching
+    // the
+    // finding-node id the front renders — otherwise the front could not resolve it.
+    assertThat(consumerNode.getConsumedFindingKeys().get(0).matchedFindingIds())
+        .containsExactly(AttackPathIds.findingNode("file", "\\\\host\\NETLOGON"));
   }
 
   @Test
@@ -207,6 +213,39 @@ class AttackPathKillChainGraphTest extends IntegrationTest {
     assertThat(nodeForStep(eqStep.get().getId()).getDependsOn()).containsExactly("port-445");
     // IN {139,445,3389} → the 445 producer matches.
     assertThat(nodeForStep(inStep.get().getId()).getDependsOn()).contains("port-445");
+  }
+
+  @Test
+  @DisplayName(
+      "a port key reaches a complex portscan finding (bucket portscan), not only a primitive port")
+  void portKeyReachesPortscanBucket() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-portscan"));
+    // The nmap scan ingests a COMPLEX portscan finding "host:port (service)", bucket "portscan".
+    AttackPathExecution producer =
+        saveExecution(tenant, "nmap", "portscan-prod", Instant.parse("2026-06-18T08:00:00Z"));
+    saveFinding(tenant, "portscan", "10.0.0.1:445 (microsoft-ds)", producer.getId());
+    // The consumer filters on the PRIMITIVE key `port EQ 445`.
+    StepComposer.Composer consumer = consumerStep(PrimitiveType.Port, ConditionType.EQ, "445");
+    saveExecution(tenant, "netexec", consumer.get().getId(), Instant.parse("2026-06-18T08:05:00Z"));
+    entityManager.flush();
+
+    assertThat(nodeForStep(consumer.get().getId()).getDependsOn()).contains("portscan-prod");
+  }
+
+  @Test
+  @DisplayName("a consumed key carries the finding-node ids it matched (back-authoritative)")
+  void consumerKeyCarriesMatchedFindingIds() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-eventdep-matched"));
+    AttackPathExecution producer =
+        saveExecution(tenant, "nmap", "portscan-prod-m", Instant.parse("2026-06-18T08:00:00Z"));
+    saveFinding(tenant, "portscan", "10.0.0.1:445 (microsoft-ds)", producer.getId());
+    StepComposer.Composer consumer = consumerStep(PrimitiveType.Port, ConditionType.EQ, "445");
+    saveExecution(tenant, "netexec", consumer.get().getId(), Instant.parse("2026-06-18T08:05:00Z"));
+    entityManager.flush();
+
+    ConsumedFindingKeyDTO key = nodeForStep(consumer.get().getId()).getConsumedFindingKeys().get(0);
+    assertThat(key.matchedFindingIds())
+        .containsExactly(AttackPathIds.findingNode("portscan", "10.0.0.1:445 (microsoft-ds)"));
   }
 
   private AttackPathExecution saveExecution(

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathKeyMatcherTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathKeyMatcherTest.java
@@ -106,4 +106,117 @@ class AttackPathKeyMatcherTest {
     assertThat(AttackPathKeyMatcher.matches(finding("port", "445"), key("port", null, "445")))
         .isFalse();
   }
+
+  @Test
+  @DisplayName("a port key reaches the port sub-field of a portscan finding (host:port (service))")
+  void matches_portscan_port_subfield() {
+    // A portscan value is the formatted "host:port (service)"
+    // (PortScanOutputProcessor.toFindingValue),
+    // one finding per host+port. A `port` key must reach the port sub-field, not compare the whole
+    // value.
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "10.0.3.11:445 (SMB)"), key("port", "EQ", "445")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "10.0.3.11:445 (SMB)"), key("port", "EQ", "22")))
+        .isFalse();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "10.0.3.11:445 (SMB)"), key("port", "IN", "139,445,3389")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "10.0.3.11:445 (SMB)"), key("port", "IS_NOT_NULL", null)))
+        .isTrue();
+    // Pitfall: an IPv6 host contains ':'; the port is the numeric token before the optional "
+    // (service)",
+    // not split(':')[1].
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "2001:db8::1:445 (SMB)"), key("port", "EQ", "445")))
+        .isTrue();
+    // Pitfall: no " (service)" segment.
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "10.0.3.11:445"), key("port", "EQ", "445")))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("username/password keys reach the sub-fields of a credentials finding (user:pass)")
+  void matches_credentials_subfields() {
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("credentials", "admin:secret"), key("username", "EQ", "admin")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("credentials", "admin:secret"), key("password", "EQ", "secret")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("credentials", "admin:secret"), key("password", "EQ", "admin")))
+        .isFalse();
+    // A password containing ':' splits on the FIRST separator (the username has none).
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("credentials", "svc:p:ss"), key("password", "EQ", "p:ss")))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("a share_name key reaches the share sub-field of a share-presented-as-file finding")
+  void matches_share_as_file_subfields() {
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", "\\\\host\\NETLOGON (RW)"), key("share_name", "EQ", "NETLOGON")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("file", "\\\\host\\NETLOGON"), key("share_name", "EQ", "SYSVOL")))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("username/domain keys reach the sub-fields of a username finding (domain\\user)")
+  void matches_username_finding_subfields() {
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("username", "CORP\\jdoe"), key("username", "EQ", "jdoe")))
+        .isTrue();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("username", "CORP\\jdoe"), key("domain", "EQ", "CORP")))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("an unparsable complex value never matches and never throws")
+  void unparsable_complex_value_never_matches() {
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("portscan", "host-no-colon"), key("port", "EQ", "445")))
+        .isFalse();
+    assertThat(
+            AttackPathKeyMatcher.matches(
+                finding("credentials", "no-colon"), key("password", "IS_NOT_NULL", null)))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName(
+      "candidate finding types = the identity type plus every complex type with the key as a"
+          + " sub-field")
+  void candidate_finding_types() {
+    // A `port` key can be satisfied by a primitive port finding OR a complex portscan finding.
+    assertThat(AttackPathKeyMatcher.candidateFindingTypes("port"))
+        .containsExactlyInAnyOrder("port", "portscan");
+    assertThat(AttackPathKeyMatcher.candidateFindingTypes("username"))
+        .containsExactlyInAnyOrder("username", "credentials");
+    assertThat(AttackPathKeyMatcher.candidateFindingTypes("share_name")).containsExactly("file");
+    assertThat(AttackPathKeyMatcher.candidateFindingTypes("cve")).containsExactly("cve");
+    assertThat(AttackPathKeyMatcher.candidateFindingTypes(null)).isEmpty();
+  }
 }

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -2230,6 +2230,7 @@ export interface ConnectorInstancePersisted {
 export interface ConsumedFindingKeyDTO {
   eventName?: string;
   keyType?: string;
+  matchedFindingIds?: string[];
   operator?: string;
   value?: string;
 }


### PR DESCRIPTION
## What

The kill-chain matcher now resolves a primitive consumed key against a COMPLEX produced finding's sub-field, so an event like `port EQ 445` matches an nmap `portscan` finding and the causal edge (Nmap → SMB) draws. Two stacked breakages, both fixed:

1. **Bucketing.** `applyEventDependencies` scanned only the `reconciledType(keyType)` bucket, so a `port` key never reached the `portscan` bucket (nmap ingests `portscan`, a distinct type). New `AttackPathKeyMatcher.candidateFindingTypes(keyType)` = the identity type plus every complex type carrying it as a sub-field (`port` → `{port, portscan}`), so a primitive key still matches a primitive finding AND a complex finding.
2. **Sub-field extraction.** `matches` extracts the sub-field from the finding's formatted value (the inverse of each `*OutputProcessor.toFindingValue`): portscan `host:port (service)` → port, credentials `user:pass`, share-as-file `\\host\share (perms)`, username `domain\user`. Primitives and single-value complex findings are unchanged.

**Back-authoritative.** The backend already runs this match (for `dependsOn`); it now also exposes the matched producing finding-node ids per key on `ConsumedFindingKeyDTO.matchedFindingIds`. The front will anchor the causal edge on these (follow-up) instead of re-matching, removing the front/back parser mirror.

Consistent with the platform model: `candidateFindingTypes` mirrors the existing `ChainingTypeRegistry` complex→primitive recipe.

Contained: no schema, no ingestion, no runtime-engine change. One additive `api-types` field (`matchedFindingIds`).

## Test plan

- `AttackPathKeyMatcherTest` (unit): sub-field extraction per type + pitfalls (IPv6, malformed → no match/no throw, EQ/IN/IS_NOT_NULL), `candidateFindingTypes`, no-regression.
- `AttackPathKillChainGraphTest` (integration): a `port EQ 445` consumer reaches a `portscan` finding; the consumed key carries the matched finding-node ids (portscan + file-presented share).
- Full `*AttackPath*` suite + architecture tests green; spotless clean; api-types regenerated.

## Follow-up (front, Sébastien)
Read `matchedFindingIds` to anchor the causal edge (drop the front re-matching); handle the empty case; humanize the `portscan` type label.

Related: #6647