### PR TITLE
fix(fds): wire the 5 confirmed color-token gaps

### DIFF
--- a/fds-migration/TOKEN-MAPPING.md
+++ b/fds-migration/TOKEN-MAPPING.md
@@ -416,10 +416,10 @@ OpenCTI and OpenAEV, for the shared Figma backlog with Thibault.
 | Concept | OpenAEV usage | OpenCTI usage | Common value today | Suggested token name |
 |---|---|---|---|---|
 | Tinted "accent" background (distinct from the base accent/code color) | `background.accent` (light only), `#d3eaff` — `ItemCopy.tsx`, `AttackPatternBox.tsx` ×2 | No direct equivalent — closest is `designSystem.background.bg1`-`bg4`, also untokenized on their side | Different per product — genuinely no shared value yet | `--color-elevation-background-tint` (working name) |
-| Multi-tier elevation background (beyond default/paper/accent) | `designSystem.background.{bg1,bg2,bg3,bg4,disabled}` — **no longer fully dead**: #6813 added the first live consumer, `.bg2` (a menu separator border in `LeftMenu.tsx`) — the other 4 sub-keys remain unconsumed | `designSystem.background.{bg1,bg2,bg3,bg4,disabled}` — **live**, 0 confident FDS match either (their own report, §6/"Tokens à créer") | n/a (both hardcoded, no shared value) | `--color-elevation-background-layer-{1..4}` extension, or a dedicated `bg-tint-*` scale |
-| Severity `none`/`default` (neutral/unset state) | `palette.severity.default`, `#004C66` fallback in `Tag.tsx` | `severity.none`/`.default` — explicitly left untouched, "no feedback-family equivalent" | Different per product | `--color-feedback-neutral-*` (new family — neither product has a "neutral" feedback tier today) |
-| Raw blue hue scale gap | `designSystem.tertiary.blue.{500,900}` (`#0099CC`/`#003242`) — now **live** as of #6813/§8.6, same 2 residual values, still no FDS match | `designSystem.tertiary.blue` (`#0099CC`/`#003242`) — no FDS match at all, closest is `blue-500` which is a completely different, much brighter color | **Now shared** — identical hardcoded values on both products (was OpenCTI-only) | `--color-blue-{step}` scale extension |
-| Generic "border" concept | `designSystem.border.{main,border1,border2}` — now **live** as of #6813/§8.6, identical values to OpenCTI's (`#D2D2D2`/`#C2C2C2`/`#999797` light) | `designSystem.border.{main,border1,border2}` — no FDS "border" concept exists today | **Now shared** — identical hardcoded values (was OpenCTI-only) | `--color-border-*` (new family) |
+| Multi-tier elevation background (beyond default/paper/accent) | `designSystem.background.{bg1,bg2,bg3,bg4,disabled}` — **RESOLVED on OpenAEV as of § 9** (reused existing `--bg-elevation-default-layer-{0-3}`/`--bg-elevation-disabled`, not a new token). `.bg2`'s live consumer (`LeftMenu.tsx`) confirmed zero/imperceptible delta | `designSystem.background.{bg1,bg2,bg3,bg4,disabled}` — **live**, 0 confident FDS match either (their own report, §6/"Tokens à créer") — unchanged, still open on their side | n/a (both hardcoded, no shared value) | `--color-elevation-background-layer-{1..4}` extension, or a dedicated `bg-tint-*` scale — **may no longer be needed for OpenAEV** if OpenCTI adopts the same existing-token reuse; still useful if a purpose-built tint scale is wanted later |
+| Severity `none`/`default` (neutral/unset state) | `palette.severity.default`, `#004C66` fallback in `Tag.tsx` — **RESOLVED on OpenAEV as of § 9** (reused existing `--color-feedback-neutral-primary`, both keys collapse to the same value) | `severity.none`/`.default` — explicitly left untouched, "no feedback-family equivalent" — unchanged, still open on their side | Different per product | `--color-feedback-neutral-*` (new family) — **may no longer be needed** now that OpenAEV reuses an existing token; kept for OpenCTI's side |
+| Raw blue hue scale gap | `designSystem.tertiary.blue.{500,900}` (`#0099CC`/`#003242`) — **RESOLVED on OpenAEV as of § 9**, but via reuse of `--color-feedback-info-secondary-transparency` (a semi-transparent alpha token) — **not** a new opaque blue-scale token; both products' dormant `.500`/`.900` are 0-consumer, see § 9.3's semantic-change caveat before ever wiring a real consumer to this | `designSystem.tertiary.blue` (`#0099CC`/`#003242`) — no FDS match at all — unchanged, still open on their side | **Was shared** — now diverges (OpenAEV reused an unrelated alpha token, OpenCTI still hardcoded) | `--color-blue-{step}` scale extension — still relevant if a real opaque-blue consumer ever appears on either product |
+| Generic "border" concept | `designSystem.border.{main,border1,border2}` — **RESOLVED on OpenAEV as of § 9** (reused existing `--border-elevation-default`/`--border-elevation-subtle`; `border1`/`border2` collapse to the same subtle value) | `designSystem.border.{main,border1,border2}` — no FDS "border" concept exists today — unchanged, still open on their side | **Was shared** — now diverges (OpenAEV resolved via reuse, OpenCTI still hardcoded) | `--color-border-*` (new family) — may no longer be needed for OpenAEV; kept for OpenCTI's side |
 | Light-mode tonic sub-shades | `designSystem.secondary.{light,dark}` (light mode only) — now **live** as of #6813/§8.7; only `.main` was retokenized this pass, `.light`/`.dark` share OpenCTI's exact residual gap | `designSystem.secondary.{light,dark}` (light mode only) — old values don't match `tonic-secondary`/`tonic-tertiary` the way dark mode's did | **Now shared** — same residual gap on both products (was OpenCTI-only) | Possibly a light-mode-specific tonic sub-shade pair |
 | Dialog/modal background (distinct from generic paper elevation) | `MuiDialog.styleOverrides.paper` hardcoded: `#0F1D34` (dark) / `#FFFFFF` (light) — now **live** as of #6813/§8.10, still unwired | `MuiDialog.styleOverrides.paper` hardcoded: `#0F1D34` (dark, distinct from paper `#0d172b`) / `#FFFFFF` (light, = paper `#ffffff`) — already self-flagged "no confident FDS match" in OpenCTI's own `TOKEN-MAPPING.md` (`THEME_DARK_DIALOG_BACKGROUND`/`THEME_LIGHT_DIALOG_BACKGROUND`) | **Now shared** — identical hardcoded pattern and values on both products (was OpenCTI-only) | `--color-elevation-background-dialog` (working name) — added following the 2026-07-13 cross-product comparison, see `reports/tokens-visual-validation.md` annex |
 
