### PR TITLE
fix(chaining): one execution per payload per asset

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -570,19 +570,32 @@ public class InjectExecutionStep implements ActionStep {
   }
 
   /**
-   * Expands condition batches into per-target batches by resolving scope assets and IPs.
+   * Expands condition batches into per-target batches by resolving scope assets and, optionally, IPs.
    *
-   * <p>Each original batch is duplicated once per in-scope asset and once per in-scope IP. The
-   * target is embedded in the batch {@code inputString} under {@code "_target"} so that {@link
-   * #ready} can bake it into the step data for {@link #run} to consume.
+   * <p>Each original batch is duplicated once per in-scope asset and, when {@code
+   * includeManualTargets} is {@code true}, once per in-scope IP. The target is embedded in the batch
+   * {@code inputString} under {@code "_target"} so that {@link #ready} can bake it into the step data
+   * for {@link #run} to consume.
+   *
+   * <p>Manual (IP) targets only make sense for external injectors, which can target a raw IP.
+   * Payload-based injects run on an agent/endpoint, so callers pass {@code includeManualTargets =
+   * false} to expand per asset only.
+   *
+   * @param batches original condition batches to expand
+   * @param workflowRun the running workflow (provides the scope)
+   * @param includeManualTargets whether to also produce one batch per in-scope manual IP target
    */
   public List<ConditionService.ExecutionBatch> expandTargetBatches(
-      List<ConditionService.ExecutionBatch> batches, Workflow workflowRun) {
+      List<ConditionService.ExecutionBatch> batches,
+      Workflow workflowRun,
+      boolean includeManualTargets) {
 
     String workflowId = workflowRun.getId();
     List<Asset> validAssets = scopeService.getValidAssets(workflowId);
     List<String> validManualTargets =
-        scopeService.getValidManualTargetsFromScopeAndGlobalState(workflowId);
+        includeManualTargets
+            ? scopeService.getValidManualTargetsFromScopeAndGlobalState(workflowId)
+            : List.of();
 
     if (validAssets.isEmpty() && validManualTargets.isEmpty()) {
       return batches;
@@ -940,10 +953,9 @@ public class InjectExecutionStep implements ActionStep {
       inject.setContent(contentWithExpectations);
 
       // Apply the per-target info baked in by ready() (asset or IP from scope).
-      // For injector-based steps, expansion set _chaining_target → one asset per step.
-      // For payload-based steps (no expansion), fall back to all scope assets so the
-      // executor can distribute the payload across every scoped endpoint — same behavior
-      // as before expandTargetBatches was introduced.
+      // Expansion sets _chaining_target → one asset per step (external injectors also expand per
+      // manual IP target). If no target was baked in (e.g. no assets in scope), fall back to all
+      // scope assets so the executor can still distribute across every scoped endpoint.
       boolean targetApplied =
           applyChainingTarget(inject, step.getData(), injectorContract.getPayload() == null);
       if (!targetApplied && step.getWorkflow() != null) {

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -570,32 +570,35 @@ public class InjectExecutionStep implements ActionStep {
   }
 
   /**
-   * Expands condition batches into per-target batches by resolving scope assets and, optionally, IPs.
+   * Expands condition batches into per-target batches by resolving scope assets and, for external
+   * injectors, IPs.
    *
-   * <p>Each original batch is duplicated once per in-scope asset and, when {@code
-   * includeManualTargets} is {@code true}, once per in-scope IP. The target is embedded in the batch
-   * {@code inputString} under {@code "_target"} so that {@link #ready} can bake it into the step data
-   * for {@link #run} to consume.
+   * <p>Each original batch is duplicated once per in-scope asset and, for external injectors, once
+   * per in-scope manual target (raw IP, including IPv4/IPv6 produced by upstream actions). The
+   * target is embedded in the batch {@code inputString} under {@code "_target"} so that {@link
+   * #ready} can bake it into the step data for {@link #run} to consume.
    *
    * <p>Manual (IP) targets only make sense for external injectors, which can target a raw IP.
-   * Payload-based injects run on an agent/endpoint, so callers pass {@code includeManualTargets =
-   * false} to expand per asset only.
+   * Payload-based injects run on an agent/endpoint, so they are expanded per asset only. This
+   * injector-vs-payload decision is owned here (via {@link #hasPayload(Step)}) so callers stay
+   * agnostic.
    *
    * @param batches original condition batches to expand
    * @param workflowRun the running workflow (provides the scope)
-   * @param includeManualTargets whether to also produce one batch per in-scope manual IP target
+   * @param stepTemplate the step template being expanded (used to detect payload vs injector)
    */
   public List<ConditionService.ExecutionBatch> expandTargetBatches(
-      List<ConditionService.ExecutionBatch> batches,
-      Workflow workflowRun,
-      boolean includeManualTargets) {
+      List<ConditionService.ExecutionBatch> batches, Workflow workflowRun, Step stepTemplate) {
 
     String workflowId = workflowRun.getId();
     List<Asset> validAssets = scopeService.getValidAssets(workflowId);
+
+    // Manual (raw IP) targets — including IPv4/IPv6 produced by upstream actions — only apply to
+    // external injectors. Payload-based injects run on an agent/endpoint, so expand per asset only.
     List<String> validManualTargets =
-        includeManualTargets
-            ? scopeService.getValidManualTargetsFromScopeAndGlobalState(workflowId)
-            : List.of();
+        hasPayload(stepTemplate)
+            ? List.of()
+            : scopeService.getValidManualTargetsFromScopeAndGlobalState(workflowId);
 
     if (validAssets.isEmpty() && validManualTargets.isEmpty()) {
       return batches;

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
@@ -23,39 +23,6 @@ public class ScopeService {
   private final WorkflowStateService workflowStateService;
 
   /**
-   * Returns the asset groups (ASSET_GROUP_ID allowlist rules) that are not explicitly denied as a
-   * whole group. Used at inject execution time to populate inject.assetGroups.
-   */
-  public List<AssetGroup> getValidAssetGroupsFromScope(String workflowId) {
-    List<WorkflowScopeRule> allRules = workflowScopeRuleRepository.findAllByWorkflowId(workflowId);
-
-    PrimitiveValidationContext context =
-        new PrimitiveValidationContext(
-            collectRuleValues(
-                allRules, ScopeRuleSelectedMode.ALLOWLIST, ScopeRuleValueType.ASSET_GROUP_ID),
-            Set.of(),
-            Set.of(),
-            Set.of(),
-            Set.of(),
-            collectRuleValues(
-                allRules, ScopeRuleSelectedMode.DENYLIST, ScopeRuleValueType.ASSET_GROUP_ID),
-            Set.of(),
-            Set.of(),
-            Set.of(),
-            Set.of());
-
-    List<String> allowedGroupIds =
-        allRules.stream()
-            .filter(r -> ScopeRuleSelectedMode.ALLOWLIST.equals(r.getSelectedMode()))
-            .filter(r -> ScopeRuleValueType.ASSET_GROUP_ID.equals(r.getValueType()))
-            .map(WorkflowScopeRule::getRuleValue)
-            .filter(id -> PrimitiveValueValidator.isAssetGroupIdAllowedByScope(id, context))
-            .toList();
-
-    return allowedGroupIds.isEmpty() ? List.of() : assetGroupService.assetGroups(allowedGroupIds);
-  }
-
-  /**
    * Returns the assets that are in scope for the given workflow and that are not denied by a value
    * in the denylist
    *

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -132,15 +132,12 @@ public class StepService {
     }
 
     // Expand each condition batch into one batch per scope target so that each READY step handles
-    // exactly one inject → one execution unit.
-    //  - External injectors (no payload): one batch per asset AND one per manual IP target.
-    //  - Payload-based injects: one batch per asset only (payloads run on an agent/endpoint, not on
-    //    a raw IP), so we exclude manual targets.
+    // exactly one inject → one execution unit. The injector-vs-payload targeting policy (external
+    // injectors also expand per manual IP target) is owned by expandTargetBatches, so StepService
+    // stays agnostic here.
     if (StepActionClass.INJECT_EXECUTION.equals(persistedTemplate.getStepAction())) {
-      boolean includeManualTargets = !injectExecutionStep.hasPayload(persistedTemplate);
       executionBatches =
-          injectExecutionStep.expandTargetBatches(
-              executionBatches, workflowRun, includeManualTargets);
+          injectExecutionStep.expandTargetBatches(executionBatches, workflowRun, persistedTemplate);
       if (executionBatches.isEmpty()) {
         return List.of();
       }

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -131,13 +131,16 @@ public class StepService {
       return List.of();
     }
 
-    // Expand each condition batch into one batch per scope target (one per asset, one per IP)
-    // so that each READY step handles exactly one inject.
-    // Only for injector-based steps (no payload): payload-based injects
-    // handle multi-asset distribution internally => one step covers all assets.
-    if (StepActionClass.INJECT_EXECUTION.equals(persistedTemplate.getStepAction())
-        && !injectExecutionStep.hasPayload(persistedTemplate)) {
-      executionBatches = injectExecutionStep.expandTargetBatches(executionBatches, workflowRun);
+    // Expand each condition batch into one batch per scope target so that each READY step handles
+    // exactly one inject → one execution unit.
+    //  - External injectors (no payload): one batch per asset AND one per manual IP target.
+    //  - Payload-based injects: one batch per asset only (payloads run on an agent/endpoint, not on
+    //    a raw IP), so we exclude manual targets.
+    if (StepActionClass.INJECT_EXECUTION.equals(persistedTemplate.getStepAction())) {
+      boolean includeManualTargets = !injectExecutionStep.hasPayload(persistedTemplate);
+      executionBatches =
+          injectExecutionStep.expandTargetBatches(
+              executionBatches, workflowRun, includeManualTargets);
       if (executionBatches.isEmpty()) {
         return List.of();
       }

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -115,7 +115,6 @@ public class InjectExecutionStepTest extends IntegrationTest {
 
     // Mock scope service: return the saved asset so that hasAssetTargets = true in run()
     doReturn(List.of(savedAsset)).when(scopeService).getValidAssets(any());
-    doReturn(List.of()).when(scopeService).getValidAssetGroupsFromScope(any());
     doReturn(List.of()).when(scopeService).getValidManualTargetsFromScopeAndGlobalState(any());
 
     injectInputJson =

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -2,6 +2,7 @@ package io.openaev.service.chaining;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -417,7 +418,7 @@ class StepServiceTest {
 
         when(conditionService.checkCondition(persistedTemplate, workflowRun, input))
             .thenReturn(List.of(new ConditionService.ExecutionBatch(input, usedMappers, null)));
-        when(injectExecutionStep.expandTargetBatches(any(), any()))
+        when(injectExecutionStep.expandTargetBatches(any(), any(), anyBoolean()))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         Step stepReady = mock(Step.class);
@@ -478,7 +479,7 @@ class StepServiceTest {
 
         when(conditionService.checkCondition(persistedTemplate, workflowRun, input))
             .thenReturn(List.of(new ConditionService.ExecutionBatch(input, usedMappers, null)));
-        when(injectExecutionStep.expandTargetBatches(any(), any()))
+        when(injectExecutionStep.expandTargetBatches(any(), any(), anyBoolean()))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         Step stepReady = mock(Step.class);

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -2,7 +2,6 @@ package io.openaev.service.chaining;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -418,7 +417,7 @@ class StepServiceTest {
 
         when(conditionService.checkCondition(persistedTemplate, workflowRun, input))
             .thenReturn(List.of(new ConditionService.ExecutionBatch(input, usedMappers, null)));
-        when(injectExecutionStep.expandTargetBatches(any(), any(), anyBoolean()))
+        when(injectExecutionStep.expandTargetBatches(any(), any(), any()))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         Step stepReady = mock(Step.class);
@@ -479,7 +478,7 @@ class StepServiceTest {
 
         when(conditionService.checkCondition(persistedTemplate, workflowRun, input))
             .thenReturn(List.of(new ConditionService.ExecutionBatch(input, usedMappers, null)));
-        when(injectExecutionStep.expandTargetBatches(any(), any(), anyBoolean()))
+        when(injectExecutionStep.expandTargetBatches(any(), any(), any()))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         Step stepReady = mock(Step.class);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do one execution per asset per payload

### Testing Instructions

1. Create chaining simulation
2. Add a payload
3. Add 2 agents on your allowlist in the scope definition 
4. Launch the simulation 
5. You should have 2 executions

### Related issues

* Closes #ISSUE-NUMBER

