### PR TITLE
fix(deps): upgrade jackson-bom, netty and tomcat for CVE fixes

### DIFF
--- a/Dockerfile_ubi9
+++ b/Dockerfile_ubi9
@@ -35,8 +35,10 @@ USER root
 # Fixed world-readable browser path so any runtime UID finds the Chromium bundle (reporting)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
+# Apply all available RHEL9 security errata (libacl, glib2, python3, openssl-libs, ...) so the
+# runtime image ships with the current fixes at build time (CVE-2026-54369/54370/15308/58016 et al.)
 RUN set -eux; \
-    microdnf upgrade -y --refresh openssl-libs; \
+    microdnf upgrade -y --refresh; \
     curl -L -o /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini; \
     echo "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c /usr/bin/tini" | sha256sum -c -; \
     chmod +x /usr/bin/tini; \

--- a/Dockerfile_ubi9_ga
+++ b/Dockerfile_ubi9_ga
@@ -5,8 +5,10 @@ USER root
 # Fixed world-readable browser path so any runtime UID finds the Chromium bundle (reporting)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
+# Apply all available RHEL9 security errata (libacl, glib2, python3, openssl-libs, ...) so the
+# runtime image ships with the current fixes at build time (CVE-2026-54369/54370/15308/58016 et al.)
 RUN set -eux; \
-    microdnf upgrade -y --refresh openssl-libs; \
+    microdnf upgrade -y --refresh; \
     curl -L -o /usr/bin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini; \
     echo "93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c /usr/bin/tini" | sha256sum -c -; \
     chmod +x /usr/bin/tini; \

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <tools-jackson-core.version>3.2.1</tools-jackson-core.version>
         <tomcat.version>10.1.56</tomcat.version>
+        <!-- Override Spring Boot BOM: httpcore5-h2 HTTP/2 HPACK DoS CVE-2026-54428 -->
+        <httpcore5.version>5.4.3</httpcore5.version>
     </properties>
 
     <distributionManagement>
@@ -106,6 +108,20 @@
                 <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${tools-jackson-core.version}</version>
+            </dependency>
+            <!-- jackson-databind 3.x lags core and resolves transitively to 3.0.0; pin to the
+                 core train (3.2.1) to fix CVE-2026-54512/54513 (Critical) and CVE-2026-59889 -->
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${tools-jackson-core.version}</version>
+            </dependency>
+            <!-- Not managed by the Spring Boot BOM; a deep transitive still pulls 1.0.5.
+                 Pin explicitly so CVE-2026-9563 (JSON parser DoS) stays fixed regardless of path. -->
+            <dependency>
+                <groupId>org.eclipse.parsson</groupId>
+                <artifactId>parsson</artifactId>
+                <version>1.1.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,11 @@
         <pyroscope.version>2.8.0</pyroscope.version>
         <spring-security-crypto.version>6.5.11</spring-security-crypto.version>
         <bouncycastle.version>1.85</bouncycastle.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <jackson-bom.version>2.21.5</jackson-bom.version>
+        <netty.version>4.1.136.Final</netty.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <tools-jackson-core.version>3.2.1</tools-jackson-core.version>
-        <tomcat.version>10.1.55</tomcat.version>
+        <tomcat.version>10.1.56</tomcat.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary

Bump three dependency versions:
- **jackson-bom** 2.21.4 → 2.21.5
- **Netty** 4.1.135.Final → 4.1.136.Final
- **Tomcat** 10.1.55 → 10.1.56

Also, to close the remaining Snyk findings:
- **jackson-databind 3.x** pinned 3.0.0 → 3.2.1 (carries the 2 Criticals, unmanaged by jackson-bom)
- **parsson** pinned → 1.1.9 (deep transitive still pulled 1.0.5)
- **httpcore5** → 5.4.3
- **UBI9 images**: full `microdnf upgrade` for base OS errata (libacl, glib2, python3)

Snyk rescan: Java layer 0 vulns, all NAB-listed base CVEs cleared.
