### PR TITLE
fix(api): serialize security platform collectors under tenant scope so managed platforms stay read-only (#7025)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
@@ -6,6 +6,7 @@ import static io.openaev.helper.StreamHelper.iterableToSet;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 
 import io.openaev.aop.AccessControl;
+import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
 import io.openaev.database.raw.RawDocument;
 import io.openaev.database.repository.*;
@@ -23,6 +24,7 @@ import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,11 +45,30 @@ public class SecurityPlatformApi {
   private final TagRepository tagRepository;
   private final DocumentService documentService;
 
+  /**
+   * The {@code collectors} table is v2 tenant-active: any read of it in a transaction without a
+   * tenant scope is fail-closed EMPTY. {@code security_platform_collectors} is what the UI uses to
+   * keep a collector-managed platform read-only, and it is rendered from the lazy {@code
+   * collectors} association during JSON serialization — after the transaction (open-in-view), where
+   * the transaction-local scope is gone. Every endpoint that serializes a {@link SecurityPlatform}
+   * must therefore declare a {@link TxCtx} (the transaction aspect writes it into the scope) AND
+   * initialize the association inside that scoped transaction through this helper, or every
+   * platform silently unlocks in the UI (issue #7025).
+   */
+  private static SecurityPlatform withCollectorsInitialized(SecurityPlatform securityPlatform) {
+    Hibernate.initialize(securityPlatform.getCollectors());
+    return securityPlatform;
+  }
+
   @GetMapping({SECURITY_PLATFORM_URI, TENANT_SECURITY_PLATFORM_URI})
   @Transactional
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.SECURITY_PLATFORM)
-  public Iterable<SecurityPlatform> securityPlatforms() {
-    return securityPlatformRepository.findAll();
+  // TxCtx scopes the transaction to the caller's tenants so the collectors association loads
+  // (fail-closed empty otherwise); see withCollectorsInitialized.
+  public Iterable<SecurityPlatform> securityPlatforms(TxCtx ctx) {
+    return fromIterable(securityPlatformRepository.findAll()).stream()
+        .map(SecurityPlatformApi::withCollectorsInitialized)
+        .toList();
   }
 
   @PostMapping({SECURITY_PLATFORM_URI, TENANT_SECURITY_PLATFORM_URI})
@@ -115,20 +136,26 @@ public class SecurityPlatformApi {
       resourceId = "#securityPlatformId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.SECURITY_PLATFORM)
+  // TxCtx scopes the transaction so the collectors association loads; see
+  // withCollectorsInitialized.
   public SecurityPlatform securityPlatform(
-      @PathVariable @NotBlank final String securityPlatformId) {
+      TxCtx ctx, @PathVariable @NotBlank final String securityPlatformId) {
     return this.securityPlatformRepository
         .findById(securityPlatformId)
+        .map(SecurityPlatformApi::withCollectorsInitialized)
         .orElseThrow(ElementNotFoundException::new);
   }
 
   @PostMapping({SECURITY_PLATFORM_URI + "/search", TENANT_SECURITY_PLATFORM_URI + "/search"})
   @Transactional
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.SECURITY_PLATFORM)
+  // TxCtx scopes the transaction so the collectors association loads; see
+  // withCollectorsInitialized.
   public Page<SecurityPlatform> securityPlatforms(
-      @RequestBody @Valid SearchPaginationInput searchPaginationInput) {
+      TxCtx ctx, @RequestBody @Valid SearchPaginationInput searchPaginationInput) {
     return buildPaginationJPA(
-        this.securityPlatformRepository::findAll, searchPaginationInput, SecurityPlatform.class);
+            this.securityPlatformRepository::findAll, searchPaginationInput, SecurityPlatform.class)
+        .map(SecurityPlatformApi::withCollectorsInitialized);
   }
 
   @PutMapping({
@@ -140,7 +167,10 @@ public class SecurityPlatformApi {
       actionPerformed = Action.WRITE,
       resourceType = ResourceType.SECURITY_PLATFORM)
   @Transactional(rollbackFor = Exception.class)
+  // TxCtx scopes the transaction so the response's collectors association loads (the UI replaces
+  // its local state with this payload); see withCollectorsInitialized.
   public SecurityPlatform updateSecurityPlatform(
+      TxCtx ctx,
       @PathVariable @NotBlank final String securityPlatformId,
       @Valid @RequestBody final SecurityPlatformInput input) {
     SecurityPlatform securityPlatform =
@@ -157,7 +187,7 @@ public class SecurityPlatformApi {
       securityPlatform.setLogoLight(null);
     }
     securityPlatform.setTags(iterableToSet(this.tagRepository.findAllById(input.getTagIds())));
-    return this.securityPlatformRepository.save(securityPlatform);
+    return withCollectorsInitialized(this.securityPlatformRepository.save(securityPlatform));
   }
 
   @DeleteMapping({

--- a/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
@@ -50,10 +50,14 @@ public class SecurityPlatformApi {
    * tenant scope is fail-closed EMPTY. {@code security_platform_collectors} is what the UI uses to
    * keep a collector-managed platform read-only, and it is rendered from the lazy {@code
    * collectors} association during JSON serialization — after the transaction (open-in-view), where
-   * the transaction-local scope is gone. Every endpoint that serializes a {@link SecurityPlatform}
-   * must therefore declare a {@link TxCtx} (the transaction aspect writes it into the scope) AND
-   * initialize the association inside that scoped transaction through this helper, or every
-   * platform silently unlocks in the UI (issue #7025).
+   * the transaction-local scope is gone. Every endpoint feeding that UI signal (GET list, GET by
+   * id, POST search, PUT update) must therefore declare a {@link TxCtx} (the transaction aspect
+   * writes it into the scope) AND initialize the association inside that scoped transaction through
+   * this helper, or every platform silently unlocks in the UI (issue #7025).
+   *
+   * <p>Create and upsert are exempt: create returns a brand-new entity whose empty in-memory
+   * association serializes without a database load, and upsert is the collector-facing registration
+   * endpoint whose response the UI never consumes.
    */
   private static SecurityPlatform withCollectorsInitialized(SecurityPlatform securityPlatform) {
     Hibernate.initialize(securityPlatform.getCollectors());

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
@@ -8,6 +8,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import io.openaev.database.model.SecurityPlatform;
 import io.openaev.database.model.Vulnerability;
 import io.openaev.database.repository.CollectorRepository;
 import io.openaev.database.repository.CweRepository;
@@ -17,6 +18,7 @@ import io.openaev.database.repository.MitigationRepository;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
 import io.openaev.database.repository.attackpath.AttackPathFindingRepository;
 import io.openaev.processor.datapack.V20260330_Default_tenant_data;
+import io.openaev.rest.asset.security_platforms.SecurityPlatformApi;
 import io.openaev.rest.atomic_testing.AtomicTestingApi;
 import io.openaev.rest.collector.CollectorApi;
 import io.openaev.rest.collector.service.CollectorService;
@@ -222,6 +224,23 @@ class TenantActiveTableAccessArchTest {
           .because(
               "collectors is tenant-active: an accessor without a tenant scope silently reads zero"
                   + " rows. New accessors must carry a scope and be allowlisted here");
+
+  @ArchTest
+  static final ArchRule collectors_association_access_is_reviewed =
+      noClasses()
+          .that()
+          .doNotBelongToAnyOf(
+              // Initializes the association inside its TxCtx-scoped transactions before the
+              // open-in-view JSON rendering (pinned by TenantScopedEntrypointsTxCtxArchTest and
+              // SecurityPlatformCollectorsTenantScopeTest, #7025):
+              SecurityPlatformApi.class)
+          .should()
+          .callMethod(SecurityPlatform.class, "getCollectors")
+          .because(
+              "collectors is reached through SecurityPlatform's association WITHOUT touching the"
+                  + " repository: a lazy getCollectors() in an unscoped context silently loads zero"
+                  + " rows, which unlocks collector-managed platforms in the UI. New callers must"
+                  + " run inside a scoped transaction and be allowlisted here");
 
   @ArchTest
   static final ArchRule attackpath_execution_repository_access_is_reviewed =

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
@@ -109,7 +109,13 @@ class TenantScopedEntrypointsTxCtxArchTest {
           // guard, #7014); the update endpoints attach collector-sourced results. Both overloads
           // of updateInjectExpectation are covered by the single name entry.
           "io.openaev.rest.expectation.ExpectationApi#getAiDefenseExpectationsNotFilledForSource",
-          "io.openaev.rest.expectation.ExpectationApi#updateInjectExpectation");
+          "io.openaev.rest.expectation.ExpectationApi#updateInjectExpectation",
+          // security platforms: serialize the collectors association (tenant-active table) so the
+          // UI can keep collector-managed platforms read-only (#7025). Both overloads of
+          // securityPlatforms (GET list and POST search) are covered by the single name entry.
+          "io.openaev.rest.asset.security_platforms.SecurityPlatformApi#securityPlatforms",
+          "io.openaev.rest.asset.security_platforms.SecurityPlatformApi#securityPlatform",
+          "io.openaev.rest.asset.security_platforms.SecurityPlatformApi#updateSecurityPlatform");
 
   @ArchTest
   static final ArchRule tx_scoped_entrypoints_must_declare_tx_ctx =

--- a/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformCollectorsTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformCollectorsTenantScopeTest.java
@@ -1,0 +1,132 @@
+package io.openaev.rest.asset.security_platforms;
+
+import static io.openaev.rest.asset.security_platforms.SecurityPlatformApi.SECURITY_PLATFORM_URI;
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Collector;
+import io.openaev.database.model.SecurityPlatform;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.CollectorRepository;
+import io.openaev.utils.fixtures.CollectorFixture;
+import io.openaev.utils.fixtures.PaginationFixture;
+import io.openaev.utils.fixtures.SecurityPlatformFixture;
+import io.openaev.utils.fixtures.composers.CollectorComposer;
+import io.openaev.utils.fixtures.composers.SecurityPlatformComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression test for #7025: with {@code collectors} on v2 tenant isolation (the production
+ * configuration since #6751, which the default test properties do NOT exercise), the security
+ * platform endpoints must carry a {@link io.openaev.context.TxCtx} tenant scope and initialize the
+ * lazy {@code collectors} association inside it. Without that, the association load is fail-closed
+ * EMPTY (no error), {@code security_platform_collectors} always serializes as {@code []}, and the
+ * UI unlocks update / delete on every collector-managed platform.
+ *
+ * <p>The collector-purge release path (the previous lifecycle work of #6956) is asserted under the
+ * same production configuration so the fix cannot regress it.
+ */
+@Transactional
+@TestPropertySource(properties = "openaev.tenant.active-tables=collectors")
+@WithMockUser(isAdmin = true)
+@DisplayName("Security platform endpoints carry the tenant scope with collectors v2-activated")
+class SecurityPlatformCollectorsTenantScopeTest extends IntegrationTest {
+
+  @Autowired private MockMvc mvc;
+  @Autowired private SecurityPlatformComposer securityPlatformComposer;
+  @Autowired private CollectorComposer collectorComposer;
+  @Autowired private CollectorRepository collectorRepository;
+
+  private String platformId;
+  private Collector collector;
+
+  @BeforeEach
+  void setUp() {
+    securityPlatformComposer.reset();
+    collectorComposer.reset();
+
+    // The TxCtx scope is the caller's authorized tenants: the mock user must be a member of the
+    // default tenant (where the collector lives) for the scope to cover it.
+    String userId = testUserHolder.get().getId();
+    tenantRepository.addUserToTenant(userId, Tenant.DEFAULT_TENANT_UUID);
+    tenantMembershipCacheManager.evict(userId, Tenant.DEFAULT_TENANT_UUID);
+
+    SecurityPlatform platform =
+        SecurityPlatformFixture.createDefault(
+            "ScopedManagedPlatform", SecurityPlatform.SECURITY_PLATFORM_TYPE.EDR.name());
+    SecurityPlatformComposer.Composer platformWrapper =
+        securityPlatformComposer.forSecurityPlatform(platform);
+    collector = CollectorFixture.createDefaultCollector("collector_scoped_managing_platform");
+    collectorComposer.forCollector(collector).withSecurityPlatform(platformWrapper).persist();
+    entityManager.flush();
+    entityManager.clear();
+
+    platformId = platformWrapper.get().getId();
+  }
+
+  @Test
+  @DisplayName("GET by id serializes the live collector link (the UI's read-only signal)")
+  void getByIdSerializesTheLiveCollectorLink() throws Exception {
+    // Without the TxCtx scope the collectors read is fail-closed empty and this list silently
+    // serializes as [] - the #7025 production regression that unlocked every managed platform.
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_collectors[0]").value(collector.getId()));
+  }
+
+  @Test
+  @DisplayName("search serializes the live collector link on each result")
+  void searchSerializesTheLiveCollectorLink() throws Exception {
+    mvc.perform(
+            post(SECURITY_PLATFORM_URI + "/search")
+                .content(asJsonString(PaginationFixture.simpleTextSearch("ScopedManagedPlatform")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].asset_id").value(platformId))
+        .andExpect(
+            jsonPath("$.content[0].security_platform_collectors[0]").value(collector.getId()));
+  }
+
+  @Test
+  @DisplayName("a purged collector still releases the platform (previous lifecycle work intact)")
+  void purgedCollectorStillReleasesThePlatform() throws Exception {
+    // First scoped request: asserts the managed state and, as a side effect, writes the tenant
+    // scope into this test transaction so the collectors delete below is not itself fail-closed
+    // (the collectors table is tenant-active for writes too).
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_collectors[0]").value(collector.getId()));
+
+    collectorRepository.deleteByCollectorId(collector.getId());
+    entityManager.flush();
+    entityManager.clear();
+
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_collectors").isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #7025.

Since the `collectors` table became v2 tenant-active, `security_platform_collectors` was always serialized as an empty array, so the UI treated every security platform as unmanaged and unlocked Update/Delete even while the owning collector was started.

Root cause chain:

- `security_platform_collectors` is rendered from the lazy `SecurityPlatform#collectors` association by `MultiIdListSerializer` during JSON serialization.
- With open-in-view, that serialization happens AFTER the controller transaction, where the tenant scope set by `TenantScopeTransactionAspect` is gone (`SecurityPlatformApi` endpoints did not declare `TxCtx`, so the scope was never set in the first place).
- `TenantStatementInspector` rewrites the collectors query with the fail-closed `can_access_tenant` predicate, which returns false when `app.current_tenants` is unset -> the association silently loads zero rows.
- The frontend's `isCollectorManaged()` checks `security_platform_collectors.length > 0` -> always false -> Delete enabled everywhere.

CI never caught it because the test profile keeps `openaev.tenant.active-tables` empty, which disables the statement inspector.

## Fix

- `SecurityPlatformApi`: the four endpoints that serialize a `SecurityPlatform` (GET list, GET by id, POST search, PUT update) now declare `TxCtx` (so the transaction aspect writes the caller's tenant scope) and force-initialize the `collectors` association inside that scoped transaction via a documented `withCollectorsInitialized` helper.

## Guardrails so it cannot regress silently

- `TenantScopedEntrypointsTxCtxArchTest`: the four `SecurityPlatformApi` entrypoints are pinned as TxCtx-scoped.
- `TenantActiveTableAccessArchTest`: new rule pinning all callers of `SecurityPlatform#getCollectors` to an allowlist, so any new code path serializing the association without a scoped transaction fails the build.
- New `SecurityPlatformCollectorsTenantScopeTest` runs with `openaev.tenant.active-tables=collectors` (production-like, inspector active) and verifies:
  - GET by id serializes the live collector link,
  - POST search serializes the live collector link,
  - after the collector is purged, the platform is released (`security_platform_collectors` empty) - protecting the previous deletable-after-catalog-removal work.

## Test plan

- [x] `mvn test -pl openaev-api -Dtest=SecurityPlatformCollectorsTenantScopeTest,TenantScopedEntrypointsTxCtxArchTest,TenantActiveTableAccessArchTest,SecurityPlatformApiTest` -> 27 tests, 0 failures
- [x] `mvn spotless:apply` clean, offline `test-compile` clean
