### PR TITLE
fix(chaining): payload steps without a condition mapper only ran once for a single asset

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -113,16 +113,6 @@ public class StepService {
     Step persistedTemplate =
         findByIdAndStatus(nextStepTemplateToExecute.getId(), StepStatus.TEMPLATE);
 
-    // NOTE: a step template with no condition mapper and a payload used to be short-circuited here
-    // after its first execution, to avoid re-creating the same non-mapper batch on every scheduling
-    // cycle. That guard predates per-target expansion and is now redundant: expandTargetBatches
-    // (see below) expands every INJECT_EXECUTION step — payload or not — into one batch per scope
-    // target, and the per-target hash dedup a few lines down (committedTargetHashes/commitHashes)
-    // already prevents an already-executed (combo, target) pair from being re-created. Keeping
-    // the old template-level guard here caused a regression: a payload step without a mapper
-    // condition would only ever execute once for a single asset and be silently skipped for every
-    // other asset in scope, while sibling injector-contract steps (hasPayload() == false) kept
-    // expanding correctly.
 
     ActionStep actionStep =
         factoryAction(persistedTemplate.getStepAction(), persistedTemplate.getId());

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -113,13 +113,15 @@ public class StepService {
     Step persistedTemplate =
         findByIdAndStatus(nextStepTemplateToExecute.getId(), StepStatus.TEMPLATE);
 
-    // If no condition mapper and step already executed, we skip the step to avoid to execute it
-    // again
-    if (!conditionService.hasConditionMapper(persistedTemplate)
-        && isStepAlreadyExecutedOnce(persistedTemplate.getId(), workflowRun.getId())
-        && injectExecutionStep.hasPayload(persistedTemplate)) {
-      return List.of();
-    }
+    // NOTE: a step template with no condition mapper and a payload used to be short-circuited here
+    // after its first execution, to avoid re-creating the same non-mapper batch on every scheduling
+    // cycle. That guard predates per-target expansion and is now redundant: expandTargetBatches (see
+    // below) expands every INJECT_EXECUTION step — payload or not — into one batch per scope target,
+    // and the per-target hash dedup a few lines down (committedTargetHashes/commitHashes) already
+    // prevents an already-executed (combo, target) pair from being re-created. Keeping the old
+    // template-level guard here caused a regression: a payload step without a mapper condition would
+    // only ever execute once for a single asset and be silently skipped for every other asset in
+    // scope, while sibling injector-contract steps (hasPayload() == false) kept expanding correctly.
 
     ActionStep actionStep =
         factoryAction(persistedTemplate.getStepAction(), persistedTemplate.getId());
@@ -272,18 +274,6 @@ public class StepService {
    */
   public long countActiveSteps(String workflowRunId) {
     return stepRepository.countActiveSteps(workflowRunId, ACTIVE_STEP_STATUS);
-  }
-
-  /**
-   * Returns {@code true} if at least one executed step references the given step template, meaning
-   * this template has already been executed at least once in the given workflow run.
-   *
-   * @param stepTemplateId the ID of the step template to check
-   * @param workflowRunId the ID of the workflow run to scope the check
-   * @return {@code true} if the step template has been executed at least once in that run
-   */
-  public boolean isStepAlreadyExecutedOnce(String stepTemplateId, String workflowRunId) {
-    return stepRepository.existsByStepTemplateIdAndWorkflowId(stepTemplateId, workflowRunId);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -115,13 +115,14 @@ public class StepService {
 
     // NOTE: a step template with no condition mapper and a payload used to be short-circuited here
     // after its first execution, to avoid re-creating the same non-mapper batch on every scheduling
-    // cycle. That guard predates per-target expansion and is now redundant: expandTargetBatches (see
-    // below) expands every INJECT_EXECUTION step — payload or not — into one batch per scope target,
-    // and the per-target hash dedup a few lines down (committedTargetHashes/commitHashes) already
-    // prevents an already-executed (combo, target) pair from being re-created. Keeping the old
-    // template-level guard here caused a regression: a payload step without a mapper condition would
-    // only ever execute once for a single asset and be silently skipped for every other asset in
-    // scope, while sibling injector-contract steps (hasPayload() == false) kept expanding correctly.
+    // cycle. That guard predates per-target expansion and is now redundant: expandTargetBatches
+    // (see below) expands every INJECT_EXECUTION step — payload or not — into one batch per scope
+    // target, and the per-target hash dedup a few lines down (committedTargetHashes/commitHashes)
+    // already prevents an already-executed (combo, target) pair from being re-created. Keeping
+    // the old template-level guard here caused a regression: a payload step without a mapper
+    // condition would only ever execute once for a single asset and be silently skipped for every
+    // other asset in scope, while sibling injector-contract steps (hasPayload() == false) kept
+    // expanding correctly.
 
     ActionStep actionStep =
         factoryAction(persistedTemplate.getStepAction(), persistedTemplate.getId());

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -113,7 +113,6 @@ public class StepService {
     Step persistedTemplate =
         findByIdAndStatus(nextStepTemplateToExecute.getId(), StepStatus.TEMPLATE);
 
-
     ActionStep actionStep =
         factoryAction(persistedTemplate.getStepAction(), persistedTemplate.getId());
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -524,9 +524,8 @@ class StepServiceTest {
        * assets.
        */
       @Test
-      void
-          given_payloadStepWithNoMapperAlreadyExecutedOnce_should_stillCreateReadySteps_forRemainingAssets()
-              throws Exception {
+      void given_payloadStepAlreadyExecutedOnce_should_stillCreateReadySteps_forRemainingAssets()
+          throws Exception {
         // Arrange
         Step nextStepTemplateToExecute = mock(Step.class);
         Step persistedTemplate = mock(Step.class);

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -506,6 +506,99 @@ class StepServiceTest {
         verify(queueChainingService, never()).readyStep(any(), any());
       }
     }
+
+    @Nested
+    class PayloadStepMultiAssetExpansion {
+
+      /**
+       * Regression test for a bug where a payload-based step with no condition mapper (e.g. a root
+       * step, or a step gated only by a non-mapper condition such as DEPEND_ON) would only ever
+       * execute once — for a single scope asset — and be silently skipped for every other in-scope
+       * asset on subsequent scheduling cycles. Injector-contract steps (hasPayload() == false) were
+       * unaffected, which is exactly what was reported: contract steps correctly expanded per asset
+       * while sibling payload steps did not.
+       *
+       * <p>Per-target deduplication is owned by expandTargetBatches/getCommittedHashes further down
+       * in createReadySteps, so the fact that this step template already produced a READY step for
+       * one asset must not prevent it from being expanded again for the remaining, not-yet-executed
+       * assets.
+       */
+      @Test
+      void
+          given_payloadStepWithNoMapperAlreadyExecutedOnce_should_stillCreateReadySteps_forRemainingAssets()
+              throws Exception {
+        // Arrange
+        Step nextStepTemplateToExecute = mock(Step.class);
+        Step persistedTemplate = mock(Step.class);
+        Workflow workflowRun = mock(Workflow.class);
+        ActionStep localActionStep = mock(ActionStep.class);
+
+        String input = "{\"x\":1}";
+        String stepId = UUID.randomUUID().toString();
+        String workflowId = UUID.randomUUID().toString();
+
+        when(nextStepTemplateToExecute.getId()).thenReturn(stepId);
+        when(persistedTemplate.getId()).thenReturn(stepId);
+        when(persistedTemplate.getStepAction()).thenReturn(StepActionClass.INJECT_EXECUTION);
+        lenient().when(workflowRun.getId()).thenReturn(workflowId);
+        when(stepService.factoryAction(StepActionClass.INJECT_EXECUTION, stepId))
+            .thenReturn(localActionStep);
+        when(stepRepository.findByIdAndStatus(stepId, StepStatus.TEMPLATE))
+            .thenReturn(Optional.of(persistedTemplate));
+
+        // NOTE: this step is a payload step with no condition mapper that has already produced a
+        // READY step for a previous asset in an earlier scheduling cycle (i.e. exactly the
+        // combination that used to be permanently short-circuited by the removed
+        // "!hasConditionMapper && isStepAlreadyExecutedOnce && hasPayload" guard). These are
+        // stubbed leniently because the fixed createReadySteps no longer consults them at all —
+        // reverting the fix would make this test start invoking them (and start failing, since the
+        // old guard would then return an empty list instead of expanding the remaining assets).
+        lenient().when(conditionService.hasConditionMapper(persistedTemplate)).thenReturn(false);
+        lenient().when(injectExecutionStep.hasPayload(persistedTemplate)).thenReturn(true);
+        lenient()
+            .when(stepRepository.existsByStepTemplateIdAndWorkflowId(stepId, workflowId))
+            .thenReturn(true);
+
+        when(conditionService.checkCondition(persistedTemplate, workflowRun, input))
+            .thenReturn(List.of(new ConditionService.ExecutionBatch(input, List.of(), null)));
+
+        // expandTargetBatches fans the single combo out to the two remaining, not-yet-executed
+        // assets in scope.
+        ConditionService.ExecutionBatch assetTwoBatch =
+            new ConditionService.ExecutionBatch(input, List.of(), "combo:asset-2");
+        ConditionService.ExecutionBatch assetThreeBatch =
+            new ConditionService.ExecutionBatch(input, List.of(), "combo:asset-3");
+        when(injectExecutionStep.expandTargetBatches(any(), eq(workflowRun), eq(persistedTemplate)))
+            .thenReturn(List.of(assetTwoBatch, assetThreeBatch));
+        when(conditionService.getCommittedHashes(persistedTemplate, workflowRun))
+            .thenReturn(Set.of());
+
+        Step stepReadyTwo = mock(Step.class);
+        Step stepReadyThree = mock(Step.class);
+        when(localActionStep.ready(persistedTemplate, input, workflowRun))
+            .thenReturn(Optional.of(stepReadyTwo), Optional.of(stepReadyThree));
+        when(stepRepository.save(stepReadyTwo)).thenReturn(stepReadyTwo);
+        when(stepRepository.save(stepReadyThree)).thenReturn(stepReadyThree);
+
+        // Act
+        List<Step> result =
+            stepService.createReadySteps(nextStepTemplateToExecute, workflowRun, input, 0);
+
+        // Assert: the step must not be silently skipped — the remaining assets still get a READY
+        // step each.
+        assertEquals(2, result.size());
+        assertTrue(result.containsAll(List.of(stepReadyTwo, stepReadyThree)));
+
+        verify(conditionService).checkCondition(persistedTemplate, workflowRun, input);
+        verify(injectExecutionStep)
+            .expandTargetBatches(any(), eq(workflowRun), eq(persistedTemplate));
+        verify(conditionService)
+            .commitHashes(
+                eq(persistedTemplate),
+                eq(workflowRun),
+                eq(Set.of("combo:asset-2", "combo:asset-3")));
+      }
+    }
   }
 
   /* ============================================================


### PR DESCRIPTION
## Summary

Refs OpenAEV-Platform/filigran-private#237

A chaining step template with a payload and **no condition mapper** (e.g. a root step, or a step gated only by a non-mapper condition such as `DEPEND_ON`) was permanently short-circuited by `StepService#createReadySteps` as soon as it had produced one `READY` step for a single scope asset. On every subsequent scheduling cycle, the following guard returned an empty list *before* `expandTargetBatches` ever ran, silently skipping every other asset in scope:

```java
if (!conditionService.hasConditionMapper(persistedTemplate)
    && isStepAlreadyExecutedOnce(persistedTemplate.getId(), workflowRun.getId())
    && injectExecutionStep.hasPayload(persistedTemplate)) {
  return List.of();
}
```

### Reported symptom

In a scenario with 3+ assets in scope and a mix of a payload-based step and an injector-contract-based step (rate limit 1 execution/min):
- the injector-contract step correctly fired once per asset across successive minutes,
- but the payload step only ever fired **once, for a single asset**, and was never retried for the remaining assets.

### Root cause

This guard predates per-target expansion for payload steps (introduced by #7060, "one execution per payload per asset"). It is now redundant and actively harmful:

- `expandTargetBatches` already fans out **every** `INJECT_EXECUTION` step — payload or not — into one batch per scope target.
- The per-target hash dedup (`committedTargetHashes` / `commitHashes`) a few lines further down in `createReadySteps` already prevents an already-executed `(combo, target)` pair from being re-created.

Because `hasPayload()` is `false` for pure injector-contract steps, the stale guard never triggered for them — only for payload steps — which is exactly the asymmetry that was reported.

## Fix

- Removed the obsolete template-level guard in `StepService#createReadySteps`.
- Removed the now-unused `StepService#isStepAlreadyExecutedOnce` helper. The repository method it wrapped (`existsByStepTemplateIdAndWorkflowId`) is still used elsewhere by `ConditionService` for `DEPEND_ON` conditions, so it was left untouched.

## Testing

- Added `StepServiceTest$Ready$PayloadStepMultiAssetExpansion`, which reproduces the exact reported scenario (payload step, no mapper, already executed once) and asserts the remaining scoped assets still get a `READY` step each.
  - Verified this new test **fails** against the previous (reverted) guard and **passes** with the fix.
- Full targeted suite: `StepServiceTest` + `ConditionServiceTest` → 160/160 passing, `BUILD SUCCESS`.

