### PR TITLE
fix(chaining): use output action as injector target (#7056)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -581,7 +581,8 @@ public class InjectExecutionStep implements ActionStep {
 
     String workflowId = workflowRun.getId();
     List<Asset> validAssets = scopeService.getValidAssets(workflowId);
-    List<String> validManualTargets = scopeService.getValidManualTargetsFromScope(workflowId);
+    List<String> validManualTargets =
+        scopeService.getValidManualTargetsFromScopeAndGlobalState(workflowId);
 
     if (validAssets.isEmpty() && validManualTargets.isEmpty()) {
       return batches;
@@ -604,7 +605,9 @@ public class InjectExecutionStep implements ActionStep {
         target.addProperty("assetId", asset.getId());
         expanded.add(
             new ConditionService.ExecutionBatch(
-                addTargetToInput(batch.inputString(), target), batch.usedMappers(), null));
+                addTargetToInput(batch.inputString(), target),
+                batch.usedMappers(),
+                perTargetHash(batch.hash(), asset.getId())));
       }
 
       // One batch per manual data
@@ -615,10 +618,27 @@ public class InjectExecutionStep implements ActionStep {
         target.addProperty("manual", manualTarget);
         expanded.add(
             new ConditionService.ExecutionBatch(
-                addTargetToInput(batch.inputString(), target), batch.usedMappers(), null));
+                addTargetToInput(batch.inputString(), target),
+                batch.usedMappers(),
+                perTargetHash(batch.hash(), manualTarget)));
       }
     }
     return expanded;
