### PR TITLE
fix(engine): keep the indexing cursor behind a grace window to survive commit-visibility races (#7100)

### DIFF
--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -156,6 +156,12 @@ Each OpenCTI connection is scoped to an OpenAEV tenant, identified by its UUID (
     
     
 
+Tuning parameters applicable to both engines:
+
+| Parameter                            | Environment variable                 | Default value | Description                                                                                                                                                                                                                                                            |
+|:-------------------------------------|:-------------------------------------|:--------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| engine.indexing-grace-window-seconds | ENGINE_INDEXING_GRACE_WINDOW_SECONDS | 60            | Indexing cursor grace window in seconds. The cursor persisted after each indexing round never gets closer to wall-clock than this window, so rows committed late by long write transactions are still indexed. Must exceed the longest expected write transaction. |
+
 If you switch your engine selector, you'll need to delete the `indexing_status` table in PostgreSQL to trigger a full
 reindex.
 

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260731110000000__Reindex_expectations_after_indexing_cursor_race_fix.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260731110000000__Reindex_expectations_after_indexing_cursor_race_fix.java
@@ -1,0 +1,37 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rebuilds the inject-expectation index after fixing the indexing cursor commit-visibility race.
+ *
+ * <p>The incremental sync fetched rows with a strictly-greater-than comparison on the persisted
+ * cursor, but {@code @UpdateTimestamp} values are assigned at Hibernate flush time while the rows
+ * only become visible at commit. A long transaction (typically the expectations expiration manager
+ * batching up to 1000 expired expectations) could therefore commit rows whose {@code updated_at}
+ * was already behind a cursor advanced by a concurrent sync round; those rows were never fetched
+ * again. Since the engine's expectation status is computed from the score at indexing time, the
+ * orphaned documents stayed frozen as PENDING forever while PostgreSQL held the correct final
+ * state.
+ *
+ * <p>The race is fixed in code by a grace window on cursor advancement; this migration converges
+ * the documents orphaned before the fix. Dropping the {@code indexing_status} row of a type makes
+ * the engine driver drop, recreate and fully re-feed that index from PostgreSQL at the next
+ * startup, so only the affected type is rebuilt. Idempotent and lock-light (targeted DELETE on a
+ * tiny bookkeeping table).
+ */
+@Component
+public class V6_20260731110000000__Reindex_expectations_after_indexing_cursor_race_fix
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "DELETE FROM indexing_status WHERE indexing_status_type = 'expectation-inject';");
+    }
+  }
+}

--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -79,6 +79,10 @@ engine.url=http://localhost:9200
 #engine.connect-timeout-ms=5000
 #engine.socket-timeout-ms=60000
 #engine.max-connections=40
+# Indexing cursor grace window in seconds (default 60). The persisted cursor never gets closer to
+# wall-clock than this window, so rows committed late by long transactions (whose updated_at was
+# assigned at flush time) are still picked up. Must exceed the longest expected write transaction.
+#engine.indexing-grace-window-seconds=60
 
 ### MINIO Configuration
 ### see also: https://docs.openaev.io/latest/deployment/configuration/#s3-bucket

--- a/openaev-api/src/test/java/io/openaev/service/EsIndexingUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/EsIndexingUtilsTest.java
@@ -169,5 +169,16 @@ class EsIndexingUtilsTest {
 
       assertThat(capped).isEqualTo(ts(999));
     }
+
+    @Test
+    @DisplayName("Negative grace window is clamped to zero and never caps into the future")
+    void given_negativeGraceWindow_should_clampToZero() {
+      // A misconfigured negative window must not push the cap past now, which would silently
+      // re-enable the commit-visibility race.
+      Instant now = ts(1000);
+
+      assertThat(EsIndexingUtils.capCursorToGraceWindow(ts(999), now, -30)).isEqualTo(ts(999));
+      assertThat(EsIndexingUtils.capCursorToGraceWindow(ts(1030), now, -30)).isEqualTo(now);
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/EsIndexingUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/EsIndexingUtilsTest.java
@@ -123,4 +123,51 @@ class EsIndexingUtilsTest {
       assertThat(cursor).isEqualTo(ts(7));
     }
   }
