### PR TITLE
fix(attack-path): draw causal edges for complex findings via backend-resolved matchedFindingIds (#6647)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -416,6 +416,7 @@ const killChainDto: AttackPathDTO = {
         keyType: 'port',
         operator: 'EQ',
         value: '445',
+        matchedFindingIds: ['find-port'],
       }],
       dependsOn: [],
     },
@@ -428,6 +429,7 @@ const killChainDto: AttackPathDTO = {
         keyType: 'share_name',
         operator: 'EQ',
         value: 'ADMIN$',
+        matchedFindingIds: ['find-share'],
       }],
       dependsOn: ['step-A'],
     },
@@ -479,11 +481,13 @@ describe('buildKillChainMeta', () => {
       keyType: 'port',
       operator: 'EQ',
       value: '445',
+      matchedFindingIds: ['find-port'],
     }]);
     expect(meta.get('inj-smb')?.consumedFindingKeys).toEqual([{
       keyType: 'share_name',
       operator: 'EQ',
       value: 'ADMIN$',
+      matchedFindingIds: ['find-share'],
     }]);
   });
 
@@ -506,8 +510,8 @@ describe('buildKillChainMeta', () => {
 });
 
 describe('buildCausalEdges', () => {
-  it('draws a solid finding edge, reconciling the primitive key type (share_name -> share)', () => {
-    // Arrange
+  it('anchors a solid finding edge on the backend-resolved matchedFindingIds', () => {
+    // Arrange: the backend resolved that this consumer's key matched the finding node 'find-share'.
     const meta = buildKillChainMeta(killChainDto);
     const nodes = [injectorNode('inj-smb'), findingNode('find-share', 'share', 'ADMIN$')];
     // Act
@@ -520,8 +524,33 @@ describe('buildCausalEdges', () => {
     expect(edges[0].data?.causalKind).toBe('finding');
   });
 
-  it('emits no edge when no produced finding matches the consumed key', () => {
+  it('links a complex finding the front cannot parse (portscan "host:port (service)") to a primitive port key', () => {
+    // Arrange: a portscan finding whose value is "host:port (service)". The old front matcher could never
+    // derive `port == 445` from that string (wrong type `portscan` != `port`, and no sub-field parse) — but
+    // the backend did, and listed the node id in matchedFindingIds. This is the exact case the migration fixes.
+    const fid = 'NODE_FINDING|portscan|10.0.0.1:445 (microsoft-ds)';
+    const meta = new Map([['inj-nmap', {
+      dependsOn: [],
+      consumedFindingKeys: [{
+        keyType: 'port',
+        operator: 'EQ',
+        value: '445',
+        matchedFindingIds: [fid],
+      }],
+    }]]);
+    const nodes = [injectorNode('inj-nmap'), findingNode(fid, 'portscan', '10.0.0.1:445 (microsoft-ds)')];
+    // Act
+    const edges = buildCausalEdges(nodes, id => (id ? meta.get(id) : undefined), tt);
+    // Assert: the solid causal edge is drawn, driven purely by the backend match.
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe(fid);
+    expect(edges[0].target).toBe('inj-nmap');
+    expect(edges[0].data?.causalKind).toBe('finding');
+  });
+
+  it('emits no finding edge when the key matched nothing on the backend (node id absent from matchedFindingIds)', () => {
     const meta = buildKillChainMeta(killChainDto);
+    // inj-nmap's key matched 'find-port'; a 'find-cve' node is not in that set, and inj-nmap has no dependsOn.
     const nodes = [injectorNode('inj-nmap'), findingNode('find-cve', 'cve', 'CVE-2024-0001')];
     const edges = buildCausalEdges(nodes, id => (id ? meta.get(id) : undefined), tt);
     expect(edges).toHaveLength(0);
@@ -576,6 +605,7 @@ const chainDto: AttackPathDTO = {
         keyType: 'port',
         operator: 'EQ',
         value: '445',
+        matchedFindingIds: ['NODE_FINDING|port|445'],
       }],
       dependsOn: ['step-A'],
     },
@@ -679,6 +709,7 @@ describe('buildCausalChainFlow', () => {
             operator: 'IS_NOT_NULL',
             value: null as unknown as string,
             eventName: 'PORT FOUND',
+            matchedFindingIds: ['NODE_FINDING|port|445'],
           }],
           dependsOn: [],
         },
@@ -742,6 +773,7 @@ describe('buildCausalChainFlow', () => {
             operator: 'IS_NOT_NULL',
             value: null as unknown as string,
             eventName: 'SHARE',
+            matchedFindingIds: ['NODE_FINDING|share|NETLOGON', 'NODE_FINDING|share|SYSVOL', 'NODE_FINDING|share|CertEnroll'],
           }],
           dependsOn: [],
         },
@@ -806,6 +838,7 @@ describe('buildCausalChainFlow', () => {
             operator: 'IS_NOT_NULL',
             value: null as unknown as string,
             eventName: 'SHARE',
+            matchedFindingIds: fids.map(v => `NODE_FINDING|share|${v}`),
           }],
           dependsOn: ['step-A'],
         },
@@ -920,6 +953,9 @@ describe('buildCausalChainFlow', () => {
             operator: 'IS_NOT_NULL',
             value: null as unknown as string,
             eventName: 'SHARE',
+            // The backend matched BOTH shares (the SHARE event); the front's dependency-preference then
+            // narrows the fan-in to the resolved producer's finding (shareA), never shareB's.
+            matchedFindingIds: ['NODE_FINDING|share|shareA', 'NODE_FINDING|share|shareB'],
           }],
           dependsOn: ['step-A'],
         },

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1165,6 +1165,11 @@ export interface CausalConsumedKey {
   // Name of the event (root filter condition) this key belongs to, so the causal edge can read
   // "Triggered <event>" rather than the raw "<key> = <value>". Optional (older/nameless events).
   eventName?: string;
+  // Finding-node ids (NODE_FINDING|type|value) this key matched, resolved by the backend (spec 011,
+  // back-authoritative). The causal edge is anchored on these ids instead of the front re-deriving the
+  // match — the backend reconciles the complex→primitive type (e.g. `port`→`portscan`) and reaches into
+  // the sub-field, which a value-string comparison on the front cannot. Empty until resolved / no match.
+  matchedFindingIds?: string[];
 }
 
 export interface CausalStepMeta {
@@ -1240,6 +1245,7 @@ export const buildKillChainMeta = (dto: AttackPathDTO | null | undefined): Map<s
             operator: key.operator ?? 'EQ',
             value: key.value ?? '',
             eventName: key.eventName,
+            matchedFindingIds: key.matchedFindingIds ?? [],
           });
         }
       }
@@ -1255,26 +1261,6 @@ export const buildKillChainMeta = (dto: AttackPathDTO | null | undefined): Map<s
   return byInjector;
 };
 