+  }
+
+  /**
+   * Builds a deterministic per-target deduplication hash for an expanded batch by combining the
+   * original combo hash (nullable, for non-mapper batches) with the target identifier (asset ID or
+   * manual target value). This keeps each (mapper combo, target) pair uniquely deduplicated so an
+   * already-executed target is never re-created, while a delayed (rate-limited) sibling target can
+   * still be retried independently.
+   *
+   * @param comboHash original batch hash (may be {@code null} when the batch has no mapper)
+   * @param targetId the target identifier this expanded batch is bound to
+   * @return a non-null hash unique to the (combo, target) pair
+   */
+  private String perTargetHash(String comboHash, String targetId) {
+    return (comboHash != null ? comboHash : "") + ":" + targetId;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -973,6 +973,26 @@ public class ConditionService {
   }
 
   /**
+   * Returns the set of execution hashes already committed in the local workflow state for the given
+   * step template. These are the input combinations (or per-target combinations) that have already
+   * been turned into READY steps and must not be executed again.
+   *
+   * @param stepTemplate the step template whose local state stores the hash set
+   * @param workflowRun the running workflow
+   * @return the committed hash set, or an empty set if no local state exists yet
+   */
+  public Set<String> getCommittedHashes(Step stepTemplate, Workflow workflowRun) {
+    WorkflowState localState =
+        workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun);
+    if (localState == null) {
+      return Set.of();
+    }
+    WorkflowStateEntries entries = deserializeEntries(localState.getEntries());
+    Set<String> hashExecution = entries.getHashExecution();
+    return hashExecution != null ? hashExecution : Set.of();
+  }
+
+  /**
    * Commits the given execution hashes into the local workflow state for the step template,
    * preventing those input combinations from being re-executed in the future.
    *

--- a/openaev-api/src/main/java/io/openaev/service/chaining/PrimitiveValueValidator.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/PrimitiveValueValidator.java
@@ -91,10 +91,19 @@ public final class PrimitiveValueValidator {
     return context.allowlistedAssetGroupIds().contains(id);
   }
 
-  static boolean isIpAllowedByScope(String ip, PrimitiveValidationContext context) {
-    if (context.denylistedIps().contains(ip)
+  /**
+   * Returns {@code true} if the IP is excluded by the scope denylist, either by an exact IP match or
+   * by falling inside a denied subnet. Unlike {@link #isIpAllowedByScope}, this ignores the
+   * allowlist: it only enforces denylist exclusion.
+   */
+  static boolean isIpDeniedByScope(String ip, PrimitiveValidationContext context) {
+    return context.denylistedIps().contains(ip)
         || context.denylistedSubnets().stream()
-            .anyMatch(subnet -> IpAddressUtils.isIpInSubnet(ip, subnet))) {
+            .anyMatch(subnet -> IpAddressUtils.isIpInSubnet(ip, subnet));
+  }
+
+  static boolean isIpAllowedByScope(String ip, PrimitiveValidationContext context) {
+    if (isIpDeniedByScope(ip, context)) {
       return false;
     }
     boolean hasAllowlist =

--- a/openaev-api/src/main/java/io/openaev/service/chaining/PrimitiveValueValidator.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/PrimitiveValueValidator.java
@@ -92,8 +92,8 @@ public final class PrimitiveValueValidator {
   }
 
   /**
-   * Returns {@code true} if the IP is excluded by the scope denylist, either by an exact IP match or
-   * by falling inside a denied subnet. Unlike {@link #isIpAllowedByScope}, this ignores the
+   * Returns {@code true} if the IP is excluded by the scope denylist, either by an exact IP match
+   * or by falling inside a denied subnet. Unlike {@link #isIpAllowedByScope}, this ignores the
    * allowlist: it only enforces denylist exclusion.
    */
   static boolean isIpDeniedByScope(String ip, PrimitiveValidationContext context) {

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
@@ -1,5 +1,7 @@
 package io.openaev.service.chaining;
 
+import static io.openaev.utils.JsonUtils.gson;
+
 import io.openaev.database.model.*;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
 import io.openaev.service.AssetGroupService;
@@ -7,6 +9,7 @@ import io.openaev.service.AssetService;
 import io.openaev.utils.IpAddressUtils;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +20,7 @@ public class ScopeService {
   private final WorkflowScopeRuleRepository workflowScopeRuleRepository;
   private final AssetService assetService;
   private final AssetGroupService assetGroupService;
+  private final WorkflowStateService workflowStateService;
 
   /**
    * Returns the asset groups (ASSET_GROUP_ID allowlist rules) that are not explicitly denied as a
@@ -161,8 +165,14 @@ public class ScopeService {
    * falls inside a denied IP_SUBNET rule. A subnet value is removed only on exact match against a
    * denied IP_SUBNET rule (partial overlap is not computed). A domain is removed only on exact
    * case-insensitive match against a denied DOMAIN rule.
+   *
+   * <p>In addition to the scope rules, this method includes every IPv4 and IPv6 value discovered in
+   * the workflow global pool (workflow states) of the current simulation. These global-pool IPs are
+   * filtered against the scope denylist only (a denied IP or an IP inside a denied subnet is
+   * excluded); the scope allowlist does not restrict them. Results are deduplicated while
+   * preserving insertion order (scope targets first, then global-state IPs).
    */
-  public List<String> getValidManualTargetsFromScope(String workflowId) {
+  public List<String> getValidManualTargetsFromScopeAndGlobalState(String workflowId) {
     List<WorkflowScopeRule> allRules = workflowScopeRuleRepository.findAllByWorkflowId(workflowId);
 
     PrimitiveValidationContext context =
@@ -180,25 +190,66 @@ public class ScopeService {
             collectRuleValues(
                 allRules, ScopeRuleSelectedMode.DENYLIST, ScopeRuleValueType.IP_SUBNET));
 
-    return allRules.stream()
-        .filter(r -> ScopeRuleSelectedMode.ALLOWLIST.equals(r.getSelectedMode()))
-        .filter(
-            r ->
-                ScopeRuleValueType.IP.equals(r.getValueType())
-                    || ScopeRuleValueType.IP_SUBNET.equals(r.getValueType())
-                    || ScopeRuleValueType.DOMAIN.equals(r.getValueType()))
-        .filter(
-            r ->
-                switch (r.getValueType()) {
-                  case IP -> PrimitiveValueValidator.isIpAllowedByScope(r.getRuleValue(), context);
-                  case IP_SUBNET ->
-                      PrimitiveValueValidator.isSubnetAllowedByScope(r.getRuleValue(), context);
-                  case DOMAIN ->
-                      PrimitiveValueValidator.isDomainAllowedByScope(r.getRuleValue(), context);
-                  default -> false;
-                })
-        .map(WorkflowScopeRule::getRuleValue)
+    Stream<String> scopeTargets =
+        allRules.stream()
+            .filter(r -> ScopeRuleSelectedMode.ALLOWLIST.equals(r.getSelectedMode()))
+            .filter(
+                r ->
+                    ScopeRuleValueType.IP.equals(r.getValueType())
+                        || ScopeRuleValueType.IP_SUBNET.equals(r.getValueType())
+                        || ScopeRuleValueType.DOMAIN.equals(r.getValueType()))
+            .filter(
+                r ->
+                    switch (r.getValueType()) {
+                      case IP ->
+                          PrimitiveValueValidator.isIpAllowedByScope(r.getRuleValue(), context);
+                      case IP_SUBNET ->
+                          PrimitiveValueValidator.isSubnetAllowedByScope(r.getRuleValue(), context);
+                      case DOMAIN ->
+                          PrimitiveValueValidator.isDomainAllowedByScope(r.getRuleValue(), context);
+                      default -> false;
+                    })
+            .map(WorkflowScopeRule::getRuleValue);
+
+    Stream<String> globalStateIps =
+        getIpsFromGlobalState(workflowId).stream()
+            .filter(ip -> !PrimitiveValueValidator.isIpDeniedByScope(ip, context));
+
+    // Preserve order (scope targets first, then global-state IPs) and deduplicate.
+    return Stream.concat(scopeTargets, globalStateIps)
+        .collect(Collectors.toCollection(LinkedHashSet::new))
+        .stream()
         .toList();
+  }
+
+  /**
+   * Collects every IPv4 and IPv6 value stored in the workflow global state (global {@link
+   * WorkflowState}) for the given workflow run.
+   *
+   * @param workflowId the workflow execution ID
+   * @return the set of IPv4/IPv6 values found in the global state, or an empty set when the global
+   *     state is missing or holds no IP entries
+   */
+  private Set<String> getIpsFromGlobalState(String workflowId) {
+    WorkflowState globalState = workflowStateService.getGlobalStateByWorkflowId(workflowId);
+    if (globalState == null || globalState.getEntries() == null) {
+      return Set.of();
+    }
+    WorkflowStateEntries entries =
+        gson.fromJson(globalState.getEntries(), WorkflowStateEntries.class);
+    if (entries == null || entries.getInputs() == null) {
+      return Set.of();
+    }
+
+    Set<String> ips = new LinkedHashSet<>();
+    for (WorkflowStateEntries.Input input : entries.getInputs()) {
+      if ((PrimitiveType.IPv4.name().equals(input.getKey())
+              || PrimitiveType.IPv6.name().equals(input.getKey()))
+          && input.getValues() != null) {
+        ips.addAll(input.getValues());
+      }
+    }
+    return ips;
   }
 
   private Set<String> collectRuleValues(

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -116,7 +116,8 @@ public class StepService {
     // If no condition mapper and step already executed, we skip the step to avoid to execute it
     // again
     if (!conditionService.hasConditionMapper(persistedTemplate)
-        && isStepAlreadyExecutedOnce(persistedTemplate.getId(), workflowRun.getId())) {
+        && isStepAlreadyExecutedOnce(persistedTemplate.getId(), workflowRun.getId())
+        && injectExecutionStep.hasPayload(persistedTemplate)) {
       return List.of();
     }
 
@@ -139,6 +140,23 @@ public class StepService {
       executionBatches = injectExecutionStep.expandTargetBatches(executionBatches, workflowRun);
       if (executionBatches.isEmpty()) {
         return List.of();
+      }
+
+      // Per-target deduplication: expanded batches carry a per-target hash (combo + target).
+      // The combo-level dedup in prepareInputsForStepExecution runs BEFORE expansion and only
+      // knows the combo hash, so it cannot skip individual targets already executed. Load the
+      // committed hashes once and drop batches whose target was already turned into a READY step,
+      // preventing the same inject from being re-executed on every scheduling cycle.
+      Set<String> committedTargetHashes =
+          conditionService.getCommittedHashes(persistedTemplate, workflowRun);
+      if (!committedTargetHashes.isEmpty()) {
+        executionBatches =
+            executionBatches.stream()
+                .filter(batch -> !committedTargetHashes.contains(batch.hash()))
+                .toList();
+        if (executionBatches.isEmpty()) {
+          return List.of();
+        }
       }
     }
     List<Step> stepReadys = new ArrayList<>();

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -116,7 +116,7 @@ public class InjectExecutionStepTest extends IntegrationTest {
     // Mock scope service: return the saved asset so that hasAssetTargets = true in run()
     doReturn(List.of(savedAsset)).when(scopeService).getValidAssets(any());
     doReturn(List.of()).when(scopeService).getValidAssetGroupsFromScope(any());
-    doReturn(List.of()).when(scopeService).getValidManualTargetsFromScope(any());
+    doReturn(List.of()).when(scopeService).getValidManualTargetsFromScopeAndGlobalState(any());
 
     injectInputJson =
         """

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
@@ -24,6 +24,7 @@ class ScopeServiceTest {
   @Mock private WorkflowScopeRuleRepository workflowScopeRuleRepository;
   @Mock private AssetService assetService;
   @Mock private AssetGroupService assetGroupService;
+  @Mock private WorkflowStateService workflowStateService;
 
   @InjectMocks private ScopeService scopeService;
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use output action from global state as targeted input for injectors 
* Create hashes

### Testing Instructions

1. create chaining simulation 
2. Add an asset in the allowlist scope definition
3. add a paylod "echo 10.1.1.1" which has an output "IPV4" 
4. add an injector 
5. Launch the simulation 
6. You should have the payload and a first execution on the asset 
7. And when the payload is finished you should have a second execution on the ipv4 for the injectors

### Related issues

* Closes #7056



