### PR TITLE
fix(api): lock injector-registered security platforms while the injector lives (#7063)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729170000000__Link_security_platforms_to_registering_injectors.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729170000000__Link_security_platforms_to_registering_injectors.java
@@ -1,0 +1,66 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Security platforms registered by an injector (e.g. the Nuclei vulnerability scanner, which
+ * declares itself as a VULNERABILITY_SCANNER platform at startup) must be read-only in the UI while
+ * the registering injector is alive, exactly like collector-managed platforms (#7063, follow-up to
+ * #7025). The collector side models this with the {@code collector_security_platform} FK ({@code ON
+ * DELETE SET NULL}), serialized as {@code security_platform_collectors}; this migration adds the
+ * symmetric injector -> platform link:
+ *
+ * <ul>
+ *   <li>{@code injectors.injector_security_platform}, FK to {@code assets} {@code ON DELETE SET
+ *       NULL}: deleting the injector from the catalog releases the platform (and its logos) for
+ *       manual cleanup, and a redeployed injector relinks it through the security platform upsert
+ *       it performs at startup.
+ *   <li>Backfill: an injector-registered platform carries the registering injector's type in {@code
+ *       asset_external_reference} (that is the documented upsert key), so live links are restored
+ *       by matching it against {@code injector_type} within the same tenant. Collector external
+ *       references are collector ids and never collide with injector types.
+ * </ul>
+ *
+ * <p>Idempotent: the column and constraint are guarded with IF NOT EXISTS, and the backfill only
+ * touches rows whose link is still unset.
+ */
+@Component
+public class V6_20260729170000000__Link_security_platforms_to_registering_injectors
+    extends BaseJavaMigration {
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.executeUpdate(
+          """
+          ALTER TABLE injectors ADD COLUMN IF NOT EXISTS injector_security_platform varchar(255);
+          """);
+      statement.executeUpdate(
+          """
+          DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1 FROM pg_constraint WHERE conname = 'fk_injector_security_platform'
+            ) THEN
+              ALTER TABLE injectors
+                ADD CONSTRAINT fk_injector_security_platform
+                FOREIGN KEY (injector_security_platform) REFERENCES assets(asset_id)
+                ON DELETE SET NULL;
+            END IF;
+          END $$;
+          """);
+      statement.executeUpdate(
+          """
+          UPDATE injectors i
+          SET injector_security_platform = a.asset_id
+          FROM assets a
+          WHERE i.injector_security_platform IS NULL
+            AND a.asset_type = 'SecurityPlatform'
+            AND a.asset_external_reference = i.injector_type
+            AND a.tenant_id = i.tenant_id;
+          """);
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260730180000000__Link_security_platforms_to_registering_injectors.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260730180000000__Link_security_platforms_to_registering_injectors.java
@@ -18,17 +18,25 @@ import org.springframework.stereotype.Component;
  *       NULL}: deleting the injector from the catalog releases the platform (and its logos) for
  *       manual cleanup, and a redeployed injector relinks it through the security platform upsert
  *       it performs at startup.
+ *   <li>A partial composite index supports the FK: {@code ON DELETE SET NULL} makes PostgreSQL look
+ *       up {@code injectors} by the referenced asset on every platform deletion, which without an
+ *       index is a sequential scan per deleted row - the class of issue that crash-looped the
+ *       platform in #6780 (see {@code V6_20260718110000000__Add_injects_injector_fk_index}).
  *   <li>Backfill: an injector-registered platform carries the registering injector's type in {@code
  *       asset_external_reference} (that is the documented upsert key), so live links are restored
  *       by matching it against {@code injector_type} within the same tenant. Collector external
  *       references are collector ids and never collide with injector types.
  * </ul>
  *
- * <p>Idempotent: the column and constraint are guarded with IF NOT EXISTS, and the backfill only
- * touches rows whose link is still unset.
+ * <p>Idempotent: the column, constraint and index are guarded with IF NOT EXISTS, and the backfill
+ * only touches rows whose link is still unset.
+ *
+ * <p>Re-dated from V6_20260729170000000 before merge: main gained migrations up to
+ * V6_20260730150000000 in the meantime, and Flyway runs with out-of-order disabled, so a version
+ * sorting below the latest released one would silently never apply on already-migrated instances.
  */
 @Component
