### PR TITLE
chore(fds-migration): regenerate COMPONENT-MAPPING.md (#7067)

### DIFF
--- a/fds-migration/COMPONENT-MAPPING.md
+++ b/fds-migration/COMPONENT-MAPPING.md
@@ -1,7 +1,7 @@
 # Component Mapping — OpenAEV
 
 GENERATED — do not edit by hand. Regenerate: `pnpm generate:fds-migration --product openaev --write-to-product` (filigran-design-system repo).
-Derived from filigran-design-system's `ROADMAP.json` × `process/mui-crosswalk.json` × `process/mui-inventory.json` (as of 2026-07-13).
+Derived from filigran-design-system's `ROADMAP.json` × `process/mui-crosswalk.json` × `process/mui-inventory.json` (as of 2026-07-29).
 
 Recognize a MUI component in this product, look up its design-system
 replacement and current readiness. "Lib status" = is the design-system
@@ -12,14 +12,15 @@ Phase 2 (components) starts (AGENTS.md rule 5: not started yet).
 
 | DS Component | Lib status | Product status | MUI identifiers | Occurrences | Files |
 |---|---|---|---|---|---|
-| Typography | todo | todo | `Typography` | 1375 | 175 |
-| Button | todo | todo | `Button`, `LoadingButton`, `buttonVariants` | 1070 | 202 |
-| Dialog | todo | todo | `Dialog`, `DialogTitle`, `DialogContent`, `DialogContentText`, `DialogActions`, `AlertDialog`, `AlertDialogAction`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle` | 1018 | 286 |
-| Inputs | todo | todo | `TextField`, `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `Input`, `InputLabel`, `InputAdornment`, `FormControl`, `FormControlLabel`, `FormGroup`, `FormLabel`, `FormHelperText`, `Form`, `FormItem`, `FormField`, `FormDescription`, `FormMessage`, `Checkbox`, `Radio`, `RadioGroup`, `Switch`, `Slider`, `Textarea`, `MultiSelectFormField` | 801 | 234 |
+| Typography | done | todo | `Typography` | 1375 | 175 |
+| Button | done | todo | `Button`, `LoadingButton`, `buttonVariants` | 1070 | 202 |
+| Dialog | done | todo | `Dialog`, `DialogTitle`, `DialogContent`, `DialogContentText`, `DialogActions`, `AlertDialog`, `AlertDialogAction`, `AlertDialogCancel`, `AlertDialogContent`, `AlertDialogDescription`, `AlertDialogFooter`, `AlertDialogHeader`, `AlertDialogTitle` | 1018 | 286 |
 | Menu | todo | todo | `Menu`, `MenuItem`, `MenuList`, `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSeparator`, `DropdownMenuTrigger` | 689 | 93 |
-| Tooltip | todo | todo | `Tooltip`, `TooltipContent`, `TooltipTrigger`, `TooltipProvider` | 444 | 110 |
-| IconButton | todo | todo | `IconButton` | 341 | 95 |
+| Inputs | todo | todo | `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue`, `InputLabel`, `FormControl`, `FormControlLabel`, `FormGroup`, `FormLabel`, `FormHelperText`, `Form`, `FormItem`, `FormField`, `FormDescription`, `FormMessage`, `Checkbox`, `Radio`, `RadioGroup`, `Slider`, `Textarea`, `MultiSelectFormField` | 519 | 142 |
+| Tooltip | done | todo | `Tooltip`, `TooltipContent`, `TooltipTrigger`, `TooltipProvider` | 444 | 110 |
+| IconButton | done | todo | `IconButton` | 341 | 95 |
 | Card | todo | todo | `Card`, `CardContent`, `CardHeader`, `CardActions`, `CardActionArea`, `CardMedia`, `CardFooter` | 270 | 69 |
+| Input | in-review | todo | `TextField`, `Input`, `InputAdornment` | 252 | 77 |
 | Alert | todo | todo | `Alert`, `AlertTitle` | 196 | 52 |
 | Chip | todo | todo | `Chip`, `Badge` | 184 | 69 |
 | Tabs | done | todo | `Tabs`, `Tab`, `TabContext`, `TabList`, `TabPanel`, `TabsList`, `TabsTrigger` | 132 | 34 |
@@ -28,12 +29,16 @@ Phase 2 (components) starts (AGENTS.md rule 5: not started yet).
 | ButtonGroup | todo | todo | `ButtonGroup`, `ToggleButton`, `ToggleButtonGroup` | 70 | 20 |
 | Avatar | todo | todo | `Avatar` | 36 | 10 |
 | Drawer | todo | todo | `Drawer`, `Sheet`, `SheetContent`, `SheetFooter`, `SheetHeader`, `SheetTitle`, `SheetTrigger` | 30 | 10 |
+| Switch | in-review | todo | `Switch` | 30 | 15 |
 | Separator | todo | todo | `Divider`, `Separator` | 29 | 11 |
 | Header | todo | todo | `AppBar`, `Toolbar` | 26 | 9 |
 | Pagination | todo | todo | `TablePagination` | 6 | 3 |
 | Breadcrumbs | todo | todo | `Breadcrumbs`, `Breadcrumb`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbList`, `BreadcrumbSeparator` | 3 | 1 |
 | Banner | todo | todo | — | — | — |
 | FilterBar | todo | todo | — | — | — |
-| Icon | in-review | todo | — | — | — |
-| Navbar | todo | todo | — | — | — |
-| SearchField | todo | todo | — | — | — |
+| Icon | done | todo | — | — | — |
+| Navbar | done | todo | — | — | — |
+| NavbarItem | done | todo | — | — | — |
+| NavbarSubmenu | done | todo | — | — | — |
+| ProductSwitcher | done | todo | — | — | — |
+| SearchField | done | todo | — | — | — |


### PR DESCRIPTION
## Summary

Regenerates `fds-migration/COMPONENT-MAPPING.md` for openaev using the `filigran-design-system` generator, so the mapping reflects the current state of `origin/main` in that repo (as of 2026-07-29).

Generated with:
```
pnpm generate:fds-migration --product openaev --write-to-product
```
(run from the `filigran-design-system` repo, updated to `origin/main` first)

## Notable changes

Several lib components moved from `todo` to `done` (built in the design system) since the mapping was last generated, including:
- `Navbar`, `NavbarItem`, `NavbarSubmenu`, `ProductSwitcher`
- `Icon`, `Typography`, `Button`, `Dialog`, `Tooltip`, `IconButton`, `Tabs`

Product status (openaev adoption) remains `todo` for all of these — this file only reflects lib readiness, not adoption.

## Scope

Only `fds-migration/COMPONENT-MAPPING.md` was committed, as requested — this is independent of the `origin/main` merge PR (#7066).

---
Generated by GitHub Copilot CLI
