### PR TITLE
fix(stix): dedupe security coverages on external id and enforce uniqueness (#7054)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729130000000__Dedupe_security_coverages_external_id.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729130000000__Dedupe_security_coverages_external_id.java
@@ -1,0 +1,79 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deduplicates {@code security_coverages} on {@code security_coverage_external_id} and enforces it
+ * with a unique constraint.
+ *
+ * <p>The table was created (V4_22) without a unique constraint on the external id, while {@code
+ * SecurityCoverageService#getByExternalIdOrCreateSecurityCoverage} is a non-atomic find-then-create
+ * upsert protected only by a JVM-local striped lock. Concurrent submissions of the same coverage
+ * (OpenCTI worker retries, multiple API replicas, or the instability window of a full reindex)
+ * could insert the same external id twice; once duplicated, every subsequent bundle for that
+ * coverage failed with {@code IncorrectResultSizeDataAccessException} and the OpenCTI worker
+ * retried forever (seen in production after the rolling upgrade).
+ *
+ * <p>Steps, all idempotent:
+ *
+ * <ol>
+ *   <li>Delete duplicate coverage rows, keeping per external id the row linked to a scenario,
+ *       breaking ties by latest update. Exercises pointing at a deleted row are detached by the
+ *       existing {@code ON DELETE SET NULL} foreign key; scenarios generated for deleted rows are
+ *       left in place (they are regular scenarios, deletable from the UI).
+ *   <li>Add the unique constraint so the race can never create duplicates again: the losing insert
+ *       now fails its own transaction and the OpenCTI retry finds the winner row.
+ * </ol>
+ */
+@Component
+public class V6_20260729130000000__Dedupe_security_coverages_external_id extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // Map every duplicate coverage to the best row sharing its external id: prefer the row
+      // already linked to a scenario, then the most recently updated one.
+      statement.execute(
+          """
+          CREATE TEMPORARY TABLE tmp_sc_duplicates ON COMMIT DROP AS
+          SELECT security_coverage_id AS duplicate_id,
+                 FIRST_VALUE(security_coverage_id) OVER (
+                   PARTITION BY security_coverage_external_id
+                   ORDER BY (security_coverage_scenario IS NOT NULL) DESC,
+                            security_coverage_updated_at DESC NULLS LAST,
+                            security_coverage_id ASC
+                 ) AS keeper_id
+          FROM security_coverages;
+          """);
+      statement.execute(
+          """
+          DELETE FROM tmp_sc_duplicates WHERE duplicate_id = keeper_id;
+          """);
+      statement.execute(
+          """
+          DELETE FROM security_coverages sc
+          USING tmp_sc_duplicates dup
+          WHERE sc.security_coverage_id = dup.duplicate_id;
+          """);
+      // Enforce the natural key used by the upsert lookup. Guarded for idempotency:
+      // ADD CONSTRAINT has no IF NOT EXISTS in PostgreSQL.
+      statement.execute(
+          """
+          DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'security_coverages_external_id_unique'
+            ) THEN
+              ALTER TABLE security_coverages
+                ADD CONSTRAINT security_coverages_external_id_unique
+                UNIQUE (security_coverage_external_id);
+            END IF;
+          END $$;
+          """);
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729130000000__Dedupe_security_coverages_external_id.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729130000000__Dedupe_security_coverages_external_id.java
@@ -35,7 +35,10 @@ public class V6_20260729130000000__Dedupe_security_coverages_external_id extends
   public void migrate(Context context) throws Exception {
     try (Statement statement = context.getConnection().createStatement()) {
       // Map every duplicate coverage to the best row sharing its external id: prefer the row
-      // already linked to a scenario, then the most recently updated one.
+      // already linked to a scenario, then the most recently updated one. The migration runs in
+      // a transaction (a failure rolls the temp table back too), but drop any leftover from a
+      // reused session so the statement is unconditionally re-runnable.
+      statement.execute("DROP TABLE IF EXISTS tmp_sc_duplicates;");
       statement.execute(
           """
           CREATE TEMPORARY TABLE tmp_sc_duplicates ON COMMIT DROP AS
@@ -67,6 +70,8 @@ public class V6_20260729130000000__Dedupe_security_coverages_external_id extends
             IF NOT EXISTS (
               SELECT 1 FROM pg_constraint
               WHERE conname = 'security_coverages_external_id_unique'
+                AND conrelid = 'security_coverages'::regclass
+                AND contype = 'u'
             ) THEN
               ALTER TABLE security_coverages
                 ADD CONSTRAINT security_coverages_external_id_unique

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -303,7 +303,29 @@ public class SecurityCoverageService {
    * @return an existing or new {@link SecurityCoverage}
    */
   public SecurityCoverage getByExternalIdOrCreateSecurityCoverage(String externalId) {
-    return securityCoverageRepository.findByExternalId(externalId).orElseGet(SecurityCoverage::new);
+    List<SecurityCoverage> coverages = securityCoverageRepository.findAllByExternalId(externalId);
+    if (coverages.isEmpty()) {
+      return new SecurityCoverage();
+    }
+    if (coverages.size() > 1) {
+      // Duplicates are prevented by the unique constraint on security_coverage_external_id
+      // (V6_20260729130000000__Dedupe_security_coverages_external_id), but a legacy-duplicated
+      // database must never fail the whole bundle with a NonUniqueResultException: pick the best
+      // row deterministically (linked to a scenario first, then most recently updated).
+      log.error(
+          "Found {} security coverages sharing external id {}; using the most relevant one."
+              + " Duplicates should have been removed by the dedupe migration.",
+          coverages.size(),
+          externalId);
+    }
+    return coverages.stream()
+        .min(
+            Comparator.<SecurityCoverage, java.lang.Boolean>comparing(
+                    coverage -> coverage.getScenario() == null)
+                .thenComparing(
+                    SecurityCoverage::getUpdatedAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                .thenComparing(SecurityCoverage::getId))
+        .orElseGet(SecurityCoverage::new);
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceDuplicateLookupTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceDuplicateLookupTest.java
@@ -1,0 +1,126 @@
+package io.openaev.service.stix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.Scenario;
+import io.openaev.database.model.SecurityCoverage;
+import io.openaev.database.repository.SecurityCoverageRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test for the duplicate-tolerant lookup in {@link
+ * SecurityCoverageService#getByExternalIdOrCreateSecurityCoverage(String)}.
+ *
+ * <p>This is a plain Mockito test on purpose: since {@code
+ * V6_20260729130000000__Dedupe_security_coverages_external_id} added the unique constraint on
+ * {@code security_coverage_external_id}, an integration test can no longer persist two rows with
+ * the same external id, so the legacy-duplicates path is only reachable with a mocked repository.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SecurityCoverageServiceDuplicateLookupTest {
+
+  private static final String EXTERNAL_ID = "security-coverage--duplicated";
+
+  @Mock private SecurityCoverageRepository securityCoverageRepository;
+  @InjectMocks private SecurityCoverageService securityCoverageService;
+
+  private SecurityCoverage coverage(String id, Scenario scenario, Instant updatedAt) {
+    SecurityCoverage coverage = new SecurityCoverage();
+    coverage.setId(id);
+    coverage.setExternalId(EXTERNAL_ID);
+    coverage.setScenario(scenario);
+    coverage.setUpdatedAt(updatedAt);
+    return coverage;
+  }
+
+  @Test
+  @DisplayName("Given no existing coverage, should return a new transient instance")
+  public void given_noExistingCoverage_should_returnNewInstance() {
+    when(securityCoverageRepository.findAllByExternalId(EXTERNAL_ID)).thenReturn(List.of());
+
+    SecurityCoverage result =
+        securityCoverageService.getByExternalIdOrCreateSecurityCoverage(EXTERNAL_ID);
+
+    assertThat(result.getId()).isNull();
+    assertThat(result.getExternalId()).isNull();
+  }
+
+  @Test
+  @DisplayName("Given a single coverage, should return it")
+  public void given_singleCoverage_should_returnIt() {
+    SecurityCoverage only = coverage("id-1", null, Instant.parse("2026-07-01T00:00:00Z"));
+    when(securityCoverageRepository.findAllByExternalId(EXTERNAL_ID)).thenReturn(List.of(only));
+
+    SecurityCoverage result =
+        securityCoverageService.getByExternalIdOrCreateSecurityCoverage(EXTERNAL_ID);
+
+    assertThat(result).isSameAs(only);
+  }
+
+  @Test
+  @DisplayName("Given duplicates, should prefer the row linked to a scenario even if older")
+  public void given_duplicates_should_preferScenarioLinkedRowEvenIfOlder() {
+    SecurityCoverage withScenario =
+        coverage("id-old", new Scenario(), Instant.parse("2026-01-01T00:00:00Z"));
+    SecurityCoverage newerWithoutScenario =
+        coverage("id-new", null, Instant.parse("2026-07-01T00:00:00Z"));
+    when(securityCoverageRepository.findAllByExternalId(EXTERNAL_ID))
+        .thenReturn(List.of(newerWithoutScenario, withScenario));
+
+    SecurityCoverage result =
+        securityCoverageService.getByExternalIdOrCreateSecurityCoverage(EXTERNAL_ID);
+
+    assertThat(result).isSameAs(withScenario);
+  }
+
+  @Test
+  @DisplayName("Given duplicates without scenario, should prefer the most recently updated row")
+  public void given_duplicatesWithoutScenario_should_preferMostRecentlyUpdatedRow() {
+    SecurityCoverage older = coverage("id-a", null, Instant.parse("2026-01-01T00:00:00Z"));
+    SecurityCoverage newer = coverage("id-b", null, Instant.parse("2026-07-01T00:00:00Z"));
+    when(securityCoverageRepository.findAllByExternalId(EXTERNAL_ID))
+        .thenReturn(List.of(older, newer));
+
+    SecurityCoverage result =
+        securityCoverageService.getByExternalIdOrCreateSecurityCoverage(EXTERNAL_ID);
+
+    assertThat(result).isSameAs(newer);
+  }
+
+  @Test
+  @DisplayName("Given duplicates with null updated timestamps, should rank null updates last")
+  public void given_duplicatesWithNullUpdatedAt_should_rankNullUpdatesLast() {
+    SecurityCoverage withoutTimestamp = coverage("id-a", null, null);
+    SecurityCoverage withTimestamp = coverage("id-b", null, Instant.parse("2026-07-01T00:00:00Z"));
+    when(securityCoverageRepository.findAllByExternalId(EXTERNAL_ID))
+        .thenReturn(List.of(withoutTimestamp, withTimestamp));
+
+    SecurityCoverage result =
+        securityCoverageService.getByExternalIdOrCreateSecurityCoverage(EXTERNAL_ID);
+
+    assertThat(result).isSameAs(withTimestamp);
+  }
+
+  @Test
+  @DisplayName("Given fully tied duplicates, should break the tie deterministically on lowest id")
+  public void given_fullyTiedDuplicates_should_breakTieOnLowestId() {
+    Instant updatedAt = Instant.parse("2026-07-01T00:00:00Z");
+    SecurityCoverage second = coverage("id-b", null, updatedAt);
+    SecurityCoverage first = coverage("id-a", null, updatedAt);
+    when(securityCoverageRepository.findAllByExternalId(EXTERNAL_ID))
+        .thenReturn(List.of(second, first));
+
+    SecurityCoverage result =
+        securityCoverageService.getByExternalIdOrCreateSecurityCoverage(EXTERNAL_ID);
+
+    assertThat(result).isSameAs(first);
+  }
+}

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/AttackFlow.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/AttackFlow.tsx
@@ -3,6 +3,7 @@ import { type FunctionComponent, type KeyboardEvent, memo, useId, useRef } from 
 
 import { useFormatter } from '../../../../../../../components/i18n';
 import useSvgVisibilityPause from '../../../../../../../utils/hooks/useSvgVisibilityPause';
+import { compactNumber } from '../../../../../../../utils/number';
 import { expectationTypeColor } from '../../../../../common/ExpectationIconByType';
 
 export interface DefenseLayer {
@@ -275,7 +276,9 @@ const AttackFlow: FunctionComponent<Props> = ({ layers, breached, onInvestigate 
                   fontWeight: 600,
                 }}
               >
-                {layer.success}
+                {/* compact readout (67.6K); the exact count stays on hover */}
+                <title>{layer.success.toLocaleString()}</title>
+                {compactNumber(layer.success)}
               </text>
               <g>
                 <title>{outcomeText}</title>
@@ -361,7 +364,8 @@ const AttackFlow: FunctionComponent<Props> = ({ layers, breached, onInvestigate 
               fontWeight: 600,
             }}
           >
-            {totalAttacks}
+            <title>{totalAttacks.toLocaleString()}</title>
+            {compactNumber(totalAttacks)}
           </text>
           {/* click-through: every attempted validation */}
           <rect
@@ -414,7 +418,8 @@ const AttackFlow: FunctionComponent<Props> = ({ layers, breached, onInvestigate 
                   fontWeight: 600,
                 }}
               >
-                {breached}
+                <title>{breached.toLocaleString()}</title>
+                {compactNumber(breached)}
               </text>
               <rect
                 x={ASSETS_X - 34}

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/ExposureConsole.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/ExposureConsole.tsx
@@ -7,6 +7,7 @@ import { useFormatter } from '../../../../../../../components/i18n';
 import { SECURITY_PLATFORM_TYPE_COLORS } from '../../../../../../../components/securityPlatformType';
 import useCountUp from '../../../../../../../utils/hooks/useCountUp';
 import useSvgVisibilityPause from '../../../../../../../utils/hooks/useSvgVisibilityPause';
+import { compactNumber } from '../../../../../../../utils/number';
 
 interface OrbitPlatform {
   id: string;
@@ -457,7 +458,7 @@ const ExposureConsole: FunctionComponent<Props> = ({ score, gaps, validations, p
             {(() => {
               if (gaps === 0 && validations === 0) return t('No validations yet');
               if (gaps === 0) return t('All controls holding');
-              return t('{count} gaps to remediate', { count: gaps });
+              return t('{count} gaps to remediate', { count: compactNumber(gaps) });
             })()}
           </Typography>
         </Box>
@@ -516,8 +517,8 @@ const ExposureConsole: FunctionComponent<Props> = ({ score, gaps, validations, p
                 {validations === 0
                   ? t('No validations have run yet.')
                   : t('{gaps} of {validations} validations breached your controls.', {
-                      gaps,
-                      validations,
+                      gaps: gaps.toLocaleString(),
+                      validations: validations.toLocaleString(),
                     })}
               </Typography>
             </Box>
@@ -541,9 +542,9 @@ const ExposureConsole: FunctionComponent<Props> = ({ score, gaps, validations, p
           >
             {t('exposure')}
             {' = '}
-            <Box component="span" sx={{ color: theme.palette.error.main }}>{`${gaps} ${t('breached')}`}</Box>
+            <Box component="span" sx={{ color: theme.palette.error.main }}>{`${compactNumber(gaps)} ${t('breached')}`}</Box>
             {' / '}
-            <Box component="span">{`${validations} ${t('total')}`}</Box>
+            <Box component="span">{`${compactNumber(validations)} ${t('total')}`}</Box>
             {` x 100 = `}
             <Box
               component="span"
@@ -578,15 +579,15 @@ const ExposureConsole: FunctionComponent<Props> = ({ score, gaps, validations, p
                       </Typography>
                       <Typography variant="body2" color="text.secondary">
                         {t('{failed} / {total} breached ({pct}%)', {
-                          failed: p.failed,
-                          total: p.total,
+                          failed: compactNumber(p.failed),
+                          total: compactNumber(p.total),
                           pct: breachPct,
                         })}
                       </Typography>
                     </Box>
                     <Tooltip title={t('{stopped} stopped - {breached} breached', {
-                      stopped: p.success,
-                      breached: p.failed,
+                      stopped: p.success.toLocaleString(),
+                      breached: p.failed.toLocaleString(),
                     })}
                     >
                       <Box sx={{

--- a/openaev-model/src/main/java/io/openaev/database/repository/SecurityCoverageRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/SecurityCoverageRepository.java
@@ -1,6 +1,7 @@
 package io.openaev.database.repository;
 
 import io.openaev.database.model.SecurityCoverage;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.CrudRepository;
@@ -11,4 +12,9 @@ public interface SecurityCoverageRepository
     extends CrudRepository<SecurityCoverage, String>, JpaSpecificationExecutor<SecurityCoverage> {
 
   Optional<SecurityCoverage> findByExternalId(String id);
+
+  // Defensive variant: duplicates are prevented by the unique constraint on
+  // security_coverage_external_id, but a legacy-duplicated database must never fail an entire
+  // bundle with a NonUniqueResultException. The caller picks the best row deterministically.
+  List<SecurityCoverage> findAllByExternalId(String id);
 }

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -1086,7 +1086,10 @@ public class ElasticService implements EngineService {
                       .size(runtime.getPagination().getSize())
                       .from(runtime.getPagination().getPage() * runtime.getPagination().getSize())
                       .query(finalQuery)
-                      .sort(engineSorts),
+                      .sort(engineSorts)
+                      // By default the engine stops counting at 10,000 and reports it as a lower
+                      // bound, which froze the pagination total of large result sets at "10000".
+                      .trackTotalHits(tth -> tth.enabled(true)),
               getClassForEntity(entityName));
       long total = response.hits().total() != null ? response.hits().total().value() : 0;
       return new EsEntities(

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -1143,7 +1143,10 @@ public class OpenSearchService implements EngineService {
                       .size(runtime.getPagination().getSize())
                       .from(runtime.getPagination().getPage() * runtime.getPagination().getSize())
                       .query(finalQuery)
-                      .sort(engineSorts),
+                      .sort(engineSorts)
+                      // By default the engine stops counting at 10,000 and reports it as a lower
+                      // bound, which froze the pagination total of large result sets at "10000".
+                      .trackTotalHits(tth -> tth.enabled(true)),
               getClassForEntity(entityName));
       long total = response.hits().total() != null ? response.hits().total().value() : 0;
       return new EsEntities(


### PR DESCRIPTION
## Summary

Fixes #7054.

After the rolling upgrade, STIX bundle processing failed permanently for a coverage with:

    IncorrectResultSizeDataAccessException: Query did not return a unique result: 2 results were returned
      at SecurityCoverageService.getByExternalIdOrCreateSecurityCoverage (SecurityCoverageService.java:306)

Root cause: security_coverages was created (V4_22) without a unique constraint on security_coverage_external_id, while getByExternalIdOrCreateSecurityCoverage is a non-atomic find-then-create upsert protected only by a JVM-local striped lock. Concurrent submissions of the same coverage (OpenCTI worker retries, multiple API replicas, or the instability window caused by the reindex storm fixed in #7051) could insert the same external id twice. Once duplicated, every subsequent bundle for that coverage 500s and the OpenCTI worker retries forever.

## Changes

- New idempotent migration V6_20260729130000000__Dedupe_security_coverages_external_id:
  - deletes duplicate coverage rows, keeping per external id the row linked to a scenario (tie-break: latest updated_at, then lowest id). Exercises pointing at a deleted row are detached by the existing ON DELETE SET NULL FK; scenarios generated for deleted rows are left in place (regular scenarios, deletable from the UI);
  - adds a UNIQUE constraint on security_coverage_external_id so the race can never create duplicates again - the losing insert now fails its own transaction and the OpenCTI retry finds the winner row. Follows the pattern of V6_20260722080000000__Dedupe_kill_chain_phases_natural_key;
  - hardened after review: drops a leftover tmp_sc_duplicates table before creating it (unconditionally re-runnable) and scopes the pg_constraint idempotency guard to the target table (conrelid) and unique constraints (contype).
- Defensive lookup in SecurityCoverageService: getByExternalIdOrCreateSecurityCoverage now fetches all rows for the external id and, if duplicates are ever present (legacy database), picks the best row deterministically and logs an error instead of failing the whole bundle. The selection rule mirrors the migration keeper choice (scenario-linked first, then latest updated_at, then lowest id).
- New SecurityCoverageServiceDuplicateLookupTest covering the full deterministic selection rule. It is a plain Mockito unit test on purpose: once the unique constraint exists, an integration test can no longer persist two rows with the same external id, so the legacy-duplicates path is only reachable with a mocked repository.

## Also in this PR (release polish)

- Exact pagination totals past 10,000: the widget-results entity search (ElasticService / OpenSearchService) did not enable track_total_hits, so the engine stopped counting at 10,000 and the list pagination showed "of 10000" for result sets that actually contain 67K+ documents. Both engines now request the exact total.
- Compact number formatting in the exposure command center: the attack-flow readouts (adversary / per-gate stopped / breached) and the exposure console badges now use the shared compactNumber() helper (67.6K, 1.2M) instead of raw values; the exact count remains available on hover.

## Notes

- security_coverages has no tenant_id column today, so the unique constraint is global on the external id; if the table becomes tenant-scoped later, the constraint will need to move to (external_id, tenant_id) in that migration (same as kill_chain_phases).

## Rollout notes for the affected instance

- The migration runs automatically at startup and immediately unblocks the failing coverage.
- A redundant auto-generated scenario may remain for the deduplicated coverage; it can be deleted from the UI.

## Test plan

- [x] Backend compiles (mvn compile -Pdev)
- [x] SecurityCoverageServiceDuplicateLookupTest passes locally (6 tests)
- [x] Frontend lint + type-check pass on the touched files
- [ ] Deploy on the affected instance and confirm the OpenCTI coverage bundle processes successfully
- [ ] Confirm the dedupe kept the coverage row linked to the existing scenario
- [ ] Confirm the widget-results list shows the real total (67K+) and the command center shows compact numbers
