### PR TITLE
fix(ai): fix response dialog (#5720)

### DIFF
--- a/openaev-front/package.json
+++ b/openaev-front/package.json
@@ -17,7 +17,7 @@
     "deprecated-start": "node builder/dev/dev.js",
     "build": "vite build",
     "deprecated-build": "node builder/prod/prod.js",
-    "lint": "cross-env DEBUG=eslint:eslint TIMING=1 eslint --max-warnings 0 --cache --rule \"{'import/namespace': 'error', 'import/no-cycle': ['error', {'ignoreExternal': true, 'disableScc': true}]}\" .",
+    "lint": "cross-env DEBUG=eslint:eslint TIMING=1 eslint --fix --max-warnings 0 --cache --rule \"{'import/namespace': 'error', 'import/no-cycle': ['error', {'ignoreExternal': true, 'disableScc': true}]}\" .",
     "control": "yarn audit --groups dependencies --summary",
     "check-ts": "tsc",
     "check-licenses": "license-checker-rseidelsohn --production --summary --onlyAllow '0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT;OFL-1.1;Python-2.0;Unlicense;UNLICENSED'",

--- a/openaev-front/src/utils/ai/ResponseDialog.tsx
+++ b/openaev-front/src/utils/ai/ResponseDialog.tsx
@@ -226,19 +226,6 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
           multiline={true}
           onChange={event => setContent(event.target.value)}
           fullWidth={true}
-          InputProps={isLegacyMode ? {
-            endAdornment: (
-              <TextFieldAskAI
-                currentValue={content}
-                setFieldValue={(val: string) => {
-                  setContent(val);
-                }}
-                format="text"
-                variant="text"
-                disabled={isDisabled}
-              />
-            ),
-          } : undefined}
         />
       )}
       {format === 'html' && (
@@ -359,6 +346,7 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
                   value={tone}
                   onChange={event => setTone(event.target.value)}
                   size="small"
+                  disabled={effectiveDisabled}
                 >
                   <MenuItem value="formal">{t('Formal')}</MenuItem>
                   <MenuItem value="informal">{t('Informal')}</MenuItem>

--- a/openaev-front/src/utils/ai/ResponseDialog.tsx
+++ b/openaev-front/src/utils/ai/ResponseDialog.tsx
@@ -11,7 +11,6 @@ import MDEditor, { commands } from '@uiw/react-md-editor/nohighlight';
 import { type FunctionComponent, useEffect, useRef, useState } from 'react';
 
 // eslint-disable-next-line import/no-cycle
-import TextFieldAskAI, { type AgentAction } from '../../admin/components/common/form/TextFieldAskAI';
 import { useFormatter } from '../../components/i18n';
 import { isNotEmptyField } from '../utils';
 import { type AgentOption, fetchAgentsForIntent } from './agentApi';
@@ -302,152 +301,134 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
           extraCommands={[]}
         />
       )}
-      {isLegacyMode && (format === 'markdown' || format === 'html') && (
-        <TextFieldAskAI
-          currentValue={content ?? ''}
-          setFieldValue={(val) => {
-            setContent(val);
-          }}
-          format={format}
-          variant={format}
-          disabled={isDisabled}
-          style={format === 'html' ? {
-            position: 'absolute',
-            top: 40,
-            right: 18,
-          } : undefined}
-        />
-      )}
     </>
   );
 
   return (
-    <>
-      <Dialog
-        PaperProps={{ elevation: 1 }}
-        open={isOpen}
-        onClose={() => {
-          setContent('');
-          handleClose();
+    <Dialog
+      PaperProps={{ elevation: 1 }}
+      open={isOpen}
+      onClose={() => {
+        setContent('');
+        handleClose();
+      }}
+      fullWidth={true}
+      maxWidth="lg"
+    >
+      <DialogTitle>{dialogTitle}</DialogTitle>
+      <DialogContent>
+        {/* Agent mode: tone selector */}
+        {agentMode?.action === 'tone' && (
+          <Box sx={{ mb: 2 }}>
+            <FormControl size="small" fullWidth>
+              <InputLabel id="tone-label">{t('Tone')}</InputLabel>
+              <Select
+                labelId="tone-label"
+                label={t('Tone')}
+                value={tone}
+                onChange={event => setTone(event.target.value)}
+                size="small"
+                disabled={effectiveDisabled}
+              >
+                <MenuItem value="formal">{t('Formal')}</MenuItem>
+                <MenuItem value="informal">{t('Informal')}</MenuItem>
+                <MenuItem value="authoritative">{t('Authoritative')}</MenuItem>
+                <MenuItem value="assertive">{t('Assertive')}</MenuItem>
+                <MenuItem value="critical">{t('Critical')}</MenuItem>
+              </Select>
+            </FormControl>
+          </Box>
+        )}
+
+        <div style={{
+          width: '100%',
+          minHeight: height,
+          height,
+          position: 'relative',
         }}
-        fullWidth={true}
-        maxWidth="lg"
-      >
-        <DialogTitle>{dialogTitle}</DialogTitle>
-        <DialogContent>
-          {/* Agent mode: tone selector */}
-          {agentMode?.action === 'tone' && (
-            <Box sx={{ mb: 2 }}>
-              <FormControl size="small" fullWidth>
-                <InputLabel id="tone-label">{t('Tone')}</InputLabel>
-                <Select
-                  labelId="tone-label"
-                  label={t('Tone')}
-                  value={tone}
-                  onChange={event => setTone(event.target.value)}
-                  size="small"
-                  disabled={effectiveDisabled}
+        >
+          {agentMode && (
+            <>
+              {/* Refresh button */}
+              <IconButton
+                size="small"
+                onClick={handleRefresh}
+                disabled={agentLoading || !selectedAgent}
+                sx={{
+                  position: 'absolute',
+                  top: 2,
+                  right: 2,
+                  zIndex: 1,
+                }}
+              >
+                <RefreshOutlined fontSize="small" />
+              </IconButton>
+
+              {((agentLoading && !content) || loadingAgents) && (
+                <Box sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '100%',
+                }}
                 >
-                  <MenuItem value="formal">{t('Formal')}</MenuItem>
-                  <MenuItem value="informal">{t('Informal')}</MenuItem>
-                  <MenuItem value="authoritative">{t('Authoritative')}</MenuItem>
-                  <MenuItem value="assertive">{t('Assertive')}</MenuItem>
-                  <MenuItem value="critical">{t('Critical')}</MenuItem>
-                </Select>
-              </FormControl>
-            </Box>
-          )}
+                  <CircularProgress size={40} />
+                </Box>
+              )}
 
-          <div style={{
-            width: '100%',
-            minHeight: height,
-            height,
-            position: 'relative',
-          }}
-          >
-            {agentMode && (
-              <>
-                {/* Refresh button */}
-                <IconButton
-                  size="small"
-                  onClick={handleRefresh}
-                  disabled={agentLoading || !selectedAgent}
-                  sx={{
-                    position: 'absolute',
-                    top: 2,
-                    right: 2,
-                    zIndex: 1,
-                  }}
+              {noAgents && !agentLoading && (
+                <Box sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '100%',
+                }}
                 >
-                  <RefreshOutlined fontSize="small" />
-                </IconButton>
+                  <Alert severity="info" variant="outlined">
+                    {t('No agent available for this action. Ask your administrator to configure XTM One.')}
+                  </Alert>
+                </Box>
+              )}
 
-                {((agentLoading && !content) || loadingAgents) && (
-                  <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                  }}
-                  >
-                    <CircularProgress size={40} />
-                  </Box>
-                )}
+              {agentError && !agentLoading && (
+                <Box sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '100%',
+                }}
+                >
+                  <Alert severity="error" variant="outlined">
+                    {agentError}
+                  </Alert>
+                </Box>
+              )}
 
