### PR TITLE
fix(chaining): dropdown list should be user friendly (OpenAEV-Platform/filigran-private#238)

### DIFF
--- a/openaev-front/src/__tests__/components/fields/AutocompleteField.test.tsx
+++ b/openaev-front/src/__tests__/components/fields/AutocompleteField.test.tsx
@@ -1,0 +1,154 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ComponentProps, type ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AutocompleteField from '../../../components/fields/AutocompleteField';
+import { type Option } from '../../../utils/Option';
+
+const theme = createTheme();
+
+const OPTIONS: Option[] = [
+  {
+    id: 'text',
+    label: 'Text',
+  },
+  {
+    id: 'number',
+    label: 'Number',
+  },
+  {
+    id: 'host',
+    label: 'Host',
+  },
+];
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider theme={theme}>
+    <IntlProvider locale="en" defaultLocale="en" onError={() => {}}>
+      {children}
+    </IntlProvider>
+  </ThemeProvider>
+);
+
+type FieldProps = ComponentProps<typeof AutocompleteField>;
+
+const renderField = (overrides: Partial<FieldProps> = {}) => {
+  const props = {
+    label: 'Primitive types',
+    options: OPTIONS,
+    multiple: true,
+    value: [] as string[],
+    onChange: vi.fn(),
+    onInputChange: vi.fn(),
+    ...overrides,
+  } as FieldProps;
+  return render(<AutocompleteField {...props} />, { wrapper });
+};
+
+describe('AutocompleteField', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  describe('Option rendering', () => {
+    it('renders every option with a checkbox in multiple mode without React key warnings', () => {
+      // Arrange
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Act
+      renderField({ open: true });
+
+      // Assert
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(OPTIONS.length);
+      options.forEach(option => expect(option.querySelector('input[type="checkbox"]')).not.toBeNull());
+      const keyWarnings = consoleError.mock.calls.filter(call => String(call[0]).includes('key'));
+      expect(keyWarnings).toHaveLength(0);
+    });
+
+    it('renders options without React key warnings when the tooltip is disabled', () => {
+      // Arrange
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Act
+      renderField({
+        open: true,
+        disableOptionTooltip: true,
+      });
+
+      // Assert
+      expect(screen.getAllByRole('option')).toHaveLength(OPTIONS.length);
+      const keyWarnings = consoleError.mock.calls.filter(call => String(call[0]).includes('key'));
+      expect(keyWarnings).toHaveLength(0);
+    });
+
+    it('shows a tooltip on option hover by default', async () => {
+      // Arrange
+      renderField({ open: true });
+
+      // Act
+      fireEvent.mouseOver(screen.getAllByRole('option')[0]);
+
+      // Assert
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip.textContent).toBe(OPTIONS[0].label);
+    });
+
+    it('does not show a tooltip on option hover when disableOptionTooltip is set', async () => {
+      // Arrange
+      renderField({
+        open: true,
+        disableOptionTooltip: true,
+      });
+
+      // Act
+      fireEvent.mouseOver(screen.getAllByRole('option')[0]);
+
+      // Assert
+      await new Promise(resolve => setTimeout(resolve, 300));
+      expect(screen.queryByRole('tooltip')).toBeNull();
+    });
+  });
+
+  describe('Focus behavior', () => {
+    it('focuses the text input on mount when autoFocus is set', () => {
+      // Arrange / Act
+      renderField({ autoFocus: true });
+
+      // Assert
+      expect(document.activeElement).toBe(screen.getByRole('combobox'));
+    });
+
+    it('does not steal focus by default', () => {
+      // Arrange / Act
+      renderField();
+
+      // Assert
+      expect(document.activeElement).not.toBe(screen.getByRole('combobox'));
+    });
+  });
+
+  describe('Multi-selection', () => {
+    it('keeps the listbox open across selections when disableCloseOnSelect is set', async () => {
+      // Arrange
+      const onChange = vi.fn();
+      renderField({
+        disableCloseOnSelect: true,
+        onChange,
+      });
+      const input = screen.getByRole('combobox');
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await screen.findByRole('listbox');
+
+      // Act
+      fireEvent.click(screen.getAllByRole('option')[0]);
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith([OPTIONS[0].id]);
+      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeNull());
+    });
+  });
+});