@@ -437,15 +437,17 @@ products, 100% resolved from `theme.css`. Every color-bearing property in
 `mui-inventory` scanner can check convergence by counting bucket (a) vs
 (b)+(c).
 
-> **Superseded by §8.** This section originally *predicted* wave 2 (written
-> before #6813 landed). #6813's merge forced wave 2 to happen now — §8 is
-> the executed record. The buckets below are updated to reflect what
-> actually shipped vs. what's still open; where §7's original prediction
-> and §8's actual execution differ (rare — mostly root-level `warn`/
-> `warning`/`success`/`dangerZone`, see the note at the end of bucket (b)),
-> that's called out explicitly rather than silently reconciled.
+> **Superseded by §8, extended by §9.** This section originally *predicted*
+> wave 2 (written before #6813 landed). #6813's merge forced wave 2 to happen
+> now — §8 is the executed record. Wave 3 (§9) then closed §8.6's 5
+> "confirmed true gaps" once the lib's mapping guide caught up (lib#52). The
+> buckets below are updated to reflect what actually shipped vs. what's
+> still open; where §7's original prediction and §8's actual execution
+> differ (rare — mostly root-level `warn`/`warning`/`success`/`dangerZone`,
+> see the note at the end of bucket (b)), that's called out explicitly
+> rather than silently reconciled.
 
-- **(a) Wired to an existing FDS token — waves 1+2, both modes unless noted**:
+- **(a) Wired to an existing FDS token — waves 1+2+3, both modes unless noted**:
   `primary`, `secondary`, `EE_COLOR`, `gradient.main`, `xtmhub.main`,
   `accent`, `paper`, `background.default`, `background.secondary` (dark
   `nav` for free) — **wave 1, 9 fields** — plus, newly wired this pass
@@ -462,12 +464,12 @@ products, 100% resolved from `theme.css`. Every color-bearing property in
   `designSystem.gradient.ia`/`.focus`, plus the `THEME_LIGHT_DEFAULT_PRIMARY`
   bug fix (rule 5). **~20 additional field families, both modes** (some
   single-value, some 3-tier `.main/.light/.dark`) — full detail in §8.1–8.5.
-- **(b) Hardcoded, DURABLE, awaiting a Figma token — remaining after wave 2**:
-  - **Confirmed true gaps (5, §8.6)**: `severity.none`/`.default`,
-    `designSystem.tertiary.blue.{500,900}`,
-    `designSystem.background.{bg1-4,disabled}`, `designSystem.border.{main,
-    border1,border2}`, `primary.light` (**dark mode only** — light is now
-    wired).
+  Plus, newly wired in **wave 3 (§9, lib#52 gap-fix)**: `severity.none/
+  .default`, `designSystem.tertiary.blue.500/900`, `designSystem.background.
+  {bg1-4,disabled}`, `designSystem.border.{main,border1,border2}`,
+  `primary.light` (**dark mode, closing the last mode-gap** — light was
+  already wired in wave 2). **5 field families, both modes.**
+- **(b) Hardcoded, DURABLE, awaiting a Figma token — remaining after wave 3**:
   - **Residual light-mode-only gap (§8.7)**: `designSystem.secondary.{light,
     dark}` — only `.main` retokenized, matches OpenCTI's own identical gap.
   - **Bridge-shape gap, not a value gap (§8.7)**: `designSystem.gradient.
@@ -496,6 +498,10 @@ products, 100% resolved from `theme.css`. Every color-bearing property in
   - `MuiDialog` background — component-level override, not a `palette.*`
     key. Now hardcoded on **both** products with matching values (§8.10,
     §6's updated row) — parity reached, still no FDS token exists.
+  - **`ThemeLight.ts` root `border.main`/`.secondary`** — found in §9.4:
+    still hardcoded (`#D2D2D2`/`#C2C2C2`) while `ThemeDark.ts`'s root
+    `border.main`/`.secondary` are already wired — an asymmetry on the same
+    guide-mapped property, flagged not fixed (not in Sandy's named 5).
 - **(c) Hardcoded, JETABLE (dies with component migration) — wave 3**: none
   identified in this lot's 6 named properties, and none of the wave-2 items
   above either (all classified DURABLE — cross-cutting platform colors, not
@@ -710,6 +716,112 @@ openaev --write-to-product`, run from `filigran-design-system`) is a
 separate cross-repo action, not authorized by this pass — flagged, not
 actioned. All other 11 conformity checks pass (bridge-integrity, wiring ×2,
 forbidden-pattern ×8).
+
+---
+
+## 9. Wave 3 — the 5 confirmed gaps resolved (lib #52 mapping-guide update)
+
+Trigger: `filigran-design-system` PR #52 (merged) completed
+`TOKEN-MIGRATION-GUIDE.md` with confident mappings for the 5 gaps §8.6 left
+hardcoded ("Option A — no FDS token exists"). Re-read the updated guide,
+re-confirmed each mapping against the current, already-committed
+`fds-tokens.generated.ts` (no bridge regeneration needed or performed — see
+§9.4), and wired all 5 in both `ThemeDark.ts`/`ThemeLight.ts`. This is a
+**value change**, not a pure rename (unlike the lib#32 pass) — deltas are
+small for 3 of 5 and exactly zero for 1 sub-case, detailed below.
+
+### 9.1 Before/after — dark mode
+
+| Property | Old (hardcoded) | New token | Resolves to | Delta |
+|---|---|---|---|---|
+| `severity.none` | `#424242` | `--color-feedback-neutral-primary` | `#7a9cd6` | notable (was neutral grey, now a blue-tinted neutral — collapses with `.default`, see 9.3) |
+| `severity.default` | `#1C2F49` | `--color-feedback-neutral-primary` | `#7a9cd6` | notable |
+| `designSystem.background.bg1` | `#0C1524` | `--bg-elevation-default-layer-0` | `#070d18` | minor |
+| `designSystem.background.bg2` | `#0D182A` | `--bg-elevation-default-layer-1` | `#0d172b` | minor — **live consumer**, see 9.2 |
+| `designSystem.background.bg3` | `#253348` | `--bg-elevation-default-layer-2` | `#13213e` | minor |
+| `designSystem.background.bg4` | `#1C2F49` | `--bg-elevation-default-layer-3` | `#1f3965` | minor |
+| `designSystem.background.disabled` | `#363B46` | `--bg-elevation-disabled` | `#18191b` | minor |
+| `designSystem.border.main` | `#2B3447` | `--border-elevation-default` | `#3665b4` | notable (0 consumers, inert) |
+| `designSystem.border.border1` | `#424751` | `--border-elevation-subtle` | `#1f3965` | notable — collapses with `border2` (0 consumers, inert) |
+| `designSystem.border.border2` | `#1C253A` | `--border-elevation-subtle` | `#1f3965` | minor (0 consumers, inert) |
+| `designSystem.tertiary.blue.500` | `#0099CC` (opaque) | `--color-feedback-info-secondary-transparency` | `#0079a84d` (≈30% alpha) | notable, **semantic** — see 9.3 (0 consumers, inert) |
+| `designSystem.tertiary.blue.900` | `#003242` (opaque) | `--color-feedback-info-secondary-transparency` | `#0079a84d` (≈30% alpha) | notable, **semantic** — see 9.3 (0 consumers, inert) |
+| `primary.light` (root, dark only) | `#B2ECFF` | `--color-filigran-brand-secondary` | `#a8e7ff` | minor, **≈approximate per the guide** (0 consumers, inert) |
+
+### 9.2 Before/after — light mode
+
+| Property | Old (hardcoded) | New token | Resolves to | Delta |
+|---|---|---|---|---|
+| `severity.none` | `#424242` | `--color-feedback-neutral-primary` | `#afb0b6` | notable (collapses with `.default`) |
+| `severity.default` | `#DDE1FE` | `--color-feedback-neutral-primary` | `#afb0b6` | notable |
+| `designSystem.background.bg1` | `#F7F7F7` | `--bg-elevation-default-layer-0` | `#f2f2f3` | minor |
+| `designSystem.background.bg2` | `#FFFFFF` | `--bg-elevation-default-layer-1` | `#ffffff` | **none — byte-identical**, live consumer (below) |
+| `designSystem.background.bg3` | `#E4E4E4` | `--bg-elevation-default-layer-2` | `#f4f4f6` | minor |
+| `designSystem.background.bg4` | `#DDE1FE` | `--bg-elevation-default-layer-3` | `#e4e5e7` | minor |
+| `designSystem.background.disabled` | `#DFDFDF` | `--bg-elevation-disabled` | `#c8d6ee` | notable (0 consumers, inert) |
+| `designSystem.border.main` | `#D2D2D2` | `--border-elevation-default` | `#7a7c85` | notable (0 consumers, inert) |
+| `designSystem.border.border1` | `#C2C2C2` | `--border-elevation-subtle` | `#cacbce` | minor — collapses with `border2` (0 consumers, inert) |
+| `designSystem.border.border2` | `#999797` | `--border-elevation-subtle` | `#cacbce` | minor (0 consumers, inert) |
+| `designSystem.tertiary.blue.500` | `#0099CC` (opaque) | `--color-feedback-info-secondary-transparency` | `#42caff4d` (≈30% alpha) | notable, **semantic** — see 9.3 (0 consumers, inert) |
+| `designSystem.tertiary.blue.900` | `#003242` (opaque) | `--color-feedback-info-secondary-transparency` | `#42caff4d` (≈30% alpha) | notable, **semantic** — see 9.3 (0 consumers, inert) |
+| `primary.light` (root, light) | *(unchanged — already wired, `FDS.scalars['--darkblue-300']` = `--color-filigran-brand-secondary` exactly)* | — | `#7587ff` | none — comment updated only (was stale re: the dark gap) |
+
+**Consumer re-check (grepped fresh this pass, matches §8.6's baseline):** every
+property above has **zero consumers** in `openaev-front/src`, **except**
+`designSystem.background.bg2` — still only `LeftMenu.tsx:42`
+(`theme.palette.designSystem.background.bg2` as a separator `borderColor`).
+Dark: `#0D182A`→`#0d172b`, a ~1-unit-per-channel shift, imperceptible.
+Light: `#FFFFFF`→`#ffffff`, exactly identical. No other new consumers
+appeared anywhere in the namespace since §8.6.
+
+### 9.3 Two caveats worth flagging even though currently inert
+
+- **`tertiary.blue.500`/`.900` — opaque → semi-transparent is a semantic
+  change, not just a hue shift.** The guide's best-fit maps both to
+  `--color-feedback-info-secondary-transparency`, an alpha-blended overlay
+  token (`color-mix(... 30%, transparent)` in `theme.css`), collapsing two
+  visually distinct *opaque* colors (bright cyan `#0099CC` vs. dark navy
+  `#003242`) into one *translucent* value. Zero consumers today (grepped,
+  both before and after), so nothing renders differently — but if either key
+  is ever consumed in the future, this is not a drop-in equivalent of the old
+  opaque color. Flagging prominently per the guide's own dormancy warning on
+  `.900`; this pass extends the same warning to `.500`.
+- **`primary.light` (dark) is an approximate match, not exact.** The guide
+  itself marks `--color-filigran-brand-secondary` as "≈" for this slot:
+  `#B2ECFF` → `#A8E7FF` (R 178→168, G 236→231, B unchanged, ~4% darker on two
+  channels). 0 consumers confirmed, so inert today; noting for the record in
+  case this is ever consumed and someone diffs against the pre-wave-3 value.
+
+### 9.4 Scope confirmations
+
+- **No bridge regeneration performed or required.** All 6 target tokens
+  (`--color-feedback-neutral-primary`, `--bg-elevation-default-layer-{0-3}`,
+  `--bg-elevation-disabled`, `--border-elevation-default`,
+  `--border-elevation-subtle`, `--color-feedback-info-secondary-transparency`,
+  `--color-filigran-brand-secondary`) already existed with correct values in
+  the currently-committed `fds-tokens.generated.ts` — confirmed by direct
+  grep. §8.11's bridge-staleness flag is unrelated: the lib commits that
+  postdate this bridge's generation (#37 Button rework, #40 Tooltip/
+  IconButton, #41 SearchField, #43 Navbar, #49/#50 overlay+blur tokens) touch
+  shadow/overlay/component tokens, not any of the 6 above — confirmed via
+  `git log`/`grep` on the lib's `theme.css`, not just inferred from commit
+  titles. Still flagged, still not actioned (unchanged from §8.11).
+- **Adjacent, NOT touched**: `ThemeLight.ts`'s **root** `border.main`
+  (`#D2D2D2`)/`.secondary` (`#C2C2C2`) are still hardcoded, while
+  `ThemeDark.ts`'s root `border.main`/`.secondary` are already wired to
+  `--border-elevation-default` (§1) — a real asymmetry on the exact same
+  guide-mapped property, found while investigating the `designSystem.border`
+  gap (a different property) but not in Sandy's named 5, so left alone and
+  flagged here rather than silently fixed.
+- **Conformity**: `node fds-migration/scripts/check-fds-conformity.mjs --warn`
+  gives an **identical** result before and after this pass — 12 checks, 1
+  issue (the pre-existing §8.11 bridge staleness, unchanged), all 4
+  forbidden-pattern checks per file still `OK`, both wiring checks still
+  `OK`. Zero regression.
+- **Gates**: `tsc --noEmit` (check-ts) clean; targeted `eslint` on both
+  changed files, 0 errors/warnings; `vite build` succeeds (pre-existing
+  chunk-size/dynamic-import warnings only, unrelated files, unchanged from
+  before this pass).
 
 ---
 

--- a/openaev-front/src/components/ThemeDark.ts
+++ b/openaev-front/src/components/ThemeDark.ts
@@ -81,7 +81,11 @@ const ThemeDark = (
     warning: { main: '#ffa726' },
     primary: {
       main: primary || THEME_DARK_DEFAULT_PRIMARY,
-      light: primary ? alpha(primary, 0.08) : '#B2ECFF',
+      // fds-migration/TOKEN-MAPPING.md § 9 — resolved (lib gap-fix lib#52) on
+      // --color-filigran-brand-secondary. ≈approximate per the guide (small delta: was #B2ECFF,
+      // token resolves #A8E7FF — R/G ~4% darker, B unchanged). 0 consumers confirmed for this root
+      // property (designSystem.primary.light is a different, already-wired property).
+      light: primary ? alpha(primary, 0.08) : FDS.colors.dark['--color-filigran-brand-secondary'],
     },
     secondary: { main: secondary || THEME_DARK_DEFAULT_SECONDARY },
     gradient: { main: EE_COLOR },
@@ -173,16 +177,17 @@ const ThemeDark = (
       text: '#F2F2F3',
     },
     // fds-migration/TOKEN-MAPPING.md § 4 — critical/high/medium/low/info mapped to the closest FDS
-    // feedback token (not 1:1, mirrors OpenCTI's own wiring). none/default: no FDS equivalent
-    // (neutral/unset states), left as-is, backlogged.
+    // feedback token (not 1:1, mirrors OpenCTI's own wiring). none/default: resolved in § 9 on
+    // --color-feedback-neutral-primary (both keys collapse to the same neutral value — lib gap-fix
+    // lib#52).
     severity: {
       critical: FDS.colors.dark['--color-feedback-error-primary'],
       high: FDS.colors.dark['--color-feedback-warning-primary'],
       medium: FDS.colors.dark['--color-feedback-alert-primary'],
       low: FDS.colors.dark['--color-feedback-success-primary'],
       info: FDS.colors.dark['--color-feedback-info-primary'],
-      none: '#424242',
-      default: '#1C2F49',
+      none: FDS.colors.dark['--color-feedback-neutral-primary'],
+      default: FDS.colors.dark['--color-feedback-neutral-primary'],
     },
     designSystem: {
       // "filigran-brand" family: light/dark are the -secondary/-tertiary tiers of `main`.
@@ -212,20 +217,22 @@ const ThemeDark = (
       },
       background: {
         main: THEME_DARK_DEFAULT_BACKGROUND,
-        // bg1-bg4/disabled: no confident 1:1 FDS token found (fds-migration/TOKEN-MAPPING.md § 5
-        // gaps), left as-is, backlogged for design arbitration.
-        bg1: '#0C1524',
-        bg2: '#0D182A',
-        bg3: '#253348',
-        bg4: '#1C2F49',
-        disabled: '#363B46',
+        // bg1-bg4/disabled: resolved in § 9 on the matching elevation layer (bgN → layer-(N-1);
+        // lib gap-fix lib#52). bg2 has a live consumer (LeftMenu.tsx separator) — delta confirmed
+        // imperceptible, see § 9 proof table.
+        bg1: FDS.colors.dark['--bg-elevation-default-layer-0'],
+        bg2: FDS.colors.dark['--bg-elevation-default-layer-1'],
+        bg3: FDS.colors.dark['--bg-elevation-default-layer-2'],
+        bg4: FDS.colors.dark['--bg-elevation-default-layer-3'],
+        disabled: FDS.colors.dark['--bg-elevation-disabled'],
       },
-      // No confident FDS token found for any of these three (fds-migration/TOKEN-MAPPING.md § 5
-      // gaps), left as-is, backlogged for design arbitration.
+      // fds-migration/TOKEN-MAPPING.md § 9 — resolved (lib gap-fix lib#52): main on
+      // --border-elevation-default, border1/border2 both collapse onto --border-elevation-subtle
+      // (0 consumers, confirmed by grep before and after).
       border: {
-        main: '#2B3447',
-        border1: '#424751',
-        border2: '#1C253A',
+        main: FDS.colors.dark['--border-elevation-default'],
+        border1: FDS.colors.dark['--border-elevation-subtle'],
+        border2: FDS.colors.dark['--border-elevation-subtle'],
       },
       gradient: {
         // No FDS gradient exactly named "background" in this bridge (only '--gradient-default', a
@@ -260,9 +267,12 @@ const ThemeDark = (
           secondary: FDS.colors.dark['--color-feedback-error-secondary'],
         },
       },
-      // fds-migration/TOKEN-MAPPING.md § 4 — retokenized on scalar ramps (mode-invariant, hence
-      // FDS.scalars not FDS.colors.dark). blue.500/900: no scalar matches these two values
-      // (fds-migration/TOKEN-MAPPING.md § 5 gaps), left as-is, backlogged.
+      // fds-migration/TOKEN-MAPPING.md § 4 — grey/darkBlue/turquoise/green/red retokenized on scalar
+      // ramps (mode-invariant, hence FDS.scalars). blue.500/900: resolved in § 9 on
+      // --color-feedback-info-secondary-transparency (mode-dependent color token, not a scalar —
+      // both keys collapse to the same semi-transparent value; ⚠ semantic change if ever consumed:
+      // was two distinct opaque colors, now one alpha overlay. 0 consumers confirmed, lib gap-fix
+      // lib#52).
       tertiary: {
         grey: {
           400: FDS.scalars['--gray-400'],
@@ -270,8 +280,8 @@ const ThemeDark = (
           800: FDS.scalars['--gray-800'],
         },
         blue: {
-          500: '#0099CC',
-          900: '#003242',
+          500: FDS.colors.dark['--color-feedback-info-secondary-transparency'],
+          900: FDS.colors.dark['--color-feedback-info-secondary-transparency'],
         },
         darkBlue: {
           300: FDS.scalars['--darkblue-300'],

--- a/openaev-front/src/components/ThemeLight.ts
+++ b/openaev-front/src/components/ThemeLight.ts
@@ -87,9 +87,10 @@ const ThemeLight = (
     warning: { main: '#ed6c02' },
     primary: {
       main: primary || THEME_LIGHT_DEFAULT_PRIMARY,
-      // fds-migration/TOKEN-MAPPING.md § 4 — retokenized (exact scalar match). Dark-mode's
-      // primary.light equivalent has no scalar match (fds-migration/TOKEN-MAPPING.md § 5 gap),
-      // stays hardcoded there.
+      // fds-migration/TOKEN-MAPPING.md § 4 — retokenized (exact scalar match: --darkblue-300 ===
+      // --color-filigran-brand-secondary in light mode). Dark-mode's primary.light equivalent is
+      // now resolved too (§ 9, lib gap-fix lib#52) — this scalar reference is kept as-is since it's
+      // already exact, no change needed here.
       light: primary ? alpha(primary, 0.08) : FDS.scalars['--darkblue-300'],
     },
     secondary: { main: secondary || THEME_LIGHT_DEFAULT_SECONDARY },
@@ -187,16 +188,17 @@ const ThemeLight = (
       text: '#18191B',
     },
     // fds-migration/TOKEN-MAPPING.md § 4 — critical/high/medium/low/info mapped to the closest FDS
-    // feedback token (not 1:1, mirrors OpenCTI's own wiring). none/default: no FDS equivalent
-    // (neutral/unset states), left as-is, backlogged.
+    // feedback token (not 1:1, mirrors OpenCTI's own wiring). none/default: resolved in § 9 on
+    // --color-feedback-neutral-primary (both keys collapse to the same neutral value — lib gap-fix
+    // lib#52).
     severity: {
       critical: FDS.colors.light['--color-feedback-error-primary'],
       high: FDS.colors.light['--color-feedback-warning-primary'],
       medium: FDS.colors.light['--color-feedback-alert-primary'],
       low: FDS.colors.light['--color-feedback-success-primary'],
       info: FDS.colors.light['--color-feedback-info-primary'],
-      none: '#424242',
-      default: '#DDE1FE',
+      none: FDS.colors.light['--color-feedback-neutral-primary'],
+      default: FDS.colors.light['--color-feedback-neutral-primary'],
     },
     designSystem: {
       primary: {
@@ -228,20 +230,23 @@ const ThemeLight = (
       },
       background: {
         main: THEME_LIGHT_DEFAULT_BACKGROUND,
-        // bg1-bg4/disabled: no confident 1:1 FDS token found (fds-migration/TOKEN-MAPPING.md § 5
-        // gaps), left as-is, backlogged for design arbitration.
-        bg1: '#F7F7F7',
-        bg2: '#FFFFFF',
-        bg3: '#E4E4E4',
-        bg4: '#DDE1FE',
-        disabled: '#DFDFDF',
+        // bg1-bg4/disabled: resolved in § 9 on the matching elevation layer (bgN → layer-(N-1);
+        // lib gap-fix lib#52). bg2 has a live consumer (LeftMenu.tsx separator) — light-mode value
+        // is BYTE-IDENTICAL (#ffffff → #ffffff), zero visual delta, see § 9 proof table.
+        bg1: FDS.colors.light['--bg-elevation-default-layer-0'],
+        bg2: FDS.colors.light['--bg-elevation-default-layer-1'],
+        bg3: FDS.colors.light['--bg-elevation-default-layer-2'],
+        bg4: FDS.colors.light['--bg-elevation-default-layer-3'],
+        disabled: FDS.colors.light['--bg-elevation-disabled'],
       },
-      // No confident FDS token found for any of these three (fds-migration/TOKEN-MAPPING.md § 5
-      // gaps; confirmed OpenCTI leaves the identical values unmapped too), left as-is, backlogged.
+      // fds-migration/TOKEN-MAPPING.md § 9 — resolved (lib gap-fix lib#52): main on
+      // --border-elevation-default, border1/border2 both collapse onto --border-elevation-subtle
+      // (0 consumers, confirmed by grep before and after; OpenCTI leaves these unmapped still —
+      // documented divergence, not a regression here).
       border: {
-        main: '#D2D2D2',
-        border1: '#C2C2C2',
-        border2: '#999797',
+        main: FDS.colors.light['--border-elevation-default'],
+        border1: FDS.colors.light['--border-elevation-subtle'],
+        border2: FDS.colors.light['--border-elevation-subtle'],
       },
       gradient: {
         // fds-migration/TOKEN-MAPPING.md backlog — OpenAEV's bridge has no '--gradient-background'
@@ -276,9 +281,12 @@ const ThemeLight = (
           secondary: FDS.colors.light['--color-feedback-error-secondary'],
         },
       },
-      // fds-migration/TOKEN-MAPPING.md § 4 — retokenized on scalar ramps (mode-invariant, hence
-      // FDS.scalars not FDS.colors.light — identical values to dark mode's ramp). blue.500/900: no
-      // scalar matches these two values (fds-migration/TOKEN-MAPPING.md § 5 gaps), left as-is.
+      // fds-migration/TOKEN-MAPPING.md § 4 — grey/darkBlue/turquoise/green/red retokenized on scalar
+      // ramps (mode-invariant, hence FDS.scalars — identical values to dark mode's ramp). blue.500/900:
+      // resolved in § 9 on --color-feedback-info-secondary-transparency (mode-dependent color token,
+      // not a scalar — both keys collapse to the same semi-transparent value; ⚠ semantic change if
+      // ever consumed: was two distinct opaque colors, now one alpha overlay. 0 consumers confirmed,
+      // lib gap-fix lib#52).
       tertiary: {
         grey: {
           400: FDS.scalars['--gray-400'],
@@ -286,8 +294,8 @@ const ThemeLight = (
           800: FDS.scalars['--gray-800'],
         },
         blue: {
-          500: '#0099CC',
-          900: '#003242',
+          500: FDS.colors.light['--color-feedback-info-secondary-transparency'],
+          900: FDS.colors.light['--color-feedback-info-secondary-transparency'],
         },
         darkBlue: {
           300: FDS.scalars['--darkblue-300'],


### PR DESCRIPTION
## Contexte

Suite à la fusion de la PR #52 dans `filigran-design-system` (`TOKEN-MIGRATION-GUIDE.md` complété), les 5 gaps couleur confirmés dans `fds-migration/TOKEN-MAPPING.md` §8.6 ont désormais un mapping FDS. Ce lot les câble.

## Les 5 gaps câblés

| Propriété | Token FDS |
|---|---|
| `severity.none` / `.default` | `--color-feedback-neutral-primary` |
| `designSystem.background.bg1-4` / `.disabled` | `--bg-elevation-default-layer-{0-3}` / `--bg-elevation-disabled` |
| `designSystem.border.main` / `border1` / `border2` | `--border-elevation-default` / `--border-elevation-subtle` (border1 et border2 convergent sur la même valeur) |
| `designSystem.tertiary.blue.500` / `.900` | `--color-feedback-info-secondary-transparency` (les 2 convergent sur la même valeur) |
| `primary.light` (dark mode uniquement — light déjà câblé) | `--color-filigran-brand-secondary` |

Détail complet (tables avant/après, dark + light) : `fds-migration/TOKEN-MAPPING.md` §9.1/§9.2.

## 2 nuances sémantiques signalées (§9.3) — pas des régressions, 0 consommateur actuel pour les deux

- **`tertiary.blue.500` / `.900`** : le token cible est un overlay semi-transparent (`color-mix(... 30%, transparent)`), alors que les 2 anciennes valeurs étaient opaques et visuellement distinctes (cyan vif vs bleu marine foncé). Si jamais consommées un jour, ce n'est pas un remplacement à l'identique.
- **`primary.light`** (dark) : le guide lui-même marque ce match "≈approximatif", pas exact — `#B2ECFF` → `#A8E7FF` (delta mineur R/G, ~4%).

## Trouvaille bonus — signalée, NON corrigée dans ce lot

`ThemeLight.ts`, racine `border.main` / `.secondary` (`#D2D2D2` / `#C2C2C2`) sont encore en dur, alors que `ThemeDark.ts` a déjà ces mêmes propriétés câblées sur `--border-elevation-default`. Asymétrie trouvée en investiguant `designSystem.border` (une propriété différente, l'une des 5 ci-dessus) — pas dans la liste des 5 gaps nommés pour ce lot, donc pas touchée ici. À arbitrer : l'inclure dans un futur lot ou laisser tel quel.

## Preuve / zéro régression

- `node fds-migration/scripts/check-fds-conformity.mjs` : résultat identique avant/après (12 checks, 1 seule issue préexistante et sans rapport — staleness du bridge, déjà documentée §8.11, inchangée).
- `check-ts`, lint ciblé (2 fichiers), `vite build` : tous verts.
- Seul consommateur réel touché parmi les 5 : `designSystem.background.bg2` (`LeftMenu.tsx`, séparateur) — delta dark imperceptible (~1 unité/canal), delta light nul (byte-identique).

## Docs mises à jour

`fds-migration/TOKEN-MAPPING.md` : nouvelle §9 (preuves complètes) ; §6 (backlog Figma) et §7 (bucket a/b) mis à jour pour refléter la résolution côté OpenAEV — OpenCTI reste ouvert sur ces mêmes gaps (signalé, pas supposé résolu chez eux).

---

Aucun merge effectué par l'agent — action humaine.
