### PR TITLE
feat(chaining): hide self-loop arrows on the attack path map (#5048)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -211,6 +211,22 @@ describe('pivotEndpointIds', () => {
       },
     ]).size).toBe(0);
   });
+
+  it('never flags an endpoint whose only source role is a self-loop (endpoint-local action)', () => {
+    // A Whoami-style local action emits source = target = the endpoint; that is not lateral movement.
+    expect(pivotEndpointIds([
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_INJECTOR|nmap',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_ENDPOINT|a',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+    ]).size).toBe(0);
+  });
 });
 
 describe('orderSimulationPickerOptions', () => {
@@ -381,6 +397,64 @@ describe('buildClusteredAttackPathFlow', () => {
     expect(ids).toContain('ep2');
     expect(nodes.find(n => n.id === 'ep1')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
     expect(edges.find(e => e.id === 'cl-ep-all-ep1')?.target).toBe('ep1');
+  });
+
+  it('keeps an endpoint reached only by an endpoint-local action (self-loop) visible, without a self arrow', () => {
+    // Arrange: ep2 is reached ONLY by a Whoami-style local action (execution edge source = target = ep2).
+    const selfLoopDto: AttackPathDTO = {
+      ...clusteredDto,
+      attackPathEdges: [
+        {
+          edgeId: 'x1',
+          edgeSourceId: 'inj',
+          edgeTargetId: 'ep1',
+          type: 'EDGE_EXECUTIONS',
+          count: 5,
+        },
+        {
+          edgeId: 'x-self',
+          edgeSourceId: 'ep2',
+          edgeTargetId: 'ep2',
+          type: 'EDGE_EXECUTIONS',
+          count: 1,
+        },
+      ],
+    };
+    // Act: collapsed (hub) and expanded views.
+    const collapsed = buildClusteredAttackPathFlow(selfLoopDto, new Map(), tt);
+    const expanded = buildClusteredAttackPathFlow(selfLoopDto, new Map([[AP_ALL_ENDPOINTS, 15]]), tt);
+    // Assert: ep2 counts as reached (hub count 2) and renders when expanded, with its findings…
+    expect(collapsed.nodes.find(n => n.id === 'cl-ep-all')?.data.count).toBe(2);
+    expect(expanded.nodes.find(n => n.id === 'ep2')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
+    // …but no arrow loops back onto it: the only edge INTO ep2 comes from the shared hub.
+    expect(expanded.edges.find(e => e.source === 'ep2' && e.target === 'ep2')).toBeUndefined();
+    expect(expanded.edges.filter(e => e.target === 'ep2').map(e => e.source)).toEqual(['cl-ep-all']);
+  });
+
+  it('still ignores a malformed execution edge that has a target but no source', () => {
+    // Arrange: ep2's only edge is sourceless — malformed, not an endpoint-local action.
+    const malformedDto: AttackPathDTO = {
+      ...clusteredDto,
+      attackPathEdges: [
+        {
+          edgeId: 'x1',
+          edgeSourceId: 'inj',
+          edgeTargetId: 'ep1',
+          type: 'EDGE_EXECUTIONS',
+          count: 5,
+        },
+        {
+          edgeId: 'x-broken',
+          edgeTargetId: 'ep2',
+          type: 'EDGE_EXECUTIONS',
+          count: 1,
+        },
+      ],
+    };
+    // Act
+    const { nodes } = buildClusteredAttackPathFlow(malformedDto, new Map(), tt);
+    // Assert: ep2 is NOT counted as reached (pre-existing behavior preserved).
+    expect(nodes.find(n => n.id === 'cl-ep-all')?.data.count).toBe(1);
   });
 });
 
@@ -1024,5 +1098,198 @@ describe('buildCausalChainFlow', () => {
     expect(toEp.map(e => e.source).sort()).toEqual(['inj-nmap', 'inj-smb']);
     // No causal edge: independent injectors share the asset but form no kill chain.
     expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE)).toHaveLength(0);
+  });
+
+  it('renders an endpoint reached only by an endpoint-local action without an injector node or self arrow', () => {
+    // Arrange: a Whoami-style local action — the execution edge's source IS its target endpoint.
+    const selfLoop: AttackPathDTO = {
+      mode: 'full',
+      attackPathNodes: [
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'DC-01',
+          ip: '10.0.0.1',
+        },
+        {
+          id: 'NODE_FINDING|username|bob',
+          type: 'FINDING',
+          typeFindings: 'username',
+          value: 'bob',
+          label: 'bob',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'x-local',
+          type: 'EXECUTION',
+          ref: 'exec-local',
+          stepTemplateId: 'step-L',
+          contractName: 'Whoami',
+          findingsNodeIds: ['NODE_FINDING|username|bob'],
+          dependsOn: [],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-local'],
+        },
+      ],
+    };
+    // Act
+    const { nodes, edges } = buildCausalChainFlow(selfLoop, tt);
+    const byId = Object.fromEntries(nodes.map(n => [n.id, n]));
+    // Assert: the endpoint and its finding render…
+    expect(byId['chain-ep|0|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
+    expect(byId['NODE_FINDING|username|bob'].type).toBe(AP_FLOW_NODE_TYPE.finding);
+    // …but no injector node is drawn for the local action and no arrow loops onto the endpoint.
+    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector)).toHaveLength(0);
+    expect(edges.find(e => e.source === 'ep-1' || e.target === 'ep-1')).toBeUndefined();
+    // Every emitted edge resolves to placed nodes (nothing dangles on the suppressed injector).
+    const nodeIds = new Set(nodes.map(n => n.id));
+    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+
+  it('emits no causal edge into an endpoint-local step (its injector node is suppressed)', () => {
+    // Arrange: nmap produces port 445 on ep-1; a LOCAL action on ep-1 consumes it (dependsOn step-A).
+    const localConsumer: AttackPathDTO = {
+      mode: 'full',
+      attackPathNodes: [
+        {
+          id: 'inj-nmap',
+          type: 'INJECTOR',
+          label: 'Nmap',
+        },
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'DC-01',
+          ip: '10.0.0.1',
+        },
+        {
+          id: 'NODE_FINDING|port|445',
+          type: 'FINDING',
+          typeFindings: 'port',
+          value: '445',
+          label: '445',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'x1',
+          type: 'EXECUTION',
+          ref: 'exec-1',
+          stepTemplateId: 'step-A',
+          findingsNodeIds: ['NODE_FINDING|port|445'],
+          dependsOn: [],
+        },
+        {
+          id: 'x-local',
+          type: 'EXECUTION',
+          ref: 'exec-local',
+          stepTemplateId: 'step-L',
+          contractName: 'Whoami',
+          consumedFindingKeys: [{
+            keyType: 'port',
+            operator: 'EQ',
+            value: '445',
+            matchedFindingIds: ['NODE_FINDING|port|445'],
+          }],
+          dependsOn: ['step-A'],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-nmap',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-1'],
+        },
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-local'],
+        },
+      ],
+    };
+    // Act
+    const { nodes, edges } = buildCausalChainFlow(localConsumer, tt);
+    // Assert: no causal edge targets the raw endpoint id (its "injector" node was never placed), and
+    // every edge still resolves to placed nodes.
+    const nodeIds = new Set(nodes.map(n => n.id));
+    expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE && e.target === 'ep-1')).toHaveLength(0);
+    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+});
+
+describe('buildFindingPathFlow', () => {
+  const pathDto: AttackPathDTO = {
+    mode: 'collapsed',
+    attackPathNodes: [
+      {
+        id: 'inj-A',
+        type: 'INJECTOR',
+        label: 'NetExec',
+      },
+      {
+        id: 'ep-1',
+        type: 'ASSET',
+        label: 'DC-01',
+        ref: 'dc-01',
+        status: 'RED',
+        findingCounts: { username: 1 },
+      },
+    ],
+    attackPathEdges: [
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'inj-A',
+        edgeTargetId: 'ep-1',
+      },
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'ep-1',
+        edgeTargetId: 'ep-1',
+      },
+    ],
+  };
+  const finding = {
+    endpointNodeId: 'ep-1',
+    endpointKey: 'dc-01',
+    type: 'username',
+    value: 'bob',
+  };
+
+  it('never lists the endpoint itself as a reaching injector (self-loop filtered)', () => {
+    // Act
+    const { nodes, edges } = buildFindingPathFlow(pathDto, finding, tt);
+    // Assert: only the real injector renders and points at the endpoint; no ep-1 -> ep-1 arrow.
+    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector).map(n => n.id)).toEqual(['inj-A']);
+    expect(edges.find(e => e.source === 'inj-A' && e.target === 'ep-1')).toBeDefined();
+    expect(edges.find(e => e.source === 'ep-1' && e.target === 'ep-1')).toBeUndefined();
+  });
+
+  it('still renders the endpoint and its finding clusters when only a local action reached it', () => {
+    // Arrange: drop the real injector edge — the endpoint is reached by the local action alone.
+    const localOnly: AttackPathDTO = {
+      ...pathDto,
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+        },
+      ],
+    };
+    // Act
+    const { nodes } = buildFindingPathFlow(localOnly, finding, tt);
+    // Assert: no injector, but the endpoint and its per-type cluster still render.
+    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector)).toHaveLength(0);
+    expect(nodes.find(n => n.id === 'ep-1')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
+    expect(nodes.find(n => n.id === 'path-cl-type|username|dc-01')?.type).toBe(AP_FLOW_NODE_TYPE.findingCluster);
   });
 });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -723,7 +723,8 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       (dto.attackPathNodes ?? []).filter(n => n.type === 'ASSET' && n.id).map(n => [n.id as string, n]),
     );
     for (const e of dto.attackPathEdges ?? []) {
-      if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeTargetId && assetById.has(e.edgeTargetId)) {
+      if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeTargetId
+        && e.edgeSourceId !== e.edgeTargetId && assetById.has(e.edgeTargetId)) {
         const ref = assetById.get(e.edgeTargetId)?.ref ?? e.edgeTargetId;
         const arr = map.get(e.edgeSourceId) ?? [];
         if (!arr.includes(ref)) {
@@ -1686,7 +1687,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       );
       const producingInjectors = new Set<string>();
       for (const e of fullDto?.attackPathEdges ?? []) {
-        if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId
+        if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeSourceId !== e.edgeTargetId
           && (e.executionIds ?? []).some(id => highlightedExecutionIds.has(id))) {
           producingInjectors.add(e.edgeSourceId);
         }
@@ -1713,7 +1714,8 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       pathSet.add(selectedNodeId);
       pathSet.add(AP_SHARED_EP_CLUSTER_ID);
       for (const e of dto?.attackPathEdges ?? []) {
-        if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === selectedNodeId && e.edgeSourceId) {
+        if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === selectedNodeId && e.edgeSourceId
+          && e.edgeSourceId !== e.edgeTargetId) {
           pathSet.add(e.edgeSourceId);
         }
       }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -724,7 +724,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     );
     for (const e of dto.attackPathEdges ?? []) {
       if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeTargetId
-        && e.edgeSourceId !== e.edgeTargetId && assetById.has(e.edgeTargetId)) {
+        && assetById.has(e.edgeTargetId)) {
         const ref = assetById.get(e.edgeTargetId)?.ref ?? e.edgeTargetId;
         const arr = map.get(e.edgeSourceId) ?? [];
         if (!arr.includes(ref)) {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -723,8 +723,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       (dto.attackPathNodes ?? []).filter(n => n.type === 'ASSET' && n.id).map(n => [n.id as string, n]),
     );
     for (const e of dto.attackPathEdges ?? []) {
-      if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeTargetId
-        && assetById.has(e.edgeTargetId)) {
+      if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeTargetId && assetById.has(e.edgeTargetId)) {
         const ref = assetById.get(e.edgeTargetId)?.ref ?? e.edgeTargetId;
         const arr = map.get(e.edgeSourceId) ?? [];
         if (!arr.includes(ref)) {
@@ -1686,13 +1685,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         baseFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector).map(n => n.id),
       );
       const producingInjectors = new Set<string>();
+      let hasProducingExecution = false;
       for (const e of fullDto?.attackPathEdges ?? []) {
-        if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId && e.edgeSourceId !== e.edgeTargetId
+        if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId
           && (e.executionIds ?? []).some(id => highlightedExecutionIds.has(id))) {
-          producingInjectors.add(e.edgeSourceId);
+          hasProducingExecution = true;
+          // A self-loop (endpoint-local action) has no injector node to light: it still activates the
+          // restriction (the producer is known — it is the endpoint itself), but adds no injector.
+          if (e.edgeSourceId !== e.edgeTargetId) {
+            producingInjectors.add(e.edgeSourceId);
+          }
         }
       }
