### PR TITLE
fix(attack-path): cluster endpoint overflow + missing maven modules in Docker build (#7108)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN yarn build
 FROM maven:3.9.16-eclipse-temurin-21 AS api-builder
 
 WORKDIR /opt/openaev-build/openaev
+COPY openaev-annotation-processor ./openaev-annotation-processor
 COPY openaev-model ./openaev-model
 COPY openaev-framework ./openaev-framework
 COPY openaev-api ./openaev-api
+COPY openaev-maven-plugin ./openaev-maven-plugin
 COPY pom.xml ./pom.xml
 COPY --from=front-builder /opt/openaev-build/openaev-front/builder/prod/build ./openaev-front/builder/prod/build
 RUN mvn install -DskipTests -Pdev

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathFlow.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathFlow.tsx
@@ -33,6 +33,9 @@ interface AttackPathFlowProps {
   edges: AttackPathFlowEdge[];
   onEndpointClick?: (nodeId: string, ref?: string, label?: string) => void;
   onClusterClick?: (injectorId: string, kind: 'header' | 'overflow') => void;
+  // The causal-chain view's per-depth "+N endpoints" overflow cluster (distinct from onClusterClick's
+  // per-injector progressive batch reveal): a plain expand/collapse toggle keyed by the cluster's own id.
+  onEndpointClusterClick?: (clusterId: string) => void;
   onFindingClusterClick?: (clusterId: string, typeFindings: string | undefined, injectorId: string | undefined, endpointRef: string | undefined, kind: 'header' | 'overflow') => void;
   onFindingSelect?: (nodeId: string, type?: string, value?: string, assetNodeId?: string) => void;
   onInjectorSelect?: (injectorId: string, label?: string) => void;
@@ -51,6 +54,7 @@ const AttackPathFlow = ({
   edges,
   onEndpointClick,
   onClusterClick,
+  onEndpointClusterClick,
   onFindingClusterClick,
   onFindingSelect,
   onInjectorSelect,
@@ -107,6 +111,8 @@ const AttackPathFlow = ({
             onEndpointClick?.(node.id, data.ref, data.label);
           } else if (node.type === AP_FLOW_NODE_TYPE.endpointCluster && data.injectorId) {
             onClusterClick?.(data.injectorId, data.clusterKind === 'overflow' ? 'overflow' : 'header');
+          } else if (node.type === AP_FLOW_NODE_TYPE.endpointCluster && data.clusterId) {
+            onEndpointClusterClick?.(data.clusterId);
           } else if (node.type === AP_FLOW_NODE_TYPE.findingCluster && data.clusterId) {
             onFindingClusterClick?.(data.clusterId, data.typeFindings, data.injectorId, data.endpointRef, data.clusterKind === 'overflow' ? 'overflow' : 'header');
           } else if (node.type === AP_FLOW_NODE_TYPE.finding) {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -328,6 +328,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
   // Finding-cluster drill-down: which finding clusters are expanded, their fetched (deduped) findings,
   // and how many are revealed (batched), keyed by the finding-cluster node id.
   const [expandedFindingClusters, setExpandedFindingClusters] = useState<Set<string>>(new Set());
+  // Causal-chain view: per-depth "+N endpoints" overflow cluster id -> how many hidden endpoints the
+  // user revealed beyond the always-shown cap, batched by ENDPOINT_BATCH_SIZE per click.
+  const [endpointClusterBatch, setEndpointClusterBatch] = useState<Map<string, number>>(new Map());
   const [findingsByCluster, setFindingsByCluster] = useState<Map<string, AttackPathNodeDTO[]>>(new Map());
   const [findingBatch, setFindingBatch] = useState<Map<string, number>>(new Map());
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -464,6 +467,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     endpointSeq.current += 1;
     setEndpointBatch(new Map());
     setExpandedFindingClusters(new Set());
+    setEndpointClusterBatch(new Map());
     setFindingsByCluster(new Map());
     setFindingBatch(new Map());
     setSelectedNodeId(null);
@@ -717,6 +721,13 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       setFitNonce(n => n + 1);
     }
   }, [endpointBatch]);
+
+  // Causal-chain view: reveal another ENDPOINT_BATCH_SIZE of a depth's hidden endpoints per click — never
+  // the whole overflow at once, so drilling into a heavy step doesn't dump the user back into a wall of
+  // nodes. Keeps the current view (no refit): the newly revealed hosts appear near where the user clicked.
+  const onEndpointClusterClick = useCallback((clusterId: string) => {
+    setEndpointClusterBatch(prev => new Map(prev).set(clusterId, (prev.get(clusterId) ?? 0) + ENDPOINT_BATCH_SIZE));
+  }, []);
 
   // injector id -> refs of the endpoints it reached (asset ref or id), for the bounded finding fetch.
   const injectorEndpointRefs = useMemo(() => {
@@ -1211,7 +1222,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           batch: findingBatch,
         });
       } else if (chainMode && fullDto) {
-        raw = buildCausalChainFlow(fullDto, t, expandedFindingClusters);
+        raw = buildCausalChainFlow(fullDto, t, expandedFindingClusters, endpointClusterBatch);
       } else {
         raw = buildClusteredAttackPathFlow(dto, endpointBatch, t, {
           expanded: expandedFindingClusters,
@@ -1238,7 +1249,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     },
     [
       dto, chainMode, fullDto, pathFinding, pathContractLabelByInjector, endpointBatch,
-      expandedFindingClusters, findingsByCluster, findingBatch, chokepointRankById, pivotNodeIds, t,
+      expandedFindingClusters, endpointClusterBatch, findingsByCluster, findingBatch, chokepointRankById, pivotNodeIds, t,
     ],
   );
 
@@ -2767,6 +2778,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                     edges={graphEdges}
                     onEndpointClick={onEndpointClick}
                     onClusterClick={onClusterClick}
+                    onEndpointClusterClick={onEndpointClusterClick}
                     onFindingClusterClick={onFindingClusterClick}
                     onFindingSelect={onFindingSelect}
                     onInjectorSelect={onInjectorSelect}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1411,6 +1411,9 @@ const CHAIN_EP_BLOCK_MIN = 120; // minimum height of one endpoint block (endpoin
 const CHAIN_FIND_HALF = 28; // half of AP_FINDING_SIZE (56), to centre a finding node on its row
 const CHAIN_FINDINGS_MAX_PER_TYPE = 4; // a type with more than this on an endpoint collapses into a "+N"
 // cluster (click to expand), so a heavy endpoint (e.g. 24 portscans) stays a few rows tall, not a column.
+const CHAIN_ENDPOINTS_MAX_PER_DEPTH = 4; // a depth column with more distinct endpoints than this collapses
+// the overflow into a single "+N" endpoint cluster (click to expand), so a step reaching dozens of hosts
+// stays a few blocks tall instead of one node per host in a long unreadable vertical stack.
 
 interface ChainStep {
   injectorId: string;
@@ -1430,6 +1433,9 @@ export const buildCausalChainFlow = (
   // Cluster ids (chain-fc|<depth>|<endpoint>|<type>) the user expanded, so their findings render
   // individually instead of collapsed into a "+N" cluster row.
   expandedChainClusters: Set<string> = new Set(),
+  // Cluster id (chain-epc|<depth>) -> how many of that depth's hidden endpoints to reveal beyond the
+  // always-shown cap, batched by ENDPOINT_BATCH_SIZE per click so a heavy depth reveals progressively.
+  endpointClusterBatch: Map<string, number> = new Map(),
 ): {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
@@ -1660,11 +1666,21 @@ export const buildCausalChainFlow = (
       }
     });
 
+    // A depth with more distinct endpoints than the cap collapses the overflow into a single "+N"
+    // endpoint cluster; each click reveals another ENDPOINT_BATCH_SIZE hosts (never all at once), so a
+    // step reaching dozens of hosts stays a few blocks tall instead of one node per host in a long
+    // unreadable vertical stack, and expanding it doesn't dump the user back into that same wall.
+    const epClusterId = `chain-epc|${d}`;
+    const hiddenTotal = Math.max(0, assetOrder.length - CHAIN_ENDPOINTS_MAX_PER_DEPTH);
+    const revealedExtra = Math.min(endpointClusterBatch.get(epClusterId) ?? 0, hiddenTotal);
+    const visibleAssetIds = hiddenTotal > 0 ? assetOrder.slice(0, CHAIN_ENDPOINTS_MAX_PER_DEPTH + revealedExtra) : assetOrder;
+    const hiddenAssetIds = hiddenTotal > 0 ? assetOrder.slice(CHAIN_ENDPOINTS_MAX_PER_DEPTH + revealedExtra) : [];
+
     // One vertical block per distinct asset, tall enough for BOTH its stacked injectors (left) and its
     // stacked findings (right). An injector that hits several assets is positioned once (first block).
     let cursorY = PADDING;
     const injectorPlaced = new Set<string>();
-    for (const epId of assetOrder) {
+    for (const epId of visibleAssetIds) {
       // Endpoint-local action: the "injector" is this very endpoint (self-loop). Drop it BEFORE the
       // layout so no injector node, no self arrow, and no empty injector slot is reserved for it —
       // the endpoint node and its findings still render.
@@ -1840,6 +1856,67 @@ export const buildCausalChainFlow = (
       });
 
       cursorY = blockTop + h + CHAIN_STEP_GAP;
+    }
+
+    // The collapsed overflow: one "+N" endpoint cluster carrying every hidden host at this depth, wired
+    // to whichever injector(s) reached them. Its own findings stay hidden until expanded — mirrors the
+    // per-type finding cluster above (collapse hides detail behind a click, not just a count).
+    if (hiddenAssetIds.length > 0) {
+      const clusterInjectors = [...new Set(hiddenAssetIds.flatMap(epId => assetInjectors.get(epId) ?? []))];
+      const hCluster = Math.max(CHAIN_EP_BLOCK_MIN, clusterInjectors.length * CHAIN_INJECTOR_ROW);
+      const blockTop = cursorY;
+      const blockCenter = blockTop + hCluster / 2;
+      const clusterStatus = aggregateStatus(hiddenAssetIds.map(epId => assetById.get(epId)?.status));
+
+      nodes.push({
+        id: epClusterId,
+        type: AP_FLOW_NODE_TYPE.endpointCluster,
+        position: {
+          x: x + chainEpDx,
+          y: blockCenter - CLUSTER_EP_HALF_H,
+        },
+        data: {
+          count: hiddenAssetIds.length,
+          clusterId: epClusterId,
+          clusterKind: revealedExtra === 0 ? 'header' : 'overflow',
+          expanded: revealedExtra > 0,
+          status: clusterStatus,
+        },
+      });
+
+      clusterInjectors.forEach((injId, i) => {
+        const s = steps.get(injId) as ChainStep;
+        if (!injectorPlaced.has(injId)) {
+          injectorPlaced.add(injId);
+          const injCenterY = clusterInjectors.length === 1
+            ? blockCenter
+            : blockTop + (i + 0.5) * (hCluster / clusterInjectors.length);
+          const injDto = injectorById.get(injId);
+          const injActionLabel = [...s.contractByEndpoint.values()][0];
+          nodes.push({
+            id: injId,
+            type: AP_FLOW_NODE_TYPE.injector,
+            position: {
+              x,
+              y: injCenterY - CLUSTER_INJECTOR_HALF_H,
+            },
+            data: injDto ? nodeData(injDto) : { label: injActionLabel || friendlyNodeId(injId) },
+          });
+        }
+        const reachedCount = hiddenAssetIds.filter(epId => (assetInjectors.get(epId) ?? []).includes(injId)).length;
+        edges.push({
+          id: `${injId}-${epClusterId}`,
+          source: injId,
+          target: epClusterId,
+          type: AP_FLOW_EDGE_TYPE,
+          data: {
+            count: reachedCount,
+            status: clusterStatus,
+          },
+        });
+      });
+
+      cursorY = blockTop + hCluster + CHAIN_STEP_GAP;
     }
   }
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1862,6 +1862,9 @@ export const buildCausalChainFlow = (
     // to whichever injector(s) reached them. Its own findings stay hidden until expanded — mirrors the
     // per-type finding cluster above (collapse hides detail behind a click, not just a count).
     if (hiddenAssetIds.length > 0) {
+      // Route the hidden endpoints' findings through the cluster too, so a downstream causal edge whose
+      // producer got collapsed still resolves to a placed node instead of a fid that was never rendered.
+      hiddenAssetIds.forEach(epId => (assetFindings.get(epId) ?? []).forEach(fid => causalSourceByFinding.set(fid, epClusterId)));
       const clusterInjectors = [...new Set(hiddenAssetIds.flatMap(epId => assetInjectors.get(epId) ?? []))];
       const hCluster = Math.max(CHAIN_EP_BLOCK_MIN, clusterInjectors.length * CHAIN_INJECTOR_ROW);
       const blockTop = cursorY;


### PR DESCRIPTION
## Summary

- **Attack path (causal-chain view)**: a depth column with more distinct endpoints than the cap (>4) rendered one node per host with no collapse, producing a long unreadable vertical stack (e.g. 56 endpoints from a /24 scope). Mirrors the existing per-type finding cluster (`CHAIN_FINDINGS_MAX_PER_TYPE`) with a new `CHAIN_ENDPOINTS_MAX_PER_DEPTH = 4` cap, collapsing the overflow into a single `apEndpointCluster` "+N" node. Clicking it reveals another `ENDPOINT_BATCH_SIZE` (10) hosts at a time rather than dumping the whole overflow at once.
- **Docker build**: the `Dockerfile`'s `api-builder` stage never `COPY`s `openaev-annotation-processor` and `openaev-maven-plugin` into the build context, even though the root `pom.xml` declares both as reactor modules — so a local `docker build` fails Maven's reactor resolution. Added the two missing `COPY` lines.

## Test plan

- [x] `yarn check-ts` passes with 0 errors
- [x] Verified visually: a simulation with 56 endpoints at one depth now shows 4 individual + one "+52" cluster node instead of a 56-node wall
- [x] Verified click-to-expand reveals 10 more endpoints per click, and the cluster count decrements accordingly
- [x] `docker build --target app` succeeds from source after the Dockerfile fix

- [x] Fixed a review finding: hidden endpoints in the collapsed cluster now route their findings through the cluster node for causal-edge purposes, so a downstream consumer of a hidden host's finding no longer loses its causal edge