-public class V6_20260729170000000__Link_security_platforms_to_registering_injectors
+public class V6_20260730180000000__Link_security_platforms_to_registering_injectors
     extends BaseJavaMigration {
   @Override
   public void migrate(Context context) throws Exception {
@@ -50,6 +58,12 @@ public class V6_20260729170000000__Link_security_platforms_to_registering_inject
                 ON DELETE SET NULL;
             END IF;
           END $$;
+          """);
+      statement.execute(
+          """
+          CREATE INDEX IF NOT EXISTS idx_injectors_security_platform
+            ON injectors (injector_security_platform, tenant_id)
+            WHERE injector_security_platform IS NOT NULL;
           """);
       statement.executeUpdate(
           """

--- a/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
@@ -6,6 +6,7 @@ import static io.openaev.helper.StreamHelper.iterableToSet;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 
 import io.openaev.aop.AccessControl;
+import io.openaev.context.TenantContext;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
 import io.openaev.database.raw.RawDocument;
@@ -44,6 +45,7 @@ public class SecurityPlatformApi {
   private final DocumentRepository documentRepository;
   private final TagRepository tagRepository;
   private final DocumentService documentService;
+  private final InjectorRepository injectorRepository;
 
   /**
    * The {@code collectors} table is v2 tenant-active: any read of it in a transaction without a
@@ -55,12 +57,18 @@ public class SecurityPlatformApi {
    * writes it into the scope) AND initialize the association inside that scoped transaction through
    * this helper, or every platform silently unlocks in the UI (issue #7025).
    *
+   * <p>{@code security_platform_injectors} (injector-registered platforms such as Nuclei, #7063)
+   * feeds the same UI signal and is initialized here for the same reason: {@code injectors} is not
+   * v2 tenant-active yet, but the association is lazy and rendered open-in-view, so it must load
+   * inside the scoped transaction to stay correct when that table is activated.
+   *
    * <p>Create and upsert are exempt: create returns a brand-new entity whose empty in-memory
-   * association serializes without a database load, and upsert is the collector-facing registration
+   * associations serialize without a database load, and upsert is the connector-facing registration
    * endpoint whose response the UI never consumes.
    */
-  private static SecurityPlatform withCollectorsInitialized(SecurityPlatform securityPlatform) {
+  private static SecurityPlatform withManagerLinksInitialized(SecurityPlatform securityPlatform) {
     Hibernate.initialize(securityPlatform.getCollectors());
+    Hibernate.initialize(securityPlatform.getInjectors());
     return securityPlatform;
   }
 
@@ -68,10 +76,10 @@ public class SecurityPlatformApi {
   @Transactional
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.SECURITY_PLATFORM)
   // TxCtx scopes the transaction to the caller's tenants so the collectors association loads
-  // (fail-closed empty otherwise); see withCollectorsInitialized.
+  // (fail-closed empty otherwise); see withManagerLinksInitialized.
   public Iterable<SecurityPlatform> securityPlatforms(TxCtx ctx) {
     return fromIterable(securityPlatformRepository.findAll()).stream()
-        .map(SecurityPlatformApi::withCollectorsInitialized)
+        .map(SecurityPlatformApi::withManagerLinksInitialized)
         .toList();
   }
 
@@ -128,7 +136,33 @@ public class SecurityPlatformApi {
       securityPlatform.setLogoLight(null);
     }
     securityPlatform.setTags(iterableToSet(this.tagRepository.findAllById(input.getTagIds())));
-    return this.securityPlatformRepository.save(securityPlatform);
+    SecurityPlatform saved = this.securityPlatformRepository.save(securityPlatform);
+    linkRegisteringInjector(saved, input.getExternalReference());
+    return saved;
+  }
+
+  /**
+   * An injector that declares itself as a security platform (e.g. Nuclei registering as a
+   * VULNERABILITY_SCANNER) upserts the platform keyed on its own injector type as the external
+   * reference — that is the documented contract of the registration call. Restore the injector ->
+   * platform link here so the platform stays read-only in the UI while the injector lives, and so a
+   * redeployed injector self-heals the link its previous deployment lost when it was deleted from
+   * the catalog (FK is ON DELETE SET NULL). Collector external references are collector ids and
+   * never match an injector type, so collector registrations are unaffected (#7063).
+   */
+  private void linkRegisteringInjector(
+      SecurityPlatform securityPlatform, String externalReference) {
+    if (externalReference == null || externalReference.isBlank()) {
+      return;
+    }
+    injectorRepository
+        .findByTypeAndTenantId(externalReference, TenantContext.getCurrentTenant())
+        .filter(injector -> injector.getSecurityPlatform() == null)
+        .ifPresent(
+            injector -> {
+              injector.setSecurityPlatform(securityPlatform);
+              injectorRepository.save(injector);
+            });
   }
 
   @GetMapping({
@@ -141,12 +175,12 @@ public class SecurityPlatformApi {
       actionPerformed = Action.READ,
       resourceType = ResourceType.SECURITY_PLATFORM)
   // TxCtx scopes the transaction so the collectors association loads; see
-  // withCollectorsInitialized.
+  // withManagerLinksInitialized.
   public SecurityPlatform securityPlatform(
       TxCtx ctx, @PathVariable @NotBlank final String securityPlatformId) {
     return this.securityPlatformRepository
         .findById(securityPlatformId)
-        .map(SecurityPlatformApi::withCollectorsInitialized)
+        .map(SecurityPlatformApi::withManagerLinksInitialized)
         .orElseThrow(ElementNotFoundException::new);
   }
 
@@ -154,12 +188,12 @@ public class SecurityPlatformApi {
   @Transactional
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.SECURITY_PLATFORM)
   // TxCtx scopes the transaction so the collectors association loads; see
-  // withCollectorsInitialized.
+  // withManagerLinksInitialized.
   public Page<SecurityPlatform> securityPlatforms(
       TxCtx ctx, @RequestBody @Valid SearchPaginationInput searchPaginationInput) {
     return buildPaginationJPA(
             this.securityPlatformRepository::findAll, searchPaginationInput, SecurityPlatform.class)
-        .map(SecurityPlatformApi::withCollectorsInitialized);
+        .map(SecurityPlatformApi::withManagerLinksInitialized);
   }
 
   @PutMapping({
@@ -172,7 +206,7 @@ public class SecurityPlatformApi {
       resourceType = ResourceType.SECURITY_PLATFORM)
   @Transactional(rollbackFor = Exception.class)
   // TxCtx scopes the transaction so the response's collectors association loads (the UI replaces
-  // its local state with this payload); see withCollectorsInitialized.
+  // its local state with this payload); see withManagerLinksInitialized.
   public SecurityPlatform updateSecurityPlatform(
       TxCtx ctx,
       @PathVariable @NotBlank final String securityPlatformId,
@@ -191,7 +225,7 @@ public class SecurityPlatformApi {
       securityPlatform.setLogoLight(null);
     }
     securityPlatform.setTags(iterableToSet(this.tagRepository.findAllById(input.getTagIds())));
-    return withCollectorsInitialized(this.securityPlatformRepository.save(securityPlatform));
+    return withManagerLinksInitialized(this.securityPlatformRepository.save(securityPlatform));
   }
 
   @DeleteMapping({

--- a/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
@@ -149,6 +149,10 @@ public class SecurityPlatformApi {
    * redeployed injector self-heals the link its previous deployment lost when it was deleted from
    * the catalog (FK is ON DELETE SET NULL). Collector external references are collector ids and
    * never match an injector type, so collector registrations are unaffected (#7063).
+   *
+   * <p>The lookup is scoped by the persisted platform row's tenant, not {@link TenantContext}: the
+   * thread-local falls back to the default tenant when unset (e.g. a call on the non-tenant URI),
+   * which could link the default tenant's injector to another tenant's platform.
    */
   private void linkRegisteringInjector(
       SecurityPlatform securityPlatform, String externalReference) {
@@ -156,7 +160,7 @@ public class SecurityPlatformApi {
       return;
     }
     injectorRepository
-        .findByTypeAndTenantId(externalReference, TenantContext.getCurrentTenant())
+        .findByTypeAndTenantId(externalReference, securityPlatform.getTenant().getId())
         .filter(injector -> injector.getSecurityPlatform() == null)
         .ifPresent(
             injector -> {

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
@@ -243,6 +243,24 @@ class TenantActiveTableAccessArchTest {
                   + " run inside a scoped transaction and be allowlisted here");
 
   @ArchTest
+  static final ArchRule injectors_association_access_is_reviewed =
+      noClasses()
+          .that()
+          .doNotBelongToAnyOf(
+              // Initializes the association inside its TxCtx-scoped transactions before the
+              // open-in-view JSON rendering, next to the collectors association (pinned by
+              // SecurityPlatformInjectorLifecycleTest, #7063):
+              SecurityPlatformApi.class)
+          .should()
+          .callMethod(SecurityPlatform.class, "getInjectors")
+          .because(
+              "security_platform_injectors feeds the same UI read-only signal as"
+                  + " security_platform_collectors (#7063). injectors is not tenant-active yet, but"
+                  + " this lazy association is rendered open-in-view: new callers must initialize it"
+                  + " inside a scoped transaction and be allowlisted here so the #7025 blind spot"
+                  + " cannot recur when the table is activated");
+
+  @ArchTest
   static final ArchRule attackpath_execution_repository_access_is_reviewed =
       noClasses()
           .that()

--- a/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
@@ -1,0 +1,149 @@
+package io.openaev.rest.asset.security_platforms;
+
+import static io.openaev.rest.asset.security_platforms.SecurityPlatformApi.SECURITY_PLATFORM_URI;
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Injector;
+import io.openaev.database.model.SecurityPlatform;
+import io.openaev.database.repository.InjectorRepository;
+import io.openaev.rest.asset.security_platforms.form.SecurityPlatformUpsertInput;
+import io.openaev.utils.fixtures.InjectorFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression test for #7063 (follow-up to #7025): a security platform registered by an injector
+ * (e.g. Nuclei declaring itself as a VULNERABILITY_SCANNER at startup) must follow the same managed
+ * lifecycle as collector-managed platforms:
+ *
+ * <ul>
+ *   <li>the registration upsert (keyed on the injector type as the external reference) links the
+ *       injector, so {@code security_platform_injectors} serializes non-empty and the UI keeps the
+ *       platform read-only;
+ *   <li>deleting the injector from the catalog releases the platform (FK is ON DELETE SET NULL);
+ *   <li>a collector-style upsert whose external reference matches no injector type links nothing.
+ * </ul>
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("Injector-registered security platforms follow the managed lifecycle")
+class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
+
+  private static final String INJECTOR_TYPE = "openaev_nuclei_lifecycle_test";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private InjectorRepository injectorRepository;
+
+  private Injector injector;
+
+  @BeforeEach
+  void setUp() {
+    injector =
+        injectorRepository.save(
+            InjectorFixture.createInjector(
+                UUID.randomUUID().toString(), "Nuclei lifecycle test", INJECTOR_TYPE));
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  private String upsertPlatform(String externalReference) throws Exception {
+    SecurityPlatformUpsertInput input = new SecurityPlatformUpsertInput();
+    input.setName("NucleiLifecyclePlatform");
+    input.setSecurityPlatformType(SecurityPlatform.SECURITY_PLATFORM_TYPE.VULNERABILITY_SCANNER);
+    input.setExternalReference(externalReference);
+    input.setDescription("Registered by the injector at startup");
+    String response =
+        mvc.perform(
+                post(SECURITY_PLATFORM_URI + "/upsert")
+                    .content(asJsonString(input))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    entityManager.flush();
+    entityManager.clear();
+    return JsonPath.read(response, "$.asset_id");
+  }
+
+  @Test
+  @DisplayName("the registration upsert links the injector and locks the platform in the UI")
+  void upsertKeyedOnTheInjectorTypeLinksTheInjector() throws Exception {
+    String platformId = upsertPlatform(INJECTOR_TYPE);
+
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_injectors[0]").value(injector.getId()))
+        .andExpect(jsonPath("$.security_platform_collectors").isEmpty());
+  }
+
+  @Test
+  @DisplayName("a re-run of the registration upsert keeps the existing link (idempotent)")
+  void upsertIsIdempotentOnTheInjectorLink() throws Exception {
+    String platformId = upsertPlatform(INJECTOR_TYPE);
+    String platformIdAgain = upsertPlatform(INJECTOR_TYPE);
+
+    assertEquals(platformId, platformIdAgain);
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_injectors[0]").value(injector.getId()));
+  }
+
+  @Test
+  @DisplayName("deleting the injector from the catalog releases the platform")
+  void deletedInjectorReleasesThePlatform() throws Exception {
+    String platformId = upsertPlatform(INJECTOR_TYPE);
+
+    Injector linked =
+        injectorRepository
+            .findByTypeAndTenantId(INJECTOR_TYPE, TenantContext.getCurrentTenant())
+            .orElseThrow();
+    injectorRepository.delete(linked);
+    entityManager.flush();
+    entityManager.clear();
+
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_injectors").isEmpty());
+  }
+
+  @Test
+  @DisplayName("a collector-style upsert (external reference matches no injector) links nothing")
+  void collectorStyleUpsertLinksNoInjector() throws Exception {
+    String platformId = upsertPlatform("stable-collector-id-no-injector");
+
+    mvc.perform(
+            get(SECURITY_PLATFORM_URI + "/" + platformId)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.security_platform_injectors").isEmpty());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
@@ -3,6 +3,7 @@ package io.openaev.rest.asset.security_platforms;
 import static io.openaev.rest.asset.security_platforms.SecurityPlatformApi.SECURITY_PLATFORM_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -14,8 +15,11 @@ import io.openaev.IntegrationTest;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.Injector;
 import io.openaev.database.model.SecurityPlatform;
+import io.openaev.database.model.Tenant;
 import io.openaev.database.repository.InjectorRepository;
+import io.openaev.database.repository.SecurityPlatformRepository;
 import io.openaev.rest.asset.security_platforms.form.SecurityPlatformUpsertInput;
+import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.InjectorFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.util.UUID;
@@ -49,6 +53,8 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
 
   @Autowired private MockMvc mvc;
   @Autowired private InjectorRepository injectorRepository;
+  @Autowired private SecurityPlatformRepository securityPlatformRepository;
+  @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
 
   private Injector injector;
 
@@ -145,5 +151,35 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
                 .with(csrf()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.security_platform_injectors").isEmpty());
+  }
+
+  /**
+   * The injector lookup must be scoped by the tenant of the platform row the upsert actually
+   * touched, not by {@code TenantContext} (which falls back to the default tenant when unset). When
+   * the upsert resolves a platform belonging to another tenant, the caller tenant's injector of the
+   * same type must not be linked to it - that would be a cross-tenant link.
+   */
+  @Test
+  @DisplayName("an upsert touching another tenant's platform does not link this tenant's injector")
+  void upsertOnAForeignTenantPlatformLinksNoInjector() throws Exception {
+    Tenant otherTenant = tenantIsolationTestHelper.createTenant("injector-lifecycle-other");
+    SecurityPlatform foreignPlatform = new SecurityPlatform();
+    foreignPlatform.setName("NucleiLifecyclePlatform");
+    foreignPlatform.setSecurityPlatformType(
+        SecurityPlatform.SECURITY_PLATFORM_TYPE.VULNERABILITY_SCANNER);
+    foreignPlatform.setExternalReference(INJECTOR_TYPE);
+    foreignPlatform.setTenant(otherTenant);
+    foreignPlatform = securityPlatformRepository.save(foreignPlatform);
+    entityManager.flush();
+    entityManager.clear();
+
+    String platformId = upsertPlatform(INJECTOR_TYPE);
+
+    assertEquals(foreignPlatform.getId(), platformId);
+    Injector reloaded =
+        injectorRepository
+            .findByTypeAndTenantId(INJECTOR_TYPE, TenantContext.getCurrentTenant())
+            .orElseThrow();
+    assertNull(reloaded.getSecurityPlatform());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
@@ -3,7 +3,7 @@ package io.openaev.rest.asset.security_platforms;
 import static io.openaev.rest.asset.security_platforms.SecurityPlatformApi.SECURITY_PLATFORM_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -154,13 +154,16 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
   }
 
   /**
-   * The injector lookup must be scoped by the tenant of the platform row the upsert actually
-   * touched, not by {@code TenantContext} (which falls back to the default tenant when unset). When
-   * the upsert resolves a platform belonging to another tenant, the caller tenant's injector of the
-   * same type must not be linked to it - that would be a cross-tenant link.
+   * The registration upsert must never link across tenants. Its platform lookups run inside the
+   * caller's tenant scope, so an external reference that another tenant's platform also carries
+   * must not resolve that foreign row: the caller gets a platform in their own tenant and the
+   * injector links to that row. The injector lookup itself is scoped by the tenant of the platform
+   * row the upsert actually touched - not the {@code TenantContext} thread-local, whose
+   * default-tenant fallback would be the wrong scope for any caller reaching the upsert without a
+   * request-bound tenant.
    */
   @Test
-  @DisplayName("an upsert touching another tenant's platform does not link this tenant's injector")
+  @DisplayName("an upsert never links across tenants: the foreign platform stays untouched")
   void upsertOnAForeignTenantPlatformLinksNoInjector() throws Exception {
     Tenant otherTenant = tenantIsolationTestHelper.createTenant("injector-lifecycle-other");
     SecurityPlatform foreignPlatform = new SecurityPlatform();
@@ -175,11 +178,13 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
 
     String platformId = upsertPlatform(INJECTOR_TYPE);
 
-    assertEquals(foreignPlatform.getId(), platformId);
+    // The tenant-scoped lookup must not resolve the foreign tenant's row.
+    assertNotEquals(foreignPlatform.getId(), platformId);
+    // The caller's injector links to the caller-tenant platform, not the foreign one.
     Injector reloaded =
         injectorRepository
             .findByTypeAndTenantId(INJECTOR_TYPE, TenantContext.getCurrentTenant())
             .orElseThrow();
-    assertNull(reloaded.getSecurityPlatform());
+    assertEquals(platformId, reloaded.getSecurityPlatform().getId());
   }
 }

--- a/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatformCard.tsx
+++ b/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatformCard.tsx
@@ -9,7 +9,7 @@ import { SECURITY_PLATFORM_BASE_URL } from '../../../../constants/BaseUrls';
 import { type SecurityPlatform } from '../../../../utils/api-types';
 import { buildTenantApiPath } from '../../../../utils/url-helper';
 import SecurityPlatformPopover from './SecurityPlatformPopover';
-import isCollectorManaged from './securityPlatformUtils';
+import isConnectorManaged from './securityPlatformUtils';
 
 interface Props {
   securityPlatform: SecurityPlatform;
@@ -73,7 +73,7 @@ const SecurityPlatformCard: FunctionComponent<Props> = ({
           onUpdate={onUpdate}
           onDelete={onDelete}
           openEditOnInit={openEditOnInit}
-          disabled={isCollectorManaged(securityPlatform)}
+          disabled={isConnectorManaged(securityPlatform)}
         />
       </Box>
 

--- a/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatformDetail.tsx
+++ b/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatformDetail.tsx
@@ -47,7 +47,7 @@ import PostureScore from '../PostureScore';
 import PostureScoreOverTimeChart from '../statistics/PostureScoreOverTimeChart';
 import useExpectationPosture from '../useExpectationPosture';
 import SecurityPlatformPopover from './SecurityPlatformPopover';
-import isCollectorManaged from './securityPlatformUtils';
+import isConnectorManaged from './securityPlatformUtils';
 
 const PLATFORM_FILTER_KEY = 'base_security_platforms_side';
 
@@ -343,7 +343,7 @@ const SecurityPlatformDetail: FunctionComponent = () => {
             }}
             onUpdate={result => setPlatform(result)}
             onDelete={() => navigate(SECURITY_PLATFORM_BASE_URL)}
-            disabled={isCollectorManaged(platform)}
+            disabled={isConnectorManaged(platform)}
           />
         )}
         stats={(

--- a/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatforms.tsx
+++ b/openaev-front/src/admin/components/assets/security_platforms/SecurityPlatforms.tsx
@@ -24,7 +24,7 @@ import { buildTenantApiPath } from '../../../../utils/url-helper';
 import SecurityPlatformCard from './SecurityPlatformCard';
 import SecurityPlatformCreation from './SecurityPlatformCreation';
 import SecurityPlatformPopover from './SecurityPlatformPopover';
-import isCollectorManaged from './securityPlatformUtils';
+import isConnectorManaged from './securityPlatformUtils';
 
 type ViewMode = 'cards' | 'list';
 const VIEW_MODE_STORAGE_KEY = 'security-platforms:view-mode';
@@ -247,7 +247,7 @@ const SecurityPlatforms = () => {
                         onUpdate={result => setSecurityPlatforms(securityPlatforms.map(e => (e.asset_id !== result.asset_id ? e : result)))}
                         onDelete={result => setSecurityPlatforms(securityPlatforms.filter(e => (e.asset_id !== result)))}
                         openEditOnInit={securityPlatform.asset_id === searchId}
-                        disabled={isCollectorManaged(securityPlatform)}
+                        disabled={isConnectorManaged(securityPlatform)}
                       />
                     )}
                   >

--- a/openaev-front/src/admin/components/assets/security_platforms/securityPlatformUtils.ts
+++ b/openaev-front/src/admin/components/assets/security_platforms/securityPlatformUtils.ts
@@ -1,12 +1,15 @@
 import { type SecurityPlatform } from '../../../../utils/api-types';
 
 /**
- * A security platform is read-only only while a collector actively manages it
- * (`security_platform_collectors` reflects the live collector -> platform link).
- * `asset_external_reference` must NOT be used for this: it is set at creation and
- * never cleared, so platforms orphaned by a collector purge would stay locked forever.
+ * A security platform is read-only only while a collector or an injector actively
+ * manages it (`security_platform_collectors` / `security_platform_injectors` reflect
+ * the live connector -> platform links; e.g. Nuclei registers its platform as an
+ * injector). `asset_external_reference` must NOT be used for this: it is set at
+ * creation and never cleared, so platforms orphaned by a connector purge would stay
+ * locked forever.
  */
-const isCollectorManaged = (securityPlatform: SecurityPlatform) =>
-  (securityPlatform.security_platform_collectors ?? []).length > 0;
+const isConnectorManaged = (securityPlatform: SecurityPlatform) =>
+  (securityPlatform.security_platform_collectors ?? []).length > 0
+  || (securityPlatform.security_platform_injectors ?? []).length > 0;
 
-export default isCollectorManaged;
+export default isConnectorManaged;

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -5751,6 +5751,7 @@ export interface Injector {
   /** @minLength 1 */
   injector_name: string;
   injector_payloads?: boolean;
+  injector_security_platform?: string;
   /** @minLength 1 */
   injector_type: string;
   /** @format date-time */
@@ -9737,6 +9738,7 @@ export interface SecurityPlatform {
   asset_url?: string;
   listened?: boolean;
   security_platform_collectors?: string[];
+  security_platform_injectors?: string[];
   security_platform_logo_dark?: string;
   security_platform_logo_light?: string;
   security_platform_traces?: InjectExpectationTrace[];

--- a/openaev-model/src/main/java/io/openaev/database/model/Injector.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Injector.java
@@ -4,12 +4,15 @@ import static java.time.Instant.now;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.hypersistence.utils.hibernate.type.array.StringArrayType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLHStoreType;
 import io.openaev.annotation.Queryable;
 import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.audit.TenantIdBaseListener;
 import io.openaev.healthcheck.enums.ExternalServiceDependency;
+import io.openaev.helper.MonoIdSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -92,6 +95,18 @@ public class Injector extends BaseConnectorEntity implements TenantIdBase {
   @Column(name = "injector_dependencies", columnDefinition = "text[]")
   @JsonProperty("injector_dependencies")
   private ExternalServiceDependency[] dependencies;
+
+  // Security platform this injector registered at startup (e.g. Nuclei declaring itself as a
+  // VULNERABILITY_SCANNER). Mirrors Collector#securityPlatform: the FK is ON DELETE SET NULL, so
+  // deleting the injector from the catalog releases the platform for manual cleanup (#7063).
+  // Serialized as a bare id: embedding the full platform would pull its lazy collectors
+  // association (a v2 tenant-active table) into every injector serialization context.
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "injector_security_platform")
+  @JsonSerialize(using = MonoIdSerializer.class)
+  @JsonProperty("injector_security_platform")
+  @Schema(implementation = String.class)
+  private SecurityPlatform securityPlatform;
 
   @OneToMany(mappedBy = "injector", fetch = FetchType.LAZY)
   @JsonIgnore

--- a/openaev-model/src/main/java/io/openaev/database/model/SecurityPlatform.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/SecurityPlatform.java
@@ -112,6 +112,25 @@ public class SecurityPlatform extends Asset implements StixDomainObjectConvertib
   @ToString.Exclude
   private List<Collector> collectors = new ArrayList<>();
 
+  /**
+   * Injectors currently declaring this security platform as theirs (e.g. Nuclei registering itself
+   * as a VULNERABILITY_SCANNER at startup). Same lifecycle contract as {@link #collectors}: the FK
+   * is {@code ON DELETE SET NULL}, so this list empties when the injector is deleted from the
+   * catalog, and the UI combines both lists into its "managed, keep read-only" signal (#7063).
+   */
+  @ArraySchema(
+      schema =
+          @Schema(
+              description = "IDs of the injectors currently managing this security platform",
+              implementation = String.class))
+  @OneToMany(mappedBy = "securityPlatform", fetch = FetchType.LAZY)
+  @BatchSize(size = 1000)
+  @JsonSerialize(using = MultiIdListSerializer.class)
+  @JsonProperty("security_platform_injectors")
+  @EqualsAndHashCode.Exclude
+  @ToString.Exclude
+  private List<Injector> injectors = new ArrayList<>();
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "security_platform_logo_light")
   @JsonSerialize(using = MonoIdSerializer.class)


### PR DESCRIPTION
﻿## Summary

Fixes #7063 (follow-up to #7025 / PR #7026).

The "managed security platform is read-only" lock only modeled the collector -> platform relationship. Platforms registered by an **injector** were not covered: the Nuclei injector declares itself as a VULNERABILITY_SCANNER platform at startup via the security platform upsert (keyed on `asset_external_reference` = its injector type), no collector is involved, so `security_platform_collectors` is always empty and the UI unlocks Update/Delete on the Nuclei entry even while the injector is started.

## Fix (mirror of the collector pattern, end to end)

- **Migration** `V6_20260730180000000`: new nullable `injector_security_platform` column on `injectors`, FK to `assets` `ON DELETE SET NULL`, a partial composite FK-supporting index `(injector_security_platform, tenant_id) WHERE injector_security_platform IS NOT NULL` (ON DELETE SET NULL looks up `injectors` by the referenced asset on every platform deletion - without the index that is a sequential scan per deleted row, the #6780 crash-loop class of issue), plus a backfill linking existing platforms whose `asset_external_reference` matches a live `injector_type` in the same tenant (this locks the already-deployed Nuclei entry on production immediately). Idempotent (IF NOT EXISTS guards, backfill only touches unset rows). Re-dated from `V6_20260729170000000` after the rebase on main: main gained migrations up to `V6_20260730150000000` in the meantime, and Flyway runs with out-of-order disabled, so the original version would silently never apply on already-migrated instances.
- **Model**: `Injector.securityPlatform` (serialized as a bare id - embedding the full platform would pull its lazy `collectors` association, a v2 tenant-active table, into every injector serialization context) and the inverse `SecurityPlatform.injectors` serialized as `security_platform_injectors` (same shape as `security_platform_collectors`).
- **API**: `upsertSecurityPlatform` resolves the injector whose type equals the upsert's external reference and restores the link - so a redeployed injector self-heals the link its previous deployment lost. The lookup is scoped by the persisted platform row's tenant, not `TenantContext` (whose default-tenant fallback on the non-tenant URI could link the default tenant's injector to another tenant's platform). Collector external references are collector ids and never match an injector type. The serializing endpoints initialize the new association inside their TxCtx-scoped transactions via the renamed `withManagerLinksInitialized` helper (same guardrails as #7025).
- **Arch rule**: new `injectors_association_access_is_reviewed` pins all callers of `SecurityPlatform#getInjectors` to an allowlist, so the association can never leak into an unscoped serialization context (forward guard for when `injectors` becomes v2 tenant-active).
- **Frontend**: the read-only gate becomes `isConnectorManaged` = managed by a collector OR an injector. `api-types.d.ts` updated with the two new fields exactly as the generator emits them (sorted).

## Lifecycle guarantees (previous work preserved)

- Injector started -> platform + logos read-only (Update/Delete disabled).
- Injector stopped and deleted from the catalog -> FK SET NULL empties `security_platform_injectors` -> platform and logos become deletable.
- Injector redeployed -> startup upsert relinks and locks again.
- Collector-managed lifecycle (#7025 / #6956) untouched and re-asserted by the existing tenant-scope regression test.

## Test plan

- [x] `SecurityPlatformInjectorLifecycleTest` (5 tests): upsert links + locks, upsert idempotent, injector deletion releases the platform, collector-style upsert links nothing, an upsert never links across tenants (a foreign tenant's platform carrying the same external reference is never resolved nor linked)
- [x] `SecurityPlatformCollectorsTenantScopeTest` (3), `TenantActiveTableAccessArchTest` (11, incl. new rule), `TenantScopedEntrypointsTxCtxArchTest` (1), `SecurityPlatformApiTest` (13)
- [x] Rebased on main; migration re-dated past `V6_20260730150000000`
- [x] Java formatting verified with google-java-format 1.24.0 under JDK 21; backend compiles clean locally
- [x] `yarn lint` + `yarn check-ts` clean on the frontend
- [x] API tests via CI