--- a/openaev-front/src/admin/components/chaining/logic/drawer/InjectDataFieldItem.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/InjectDataFieldItem.tsx
@@ -109,13 +109,16 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
   useEffect(() => {
     if (!isTypeSelectorOpen) {
       setSelectorReady(false);
-      return;
+      return undefined;
     }
+    let raf2 = 0;
     const raf1 = requestAnimationFrame(() => {
-      const raf2 = requestAnimationFrame(() => setSelectorReady(true));
-      return () => cancelAnimationFrame(raf2);
+      raf2 = requestAnimationFrame(() => setSelectorReady(true));
     });
-    return () => cancelAnimationFrame(raf1);
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
   }, [isTypeSelectorOpen]);
 
   return (
@@ -266,7 +269,13 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
         }}
       >
         <ClickAwayListener onClickAway={closeTypeSelector}>
-          <Paper elevation={4} sx={{ p: 1.5, minHeight: 56 }}>
+          <Paper
+            elevation={4}
+            sx={{
+              p: 1.5,
+              minHeight: 56,
+            }}
+          >
             {selectorReady && (
               <AutocompleteField
                 autoFocus
@@ -281,9 +290,7 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
                 }))}
                 value={normalizedLinkOutputTypes.filter(type => menuItems.includes(type))}
                 onInputChange={() => {}}
-                onChange={(nextOutputTypes) => {
-                  handleOutputTypesChange(nextOutputTypes);
-                }}
+                onChange={handleOutputTypesChange}
               />
             )}
           </Paper>

--- a/openaev-front/src/admin/components/chaining/logic/drawer/InjectDataFieldItem.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/InjectDataFieldItem.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { type FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { type FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
 
 import AutocompleteField from '../../../../../components/fields/AutocompleteField';
 import { useFormatter } from '../../../../../components/i18n';
@@ -61,8 +61,19 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
   const { t } = useFormatter();
   const { argumentTypes } = useArgumentTypes();
 
+  // Stable anchor that persists across the "Link an Output" <-> "Edit links" transition:
+  // those are two different DOM elements (mounted conditionally on `link`), so anchoring
+  // the Popper directly to the clicked button leaves it pointing at a now-detached node
+  // once the link state changes (e.g. right after the first selection), causing the
+  // Popper to collapse to the top-left corner of the screen.
+  const containerRef = useRef<HTMLDivElement>(null);
   const [typeSelectorAnchorEl, setTypeSelectorAnchorEl] = useState<HTMLElement | null>(null);
   const isTypeSelectorOpen = Boolean(typeSelectorAnchorEl);
+  // Mounting the inner Autocomplete (and its autoFocus) in the same tick as the outer
+  // Popper would make it compute its position before the outer Popper has settled,
+  // making the listbox jump to the top-left corner on first open. Delaying its mount
+  // by a couple of frames lets the outer Popper finish positioning first.
+  const [selectorReady, setSelectorReady] = useState(false);
 
   const menuItems = useMemo(
     () => (argumentTypes.length > 0 ? argumentTypes : ['text']),
@@ -74,12 +85,11 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
     return link.outputTypes ?? [];
   }, [link]);
 
-  const openTypeSelector = (anchor: HTMLElement) => setTypeSelectorAnchorEl(anchor);
+  const openTypeSelector = () => setTypeSelectorAnchorEl(containerRef.current);
   const closeTypeSelector = () => setTypeSelectorAnchorEl(null);
 
   const handleOutputTypesChange = (nextOutputTypes: string[]) => {
     if (nextOutputTypes.length === 0) {
-      closeTypeSelector();
       onUnlink(fieldKey);
       return;
     }
@@ -96,8 +106,21 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
     }
   }, [panelOpen]);
 
