### PR TITLE
fix(api): hide agent expiration rows on vulnerability asset results already answered by a scanner (#7040)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1,5 +1,6 @@
 package io.openaev.service;
 
+import static io.openaev.collectors.expectations_expiration_manager.service.ExpectationsExpirationManagerService.EXPIRED;
 import static io.openaev.collectors.expectations_vulnerability_manager.ExpectationsVulnerabilityManagerCollector.EXPECTATIONS_VULNERABILITY_COLLECTOR_ID;
 import static io.openaev.database.model.BaseInjectExpectation.EXPECTATION_TYPE.*;
 import static io.openaev.expectation.DetectionExpectation.detectionExpectationForAssetGroup;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.aop.WorkflowUpdateEvent;
+import io.openaev.collectors.expectations_expiration_manager.config.ExpectationsExpirationManagerConfig;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.InjectExpectationRepository;
@@ -1346,6 +1348,32 @@ public class InjectExpectationService {
                                   // Prefer an answered result over a pending one for the same
                                   // source.
                                   existing.getResult() != null ? existing : candidate));
+              // A VULNERABILITY row a genuine platform already answered needs no expiration entry
+              // in the merged display either: the union pulls the agents' expiration rows (the
+              // vulnerability default "Not vulnerable") onto the asset view, where they render as
+              // redundant - or contradictory - entries next to the real scan verdict. Same rule as
+              // the write path (InjectExpectationUtils.computeScores): the expiration default is
+              // the absence-of-signal fallback, a real answer supersedes it.
+              if (BaseInjectExpectation.EXPECTATION_TYPE.VULNERABILITY.equals(
+                  expectation.getType())) {
+                boolean hasGenuineAnswer =
+                    bySource.values().stream()
+                        .anyMatch(
+                            r ->
+                                !ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(
+                                        r.getSourceId())
+                                    && r.getResult() != null
+                                    && !r.getResult().isBlank()
+                                    && !EXPIRED.equals(r.getResult()));
+                if (hasGenuineAnswer) {
+                  bySource
+                      .values()
+                      .removeIf(
+                          r ->
+                              ExpectationsExpirationManagerConfig.COLLECTOR_ID.equals(
+                                  r.getSourceId()));
+                }
+              }
               clone.setResults(new ArrayList<>(bySource.values()));
               return clone;
             })

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.collectors.expectations_expiration_manager.config.ExpectationsExpirationManagerConfig;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.SecurityPlatformRepository;
@@ -1086,6 +1087,84 @@ class InjectExpectationServiceTest {
       assertEquals(List.of(collectorResult), merged.get(0).getResults());
       // The enrichment must stay display-only: the persistent entity is untouched.
       assertTrue(assetExpectation.getResults().isEmpty());
+    }
+
+    @Test
+    @DisplayName(
+        "Vulnerability display merge drops the expiration manager row when a platform answered")
+    void vulnerabilityDisplayMergeDropsExpirationManagerRowWhenPlatformAnswered() {
+      // Regression: the asset target-results view unions the agent children's collector results
+      // onto the asset expectation. The agents legitimately expire to the vulnerability default
+      // "Not vulnerable" (an agentless scanner never fills them), so the union displayed a
+      // redundant - or contradictory - "Expectations Expiration Manager" row next to the genuine
+      // scan verdict persisted on the asset row.
+      VulnerabilityInjectExpectation assetExpectation = new VulnerabilityInjectExpectation();
+      assetExpectation.setId("asset-expectation");
+      InjectExpectationResult nucleiResult =
+          InjectExpectationResult.builder()
+              .sourceId("nuclei-security-platform")
+              .sourceType("security-platform")
+              .sourceName("Nuclei")
+              .result("Not vulnerable")
+              .score(100.0)
+              .build();
+      assetExpectation.setResults(new ArrayList<>(List.of(nucleiResult)));
+      VulnerabilityInjectExpectation agentExpectation = new VulnerabilityInjectExpectation();
+      agentExpectation.setId("agent-expectation");
+      InjectExpectationResult managerResult =
+          InjectExpectationResult.builder()
+              .sourceId(ExpectationsExpirationManagerConfig.COLLECTOR_ID)
+              .sourceType("collector")
+              .sourceName("Expectations Expiration Manager")
+              .result("Not vulnerable")
+              .score(100.0)
+              .build();
+      agentExpectation.setResults(new ArrayList<>(List.of(managerResult)));
+      when(injectExpectationRepository.findAllByInjectAndAsset("inject-id", "asset-id"))
+          .thenReturn(List.of(assetExpectation));
+      when(injectExpectationRepository.findAllAgentExpectationsByInjectAndAsset(
+              "inject-id", "asset-id"))
+          .thenReturn(List.of(agentExpectation));
+
+      List<? extends BaseInjectExpectation> merged =
+          injectExpectationService.findMergedExpectationsByInjectAndTargetAndTargetType(
+              "inject-id", "asset-id", "parent-id", "ASSETS");
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(nucleiResult), merged.get(0).getResults());
+    }
+
+    @Test
+    @DisplayName(
+        "Vulnerability display merge keeps the expiration manager row when nothing answered")
+    void vulnerabilityDisplayMergeKeepsExpirationManagerRowWhenNothingAnswered() {
+      // When no platform ever answered, the expiration manager row IS the verdict
+      // ("Not vulnerable" by silence) and must stay visible on the asset view.
+      VulnerabilityInjectExpectation assetExpectation = new VulnerabilityInjectExpectation();
+      assetExpectation.setId("asset-expectation");
+      VulnerabilityInjectExpectation agentExpectation = new VulnerabilityInjectExpectation();
+      agentExpectation.setId("agent-expectation");
+      InjectExpectationResult managerResult =
+          InjectExpectationResult.builder()
+              .sourceId(ExpectationsExpirationManagerConfig.COLLECTOR_ID)
+              .sourceType("collector")
+              .sourceName("Expectations Expiration Manager")
+              .result("Not vulnerable")
+              .score(100.0)
+              .build();
+      agentExpectation.setResults(new ArrayList<>(List.of(managerResult)));
+      when(injectExpectationRepository.findAllByInjectAndAsset("inject-id", "asset-id"))
+          .thenReturn(List.of(assetExpectation));
+      when(injectExpectationRepository.findAllAgentExpectationsByInjectAndAsset(
+              "inject-id", "asset-id"))
+          .thenReturn(List.of(agentExpectation));
+
+      List<? extends BaseInjectExpectation> merged =
+          injectExpectationService.findMergedExpectationsByInjectAndTargetAndTargetType(
+              "inject-id", "asset-id", "parent-id", "ASSETS");
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(managerResult), merged.get(0).getResults());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #7040 (follow-up to #7022 / #7023)

The database is clean after #7023, but the asset target-results view still displayed an "Expectations Expiration Manager - Not vulnerable" entry next to the genuine Nuclei verdict on endpoints running an agent. The endpoint's display union (`enrichAssetExpectationsWithAgentSecurityPlatforms`) pulls the agent children's collector results onto the asset expectation, and the agent rows legitimately carry the expiration-manager result (the agents expired to the vulnerability default - an agentless scanner never fills them). Agentless endpoints were unaffected, hence the "sometimes there, sometimes not" pattern.

## Changes

- `InjectExpectationService.enrichAssetExpectationsWithAgentSecurityPlatforms`: for VULNERABILITY expectations, drop expiration-manager rows from the merged display when a genuine (non-manager, non-Expired) answered result is present - same rule as the write path in `InjectExpectationUtils.computeScores`. When nothing answered, the manager row IS the verdict and stays visible.
- Two regression tests in `InjectExpectationServiceTest` (manager row dropped when a platform answered, kept when nothing answered).

Display-only change: the persisted expectation rows are never modified (the enrichment already works on detached clones).

## Test plan

- [x] `mvn -pl openaev-api test -Dtest=InjectExpectationServiceTest` - 46/46 green, including the 2 new regression tests