+
+  @Nested
+  @DisplayName("capCursorToGraceWindow")
+  class CapCursorToGraceWindow {
+
+    @Test
+    @DisplayName("Cursor inside the grace window is capped to now minus the window")
+    void given_cursorInsideGraceWindow_should_capToNowMinusWindow() {
+      // A row updated 10s ago must not move the cursor past now-60s: a transaction that flushed
+      // its timestamps earlier but has not committed yet could still surface behind it.
+      Instant now = ts(1000);
+
+      Instant capped = EsIndexingUtils.capCursorToGraceWindow(ts(990), now, 60);
+
+      assertThat(capped).isEqualTo(ts(940));
+    }
+
+    @Test
+    @DisplayName("Cursor older than the grace window is kept as-is")
+    void given_cursorOlderThanGraceWindow_should_keepCursor() {
+      Instant now = ts(1000);
+
+      Instant capped = EsIndexingUtils.capCursorToGraceWindow(ts(900), now, 60);
+
+      assertThat(capped).isEqualTo(ts(900));
+    }
+
+    @Test
+    @DisplayName("Cursor exactly at the window boundary is kept as-is")
+    void given_cursorExactlyAtBoundary_should_keepCursor() {
+      Instant now = ts(1000);
+
+      Instant capped = EsIndexingUtils.capCursorToGraceWindow(ts(940), now, 60);
+
+      assertThat(capped).isEqualTo(ts(940));
+    }
+
+    @Test
+    @DisplayName("Zero grace window disables the cap for timestamps up to now")
+    void given_zeroGraceWindow_should_notCapPastTimestamps() {
+      Instant now = ts(1000);
+
+      Instant capped = EsIndexingUtils.capCursorToGraceWindow(ts(999), now, 0);
+
+      assertThat(capped).isEqualTo(ts(999));
+    }
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/config/EngineConfig.java
+++ b/openaev-model/src/main/java/io/openaev/config/EngineConfig.java
@@ -105,6 +105,18 @@ public class EngineConfig {
      * per-route limit is the effective cap).
      */
     public static final int MAX_CONNECTIONS = 40;
+
+    /**
+     * Default indexing cursor grace window, in seconds. {@code @UpdateTimestamp} values are
+     * assigned when Hibernate flushes, but the rows only become visible to the indexing fetch at
+     * commit: a long transaction can therefore commit rows whose {@code updated_at} is already
+     * behind a cursor advanced by a concurrent sync round, and a strictly-greater-than fetch would
+     * never see them again. The persisted cursor is kept at least this far behind wall-clock, so
+     * recent rows are re-fetched (and idempotently re-upserted) on every round until they age past
+     * the window; any writer committing within the window is guaranteed to be indexed. Must exceed
+     * the longest expected write transaction (plus inter-node clock skew).
+     */
+    public static final long INDEXING_GRACE_WINDOW_SECONDS = 60;
   }
 
   private String engineSelector = Defaults.ENGINE_SELECTOR;