-      const restrictInjectors = producingInjectors.size > 0;
+      const restrictInjectors = hasProducingExecution;
       pathSet.add(selectedFindingId);
       for (let pass = 0; pass < 6; pass += 1) {
         for (const e of baseFlow.edges) {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -475,7 +475,15 @@ export const buildClusteredAttackPathFlow = (
   for (const e of execEdges) {
     const src = e.edgeSourceId;
     const tgt = e.edgeTargetId;
-    if (!src || !tgt || !assetById.has(tgt)) {
+    if (!tgt || !assetById.has(tgt)) {
+      continue;
+    }
+    // The endpoint is a reached node even for endpoint-local actions.
+    if (!reachedOrder.includes(tgt)) {
+      reachedOrder.push(tgt);
+    }
+    // Endpoint-local action (source === target): not reached "by" an injector — no self arrow.
+    if (!src || src === tgt) {
       continue;
     }
     const injs = injectorsByEndpoint.get(tgt) ?? [];
@@ -483,9 +491,6 @@ export const buildClusteredAttackPathFlow = (
       injs.push(src);
     }
     injectorsByEndpoint.set(tgt, injs);
-    if (!reachedOrder.includes(tgt)) {
-      reachedOrder.push(tgt);
-    }
   }
 
   // Reveal the most-exposed endpoints first (most findings = highest chokepoint score), so expanding
@@ -724,6 +729,10 @@ export const pivotEndpointIds = (
     if (e.type !== EDGE_EXECUTIONS) {
       continue;
     }
+    // A self-loop (endpoint-local action) is not a pivot.
+    if (e.edgeSourceId === e.edgeTargetId) {
+      continue;
+    }
     if (e.edgeSourceId) {
       sources.add(e.edgeSourceId);
     }
@@ -804,7 +813,8 @@ export const buildFindingPathFlow = (
   // The injector(s) that reached this endpoint (execution edges into it).
   const injectorIds = new Set<string>();
   for (const e of dto.attackPathEdges ?? []) {
-    if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === endpointId && e.edgeSourceId) {
+    if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === endpointId && e.edgeSourceId
+      && e.edgeSourceId !== e.edgeTargetId) {
       injectorIds.add(e.edgeSourceId);
     }
   }
@@ -1709,6 +1719,11 @@ export const buildCausalChainFlow = (
       // Injectors that hit this asset, stacked within the block, each with its own labelled edge.
       injectors.forEach((injId, i) => {
         const s = steps.get(injId) as ChainStep;
+        // Endpoint-local action: the "injector" is this very endpoint (self-loop). Draw no injector
+        // node and no self arrow — the endpoint node and its findings already render above.
+        if (injId === epId) {
+          return;
+        }
         if (!injectorPlaced.has(injId)) {
           injectorPlaced.add(injId);
           const injCenterY = injectors.length === 1

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -475,7 +475,8 @@ export const buildClusteredAttackPathFlow = (
   for (const e of execEdges) {
     const src = e.edgeSourceId;
     const tgt = e.edgeTargetId;
-    if (!tgt || !assetById.has(tgt)) {
+    // A sourceless edge is malformed and ignored entirely (as before this guard was split).
+    if (!src || !tgt || !assetById.has(tgt)) {
       continue;
     }
     // The endpoint is a reached node even for endpoint-local actions.
@@ -483,7 +484,7 @@ export const buildClusteredAttackPathFlow = (
       reachedOrder.push(tgt);
     }
     // Endpoint-local action (source === target): not reached "by" an injector — no self arrow.
-    if (!src || src === tgt) {
+    if (src === tgt) {
       continue;
     }
     const injs = injectorsByEndpoint.get(tgt) ?? [];
@@ -1664,7 +1665,10 @@ export const buildCausalChainFlow = (
     let cursorY = PADDING;
     const injectorPlaced = new Set<string>();
     for (const epId of assetOrder) {
-      const injectors = assetInjectors.get(epId) as string[];
+      // Endpoint-local action: the "injector" is this very endpoint (self-loop). Drop it BEFORE the
+      // layout so no injector node, no self arrow, and no empty injector slot is reserved for it —
+      // the endpoint node and its findings still render.
+      const injectors = (assetInjectors.get(epId) as string[]).filter(injId => injId !== epId);
       const findingIds = assetFindings.get(epId) as string[];
       // Group the endpoint's findings by type; a type with more than the cap collapses into ONE "+N"
       // cluster row (unless the user expanded it), so a heavy endpoint stays a handful of rows tall.
@@ -1719,11 +1723,6 @@ export const buildCausalChainFlow = (
       // Injectors that hit this asset, stacked within the block, each with its own labelled edge.
       injectors.forEach((injId, i) => {
         const s = steps.get(injId) as ChainStep;
-        // Endpoint-local action: the "injector" is this very endpoint (self-loop). Draw no injector
-        // node and no self arrow — the endpoint node and its findings already render above.
-        if (injId === epId) {
-          return;
-        }
         if (!injectorPlaced.has(injId)) {
           injectorPlaced.add(injId);
           const injCenterY = injectors.length === 1
@@ -1866,6 +1865,11 @@ export const buildCausalChainFlow = (
   const drawnCausalEdges = new Set<string>();
   const labelledCausal = new Set<string>();
   for (const [injId, s] of steps) {
+    // An endpoint-local step (self-loop) has no injector node in the graph, so there is nothing to
+    // anchor a causal edge on — emitting one would target a node React Flow cannot resolve.
+    if (!nodeById.has(injId)) {
+      continue;
+    }
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
@@ -1921,7 +1925,8 @@ export const buildCausalChainFlow = (
     }
     if (!matched) {
       for (const dep of s.deps) {
-        if (steps.has(dep)) {
+        // The depended step's node may itself be an unplaced endpoint-local step — same guard.
+        if (steps.has(dep) && nodeById.has(dep)) {
           edges.push({
             id: `${AP_FLOW_CAUSAL_EDGE_TYPE}-depend-${dep}-${injId}`,
             source: dep,


### PR DESCRIPTION
### Proposed changes

- Stop rendering self-looping arrows on the attack-path map for endpoint-local actions (source = target = same endpoint, e.g. `Whoami`): the backend still emits the execution edges (so endpoints stay discoverable), and the frontend filters the self-loop only at render time.
- Endpoints reached solely by local actions now stay visible with their findings, but without a self arrow.
- Review hardening: a malformed execution edge (target but no source) stays ignored as before; the causal-chain layout no longer reserves an empty injector slot for a suppressed local action and never emits causal edges anchored on the suppressed node; a finding produced only by a local action keeps the producing-injector highlight restriction active instead of lighting every injector that merely reached the endpoint.

### Testing Instructions

1. Open a simulation whose attack path contains an endpoint-local action (e.g. `Whoami`) that targets its own endpoint.
2. Open the attack-path map (full / causal-chain view, and clustered view).
3. Verify the endpoint and its findings are displayed **without** any arrow that exits and loops back onto it.
4. Verify pivots (endpoint A -> endpoint B) and injector -> endpoint edges are still drawn normally.

### Related issues

- #5048

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

The self-loop is filtered in the frontend (not dropped in the backend) so endpoint discovery, which relies on execution edges, keeps working: dropping the edge would have made endpoints reached only by local actions disappear entirely. Filters were added to every `EDGE_EXECUTIONS` consumer (`buildCausalChainFlow`, `buildClusteredAttackPathFlow`, `buildFindingPathFlow`, `pivotEndpointIds`, and the highlight/selection paths in `SimulationAttackPath.tsx`). The self-loop behavior of each helper is covered by unit tests in `attack-path-flow-helpers.test.ts`.
