### PR TITLE
fix(api): exclude asset group children from inject global score aggregation (#7027)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/rest/inject_expectation/InjectExpectationGlobalScoreTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject_expectation/InjectExpectationGlobalScoreTest.java
@@ -1,0 +1,233 @@
+package io.openaev.rest.inject_expectation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.*;
+import io.openaev.database.raw.RawInjectExpectationIndexing;
+import io.openaev.database.repository.*;
+import io.openaev.expectation.ExpectationType;
+import io.openaev.utils.InjectExpectationResultUtils.ExpectationResultsByType;
+import io.openaev.utils.ResultUtils;
+import io.openaev.utils.fixtures.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Covers the global-score aggregation queries used by inject lists, simulation cards and scenario
+ * statistics (issue #7027).
+ *
+ * <p>The global score must be computed from primary (target-level) expectations only: the per-asset
+ * children of a targeted asset group are already rolled up into the group parent row according to
+ * the configured validation mode ("all assets" vs "at least one asset"), so counting them again
+ * dilutes a failed group into a PARTIAL global score.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class InjectExpectationGlobalScoreTest extends IntegrationTest {
+
+  private static final String INJECTION_NAME = "Global score aggregation inject";
+  private static final Double EXPECTED_SCORE = 100.0;
+  private static final Long EXPIRATION_TIME = 21600L;
+
+  @Autowired private InjectorFixture injectorFixture;
+  @Autowired private InjectorContractRepository injectorContractRepository;
+  @Autowired private InjectorRepository injectorRepository;
+  @Autowired private InjectRepository injectRepository;
+  @Autowired private AssetRepository assetRepository;
+  @Autowired private AssetGroupRepository assetGroupRepository;
+  @Autowired private InjectExpectationRepository injectExpectationRepository;
+  @Autowired private ResultUtils resultUtils;
+
+  private InjectorContract savedInjectorContract;
+  private Asset asset1;
+  private Asset asset2;
+  private Asset asset3;
+
+  @BeforeAll
+  void beforeAll() throws JsonProcessingException {
+    InjectorContract injectorContract =
+        InjectorContractFixture.createInjectorContract(Map.of("en", INJECTION_NAME));
+    Injector savedInjector = injectorFixture.getWellKnownOaevImplantInjector();
+    injectorContract.addInjector(savedInjector);
+    savedInjectorContract = injectorContractRepository.save(injectorContract);
+    savedInjector.linkContract(savedInjectorContract);
+    injectorRepository.save(savedInjector);
+
+    asset1 = assetRepository.save(AssetFixture.createDefaultAsset("global-score-asset-1"));
+    asset2 = assetRepository.save(AssetFixture.createDefaultAsset("global-score-asset-2"));
+    asset3 = assetRepository.save(AssetFixture.createDefaultAsset("global-score-asset-3"));
+  }
+
+  @AfterEach
+  void afterEach() {
+    injectExpectationRepository.deleteAll();
+    injectRepository.deleteAll();
+    assetGroupRepository.deleteAll();
+  }
+
+  @AfterAll
+  void afterAll() {
+    assetRepository.deleteAll();
+  }
+
+  private Inject saveInjectWithAssetGroup(AssetGroup assetGroup) {
+    Inject inject =
+        InjectFixture.createTechnicalInjectWithAssetGroup(
+            savedInjectorContract, INJECTION_NAME, assetGroup);
+    inject.setTenant(new Tenant(TenantContext.getCurrentTenant()));
+    return injectRepository.save(inject);
+  }
+
+  private VulnerabilityInjectExpectation saveVulnerabilityExpectation(
+      Inject inject, Asset asset, AssetGroup assetGroup, Double score, boolean expectationGroup) {
+    VulnerabilityInjectExpectation expectation = new VulnerabilityInjectExpectation();
+    expectation.setInject(inject);
+    expectation.setAsset(asset);
+    expectation.setAssetGroup(assetGroup);
+    expectation.setName("Not vulnerable");
+    expectation.setScore(score);
+    expectation.setExpectedScore(EXPECTED_SCORE);
+    expectation.setExpirationTime(EXPIRATION_TIME);
+    expectation.setExpectationGroup(expectationGroup);
+    return injectExpectationRepository.save(expectation);
+  }
+
+  @Test
+  @DisplayName(
+      "Global score should be FAILED when the asset group expectation fails in all-assets"
+          + " validation mode, even if most per-asset children succeeded")
+  void globalScoreShouldBeFailedWhenAssetGroupAllModeFails() {
+    AssetGroup assetGroup =
+        assetGroupRepository.save(
+            AssetGroupFixture.createAssetGroupWithAssets(
+                "all endpoints", List.of(asset1, asset2, asset3)));
+    Inject inject = saveInjectWithAssetGroup(assetGroup);
+
+    // Group parent row: "all assets must validate" failed because one asset is vulnerable
+    saveVulnerabilityExpectation(inject, null, assetGroup, 0.0, false);
+    // Per-asset children: two not vulnerable, one vulnerable
+    saveVulnerabilityExpectation(inject, asset1, assetGroup, 100.0, false);
+    saveVulnerabilityExpectation(inject, asset2, assetGroup, 100.0, false);
+    saveVulnerabilityExpectation(inject, asset3, assetGroup, 0.0, false);
+
+    List<RawInjectExpectationIndexing> raws =
+        injectExpectationRepository.rawForComputeGlobalByInjectIds(Set.of(inject.getId()));
+
+    // Only the group parent row is aggregated, not its per-asset children
+    assertThat(raws).hasSize(1);
+    assertThat(raws.get(0).getAsset_id()).isNull();
+    assertThat(raws.get(0).getAsset_group_id()).isEqualTo(assetGroup.getId());
+
+    List<ExpectationResultsByType> results =
+        resultUtils.computeGlobalExpectationResults(Set.of(inject.getId()));
+
+    assertThat(results)
+        .filteredOn(result -> result.type() == ExpectationType.VULNERABILITY)
+        .singleElement()
+        .extracting(ExpectationResultsByType::avgResult)
+        .isEqualTo(BaseInjectExpectation.EXPECTATION_STATUS.FAILED);
+  }
+
+  @Test
+  @DisplayName(
+      "Global score should be SUCCESS when the asset group expectation succeeds in at-least-one"
+          + " validation mode, even if some per-asset children failed")
+  void globalScoreShouldBeSuccessWhenAssetGroupAtLeastOneModeSucceeds() {
+    AssetGroup assetGroup =
+        assetGroupRepository.save(
+            AssetGroupFixture.createAssetGroupWithAssets(
+                "all endpoints", List.of(asset1, asset2, asset3)));
+    Inject inject = saveInjectWithAssetGroup(assetGroup);
+
+    // Group parent row: "at least one asset must validate" succeeded
+    saveVulnerabilityExpectation(inject, null, assetGroup, 100.0, true);
+    // Per-asset children: one not vulnerable, two vulnerable
+    saveVulnerabilityExpectation(inject, asset1, assetGroup, 100.0, true);
+    saveVulnerabilityExpectation(inject, asset2, assetGroup, 0.0, true);
+    saveVulnerabilityExpectation(inject, asset3, assetGroup, 0.0, true);
+
+    List<ExpectationResultsByType> results =
+        resultUtils.computeGlobalExpectationResults(Set.of(inject.getId()));
+
+    assertThat(results)
+        .filteredOn(result -> result.type() == ExpectationType.VULNERABILITY)
+        .singleElement()
+        .extracting(ExpectationResultsByType::avgResult)
+        .isEqualTo(BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS);
+  }
+
+  @Test
+  @DisplayName(
+      "Directly-targeted asset expectations should still count in the global score, including"
+          + " assets that also belong to a targeted asset group")
+  void globalScoreShouldKeepDirectlyTargetedAssets() {
+    // asset1 is both a direct inject target and a member of the targeted group
+    AssetGroup assetGroup =
+        assetGroupRepository.save(
+            AssetGroupFixture.createAssetGroupWithAssets("all endpoints", List.of(asset1, asset2)));
+    Inject inject =
+        InjectFixture.createTechnicalInjectWithAssetGroup(
+            savedInjectorContract, INJECTION_NAME, assetGroup);
+    inject.setAssets(List.of(asset1, asset3));
+    inject.setTenant(new Tenant(TenantContext.getCurrentTenant()));
+    inject = injectRepository.save(inject);
+
+    // Group parent row succeeded
+    saveVulnerabilityExpectation(inject, null, assetGroup, 100.0, false);
+    // asset1: direct target AND group member, its row carries the asset group reference
+    saveVulnerabilityExpectation(inject, asset1, assetGroup, 100.0, false);
+    // asset2: group member only, rolled up into the parent
+    saveVulnerabilityExpectation(inject, asset2, assetGroup, 100.0, false);
+    // asset3: direct target only, failed
+    saveVulnerabilityExpectation(inject, asset3, null, 0.0, false);
+
+    List<RawInjectExpectationIndexing> raws =
+        injectExpectationRepository.rawForComputeGlobalByInjectIds(Set.of(inject.getId()));
+
+    // Parent + asset1 (direct target) + asset3 (direct target); asset2 child is excluded
+    assertThat(raws).hasSize(3);
+    assertThat(raws)
+        .noneMatch(
+            raw -> asset2.getId().equals(raw.getAsset_id()) && raw.getAsset_group_id() != null);
+
+    List<ExpectationResultsByType> results =
+        resultUtils.computeGlobalExpectationResults(Set.of(inject.getId()));
+
+    // Two successes (parent + asset1) and one failure (asset3) -> PARTIAL
+    assertThat(results)
+        .filteredOn(result -> result.type() == ExpectationType.VULNERABILITY)
+        .singleElement()
+        .extracting(ExpectationResultsByType::avgResult)
+        .isEqualTo(BaseInjectExpectation.EXPECTATION_STATUS.PARTIAL);
+  }
+
+  @Test
+  @DisplayName(
+      "Entity-based global score query should apply the same primary-expectation filtering")
+  void entityGlobalScoreQueryShouldExcludeAssetGroupChildren() {
+    AssetGroup assetGroup =
+        assetGroupRepository.save(
+            AssetGroupFixture.createAssetGroupWithAssets(
+                "all endpoints", List.of(asset1, asset2, asset3)));
+    Inject inject = saveInjectWithAssetGroup(assetGroup);
+
+    saveVulnerabilityExpectation(inject, null, assetGroup, 0.0, false);
+    saveVulnerabilityExpectation(inject, asset1, assetGroup, 100.0, false);
+    saveVulnerabilityExpectation(inject, asset2, assetGroup, 100.0, false);
+    saveVulnerabilityExpectation(inject, asset3, assetGroup, 0.0, false);
+
+    List<BaseInjectExpectation> expectations =
+        injectExpectationRepository.findAllForGlobalScoreByInjects(Set.of(inject.getId()));
+
+    assertThat(expectations).hasSize(1);
+    assertThat(expectations.get(0)).isInstanceOf(TechnicalInjectExpectation.class);
+    TechnicalInjectExpectation parent = (TechnicalInjectExpectation) expectations.get(0);
+    assertThat(parent.getAsset()).isNull();
+    assertThat(parent.getAssetGroup()).isNotNull();
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -358,9 +358,16 @@ public interface InjectExpectationRepository
               + "FROM injects_expectations i "
               + "WHERE i.inject_id IN (:injectIds) "
               + "AND i.user_id is null "
-              + "AND i.agent_id is null ;",
+              + "AND i.agent_id is null "
+              + "AND (i.asset_id IS NULL OR i.asset_group_id IS NULL "
+              + "  OR i.asset_id IN (SELECT ia.asset_id FROM injects_assets ia WHERE ia.inject_id = i.inject_id)) ;",
       nativeQuery = true)
-  // We don't include expectations for players, only for the team, neither for agents, if applicable
+  // Global score aggregates primary (target-level) expectations only: team rows, asset-group
+  // parent rows and directly-targeted asset rows. Player and agent rows are excluded, and so are
+  // the per-asset children of a targeted asset group (asset_id and asset_group_id both set,
+  // asset not a direct inject target): their verdict is already rolled up into the group parent
+  // row according to the configured validation mode (all assets / at least one asset), so
+  // counting them again dilutes a failed group into a PARTIAL global score.
   List<RawInjectExpectationIndexing> rawForComputeGlobalByInjectIds(
       @Param("injectIds") Set<String> injectIds);
 
@@ -382,15 +389,21 @@ public interface InjectExpectationRepository
               + "FROM injects_expectations i "
               + "WHERE i.exercise_id IN (:exerciseIds) "
               + "AND i.user_id is null "
-              + "AND i.agent_id is null ;",
+              + "AND i.agent_id is null "
+              + "AND (i.asset_id IS NULL OR i.asset_group_id IS NULL "
+              + "  OR i.asset_id IN (SELECT ia.asset_id FROM injects_assets ia WHERE ia.inject_id = i.inject_id)) ;",
       nativeQuery = true)
-  // We don't include expectations for players, only for the team, if applicable
+  // Same primary-expectation filtering as rawForComputeGlobalByInjectIds (see comment there).
   List<RawInjectExpectationIndexing> rawForComputeGlobalByExerciseIds(
       @Param("exerciseIds") Set<String> exerciseIds);
 
   @Query(
       value =
-          "select i from InjectExpectation i where i.inject.id in :injectIds and i.agent is null and i.user is null")
+          "select i from InjectExpectation i where i.inject.id in :injectIds"
+              + " and i.agent is null and i.user is null"
+              + " and (i.asset is null or i.assetGroup is null"
+              + "   or i.asset.id in (select a.id from Inject inj join inj.assets a where inj.id = i.inject.id))")
+  // Same primary-expectation filtering as rawForComputeGlobalByInjectIds (see comment there).
   List<BaseInjectExpectation> findAllForGlobalScoreByInjects(
       @Param("injectIds") Set<String> injectIds);
 


### PR DESCRIPTION
## Proposed changes

Fixes #7027.

When an inject targets an asset group, the platform stores one parent expectation row for the group plus one child row per asset in the group. The group parent's verdict is computed from its children according to the configured validation mode ("all assets must validate" / "at least one asset must validate").

The global score queries (`rawForComputeGlobalByInjectIds`, `rawForComputeGlobalByExerciseIds`, `findAllForGlobalScoreByInjects`) fetched BOTH the group parent row and all its per-asset children, then averaged everything. With a group in "all assets" mode where 5 of 6 assets are not vulnerable, the average was (0 + 5x100 + 0) / ... instead of just the parent's 0 -> the inject global score displayed PARTIAL (orange) instead of FAILED (red), even though the group verdict itself was correctly FAILED.

This change filters the three global score queries down to primary (target-level) expectations only:

- team rows (player and agent rows were already excluded),
- asset group parent rows (`asset_group_id` set, `asset_id` null),
- directly-targeted asset rows (`asset_id` present in `injects_assets` for the inject).

Per-asset children of a targeted asset group are excluded: their verdict is already rolled up into the group parent row by the validation mode, so counting them again dilutes a failed group into PARTIAL. An asset that is BOTH a member of a targeted group and a direct target of the inject keeps its own row (it is a primary target in its own right).

Affected surfaces (all fed by these queries): inject "Global score" column in simulation inject lists, atomic testing list/global scores, simulation-level aggregates and security coverage. The inject overview header (`InjectMapper.getPrimaryExpectations`) already filtered correctly and is unchanged. Attack paths use a different verdict pipeline and are not affected.

Simulation-level PARTIAL semantics are intentionally preserved: a simulation with some green and some red injects still shows PARTIAL; only the per-inject aggregation is corrected.

## Testing

New integration test class `InjectExpectationGlobalScoreTest` (real DB, no mocks) covering:

- asset group in "all assets" mode with one failing asset -> global score FAILED (the bug scenario),
- asset group in "at least one" mode with one succeeding asset -> global score SUCCESS,
- asset directly targeted AND member of a targeted group -> direct row kept, child rows excluded, mixed results -> PARTIAL,
- same filtering on the JPQL entity query `findAllForGlobalScoreByInjects`.

Also ran `ResultUtilsTest`, `ExerciseServiceUnitTest`, `SecurityCoverageServiceTest`, `ScenarioStatisticServiceTest` (30 tests) - all green.

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I added/update the required tests
- [ ] I updated the documentation (not needed - bug fix, no functional contract change)
- [x] Where necessary I refactored code to improve the overall quality