@@ -150,6 +162,8 @@ public class EngineConfig {
   private int socketTimeoutMs = Defaults.SOCKET_TIMEOUT_MS;
 
   private int maxConnections = Defaults.MAX_CONNECTIONS;
+
+  private long indexingGraceWindowSeconds = Defaults.INDEXING_GRACE_WINDOW_SECONDS;
 
   /**
    * Wildcard pattern matching all indices of this platform and only them.

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -454,11 +454,15 @@ public class ElasticService implements EngineService {
                               newCursor,
                               Instant.now(),
                               engineConfig.getIndexingGraceWindowSeconds());
-                      if (fetchInstant != null && !persistedCursor.isAfter(fetchInstant)) {
-                        // Everything fetched is still inside the grace window: keep the current
-                        // cursor and re-process those rows next round.
+                      if (persistedCursor.equals(fetchInstant)) {
+                        // The cap lands exactly on the current cursor: persisting would be a
+                        // no-op, keep it and re-process those rows next round.
                         return null;
                       }
+                      // persistedCursor may be BEHIND fetchInstant when the stored cursor is
+                      // closer to wall-clock than the grace window allows (e.g. persisted before
+                      // the window existed): saving it deliberately moves the cursor backwards so
+                      // rows committing late inside the window are fetched again.
                       if (indexingStatus.isPresent()) {
                         IndexingStatus status = indexingStatus.get();
                         status.setLastIndexing(persistedCursor);

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -444,14 +444,29 @@ public class ElasticService implements EngineService {
                             fetchInstant,
                             newCursor);
                       }
+                      // Rows flushed by a still-open transaction commit later with an already-past
+                      // updated_at: persisting a cursor beyond those timestamps would skip them
+                      // forever (the fetch is strictly greater-than). Keep the cursor at least the
+                      // grace window behind wall-clock; recent rows are re-fetched and re-upserted
+                      // (idempotent) on every round until they age past the window.
+                      Instant persistedCursor =
+                          EsIndexingUtils.capCursorToGraceWindow(
+                              newCursor,
+                              Instant.now(),
+                              engineConfig.getIndexingGraceWindowSeconds());
+                      if (fetchInstant != null && !persistedCursor.isAfter(fetchInstant)) {
+                        // Everything fetched is still inside the grace window: keep the current
+                        // cursor and re-process those rows next round.
+                        return null;
+                      }
                       if (indexingStatus.isPresent()) {
                         IndexingStatus status = indexingStatus.get();
-                        status.setLastIndexing(newCursor);
+                        status.setLastIndexing(persistedCursor);
                         return status;
                       } else {
                         IndexingStatus status = new IndexingStatus();
                         status.setType(model.getName());
-                        status.setLastIndexing(newCursor);
+                        status.setLastIndexing(persistedCursor);
                         return status;
                       }
                     } catch (IOException e) {

--- a/openaev-model/src/main/java/io/openaev/service/EsIndexingUtils.java
+++ b/openaev-model/src/main/java/io/openaev/service/EsIndexingUtils.java
@@ -82,4 +82,27 @@ public final class EsIndexingUtils {
         results.size());
     return boundary;
   }
+
+  /**
+   * Caps a computed cursor so it never gets closer to wall-clock than the configured grace window.
+   *
+   * <p>{@code @UpdateTimestamp} values are assigned when Hibernate flushes, but the rows only
+   * become visible to the (read-committed) indexing fetch at commit. Without a grace window, a
+   * transaction that commits after a concurrent sync round advanced the cursor leaves rows with
+   * {@code updated_at <= cursor} that a strictly-greater-than fetch will never see again - the
+   * documents stay stale in the engine forever while PostgreSQL is correct. Keeping the persisted
+   * cursor at least {@code graceWindowSeconds} behind {@code now} means rows younger than the
+   * window are re-fetched (and idempotently re-upserted) on every round until they age past it, so
+   * any writer committing within the window is guaranteed to be indexed.
+   *
+   * @param cursor the cursor computed from the processed batch (see {@link #computeNewCursor})
+   * @param now the current wall-clock instant
+   * @param graceWindowSeconds the grace window in seconds
+   * @return the capped cursor: {@code min(cursor, now - graceWindowSeconds)}
+   */
+  public static Instant capCursorToGraceWindow(
+      Instant cursor, Instant now, long graceWindowSeconds) {
+    Instant maxSafeCursor = now.minusSeconds(graceWindowSeconds);
+    return cursor.isAfter(maxSafeCursor) ? maxSafeCursor : cursor;
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/service/EsIndexingUtils.java
+++ b/openaev-model/src/main/java/io/openaev/service/EsIndexingUtils.java
@@ -97,12 +97,13 @@ public final class EsIndexingUtils {
    *
    * @param cursor the cursor computed from the processed batch (see {@link #computeNewCursor})
    * @param now the current wall-clock instant
-   * @param graceWindowSeconds the grace window in seconds
-   * @return the capped cursor: {@code min(cursor, now - graceWindowSeconds)}
+   * @param graceWindowSeconds the grace window in seconds; negative values are treated as zero so a
+   *     misconfiguration can never push the cap into the future and re-enable the race
+   * @return the capped cursor: {@code min(cursor, now - max(0, graceWindowSeconds))}
    */
   public static Instant capCursorToGraceWindow(
       Instant cursor, Instant now, long graceWindowSeconds) {
-    Instant maxSafeCursor = now.minusSeconds(graceWindowSeconds);
+    Instant maxSafeCursor = now.minusSeconds(Math.max(0, graceWindowSeconds));
     return cursor.isAfter(maxSafeCursor) ? maxSafeCursor : cursor;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -521,11 +521,15 @@ public class OpenSearchService implements EngineService {
                               newCursor,
                               Instant.now(),
                               engineConfig.getIndexingGraceWindowSeconds());
-                      if (fetchInstant != null && !persistedCursor.isAfter(fetchInstant)) {
-                        // Everything fetched is still inside the grace window: keep the current
-                        // cursor and re-process those rows next round.
+                      if (persistedCursor.equals(fetchInstant)) {
+                        // The cap lands exactly on the current cursor: persisting would be a
+                        // no-op, keep it and re-process those rows next round.
                         return null;
                       }
+                      // persistedCursor may be BEHIND fetchInstant when the stored cursor is
+                      // closer to wall-clock than the grace window allows (e.g. persisted before
+                      // the window existed): saving it deliberately moves the cursor backwards so
+                      // rows committing late inside the window are fetched again.
                       if (indexingStatus.isPresent()) {
                         IndexingStatus status = indexingStatus.get();
                         status.setLastIndexing(persistedCursor);

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -511,14 +511,29 @@ public class OpenSearchService implements EngineService {
                             fetchInstant,
                             newCursor);
                       }
+                      // Rows flushed by a still-open transaction commit later with an already-past
+                      // updated_at: persisting a cursor beyond those timestamps would skip them
+                      // forever (the fetch is strictly greater-than). Keep the cursor at least the
+                      // grace window behind wall-clock; recent rows are re-fetched and re-upserted
+                      // (idempotent) on every round until they age past the window.
+                      Instant persistedCursor =
+                          EsIndexingUtils.capCursorToGraceWindow(
+                              newCursor,
+                              Instant.now(),
+                              engineConfig.getIndexingGraceWindowSeconds());
+                      if (fetchInstant != null && !persistedCursor.isAfter(fetchInstant)) {
+                        // Everything fetched is still inside the grace window: keep the current
+                        // cursor and re-process those rows next round.
+                        return null;
+                      }
                       if (indexingStatus.isPresent()) {
                         IndexingStatus status = indexingStatus.get();
-                        status.setLastIndexing(newCursor);
+                        status.setLastIndexing(persistedCursor);
                         return status;
                       } else {
                         IndexingStatus status = new IndexingStatus();
                         status.setType(model.getName());
-                        status.setLastIndexing(newCursor);
+                        status.setLastIndexing(persistedCursor);
                         return status;
                       }
                     } catch (IOException e) {


### PR DESCRIPTION
Closes #7100

## Problem

In production, vulnerability inject expectations stayed **Pending** in every Elasticsearch-backed view (Findings > Vulnerability) while PostgreSQL held the correct final state (expired/failed scores set). The stale documents never converged.

Root cause: the incremental sync (every 15 s per model) fetches rows with a strictly-greater-than comparison on a persisted timestamp cursor, but `@UpdateTimestamp` values are assigned at Hibernate **flush** time while the rows only become visible at **commit**. A long transaction - typically `ExpectationsExpirationManagerService.computeExpectations()`, one `@Transactional` batch of up to 1000 expired expectations plus parent propagation - can commit rows whose `updated_at` is already behind a cursor advanced by a concurrent sync round. The `> :from` fetch never sees those rows again. Since the engine's `inject_expectation_status` is computed from the score at indexing time (`score == null -> PENDING`), the orphaned documents stay frozen as Pending forever. The race affects every indexed model; expectations are just the most visible victim.

Full investigation in #7100.

## Fix

- **Grace window on cursor advancement** (`EsIndexingUtils.capCursorToGraceWindow`, applied in both `ElasticService` and `OpenSearchService`): the persisted cursor never gets closer to wall-clock than `engine.indexing-grace-window-seconds` (default 60, documented in `application.properties`). Rows younger than the window are re-fetched and idempotently re-upserted on every round until they age past it, so any writer committing within the window is guaranteed to be indexed. Indexing latency is unchanged (recent rows are still picked up every 15 s round); only the persisted cursor trails.
- **Repair migration** `V6_20260731110000000__Reindex_expectations_after_indexing_cursor_race_fix`: drops the `expectation-inject` row from `indexing_status`, which makes the engine drop, recreate and fully re-feed that index at next startup (established recovery pattern, cf. `V6_20260725100000000`). This converges the documents orphaned before the fix. Idempotent, lock-light.

## Notes for reviewers

- The stuck-cursor error log still checks the raw (uncapped) cursor, so it keeps detecting genuine query bugs; when the capped cursor cannot advance (everything fetched is inside the grace window) the round simply keeps the current cursor and re-processes next time - this is the expected steady state under continuous writes, not an error.
- The grace window must exceed the longest expected write transaction (plus inter-node clock skew); it is configurable for deployments with heavier batch jobs.

## Test plan

- [x] `EsIndexingUtilsTest` extended with a `capCursorToGraceWindow` nest (inside window -> capped, older than window -> untouched, boundary, zero window). 12/12 tests green locally.
- [x] `mvn spotless:apply` clean, `openaev-model` + `openaev-api` compile green.
- [ ] CI green.
