### PR TITLE
fix(api): throttle engine sync concurrency and tune engine client limits (#7050)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
@@ -5,6 +5,7 @@ import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import static org.quartz.TriggerBuilder.newTrigger;
 
 import io.openaev.aop.LogExecutionTime;
+import io.openaev.config.EngineConfig;
 import io.openaev.engine.EngineContext;
 import io.openaev.engine.EngineService;
 import io.openaev.engine.EsModel;
@@ -12,6 +13,7 @@ import io.openaev.engine.model.EsBase;
 import io.openaev.scheduler.SelfConfiguredPlatformJob;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
@@ -24,10 +26,25 @@ import org.springframework.stereotype.Component;
 public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
   private static final String MODEL_NAME_KEY = "modelName";
 
+  /**
+   * Caps how many model syncs may run at the same time. Every sync pass holds a database connection
+   * for the whole duration of its fetch query; during a full reindex (indexing cursors reset to
+   * epoch by a migration) these queries re-rank entire tables and can run for a long time. Without
+   * a cap, up to {@code org.quartz.threadPool.threadCount} syncs run concurrently and, together
+   * with the regular jobs and HTTP traffic, exhaust the HikariCP pool - starving the whole platform
+   * until the rebuild completes. A pass that does not get a permit is simply skipped: the 15-second
+   * trigger retries it shortly after, so no work is lost.
+   */
+  private final Semaphore concurrentSyncs;
+
   protected EngineSyncExecutionJob(
-      Scheduler scheduler, EngineService engineService, EngineContext engineContext)
+      Scheduler scheduler,
+      EngineService engineService,
+      EngineContext engineContext,
+      EngineConfig engineConfig)
       throws SchedulerException {
     super(scheduler, engineService, engineContext);
+    this.concurrentSyncs = new Semaphore(engineConfig.getIndexingMaxConcurrentModels());
   }
 
   @DisallowConcurrentExecution
@@ -48,8 +65,19 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
                 .formatted(requestedModelName));
       }
 
-      log.info("Executing engine sync for model {}", model.get().getName());
-      engineService.bulkProcessing(Stream.of(model.get()));
+      if (!concurrentSyncs.tryAcquire()) {
+        log.debug(
+            "Skipping engine sync for model {}: concurrency cap reached"
+                + " (engine.indexing-max-concurrent-models), will retry at the next trigger",
+            model.get().getName());
+        return;
+      }
+      try {
+        log.info("Executing engine sync for model {}", model.get().getName());
+        engineService.bulkProcessing(Stream.of(model.get()));
+      } finally {
+        concurrentSyncs.release();
+      }
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
@@ -44,7 +44,17 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
       EngineConfig engineConfig)
       throws SchedulerException {
     super(scheduler, engineService, engineContext);
-    this.concurrentSyncs = new Semaphore(engineConfig.getIndexingMaxConcurrentModels());
+    // Clamp to at least 1: zero (or negative) permits would silently disable engine sync
+    // altogether, which is never what a tuning knob should do.
+    int maxConcurrentModels = engineConfig.getIndexingMaxConcurrentModels();
+    if (maxConcurrentModels < 1) {
+      log.warn(
+          "engine.indexing-max-concurrent-models is set to {}, which would disable engine sync"
+              + " entirely; clamping to 1",
+          maxConcurrentModels);
+      maxConcurrentModels = 1;
+    }
+    this.concurrentSyncs = new Semaphore(maxConcurrentModels);
   }
 
   @DisallowConcurrentExecution

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -71,6 +71,14 @@ engine.engine-selector=elk
 engine.index-prefix=openaev
 engine.index-suffix=-000001
 engine.url=http://localhost:9200
