### PR TITLE
fix(attack-path): sort the simulation picker by most recent run first (#6647)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, friendlyNodeId, maskFindingValue, pivotEndpointIds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -210,6 +210,53 @@ describe('pivotEndpointIds', () => {
         edgeTargetId: 'NODE_ENDPOINT|a',
       },
     ]).size).toBe(0);
+  });
+});
+
+describe('orderSimulationPickerOptions', () => {
+  // ISO start dates keyed by simulation id (the shape the picker resolves from simulation meta).
+  const dates: Record<string, string> = {
+    a: '2026-07-27T12:24:00Z',
+    b: '2026-07-28T08:05:00Z',
+    c: '2026-07-29T11:20:00Z',
+  };
+  const startDateOf = (simId?: string) => dates[simId ?? ''] ?? '';
+
+  it('orders the options most recent first, regardless of the incoming order', () => {
+    // Arrange: rows in a jumbled order (as the backend returns them).
+    const rows = [{ simulationId: 'a' }, { simulationId: 'c' }, { simulationId: 'b' }];
+    // Act
+    const ordered = orderSimulationPickerOptions(rows, null, startDateOf);
+    // Assert: newest (c, Jul 29) first, oldest (a, Jul 27) last.
+    expect(ordered.map(o => o.simulationId)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const rows = [{ simulationId: 'a' }, { simulationId: 'c' }, { simulationId: 'b' }];
+    orderSimulationPickerOptions(rows, null, startDateOf);
+    expect(rows.map(o => o.simulationId)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('keeps a selected row that is absent from the list and orders it by its own date', () => {
+    // Arrange: the selected run has no summary row in `simulations` yet, but its date resolves.
+    const rows = [{ simulationId: 'a' }, { simulationId: 'b' }];
+    const selected = { simulationId: 'c' };
+    // Act
+    const ordered = orderSimulationPickerOptions(rows, selected, startDateOf);
+    // Assert: selected (newest) is included and sorted to the front, not just prepended blindly.
+    expect(ordered.map(o => o.simulationId)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('does not duplicate a selected row that is already in the list', () => {
+    const rows = [{ simulationId: 'a' }, { simulationId: 'c' }, { simulationId: 'b' }];
+    const ordered = orderSimulationPickerOptions(rows, { simulationId: 'c' }, startDateOf);
+    expect(ordered.map(o => o.simulationId)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('sorts rows with an unknown date to the end', () => {
+    const rows = [{ simulationId: 'unknown' }, { simulationId: 'b' }, { simulationId: 'c' }];
+    const ordered = orderSimulationPickerOptions(rows, null, startDateOf);
+    expect(ordered.map(o => o.simulationId)).toEqual(['c', 'b', 'unknown']);
   });
 });
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -16,7 +16,7 @@ import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathDTO, AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import attackPathStatusColor, { attackPathChokepointColor } from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, type PathFinding, pivotEndpointIds } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds } from './attack-path-flow-helpers';
 import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
@@ -1974,9 +1974,11 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   const selectedRow: AttackPathSimSummaryRow | null = simulationId
     ? (simulations.find(s => s.simulationId === simulationId) ?? { simulationId })
     : null;
-  const pickerOptions = selectedRow && !simulations.some(s => s.simulationId === selectedRow.simulationId)
-    ? [selectedRow, ...simulations]
-    : simulations;
+  const pickerOptions = orderSimulationPickerOptions(
+    simulations,
+    selectedRow,
+    simId => metaById.get(simId ?? '')?.exercise_start_date ?? '',
+  );
 
   // Chokepoint accent (violet), reserved so it never reads as a prevention/detection verdict.
   const chokepointColor = attackPathChokepointColor(theme);

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -740,6 +740,21 @@ export const pivotEndpointIds = (
   return pivots;
 };
 
+// Order the simulation picker options: most recent first, by exercise start date. Dates come from the
+// resolved simulation meta as ISO strings, so a plain lexicographic compare is chronological (same key
+// the default-run selection uses). The currently-selected row is kept in the list even when it has no
+// summary/meta yet — it sorts by its own resolved date, or falls to the end when the date is unknown.
+export const orderSimulationPickerOptions = <T extends { simulationId?: string }>(
+  simulations: T[],
+  selectedRow: T | null,
+  startDateOf: (simId?: string) => string,
+): T[] => {
+  const base = selectedRow && !simulations.some(s => s.simulationId === selectedRow.simulationId)
+    ? [selectedRow, ...simulations]
+    : simulations;
+  return [...base].sort((a, b) => startDateOf(b.simulationId).localeCompare(startDateOf(a.simulationId)));
+};
+
 // Human-readable plural noun for a finding type, used to give contextual cluster edges a label with
 // meaning (e.g. "6 credentials" instead of a bare "6+"). Mixed clusters fall back to "findings".
 export const findingCategoryNoun = (typeFindings?: string): string => {


### PR DESCRIPTION
Fixes the simulation picker ordering on the scenario **Attack path** tab: runs were listed in raw backend order, so a July 27 run could sit above a July 29 one.

## Root cause
The dropdown renders `pickerOptions`, which was just `simulations` in the order returned by `fetchAttackPathSimulations` — never sorted. The only date sort (`exercise_start_date`) was used solely to pick the **default** run, not to order the list.

## Fix
Extract a pure `orderSimulationPickerOptions(simulations, selectedRow, startDateOf)` helper and route the Autocomplete `options` through it:
- most recent first, by resolved `exercise_start_date` (ISO lexicographic desc — same key the default-run selection uses);
- keeps the currently-selected row in the list even when it has no summary/meta yet (sorts by its own date, or last when unknown);
- does not mutate the input array.

## Tests
5 unit tests in `attack-path-flow-helpers.test.ts`: desc ordering regardless of input order, no input mutation, an absent selected row kept and ordered by its own date, no duplicate of an already-present selected row, unknown-date rows sorted last. check-ts + eslint + vitest green.

Behind the `ATTACK_PATH` feature flag.
