### PR TITLE
fix(engine): stagger engine sync triggers so the concurrency cap cannot starve models (#7112)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/scheduler/SelfConfiguredPlatformJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/SelfConfiguredPlatformJob.java
@@ -3,29 +3,64 @@ package io.openaev.scheduler;
 import io.openaev.engine.EngineContext;
 import io.openaev.engine.EngineService;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 
-public abstract class SelfConfiguredPlatformJob {
+/**
+ * Base class for jobs that compute their own job definitions from application state.
+ *
+ * <p>Trigger registration is deferred to {@link #afterSingletonsInstantiated()} (i.e. once the
+ * Spring context has instantiated every singleton) instead of the constructor. Subclasses derive
+ * their job definitions from dynamic bean lookups (e.g. {@link EngineContext#getModels()} scans
+ * {@code Handler} beans): running that lookup at construction time only sees the beans created so
+ * far, which silently dropped sync jobs for every model whose handler bean had not been
+ * instantiated yet.
+ */
+@Slf4j
+public abstract class SelfConfiguredPlatformJob implements SmartInitializingSingleton {
   private final Scheduler scheduler;
   protected final EngineService engineService;
   protected final EngineContext engineContext;
 
   protected SelfConfiguredPlatformJob(
-      Scheduler scheduler, EngineService engineService, EngineContext engineContext)
-      throws SchedulerException {
+      Scheduler scheduler, EngineService engineService, EngineContext engineContext) {
     this.scheduler = scheduler;
     this.engineService = engineService;
     this.engineContext = engineContext;
-    registerTriggers();
   }
 
   protected abstract List<JobDetail> getJobDetails();
 
-  protected abstract Trigger getTrigger();
+  /**
+   * Builds the trigger for the job definition at the given index. The index lets implementations
+   * stagger the start time of each trigger: triggers built with the same schedule and the same
+   * start instant all fire at the exact same moment forever, which starves models behind a
+   * concurrency cap (see {@code EngineSyncExecutionJob}).
+   *
+   * @param jobIndex position of the job definition in the {@link #getJobDetails()} list
+   */
+  protected abstract Trigger getTrigger(int jobIndex);
+
+  @Override
+  public void afterSingletonsInstantiated() {
+    try {
+      registerTriggers();
+    } catch (SchedulerException e) {
+      throw new IllegalStateException(
+          "Failed to register triggers for " + getClass().getSimpleName(), e);
+    }
+  }
 
   private void registerTriggers() throws SchedulerException {
-    for (JobDetail jd : getJobDetails()) {
-      scheduler.scheduleJob(jd, getTrigger());
+    List<JobDetail> jobDetails = getJobDetails();
+    for (int i = 0; i < jobDetails.size(); i++) {
+      scheduler.scheduleJob(jobDetails.get(i), getTrigger(i));
     }
+    log.info(
+        "Registered {} job(s) for {}: {}",
+        jobDetails.size(),
+        getClass().getSimpleName(),
+        jobDetails.stream().map(jd -> jd.getKey().getName()).toList());
   }
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
@@ -11,9 +11,13 @@ import io.openaev.engine.EngineService;
 import io.openaev.engine.EsModel;
 import io.openaev.engine.model.EsBase;
 import io.openaev.scheduler.SelfConfiguredPlatformJob;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
@@ -25,6 +29,14 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
   private static final String MODEL_NAME_KEY = "modelName";
+  private static final int SYNC_INTERVAL_SECONDS = 15;
+
+  /**
+   * Warn every this many consecutive skipped passes (20 passes x 15s = every 5 minutes). Starved
+   * models must be visible at default log level: the per-skip message is debug-only and a model
+   * that never wins a permit would otherwise disappear from the logs entirely.
+   */
+  private static final int CONSECUTIVE_SKIPS_WARN_THRESHOLD = 20;
 
   /**
    * Caps how many model syncs may run at the same time. Every sync pass holds a database connection
@@ -37,12 +49,18 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
    */
   private final Semaphore concurrentSyncs;
 
+  /**
+   * Consecutive skipped passes per model, reset whenever the model wins a permit. Only used to
+   * surface starvation (see {@link #CONSECUTIVE_SKIPS_WARN_THRESHOLD}).
+   */
+  private final ConcurrentHashMap<String, AtomicInteger> consecutiveSkips =
+      new ConcurrentHashMap<>();
+
   protected EngineSyncExecutionJob(
       Scheduler scheduler,
       EngineService engineService,
       EngineContext engineContext,
-      EngineConfig engineConfig)
-      throws SchedulerException {
+      EngineConfig engineConfig) {
     super(scheduler, engineService, engineContext);
     // Clamp to at least 1: zero (or negative) permits would silently disable engine sync
     // altogether, which is never what a tuning knob should do.
@@ -75,15 +93,29 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
                 .formatted(requestedModelName));
       }
 
+      String modelName = model.get().getName();
       if (!concurrentSyncs.tryAcquire()) {
-        log.debug(
-            "Skipping engine sync for model {}: concurrency cap reached"
-                + " (engine.indexing-max-concurrent-models), will retry at the next trigger",
-            model.get().getName());
+        int skips =
+            consecutiveSkips
+                .computeIfAbsent(modelName, key -> new AtomicInteger())
+                .incrementAndGet();
+        if (skips % CONSECUTIVE_SKIPS_WARN_THRESHOLD == 0) {
+          log.warn(
+              "Engine sync for model {} has been skipped {} consecutive passes: the concurrency"
+                  + " cap (engine.indexing-max-concurrent-models) is monopolised by other models",
+              modelName,
+              skips);
+        } else {
+          log.debug(
+              "Skipping engine sync for model {}: concurrency cap reached"
+                  + " (engine.indexing-max-concurrent-models), will retry at the next trigger",
+              modelName);
+        }
         return;
       }
+      consecutiveSkips.remove(modelName);
       try {
-        log.info("Executing engine sync for model {}", model.get().getName());
+        log.info("Executing engine sync for model {}", modelName);
         engineService.bulkProcessing(Stream.of(model.get()));
       } finally {
         concurrentSyncs.release();
@@ -113,11 +145,22 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
         .toList();
   }
 
+  /**
+   * All model triggers share the same 15-second interval, so triggers created with the same start
+   * instant fire at the exact same moment on every pass, forever. Quartz fires simultaneous
+   * triggers in a deterministic order (tied by trigger key, rolled once per boot), so with the
+   * concurrency cap the same {@code engine.indexing-max-concurrent-models} models won every permit
+   * on every pass and the remaining models were never synced at all for the lifetime of the JVM.
+   * Staggering each trigger's start by one second (modulo the interval) gives every model its own
+   * phase, spreading fires across the whole interval instead of one contended burst.
+   */
   @Override
-  protected Trigger getTrigger() {
-    SimpleScheduleBuilder _15_seconds = simpleSchedule().withIntervalInSeconds(15).repeatForever();
+  protected Trigger getTrigger(int jobIndex) {
+    SimpleScheduleBuilder _15_seconds =
+        simpleSchedule().withIntervalInSeconds(SYNC_INTERVAL_SECONDS).repeatForever();
 
     return newTrigger()
+        .startAt(Date.from(Instant.now().plusSeconds(jobIndex % SYNC_INTERVAL_SECONDS)))
         .withSchedule(_15_seconds.withMisfireHandlingInstructionNextWithRemainingCount())
         .build();
   }

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
@@ -10,16 +10,20 @@ import io.openaev.engine.EngineService;
 import io.openaev.engine.EsModel;
 import io.openaev.engine.model.EsBase;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.Scheduler;
+import org.quartz.Trigger;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("EngineSyncExecutionJob Unit Tests")
@@ -100,6 +104,67 @@ class EngineSyncExecutionJobTest {
 
     pass.execute(jobExecutionContext);
     verify(engineService, times(1)).bulkProcessing(any());
+  }
+
+  @Test
+  @DisplayName("Registers one job per model once all singletons are instantiated")
+  void given_models_should_registerOneJobPerModelAfterContextStartup() throws Exception {
+    List<EsModel<EsBase>> models =
+        IntStream.range(0, 13)
+            .mapToObj(
+                i -> {
+                  @SuppressWarnings("unchecked")
+                  EsModel<EsBase> mdl = mock(EsModel.class);
+                  when(mdl.getName()).thenReturn("model-" + i);
+                  return mdl;
+                })
+            .toList();
+    when(engineContext.getModels()).thenReturn(models);
+    EngineSyncExecutionJob job = buildJob();
+
+    // Registration must not happen at construction time: the model list is a live bean lookup
+    // that is only guaranteed complete once the whole context is up.
+    verify(scheduler, never()).scheduleJob(any(JobDetail.class), any(Trigger.class));
+
+    job.afterSingletonsInstantiated();
+
+    ArgumentCaptor<JobDetail> jobCaptor = ArgumentCaptor.forClass(JobDetail.class);
+    verify(scheduler, times(13)).scheduleJob(jobCaptor.capture(), any(Trigger.class));
+    assertEquals(
+        models.stream().map(m -> "EngineSyncExecutionJob_forModel_" + m.getName()).toList(),
+        jobCaptor.getAllValues().stream().map(jd -> jd.getKey().getName()).toList());
+  }
+
+  @Test
+  @DisplayName("Staggers trigger phases so the concurrency cap cannot starve the same models")
+  void given_models_should_staggerTriggerStartTimes() throws Exception {
+    List<EsModel<EsBase>> models =
+        IntStream.range(0, 5)
+            .mapToObj(
+                i -> {
+                  @SuppressWarnings("unchecked")
+                  EsModel<EsBase> mdl = mock(EsModel.class);
+                  when(mdl.getName()).thenReturn("model-" + i);
+                  return mdl;
+                })
+            .toList();
+    when(engineContext.getModels()).thenReturn(models);
+    EngineSyncExecutionJob job = buildJob();
+
+    job.afterSingletonsInstantiated();
+
+    ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+    verify(scheduler, times(5)).scheduleJob(any(JobDetail.class), triggerCaptor.capture());
+    List<Trigger> triggers = triggerCaptor.getAllValues();
+    long baseStart = triggers.get(0).getStartTime().getTime();
+    for (int i = 1; i < triggers.size(); i++) {
+      long offsetMs = triggers.get(i).getStartTime().getTime() - baseStart;
+      // Each trigger is shifted by (index % interval) seconds; allow scheduling-time jitter.
+      assertTrue(
+          Math.abs(offsetMs - i * 1000L) < 500,
+          "Trigger %d should start ~%ds after the first but was offset by %dms"
+              .formatted(i, i, offsetMs));
+    }
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
@@ -130,9 +130,13 @@ class EngineSyncExecutionJobTest {
 
     ArgumentCaptor<JobDetail> jobCaptor = ArgumentCaptor.forClass(JobDetail.class);
     verify(scheduler, times(13)).scheduleJob(jobCaptor.capture(), any(Trigger.class));
+    // Compare sorted names: the test only guarantees one job per model, not a discovery order.
     assertEquals(
-        models.stream().map(m -> "EngineSyncExecutionJob_forModel_" + m.getName()).toList(),
-        jobCaptor.getAllValues().stream().map(jd -> jd.getKey().getName()).toList());
+        models.stream()
+            .map(m -> "EngineSyncExecutionJob_forModel_" + m.getName())
+            .sorted()
+            .toList(),
+        jobCaptor.getAllValues().stream().map(jd -> jd.getKey().getName()).sorted().toList());
   }
 
   @Test
@@ -159,9 +163,15 @@ class EngineSyncExecutionJobTest {
     long baseStart = triggers.get(0).getStartTime().getTime();
     for (int i = 1; i < triggers.size(); i++) {
       long offsetMs = triggers.get(i).getStartTime().getTime() - baseStart;
-      // Each trigger is shifted by (index % interval) seconds; allow scheduling-time jitter.
+      // Each trigger is shifted by (index % interval) seconds from its own build instant, and
+      // trigger i is built after trigger 0, so the offset can never be below i seconds. The upper
+      // bound only guards against a wrong phase and is generous to absorb CI noise/GC pauses.
       assertTrue(
-          Math.abs(offsetMs - i * 1000L) < 500,
+          offsetMs >= i * 1000L,
+          "Trigger %d should start at least %ds after the first but was offset by %dms"
+              .formatted(i, i, offsetMs));
+      assertTrue(
+          offsetMs < i * 1000L + 5000L,
           "Trigger %d should start ~%ds after the first but was offset by %dms"
               .formatted(i, i, offsetMs));
     }


### PR DESCRIPTION
## Summary

Fixes #7112.

Since 3.260731.0, the `engine.indexing-max-concurrent-models` semaphore (default 3) could permanently starve every model outside a fixed subset: all sync triggers were built with the same 15-second schedule and the same start instant, so they fired at the exact same moment on every pass, and Quartz breaks the tie in a fixed order (random trigger key, rolled once per boot). The same 3 models won the permits on every pass; the other 10 were skipped forever, with only a debug-level log line. Observed on main-ff where `expectation-inject` never rebuilt after the forced reindex migration (empty index, cursor stuck at epoch).

## Changes

- `EngineSyncExecutionJob#getTrigger(int)`: stagger each model trigger's start by `index % 15` seconds so each model owns its own phase within the interval and steady-state contention on the semaphore disappears.
- `EngineSyncExecutionJob.Job#execute`: count consecutive skipped passes per model and emit a `warn` every 20 consecutive skips (5 minutes of starvation), reset when the model wins a permit. Starvation can no longer be silent.
- `SelfConfiguredPlatformJob`: defer trigger registration from the constructor to `SmartInitializingSingleton.afterSingletonsInstantiated()` (the job-definition list comes from a live `getBeansOfType(Handler.class)` lookup that is only guaranteed complete once the context is up) and log the registered job list at startup so a partial registration is immediately visible.

## Test plan

- [x] `EngineSyncExecutionJobTest`: 2 new unit tests - one job per model registered after `afterSingletonsInstantiated` (none at construction), trigger start times staggered by ~1s per model index; 4 pre-existing tests still green (6/6).
- [ ] CI green.
- [ ] On a deployed platform: after restart, all 13 models appear in "Executing engine sync for model" logs and `indexing_status` cursors advance for every type.
