### PR TITLE
fix(api): restore endpoint type on assets demoted by the taxonomy remodel (#7048)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260717120000000__Remodel_asset_taxonomy.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260717120000000__Remodel_asset_taxonomy.java
@@ -6,9 +6,9 @@ import org.flywaydb.core.api.migration.Context;
 import org.springframework.stereotype.Component;
 
 /**
- * Remodels the asset taxonomy so a single concrete {@code Asset} is the target concept driven by
- * {@code asset_category}, with {@code Endpoint} the only agent-capable subtype and {@code
- * SecurityPlatform} a separate detection-source concept.
+ * Remodels the asset taxonomy so a single concrete {@code Asset} is the base concept driven by
+ * {@code asset_category}, with {@code Endpoint} the executable-target subtype (agent-based or
+ * agentless) and {@code SecurityPlatform} a separate detection-source concept.
  *
  * <p>All steps are idempotent and either metadata-only or targeted updates (no table rewrite):
  *
@@ -16,14 +16,13 @@ import org.springframework.stereotype.Component;
  *   <li>Rename the target-relevant network columns {@code endpoint_* -> asset_*} - they now live on
  *       the {@code Asset} base since they are relevant to more than agent hosts (web / cloud /
  *       network categories).
- *   <li>Re-discriminate rows: former {@code AiTarget} rows and non-host {@code Endpoint} rows
- *       without agents become the base {@code Asset} type ({@code asset_type = 'Asset'}); {@code
- *       SecurityPlatform} rows are left untouched. The category column continues to carry the
- *       product taxonomy.
+ *   <li>Re-discriminate rows: former {@code AiTarget} rows become the base {@code Asset} type
+ *       ({@code asset_type = 'Asset'}); {@code Endpoint} and {@code SecurityPlatform} rows are left
+ *       untouched. The category column continues to carry the product taxonomy.
  *   <li>Backfill {@code asset_category = 'HOST'} on legacy endpoints with a NULL category.
  *   <li>Rewrite stored dynamic asset-group filter keys to the renamed properties.
- *   <li>Reset the indexing status of the endpoint-derived ES indexes so stale documents of demoted
- *       rows are rebuilt away.
+ *   <li>Reset the indexing status of the endpoint-derived ES indexes so stale documents of
+ *       re-discriminated rows are rebuilt away.
  * </ol>
  */
 @Component
@@ -41,18 +40,14 @@ public class V6_20260717120000000__Remodel_asset_taxonomy extends BaseJavaMigrat
 
       // -- 2. Re-discriminate to the concrete Asset base --
       // Former AI targets: AI is now a category, not an entity type.
+      // NOTE: an earlier revision of this migration also demoted agentless non-host Endpoint rows
+      // (CLOUD_RESOURCE / WEB_APPLICATION / ... / GENERIC_ASSET) to the base Asset type. That
+      // demotion was reverted: the edit flow (GET/PUT /api/endpoints/{id}) and the inject target
+      // picker (POST /api/endpoints/search) are Endpoint-typed, so demoted rows 404ed on edit and
+      // vanished from target selection, while creation still persists every non-AI category as an
+      // agentless Endpoint. Platforms that already ran the demoting revision are repaired by
+      // V6_20260729120000000__Restore_demoted_endpoint_assets.
       statement.execute("UPDATE assets SET asset_type = 'Asset' WHERE asset_type = 'AiTarget';");
-      // Non-host endpoints become generic assets; agent-capable host categories stay Endpoint.
-      // Rows that carry agents are never demoted regardless of category: agents only exist on
-      // Endpoint, so demoting an agent-bearing row (e.g. a host a user categorized as
-      // CLOUD_RESOURCE, or a legacy platform bucketed into GENERIC_ASSET) would orphan its agents
-      // and silently break execution on that host.
-      statement.execute(
-          "UPDATE assets SET asset_type = 'Asset' "
-              + "WHERE asset_type = 'Endpoint' AND asset_category IN ("
-              + "'CLOUD_RESOURCE','WEB_APPLICATION','NETWORK_DEVICE','IOT_OT_DEVICE',"
-              + "'IDENTITY','SAAS_APPLICATION','GENERIC_ASSET') "
-              + "AND NOT EXISTS (SELECT 1 FROM agents ag WHERE ag.agent_asset = assets.asset_id);");
 
       // -- 3. Backfill the category on legacy endpoints that predate the asset_category column --
       // These rows carry a NULL category, so the inventory shows an empty "Category" cell. Endpoint
@@ -89,7 +84,7 @@ public class V6_20260717120000000__Remodel_asset_taxonomy extends BaseJavaMigrat
       }
 
       // -- 5. Rebuild the endpoint-derived ES indexes --
