### PR TITLE
fix(attack-path): highlight the full causal chain when clicking a finding (#7118)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1743,13 +1743,28 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           }
         }
       }
+    } else if (selectedFindingId && chainMode) {
+      // Chain view: mirror the selectedInjectorId&&chainMode branch above — a finding several hops
+      // into the causal chain (e.g. a captured file dropped by a late-stage action) previously only
+      // lit its immediate producing injector, because the restricted walk below (kept for the
+      // non-chain/clustered case) explicitly skips causal edges. In chain mode there's no shared-hub
+      // ambiguity to guard against, so walk the same unrestricted way: from the first action through
+      // every action that led to this finding.
+      pathSet.add(selectedFindingId);
+      for (let pass = 0; pass < 8; pass += 1) {
+        for (const e of baseFlow.edges) {
+          if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
+            pathSet.add(e.source);
+          }
+        }
+      }
     } else if (selectedFindingId) {
       // Walk UP a finding's PRODUCTION path only: endpoint(s) it was found on, then the injector(s) that
-      // actually produced it. Two guards keep it scoped on a shared/hub endpoint (chain mode): never follow
-      // a causal ("Triggered …") edge — those point forward to the NEXT action, so following them lit the
-      // whole downstream kill-chain (NetExec + shares) off a mere portscan click; and when we know the
-      // producing injector(s) from the finding's executions, don't light the other injectors that merely
-      // also reached the endpoint.
+      // actually produced it. Two guards keep it scoped on a shared/hub endpoint (clustered view): never
+      // follow a causal ("Triggered …") edge — those point forward to the NEXT action, so following them
+      // lit the whole downstream kill-chain (NetExec + shares) off a mere portscan click; and when we know
+      // the producing injector(s) from the finding's executions, don't light the other injectors that
+      // merely also reached the endpoint.
       const injectorNodeIds = new Set(
         baseFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector).map(n => n.id),
       );

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1796,6 +1796,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
           }
         }
       }
+    } else if (selectedNodeId && chainMode) {
+      // Chain view: same unrestricted backward walk as the injector/finding branches above — an
+      // endpoint click previously fell through to the clustered branch below, which compares
+      // against `dto`'s (collapsed-view) node ids and never matches the chain graph's own
+      // (`chain-ep|depth|id`-style) ids, so it found nothing to light past the endpoint itself.
+      pathSet.add(selectedNodeId);
+      for (let pass = 0; pass < 8; pass += 1) {
+        for (const e of baseFlow.edges) {
+          if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
+            pathSet.add(e.source);
+          }
+        }
+      }
     } else if (selectedNodeId) {
       // Clustered endpoint click: injectors converge on the shared hub, so walking the rendered edges up
       // would light EVERY injector. Instead resolve the injectors that actually target this endpoint from


### PR DESCRIPTION
## Summary
Clicking an action/injector node in chain mode already walked the whole causal ancestry (an explicit branch follows "Triggered..." edges backward, unrestricted). Clicking a **finding** node used a different branch that explicitly skips causal edges and restricts the walk to only the immediate producing injector, so a finding several hops into the chain (e.g. a captured file dropped by a late-stage action, like `arya.txt` in a NetExec share-spidering chain) only lit its last hop instead of the full path back to the first action.

Chain mode's graph has no shared-hub ambiguity (unlike the clustered view, where the causal-edge skip and producing-injector restriction still make sense and are kept), so this mirrors the injector branch's unrestricted walk for findings there too.

Note: this exact fix was already written and pushed as a 3rd commit on #7107's branch, but PR #7107 got merged before GitHub's PR view picked up that push (a sync delay), so it never landed in `main`. Redone here as its own PR against current `main`.

## Test plan
- [x] `yarn check-ts` clean
- [x] `yarn eslint` clean on the changed file
- [x] `yarn vitest run` on the attack-path test suite: 89/89 passing, no regressions
- [ ] Manual: in a run with recorded executions, click a finding several hops into the causal chain (e.g. a captured file) — the highlighted path should now reach all the way back to the first action, not just the immediate producer