-// Read a finding node's produced value (stored on data.label for finding leaf nodes, with an optional
-// data.value mirror), as a string for comparison against a consumed finding key.
-const findingNodeValue = (node: AttackPathFlowNode): string => {
-  const raw = node.data.value ?? node.data.label;
-  return typeof raw === 'string' ? raw : '';
-};
-
-// A consumed key uses the raw PrimitiveType vocabulary (e.g. `share_name`, `password`) while finding
-// nodes use the finding-type vocabulary (`file`, `credentials`). Reconcile the known complex sub-field
-// keys to their finding type here. Primitives that already match a finding type 1:1 (`port`, `cve`,
-// `ipv4`, `username`, `hostname`, `hash`…) are left untouched (identity). NOTE: reconciling the VALUE of
-// a complex finding (reaching into its sub-field, e.g. a share's `share_name`) is the front-side complex
-// matching still to come — today only the TYPE is reconciled and value comparison stays direct, which is
-// correct for primitives; complex value-matching is a follow-up (see backend requirements topo).
-const KEYTYPE_TO_FINDING_TYPE: Record<string, string> = {
-  share_name: 'share',
-  file_name: 'file',
-  password: 'credentials',
-};
-
 // Label for a causal (finding → consuming action) edge. When the backend named the event (the root
 // filter condition the key belongs to), read it as "Triggered <event>" so the analyst sees WHY the next
 // action ran (its event matched); otherwise fall back to the raw "<key> = <masked value>" match.
@@ -1282,48 +1268,6 @@ const causalKeyLabel = (key: CausalConsumedKey, t: ApTranslate): string =>
   (key.eventName && key.eventName.trim()
     ? t('Triggered {event}', { event: key.eventName })
     : `${key.keyType} = ${maskFindingValue(key.keyType, key.value)}`);
