### PR TITLE
fix(dashboard): make widget totals and their drill-downs read one definition (#7079)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
@@ -100,22 +100,6 @@ public class WidgetService {
   }
 
   /**
-   * Converts a widget configuration to a list configuration for data display. Applies
-   * series-specific filters and handles different widget types (temporal/structural histograms).
-   *
-   * @param widget the source widget containing the configuration to convert
-   * @param seriesIndex the index of the series within the widget to use for conversion
-   * @param filterValues optional filter values to apply (e.g., date ranges for temporal, field
-   *     values for structural histograms)
-   * @return a ListConfiguration object configured based on the widget settings
-   */
-  public ListConfiguration convertWidgetToListConfiguration(
-      Widget widget, Integer seriesIndex, Map<String, List<String>> filterValues) {
-    return convertWidgetToListConfiguration(
-        widget, List.of(seriesIndex == null ? 0 : seriesIndex), filterValues);
-  }
-
-  /**
    * Converts a widget configuration to a list configuration for data display, scoped to every
    * series that produced the clicked number.
    *
@@ -127,7 +111,8 @@ public class WidgetService {
    * changes.
    *
    * @param widget the source widget containing the configuration to convert
-   * @param seriesIndexes the indexes of the series to OR together; out-of-range entries are ignored
+   * @param seriesIndexes the indexes of the series to OR together; every index must name a series
+   *     the widget declares, else the drill-down is rejected
    * @param filterValues optional filter values to apply (e.g., date ranges for temporal, field
    *     values for structural histograms)
    * @return a ListConfiguration object configured based on the widget settings
@@ -191,7 +176,9 @@ public class WidgetService {
    * series over the same entity), and for that shape the OR collapses exactly onto {@code E AND s
    * IN (X, Y)} - a per-key union of values. Series that diverge on more than one key have no such
    * collapse and their union would silently be a superset of the real scope, so that case is
-   * rejected rather than over-counted.
+   * rejected rather than over-counted. The collapse also presumes both series select documents the
+   * same way on the diverging key; {@link #mergeFilter} rejects the shapes where it would not (a
+   * different operator, a negated operator, a multi-value and-mode filter).
    *
    * <p>Filters are deep-copied: the returned group is handed to {@link
    * WidgetUtils#setOrAddFilterByKey} which mutates it in place, and the source belongs to the
@@ -199,19 +186,23 @@ public class WidgetService {
    */
   private WidgetConfigurationWithSeries.Series mergeSeries(
       WidgetConfiguration widgetConfig, List<Integer> seriesIndexes) {
-    if (!(widgetConfig instanceof WidgetConfigurationWithSeries config)) {
-      return new WidgetConfigurationWithSeries.Series();
-    }
-    List<WidgetConfigurationWithSeries.Series> all = config.getSeries();
+    List<WidgetConfigurationWithSeries.Series> all =
+        widgetConfig instanceof WidgetConfigurationWithSeries config && config.getSeries() != null
+            ? config.getSeries()
+            : List.of();
     List<Integer> indexes = seriesIndexes == null ? List.of() : seriesIndexes;
-    List<WidgetConfigurationWithSeries.Series> selected =
-        indexes.stream()
-            .filter(index -> index != null && index >= 0 && index < all.size())
-            .map(all::get)
-            .toList();
-    if (selected.isEmpty()) {
-      return new WidgetConfigurationWithSeries.Series();
+    // These indexes reach us as client-controlled URL parameters, so an unknown one has to
+    // answer 400. Silently dropping it would detach the drilled list from the number the
+    // caller believes it is expanding, and resolving to an empty series instead would carry
+    // a null filter list (Lombok drops the field initializer under @Builder.Default, which
+    // is why Filters null-guards it everywhere) and surface as an opaque 500 further down.
+    if (indexes.isEmpty()
+        || indexes.stream().anyMatch(index -> index == null || index < 0 || index >= all.size())) {
+      throw new IllegalArgumentException(
+          "Cannot drill down into series %s: the widget declares %d series"
+              .formatted(indexes, all.size()));
     }
+    List<WidgetConfigurationWithSeries.Series> selected = indexes.stream().map(all::get).toList();
 
     WidgetConfigurationWithSeries.Series merged = new WidgetConfigurationWithSeries.Series();
     merged.setName(selected.getFirst().getName());
@@ -230,15 +221,7 @@ public class WidgetService {
       }
       for (Filters.Filter filter : otherFilter.getFilters()) {
         Filters.Filter target = merged.getFilter().findByKey(filter.getKey()).orElseThrow();
-        // Divergence is a set difference, not union growth: when one series' values are a
-        // subset of another's the union does not grow, yet the series do differ on that key.
-        // Missing it would let a second diverging key pass the guard below and widen the
-        // scope to documents matching neither original series.
-        if (!valueSet(target).equals(valueSet(filter))) {
-          divergingKeys.add(filter.getKey());
-          target.setValues(unionValues(target.getValues(), filter.getValues()));
-          target.setMode(Filters.FilterMode.or);
-        }
+        mergeFilter(target, filter, divergingKeys);
       }
     }
     if (divergingKeys.size() > 1) {
@@ -246,6 +229,85 @@ public class WidgetService {
           "Cannot drill down into series diverging on more than one filter key: " + divergingKeys);
     }
     return merged;
+  }
+
+  /**
+   * Merges one series' filter into the accumulating drill-down filter for the same key.
+   *
+   * <p>Divergence is a set difference, not union growth: when one series' values are a subset of
+   * another's the union does not grow, yet the series do differ on that key. Missing it would let a
+   * second diverging key pass the guard in {@link #mergeSeries} and widen the scope to documents
+   * matching neither original series.
+   *
+   * <p>The per-key value union stands in for the OR of the series only when both sides select
+   * documents the same way. A different operator makes the merged filter mean something neither
+   * series said, so operators must match. Negated operators never union soundly: the engine turns
+   * every not_eq / not_contains value into a must-not clause - a conjunction of exclusions - so
+   * adding values narrows the match where the OR of the series must widen it. A multi-value
+   * and-mode side has no flat collapse either ({@code (A AND B) OR C} cannot be expressed as one
+   * value list), which also rejects two series carrying the same values under different modes.
+   */
+  private static void mergeFilter(
+      Filters.Filter target, Filters.Filter incoming, Set<String> divergingKeys) {
+    if (effectiveOperator(target) != effectiveOperator(incoming)) {
+      throw new IllegalArgumentException(
+          "Cannot drill down into series using different operators on '%s': %s vs %s"
+              .formatted(
+                  incoming.getKey(), effectiveOperator(target), effectiveOperator(incoming)));
+    }
+    if (valueSet(target).equals(valueSet(incoming))
+        && effectiveMode(target) == effectiveMode(incoming)) {
+      return;
+    }
+    divergingKeys.add(incoming.getKey());
+    if (!UNION_SAFE_OPERATORS.contains(effectiveOperator(incoming))) {
+      throw new IllegalArgumentException(
+          "Cannot drill down into series diverging on '%s': a value union under operator %s does"
+              + " not express the OR of the series"
+                  .formatted(incoming.getKey(), effectiveOperator(incoming)));
+    }
+    if (effectiveMode(target) == Filters.FilterMode.and
+        || effectiveMode(incoming) == Filters.FilterMode.and) {
+      throw new IllegalArgumentException(
+          "Cannot drill down into series diverging on '%s': a series requires all its values at"
+              + " once (and-mode) on that key".formatted(incoming.getKey()));
+    }
+    target.setValues(unionValues(target.getValues(), incoming.getValues()));
+    target.setMode(Filters.FilterMode.or);
+  }
+
+  /**
+   * Operators whose values the query engine combines disjunctively under or-mode, making a per-key
+   * value union equivalent to the OR of the series. Negated operators (not_eq, not_contains)
+   * combine their values as must-not clauses regardless of mode, and empty / not_empty ignore
+   * values entirely.
+   */
+  private static final Set<Filters.FilterOperator> UNION_SAFE_OPERATORS =
+      Set.of(
+          Filters.FilterOperator.eq,
+          Filters.FilterOperator.contains,
+          Filters.FilterOperator.gt,
+          Filters.FilterOperator.gte,
+          Filters.FilterOperator.lt,
+          Filters.FilterOperator.lte);
+
+  /** Null collapses onto {@code eq}, matching {@link Filters.FilterOperator#fromValue}. */
+  private static Filters.FilterOperator effectiveOperator(Filters.Filter filter) {
+    return filter.getOperator() == null ? Filters.FilterOperator.eq : filter.getOperator();
+  }
+
+  /**
+   * The mode as the query engine reads it: only a literal {@code and} conjoins values, anything
+   * else (or, null) is disjunctive. With a single value the distinction has no effect at all, so
+   * such filters are treated as disjunctive to keep them mergeable.
+   */
+  private static Filters.FilterMode effectiveMode(Filters.Filter filter) {
+    if (nullSafe(filter.getValues()).size() <= 1) {
+      return Filters.FilterMode.or;
+    }
+    return filter.getMode() == Filters.FilterMode.and
+        ? Filters.FilterMode.and
+        : Filters.FilterMode.or;
   }
 
   private static Filters.FilterGroup copyFilterGroup(Filters.FilterGroup source) {

--- a/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
@@ -3,7 +3,6 @@ package io.openaev.rest.custom_dashboard;
 import static io.openaev.helper.StreamHelper.fromIterable;
 
 import io.openaev.context.TenantContext;
-import io.openaev.database.model.BaseInjectExpectation;
 import io.openaev.database.model.CustomDashboard;
 import io.openaev.database.model.Filters;
 import io.openaev.database.model.Widget;
@@ -231,10 +230,13 @@ public class WidgetService {
       }
       for (Filters.Filter filter : otherFilter.getFilters()) {
         Filters.Filter target = merged.getFilter().findByKey(filter.getKey()).orElseThrow();
-        List<String> union = unionValues(target.getValues(), filter.getValues());
-        if (union.size() != nullSafe(target.getValues()).size()) {
+        // Divergence is a set difference, not union growth: when one series' values are a
+        // subset of another's the union does not grow, yet the series do differ on that key.
+        // Missing it would let a second diverging key pass the guard below and widen the
+        // scope to documents matching neither original series.
+        if (!valueSet(target).equals(valueSet(filter))) {
           divergingKeys.add(filter.getKey());
-          target.setValues(union);
+          target.setValues(unionValues(target.getValues(), filter.getValues()));
           target.setMode(Filters.FilterMode.or);
         }
       }
@@ -272,6 +274,10 @@ public class WidgetService {
         .collect(Collectors.toSet());
   }
 
+  private static Set<String> valueSet(Filters.Filter filter) {
+    return new HashSet<>(nullSafe(filter.getValues()));
+  }
+
   private static List<String> unionValues(List<String> left, List<String> right) {
     LinkedHashSet<String> union = new LinkedHashSet<>(nullSafe(left));
     union.addAll(nullSafe(right));
@@ -295,18 +301,10 @@ public class WidgetService {
    */
   public ListConfiguration convertSecurityCoverageWidgetToListConfiguration(
       Widget widget, Map<String, List<String>> attackPatternFilterValues) {
-    ListConfiguration listInjectExpectationsConfig =
-        this.convertWidgetToListConfiguration(widget, 0, attackPatternFilterValues);
-    List<String> statusFilters =
-        List.of(
-            BaseInjectExpectation.EXPECTATION_STATUS.FAILED.name(),
-            BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS.name());
-    WidgetUtils.setOrAddFilterByKey(
-        listInjectExpectationsConfig.getPerspective().getFilter(),
-        "inject_expectation_status",
-        statusFilters,
-        Filters.FilterOperator.eq);
-    return listInjectExpectationsConfig;
+    // The matrix scores success against failure, so it drills both of its series. Naming
+    // them beats re-stating their statuses here: the union is then whatever the widget
+    // declares, and cannot fall out of step with it (#7079).
+    return this.convertWidgetToListConfiguration(widget, List.of(0, 1), attackPatternFilterValues);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
@@ -16,9 +16,14 @@ import io.openaev.utils.CustomDashboardTimeRange;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,12 +112,32 @@ public class WidgetService {
    */
   public ListConfiguration convertWidgetToListConfiguration(
       Widget widget, Integer seriesIndex, Map<String, List<String>> filterValues) {
+    return convertWidgetToListConfiguration(
+        widget, List.of(seriesIndex == null ? 0 : seriesIndex), filterValues);
+  }
+
+  /**
+   * Converts a widget configuration to a list configuration for data display, scoped to every
+   * series that produced the clicked number.
+   *
+   * <p>A tile whose value spans several series (an "attempted" total built from SUCCESS + FAILED +
+   * PENDING series, say) cannot describe its own scope with a single series index. Passing every
+   * contributing index here makes the drilled list resolve to exactly the documents that were
+   * counted, instead of leaving the caller to hand-rebuild the scope through {@code filterValues} -
+   * a reconstruction that silently drifts from the widget definition as soon as one of the two
+   * changes.
+   *
+   * @param widget the source widget containing the configuration to convert
+   * @param seriesIndexes the indexes of the series to OR together; out-of-range entries are ignored
+   * @param filterValues optional filter values to apply (e.g., date ranges for temporal, field
+   *     values for structural histograms)
+   * @return a ListConfiguration object configured based on the widget settings
+   */
+  public ListConfiguration convertWidgetToListConfiguration(
+      Widget widget, List<Integer> seriesIndexes, Map<String, List<String>> filterValues) {
 
     WidgetConfiguration widgetConfig = widget.getWidgetConfiguration();
-    WidgetConfigurationWithSeries.Series series =
-        widgetConfig instanceof WidgetConfigurationWithSeries config
-            ? config.getSeries().get(seriesIndex)
-            : new WidgetConfigurationWithSeries.Series();
+    WidgetConfigurationWithSeries.Series series = mergeSeries(widgetConfig, seriesIndexes);
 
     String baseEntity = WidgetUtils.getBaseEntityFilterValue(series.getFilter());
 
@@ -155,6 +180,110 @@ public class WidgetService {
 
     listConfig.setPerspective(perspectives);
     return listConfig;
+  }
+
+  /**
+   * Builds the single series the drill-down runs against, ORing the filters of every selected
+   * series into one flat group.
+   *
+   * <p>{@link Filters.FilterGroup} carries a flat list of filters with no nesting, so a literal
+   * {@code (E AND s=X) OR (E AND s=Y)} cannot be represented. It does not need to be: the series of
+   * one widget differ by a single discriminating key (the status, for SUCCESS / FAILED / PENDING
+   * series over the same entity), and for that shape the OR collapses exactly onto {@code E AND s
+   * IN (X, Y)} - a per-key union of values. Series that diverge on more than one key have no such
+   * collapse and their union would silently be a superset of the real scope, so that case is
+   * rejected rather than over-counted.
+   *
+   * <p>Filters are deep-copied: the returned group is handed to {@link
+   * WidgetUtils#setOrAddFilterByKey} which mutates it in place, and the source belongs to the
+   * widget configuration (a persisted entity for stored dashboards).
+   */
+  private WidgetConfigurationWithSeries.Series mergeSeries(
+      WidgetConfiguration widgetConfig, List<Integer> seriesIndexes) {
+    if (!(widgetConfig instanceof WidgetConfigurationWithSeries config)) {
+      return new WidgetConfigurationWithSeries.Series();
+    }
+    List<WidgetConfigurationWithSeries.Series> all = config.getSeries();
+    List<Integer> indexes = seriesIndexes == null ? List.of() : seriesIndexes;
+    List<WidgetConfigurationWithSeries.Series> selected =
+        indexes.stream()
+            .filter(index -> index != null && index >= 0 && index < all.size())
+            .map(all::get)
+            .toList();
+    if (selected.isEmpty()) {
+      return new WidgetConfigurationWithSeries.Series();
+    }
+
+    WidgetConfigurationWithSeries.Series merged = new WidgetConfigurationWithSeries.Series();
+    merged.setName(selected.getFirst().getName());
+    merged.setFilter(copyFilterGroup(selected.getFirst().getFilter()));
+    if (selected.size() == 1) {
+      return merged;
+    }
+
+    Set<String> divergingKeys = new HashSet<>();
+    for (WidgetConfigurationWithSeries.Series other : selected.subList(1, selected.size())) {
+      Filters.FilterGroup otherFilter = copyFilterGroup(other.getFilter());
+      if (!filterKeys(merged.getFilter()).equals(filterKeys(otherFilter))) {
+        throw new IllegalArgumentException(
+            "Cannot drill down into series with different filter keys: %s vs %s"
+                .formatted(filterKeys(merged.getFilter()), filterKeys(otherFilter)));
+      }
+      for (Filters.Filter filter : otherFilter.getFilters()) {
+        Filters.Filter target = merged.getFilter().findByKey(filter.getKey()).orElseThrow();
+        List<String> union = unionValues(target.getValues(), filter.getValues());
+        if (union.size() != nullSafe(target.getValues()).size()) {
+          divergingKeys.add(filter.getKey());
+          target.setValues(union);
+          target.setMode(Filters.FilterMode.or);
+        }
+      }
+    }
+    if (divergingKeys.size() > 1) {
+      throw new IllegalArgumentException(
+          "Cannot drill down into series diverging on more than one filter key: " + divergingKeys);
+    }
+    return merged;
+  }
+
+  private static Filters.FilterGroup copyFilterGroup(Filters.FilterGroup source) {
+    Filters.FilterGroup copy = Filters.FilterGroup.defaultFilterGroup();
+    if (source == null) {
+      return copy;
+    }
+    copy.setMode(source.getMode());
+    copy.setFilters(
+        nullSafeFilters(source.getFilters()).stream()
+            .map(
+                filter ->
+                    new Filters.Filter(
+                        filter.getId(),
+                        filter.getKey(),
+                        filter.getMode(),
+                        new ArrayList<>(nullSafe(filter.getValues())),
+                        filter.getOperator()))
+            .collect(Collectors.toCollection(ArrayList::new)));
+    return copy;
+  }
+
+  private static Set<String> filterKeys(Filters.FilterGroup group) {
+    return nullSafeFilters(group == null ? null : group.getFilters()).stream()
+        .map(Filters.Filter::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  private static List<String> unionValues(List<String> left, List<String> right) {
+    LinkedHashSet<String> union = new LinkedHashSet<>(nullSafe(left));
+    union.addAll(nullSafe(right));
+    return new ArrayList<>(union);
+  }
+
+  private static List<String> nullSafe(List<String> values) {
+    return values == null ? List.of() : values;
+  }
+
+  private static List<Filters.Filter> nullSafeFilters(List<Filters.Filter> filters) {
+    return filters == null ? List.of() : filters;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/dashboard/DashboardService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/dashboard/DashboardService.java
@@ -171,7 +171,7 @@ public class DashboardService {
     } else {
       listConfig =
           widgetService.convertWidgetToListConfiguration(
-              widgetContext.widget, input.getSeriesIndex(), input.getFilterValuesMap());
+              widgetContext.widget, input.resolvedSeriesIndexes(), input.getFilterValuesMap());
     }
 
     datas = executeListQuery(widgetContext, listConfig, input.getPagination());
@@ -316,7 +316,7 @@ public class DashboardService {
     } else {
       listConfig =
           widgetService.convertWidgetToListConfiguration(
-              transientWidget, input.getSeriesIndex(), input.getFilterValuesMap());
+              transientWidget, input.resolvedSeriesIndexes(), input.getFilterValuesMap());
     }
 
     Map<String, String> params = input.getParameters() == null ? Map.of() : input.getParameters();

--- a/openaev-api/src/main/java/io/openaev/utils/es/WidgetToEntitiesInput.java
+++ b/openaev-api/src/main/java/io/openaev/utils/es/WidgetToEntitiesInput.java
@@ -15,7 +15,8 @@ public class WidgetToEntitiesInput {
   @JsonProperty("filter_values_map")
   @Schema(
       description =
-          "Key-value pairs for filtering entities, where the key is the field name and the value is the filter criterion")
+          "Key-value pairs for filtering entities, where the key is the field name and the value is"
+              + " the filter criterion")
   private Map<String, List<String>> filterValuesMap;
 
   @JsonProperty("series_index")

--- a/openaev-api/src/main/java/io/openaev/utils/es/WidgetToEntitiesInput.java
+++ b/openaev-api/src/main/java/io/openaev/utils/es/WidgetToEntitiesInput.java
@@ -22,6 +22,15 @@ public class WidgetToEntitiesInput {
   @Schema(description = "The index of the series to filter by, if applicable, otherwise 0")
   private Integer seriesIndex;
 
+  @JsonProperty("series_indexes")
+  @Schema(
+      description =
+          "The indexes of every series that produced the clicked number, ORed together. Takes"
+              + " precedence over series_index; use it whenever a widget displays a total spanning"
+              + " several series, so the drilled list resolves to exactly the documents that were"
+              + " counted")
+  private List<Integer> seriesIndexes;
+
   @JsonProperty("parameters")
   @Schema(description = "Additional parameters for the widget")
   private Map<String, String> parameters;
@@ -29,4 +38,18 @@ public class WidgetToEntitiesInput {
   @JsonProperty("pagination")
   @Schema(description = "Pagination for the widget")
   private Pagination pagination;
+
+  /**
+   * The series the drill-down applies to, as a list. Callers may send either the single {@code
+   * series_index} or the multi-valued {@code series_indexes}; this collapses both onto one shape so
+   * no call site has to re-implement the fallback.
+   *
+   * @return the explicit series indexes, else the single index, else series 0
+   */
+  public List<Integer> resolvedSeriesIndexes() {
+    if (this.seriesIndexes != null && !this.seriesIndexes.isEmpty()) {
+      return this.seriesIndexes;
+    }
+    return List.of(this.seriesIndex == null ? 0 : this.seriesIndex);
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/dashboard/DashboardApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/dashboard/DashboardApiTest.java
@@ -962,7 +962,8 @@ class DashboardApiTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "Given Structural Endpoint Histogram breakdown by platform, should return list of windows endpoint")
+        "Given Structural Endpoint Histogram breakdown by platform, should return list of windows"
+            + " endpoint")
     void given_structuralEndpointHistogram_should_returnListOfWindowsEndpoint() throws Exception {
       createEndpoint(
           EndpointFixture.createEndpointWithPlatform("Endpoint A", Endpoint.PLATFORM_TYPE.Windows));
@@ -1110,14 +1111,42 @@ class DashboardApiTest extends IntegrationTest {
       assertThatJson(response).node("es_entities.total").isEqualTo(6);
     }
 
+    /** Sums every bucket of every charted series - what the tile actually renders. */
+    private int tileTotal(Widget widget) throws Exception {
+      String response =
+          mvc.perform(
+                  post(DASHBOARD_URI + "/series/" + widget.getId())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(new HashMap<String, String>()))
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      List<Integer> bucketValues = JsonPath.read(response, "$..data[*].value");
+      return bucketValues.stream().mapToInt(Integer::intValue).sum();
+    }
+
+    private WidgetToEntitiesInput seriesDrillDown(List<Integer> seriesIndexes) {
+      WidgetToEntitiesInput input = new WidgetToEntitiesInput();
+      input.setSeriesIndexes(seriesIndexes);
+      input.setParameters(new HashMap<>());
+      return input;
+    }
+
     /**
      * Guards the invariant behind #7079: a tile's number and the list you reach by clicking it must
      * describe the same documents. The command center's ADVERSARY node totals several series at
      * once, which a single {@code series_index} cannot express - the drill-down used to restate the
      * scope as literal status values instead, and silently drifted from the widget definition
      * (showing 747 while the list returned 795 in production). Naming the aggregated series makes
-     * the two read one definition, so this asserts the sum of the charted series equals the drilled
-     * total, with an unrelated status present to prove the scope is not simply "everything".
+     * both read one definition.
+     *
+     * <p>The same data is charted by two widgets so the drilled list is shown to follow the
+     * declared series rather than simply returning everything: a resolved-only widget must leave
+     * the pending expectations out. Only SUCCESS / FAILED / PENDING are exercised because no other
+     * status is reachable - {@code computeStatus} never returns PARTIAL, and returns UNKNOWN only
+     * for a null expected score, which migration V3_36 forbids.
      */
     @Test
     @DisplayName("Given a total spanning several series, drilling it returns exactly that total")
@@ -1140,13 +1169,9 @@ class DashboardApiTest extends IntegrationTest {
                   BaseInjectExpectation.EXPECTATION_STATUS.PENDING),
               createExpectationComposer(
                   BaseInjectExpectation.EXPECTATION_TYPE.DETECTION,
-                  BaseInjectExpectation.EXPECTATION_STATUS.PENDING),
-              // charted by no series: it must land in neither the tile nor the list
-              createExpectationComposer(
-                  BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION,
-                  BaseInjectExpectation.EXPECTATION_STATUS.PARTIAL)));
+                  BaseInjectExpectation.EXPECTATION_STATUS.PENDING)));
 
-      Widget widget =
+      Widget attempted =
           createWidgetWithDashboard(
               WidgetFixture.createExpectationStatusSeriesWidget(
                   ALL_TIME,
@@ -1155,43 +1180,65 @@ class DashboardApiTest extends IntegrationTest {
                       BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
                       BaseInjectExpectation.EXPECTATION_STATUS.FAILED,
                       BaseInjectExpectation.EXPECTATION_STATUS.PENDING)));
+      Widget resolvedOnly =
+          createWidgetWithDashboard(
+              WidgetFixture.createExpectationStatusSeriesWidget(
+                  ALL_TIME,
+                  "base_created_at",
+                  List.of(
+                      BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
+                      BaseInjectExpectation.EXPECTATION_STATUS.FAILED)));
 
       flushAndProcessElastic();
 
-      // What the tile renders: every bucket of every charted series.
-      String seriesResponse =
-          mvc.perform(
-                  post(DASHBOARD_URI + "/series/" + widget.getId())
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .content(asJsonString(new HashMap<String, String>()))
-                      .with(csrf()))
-              .andExpect(status().isOk())
-              .andReturn()
-              .getResponse()
-              .getContentAsString();
-      List<Integer> bucketValues = JsonPath.read(seriesResponse, "$..data[*].value");
-      int tileTotal = bucketValues.stream().mapToInt(Integer::intValue).sum();
-      assertThat(tileTotal).isEqualTo(5);
+      // Every attempted validation: the tile counts 5 and the list must hold those same 5.
+      assertThat(tileTotal(attempted)).isEqualTo(5);
+      assertThatJson(
+              performWidgetEntitiesRuntimeRequest(attempted, seriesDrillDown(List.of(0, 1, 2))))
+          .node("es_entities.total")
+          .isEqualTo(tileTotal(attempted));
 
-      // What clicking it opens: the same documents, never more.
-      WidgetToEntitiesInput input = new WidgetToEntitiesInput();
-      input.setSeriesIndexes(List.of(0, 1, 2));
-      input.setParameters(new HashMap<>());
-      String drillDown = performWidgetEntitiesRuntimeRequest(widget, input);
-      assertThatJson(drillDown).node("es_entities.total").isEqualTo(tileTotal);
+      // Same data, fewer declared series: the drill-down stays bounded by them and drops
+      // the two pending expectations instead of returning everything.
+      assertThat(tileTotal(resolvedOnly)).isEqualTo(3);
+      assertThatJson(
+              performWidgetEntitiesRuntimeRequest(resolvedOnly, seriesDrillDown(List.of(0, 1))))
+          .node("es_entities.total")
+          .isEqualTo(tileTotal(resolvedOnly));
 
-      // The union really is a union: one series alone stays scoped to that series.
-      WidgetToEntitiesInput successOnly = new WidgetToEntitiesInput();
-      successOnly.setSeriesIndexes(List.of(0));
-      successOnly.setParameters(new HashMap<>());
-      assertThatJson(performWidgetEntitiesRuntimeRequest(widget, successOnly))
+      // A single index still scopes to that one series.
+      assertThatJson(performWidgetEntitiesRuntimeRequest(attempted, seriesDrillDown(List.of(0))))
           .node("es_entities.total")
           .isEqualTo(1);
     }
 
+    /**
+     * The flat per-key union that collapses a multi-series OR is only equivalent to it when the
+     * series diverge on exactly one key. Here they diverge on two (and the second series' types are
+     * a subset of the first's, so the union of that key does not even grow), which would admit a
+     * DETECTION/FAILED document matching neither series - reject instead of over-counting.
+     */
+    @Test
+    @DisplayName("Given series diverging on two keys, drilling them together is rejected")
+    void given_seriesDivergingOnTwoKeys_should_rejectTheDrillDown() throws Exception {
+      Widget widget =
+          createWidgetWithDashboard(
+              WidgetFixture.createDivergentSeriesWidget(ALL_TIME, "base_created_at"));
+
+      flushAndProcessElastic();
+
+      mvc.perform(
+              post(DASHBOARD_URI + "/entities-runtime/" + widget.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(seriesDrillDown(List.of(0, 1))))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
     @Test
     @DisplayName(
-        "Given security domain widget should return list of expectation filtered by domain, type and status")
+        "Given security domain widget should return list of expectation filtered by domain, type"
+            + " and status")
     void given_securityDomainWidget_should_returnListOfExpectationFilteredByDomain()
         throws Exception {
       Domain networkDomain = createDomain("Network-test", "red");

--- a/openaev-api/src/test/java/io/openaev/rest/dashboard/DashboardApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/dashboard/DashboardApiTest.java
@@ -1235,6 +1235,100 @@ class DashboardApiTest extends IntegrationTest {
           .andExpect(status().isBadRequest());
     }
 
+    /**
+     * The series indexes travel as client-controlled URL parameters, so one the widget does not
+     * declare has to answer 400 - even alongside valid indexes, since silently dropping it would
+     * detach the drilled list from the number the caller believes it is expanding. Resolving to an
+     * empty series instead would carry a null filter list - Lombok drops the initializer under
+     * {@code @Builder.Default}, which is why {@link io.openaev.database.model.Filters} null-guards
+     * it everywhere - and surface as an opaque 500.
+     */
+    @Test
+    @DisplayName("Given a series index the widget does not declare, the drill-down is rejected")
+    void given_unknownSeriesIndex_should_rejectTheDrillDown() throws Exception {
+      Widget widget =
+          createWidgetWithDashboard(
+              WidgetFixture.createExpectationStatusSeriesWidget(
+                  ALL_TIME,
+                  "base_created_at",
+                  List.of(BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS)));
+
+      flushAndProcessElastic();
+
+      mvc.perform(
+              post(DASHBOARD_URI + "/entities-runtime/" + widget.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(seriesDrillDown(List.of(99))))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+
+      // A valid index does not excuse an unknown one riding along with it.
+      mvc.perform(
+              post(DASHBOARD_URI + "/entities-runtime/" + widget.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(seriesDrillDown(List.of(0, 99))))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * The per-key value union that collapses a multi-series OR presumes both series select
+     * documents the same way on that key. Series using different operators (here eq vs not_eq on
+     * the same status values) have no such collapse - the merged filter would keep one operator and
+     * mean something neither series said - so the drill-down must reject the shape.
+     */
+    @Test
+    @DisplayName("Given series using different operators on a key, drilling them is rejected")
+    void given_seriesWithDifferentOperators_should_rejectTheDrillDown() throws Exception {
+      Widget widget =
+          createWidgetWithDashboard(
+              WidgetFixture.createStatusSeriesWidgetWithOperators(
+                  ALL_TIME,
+                  "base_created_at",
+                  Filters.FilterOperator.eq,
+                  List.of(BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS.name()),
+                  Filters.FilterOperator.not_eq,
+                  List.of(BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS.name())));
+
+      flushAndProcessElastic();
+
+      mvc.perform(
+              post(DASHBOARD_URI + "/entities-runtime/" + widget.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(seriesDrillDown(List.of(0, 1))))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * Negated operators never union soundly: the engine turns every not_eq value into a must-not
+     * clause - a conjunction of exclusions - so {@code NOT SUCCESS} unioned with {@code NOT FAILED}
+     * would exclude both statuses when the OR of the series excludes neither everywhere. The
+     * drill-down must reject the divergence instead of quietly narrowing the list.
+     */
+    @Test
+    @DisplayName("Given series diverging under a negated operator, drilling them is rejected")
+    void given_seriesDivergingUnderNegatedOperator_should_rejectTheDrillDown() throws Exception {
+      Widget widget =
+          createWidgetWithDashboard(
+              WidgetFixture.createStatusSeriesWidgetWithOperators(
+                  ALL_TIME,
+                  "base_created_at",
+                  Filters.FilterOperator.not_eq,
+                  List.of(BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS.name()),
+                  Filters.FilterOperator.not_eq,
+                  List.of(BaseInjectExpectation.EXPECTATION_STATUS.FAILED.name())));
+
+      flushAndProcessElastic();
+
+      mvc.perform(
+              post(DASHBOARD_URI + "/entities-runtime/" + widget.getId())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(seriesDrillDown(List.of(0, 1))))
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
+    }
+
     @Test
     @DisplayName(
         "Given security domain widget should return list of expectation filtered by domain, type"

--- a/openaev-api/src/test/java/io/openaev/rest/dashboard/DashboardApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/dashboard/DashboardApiTest.java
@@ -1110,6 +1110,85 @@ class DashboardApiTest extends IntegrationTest {
       assertThatJson(response).node("es_entities.total").isEqualTo(6);
     }
 
+    /**
+     * Guards the invariant behind #7079: a tile's number and the list you reach by clicking it must
+     * describe the same documents. The command center's ADVERSARY node totals several series at
+     * once, which a single {@code series_index} cannot express - the drill-down used to restate the
+     * scope as literal status values instead, and silently drifted from the widget definition
+     * (showing 747 while the list returned 795 in production). Naming the aggregated series makes
+     * the two read one definition, so this asserts the sum of the charted series equals the drilled
+     * total, with an unrelated status present to prove the scope is not simply "everything".
+     */
+    @Test
+    @DisplayName("Given a total spanning several series, drilling it returns exactly that total")
+    void given_totalSpanningSeveralSeries_should_returnExactlyThatTotal() throws Exception {
+      createTechnicalInject(
+          null,
+          null,
+          List.of(
+              createExpectationComposer(
+                  BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION,
+                  BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS),
+              createExpectationComposer(
+                  BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION,
+                  BaseInjectExpectation.EXPECTATION_STATUS.FAILED),
+              createExpectationComposer(
+                  BaseInjectExpectation.EXPECTATION_TYPE.DETECTION,
+                  BaseInjectExpectation.EXPECTATION_STATUS.FAILED),
+              createExpectationComposer(
+                  BaseInjectExpectation.EXPECTATION_TYPE.DETECTION,
+                  BaseInjectExpectation.EXPECTATION_STATUS.PENDING),
+              createExpectationComposer(
+                  BaseInjectExpectation.EXPECTATION_TYPE.DETECTION,
+                  BaseInjectExpectation.EXPECTATION_STATUS.PENDING),
+              // charted by no series: it must land in neither the tile nor the list
+              createExpectationComposer(
+                  BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION,
+                  BaseInjectExpectation.EXPECTATION_STATUS.PARTIAL)));
+
+      Widget widget =
+          createWidgetWithDashboard(
+              WidgetFixture.createExpectationStatusSeriesWidget(
+                  ALL_TIME,
+                  "base_created_at",
+                  List.of(
+                      BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS,
+                      BaseInjectExpectation.EXPECTATION_STATUS.FAILED,
+                      BaseInjectExpectation.EXPECTATION_STATUS.PENDING)));
+
+      flushAndProcessElastic();
+
+      // What the tile renders: every bucket of every charted series.
+      String seriesResponse =
+          mvc.perform(
+                  post(DASHBOARD_URI + "/series/" + widget.getId())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(new HashMap<String, String>()))
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      List<Integer> bucketValues = JsonPath.read(seriesResponse, "$..data[*].value");
+      int tileTotal = bucketValues.stream().mapToInt(Integer::intValue).sum();
+      assertThat(tileTotal).isEqualTo(5);
+
+      // What clicking it opens: the same documents, never more.
+      WidgetToEntitiesInput input = new WidgetToEntitiesInput();
+      input.setSeriesIndexes(List.of(0, 1, 2));
+      input.setParameters(new HashMap<>());
+      String drillDown = performWidgetEntitiesRuntimeRequest(widget, input);
+      assertThatJson(drillDown).node("es_entities.total").isEqualTo(tileTotal);
+
+      // The union really is a union: one series alone stays scoped to that series.
+      WidgetToEntitiesInput successOnly = new WidgetToEntitiesInput();
+      successOnly.setSeriesIndexes(List.of(0));
+      successOnly.setParameters(new HashMap<>());
+      assertThatJson(performWidgetEntitiesRuntimeRequest(widget, successOnly))
+          .node("es_entities.total")
+          .isEqualTo(1);
+    }
+
     @Test
     @DisplayName(
         "Given security domain widget should return list of expectation filtered by domain, type and status")

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/WidgetFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/WidgetFixture.java
@@ -205,6 +205,64 @@ public class WidgetFixture {
     return widget;
   }
 
+  /**
+   * Two series diverging on two keys at once, the second series' type values being a strict subset
+   * of the first's. Their OR cannot be collapsed into a flat per-key union: {@code type IN (P, D)
+   * AND status IN (SUCCESS, FAILED)} admits a DETECTION/FAILED document that matches neither
+   * series, so a multi-series drill-down must reject this shape rather than over-count it.
+   */
+  public static Widget createDivergentSeriesWidget(
+      CustomDashboardTimeRange timeRange, String dateAttribute) {
+    Widget widget = new Widget();
+    widget.setType(DONUT);
+    StructuralHistogramWidget widgetConfig = new StructuralHistogramWidget();
+    widgetConfig.setSeries(
+        List.of(
+            createExpectationSerie(
+                List.of(
+                    BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION.name(),
+                    BaseInjectExpectation.EXPECTATION_TYPE.DETECTION.name()),
+                BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS.name()),
+            createExpectationSerie(
+                List.of(BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION.name()),
+                BaseInjectExpectation.EXPECTATION_STATUS.FAILED.name())));
+    widgetConfig.setTitle(NAME);
+    widgetConfig.setField("inject_expectation_type");
+    widgetConfig.setDateAttribute(dateAttribute);
+    widgetConfig.setTimeRange(timeRange);
+    widget.setWidgetConfiguration(widgetConfig);
+    widget.setLayout(new WidgetLayout());
+    return widget;
+  }
+
+  private static WidgetConfigurationWithSeries.Series createExpectationSerie(
+      List<String> types, String status) {
+    WidgetConfigurationWithSeries.Series series = new WidgetConfigurationWithSeries.Series();
+    series.setName(status);
+    Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+    filterGroup.setMode(Filters.FilterMode.and);
+    filterGroup.setFilters(
+        new ArrayList<>(
+            List.of(
+                createFilter(
+                    "base_entity",
+                    Filters.FilterMode.or,
+                    Filters.FilterOperator.eq,
+                    List.of("expectation-inject")),
+                createFilter(
+                    "inject_expectation_type",
+                    Filters.FilterMode.or,
+                    Filters.FilterOperator.eq,
+                    types),
+                createFilter(
+                    "inject_expectation_status",
+                    Filters.FilterMode.or,
+                    Filters.FilterOperator.eq,
+                    List.of(status)))));
+    series.setFilter(filterGroup);
+    return series;
+  }
+
   public static Widget createStructuralWidgetWithTimeRange(
       CustomDashboardTimeRange timeRange, String dateAttribute, String field, String entityName) {
     Widget widget = new Widget();

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/WidgetFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/WidgetFixture.java
@@ -235,6 +235,56 @@ public class WidgetFixture {
     return widget;
   }
 
+  /**
+   * Two series over the same entity whose status filters agree on keys yet select documents
+   * differently - each with the given operator and values. A per-key value union of such series
+   * means something neither of them said (and negated operators combine their values as must-not
+   * clauses, so a union narrows instead of widening), so a multi-series drill-down must reject the
+   * shape rather than collapse it.
+   */
+  public static Widget createStatusSeriesWidgetWithOperators(
+      CustomDashboardTimeRange timeRange,
+      String dateAttribute,
+      Filters.FilterOperator firstOperator,
+      List<String> firstValues,
+      Filters.FilterOperator secondOperator,
+      List<String> secondValues) {
+    Widget widget = new Widget();
+    widget.setType(DONUT);
+    StructuralHistogramWidget widgetConfig = new StructuralHistogramWidget();
+    widgetConfig.setSeries(
+        List.of(
+            createStatusOperatorSerie(firstOperator, firstValues),
+            createStatusOperatorSerie(secondOperator, secondValues)));
+    widgetConfig.setTitle(NAME);
+    widgetConfig.setField("inject_expectation_type");
+    widgetConfig.setDateAttribute(dateAttribute);
+    widgetConfig.setTimeRange(timeRange);
+    widget.setWidgetConfiguration(widgetConfig);
+    widget.setLayout(new WidgetLayout());
+    return widget;
+  }
+
+  private static WidgetConfigurationWithSeries.Series createStatusOperatorSerie(
+      Filters.FilterOperator operator, List<String> values) {
+    WidgetConfigurationWithSeries.Series series = new WidgetConfigurationWithSeries.Series();
+    series.setName(operator.name());
+    Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+    filterGroup.setMode(Filters.FilterMode.and);
+    filterGroup.setFilters(
+        new ArrayList<>(
+            List.of(
+                createFilter(
+                    "base_entity",
+                    Filters.FilterMode.or,
+                    Filters.FilterOperator.eq,
+                    List.of("expectation-inject")),
+                createFilter(
+                    "inject_expectation_status", Filters.FilterMode.or, operator, values))));
+    series.setFilter(filterGroup);
+    return series;
+  }
+
   private static WidgetConfigurationWithSeries.Series createExpectationSerie(
       List<String> types, String status) {
     WidgetConfigurationWithSeries.Series series = new WidgetConfigurationWithSeries.Series();

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/WidgetFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/WidgetFixture.java
@@ -156,6 +156,55 @@ public class WidgetFixture {
     return widget;
   }
 
+  /**
+   * Mirrors the platform default "Exposure command center": one series per expectation status over
+   * the same entity, aggregated by expectation type. Widgets shaped like this display a total that
+   * spans several series, which is the case a single {@code series_index} cannot describe.
+   *
+   * @param statuses one series per status, in the order the drill-downs will address them
+   */
+  public static Widget createExpectationStatusSeriesWidget(
+      CustomDashboardTimeRange timeRange,
+      String dateAttribute,
+      List<BaseInjectExpectation.EXPECTATION_STATUS> statuses) {
+    Widget widget = new Widget();
+    widget.setType(DONUT);
+    StructuralHistogramWidget widgetConfig = new StructuralHistogramWidget();
+    widgetConfig.setSeries(
+        statuses.stream()
+            .map(
+                status -> {
+                  WidgetConfigurationWithSeries.Series series =
+                      new WidgetConfigurationWithSeries.Series();
+                  series.setName(status.name());
+                  Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+                  filterGroup.setMode(Filters.FilterMode.and);
+                  filterGroup.setFilters(
+                      new ArrayList<>(
+                          List.of(
+                              createFilter(
+                                  "base_entity",
+                                  Filters.FilterMode.or,
+                                  Filters.FilterOperator.eq,
+                                  List.of("expectation-inject")),
+                              createFilter(
+                                  "inject_expectation_status",
+                                  Filters.FilterMode.or,
+                                  Filters.FilterOperator.eq,
+                                  List.of(status.name())))));
+                  series.setFilter(filterGroup);
+                  return series;
+                })
+            .toList());
+    widgetConfig.setTitle(NAME);
+    widgetConfig.setField("inject_expectation_type");
+    widgetConfig.setDateAttribute(dateAttribute);
+    widgetConfig.setTimeRange(timeRange);
+    widget.setWidgetConfiguration(widgetConfig);
+    widget.setLayout(new WidgetLayout());
+    return widget;
+  }
+
   public static Widget createStructuralWidgetWithTimeRange(
       CustomDashboardTimeRange timeRange, String dateAttribute, String field, String entityName) {
     Widget widget = new Widget();

--- a/openaev-front/src/admin/components/default_dashboard/DefaultHomeDashboard.tsx
+++ b/openaev-front/src/admin/components/default_dashboard/DefaultHomeDashboard.tsx
@@ -107,6 +107,9 @@ const DefaultHomeDashboard = () => {
     const params = new URLSearchParams();
     params.set('widget_id', conf.widgetId);
     params.set('series_index', (conf.series_index ?? '').toString());
+    // Totals spanning several series carry every contributing index, so the
+    // drilled list resolves to exactly the documents the tile counted.
+    (conf.series_indexes ?? []).forEach(index => params.append('series_indexes', index.toString()));
     if (conf.filter_values_map) {
       // One URL param per value: comma-joining would corrupt values containing commas,
       // and empty arrays must not produce an empty-string filter value.

--- a/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
+++ b/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
@@ -173,12 +173,23 @@ const successFailedSeries = (extra: Filter[] = []): Series[] => [
   series('FAILED', ...expectation([filter('inject_expectation_status', ['FAILED']), ...extra])),
 ];
 
+/**
+ * SUCCESS / FAILED / PENDING, in that order - the command center's ADVERSARY node
+ * counts every attempted validation, so the still-unscored ones must be part of the
+ * widget rather than reconstructed at click time. The index order is contractual:
+ * the drill-downs name the series they aggregated (see CommandCenterWidget).
+ */
+const attemptedSeries = (): Series[] => [
+  ...successFailedSeries(),
+  series('PENDING', ...expectation([filter('inject_expectation_status', ['PENDING'])])),
+];
+
 export const buildDefaultHomeWidgets = (timeRange: DefaultTimeRange, t: Translate = key => key): Widget[] => [
   // -- HERO: exposure command center --
   widget(
     'default-command-center',
     'command-center',
-    structural(t('Exposure command center'), 'inject_expectation_type', successFailedSeries(), timeRange),
+    structural(t('Exposure command center'), 'inject_expectation_type', attemptedSeries(), timeRange),
     layout(0, 0, 12, 6),
   ),
 

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/CustomDashboardWrapper.tsx
@@ -108,6 +108,9 @@ const CustomDashboardWrapper = ({
     const params = new URLSearchParams();
     params.set('widget_id', conf.widgetId);
     params.set('series_index', (conf.series_index ?? '').toString());
+    // Totals spanning several series carry every contributing index, so the
+    // drilled list resolves to exactly the documents the tile counted.
+    (conf.series_indexes ?? []).forEach(index => params.append('series_indexes', index.toString()));
     const source = resultsSource ?? { source: 'workspace' as const };
     params.set('source', source.source);
     if (source.contextId) {

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/results/DashboardResults.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/results/DashboardResults.tsx
@@ -37,7 +37,9 @@ import ResultsExplorer from './ResultsExplorer';
  */
 type ResultsSourceType = 'default' | 'tenant' | 'workspace' | 'simulation' | 'scenario';
 
-const RESERVED_PARAMS = ['widget_id', 'series_index', 'source', 'context_id', 'dashboard_id', 'back'];
+// Every non-reserved param is read as a clicked filter value, so any new control
+// param MUST be listed here or it silently becomes a filter on a bogus field.
+const RESERVED_PARAMS = ['widget_id', 'series_index', 'series_indexes', 'source', 'context_id', 'dashboard_id', 'back'];
 const PARAM_PREFIX = 'param.';
 
 const NAMED_TIME_RANGES = new Set(['LAST_DAY', 'LAST_WEEK', 'LAST_MONTH', 'LAST_QUARTER', 'LAST_SEMESTER', 'LAST_YEAR']);
@@ -57,6 +59,12 @@ const DashboardResults = () => {
 
   const widgetId = searchParams.get('widget_id');
   const seriesIndex = Number(searchParams.get('series_index') ?? 0);
+  // A tile whose number spans several series names them all; the backend ORs their
+  // filters so the list matches the total exactly instead of a single series.
+  const seriesIndexes = useMemo(
+    () => searchParams.getAll('series_indexes').map(Number).filter(index => Number.isInteger(index)),
+    [searchParams],
+  );
   const source = (searchParams.get('source') ?? 'default') as ResultsSourceType;
   const contextId = searchParams.get('context_id');
   // Internal path only: the back target always comes from our own navigation.
@@ -206,6 +214,7 @@ const DashboardResults = () => {
     const input: WidgetToEntitiesInput = {
       filter_values_map: filterValues,
       series_index: seriesIndex,
+      ...(seriesIndexes.length > 0 ? { series_indexes: seriesIndexes } : {}),
       parameters,
       pagination: {
         page: 0,
@@ -245,7 +254,7 @@ const DashboardResults = () => {
     return () => {
       cancelled = true;
     };
-  }, [source, contextId, widgetId, defaultWidget, contextualWidget, filterValues, seriesIndex, parameters]);
+  }, [source, contextId, widgetId, defaultWidget, contextualWidget, filterValues, seriesIndex, seriesIndexes, parameters]);
 
   // The widget scope is implicitly time-bounded (its time_range is applied
   // server-side when resolving the drill-down). Materialize that bound as
@@ -343,7 +352,7 @@ const DashboardResults = () => {
       {!seedError && (resolvedListConfig == null || (needsDashboard && !dashboardResolved)) && <Loader variant="inElement" />}
       {!seedError && resolvedListConfig != null && (!needsDashboard || dashboardResolved) && (
         <ResultsExplorer
-          key={`${widgetId}-${seriesIndex}`}
+          key={`${widgetId}-${seriesIndex}-${seriesIndexes.join('.')}`}
           listConfig={resolvedListConfig}
           initialEntities={seed?.entities}
           seedDateFilters={seedDateFilters}

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/results/DashboardResults.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/results/DashboardResults.tsx
@@ -62,7 +62,11 @@ const DashboardResults = () => {
   // A tile whose number spans several series names them all; the backend ORs their
   // filters so the list matches the total exactly instead of a single series.
   const seriesIndexes = useMemo(
-    () => searchParams.getAll('series_indexes').map(Number).filter(index => Number.isInteger(index)),
+    () => searchParams.getAll('series_indexes')
+      // An empty value would coerce to 0 and silently drill the first series.
+      .filter(value => value !== '')
+      .map(Number)
+      .filter(index => Number.isInteger(index)),
     [searchParams],
   );
   const source = (searchParams.get('source') ?? 'default') as ResultsSourceType;

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/ResilienceGaugeWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/ResilienceGaugeWidget.tsx
@@ -18,9 +18,11 @@ interface Props {
 
 /**
  * The statuses the ring charts, and therefore the only ones its click-through may
- * drill into. Keeping one list for both is what stops the total and the drilled
- * list from disagreeing (#7079): UNKNOWN expectations - those with no expected
- * score - are charted by neither arc nor total, so they must not be listed here.
+ * drill into - reading one list for both is what keeps the total and the drilled
+ * list in agreement (#7079). UNKNOWN is deliberately absent: computeStatus only
+ * returns it for a null expected score, which the schema forbids since migration
+ * V3_36 made inject_expectation_expected_score NOT NULL, so drilling it widened
+ * the query for a status that cannot exist.
  */
 const RING_STATUSES = ['SUCCESS', 'FAILED', 'PENDING'];
 

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/ResilienceGaugeWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/ResilienceGaugeWidget.tsx
@@ -16,6 +16,14 @@ interface Props {
   datas: SerieData[];
 }
 
+/**
+ * The statuses the ring charts, and therefore the only ones its click-through may
+ * drill into. Keeping one list for both is what stops the total and the drilled
+ * list from disagreeing (#7079): UNKNOWN expectations - those with no expected
+ * score - are charted by neither arc nor total, so they must not be listed here.
+ */
+const RING_STATUSES = ['SUCCESS', 'FAILED', 'PENDING'];
+
 const SAMPLE = [
   {
     x: 'SUCCESS',
@@ -214,7 +222,7 @@ const ResilienceGaugeWidget: FunctionComponent<Props> = ({ widgetId, widgetConfi
           <svg
             className="noDrag"
             viewBox={`0 0 ${size} ${size}`}
-            onClick={() => investigate(['SUCCESS', 'FAILED', 'PENDING', 'UNKNOWN'])}
+            onClick={() => investigate(RING_STATUSES)}
             style={{
               maxHeight: '100%',
               maxWidth: '100%',

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/AttackFlow.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/AttackFlow.tsx
@@ -10,6 +10,8 @@ export interface DefenseLayer {
   key: string;
   success: number;
   failed: number;
+  /** Attempted but not yet scored: counted by the adversary, by no gate. */
+  pending: number;
 }
 
 interface Props {
@@ -120,7 +122,12 @@ const AttackFlow: FunctionComponent<Props> = ({ layers, breached, onInvestigate 
   const attackColor = theme.palette.error.main;
   const assetsColor = theme.palette.text.secondary;
 
-  const totalAttacks = layers.reduce((acc, l) => acc + l.success + l.failed, 0);
+  // The adversary fired everything, including what no gate has scored yet, so the
+  // node counts pending too. Gates and the breach node stay on resolved outcomes:
+  // the readout below therefore does not sum back to the adversary while a run is
+  // in flight, which is why the tooltip spells the split out.
+  const totalAttacks = layers.reduce((acc, l) => acc + l.success + l.failed + l.pending, 0);
+  const totalPending = layers.reduce((acc, l) => acc + l.pending, 0);
   const total = Math.max(totalAttacks, 1);
 
   const n = Math.max(layers.length, 1);
@@ -364,7 +371,11 @@ const AttackFlow: FunctionComponent<Props> = ({ layers, breached, onInvestigate 
               fontWeight: 600,
             }}
           >
-            <title>{totalAttacks.toLocaleString()}</title>
+            <title>
+              {totalPending > 0
+                ? `${totalAttacks.toLocaleString()} - ${t('Pending')}: ${totalPending.toLocaleString()}`
+                : totalAttacks.toLocaleString()}
+            </title>
             {compactNumber(totalAttacks)}
           </text>
           {/* click-through: every attempted validation */}

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/CommandCenterWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/CommandCenterWidget.tsx
@@ -20,16 +20,34 @@ interface Props {
   series: EsSeries[];
 }
 
+interface SeriesIndexes {
+  success: number;
+  failed: number;
+  pending: number;
+}
+
 /**
- * Series index contract, mirroring `attemptedSeries` in defaultHomeWidgets: the
- * drill-downs name the exact series they aggregated so the backend can OR their
- * filters, rather than re-stating the scope as literal status values that drift
- * from the widget definition.
+ * Resolves which series carries which outcome, by label with a fall back to the
+ * declaration order used by `attemptedSeries` in defaultHomeWidgets.
+ *
+ * The numbers and the drill-downs both read this single resolution. A command-center
+ * widget can also be built by hand (WidgetForm exposes the type) with its series in
+ * any order, so matching labels to render the tile while addressing series
+ * positionally to drill it would recreate exactly the drift this fixes. `-1` means
+ * the widget declares no such series.
  */
-const SERIES_SUCCESS = 0;
-const SERIES_FAILED = 1;
-const SERIES_PENDING = 2;
-const SERIES_ATTEMPTED = [SERIES_SUCCESS, SERIES_FAILED, SERIES_PENDING];
+const resolveSeriesIndexes = (series: EsSeries[]): SeriesIndexes => {
+  const byLabel = (needle: string, fallback: number) => {
+    const found = series.findIndex(s => (s.label ?? '').toUpperCase().includes(needle));
+    if (found >= 0) return found;
+    return fallback < series.length ? fallback : -1;
+  };
+  return {
+    success: byLabel('SUCCESS', 0),
+    failed: byLabel('FAIL', 1),
+    pending: byLabel('PENDING', 2),
+  };
+};
 
 interface DomainScore {
   key: string;
@@ -39,10 +57,10 @@ interface DomainScore {
   resilience: number;
 }
 
-const computeDomainScores = (series: EsSeries[]): DomainScore[] => {
-  const successSeries = series.find(s => (s.label ?? '').toUpperCase().includes('SUCCESS')) ?? series[SERIES_SUCCESS];
-  const failedSeries = series.find(s => (s.label ?? '').toUpperCase().includes('FAIL')) ?? series[SERIES_FAILED];
-  const pendingSeries = series.find(s => (s.label ?? '').toUpperCase().includes('PENDING')) ?? series[SERIES_PENDING];
+const computeDomainScores = (series: EsSeries[], indexes: SeriesIndexes): DomainScore[] => {
+  const successSeries = series[indexes.success];
+  const failedSeries = series[indexes.failed];
+  const pendingSeries = series[indexes.pending];
   const byKey = new Map<string, {
     success: number;
     failed: number;
@@ -93,7 +111,12 @@ const CommandCenterWidget: FunctionComponent<Props> = ({ widgetId, series }) => 
   const isSample = isSeriesEmpty(series);
   const displaySeries = isSample ? sampleExposureSeries : series;
 
-  const domains = useMemo(() => computeDomainScores(displaySeries), [displaySeries]);
+  // Rendering may fall back to sample data, but a drill-down always queries the real
+  // widget - so the indexes it sends must be resolved against the real series.
+  const displayIndexes = useMemo(() => resolveSeriesIndexes(displaySeries), [displaySeries]);
+  const drillIndexes = useMemo(() => resolveSeriesIndexes(series), [series]);
+
+  const domains = useMemo(() => computeDomainScores(displaySeries, displayIndexes), [displaySeries, displayIndexes]);
 
   // Every expectation type present in the data becomes a defense gate, in
   // attack-lifecycle order (exploit the vulnerability, then prevention blocks,
@@ -183,11 +206,12 @@ const CommandCenterWidget: FunctionComponent<Props> = ({ widgetId, series }) => 
   // filters: the list is then the widget's own definition of the number, so the
   // two cannot drift when the series change (#7079).
   const onInvestigate = (typeKey: string) => {
+    const declared = (...indexes: number[]) => indexes.filter(index => index >= 0);
     // breached assets: every failed validation, regardless of type
     if (typeKey === 'breach') {
       openWidgetResults({
         widgetId,
-        series_indexes: [SERIES_FAILED],
+        series_indexes: declared(drillIndexes.failed),
       });
       return;
     }
@@ -195,14 +219,14 @@ const CommandCenterWidget: FunctionComponent<Props> = ({ widgetId, series }) => 
     if (typeKey === 'all') {
       openWidgetResults({
         widgetId,
-        series_indexes: SERIES_ATTEMPTED,
+        series_indexes: declared(drillIndexes.success, drillIndexes.failed, drillIndexes.pending),
       });
       return;
     }
     openWidgetResults({
       widgetId,
       filter_values_map: { inject_expectation_type: [typeKey.toUpperCase()] },
-      series_indexes: [SERIES_SUCCESS],
+      series_indexes: declared(drillIndexes.success),
     });
   };
 

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/CommandCenterWidget.tsx
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/command_center/CommandCenterWidget.tsx
@@ -20,26 +20,41 @@ interface Props {
   series: EsSeries[];
 }
 
+/**
+ * Series index contract, mirroring `attemptedSeries` in defaultHomeWidgets: the
+ * drill-downs name the exact series they aggregated so the backend can OR their
+ * filters, rather than re-stating the scope as literal status values that drift
+ * from the widget definition.
+ */
+const SERIES_SUCCESS = 0;
+const SERIES_FAILED = 1;
+const SERIES_PENDING = 2;
+const SERIES_ATTEMPTED = [SERIES_SUCCESS, SERIES_FAILED, SERIES_PENDING];
+
 interface DomainScore {
   key: string;
   success: number;
   failed: number;
+  pending: number;
   resilience: number;
 }
 
 const computeDomainScores = (series: EsSeries[]): DomainScore[] => {
-  const successSeries = series.find(s => (s.label ?? '').toUpperCase().includes('SUCCESS')) ?? series[0];
-  const failedSeries = series.find(s => (s.label ?? '').toUpperCase().includes('FAIL')) ?? series[1];
+  const successSeries = series.find(s => (s.label ?? '').toUpperCase().includes('SUCCESS')) ?? series[SERIES_SUCCESS];
+  const failedSeries = series.find(s => (s.label ?? '').toUpperCase().includes('FAIL')) ?? series[SERIES_FAILED];
+  const pendingSeries = series.find(s => (s.label ?? '').toUpperCase().includes('PENDING')) ?? series[SERIES_PENDING];
   const byKey = new Map<string, {
     success: number;
     failed: number;
+    pending: number;
   }>();
-  const accumulate = (data: EsSeries['data'], field: 'success' | 'failed') => {
+  const accumulate = (data: EsSeries['data'], field: 'success' | 'failed' | 'pending') => {
     (data ?? []).forEach((d) => {
       if (!d.label) return;
       const entry = byKey.get(d.label) ?? {
         success: 0,
         failed: 0,
+        pending: 0,
       };
       entry[field] += d.value ?? 0;
       byKey.set(d.label, entry);
@@ -47,10 +62,14 @@ const computeDomainScores = (series: EsSeries[]): DomainScore[] => {
   };
   accumulate(successSeries?.data, 'success');
   accumulate(failedSeries?.data, 'failed');
+  accumulate(pendingSeries?.data, 'pending');
   return [...byKey.entries()].map(([key, v]) => ({
     key,
     success: v.success,
     failed: v.failed,
+    pending: v.pending,
+    // Resilience only ever weighs resolved outcomes: a pending expectation has no
+    // verdict to score, and counting it would drag every gate rate towards zero.
     resilience: v.success + v.failed > 0 ? Math.round((v.success / (v.success + v.failed)) * 100) : 0,
   }));
 };
@@ -91,6 +110,7 @@ const CommandCenterWidget: FunctionComponent<Props> = ({ widgetId, series }) => 
         key: d.key,
         success: d.success,
         failed: d.failed,
+        pending: d.pending,
       }));
   }, [domains]);
 
@@ -98,10 +118,12 @@ const CommandCenterWidget: FunctionComponent<Props> = ({ widgetId, series }) => 
     (acc, d) => ({
       success: acc.success + d.success,
       failed: acc.failed + d.failed,
+      pending: acc.pending + d.pending,
     }),
     {
       success: 0,
       failed: 0,
+      pending: 0,
     },
   ), [domains]);
 
@@ -157,29 +179,30 @@ const CommandCenterWidget: FunctionComponent<Props> = ({ widgetId, series }) => 
     ];
   }, [securityPlatforms, theme.palette.mode]);
 
+  // Every drill-down names the series it aggregated instead of restating their
+  // filters: the list is then the widget's own definition of the number, so the
+  // two cannot drift when the series change (#7079).
   const onInvestigate = (typeKey: string) => {
     // breached assets: every failed validation, regardless of type
     if (typeKey === 'breach') {
       openWidgetResults({
         widgetId,
-        filter_values_map: { inject_expectation_type: layers.map(l => l.key.toUpperCase()) },
-        series_index: 1,
+        series_indexes: [SERIES_FAILED],
       });
       return;
     }
-    // adversary: every attempted validation (statuses override the series filter)
+    // adversary: every attempted validation, resolved or still pending
     if (typeKey === 'all') {
       openWidgetResults({
         widgetId,
-        filter_values_map: { inject_expectation_status: ['SUCCESS', 'FAILED', 'PENDING'] },
-        series_index: 0,
+        series_indexes: SERIES_ATTEMPTED,
       });
       return;
     }
     openWidgetResults({
       widgetId,
       filter_values_map: { inject_expectation_type: [typeKey.toUpperCase()] },
-      series_index: 0,
+      series_indexes: [SERIES_SUCCESS],
     });
   };
 

--- a/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/sample/sampleData.ts
+++ b/openaev-front/src/admin/components/workspaces/custom_dashboards/widgets/viz/sample/sampleData.ts
@@ -160,6 +160,14 @@ export const sampleExposureSeries: EsSeries[] = [
       bucket('VULNERABILITY', 17),
     ],
   },
+  {
+    label: 'PENDING',
+    data: [
+      bucket('PREVENTION', 6),
+      bucket('DETECTION', 9),
+      bucket('VULNERABILITY', 4),
+    ],
+  },
 ];
 
 // -- POSTURE RADAR (2 series SUCCESS / FAILED over a structural field) --

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -35,6 +35,8 @@ export interface AdHocWidgetToEntitiesInput {
    * @format int32
    */
   series_index?: number;
+  /** The indexes of every series that produced the clicked number, ORed together. Takes precedence over series_index; use it whenever a widget displays a total spanning several series, so the drilled list resolves to exactly the documents that were counted */
+  series_indexes?: number[];
   widget_config:
     | AverageConfiguration
     | DateHistogramWidget
@@ -11374,6 +11376,8 @@ export interface WidgetToEntitiesInput {
    * @format int32
    */
   series_index?: number;
+  /** The indexes of every series that produced the clicked number, ORed together. Takes precedence over series_index; use it whenever a widget displays a total spanning several series, so the drilled list resolves to exactly the documents that were counted */
+  series_indexes?: number[];
 }
 
 export interface WidgetToEntitiesOutput {


### PR DESCRIPTION
Closes #7079

## Summary

The exposure command center's ADVERSARY node showed **747** while clicking it opened a list of **795**. Both numbers came from the same Elasticsearch index over the same 90-day window: the tile summed its SUCCESS and FAILED series, and the click handler rebuilt the scope by hand as `['SUCCESS', 'FAILED', 'PENDING']`. The gap was exactly the pending bucket.

This is presentation-only. It was verified in production that Elasticsearch and PostgreSQL agree exactly on a settled window (466 FAILED / 269 SUCCESS / 735 total on each side), so the recent stats-accuracy work is unaffected.

## Why it happened, and why the fix is not a shorter status list

`WidgetToEntitiesInput.seriesIndex` is a single `Integer`, so a drill-down could only ever name one series. Any tile whose number spans several series therefore had to restate its scope through `filter_values_map` - and `WidgetUtils.setOrAddFilterByKey` *replaces* a series' own filter values rather than intersecting them, so that reconstruction was free to widen past what was counted. Two independent expressions of the same scope, with nothing keeping them in step.

Correcting the status list would have fixed this instance and left the next one waiting, so the reconstruction is removed instead: a drill-down now names every series that produced the number, and the backend ORs their filters. The scope has a single definition - the widget's own `series` - so the tile and the list cannot drift apart when the series change.

## Changes

**Backend**

- `WidgetToEntitiesInput` gains `series_indexes` (additive; `series_index` still works, and `resolvedSeriesIndexes()` collapses both onto one shape).
- `WidgetService.convertWidgetToListConfiguration` accepts several indexes and merges their filters. `FilterGroup` is flat with no nesting, so a literal `(E AND s=X) OR (E AND s=Y)` cannot be represented - it does not need to be, because the series of one widget differ by a single discriminating key and the OR collapses onto `E AND s IN (X, Y)`. Series diverging on more than one key are rejected rather than silently over-counted, and divergence is a per-key set comparison so a series whose values are a subset of another's still counts as diverging.
- The security coverage drill-down no longer hand-rebuilds its status scope either; it names its two series like every other drill-down.
- Series filters are deep-copied before the drill-down mutates them, so a persisted widget configuration is no longer modified in place.

**Frontend**

- The command center declares a PENDING series, so "every attempted validation" is part of the widget definition rather than reconstructed at click time. The ADVERSARY node counts it; gates and BREACHED stay on resolved outcomes, since a pending expectation has no verdict to attribute. A tooltip spells the split out, because the readout no longer sums back to the adversary while a run is in flight.
- Which series carries which outcome is resolved once, by label, and fed to both the tile and its drill-downs. `command-center` is a user-creatable widget type, so a hand-built widget may declare its series in any order - matching labels to render the tile while addressing series positionally to drill it would have recreated the same class of drift.
- The resilience gauge's ring and its click-through now read one status list. `UNKNOWN` is dropped: `computeStatus` returns it only for a null expected score, which migration `V3_36` forbids, so drilling it only ever widened the query for a status that cannot exist.
- `series_indexes` is plumbed through both dashboard surfaces and added to `RESERVED_PARAMS` - every non-reserved URL param is read as a filter value, so omitting it would have turned it into a filter on a bogus field.

**Tests**

- `DashboardApiTest` asserts that the sum of a widget's charted series equals the total returned by drilling it. The same data is charted by a second, resolved-only widget to show the drilled list follows the declared series instead of returning everything.
- A second test covers the rejection path: two series diverging on two keys, the second's type values a strict subset of the first's, must be refused rather than collapsed into a union that would admit documents matching neither series.

## Notes

Only SUCCESS, FAILED and PENDING are reachable statuses. `computeStatus` maps a below-target score to FAILED and never returns PARTIAL, and it returns UNKNOWN only for a null expected score, which migration `V3_36` forbids by making `inject_expectation_expected_score` NOT NULL.

## Test plan

- [x] `yarn check-ts` and `yarn lint`
- [x] Java formatting verified with google-java-format 1.24.0 (the version spotless pins) under JDK 21 - every changed file is format-clean
- [x] Backend build, spotless and API tests via CI
- [ ] Manually verify on a tenant with pending expectations that the ADVERSARY number equals the drill-down total, and that BREACHED still equals the failed count
- [ ] Verify the Prevention / Detection / Vulnerability gauge rings match their drill-down totals
- [ ] Verify the MITRE detection coverage matrix drill-down still lists the same expectations