+  useEffect(() => {
+    if (!isTypeSelectorOpen) {
+      setSelectorReady(false);
+      return;
+    }
+    const raf1 = requestAnimationFrame(() => {
+      const raf2 = requestAnimationFrame(() => setSelectorReady(true));
+      return () => cancelAnimationFrame(raf2);
+    });
+    return () => cancelAnimationFrame(raf1);
+  }, [isTypeSelectorOpen]);
+
   return (
     <Box
+      ref={containerRef}
       sx={{
         backgroundColor: 'background.paper',
         borderRadius: 1,
@@ -157,7 +180,7 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
                   variant="text"
                   color="primary"
                   endIcon={<KeyboardArrowDown />}
-                  onClick={event => openTypeSelector(event.currentTarget)}
+                  onClick={openTypeSelector}
                 >
                   {t('Edit links')}
                 </Button>
@@ -220,7 +243,7 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
               variant="text"
               color="primary"
               endIcon={<KeyboardArrowDown />}
-              onClick={event => openTypeSelector(event.currentTarget)}
+              onClick={openTypeSelector}
               sx={{
                 whiteSpace: 'nowrap',
                 textTransform: 'none',
@@ -243,28 +266,26 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
         }}
       >
         <ClickAwayListener onClickAway={closeTypeSelector}>
-          <Paper elevation={4} sx={{ p: 1.5 }}>
-            <AutocompleteField
-              open={isTypeSelectorOpen}
-              label={t('Primitive types')}
-              variant="standard"
-              multiple
-              options={menuItems.map(type => ({
-                id: type,
-                label: t(formatPrimitiveTypeLabel(type)),
-              }))}
-              value={normalizedLinkOutputTypes.filter(type => menuItems.includes(type))}
-              onInputChange={() => {}}
-              onChange={(nextOutputTypes) => {
-                if (nextOutputTypes.length === 0) {
-                  closeTypeSelector();
-                  onUnlink(fieldKey);
-                  return;
-                }
-                handleOutputTypesChange(nextOutputTypes);
-                closeTypeSelector();
-              }}
-            />
+          <Paper elevation={4} sx={{ p: 1.5, minHeight: 56 }}>
+            {selectorReady && (
+              <AutocompleteField
+                autoFocus
+                label={t('Primitive types')}
+                variant="standard"
+                multiple
+                disableCloseOnSelect
+                disableOptionTooltip
+                options={menuItems.map(type => ({
+                  id: type,
+                  label: t(formatPrimitiveTypeLabel(type)),
+                }))}
+                value={normalizedLinkOutputTypes.filter(type => menuItems.includes(type))}
+                onInputChange={() => {}}
+                onChange={(nextOutputTypes) => {
+                  handleOutputTypesChange(nextOutputTypes);
+                }}
+              />
+            )}
           </Paper>
         </ClickAwayListener>
       </Popper>

--- a/openaev-front/src/components/fields/AutocompleteField.tsx
+++ b/openaev-front/src/components/fields/AutocompleteField.tsx
@@ -1,6 +1,6 @@
 import { Autocomplete, Box, Checkbox, TextField, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { type CSSProperties, type FunctionComponent, type HTMLAttributes, type ReactNode, useMemo } from 'react';
+import { type CSSProperties, type FunctionComponent, type HTMLAttributes, type Key, type ReactNode, useMemo } from 'react';
 
 import { type GroupOption, type Option } from '../../utils/Option';
 import { useFormatter } from '../i18n';
@@ -27,7 +27,6 @@ interface BaseProps {
   openOnFocus?: boolean;
   selectOnFocus?: boolean;
   autoFocus?: boolean;
-  disablePortal?: boolean;
 }
 
 interface SingleProps extends BaseProps {
@@ -58,7 +57,6 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
     selectOnFocus = true,
     disableOptionTooltip = false,
     autoFocus = false,
-    disablePortal = false,
   } = props;
 
   const multiple = props.multiple === true;
@@ -91,16 +89,22 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
   };
 
   const defaultRenderOption = (
-    props: HTMLAttributes<HTMLLIElement>,
+    liProps: HTMLAttributes<HTMLLIElement> & { key?: Key },
     option: AutocompleteOption,
   ) => {
     const checked = multiple
       ? value?.includes(option.id)
       : value === option.id;
 
-    const listItem = (itemProps: HTMLAttributes<HTMLLIElement>) => (
+    // React ignores a `key` arriving through a props spread, so extract it and
+    // set it explicitly on the outermost element of the returned node.
+    const { key, ...itemProps } = liProps;
+    const optionKey = key ?? option.id;
+
+    const listItem = (itemKey?: Key) => (
       <Box
         component="li"
+        key={itemKey}
         {...itemProps}
         sx={{
           whiteSpace: 'nowrap',
@@ -128,12 +132,12 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
     );
 
     if (disableOptionTooltip) {
-      return listItem({ ...props, key: option.id } as HTMLAttributes<HTMLLIElement>);
+      return listItem(optionKey);
     }
 
     return (
-      <Tooltip key={option.id} title={option.label}>
-        {listItem(props)}
+      <Tooltip key={optionKey} title={option.label}>
+        {listItem()}
       </Tooltip>
     );
   };
@@ -148,7 +152,6 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
       selectOnFocus={selectOnFocus}
       openOnFocus={openOnFocus}
       autoHighlight
-      autoFocus={autoFocus}
       disableCloseOnSelect={props.disableCloseOnSelect ?? false}
       noOptionsText={t('No available options')}
       multiple={multiple}
@@ -157,7 +160,6 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
       groupBy={option => ('group' in option ? option.group : '')}
       getOptionLabel={option => option.label ?? ''}
       isOptionEqualToValue={(option, val) => option.id === val.id}
-      slotProps={{ popper: { disablePortal } }}
       onInputChange={(_, search, reason) => {
         if (reason === 'input') {
           onInputChange(search);
@@ -172,6 +174,9 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
           size="small"
           required={required}
           error={error}
+          // autoFocus must live on the TextField: on the Autocomplete root it
+          // would land on a plain div and never focus the input.
+          autoFocus={autoFocus}
         />
       )}
       renderOption={(liProps, option) => {

--- a/openaev-front/src/components/fields/AutocompleteField.tsx
+++ b/openaev-front/src/components/fields/AutocompleteField.tsx
@@ -12,6 +12,7 @@ interface BaseProps {
   options: AutocompleteOption[];
   onInputChange: (search: string) => void;
   disableCloseOnSelect?: boolean;
+  disableOptionTooltip?: boolean;
   open?: boolean;
   required?: boolean;
   error?: boolean;
@@ -25,6 +26,8 @@ interface BaseProps {
   ) => ReactNode;
   openOnFocus?: boolean;
   selectOnFocus?: boolean;
+  autoFocus?: boolean;
+  disablePortal?: boolean;
 }
 
 interface SingleProps extends BaseProps {
@@ -53,6 +56,9 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
     disabled,
     openOnFocus = true,
     selectOnFocus = true,
+    disableOptionTooltip = false,
+    autoFocus = false,
+    disablePortal = false,
   } = props;
 
   const multiple = props.multiple === true;
@@ -92,34 +98,42 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
       ? value?.includes(option.id)
       : value === option.id;
 
-    return (
-      <Tooltip key={option.id} title={option.label}>
+    const listItem = (itemProps: HTMLAttributes<HTMLLIElement>) => (
+      <Box
+        component="li"
+        {...itemProps}
+        sx={{
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          padding: 0,
+          margin: 0,
+          display: 'flex',
+          alignItems: 'center',
+        }}
+      >
+        {multiple && <Checkbox checked={checked} />}
+
         <Box
-          component="li"
-          {...props}
           sx={{
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            padding: 0,
-            margin: 0,
-            display: 'flex',
-            alignItems: 'center',
+            display: 'inline-block',
+            flexGrow: 1,
+            marginLeft: multiple ? theme.spacing(1) : 0,
+            fontStyle: option.italic ? 'italic' : 'normal',
           }}
         >
-          {multiple && <Checkbox checked={checked} />}
-
-          <Box
-            sx={{
-              display: 'inline-block',
-              flexGrow: 1,
-              marginLeft: multiple ? theme.spacing(1) : 0,
-              fontStyle: option.italic ? 'italic' : 'normal',
-            }}
-          >
-            {option.label}
-          </Box>
+          {option.label}
         </Box>
+      </Box>
+    );
+
+    if (disableOptionTooltip) {
+      return listItem({ ...props, key: option.id } as HTMLAttributes<HTMLLIElement>);
+    }
+
+    return (
+      <Tooltip key={option.id} title={option.label}>
+        {listItem(props)}
       </Tooltip>
     );
   };
@@ -134,6 +148,7 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
       selectOnFocus={selectOnFocus}
       openOnFocus={openOnFocus}
       autoHighlight
+      autoFocus={autoFocus}
       disableCloseOnSelect={props.disableCloseOnSelect ?? false}
       noOptionsText={t('No available options')}
       multiple={multiple}
@@ -142,6 +157,7 @@ const AutocompleteField: FunctionComponent<Props> = (props) => {
       groupBy={option => ('group' in option ? option.group : '')}
       getOptionLabel={option => option.label ?? ''}
       isOptionEqualToValue={(option, val) => option.id === val.id}
+      slotProps={{ popper: { disablePortal } }}
       onInputChange={(_, search, reason) => {
         if (reason === 'input') {
           onInputChange(search);


### PR DESCRIPTION
## Description

Fixes the "Link an Output" / "Edit links" primitive-type dropdown in the chaining inject-data drawer:

1. **Dropdown closed after every selection** - required reopening the list for each additional value. Now it stays open across multiple selections and only closes on click-away.
2. **Dropdown jumped to a corner of the screen after the first selection** - root cause: the Popper's `anchorEl` was bound to the clicked button ("Link an Output"), but selecting a value transitions the field to its linked state, swapping in a different button ("Edit links"). The old anchor DOM node became detached, and MUI/Popper.js collapsed its position to (0,0). Fixed by anchoring the Popper to a stable container ref that persists across that state transition instead of the transient button element.
3. **Removed the per-option hover tooltip** in the dropdown list per product feedback - not needed.

Review follow-up hardening (7c0b5e8):

- React keys are applied explicitly on the rendered option elements in `AutocompleteField` (a `key` passed through a props spread is ignored by React), removing the `HTMLAttributes` cast.
- `autoFocus` is forwarded to the `TextField` in `renderInput` so the input actually receives focus (on the `Autocomplete` root it would land on a plain `div`).
- Removed the unused `disablePortal` prop from the shared `AutocompleteField`.
- Both `requestAnimationFrame` ids of the delayed selector mount are tracked and cancelled in the effect cleanup (the nested return was dead code).
- Added a vitest suite for `AutocompleteField` covering option keys, the tooltip toggle, autofocus and `disableCloseOnSelect`.

## Testing

Manually verified locally (Docker) and with an automated headless-browser (Playwright) script exercising the exact repro steps: open drawer -> click "Link an Output" -> select first value -> verify position -> select second value -> verify position -> hover option (no tooltip) -> click away (list closes, values persist).

Unit tests: `openaev-front/src/__tests__/components/fields/AutocompleteField.test.tsx` (7 tests) covering keyed option rendering with and without the tooltip, tooltip visibility on hover, autofocus behavior, and multi-select with `disableCloseOnSelect` keeping the listbox open. `yarn lint` and `yarn check-ts` pass locally.

Fixes https://github.com/OpenAEV-Platform/filigran-private/issues/238
