### PR TITLE
fix(inject): resolve payload argument placeholders in terminal view (#7110)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/InjectExecutionResultService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/InjectExecutionResultService.java
@@ -54,8 +54,7 @@ public class InjectExecutionResultService {
             .orElse(new ArrayList<>());
     InjectResultPayloadExecutionOutputBuilder output =
         InjectResultPayloadExecutionOutput.builder()
-            .payloadCommandBlocks(
-                resolveArgumentPlaceholders(injectId, payloadCommandBlocks));
+            .payloadCommandBlocks(resolveArgumentPlaceholders(injectId, payloadCommandBlocks));
 
     // Group execution traces per target key. Agent-based executions are keyed by agent id;
     // agentless
@@ -90,9 +89,9 @@ public class InjectExecutionResultService {
   /**
    * Resolves every {@code #{argumentKey}} placeholder in the payload's command/cleanup templates
    * (e.g. {@code echo #{host}:#{port}}) to its actual value, mirroring what is actually sent for
-   * execution ({@link ExecutableInjectService#replaceArgumentsByValue}) instead of the raw
-   * template — so the terminal view shows {@code echo localhost:22} rather than the unresolved
-   * placeholders. Falls back to the raw blocks if the inject has no payload to resolve against.
+   * execution ({@link ExecutableInjectService#replaceArgumentsByValue}) instead of the raw template
+   * — so the terminal view shows {@code echo localhost:22} rather than the unresolved placeholders.
+   * Falls back to the raw blocks if the inject has no payload to resolve against.
    */
   private List<PayloadCommandBlock> resolveArgumentPlaceholders(
       final String injectId, final List<PayloadCommandBlock> payloadCommandBlocks) {

--- a/openaev-api/src/main/java/io/openaev/rest/inject/InjectExecutionResultService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/InjectExecutionResultService.java
@@ -5,19 +5,26 @@ import static io.openaev.utils.mapper.InjectStatusMapper.toExecutionTracesOutput
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.api.inject_result.dto.InjectResultPayloadExecutionOutput;
 import io.openaev.api.inject_result.dto.InjectResultPayloadExecutionOutput.InjectResultPayloadExecutionOutputBuilder;
 import io.openaev.database.model.Agent;
 import io.openaev.database.model.ExecutionTrace;
+import io.openaev.database.model.Inject;
 import io.openaev.database.model.InjectStatus;
+import io.openaev.database.model.PayloadArgument;
+import io.openaev.database.model.PayloadCommandBlock;
 import io.openaev.database.model.StatusPayload;
 import io.openaev.rest.atomic_testing.form.ExecutionTraceOutput;
+import io.openaev.rest.inject.service.ExecutableInjectService;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.rest.inject.service.InjectStatusService;
 import io.openaev.utils.TargetType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.*;
+import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,19 +40,22 @@ public class InjectExecutionResultService {
 
   private final InjectService injectService;
   private final InjectStatusService injectStatusService;
+  private final ExecutableInjectService executableInjectService;
 
   public InjectResultPayloadExecutionOutput injectExecutionResultPayload(
       @NotBlank final String injectId,
       @NotBlank final String targetId,
       @NotNull final TargetType targetType) {
     InjectStatus injectStatus = this.injectStatusService.findInjectStatusByInjectId(injectId);
+    List<PayloadCommandBlock> payloadCommandBlocks =
+        Optional.of(injectStatus)
+            .map(InjectStatus::getPayloadOutput)
+            .map(StatusPayload::getPayloadCommandBlocks)
+            .orElse(new ArrayList<>());
     InjectResultPayloadExecutionOutputBuilder output =
         InjectResultPayloadExecutionOutput.builder()
             .payloadCommandBlocks(
-                Optional.of(injectStatus)
-                    .map(InjectStatus::getPayloadOutput)
-                    .map(StatusPayload::getPayloadCommandBlocks)
-                    .orElse(new ArrayList<>()));
+                resolveArgumentPlaceholders(injectId, payloadCommandBlocks));
 
     // Group execution traces per target key. Agent-based executions are keyed by agent id;
     // agentless
@@ -75,6 +85,67 @@ public class InjectExecutionResultService {
 
     output.traces(result);
     return output.build();
+  }
+
+  /**
+   * Resolves every {@code #{argumentKey}} placeholder in the payload's command/cleanup templates
+   * (e.g. {@code echo #{host}:#{port}}) to its actual value, mirroring what is actually sent for
+   * execution ({@link ExecutableInjectService#replaceArgumentsByValue}) instead of the raw
+   * template — so the terminal view shows {@code echo localhost:22} rather than the unresolved
+   * placeholders. Falls back to the raw blocks if the inject has no payload to resolve against.
+   */
+  private List<PayloadCommandBlock> resolveArgumentPlaceholders(
+      final String injectId, final List<PayloadCommandBlock> payloadCommandBlocks) {
+    if (payloadCommandBlocks.isEmpty()) {
+      return payloadCommandBlocks;
+    }
+    Inject inject = injectService.inject(injectId);
+    return inject
+        .getPayload()
+        .map(
+            payload -> {
+              List<PayloadArgument> arguments =
+                  Optional.ofNullable(payload.getArguments()).orElse(List.of());
+              List<ObjectNode> injectorContractFields =
+                  inject
+                      .getInjectorContract()
+                      .map(
+                          contract -> {
+                            JsonNode fields = contract.getConvertedContent().get("fields");
+                            return fields == null
+                                ? List.<ObjectNode>of()
+                                : StreamSupport.stream(fields.spliterator(), false)
+                                    .map(ObjectNode.class::cast)
+                                    .toList();
+                          })
+                      .orElse(List.of());
+              return payloadCommandBlocks.stream()
+                  .map(
+                      block -> {
+                        String resolvedContent =
+                            executableInjectService.replaceArgumentsByValue(
+                                block.getContent(),
+                                arguments,
+                                injectorContractFields,
+                                inject.getContent());
+                        List<String> resolvedCleanup =
+                            block.getCleanupCommand() == null
+                                ? null
+                                : block.getCleanupCommand().stream()
+                                    .map(
+                                        cmd ->
+                                            executableInjectService.replaceArgumentsByValue(
+                                                cmd,
+                                                arguments,
+                                                injectorContractFields,
+                                                inject.getContent()))
+                                    .toList();
+                        return new PayloadCommandBlock(
+                            block.getExecutor(), resolvedContent, resolvedCleanup);
+                      })
+                  .toList();
+            })
+        .orElse(payloadCommandBlocks);
   }
 
   private static String traceKey(final ExecutionTrace trace) {

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -81,7 +81,14 @@ public class ExecutableInjectService {
     return String.join(assetSeparator, valuesAssetsMap.keySet());
   }
 
-  private String replaceArgumentsByValue(
+  /**
+   * Resolves every {@code #{argumentKey}} placeholder in a command template to its actual value:
+   * the inject's own content when set, otherwise the payload argument's default value. Shared by
+   * the real execution path ({@link #processAndEncodeCommand}, before obfuscation/encoding) and by
+   * read-only display of a payload's command (e.g. the terminal view), so both stay in sync with a
+   * single resolution rule.
+   */
+  public String replaceArgumentsByValue(
       String command,
       List<PayloadArgument> defaultPayloadArguments,
       List<ObjectNode> injectorContractContentFields,


### PR DESCRIPTION
## Summary

- `InjectExecutionResultService.injectExecutionResultPayload` returned the payload's raw command/cleanup templates (e.g. `echo #{host}:#{port}`) straight from `StatusPayload`, with no placeholder substitution. Both the inject's own "Terminal view" and the attack-path popup's live tab share the same `TerminalView` component, so both showed the unresolved template — unlike the attack-path's pre-resolved snapshot detail path, which already displayed `echo localhost:22`.
- `ExecutableInjectService` already resolves these exact `#{argumentKey}` placeholders (inject content, falling back to the payload argument's default value) before sending a command for real execution, via the private `replaceArgumentsByValue` — it just never ran for display purposes.
- Made that method `public` and call it from `InjectExecutionResultService` to resolve every `payloadCommandBlocks` entry (command + cleanup commands) before returning them.
- No frontend change needed: `TerminalView.tsx` already renders whatever `command_content` the API returns, so both UI locations pick up the fix automatically.

## Test plan

- [x] `mvn install -DskipTests -Pdev` (full reactor) builds clean
- [ ] Manually verify: a payload inject with a `host`/`port` argument (defaults `localhost`/`22`) now shows `echo localhost:22` in both the inject's own terminal view and the attack-path popup's live tab, instead of `echo #{host}:#{port}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)