### PR TITLE
fix(connectors): prevent managed entity mutation in connector read paths (#7092)

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -48,6 +48,7 @@ Then:
 | **Naming** | PascalCase entities, camelCase methods, `snake_case` DB columns? |
 | **DTO pattern** | API never exposes JPA entities — always through Output records + Mapper |
 | **Service pattern** | Business logic in `@Service`, `@Transactional` on each method, `readOnly = true` on reads |
+| **No writes in read paths** | GET/list code never calls setters on managed entities (`readOnly = true` does NOT prevent the OSIV flush at response commit) — display-only values go into the output DTO via mapper parameters |
 | **Error handling** | Uses `ElementNotFoundException`? Returns proper HTTP status codes? |
 | **Logging** | Uses `@Slf4j`? No `System.out.println`? No sensitive data in logs? |
 

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -78,10 +78,13 @@ public Page<{Entity}Output> search(...) { return service.search(input).map({Enti
 - `@Transactional` does NOT work on self-calls (Spring proxy bypass)
 - Background tasks: explicit `@Transactional` (no OSIV outside controllers)
 - `deleteById()` does a SELECT first — use native `@Query @Modifying` for perf-critical deletes
-- **`@Transactional(readOnly = true)` permits safe entity mutation**: Hibernate disables dirty-check
-  in read-only sessions, so setting a transient display field on a managed entity (e.g.
-  `connector.setName(resolved)`) will never flush to DB. Prefer this over threading an extra
-  parameter through abstract method signatures and mapper call chains.
+- **Never mutate a managed entity in a read path — `readOnly = true` does NOT make it safe**:
+  with OSIV the Hibernate session outlives the controller's read-only transaction, and any later
+  read-write transaction on the same thread (e.g. the spring-session JDBC save at response commit)
+  flushes the dirtied entity. If the row was deleted/changed in between, the flush fails with
+  `StaleStateException` and the GET returns a 500 (issue #7092, regression of #6469). Resolve
+  display-only values into the output DTO (pass them as mapper parameters) instead of calling
+  setters on managed entities.
 
 ## Services
 

--- a/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
@@ -83,10 +83,12 @@ public class ExecutorService extends AbstractConnectorService<Executor, Executor
   @Override
   protected ExecutorOutput mapToOutput(
       Executor executor,
+      String displayName,
       CatalogConnector catalogConnector,
       ConnectorInstance instance,
       boolean existingExecutor) {
-    return executorMapper.toExecutorOutput(executor, catalogConnector, instance, existingExecutor);
+    return executorMapper.toExecutorOutput(
+        executor, displayName, catalogConnector, instance, existingExecutor);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
@@ -84,11 +84,12 @@ public class CollectorService extends AbstractConnectorService<Collector, Collec
   @Override
   protected CollectorOutput mapToOutput(
       Collector collector,
+      String displayName,
       CatalogConnector catalogConnector,
       ConnectorInstance connectorInstance,
       boolean existingCollector) {
     return collectorMapper.toCollectorOutput(
-        collector, catalogConnector, connectorInstance, existingCollector);
+        collector, displayName, catalogConnector, connectorInstance, existingCollector);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/service/InjectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectorService.java
@@ -122,10 +122,12 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
   @Override
   protected InjectorOutput mapToOutput(
       Injector injector,
+      String displayName,
       CatalogConnector catalogConnector,
       ConnectorInstance instance,
       boolean existingInjector) {
-    return injectorMapper.toInjectorOutput(injector, catalogConnector, instance, existingInjector);
+    return injectorMapper.toInjectorOutput(
+        injector, displayName, catalogConnector, instance, existingInjector);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -37,8 +37,20 @@ public abstract class AbstractConnectorService<
 
   protected abstract T getConnectorById(String id);
 
+  /**
+   * Maps a connector entity to its output DTO.
+   *
+   * @param connector the connector entity (may be Hibernate-managed: implementations must never
+   *     mutate it, see {@link #toConnectorOutput})
+   * @param displayName the resolved display name to expose (instance-configured name when the
+   *     connector is deployed through the Integration Manager, entity name otherwise)
+   * @param catalogConnector the matching catalog entry, if any
+   * @param instance the owning connector instance, if any
+   * @param existingConnector false for pending connectors not yet registered
+   */
   protected abstract Output mapToOutput(
       T connector,
+      String displayName,
       CatalogConnector catalogConnector,
       ConnectorInstance instance,
       boolean existingConnector);
@@ -72,10 +84,17 @@ public abstract class AbstractConnectorService<
         isVerified && instance instanceof ConnectorInstancePersisted
             ? ((ConnectorInstancePersisted) instance).getCatalogConnector()
             : catalogConnectorService.findBySlug(connector.getType()).orElse(null);
+    // The instance-configured name is a pure display concern: resolve it into the DTO without
+    // touching the managed entity. Calling connector.setName() here dirties the entity, and the
+    // open-in-view session flushes that UPDATE at response commit (outside the controller's
+    // read-only transaction, via the spring-session save) - a connector deleted or re-registered
+    // in between then makes the flush fail with StaleStateException and the GET returns a 500
+    // (issue #7092, regression of #6469).
+    String displayName = connector.getName();
     if (instance instanceof ConnectorInstancePersisted persistedInstance) {
-      getConfiguredConnectorName(persistedInstance).ifPresent(connector::setName);
+      displayName = getConfiguredConnectorName(persistedInstance).orElse(displayName);
     }
-    return mapToOutput(connector, catalogConnector, instance, true);
+    return mapToOutput(connector, displayName, catalogConnector, instance, true);
   }
 
   private Output toExistingConnectorOutput(
@@ -194,6 +213,7 @@ public abstract class AbstractConnectorService<
                 result.add(
                     mapToOutput(
                         newConnector,
+                        newConnector.getName(),
                         entry.getValue().getCatalogConnector(),
                         entry.getValue(),
                         false));

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/CollectorMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/CollectorMapper.java
@@ -19,12 +19,13 @@ public class CollectorMapper {
 
   public CollectorOutput toCollectorOutput(
       Collector collector,
+      String displayName,
       @Nullable CatalogConnector catalogConnector,
       ConnectorInstance connectorInstance,
       boolean existingCollector) {
     return CollectorOutput.builder()
         .id(collector.getId())
-        .name(collector.getName())
+        .name(displayName)
         .type(collector.getType())
         .external(collector.isExternal())
         .lastExecution(collector.getUpdatedAt())

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/ExecutorMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/ExecutorMapper.java
@@ -18,12 +18,13 @@ public class ExecutorMapper {
 
   public ExecutorOutput toExecutorOutput(
       Executor executor,
+      String displayName,
       @Nullable CatalogConnector catalogConnector,
       ConnectorInstance connectorInstance,
       boolean existingExecutor) {
     return ExecutorOutput.builder()
         .id(executor.getId())
-        .name(executor.getName())
+        .name(displayName)
         .type(executor.getType())
         .updatedAt(executor.getUpdatedAt())
         .catalog(catalogConnectorMapper.toCatalogSimpleOutput(catalogConnector))

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/InjectorMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/InjectorMapper.java
@@ -18,12 +18,13 @@ public class InjectorMapper {
 
   public InjectorOutput toInjectorOutput(
       Injector injector,
+      String displayName,
       @Nullable CatalogConnector catalogConnector,
       ConnectorInstance connectorInstance,
       boolean existingInjector) {
     return InjectorOutput.builder()
         .id(injector.getId())
-        .name(injector.getName())
+        .name(displayName)
         .type(injector.getType())
         .external(injector.isExternal())
         .catalog(catalogConnectorMapper.toCatalogSimpleOutput(catalogConnector))

--- a/openaev-api/src/test/java/io/openaev/rest/CollectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/CollectorApiTest.java
@@ -26,6 +26,7 @@ import io.openaev.utils.fixtures.CollectorFixture;
 import io.openaev.utils.fixtures.SecurityPlatformFixture;
 import io.openaev.utils.fixtures.composers.*;
 import io.openaev.utils.mockUser.WithMockUser;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -56,6 +57,7 @@ public class CollectorApiTest extends IntegrationTest {
   @Autowired private SecurityPlatformComposer securityPlatformComposer;
   @Autowired private CollectorTypeComposer collectorTypeComposer;
   @Autowired private TenantIsolationTestHelper tenantHelper;
+  @Autowired private EntityManager entityManager;
 
   private MockMultipartFile buildInputPart(CollectorCreateInput input) {
     return new MockMultipartFile(
@@ -133,6 +135,54 @@ public class CollectorApiTest extends IntegrationTest {
           .containsExactly(connectorInstanceLinkToCreatedCollector.getCatalogConnector().getId());
 
       assertThatJson(response).inPath(path + ".is_verified").isArray().containsExactly(true);
+    }
+
+    @Test
+    @DisplayName(
+        "Given an instance-configured name, should expose it in the output without dirtying the collector entity")
+    void givenInstanceConfiguredName_shouldNotDirtyCollectorEntity() throws Exception {
+      Collector collector = getCollector("Registered name");
+      connectorInstanceComposer
+          .forConnectorInstance(createDefaultConnectorInstance())
+          .withCatalogConnector(
+              catalogConnectorComposer.forCatalogConnector(
+                  createDefaultCatalogConnectorManagedByXtmComposer("Configured collector")))
+          .withConnectorInstanceConfiguration(
+              connectorInstanceConfigurationComposer.forConnectorInstanceConfiguration(
+                  createConnectorInstanceConfiguration("COLLECTOR_ID", collector.getId())))
+          .withConnectorInstanceConfiguration(
+              connectorInstanceConfigurationComposer.forConnectorInstanceConfiguration(
+                  createConnectorInstanceConfiguration("COLLECTOR_NAME", "Configured name")))
+          .persist();
+
+      String response =
+          mvc.perform(
+                  get(COLLECTOR_URI)
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String path = "$[?(@.collector_id == '" + collector.getId() + "')]";
+      assertThatJson(response)
+          .inPath(path + ".collector_name")
+          .isArray()
+          .containsExactly("Configured name");
+
+      // A read path that dirties the managed entity would flush the configured name to the DB
+      // here and silently overwrite the registered name (issue #7092: in prod the flush happens
+      // at response commit and turns the GET into a 500 when the row is gone).
+      entityManager.flush();
+      entityManager.clear();
+      Collector reloaded =
+          fromIterable(collectorRepository.findAll()).stream()
+              .filter(c -> collector.getId().equals(c.getId()))
+              .findFirst()
+              .orElseThrow();
+      assertThat(reloaded.getName()).isEqualTo("Registered name");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #7092

Production platforms upgraded to the latest release intermittently return 500 (Internal error toast) when navigating to inject or asset overviews. The failing call is `GET /api/tenants/{tenantId}/collectors?include_next=false`, which dies at response commit with:

```
ObjectOptimisticLockingFailureException / StaleStateException:
Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1;
update collectors set ... where collector_id=? and tenant_id=?
```

### Root cause

`AbstractConnectorService.toConnectorOutput()` calls `connector.setName(...)` on the Hibernate-managed entity to expose the Integration Manager's configured display name. This dirties the entity during a GET.

Issue #6469 / PR #6472 previously addressed this by marking the list endpoints `@Transactional(readOnly = true)`, assuming a read-only transaction never flushes. That does not hold under OSIV: the session is created before (and outlives) the controller transaction, so entity snapshots exist and the session stays open. When spring-session persists the HTTP session at response commit (`JdbcIndexedSessionRepository.save` inside a read-write `TransactionTemplate`), the commit flushes the dirty entity. If the connector row was deleted or re-registered in between (Integration Manager / XTM Composer lifecycle churn, which is exactly what happens while platforms are upgraded), the `UPDATE ... WHERE collector_id=? AND tenant_id=?` matches 0 rows and the whole GET turns into a 500. Even when the update succeeds, the GET silently overwrites the connector's registered name in the database.

The same shared code serves injectors and executors, so all three list endpoints (and the single-connector GET) are affected.

### Fix

A read path must never write. The instance-configured display name is now resolved into the output DTO instead of being written onto the entity:

- `AbstractConnectorService.toConnectorOutput()` computes the display name and passes it to `mapToOutput(...)` as a new parameter; the managed entity is left untouched.
- `CollectorService` / `InjectorService` / `ExecutorService` and `CollectorMapper` / `InjectorMapper` / `ExecutorMapper` thread the resolved name through to the DTO builders.
- `backend.instructions.md`: the guidance added by #6472 recommending managed-entity mutation under `readOnly = true` was factually wrong under OSIV + spring-session and is replaced with a "never mutate managed entities in read paths" rule; `code-reviewer.agent.md` updated accordingly (agent maintenance rule).

### Test

New regression test in `CollectorApiTest`: a collector with an instance-configured `COLLECTOR_NAME` must expose the configured name in the list output while an explicit flush + reload proves the entity/database name was not modified. The test fails with the previous implementation (the flush persists the configured name) and passes with this fix.

## Test plan

- [x] `mvn spotless:apply` / `spotless:check` clean
- [x] `mvn test-compile -Pdev` green
- [ ] `CollectorApiTest` (including new regression test) green in CI
- [ ] Full CI green