-                {noAgents && !agentLoading && (
-                  <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                  }}
-                  >
-                    <Alert severity="info" variant="outlined">
-                      {t('No agent available for this action. Ask your administrator to configure XTM One.')}
-                    </Alert>
-                  </Box>
-                )}
-
-                {agentError && !agentLoading && (
-                  <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                  }}
-                  >
-                    <Alert severity="error" variant="outlined">
-                      {agentError}
-                    </Alert>
-                  </Box>
-                )}
-
-                {(!agentLoading || content) && !loadingAgents && !noAgents && !agentError && renderContentEditors()}
-              </>
-            )}
-
-            {/* Legacy mode: always show content editors */}
-            {isLegacyMode && renderContentEditors()}
-          </div>
-          <div className="clearfix" />
-          {isLegacyMode && (
-            <Alert severity="warning" variant="outlined" style={format === 'html' ? { marginTop: 30 } : {}}>
-              {t('Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.')}
-            </Alert>
+              {(!agentLoading || content) && !loadingAgents && !noAgents && !agentError && renderContentEditors()}
+            </>
           )}
-        </DialogContent>
-        <DialogActions>
-          <Button variant="outlined" color="primary" onClick={handleClose}>
-            {t('Close')}
-          </Button>
-          {isAcceptable && (
-            <LoadingButton loading={effectiveDisabled} variant="contained" color="primary" disabled={!!agentError} onClick={() => handleAccept(content)}>
-              {t('Accept')}
-            </LoadingButton>
-          )}
-        </DialogActions>
-      </Dialog>
-    </>
+
+          {/* Legacy mode: always show content editors */}
+          {isLegacyMode && renderContentEditors()}
+        </div>
+        <div className="clearfix" />
+        {isLegacyMode && (
+          <Alert severity="warning" variant="outlined" style={format === 'html' ? { marginTop: 30 } : {}}>
+            {t('Generative AI is a beta feature as we are currently fine-tuning our models. Consider checking important information.')}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" color="primary" onClick={handleClose}>
+          {t('Close')}
+        </Button>
+        {isAcceptable && (
+          <LoadingButton loading={effectiveDisabled} variant="contained" color="primary" disabled={!!agentError} onClick={() => handleAccept(content)}>
+            {t('Accept')}
+          </LoadingButton>
+        )}
+      </DialogActions>
+    </Dialog>
   );
 };
 

--- a/openaev-front/src/utils/ai/ResponseDialog.tsx
+++ b/openaev-front/src/utils/ai/ResponseDialog.tsx
@@ -16,6 +16,7 @@ import { isNotEmptyField } from '../utils';
 import { type AgentOption, fetchAgentsForIntent } from './agentApi';
 import AgentSelector from './AgentSelector';
 import useAgentStream from './useAgentStream';
+import { AgentAction } from "../../admin/components/common/form/TextFieldAskAI";
 
 export interface AgentMode {
   intent: string;


### PR DESCRIPTION
### Proposed changes

* Fix AI response modal to avoid issues
* For XTM One mode, the select is now disabled when a text generation is ongoing, to avoid changes before the end of the process
* For Legacy mode, the "Ask AI" button is removed from the response modal to avoid the avalaibility of opening an infinite amount of response modal, forcing the user to validate each one of them when new options are openned from it.

### Testing Instructions

1. With AI is activated and XTM One mode is activated too, click on the Ask AI button on a text field.
2. Try to change the tone for example
3. Once the text generation is ongoing, you shouldn't be able to modify the tone again, you have to wait for the end of the generation
4. Change your settings to enable de Legacy mode
5. When you click on the "Ask AI" button and change the tone, on the response table you should not have another "Ask AI" button

### Related issues

* Closes #5720 