### PR TITLE
fix(queue): make BatchQueueService's internal maps thread-safe (#7116)

### DIFF
--- a/openaev-model/src/main/java/io/openaev/service/queue/BatchQueueService.java
+++ b/openaev-model/src/main/java/io/openaev/service/queue/BatchQueueService.java
@@ -41,6 +41,11 @@ public class BatchQueueService<T extends Queueable> {
   private final String exchangeName;
   private final String queueName;
 
+  // ConcurrentHashMap: read/mutated from both the AMQP delivery threads (deliverCallback, on a new
+  // key) and the dedicated scheduler thread (the periodic flush below) with no external locking. A
+  // plain HashMap under that access pattern can throw ConcurrentModificationException inside the
+  // scheduler's task — which, being uncaught in a scheduleAtFixedRate Runnable, silently cancels
+  // every future tick for this instance, permanently stalling the queue with no error logged.
   private final Map<Integer, BlockingQueue<T>> queue;
 
   private final Map<T, DeliveryContext> deliveryTable = new ConcurrentHashMap<>();
@@ -51,7 +56,13 @@ public class BatchQueueService<T extends Queueable> {
   private final ShutdownListener shutdownListener;
 
   private final List<Channel> consumerChannels = new CopyOnWriteArrayList<>();
-  private final Map<Integer, AtomicBoolean> insertInProgress = new HashMap<>();
+  // ConcurrentHashMap for the same reason as `queue` above: computeIfAbsent on a plain HashMap is
+  // not atomic for concurrent callers on a new key, so the AMQP delivery thread's immediate-trigger
+  // path (deliverCallback -> processBufferedBatch) racing the scheduler's periodic call for the same
+  // brand-new workerId can hand two different callers two different AtomicBoolean instances for what
+  // should be one shared guard — desyncing it permanently stuck at true for that worker, with no
+  // exception thrown (compareAndSet just silently keeps returning false).
+  private final Map<Integer, AtomicBoolean> insertInProgress = new ConcurrentHashMap<>();
   private final ExecutorService executor;
 
   /**
@@ -90,17 +101,26 @@ public class BatchQueueService<T extends Queueable> {
         rabbitmqPrefix + String.format(BatchQueueService.QUEUE_NAME, queueConfig.getQueueName());
 
     // The queue that will contain the object we need to process
-    queue = new HashMap<>();
+    queue = new ConcurrentHashMap<>();
     for (int i = 0; i < queueConfig.getWorkerNumber(); i++) {
       queue.put(i, new LinkedBlockingQueue<>());
     }
 
     establishConnection();
 
-    // A scheduler to handle batches that did not reach the critical mass
+    // A scheduler to handle batches that did not reach the critical mass. Wrapped in a try/catch as
+    // a second, independent safeguard: an uncaught exception here would otherwise cancel every
+    // future invocation of this scheduleAtFixedRate task permanently (a standalone JDK footgun,
+    // unrelated to the map's thread-safety above), silently stalling the queue with nothing logged.
     this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
     this.scheduledExecutor.scheduleAtFixedRate(
-        () -> queue.keySet().forEach(this::processBufferedBatch),
+        () -> {
+          try {
+            queue.keySet().forEach(this::processBufferedBatch);
+          } catch (Exception e) {
+            log.error("Error while flushing buffered batches for queue {}", queueName, e);
+          }
+        },
         this.queueConfig.getWorkerFrequency(),
         this.queueConfig.getWorkerFrequency(),
         TimeUnit.MILLISECONDS);

--- a/openaev-model/src/main/java/io/openaev/service/queue/BatchQueueService.java
+++ b/openaev-model/src/main/java/io/openaev/service/queue/BatchQueueService.java
@@ -58,10 +58,10 @@ public class BatchQueueService<T extends Queueable> {
   private final List<Channel> consumerChannels = new CopyOnWriteArrayList<>();
   // ConcurrentHashMap for the same reason as `queue` above: computeIfAbsent on a plain HashMap is
   // not atomic for concurrent callers on a new key, so the AMQP delivery thread's immediate-trigger
-  // path (deliverCallback -> processBufferedBatch) racing the scheduler's periodic call for the same
-  // brand-new workerId can hand two different callers two different AtomicBoolean instances for what
-  // should be one shared guard — desyncing it permanently stuck at true for that worker, with no
-  // exception thrown (compareAndSet just silently keeps returning false).
+  // path (deliverCallback -> processBufferedBatch) racing the scheduler's periodic call for the
+  // same brand-new workerId can hand two different callers two different AtomicBoolean instances
+  // for what should be one shared guard — desyncing it permanently stuck at true for that worker,
+  // with no exception thrown (compareAndSet just silently keeps returning false).
   private final Map<Integer, AtomicBoolean> insertInProgress = new ConcurrentHashMap<>();
   private final ExecutorService executor;
 


### PR DESCRIPTION
## Summary
`BatchQueueService`'s `queue` and `insertInProgress` fields were plain `HashMap`s, but they're read/mutated from two unsynchronized threads:
- the RabbitMQ AMQP delivery callback, on a brand-new worker key (`computeIfAbsent`)
- the dedicated periodic scheduler thread (the batch-flush tick, `scheduleAtFixedRate`)

`HashMap.computeIfAbsent` is documented as non-atomic for concurrent callers on a new key. A race between these two threads can:
- desync `insertInProgress`'s CAS guard — two callers get two different `AtomicBoolean` instances for what should be one shared flag, leaving it permanently stuck `true` for that worker (so `compareAndSet(false, true)` silently keeps failing forever), or
- throw an uncaught `ConcurrentModificationException` inside the scheduler's `scheduleAtFixedRate` task, which — uncaught — cancels every future tick for that instance permanently.

Both failure modes look identical in production: the queue stops draining, its worker thread returns to idle (not crashed, not blocked), and nothing gets logged, because there's no exception to log in the desync case, and the scheduler cancellation is silent by default. Observed exactly this: a queue drained fine, then permanently stalled at a handful of unacknowledged messages with zero throughput — only recoverable by restarting the process (which reinitializes the maps fresh).

## Fix
- Switched both fields to `ConcurrentHashMap`.
- Added a `try/catch` around the scheduler's flush call as a second, independent safeguard against the `scheduleAtFixedRate` footgun (any uncaught exception there, from any future cause, would otherwise silently cancel all future ticks — not just this specific race).

## Test plan
- [x] Existing `BatchQueueServiceTest` / `BatchQueueServiceConcurrencyTest` / `BatchQueueServiceReconnectionTest` / `BatchQueueServiceBatchProcessingTest` / `BatchQueueServiceDeliveryCallbackTest` suites cover the CAS guard and multi-worker behavior against the `Map` interface, unaffected by the concrete implementation swap.
- [ ] CI backend test suite (no local JDK/Maven available in this environment to run it directly).