-
-// Does a produced finding node satisfy a consumed finding key?
-//   - the finding's type (data.typeFindings) must equal the reconciled key type, and
-//   - EQ => the finding value equals key.value exactly;
-//   - IN => the finding value is one of key.value's comma-separated members (a small, explicit list
-//     semantics; trimmed). Falls back to substring containment for a single-token key.
-//   - IS_NOT_NULL => any produced finding of the reconciled type matches (presence, not value).
-// EQ, IN and IS_NOT_NULL are handled. SKIPPED operators (no edge emitted, no silent cap): NEQ, GT, GTE,
-// LT, LTE, CONTAINS, REGEX, and any other — add them here when the backend needs them.
-// The type/value core of the match, shared by the flow-node matcher and the logical-finding matcher used
-// by the chain layout (where a finding may be collapsed into a cluster and so has no leaf flow node).
-const matchesKeyValue = (typeFindings: string, value: string, key: CausalConsumedKey): boolean => {
-  const reconciledType = KEYTYPE_TO_FINDING_TYPE[key.keyType] ?? key.keyType;
-  if (typeFindings !== reconciledType) {
-    return false;
-  }
-  // IS_NOT_NULL matches on presence, not value (e.g. "triggered when any share is found"); its key.value is
-  // null, so handle it before the string guard below.
-  if (key.operator === 'IS_NOT_NULL') {
-    return value.length > 0;
-  }
-  // Guard the real DTO field (the mock is always a string, but the backend value may be null/undefined).
-  if (typeof key.value !== 'string') {
-    return false;
-  }
-  if (key.operator === 'EQ') {
-    return value === key.value;
-  }
-  if (key.operator === 'IN') {
-    const members = key.value.split(',').map(s => s.trim()).filter(Boolean);
-    if (members.length > 1) {
-      return members.includes(value);
-    }
-    return value.includes(key.value);
-  }
-  // Unsupported operator (see list above): ignore, emit nothing.
-  return false;
-};
-
-const findingMatchesKey = (node: AttackPathFlowNode, key: CausalConsumedKey): boolean =>
-  node.type === AP_FLOW_NODE_TYPE.finding
-  && matchesKeyValue(node.data.typeFindings ?? '', findingNodeValue(node), key);
 
 /**
  * Build the additive kill-chain causal edges for a set of flow nodes (issue 6647).
@@ -1387,8 +1331,12 @@ export const buildCausalEdges = (
     }
     let matchedAnyFinding = false;
     for (const key of meta.consumedFindingKeys ?? []) {
+      // Backend-authoritative: anchor the edge on the finding-node ids the backend matched for this key
+      // (spec 011). No front re-derivation — the backend already reconciled the complex→primitive type
+      // (e.g. `port`→`portscan`) and reached into the sub-field, which a value-string compare cannot.
+      const matched = new Set(key.matchedFindingIds ?? []);
       for (const finding of findingNodes) {
-        if (!findingMatchesKey(finding, key)) {
+        if (!matched.has(finding.id)) {
           continue;
         }
         matchedAnyFinding = true;
@@ -1567,6 +1515,7 @@ export const buildCausalChainFlow = (
           operator: k.operator ?? 'EQ',
           value: k.value ?? '',
           eventName: k.eventName,
+          matchedFindingIds: k.matchedFindingIds ?? [],
         });
       }
     }
@@ -1905,10 +1854,10 @@ export const buildCausalChainFlow = (
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
-      const allFids = [...producersByFinding.keys()].filter((fid) => {
-        const f = findingById.get(fid);
-        return !!f && matchesKeyValue(f.typeFindings ?? '', (f.value ?? f.label ?? ''), key);
-      });
+      // Backend-authoritative: the finding-node ids this key matched (spec 011), intersected with the
+      // findings actually produced in this graph. No front re-derivation of the type/value match.
+      const matchedIds = new Set(key.matchedFindingIds ?? []);
+      const allFids = [...producersByFinding.keys()].filter(fid => matchedIds.has(fid));
       // Prefer findings produced by this consumer's resolved dependency (#6985 populates dependsOn with the
       // real producer step), so the fan-in stays on the real producer's findings and never reaches a
       // same-typed finding from an unrelated injector. Fall back to every match when no dependency resolved.


### PR DESCRIPTION
Draws the causal finding→action edges for **complex** findings in the attack-path graph, by consuming the backend-resolved match instead of re-deriving it on the front.

## Problem
The causal overlay never drew an edge for complex findings (e.g. Nmap's `portscan` → NetExec's `port EQ 445` condition). The front re-matched each consumed key by parsing the formatted finding value and reconciling the key type — a mirror of the backend logic that could **not** reconcile the complex→primitive type (`port` vs the stored `portscan`) nor reach into the sub-field of `host:port (service)`. Result: `Nmap → NetExec` fell back to a dashed `dependsOn` edge instead of a solid causal link, while primitive/presence matches (e.g. `share_name IS_NOT_NULL`) worked.

## Fix
#7017 made the backend authoritative: `ConsumedFindingKeyDTO.matchedFindingIds` lists the finding-node ids each key matched. The front now **anchors the causal edge on those ids** in both `buildCausalEdges` and the chain view (`buildCausalChainFlow`), instead of re-matching. This removes the front mirror entirely — `findingMatchesKey`, `matchesKeyValue`, `KEYTYPE_TO_FINDING_TYPE`, `findingNodeValue` are deleted.

The node ids are used verbatim (the backend escapes `\` and `|`), so no fragile `NODE_FINDING|type|value` reconstruction.

## Verified live
On a real scenario run the backend populates `matchedFindingIds`, including `port EQ 445` → `NODE_FINDING|portscan|108.143.7.251:445 (microsoft-ds)` — the previously-broken case. The dashed `Nmap → NetExec` edge becomes a solid causal edge.

## Tests
Causal-edge and chain fixtures now carry `matchedFindingIds`; added a test proving a complex `portscan` finding (value `host:port (service)`, which the old front matcher could never parse) links to a primitive `port` key. check-ts + eslint + vitest green (37).

## Note for @laugiov
Touches `attack-path-flow-helpers.ts` (`buildCausalEdges` / chain matcher) — the same file as the pending #7016 matcher reconciliation, but orthogonal: this only changes the **source** of the match (to your `matchedFindingIds` output), not the share/file semantics. Flagging for merge sequencing.

Depends on #7017 (merged). Behind the `ATTACK_PATH` feature flag.