-      // Demoted rows (former AI targets / non-host endpoints) leave stale documents behind in
+      // Re-discriminated rows (former AI targets) leave stale documents behind in
       // the endpoint index (re-discrimination is an UPDATE, not a DELETE, so the incremental
       // indexer never removes them). Dropping the indexing status makes the engine recreate and
       // fully reindex these indexes at startup. Idempotent by nature.

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729120000000__Restore_demoted_endpoint_assets.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729120000000__Restore_demoted_endpoint_assets.java
@@ -1,0 +1,55 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Repairs assets demoted by an earlier revision of {@code
+ * V6_20260717120000000__Remodel_asset_taxonomy}: agentless endpoints whose category was
+ * CLOUD_RESOURCE / WEB_APPLICATION / NETWORK_DEVICE / IOT_OT_DEVICE / IDENTITY / SAAS_APPLICATION /
+ * GENERIC_ASSET were re-discriminated from {@code Endpoint} to the base {@code Asset} type. The
+ * rest of the product was not ready for base-typed targets: the edit flow ({@code GET/PUT
+ * /api/endpoints/{id}}) resolves through the {@code Endpoint} entity and returns 404 for them, the
+ * atomic-testing target picker ({@code POST /api/endpoints/search}) is {@code Endpoint}-typed so
+ * they disappear from target selection, and the creation flow still persists every non-AI category
+ * as an agentless {@code Endpoint}. The demotion has been removed from the original migration for
+ * platforms upgrading from stable; this migration restores the rows on platforms that already ran
+ * the demoting revision.
+ *
+ * <p>Idempotent and targeted (no table rewrite):
+ *
+ * <ol>
+ *   <li>Re-promote base {@code Asset} rows of the seven demoted categories back to {@code
+ *       Endpoint}. AI targets are untouched: they are the only rows legitimately persisted with the
+ *       base type (via {@code /api/ai_targets}) and always carry {@code asset_category =
+ *       'AI_TARGET'}, which is not part of the list. Once re-promoted, the second run matches
+ *       nothing.
+ *   <li>Reset the indexing status of the asset-derived ES indexes so documents indexed with the
+ *       demoted type are rebuilt.
+ * </ol>
+ */
+@Component
+public class V6_20260729120000000__Restore_demoted_endpoint_assets extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // -- 1. Re-promote demoted rows back to Endpoint --
+      statement.execute(
+          "UPDATE assets SET asset_type = 'Endpoint' "
+              + "WHERE asset_type = 'Asset' AND asset_category IN ("
+              + "'CLOUD_RESOURCE','WEB_APPLICATION','NETWORK_DEVICE','IOT_OT_DEVICE',"
+              + "'IDENTITY','SAAS_APPLICATION','GENERIC_ASSET');");
+
+      // -- 2. Rebuild the asset-derived ES indexes --
+      // The re-promotion is an UPDATE, so the incremental indexer would leave documents carrying
+      // the demoted type behind. Dropping the indexing status makes the engine recreate and fully
+      // reindex these indexes at startup. Idempotent by nature.
+      statement.execute(
+          "DELETE FROM indexing_status "
+              + "WHERE indexing_status_type IN ('asset', 'vulnerable-endpoint');");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/organization/OrganizationApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/organization/OrganizationApi.java
@@ -154,8 +154,8 @@ public class OrganizationApi extends RestBehavior {
           "Deletes the organizations matching either an explicit id list"
               + " (organization_ids_to_process) or a search scope (search_pagination_input) with"
               + " optional exclusions (organization_ids_to_ignore) - exactly one of the two"
-              + " selection modes must be provided. Organizations from other tenants or outside"
-              + " the caller's grants are silently skipped.")
+              + " selection modes must be provided. Organizations from other tenants are silently"
+              + " skipped.")
   @DeleteMapping({ORGANIZATION_URI, TENANT_ORGANIZATION_URI})
   // SUPPORTS (not REQUIRED): the deletion runs in small independent chunk transactions with
   // deadlock retry; a request-wide transaction would force everything back into one transaction.