+# How many models may run their indexing sync concurrently (default 3). Each sync pass holds a
+# database connection for its whole fetch query; during a full reindex those queries are heavy,
+# so a higher value trades platform responsiveness for reindexing throughput.
+#engine.indexing-max-concurrent-models=3
+# Engine client timeouts and connection cap (defaults: 5s connect, 60s socket, 40 connections).
+#engine.connect-timeout-ms=5000
+#engine.socket-timeout-ms=60000
+#engine.max-connections=40
 
 ### MINIO Configuration
 ### see also: https://docs.openaev.io/latest/deployment/configuration/#s3-bucket

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
@@ -1,0 +1,119 @@
+package io.openaev.scheduler.jobs.engine_sync;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.openaev.config.EngineConfig;
+import io.openaev.engine.EngineContext;
+import io.openaev.engine.EngineService;
+import io.openaev.engine.EsModel;
+import io.openaev.engine.model.EsBase;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.Scheduler;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EngineSyncExecutionJob Unit Tests")
+class EngineSyncExecutionJobTest {
+
+  private static final String MODEL_NAME = "test-model";
+
+  @Mock private Scheduler scheduler;
+  @Mock private EngineService engineService;
+  @Mock private EngineContext engineContext;
+  @Mock private EsModel<EsBase> esModel;
+  @Mock private JobExecutionContext jobExecutionContext;
+
+  private EngineConfig engineConfig;
+
+  @BeforeEach
+  void setUp() {
+    engineConfig = new EngineConfig();
+    lenient().when(esModel.getName()).thenReturn(MODEL_NAME);
+    lenient().when(engineContext.getModels()).thenReturn(List.of(esModel));
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.put("modelName", MODEL_NAME);
+    lenient().when(jobExecutionContext.getMergedJobDataMap()).thenReturn(jobDataMap);
+  }
+
+  private EngineSyncExecutionJob buildJob() throws Exception {
+    return new EngineSyncExecutionJob(scheduler, engineService, engineContext, engineConfig);
+  }
+
+  @Test
+  @DisplayName("Skips the sync pass when the concurrency cap is reached, without losing the work")
+  void given_capReached_should_skipPassAndRetryLater() throws Exception {
+    engineConfig.setIndexingMaxConcurrentModels(1);
+    EngineSyncExecutionJob job = buildJob();
+    EngineSyncExecutionJob.Job pass = job.new Job();
+    EngineSyncExecutionJob.Job concurrentPass = job.new Job();
+
+    // While the only permit is held by the running pass, a concurrent pass must skip silently.
+    doAnswer(
+            invocation -> {
+              concurrentPass.execute(jobExecutionContext);
+              return null;
+            })
+        .when(engineService)
+        .bulkProcessing(any());
+
+    pass.execute(jobExecutionContext);
+    verify(engineService, times(1)).bulkProcessing(any());
+
+    // The permit was released after the pass: the next trigger processes the model again.
+    doNothing().when(engineService).bulkProcessing(any());
+    concurrentPass.execute(jobExecutionContext);
+    verify(engineService, times(2)).bulkProcessing(any());
+  }
+
+  @Test
+  @DisplayName("Releases the permit when the sync pass fails")
+  void given_failingSync_should_releasePermit() throws Exception {
+    engineConfig.setIndexingMaxConcurrentModels(1);
+    EngineSyncExecutionJob job = buildJob();
+    EngineSyncExecutionJob.Job pass = job.new Job();
+
+    doThrow(new RuntimeException("boom")).when(engineService).bulkProcessing(any());
+    assertThrows(RuntimeException.class, () -> pass.execute(jobExecutionContext));
+
+    // The failed pass must not leak its permit: the next trigger still gets one.
+    doNothing().when(engineService).bulkProcessing(any());
+    pass.execute(jobExecutionContext);
+    verify(engineService, times(2)).bulkProcessing(any());
+  }
+
+  @Test
+  @DisplayName("Clamps a non-positive concurrency cap to 1 instead of disabling sync")
+  void given_nonPositiveCap_should_clampToOne() throws Exception {
+    engineConfig.setIndexingMaxConcurrentModels(0);
+    EngineSyncExecutionJob job = buildJob();
+    EngineSyncExecutionJob.Job pass = job.new Job();
+
+    pass.execute(jobExecutionContext);
+    verify(engineService, times(1)).bulkProcessing(any());
+  }
+
+  @Test
+  @DisplayName("Fails the pass when the requested model is unknown")
+  void given_unknownModel_should_throwJobExecutionException() throws Exception {
+    engineConfig.setIndexingMaxConcurrentModels(1);
+    EngineSyncExecutionJob job = buildJob();
+    EngineSyncExecutionJob.Job pass = job.new Job();
+
+    JobDataMap jobDataMap = new JobDataMap();
+    jobDataMap.put("modelName", "unknown-model");
+    when(jobExecutionContext.getMergedJobDataMap()).thenReturn(jobDataMap);
+
+    assertThrows(JobExecutionException.class, () -> pass.execute(jobExecutionContext));
+    verify(engineService, never()).bulkProcessing(any());
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/config/EngineConfig.java
+++ b/openaev-model/src/main/java/io/openaev/config/EngineConfig.java
@@ -84,6 +84,27 @@ public class EngineConfig {
 
     /** Default maximum number of records fetched per indexing batch. */
     public static final int INDEXING_BATCH_SIZE = 500;
+
+    /**
+     * Default maximum number of models whose indexing sync may run concurrently. Each sync pass
+     * holds a database connection for the duration of its (potentially heavy) fetch query; during a
+     * full reindex these queries can run for a long time, so letting every model sync at once
+     * exhausts the connection pool and starves the rest of the platform.
+     */
+    public static final int INDEXING_MAX_CONCURRENT_MODELS = 3;
+
+    /** Default connect timeout for the search engine client, in milliseconds. */
+    public static final int CONNECT_TIMEOUT_MS = 5_000;
+
+    /** Default socket (response) timeout for the search engine client, in milliseconds. */
+    public static final int SOCKET_TIMEOUT_MS = 60_000;
+
+    /**
+     * Default maximum number of concurrent connections of the search engine client. Applied to both
+     * the per-route and the total limit (the platform talks to a single engine endpoint, so the
+     * per-route limit is the effective cap).
+     */
+    public static final int MAX_CONNECTIONS = 40;
   }
 
   private String engineSelector = Defaults.ENGINE_SELECTOR;
@@ -121,6 +142,14 @@ public class EngineConfig {
   private boolean rejectUnauthorized = Defaults.REJECT_UNAUTHORIZED;
 
   private int indexingBatchSize = Defaults.INDEXING_BATCH_SIZE;
+
+  private int indexingMaxConcurrentModels = Defaults.INDEXING_MAX_CONCURRENT_MODELS;
+
+  private int connectTimeoutMs = Defaults.CONNECT_TIMEOUT_MS;
+
+  private int socketTimeoutMs = Defaults.SOCKET_TIMEOUT_MS;
+
+  private int maxConnections = Defaults.MAX_CONNECTIONS;
 
   /**
    * Wildcard pattern matching all indices of this platform and only them.

--- a/openaev-model/src/main/java/io/openaev/driver/ElasticDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/ElasticDriver.java
@@ -74,7 +74,19 @@ public class ElasticDriver {
 
   private ElasticsearchClient getElasticClient() {
     RestClientBuilder restClientBuilder = RestClient.builder(HttpHost.create(config.getUrl()));
+    // The library defaults (1s connect / 30s socket timeout, 10 connections per route) are too
+    // tight for this platform: during bulk indexing (full reindex after a migration) the async
+    // client saturates and cancels pending requests, surfacing as "Request execution cancelled"
+    // in dashboard queries and engine jobs. Configure explicit limits instead.
+    restClientBuilder.setRequestConfigCallback(
+        requestConfig ->
+            requestConfig
+                .setConnectTimeout(config.getConnectTimeoutMs())
+                .setSocketTimeout(config.getSocketTimeoutMs()));
     HttpAsyncClientBuilder clientBuilder = HttpAsyncClientBuilder.create();
+    clientBuilder
+        .setMaxConnTotal(config.getMaxConnections())
+        .setMaxConnPerRoute(config.getMaxConnections());
     if (config.getUsername() != null) {
       BasicCredentialsProvider credsProv = new BasicCredentialsProvider();
       credsProv.setCredentials(


### PR DESCRIPTION
## Summary

Fixes #7050. Follow-up to #7048 / #7049.

During the post-migration full reindex the platform starves its own database pool (`HikariPool-1 - Connection is not available ... total=20, active=20, idle=0`) and the Elasticsearch client cancels requests ("Request execution cancelled"), leaving dashboards empty and Quartz jobs failing until the rebuild completes.

Root cause:

- `EngineSyncExecutionJob` registers one Quartz job per ES model (13 models), each firing every 15s on a 10-thread Quartz pool, so up to 10 model syncs run concurrently.
- Each sync pass holds a PostgreSQL connection for the whole duration of its fetch query. With indexing cursors reset to epoch by a migration, the ranked-CTE fetch queries re-rank entire tables and run for seconds to minutes - up to 10 of them in parallel, plus regular jobs and HTTP traffic, exhaust the 20-connection HikariCP pool.
- The low-level Elasticsearch RestClient ran on library defaults (1s connect / 30s socket timeout, 10 connections per route); under sustained bulk-indexing load the async client saturates and cancels pending requests, which surfaced simultaneously in `bulkProcessing`, `termHistogram` and `getEngineVersion`.

Changes:

- Cap concurrent engine sync executions with a semaphore in `EngineSyncExecutionJob` (new `engine.indexing-max-concurrent-models` property, default 3, clamped to at least 1 with a warning so a misconfigured value cannot silently disable sync). A pass that does not get a permit is skipped and retried at the next 15s trigger, so no work is lost; the DB pool keeps headroom for the rest of the platform during full rebuilds.
- Configure the Elasticsearch client with explicit timeouts and connection limits in `ElasticDriver` (new `engine.connect-timeout-ms` = 5s, `engine.socket-timeout-ms` = 60s, `engine.max-connections` = 40 properties).
- Document the new knobs in `application.properties`.
- Add `EngineSyncExecutionJobTest` covering the concurrency cap, permit release on success and on failure, the clamp, and the unknown-model error path.

Notes:

- The cap lives in the Quartz job, so it applies to both ELK and OpenSearch engines. The client tuning is scoped to `ElasticDriver` (default `elk` engine); the OpenSearch driver keeps its HttpClient5 defaults.
- Steady-state incremental syncs are unaffected in practice: passes are fast, and a skipped pass is retried 15s later.

## Test plan

- [x] `EngineSyncExecutionJobTest` (4 tests) green locally
- [x] `mvn spotless:apply` clean, `mvn install` on openaev-model + openaev-api passes
- [ ] Bump a stable instance to this build: during the full reindex, the platform stays responsive (no HikariCP exhaustion storm), dashboards keep rendering, and all 13 models eventually catch up
