### PR TITLE
fix(expectations): normalize legacy inject expectation signature types (#7114)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260731150000000__Normalize_legacy_inject_expectation_signature_types.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260731150000000__Normalize_legacy_inject_expectation_signature_types.java
@@ -1,0 +1,61 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rewrites legacy inject expectation signature types to their canonical names (the constants in
+ * {@code ExpectationSignatureUtils}). The signature type is a free string column and early
+ * injectors persisted short-form names ({@code start_time}, {@code source_ipv4}, ...). Collectors
+ * validate the type against a strict enum of the canonical names and crash on the legacy values
+ * when processing pending expectations, so the legacy rows must be rewritten in place.
+ *
+ * <p>The primary key is (expectation id, type, value): a legacy row is only rewritten when the
+ * expectation does not already carry the same signature under the canonical type; remaining legacy
+ * duplicates are deleted.
+ */
+@Component
+public class V6_20260731150000000__Normalize_legacy_inject_expectation_signature_types
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          """
+          UPDATE injects_expectations_signatures s
+          SET inject_expectation_signature_type = m.new_type
+          FROM (VALUES
+            ('start_time', 'start_date'),
+            ('end_time', 'end_date'),
+            ('source_ipv4', 'source_ipv4_address'),
+            ('source_ipv6', 'source_ipv6_address'),
+            ('target_ipv4', 'target_ipv4_address'),
+            ('target_ipv6', 'target_ipv6_address'),
+            ('target_hostname', 'target_hostname_address')
+          ) AS m(old_type, new_type)
+          WHERE s.inject_expectation_signature_type = m.old_type
+            AND NOT EXISTS (
+              SELECT 1 FROM injects_expectations_signatures t
+              WHERE t.inject_expectation_signature_inject_expectation_id =
+                      s.inject_expectation_signature_inject_expectation_id
+                AND t.inject_expectation_signature_type = m.new_type
+                AND t.inject_expectation_signature_value = s.inject_expectation_signature_value
+            );
+          """);
+      // Legacy rows whose canonical twin already existed on the same expectation are duplicates.
+      statement.execute(
+          """
+          DELETE FROM injects_expectations_signatures
+          WHERE inject_expectation_signature_type IN (
+            'start_time', 'end_time',
+            'source_ipv4', 'source_ipv6',
+            'target_ipv4', 'target_ipv6',
+            'target_hostname'
+          );
+          """);
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/migration/NormalizeLegacyInjectExpectationSignatureTypesMigrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/migration/NormalizeLegacyInjectExpectationSignatureTypesMigrationTest.java
@@ -1,0 +1,157 @@
+package io.openaev.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.BaseInjectExpectation;
+import io.openaev.utils.fixtures.InjectExpectationFixture;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectExpectationComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.util.List;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.migration.Context;
+import org.hibernate.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the legacy signature type repair: short-form types are rewritten to the canonical {@code
+ * ExpectationSignatureUtils} names, legacy rows whose canonical twin already exists are dropped
+ * instead of violating the (expectation, type, value) primary key, canonical rows are left
+ * untouched, and re-running the migration is a no-op.
+ *
+ * <p>{@code @Transactional} so the seeded rows and migration side effects roll back with the test
+ * transaction.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("Normalize legacy inject expectation signature types migration")
+class NormalizeLegacyInjectExpectationSignatureTypesMigrationTest extends IntegrationTest {
+
+  @Autowired
+  private V6_20260731150000000__Normalize_legacy_inject_expectation_signature_types migration;
+
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectExpectationComposer injectExpectationComposer;
+
+  private String persistExpectation() {
+    BaseInjectExpectation expectation =
+        InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+    injectComposer
+        .forInject(InjectFixture.getDefaultInject())
+        .withExpectation(injectExpectationComposer.forExpectation(expectation))
+        .persist();
+    entityManager.flush();
+    return expectation.getId();
+  }
+
+  private void insertSignature(String expectationId, String type, String value) {
+    entityManager
+        .createNativeQuery(
+            "INSERT INTO injects_expectations_signatures ("
+                + "inject_expectation_signature_inject_expectation_id, "
+                + "inject_expectation_signature_type, "
+                + "inject_expectation_signature_value) VALUES (:id, :type, :value)")
+        .setParameter("id", expectationId)
+        .setParameter("type", type)
+        .setParameter("value", value)
+        .executeUpdate();
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object[]> signaturesOf(String expectationId) {
+    return entityManager
+        .createNativeQuery(
+            "SELECT inject_expectation_signature_type, inject_expectation_signature_value "
+                + "FROM injects_expectations_signatures "
+                + "WHERE inject_expectation_signature_inject_expectation_id = :id "
+                + "ORDER BY inject_expectation_signature_type, inject_expectation_signature_value")
+        .setParameter("id", expectationId)
+        .getResultList();
+  }
+
+  private void runMigration() {
+    entityManager
+        .unwrap(Session.class)
+        .doWork(
+            connection -> {
+              try {
+                migration.migrate(
+                    new Context() {
+                      @Override
+                      public Configuration getConfiguration() {
+                        return null;
+                      }
+
+                      @Override
+                      public java.sql.Connection getConnection() {
+                        return connection;
+                      }
+                    });
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+
+  @Test
+  @DisplayName("Rewrites every legacy type to its canonical name and keeps canonical rows intact")
+  void legacy_types_are_rewritten() {
+    String expectationId = persistExpectation();
+    insertSignature(expectationId, "start_time", "2026-07-31T10:00:00Z");
+    insertSignature(expectationId, "end_time", "2026-07-31T11:00:00Z");
+    insertSignature(expectationId, "source_ipv4", "10.0.0.1");
+    insertSignature(expectationId, "source_ipv6", "::1");
+    insertSignature(expectationId, "target_ipv4", "10.0.0.2");
+    insertSignature(expectationId, "target_ipv6", "::2");
+    insertSignature(expectationId, "target_hostname", "host-a");
+    insertSignature(expectationId, "parent_process_name", "implant.exe");
+
+    runMigration();
+
+    assertThat(signaturesOf(expectationId))
+        .extracting(row -> row[0] + "=" + row[1])
+        .containsExactly(
+            "end_date=2026-07-31T11:00:00Z",
+            "parent_process_name=implant.exe",
+            "source_ipv4_address=10.0.0.1",
+            "source_ipv6_address=::1",
+            "start_date=2026-07-31T10:00:00Z",
+            "target_hostname_address=host-a",
+            "target_ipv4_address=10.0.0.2",
+            "target_ipv6_address=::2");
+  }
+
+  @Test
+  @DisplayName("Drops a legacy row whose canonical twin already exists instead of violating the PK")
+  void legacy_duplicates_are_dropped() {
+    String expectationId = persistExpectation();
+    insertSignature(expectationId, "source_ipv4", "10.0.0.1");
+    insertSignature(expectationId, "source_ipv4_address", "10.0.0.1");
+
+    runMigration();
+
+    assertThat(signaturesOf(expectationId))
+        .extracting(row -> row[0] + "=" + row[1])
+        .containsExactly("source_ipv4_address=10.0.0.1");
+  }
+
+  @Test
+  @DisplayName("Re-running the migration is a no-op (idempotent)")
+  void migration_is_idempotent() {
+    String expectationId = persistExpectation();
+    insertSignature(expectationId, "start_time", "2026-07-31T10:00:00Z");
+
+    runMigration();
+    assertThatCode(this::runMigration).doesNotThrowAnyException();
+
+    assertThat(signaturesOf(expectationId))
+        .extracting(row -> row[0] + "=" + row[1])
+        .containsExactly("start_date=2026-07-31T10:00:00Z");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #7114.

Python collectors crash with Pydantic validation errors on pending expectations that carry legacy signature type names (`start_time`, `end_time`, `source_ipv4`, `target_ipv4`, `target_ipv6`, `target_hostname` - 776 rows observed on main-ff). The type is a free string column served verbatim via `/api/injects/expectations*`; the canonical names (constants in `ExpectationSignatureUtils`) have been the only ones produced since July 2025, but no migration ever repaired the historical rows.

## Changes

- `V6_20260731150000000__Normalize_legacy_inject_expectation_signature_types`: rewrites the six legacy types to their canonical names in place. The primary key is (expectation id, type, value), so a legacy row is only rewritten when the canonical twin does not already exist on the same expectation; remaining legacy duplicates are then deleted. Idempotent; no search-engine reindex needed (signatures are not embedded in engine documents).

## Test plan

- [x] `NormalizeLegacyInjectExpectationSignatureTypesMigrationTest` (3 integration tests, all green): every legacy type rewritten while canonical rows stay intact, legacy duplicate dropped instead of violating the PK, re-run is a no-op.
- [ ] CI green.
- [ ] After deploy: `SELECT inject_expectation_signature_type, count(*) FROM injects_expectations_signatures GROUP BY 1;` shows canonical names only, and collectors stop crashing on pending expectations.
