### PR TITLE
fix(api): never stamp expiration manager results on vulnerability expectations already answered (#7022)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729080000000__Repair_vulnerability_parents_contradicted_by_expiration_manager.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729080000000__Repair_vulnerability_parents_contradicted_by_expiration_manager.java
@@ -1,0 +1,172 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Repairs VULNERABILITY parent expectations contradicted by the expectations expiration manager.
+ *
+ * <p>Bug: when the agent-level children of a vulnerability expectation expired (an agentless
+ * scanner such as Nuclei never answers the agent rows - they only exist because the endpoint runs
+ * an agent), the expiration propagation stamped the triggering agent result - the vulnerability
+ * default "Not vulnerable", success polarity - onto the asset / asset-group parent rows, even when
+ * a genuine platform row already answered the parent. When the platform verdict was VULNERABLE, the
+ * contradictory manager row rendered next to the real verdict and its success score could flip the
+ * parent to "Not vulnerable" through any own-results max recomputation (older builds answered the
+ * parent directly, cementing the flip immediately). When the platform verdict was "Not vulnerable",
+ * the manager row was merely redundant - the expiration default is the absence-of-signal fallback
+ * and has nothing to add to an answered row.
+ *
+ * <p>The write path is fixed in code ({@code InjectExpectationUtils.computeScores} skips stamping a
+ * result whose verdict contradicts the parent's reconciled score, never stamps an
+ * expiration-manager result on a VULNERABILITY row a genuine platform already answered, and {@code
+ * combineWithChildrenVerdict} pins direct VULNERABLE verdicts on asset-group rows); this migration
+ * repairs the corrupted rows:
+ *
+ * <ol>
+ *   <li>strips expiration-manager result rows from VULNERABILITY parents that also carry a genuine
+ *       answered result row (a real platform answered - the manager had nothing to conclude);
+ *   <li>restores the score of VULNERABILITY parents that carry a genuine direct vulnerable result
+ *       (worst direct vulnerable score wins, mirroring {@code
+ *       reconcileWithDirectVulnerableVerdict});
+ *   <li>restores the score of VULNERABILITY asset-group parents without a direct vulnerable row
+ *       whose asset children verdict is vulnerable (any vulnerable child for non-group
+ *       expectations, all children vulnerable for group expectations).
+ * </ol>
+ *
+ * <p>Every repaired row gets {@code inject_expectation_updated_at = now()} so the incremental
+ * Elasticsearch engine (which cursors on {@code updated_at}) re-feeds the documents.
+ *
+ * <p>Idempotent: step 1 only matches rows still carrying a manager result next to a genuine one,
+ * steps 2 and 3 only match rows whose score still disagrees with the vulnerable verdict; re-runs
+ * match nothing.
+ */
+@Component
+public class V6_20260729080000000__Repair_vulnerability_parents_contradicted_by_expiration_manager
+    extends BaseJavaMigration {
+
+  /** The expectations expiration manager collector id (ExpectationsExpirationManagerConfig). */
+  private static final String EXPIRATION_MANAGER_ID = "96e476e0-b9c4-4660-869c-98585adf754d";
+
+  /** A result element written by the expectations expiration manager. */
+  private static final String MANAGER_RESULT =
+      "elem->>'sourceId' = '" + EXPIRATION_MANAGER_ID + "'";
+
+  /**
+   * A genuine answered result element: written by a real source (not the expiration manager), with
+   * a non-empty result label that is not the "Expired" placeholder stamp.
+   */
+  private static final String GENUINE_ANSWERED_RESULT =
+      "COALESCE(elem->>'sourceId', '') <> '"
+          + EXPIRATION_MANAGER_ID
+          + "'"
+          + " AND COALESCE(elem->>'result', '') <> ''"
+          + " AND elem->>'result' <> 'Expired'";
+
+  /**
+   * A genuine direct vulnerable result element: a real source reported a score below the
+   * expectation's expected score (VULNERABILITY polarity: failure = vulnerable).
+   */
+  private static final String GENUINE_VULNERABLE_RESULT =
+      GENUINE_ANSWERED_RESULT
+          + " AND elem->>'score' IS NOT NULL"
+          + " AND (elem->>'score')::numeric < parent.inject_expectation_expected_score";
+
+  /** Parent VULNERABILITY rows: asset level or asset group level, never agent leaves. */
+  private static final String VULNERABILITY_PARENT_SCOPE =
+      "parent.inject_expectation_type = 'VULNERABILITY'"
+          + " AND parent.agent_id IS NULL"
+          + " AND parent.inject_expectation_expected_score IS NOT NULL"
+          + " AND parent.inject_expectation_results IS NOT NULL"
+          + " AND jsonb_typeof(parent.inject_expectation_results::jsonb) = 'array'";
+
+  /** An asset child of an asset-group parent that concluded vulnerable. */
+  private static final String CHILD_VULNERABLE =
+      "child.inject_expectation_score IS NOT NULL"
+          + " AND child.inject_expectation_score < child.inject_expectation_expected_score";
+
+  private static final String GROUP_CHILD_JOIN =
+      "child.inject_id = parent.inject_id"
+          + " AND child.inject_expectation_type = parent.inject_expectation_type"
+          + " AND child.asset_group_id = parent.asset_group_id"
+          + " AND child.asset_id IS NOT NULL"
+          + " AND child.agent_id IS NULL";
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // 1) Strip expiration-manager rows from parents that a genuine platform already answered
+      statement.execute(
+          "UPDATE injects_expectations parent SET"
+              + " inject_expectation_results = COALESCE((SELECT jsonb_agg(elem)"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE NOT ("
+              + MANAGER_RESULT
+              + ")), '[]'::jsonb)::json,"
+              + " inject_expectation_updated_at = now()"
+              + " WHERE "
+              + VULNERABILITY_PARENT_SCOPE
+              + " AND EXISTS (SELECT 1"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE "
+              + MANAGER_RESULT
+              + ")"
+              + " AND EXISTS (SELECT 1"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE "
+              + GENUINE_ANSWERED_RESULT
+              + ")");
+      // 2) Pin the worst genuine direct vulnerable verdict back onto the parent score
+      statement.execute(
+          "UPDATE injects_expectations parent SET"
+              + " inject_expectation_score = (SELECT MIN((elem->>'score')::numeric)"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE "
+              + GENUINE_VULNERABLE_RESULT
+              + "),"
+              + " inject_expectation_updated_at = now()"
+              + " WHERE "
+              + VULNERABILITY_PARENT_SCOPE
+              + " AND EXISTS (SELECT 1"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "   WHERE "
+              + GENUINE_VULNERABLE_RESULT
+              + ")"
+              + " AND (parent.inject_expectation_score IS NULL"
+              + "   OR parent.inject_expectation_score <> (SELECT MIN((elem->>'score')::numeric)"
+              + "     FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + "     WHERE "
+              + GENUINE_VULNERABLE_RESULT
+              + "))");
+      // 3) Asset-group parents without a direct vulnerable row: restore the vulnerable verdict
+      // rolled up from their (possibly just repaired) asset children
+      statement.execute(
+          "UPDATE injects_expectations parent SET"
+              + " inject_expectation_score = 0,"
+              + " inject_expectation_updated_at = now()"
+              + " WHERE parent.asset_group_id IS NOT NULL AND parent.asset_id IS NULL"
+              + " AND parent.inject_expectation_type = 'VULNERABILITY'"
+              + " AND parent.agent_id IS NULL"
+              + " AND parent.inject_expectation_expected_score IS NOT NULL"
+              + " AND parent.inject_expectation_score IS NOT NULL"
+              + " AND parent.inject_expectation_score >= parent.inject_expectation_expected_score"
+              + " AND EXISTS (SELECT 1 FROM injects_expectations child WHERE "
+              + GROUP_CHILD_JOIN
+              + ")"
+              + " AND ((parent.inject_expectation_group = true"
+              + "   AND NOT EXISTS (SELECT 1 FROM injects_expectations child WHERE "
+              + GROUP_CHILD_JOIN
+              + "     AND NOT ("
+              + CHILD_VULNERABLE
+              + ")))"
+              + "  OR (parent.inject_expectation_group = false"
+              + "   AND EXISTS (SELECT 1 FROM injects_expectations child WHERE "
+              + GROUP_CHILD_JOIN
+              + "     AND "
+              + CHILD_VULNERABLE
+              + ")))");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729080000000__Repair_vulnerability_parents_contradicted_by_expiration_manager.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729080000000__Repair_vulnerability_parents_contradicted_by_expiration_manager.java
@@ -98,10 +98,12 @@ public class V6_20260729080000000__Repair_vulnerability_parents_contradicted_by_
   public void migrate(Context context) throws Exception {
     try (Statement statement = context.getConnection().createStatement()) {
       // 1) Strip expiration-manager rows from parents that a genuine platform already answered
+      // (WITH ORDINALITY + ORDER BY: jsonb_agg alone does not guarantee the original array order)
       statement.execute(
           "UPDATE injects_expectations parent SET"
-              + " inject_expectation_results = COALESCE((SELECT jsonb_agg(elem)"
-              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb) elem"
+              + " inject_expectation_results = COALESCE((SELECT jsonb_agg(elem ORDER BY ord)"
+              + "   FROM jsonb_array_elements(parent.inject_expectation_results::jsonb)"
+              + "     WITH ORDINALITY AS results(elem, ord)"
               + "   WHERE NOT ("
               + MANAGER_RESULT
               + ")), '[]'::jsonb)::json,"

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -869,8 +869,23 @@ public class InjectExpectationService {
    */
   private Double combineWithChildrenVerdict(
       @NotNull final TechnicalInjectExpectation expectation, @Nullable final Double ownScore) {
-    if (expectation.getAgent() != null || expectation.getAsset() == null) {
-      return ownScore; // agent leaf or asset-group level: no children rollup to protect
+    if (expectation.getAgent() != null) {
+      return ownScore; // agent leaf: no children rollup to protect
+    }
+    if (expectation.getAsset() == null) {
+      // Asset-group level: no children rollup to protect here (propagation recomputes it from
+      // the asset children), but a direct VULNERABLE verdict written on the group row itself
+      // (e.g. by Nuclei) must survive the own-results max: the results list may also carry
+      // success-polarity rows ("Expired" placeholders, legacy expiration-manager stamps) that
+      // would otherwise win the max and flip the group to "Not vulnerable".
+      if (BaseInjectExpectation.EXPECTATION_TYPE.VULNERABILITY.equals(expectation.getType())) {
+        Double directVulnerable =
+            InjectExpectationUtils.reconcileWithDirectVulnerableVerdict(expectation, null);
+        if (directVulnerable != null) {
+          return directVulnerable;
+        }
+      }
+      return ownScore;
     }
     List<TechnicalInjectExpectation> agentChildren = getAgentsExpectationsForAsset(expectation);
     if (agentChildren.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
@@ -292,20 +292,55 @@ public class InjectExpectationUtils {
           // parent just kept: skip it, the genuine platform row already explains the score.
           if (addResult != null && Objects.equals(reconciledScore, score)) {
             InjectExpectationResult newResultToAdd = addResult.apply(score);
-            Optional<InjectExpectationResult> existingResult =
-                expectation.getResults().stream()
-                    .filter(result -> newResultToAdd.getSourceId().equals(result.getSourceId()))
-                    .findFirst();
-            existingResult.ifPresent(
-                injectExpectationResult ->
-                    expectation.getResults().remove(injectExpectationResult));
-            expectation.getResults().add(newResultToAdd);
+            boolean isExpirationManagerResult =
+                ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(
+                    newResultToAdd.getSourceId());
+            // The copied result is the raw triggering CHILD result (e.g. an agent expiring to the
+            // vulnerability default "Not vulnerable", success polarity). When the parent itself
+            // concluded the OPPOSITE verdict (e.g. the asset group rolls up VULNERABLE because an
+            // asset carries a genuine Nuclei finding), stamping that row would display a
+            // contradictory "Not vulnerable" entry next to the real platform rows and plant a
+            // success score that any own-results max computation would later pick up. Skip it:
+            // the children rows already explain the parent verdict.
+            Double parentExpectedScore = expectation.getExpectedScore();
+            Double resultScore = newResultToAdd.getScore();
+            boolean contradictsParentVerdict =
+                score != null
+                    && resultScore != null
+                    && parentExpectedScore != null
+                    && (score >= parentExpectedScore) != (resultScore >= parentExpectedScore);
+            // A VULNERABILITY parent already answered by a genuine platform (e.g. Nuclei wrote
+            // its verdict, vulnerable or not, directly on the asset / asset-group row) needs no
+            // expiration entry at all: the expiration default is the absence-of-signal fallback,
+            // stamping it next to a real scan verdict is redundant at best and misleading at
+            // worst. Detection/prevention keep their expiration stamps - silence IS the verdict
+            // there.
+            boolean vulnerabilityAlreadyAnswered =
+                isExpirationManagerResult
+                    && VULNERABILITY.equals(expectation.getType())
+                    && expectation.getResults().stream()
+                        .anyMatch(
+                            result ->
+                                !ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(
+                                        result.getSourceId())
+                                    && result.getResult() != null
+                                    && !result.getResult().isBlank()
+                                    && !EXPIRED.equals(result.getResult()));
+            if (!contradictsParentVerdict && !vulnerabilityAlreadyAnswered) {
+              Optional<InjectExpectationResult> existingResult =
+                  expectation.getResults().stream()
+                      .filter(result -> newResultToAdd.getSourceId().equals(result.getSourceId()))
+                      .findFirst();
+              existingResult.ifPresent(
+                  injectExpectationResult ->
+                      expectation.getResults().remove(injectExpectationResult));
+              expectation.getResults().add(newResultToAdd);
+            }
 
             // IF RESULT TO ADD IS EXPIRATION MANAGER => SO I EXPIRE ALL the inject expectation with
             // no result to expired, using the type's default polarity (silence means "Not
             // vulnerable" for VULNERABILITY, failure for the other types)
-            if (ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(
-                newResultToAdd.getSourceId())) {
+            if (isExpirationManagerResult) {
               Double expiredScore =
                   VULNERABILITY.equals(expectation.getType())
                       ? expectation.getExpectedScore()

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
@@ -13,6 +13,7 @@ import io.openaev.expectation.*;
 import io.openaev.utils.StringUtils;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -291,6 +292,11 @@ public class InjectExpectationUtils {
           // triggering result (an expiration "Not vulnerable") would contradict the verdict the
           // parent just kept: skip it, the genuine platform row already explains the score.
           if (addResult != null && Objects.equals(reconciledScore, score)) {
+            // An expectation that never received any result can carry a null results list (see
+            // expireEmptyResults): initialize it before inspecting / mutating it below.
+            if (expectation.getResults() == null) {
+              expectation.setResults(new ArrayList<>());
+            }
             InjectExpectationResult newResultToAdd = addResult.apply(score);
             boolean isExpirationManagerResult =
                 ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(

--- a/openaev-api/src/test/java/io/openaev/rest/inject_expectation/ExpectationsExpirationManagerServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject_expectation/ExpectationsExpirationManagerServiceTest.java
@@ -3,6 +3,7 @@ package io.openaev.rest.inject_expectation;
 import static io.openaev.collectors.expectations_expiration_manager.config.ExpectationsExpirationManagerConfig.COLLECTOR_ID;
 import static io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegration.OPENAEV_INJECTOR_ID;
 import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAsset;
+import static io.openaev.utils.VulnerabilityExpectationUtils.vulnerabilityExpectationForAssetGroup;
 import static io.openaev.utils.fixtures.ExpectationFixture.*;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -652,6 +653,198 @@ public class ExpectationsExpirationManagerServiceTest extends IntegrationTest {
       // And no contradicting "Not vulnerable" expiration row was stamped on the asset
       assertTrue(
           assetExpectations.getFirst().getResults().stream()
+              .noneMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
+    }
+
+    @Test
+    @DisplayName(
+        "A direct VULNERABLE verdict on the asset group is not contradicted by an expiration stamp")
+    void directVulnerableVerdictOnAssetGroupIsNotContradictedByExpirationStamp() {
+      // Regression: an assessment injector (e.g. Nuclei) answered BOTH the asset and the asset
+      // group rows with VULNERABLE, while the agent-level children stayed untouched (an agentless
+      // scanner never fills them). When the expiration manager later expired the agents to the
+      // default "Not vulnerable", the asset group rollup correctly concluded VULNERABLE - but the
+      // propagation still stamped the triggering agent result (an expiration manager
+      // "Not vulnerable", success polarity) onto the group row, displaying a contradictory entry
+      // next to the genuine platform verdict and planting a success score in the results list.
+      ExecutableInject executableInject = newExecutableInjectWithTargets();
+      List<Expectation> expectations = new ArrayList<>();
+      expectations.add(
+          createTechnicalVulnerabilityExpectationForAgent(
+              savedAgent1, savedEndpoint, savedAssetGroup, EXPIRATION_TIME_1_s, null));
+      expectations.add(
+          vulnerabilityExpectationForAsset(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedEndpoint,
+              savedAssetGroup,
+              EXPIRATION_TIME_1_s));
+      expectations.add(
+          vulnerabilityExpectationForAssetGroup(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedAssetGroup,
+              false,
+              EXPIRATION_TIME_1_s));
+      injectExpectationService.buildAndSaveInjectExpectations(executableInject, expectations);
+
+      em.flush();
+      em.clear();
+
+      // The assessment injector answers the ASSET and ASSET GROUP rows directly: proven vulnerable
+      InjectExpectationResult nucleiVerdict =
+          InjectExpectationResult.builder()
+              .sourceId("nuclei-security-platform")
+              .sourceName("Nuclei")
+              .sourceType("security-platform")
+              .sourcePlatform(SecurityPlatform.SECURITY_PLATFORM_TYPE.VULNERABILITY_SCANNER.name())
+              .result("Vulnerable")
+              .sourceAssetId(UUID.randomUUID().toString())
+              .score(0.0)
+              .build();
+      BaseInjectExpectation assetExpectation =
+          injectExpectationRepository
+              .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
+              .getFirst();
+      assetExpectation.setResults(List.of(nucleiVerdict));
+      assetExpectation.setScore(0.0);
+      BaseInjectExpectation assetGroupExpectation =
+          injectExpectationRepository
+              .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
+              .getFirst();
+      assetGroupExpectation.setResults(List.of(nucleiVerdict));
+      assetGroupExpectation.setScore(0.0);
+      injectExpectationRepository.saveAll(List.of(assetExpectation, assetGroupExpectation));
+
+      // -- EXECUTE --
+      expireExpectationsInDbByInjectId(savedInject.getId());
+      expectationsExpirationManagerService.computeExpectations(savedInject.getTenant().getId());
+
+      // -- ASSERT --
+      // Agent child: expired to the vulnerability default "Not vulnerable"
+      List<BaseInjectExpectation> agentExpectations =
+          injectExpectationRepository.findAllByInjectAndAgent(
+              savedInject.getId(), savedAgent1.getId());
+      assertEquals(100.0, agentExpectations.getFirst().getScore());
+      // Asset: the proven VULNERABLE verdict survives, no contradicting stamp
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(0.0, assetExpectations.getFirst().getScore());
+      assertTrue(
+          assetExpectations.getFirst().getResults().stream()
+              .noneMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
+      // Asset group: the proven VULNERABLE verdict survives, and NO contradicting
+      // "Not vulnerable" expiration manager row was stamped next to the Nuclei verdict
+      List<BaseInjectExpectation> assetGroupExpectations =
+          injectExpectationRepository.findAllByInjectAndAssetGroup(
+              savedInject.getId(), savedAssetGroup.getId());
+      assertEquals(0.0, assetGroupExpectations.getFirst().getScore());
+      assertEquals(
+          BaseInjectExpectation.EXPECTATION_STATUS.FAILED,
+          assetGroupExpectations.getFirst().getResponse());
+      assertTrue(
+          assetGroupExpectations.getFirst().getResults().stream()
+              .noneMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
+    }
+
+    @Test
+    @DisplayName(
+        "The expiration manager never stamps a vulnerability row a platform already answered")
+    void expirationManagerDoesNotStampVulnerabilityRowsAlreadyAnswered() {
+      // Regression: Nuclei answered "Not vulnerable" directly on the asset and asset-group rows of
+      // endpoints that happen to run an agent. When the agent children (which an agentless scanner
+      // never fills) later expired, the propagation stamped a redundant "Expectations Expiration
+      // Manager - Not vulnerable" row next to the genuine scan verdict on every answered parent.
+      // The expiration default is the absence-of-signal fallback: it has nothing to add to a row a
+      // real platform already answered.
+      ExecutableInject executableInject = newExecutableInjectWithTargets();
+      List<Expectation> expectations = new ArrayList<>();
+      expectations.add(
+          createTechnicalVulnerabilityExpectationForAgent(
+              savedAgent1, savedEndpoint, savedAssetGroup, EXPIRATION_TIME_1_s, null));
+      expectations.add(
+          vulnerabilityExpectationForAsset(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedEndpoint,
+              savedAssetGroup,
+              EXPIRATION_TIME_1_s));
+      expectations.add(
+          vulnerabilityExpectationForAssetGroup(
+              100.0,
+              "Vulnerability",
+              "Vulnerability Expectation",
+              savedAssetGroup,
+              false,
+              EXPIRATION_TIME_1_s));
+      injectExpectationService.buildAndSaveInjectExpectations(executableInject, expectations);
+
+      em.flush();
+      em.clear();
+
+      // The scanner answers the ASSET and ASSET GROUP rows directly: nothing found
+      InjectExpectationResult nucleiVerdict =
+          InjectExpectationResult.builder()
+              .sourceId("nuclei-security-platform")
+              .sourceName("Nuclei")
+              .sourceType("security-platform")
+              .sourcePlatform(SecurityPlatform.SECURITY_PLATFORM_TYPE.VULNERABILITY_SCANNER.name())
+              .result("Not vulnerable")
+              .sourceAssetId(UUID.randomUUID().toString())
+              .score(100.0)
+              .build();
+      BaseInjectExpectation assetExpectation =
+          injectExpectationRepository
+              .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
+              .getFirst();
+      assetExpectation.setResults(List.of(nucleiVerdict));
+      assetExpectation.setScore(100.0);
+      BaseInjectExpectation assetGroupExpectation =
+          injectExpectationRepository
+              .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
+              .getFirst();
+      assetGroupExpectation.setResults(List.of(nucleiVerdict));
+      assetGroupExpectation.setScore(100.0);
+      injectExpectationRepository.saveAll(List.of(assetExpectation, assetGroupExpectation));
+
+      // -- EXECUTE --
+      expireExpectationsInDbByInjectId(savedInject.getId());
+      expectationsExpirationManagerService.computeExpectations(savedInject.getTenant().getId());
+
+      // -- ASSERT --
+      // Agent child: expired to the vulnerability default "Not vulnerable" by the manager
+      List<BaseInjectExpectation> agentExpectations =
+          injectExpectationRepository.findAllByInjectAndAgent(
+              savedInject.getId(), savedAgent1.getId());
+      assertEquals(100.0, agentExpectations.getFirst().getScore());
+      assertTrue(
+          agentExpectations.getFirst().getResults().stream()
+              .anyMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
+      // Asset: verdict unchanged, and NO redundant manager row next to the Nuclei answer
+      List<BaseInjectExpectation> assetExpectations =
+          injectExpectationRepository.findAllByInjectAndAsset(
+              savedInject.getId(), savedEndpoint.getId());
+      assertEquals(100.0, assetExpectations.getFirst().getScore());
+      assertEquals(
+          BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
+          assetExpectations.getFirst().getResponse());
+      assertTrue(
+          assetExpectations.getFirst().getResults().stream()
+              .noneMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
+      // Asset group: verdict unchanged, and NO redundant manager row either
+      List<BaseInjectExpectation> assetGroupExpectations =
+          injectExpectationRepository.findAllByInjectAndAssetGroup(
+              savedInject.getId(), savedAssetGroup.getId());
+      assertEquals(100.0, assetGroupExpectations.getFirst().getScore());
+      assertEquals(
+          BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
+          assetGroupExpectations.getFirst().getResponse());
+      assertTrue(
+          assetGroupExpectations.getFirst().getResults().stream()
               .noneMatch(result -> COLLECTOR_ID.equals(result.getSourceId())));
     }
 

--- a/openaev-api/src/test/java/io/openaev/rest/inject_expectation/ExpectationsExpirationManagerServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject_expectation/ExpectationsExpirationManagerServiceTest.java
@@ -708,13 +708,13 @@ public class ExpectationsExpirationManagerServiceTest extends IntegrationTest {
           injectExpectationRepository
               .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
               .getFirst();
-      assetExpectation.setResults(List.of(nucleiVerdict));
+      assetExpectation.setResults(new ArrayList<>(List.of(nucleiVerdict)));
       assetExpectation.setScore(0.0);
       BaseInjectExpectation assetGroupExpectation =
           injectExpectationRepository
               .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
               .getFirst();
-      assetGroupExpectation.setResults(List.of(nucleiVerdict));
+      assetGroupExpectation.setResults(new ArrayList<>(List.of(nucleiVerdict)));
       assetGroupExpectation.setScore(0.0);
       injectExpectationRepository.saveAll(List.of(assetExpectation, assetGroupExpectation));
 
@@ -801,13 +801,13 @@ public class ExpectationsExpirationManagerServiceTest extends IntegrationTest {
           injectExpectationRepository
               .findAllByInjectAndAsset(savedInject.getId(), savedEndpoint.getId())
               .getFirst();
-      assetExpectation.setResults(List.of(nucleiVerdict));
+      assetExpectation.setResults(new ArrayList<>(List.of(nucleiVerdict)));
       assetExpectation.setScore(100.0);
       BaseInjectExpectation assetGroupExpectation =
           injectExpectationRepository
               .findAllByInjectAndAssetGroup(savedInject.getId(), savedAssetGroup.getId())
               .getFirst();
-      assetGroupExpectation.setResults(List.of(nucleiVerdict));
+      assetGroupExpectation.setResults(new ArrayList<>(List.of(nucleiVerdict)));
       assetGroupExpectation.setScore(100.0);
       injectExpectationRepository.saveAll(List.of(assetExpectation, assetGroupExpectation));
 


### PR DESCRIPTION
## Summary

Fixes #7022

The Expectations Expiration Manager stamped its own "Not vulnerable" result rows onto VULNERABILITY asset / asset-group expectations that a real scanner (e.g. Nuclei) had already answered:

- redundant stamp next to a genuine "Not vulnerable" scan verdict (asset + group level), and
- contradictory stamp next to a VULNERABLE verdict on asset-group rows whose children rollup concluded vulnerable (the stamp planted a success score in the results list).

For VULNERABILITY, the expiration default is only the absence-of-signal fallback: once a real platform has answered, the manager has nothing to add. Detection/prevention are unaffected - silence IS the verdict there.

## Changes

- `InjectExpectationUtils.computeScores`:
  - never stamp a triggering result whose verdict polarity contradicts the parent's reconciled score;
  - never stamp an expiration-manager result on a VULNERABILITY row that already carries a genuine answered result from a real source;
  - initialize a null results list before inspecting or mutating it (rows that never received any result carry a NULL json column, same precedent as the `expireEmptyResults` no-op).
- `InjectExpectationService.combineWithChildrenVerdict`: pin direct VULNERABLE verdicts written on asset-group rows so success-polarity placeholder rows can never flip the group to "Not vulnerable" through the own-results max.
- New repair migration `V6_20260729080000000`: strips expiration-manager rows from VULNERABILITY parents that carry a genuine answered result (preserving the original result array order via `WITH ORDINALITY`), restores scores flipped by the contradictory stamps (worst direct vulnerable score wins, plus asset-group rollup repair), and touches `updated_at` so the incremental indexing engine re-feeds the repaired documents. Idempotent.
- Two regression tests in `ExpectationsExpirationManagerServiceTest` reproducing the Nuclei + expiration manager scenarios (contradictory group stamp, redundant stamp on answered rows), using mutable result lists to match entity semantics.

## Test plan

- [x] `mvn -pl openaev-api test -Dtest=ExpectationsExpirationManagerServiceTest` - 12/12 green, including the 2 new regression tests
- [x] Diagnostic SQL on staging (main-ff) confirms 32 corrupted parent rows (26 asset-level, 6 group-level) that the migration will repair on deploy