--- a/openaev-api/src/main/java/io/openaev/service/organization/OrganizationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/organization/OrganizationService.java
@@ -1,19 +1,15 @@
 package io.openaev.service.organization;
 
-import static io.openaev.database.specification.OrganizationSpecification.findGrantedFor;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 import static io.openaev.utils.pagination.SearchUtilsJpa.computeSearchJpa;
 
 import io.openaev.context.TenantContext;
-import io.openaev.database.model.Capability;
 import io.openaev.database.model.Organization;
 import io.openaev.database.model.Tenant;
-import io.openaev.database.model.User;
 import io.openaev.database.repository.OrganizationRepository;
 import io.openaev.database.specification.SpecificationUtils;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.organization.form.OrganizationBulkProcessingInput;
-import io.openaev.service.UserService;
 import io.openaev.service.utils.BulkDeleteExecutor;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.pagination.SearchPaginationInput;
@@ -21,7 +17,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -31,8 +26,6 @@ import org.springframework.util.CollectionUtils;
 public class OrganizationService {
 
   private final OrganizationRepository organizationRepository;
-
-  private final UserService userService;
 
   private final BulkDeleteExecutor bulkDeleteExecutor;
 
@@ -92,12 +85,6 @@ public class OrganizationService {
               } else {
                 specification = SpecificationUtils.hasIdIn(input.getOrganizationIdsToProcess());
               }
-              User currentUser = userService.currentUser();
-              if (!currentUser.isAdminOrBypass()
-                  && !currentUser.getCapabilities().contains(Capability.ACCESS_PLATFORM_SETTINGS)) {
-                // Same grant scoping as the list search: the user can only delete what they see.
-                specification = findGrantedFor(currentUser.getId()).and(specification);
-              }
               if (!CollectionUtils.isEmpty(input.getOrganizationIdsToIgnore())) {
                 List<String> idsToIgnore = input.getOrganizationIdsToIgnore();
                 specification =
@@ -115,18 +102,12 @@ public class OrganizationService {
 
   public Page<Organization> organizationPagination(
       @NotNull SearchPaginationInput searchPaginationInput) {
-    User currentUser = userService.currentUser();
-    if (currentUser.isAdminOrBypass()
-        || currentUser.getCapabilities().contains(Capability.ACCESS_PLATFORM_SETTINGS)) {
-      return buildPaginationJPA(
-          this.organizationRepository::findAll, searchPaginationInput, Organization.class);
-    } else {
-      return buildPaginationJPA(
-          (Specification<Organization> specification, Pageable pageable) ->
-              this.organizationRepository.findAll(
-                  findGrantedFor(currentUser.getId()).and(specification), pageable),
-          searchPaginationInput,
-          Organization.class);
-    }
+    // Visibility is capability-gated at the API layer (@AccessControl SEARCH) and tenant-scoped by
+    // the Hibernate tenant filter, like every other organization endpoint (raw list, options,
+    // single read). The former per-group grant scoping joined Organization.groups, a mapping
+    // removed along with the groups_organizations table (V4_38): keeping it made every non-admin
+    // search fail with "Could not resolve attribute 'groups'".
+    return buildPaginationJPA(
+        this.organizationRepository::findAll, searchPaginationInput, Organization.class);
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/specification/OrganizationSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/OrganizationSpecification.java
@@ -2,9 +2,6 @@ package io.openaev.database.specification;
 
 import io.openaev.database.model.Organization;
 import jakarta.annotation.Nullable;
-import jakarta.persistence.criteria.JoinType;
-import jakarta.persistence.criteria.Path;
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.domain.Specification;
 
 public class OrganizationSpecification {
@@ -13,13 +10,5 @@ public class OrganizationSpecification {
 
   public static Specification<Organization> byName(@Nullable final String searchText) {
     return UtilsSpecification.byName(searchText, "name");
-  }
-
-  public static Specification<Organization> findGrantedFor(@NotBlank final String userId) {
-    return (root, query, cb) -> {
-      query.distinct(true);
-      Path<?> path = root.join("groups", JoinType.INNER).join("users", JoinType.INNER).get("id");
-      return cb.equal(path, userId);
-    };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the post-upgrade asset regression reported in #7048: agentless non-host assets (e.g. a "Filigran Website" web application, a "honey.scanme.sh" generic asset) were demoted from the `Endpoint` JPA type to the base `Asset` type by `V6_20260717120000000__Remodel_asset_taxonomy`, which made them:

- return **404** on edit (the edit flow is `GET/PUT /api/endpoints/{id}`, resolved through the `Endpoint` entity), and
- **disappear from inject target selection** (the atomic-testing picker calls the `Endpoint`-typed `POST /api/endpoints/search`).

The creation flow still persists every non-AI category as an agentless `Endpoint`, so the demotion left migrated data inconsistent with what the product creates and can serve.

### Changes

- **New idempotent repair migration** `V6_20260729120000000__Restore_demoted_endpoint_assets`: re-promotes base `Asset` rows of the seven demoted categories (CLOUD_RESOURCE, WEB_APPLICATION, NETWORK_DEVICE, IOT_OT_DEVICE, IDENTITY, SAAS_APPLICATION, GENERIC_ASSET) back to `Endpoint`, then resets the `asset` / `vulnerable-endpoint` indexing status so ES documents indexed with the demoted type are fully rebuilt. It applies to platforms **already migrated** to main rolling. AI targets are untouched: they are the only rows legitimately persisted with the base type (via `/api/ai_targets`) and always carry category AI_TARGET, which is not in the list. Re-running matches nothing (idempotent).
- **Removed the demotion from `V6_20260717120000000__Remodel_asset_taxonomy`** so platforms upgrading from stable never demote in the first place. The `AiTarget -> Asset` re-discrimination, the column renames, the category backfill, the dynamic-filter key rewrite and the reindex reset are all kept. Java migrations carry no Flyway checksum, so editing the class is safe for platforms that already ran it (they are covered by the new repair migration, which orders after it).
- **Fixed the organizations listing error** `Could not resolve attribute 'groups' of 'io.openaev.database.model.Organization'`: `OrganizationSpecification.findGrantedFor` still joined `Organization.groups`, a mapping removed together with the `groups_organizations` table (`V4_38`). Every non-admin search (`POST /api/organizations/search`) and non-admin bulk delete scope resolution crashed on it. The dead grant scoping is removed; visibility stays gated by `@AccessControl` and the Hibernate tenant filter, consistent with the sibling organization endpoints (raw list, options, single read/delete) which never had grant scoping.

### Why re-promote instead of supporting base-typed targets

The taxonomy remodel intent (base `Asset` as the target concept) is not wired through the product yet: edit, target picking and creation are all `Endpoint`-typed. Re-promotion restores the exact pre-upgrade behavior with a targeted `UPDATE` and no API/frontend changes, which is the safest possible fix in the middle of the release process. Moving targets to the base type can be redone later together with the API/frontend work.

## Test plan

- [x] `mvn compile` on openaev-model / openaev-api passes; `mvn spotless:apply` clean
- [ ] On an instance already migrated to main rolling: after deploy, "Filigran Website" and "honey.scanme.sh" show up again as endpoint-typed assets, are editable, and appear in the atomic testing target list
- [ ] Migration re-run is a no-op (idempotent)
- [ ] Fresh upgrade from latest stable to this branch never demotes the assets
- [ ] `/admin/organizations` loads for a non-admin user without ACCESS_PLATFORM_SETTINGS

Closes #7048
