### PR TITLE
fix(connectors): surface real migration errors and keep catalog-less connectors manageable (#7122)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/ExecutorService.java
@@ -219,6 +219,11 @@ public class ExecutorService extends AbstractConnectorService<Executor, Executor
    */
   @Transactional
   public void remove(String id) throws ConnectorStatusException {
+    // A started executor can never be deleted (OpenCTI parity): stop it first.
+    executorRepository
+        .findByIdAndTenantId(id, TenantContext.getCurrentTenant())
+        .filter(BaseConnectorEntity::isExternal)
+        .ifPresent(executor -> throwIfConnectorRunning(executor, executor.getUpdatedAt()));
     if (deleteOwningConnectorInstance(id)) {
       return;
     }

--- a/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/CollectorApi.java
@@ -19,6 +19,7 @@ import io.openaev.rest.collector.form.CollectorUpdateInput;
 import io.openaev.rest.collector.service.CollectorService;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.service.FileService;
+import io.openaev.service.exception.ConnectorStatusException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -210,13 +211,16 @@ public class CollectorApi extends RestBehavior {
   @Operation(
       summary = "Delete a collector",
       description =
-          "Removes a registered collector. Intended for stopped collectors that no longer ping;"
-              + " an active collector re-registers on its next heartbeat.")
+          "Removes a registered collector. A started collector is rejected (stop it first): a"
+              + " managed one needs a stop requested on its instance, an unmanaged one must have"
+              + " stopped pinging - an active collector re-registers on its next heartbeat"
+              + " anyway.")
   @Transactional(rollbackFor = Exception.class)
-  public void deleteCollector(@RequireTenantSelector TxCtx ctx, @PathVariable String collectorId) {
+  public void deleteCollector(@RequireTenantSelector TxCtx ctx, @PathVariable String collectorId)
+      throws ConnectorStatusException {
     // Enforce a single-tenant write scope (400 on ambiguous selector) before issuing the delete.
-    writeScopeResolver.tenantForWrite(ctx, null);
-    collectorRepository.deleteByCollectorId(collectorId);
+    String tenantId = writeScopeResolver.tenantForWrite(ctx, null);
+    collectorService.deleteCollector(collectorId, tenantId);
   }
 
   @PostMapping(

--- a/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
@@ -21,7 +21,6 @@ import io.openaev.service.exception.ConnectorStatusException;
 import io.openaev.utils.mapper.CatalogConnectorMapper;
 import io.openaev.utils.mapper.CollectorMapper;
 import jakarta.annotation.Resource;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.io.InputStream;
 import java.time.Instant;
@@ -318,20 +317,5 @@ public class CollectorService extends AbstractConnectorService<Collector, Collec
               collector.setLastExecution(Instant.now());
               collectorRepository.save(collector);
             });
-  }
-
-  /**
-   * Deletes a collector and, when it was deployed through the Integration Manager, the connector
-   * instance that owns it - otherwise the deployment keeps running against a collector that no
-   * longer exists and recreates it on its next registration heartbeat (see {@link
-   * io.openaev.service.connectors.AbstractConnectorService#deleteOwningConnectorInstance}).
-   *
-   * @param collectorId collector identifier
-   */
-  @Transactional(rollbackFor = Exception.class)
-  public void deleteCollector(@NotBlank final String collectorId) throws ConnectorStatusException {
-    if (!deleteOwningConnectorInstance(collectorId)) {
-      collectorRepository.deleteByCollectorId(collectorId);
-    }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
@@ -120,6 +120,25 @@ public class CollectorService extends AbstractConnectorService<Collector, Collec
   }
 
   /**
+   * Deletes a collector. A started collector can never be deleted (OpenCTI parity): a managed one
+   * must have a stop requested or effective on its owning instance, an unmanaged one must have
+   * stopped pinging (see {@link #throwIfConnectorRunning}). When the collector was deployed through
+   * the Integration Manager, the owning instance is torn down with it - deleting the row alone
+   * would leave the container running and the entity would reappear on its next registration
+   * heartbeat.
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void deleteCollector(String collectorId, String tenantId) throws ConnectorStatusException {
+    Collector collector = collector(collectorId, tenantId);
+    if (collector.isExternal()) {
+      throwIfConnectorRunning(collector, collector.getUpdatedAt());
+    }
+    if (!deleteOwningConnectorInstance(collectorId)) {
+      collectorRepository.deleteByCollectorId(collectorId);
+    }
+  }
+
+  /**
    * Retrieve all collectors
    *
    * @return List of collectors

--- a/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/collector/service/CollectorService.java
@@ -133,7 +133,10 @@ public class CollectorService extends AbstractConnectorService<Collector, Collec
       throwIfConnectorRunning(collector, collector.getUpdatedAt());
     }
     if (!deleteOwningConnectorInstance(collectorId)) {
-      collectorRepository.deleteByCollectorId(collectorId);
+      // Tenant-exact delete on the composite PK (collector_id, tenant_id): the entity was
+      // resolved with the explicit tenantId above, so the delete must not rely on the tenant
+      // rewriting of the id-only DELETE.
+      collectorRepository.delete(collector);
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -205,6 +205,17 @@ public class RestBehavior {
     return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
   }
 
+  // Without this handler the class-level @ResponseStatus lets Spring produce the default /error
+  // body, whose "message" field is empty unless server.error.include-message=always - the frontend
+  // then shows a generic "Bad request" instead of the actual reason.
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<ErrorMessage> handleBadRequestException(BadRequestException ex) {
+    ErrorMessage message = new ErrorMessage(ex.getMessage());
+    log.warn(String.format("BadRequestException: %s", ex.getMessage()), ex);
+    return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
+  }
+
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(TenantSelectorRequiredException.class)
   public ResponseEntity<ErrorMessage> handleTenantSelectorRequiredException(

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -212,7 +212,9 @@ public class RestBehavior {
   @ExceptionHandler(BadRequestException.class)
   public ResponseEntity<ErrorMessage> handleBadRequestException(BadRequestException ex) {
     ErrorMessage message = new ErrorMessage(ex.getMessage());
-    log.warn(String.format("BadRequestException: %s", ex.getMessage()), ex);
+    // Client error thrown all over the codebase: DEBUG (with the stack) keeps prod logs
+    // actionable while still supporting troubleshooting.
+    log.debug("BadRequestException: {}", ex.getMessage(), ex);
     return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/InjectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectorService.java
@@ -157,6 +157,10 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
       throw new BadRequestException(
           "The implant injector is required by the platform and cannot be deleted");
     }
+    // A started injector can never be deleted (OpenCTI parity): stop it first.
+    if (injector.isExternal()) {
+      throwIfConnectorRunning(injector, injector.getUpdatedAt());
+    }
     List<String> orphanedContractIds =
         injectorContractRepository.findByInjectorsContaining(injector).stream()
             .filter(

--- a/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
@@ -16,6 +16,7 @@ import io.openaev.integration.ManagerFactory;
 import io.openaev.rest.connector_instance.dto.ConnectorInstanceHealthInput;
 import io.openaev.rest.connector_instance.dto.ConnectorInstanceOutput;
 import io.openaev.rest.connector_instance.dto.CreateConnectorInstanceInput;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.service.EndpointService;
 import io.openaev.service.connectors.ConnectorOrchestrationService;
 import io.openaev.service.exception.ConnectorStatusException;
@@ -362,7 +363,32 @@ public class ConnectorInstanceService {
   }
 
   /**
-   * Deletes a connector instance by its ID.
+   * Rejects the deletion of a connector instance that is still running (OpenCTI parity: a started
+   * connector can never be deleted). Deletion is only allowed once a stop has been requested
+   * ({@code requestedStatus == stopping}) or is effective ({@code currentStatus == stopped}).
+   *
+   * @param id the connector instance ID about to be deleted
+   */
+  public void throwIfInstanceRunning(String id) throws BadRequestException {
+    connectorInstanceRepository
+        .findById(id)
+        .ifPresent(ConnectorInstanceService::throwIfInstanceRunning);
+  }
+
+  public static void throwIfInstanceRunning(ConnectorInstance instance) throws BadRequestException {
+    boolean stopRequested =
+        ConnectorInstance.REQUESTED_STATUS_TYPE.stopping.equals(instance.getRequestedStatus());
+    boolean stopped =
+        ConnectorInstance.CURRENT_STATUS_TYPE.stopped.equals(instance.getCurrentStatus());
+    if (!stopRequested && !stopped) {
+      throw new BadRequestException(
+          "The connector instance is started: stop it before deleting it");
+    }
+  }
+
+  /**
+   * Deletes a connector instance by its ID. A started instance is rejected: it must be stopped (or
+   * at least have a stop requested) first.
    *
    * @param id the connector instance ID to delete
    */
@@ -374,6 +400,8 @@ public class ConnectorInstanceService {
             .orElseThrow(
                 () ->
                     new EntityNotFoundException("ConnectorInstance with id " + id + " not found"));
+
+    throwIfInstanceRunning(connectorInstance);
 
     if (managerFactory
             .getManager(connectorInstance.getTenant().getId())

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -3,17 +3,28 @@ package io.openaev.service.connectors;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.ConnectorInstanceConfigurationRepository;
 import io.openaev.rest.catalog_connector.dto.ConnectorIds;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
 import io.openaev.service.exception.ConnectorStatusException;
 import io.openaev.utils.mapper.CatalogConnectorMapper;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class AbstractConnectorService<
     T extends BaseConnectorEntity & TenantIdBase, Output> {
+
+  /**
+   * An external connector that pinged within this window is considered running. Mirrors the
+   * frontend liveliness threshold (LIVELINESS_THRESHOLD_MS): external connectors re-register every
+   * ~40s, so two minutes without a heartbeat means the process is down.
+   */
+  public static final Duration ACTIVE_HEARTBEAT_WINDOW = Duration.ofMinutes(2);
+
   protected final ConnectorType connectorType;
   protected final ConnectorInstanceConfigurationRepository connectorInstanceConfigurationRepository;
   protected final CatalogConnectorService catalogConnectorService;
@@ -271,6 +282,47 @@ public abstract class AbstractConnectorService<
    * @param connectorId the collector / injector / executor id being deleted
    * @return true when an instance was found and deleted, so the connector row is already gone
    */
+  /**
+   * Rejects the deletion of a connector that is still running (OpenCTI parity: a started connector
+   * can never be deleted, it must be stopped first).
+   *
+   * <p>Two cases, mirroring the frontend gating:
+   *
+   * <ul>
+   *   <li>deployed through the Integration Manager: the owning instance decides - deletion is only
+   *       allowed once a stop has been requested ({@code requestedStatus == stopping}) or is
+   *       effective ({@code currentStatus == stopped});
+   *   <li>unmanaged external connector: the registration heartbeat decides - a ping within {@link
+   *       #ACTIVE_HEARTBEAT_WINDOW} means the container is alive and must be stopped (externally)
+   *       before the row can be removed. Deleting an active row is futile anyway: the connector
+   *       re-registers on its next heartbeat.
+   * </ul>
+   *
+   * @param connector the connector entity being deleted
+   * @param lastHeartbeat the connector's last registration heartbeat ({@code updatedAt})
+   */
+  protected void throwIfConnectorRunning(T connector, Instant lastHeartbeat)
+      throws BadRequestException {
+    ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase relatedIds =
+        connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+            this.connectorType.getIdKeyName(), connector.getId(), connector.getTenantId());
+    if (relatedIds != null && relatedIds.getConnectorInstanceId() != null) {
+      connectorInstanceService.throwIfInstanceRunning(relatedIds.getConnectorInstanceId());
+      return;
+    }
+    if (lastHeartbeat != null
+        && lastHeartbeat.isAfter(Instant.now().minus(ACTIVE_HEARTBEAT_WINDOW))) {
+      throw new BadRequestException(
+          "The "
+              + this.connectorType.name().toLowerCase()
+              + " "
+              + connector.getName()
+              + " is still running (last heartbeat "
+              + lastHeartbeat
+              + "): stop it before deleting it");
+    }
+  }
+
   protected boolean deleteOwningConnectorInstance(String connectorId)
       throws ConnectorStatusException {
     T connector = getConnectorById(connectorId);

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -295,7 +295,7 @@ public abstract class AbstractConnectorService<
         && lastHeartbeat.isAfter(Instant.now().minus(ACTIVE_HEARTBEAT_WINDOW))) {
       throw new BadRequestException(
           "The "
-              + this.connectorType.name().toLowerCase()
+              + this.connectorType.name().toLowerCase(Locale.ROOT)
               + " "
               + connector.getName()
               + " is still running (last heartbeat "

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -264,25 +264,6 @@ public abstract class AbstractConnectorService<
   }
 
   /**
-   * Deletes the connector instance that owns this connector, when the connector was deployed
-   * through the Integration Manager.
-   *
-   * <p>The instance list is the desired state the XTM Composer polls, and the composer only tears a
-   * deployment down when its id disappears from that list. Deleting the connector entity alone
-   * therefore leaves the container running against a connector that no longer exists - and the
-   * container recreates the entity on its next registration heartbeat, so the deletion looks like
-   * it silently failed. The instance delete removes the connector entity too, hence the return
-   * value: callers must not delete the row again.
-   *
-   * <p>Tenant safety: the owning instance is resolved with an explicit tenant predicate (native
-   * queries bypass the Hibernate tenant filter) and only when the connector itself is visible in
-   * the current tenant, so a foreign or crafted connector id can never tear down another tenant's
-   * deployment.
-   *
-   * @param connectorId the collector / injector / executor id being deleted
-   * @return true when an instance was found and deleted, so the connector row is already gone
-   */
-  /**
    * Rejects the deletion of a connector that is still running (OpenCTI parity: a started connector
    * can never be deleted, it must be stopped first).
    *
@@ -323,6 +304,25 @@ public abstract class AbstractConnectorService<
     }
   }
 
+  /**
+   * Deletes the connector instance that owns this connector, when the connector was deployed
+   * through the Integration Manager.
+   *
+   * <p>The instance list is the desired state the XTM Composer polls, and the composer only tears a
+   * deployment down when its id disappears from that list. Deleting the connector entity alone
+   * therefore leaves the container running against a connector that no longer exists - and the
+   * container recreates the entity on its next registration heartbeat, so the deletion looks like
+   * it silently failed. The instance delete removes the connector entity too, hence the return
+   * value: callers must not delete the row again.
+   *
+   * <p>Tenant safety: the owning instance is resolved with an explicit tenant predicate (native
+   * queries bypass the Hibernate tenant filter) and only when the connector itself is visible in
+   * the current tenant, so a foreign or crafted connector id can never tear down another tenant's
+   * deployment.
+   *
+   * @param connectorId the collector / injector / executor id being deleted
+   * @return true when an instance was found and deleted, so the connector row is already gone
+   */
   protected boolean deleteOwningConnectorInstance(String connectorId)
       throws ConnectorStatusException {
     T connector = getConnectorById(connectorId);

--- a/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
@@ -1,5 +1,6 @@
 package io.openaev.service.connectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.openaev.api.xtm_composer.dto.XtmComposerInstanceOutput;
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.database.model.*;
@@ -132,11 +133,15 @@ public class ConnectorOrchestrationService {
                     configurationInput.getKey().equals(catalogConnector.getContainerType() + "_ID"))
             .findFirst()
             .map(CreateConnectorInstanceInput.ConfigurationInput::getValue)
+            // A JSON null or blank value carries no id: treat it like a missing
+            // configuration so the failure stays a 400, never a NullPointerException.
+            .filter(value -> !value.isNull())
+            .map(JsonNode::asText)
+            .filter(text -> !text.isBlank())
             .orElseThrow(
                 () ->
                     new BadRequestException(
-                        "A connector id is required to migrate an existing connector"))
-            .asText();
+                        "A connector id is required to migrate an existing connector"));
     try {
       if (catalogConnector.getContainerType().equals(ConnectorType.COLLECTOR)) {
         collectorService.collector(connectorId);

--- a/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
@@ -17,13 +17,13 @@ import io.openaev.service.connector_instances.ConnectorInstanceLogService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -118,9 +118,9 @@ public class ConnectorOrchestrationService {
    * Validates that the connector referenced by a migration input actually exists.
    *
    * <p>Failures are client errors (400 with the real message), NOT {@link
-   * DataIntegrityViolationException}: that exception maps to HTTP 409, which the frontend renders
-   * as a blanket "The element already exists" - utterly misleading when the actual problem is a
-   * missing id or a connector that is not visible in the current tenant.
+   * org.springframework.dao.DataIntegrityViolationException}: that exception maps to HTTP 409,
+   * which the frontend renders as a blanket "The element already exists" - utterly misleading when
+   * the actual problem is a missing id or a connector that is not visible in the current tenant.
    */
   private void throwIfConnectorIdDoesNotExist(
       CreateConnectorInstanceInput collectorInput, CatalogConnector catalogConnector)
@@ -149,7 +149,7 @@ public class ConnectorOrchestrationService {
       log.warn(e.getMessage());
       throw new BadRequestException(
           "Cannot migrate: no "
-              + catalogConnector.getContainerType().name().toLowerCase()
+              + catalogConnector.getContainerType().name().toLowerCase(Locale.ROOT)
               + " with id "
               + connectorId
               + " is visible in the current tenant");

--- a/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
@@ -146,7 +146,9 @@ public class ConnectorOrchestrationService {
         executorService.executor(connectorId);
       }
     } catch (ElementNotFoundException e) {
-      log.warn(e.getMessage());
+      // User-triggered 400 (bad connector id / not visible in tenant): DEBUG keeps prod
+      // logs quiet, mirroring RestBehavior's BadRequestException handling.
+      log.debug(e.getMessage(), e);
       throw new BadRequestException(
           "Cannot migrate: no "
               + catalogConnector.getContainerType().name().toLowerCase(Locale.ROOT)

--- a/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/ConnectorOrchestrationService.java
@@ -114,9 +114,17 @@ public class ConnectorOrchestrationService {
     return connectorInstanceService.updateRequestedStatus(instance, requestedStatus);
   }
 
+  /**
+   * Validates that the connector referenced by a migration input actually exists.
+   *
+   * <p>Failures are client errors (400 with the real message), NOT {@link
+   * DataIntegrityViolationException}: that exception maps to HTTP 409, which the frontend renders
+   * as a blanket "The element already exists" - utterly misleading when the actual problem is a
+   * missing id or a connector that is not visible in the current tenant.
+   */
   private void throwIfConnectorIdDoesNotExist(
       CreateConnectorInstanceInput collectorInput, CatalogConnector catalogConnector)
-      throws DataIntegrityViolationException {
+      throws BadRequestException {
     String connectorId =
         collectorInput.getConfigurations().stream()
             .filter(
@@ -125,7 +133,9 @@ public class ConnectorOrchestrationService {
             .findFirst()
             .map(CreateConnectorInstanceInput.ConfigurationInput::getValue)
             .orElseThrow(
-                () -> new DataIntegrityViolationException("Connector ID is required for migration"))
+                () ->
+                    new BadRequestException(
+                        "A connector id is required to migrate an existing connector"))
             .asText();
     try {
       if (catalogConnector.getContainerType().equals(ConnectorType.COLLECTOR)) {
@@ -137,8 +147,12 @@ public class ConnectorOrchestrationService {
       }
     } catch (ElementNotFoundException e) {
       log.warn(e.getMessage());
-      throw new DataIntegrityViolationException(
-          "Connector with id " + connectorId + " does not exist");
+      throw new BadRequestException(
+          "Cannot migrate: no "
+              + catalogConnector.getContainerType().name().toLowerCase()
+              + " with id "
+              + connectorId
+              + " is visible in the current tenant");
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/integration/ManagerTest.java
+++ b/openaev-api/src/test/java/io/openaev/integration/ManagerTest.java
@@ -15,6 +15,7 @@ import io.openaev.integration.local_fixtures.factory_throws.TestIntegrationFacto
 import io.openaev.integration.local_fixtures.integration_throws.TestIntegrationFactoryIntegrationThrows;
 import io.openaev.integration.local_fixtures.integration_throws.TestIntegrationStartThrows;
 import io.openaev.integration.local_fixtures.regular.*;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.service.FileService;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
@@ -305,7 +306,7 @@ public class ManagerTest {
   }
 
   @Test
-  @DisplayName("When instance is deleted, manager stops integration and deletes")
+  @DisplayName("When instance is deleted after a stop request, manager stops it and deletes")
   public void whenInstanceIsDeleted_managerStopsIntegrationAndDeletes() throws Exception {
     Manager manager = new Manager(Tenant.DEFAULT_TENANT_UUID, List.of(getRegularFactory()));
 
@@ -323,6 +324,14 @@ public class ManagerTest {
         .isEqualTo(ConnectorInstance.REQUESTED_STATUS_TYPE.starting);
     assertThat(manager.getSpawnedIntegrations().get(singleInstance).getCurrentStatus())
         .isEqualTo(ConnectorInstance.CURRENT_STATUS_TYPE.started);
+
+    // A started instance can never be deleted (OpenCTI parity): stop it first.
+    assertThatThrownBy(() -> connectorInstanceService.deleteById(singleInstance.getId()))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("stop it before deleting it");
+
+    singleInstance.setRequestedStatus(ConnectorInstance.REQUESTED_STATUS_TYPE.stopping);
+    connectorInstanceService.save(singleInstance);
 
     connectorInstanceService.deleteById(singleInstance.getId());
 

--- a/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
@@ -383,13 +383,15 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .accept(MediaType.APPLICATION_JSON)
                   .with(csrf()))
-          .andExpect(status().is4xxClientError())
+          .andExpect(status().isBadRequest())
           .andExpect(
               result -> {
                 String errorMessage = result.getResolvedException().getMessage();
                 assertTrue(
                     errorMessage.contains(
-                        "Connector with id " + fakeCollectorId + " does not exist"));
+                        "no collector with id "
+                            + fakeCollectorId
+                            + " is visible in the current tenant"));
               });
 
       List<ConnectorInstancePersisted> instanceDb =

--- a/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
@@ -384,15 +384,14 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
                   .accept(MediaType.APPLICATION_JSON)
                   .with(csrf()))
           .andExpect(status().isBadRequest())
+          // The frontend renders the JSON body message: assert the response body (the
+          // contract), not the resolved exception.
           .andExpect(
-              result -> {
-                String errorMessage = result.getResolvedException().getMessage();
-                assertTrue(
-                    errorMessage.contains(
-                        "no collector with id "
-                            + fakeCollectorId
-                            + " is visible in the current tenant"));
-              });
+              jsonPath("$.message")
+                  .value(
+                      "Cannot migrate: no collector with id "
+                          + fakeCollectorId
+                          + " is visible in the current tenant"));
 
       List<ConnectorInstancePersisted> instanceDb =
           connectorInstanceRepository.findAllByCatalogConnectorId(catalogConnector.getId());

--- a/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
@@ -1,0 +1,147 @@
+package io.openaev.rest.collector.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.Collector;
+import io.openaev.database.model.ConnectorCompositeId;
+import io.openaev.database.repository.CollectorRepository;
+import io.openaev.database.repository.CollectorTypeRepository;
+import io.openaev.database.repository.ConnectorInstanceConfigurationRepository;
+import io.openaev.database.repository.SecurityPlatformRepository;
+import io.openaev.rest.exception.BadRequestException;
+import io.openaev.service.FileService;
+import io.openaev.service.catalog_connectors.CatalogConnectorService;
+import io.openaev.service.connector_instances.ConnectorInstanceService;
+import io.openaev.utils.mapper.CatalogConnectorMapper;
+import io.openaev.utils.mapper.CollectorMapper;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * A started collector can never be deleted (OpenCTI parity): an unmanaged one must have stopped
+ * pinging, a managed one must have a stop requested or effective on its owning instance.
+ */
+@ExtendWith(MockitoExtension.class)
+class CollectorServiceDeleteTest {
+
+  private static final String COLLECTOR_ID = "76110e06-12b5-4132-baf4-56b2c2b5771a";
+  private static final String TENANT_ID = "2cffad3a-0001-4078-b0e2-ef74274022c3";
+  private static final String INSTANCE_ID = "55220888-d568-4c3b-a581-52e3851d21b7";
+
+  @Mock private CollectorRepository collectorRepository;
+  @Mock private CollectorTypeRepository collectorTypeRepository;
+  @Mock private ConnectorInstanceConfigurationRepository connectorInstanceConfigurationRepository;
+  @Mock private SecurityPlatformRepository securityPlatformRepository;
+  @Mock private FileService fileService;
+  @Mock private ConnectorInstanceService connectorInstanceService;
+  @Mock private CatalogConnectorService catalogConnectorService;
+  @Mock private CollectorMapper collectorMapper;
+  @Mock private CatalogConnectorMapper catalogConnectorMapper;
+
+  @Mock private ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase owningInstanceIds;
+
+  private CollectorService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new CollectorService(
+            collectorRepository,
+            collectorTypeRepository,
+            connectorInstanceConfigurationRepository,
+            securityPlatformRepository,
+            fileService,
+            connectorInstanceService,
+            catalogConnectorService,
+            collectorMapper,
+            catalogConnectorMapper);
+  }
+
+  private Collector collector(Instant heartbeat) {
+    Collector collector = new Collector();
+    collector.setId(COLLECTOR_ID);
+    collector.setTenantId(TENANT_ID);
+    collector.setName("Vault Demo Collector");
+    collector.setExternal(true);
+    collector.setUpdatedAt(heartbeat);
+    when(collectorRepository.findById(ConnectorCompositeId.of(COLLECTOR_ID, TENANT_ID)))
+        .thenReturn(Optional.of(collector));
+    return collector;
+  }
+
+  @Test
+  @DisplayName("An unmanaged collector with a fresh heartbeat cannot be deleted")
+  void unmanagedRunningCollectorCannotBeDeleted() {
+    collector(Instant.now());
+    when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+            "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
+        .thenReturn(null);
+
+    assertThatThrownBy(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("stop it before deleting it");
+    verify(collectorRepository, never()).deleteByCollectorId(any());
+  }
+
+  @Test
+  @DisplayName("An unmanaged collector that stopped pinging can be deleted")
+  void unmanagedStoppedCollectorCanBeDeleted() {
+    Collector stale = collector(Instant.now().minus(Duration.ofMinutes(10)));
+    when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+            "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
+        .thenReturn(null);
+    // deleteOwningConnectorInstance re-resolves the connector before looking for an owner.
+    when(collectorRepository.findByCollectorId(COLLECTOR_ID)).thenReturn(Optional.of(stale));
+
+    assertThatCode(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
+        .doesNotThrowAnyException();
+    verify(collectorRepository).deleteByCollectorId(COLLECTOR_ID);
+  }
+
+  @Test
+  @DisplayName("A managed collector whose instance is started cannot be deleted")
+  void managedRunningCollectorCannotBeDeleted() {
+    collector(Instant.now());
+    when(owningInstanceIds.getConnectorInstanceId()).thenReturn(INSTANCE_ID);
+    when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+            "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
+        .thenReturn(owningInstanceIds);
+    doThrow(new BadRequestException("The connector instance is started: stop it before deleting"))
+        .when(connectorInstanceService)
+        .throwIfInstanceRunning(INSTANCE_ID);
+
+    assertThatThrownBy(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
+        .isInstanceOf(BadRequestException.class);
+    verify(collectorRepository, never()).deleteByCollectorId(any());
+  }
+
+  @Test
+  @DisplayName("A managed collector whose instance has a stop requested is deleted via its owner")
+  void managedStoppableCollectorIsDeletedThroughItsInstance() throws Exception {
+    Collector managed = collector(Instant.now());
+    when(owningInstanceIds.getConnectorInstanceId()).thenReturn(INSTANCE_ID);
+    when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+            "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
+        .thenReturn(owningInstanceIds);
+    when(collectorRepository.findByCollectorId(COLLECTOR_ID)).thenReturn(Optional.of(managed));
+
+    assertThatCode(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
+        .doesNotThrowAnyException();
+    // The instance delete removes the collector row too: no direct row delete.
+    verify(connectorInstanceService).deleteById(INSTANCE_ID);
+    verify(collectorRepository, never()).deleteByCollectorId(any());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
@@ -84,7 +84,7 @@ class CollectorServiceDeleteTest {
 
   @Test
   @DisplayName("An unmanaged collector with a fresh heartbeat cannot be deleted")
-  void unmanagedRunningCollectorCannotBeDeleted() {
+  void given_unmanagedCollectorWithFreshHeartbeat_should_rejectDeletion() {
     collector(Instant.now());
     when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
             "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
@@ -98,7 +98,7 @@ class CollectorServiceDeleteTest {
 
   @Test
   @DisplayName("An unmanaged collector that stopped pinging can be deleted")
-  void unmanagedStoppedCollectorCanBeDeleted() {
+  void given_unmanagedCollectorWithStaleHeartbeat_should_allowDeletion() {
     Collector stale = collector(Instant.now().minus(Duration.ofMinutes(10)));
     when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
             "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
@@ -113,7 +113,7 @@ class CollectorServiceDeleteTest {
 
   @Test
   @DisplayName("A managed collector whose instance is started cannot be deleted")
-  void managedRunningCollectorCannotBeDeleted() {
+  void given_managedCollectorWithStartedInstance_should_rejectDeletion() {
     collector(Instant.now());
     when(owningInstanceIds.getConnectorInstanceId()).thenReturn(INSTANCE_ID);
     when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
@@ -130,7 +130,8 @@ class CollectorServiceDeleteTest {
 
   @Test
   @DisplayName("A managed collector whose instance has a stop requested is deleted via its owner")
-  void managedStoppableCollectorIsDeletedThroughItsInstance() throws Exception {
+  void given_managedCollectorWithStopRequestedInstance_should_deleteThroughItsInstance()
+      throws Exception {
     Collector managed = collector(Instant.now());
     when(owningInstanceIds.getConnectorInstanceId()).thenReturn(INSTANCE_ID);
     when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(

--- a/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
@@ -93,7 +93,7 @@ class CollectorServiceDeleteTest {
     assertThatThrownBy(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("stop it before deleting it");
-    verify(collectorRepository, never()).deleteByCollectorId(any());
+    verify(collectorRepository, never()).delete(any(Collector.class));
   }
 
   @Test
@@ -108,7 +108,9 @@ class CollectorServiceDeleteTest {
 
     assertThatCode(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
         .doesNotThrowAnyException();
-    verify(collectorRepository).deleteByCollectorId(COLLECTOR_ID);
+    // Tenant-exact delete of the entity resolved on the composite PK, never the id-only DELETE.
+    verify(collectorRepository).delete(stale);
+    verify(collectorRepository, never()).deleteByCollectorId(any());
   }
 
   @Test
@@ -125,7 +127,7 @@ class CollectorServiceDeleteTest {
 
     assertThatThrownBy(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
         .isInstanceOf(BadRequestException.class);
-    verify(collectorRepository, never()).deleteByCollectorId(any());
+    verify(collectorRepository, never()).delete(any(Collector.class));
   }
 
   @Test
@@ -143,6 +145,6 @@ class CollectorServiceDeleteTest {
         .doesNotThrowAnyException();
     // The instance delete removes the collector row too: no direct row delete.
     verify(connectorInstanceService).deleteById(INSTANCE_ID);
-    verify(collectorRepository, never()).deleteByCollectorId(any());
+    verify(collectorRepository, never()).delete(any(Collector.class));
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/connector_instances/ConnectorInstanceDeletionGuardTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connector_instances/ConnectorInstanceDeletionGuardTest.java
@@ -27,7 +27,7 @@ class ConnectorInstanceDeletionGuardTest {
 
   @Test
   @DisplayName("A started instance without a stop request cannot be deleted")
-  void startedInstanceCannotBeDeleted() {
+  void given_startedInstanceWithoutStopRequest_should_rejectDeletion() {
     assertThatThrownBy(
             () ->
                 ConnectorInstanceService.throwIfInstanceRunning(
@@ -40,7 +40,7 @@ class ConnectorInstanceDeletionGuardTest {
 
   @Test
   @DisplayName("A started instance with no requested status at all cannot be deleted")
-  void startedInstanceWithoutRequestedStatusCannotBeDeleted() {
+  void given_startedInstanceWithoutRequestedStatus_should_rejectDeletion() {
     assertThatThrownBy(
             () ->
                 ConnectorInstanceService.throwIfInstanceRunning(
@@ -50,7 +50,7 @@ class ConnectorInstanceDeletionGuardTest {
 
   @Test
   @DisplayName("A started instance whose stop has been requested can be deleted")
-  void stopRequestedInstanceCanBeDeleted() {
+  void given_stopRequestedInstance_should_allowDeletion() {
     assertThatCode(
             () ->
                 ConnectorInstanceService.throwIfInstanceRunning(
@@ -62,7 +62,7 @@ class ConnectorInstanceDeletionGuardTest {
 
   @Test
   @DisplayName("A stopped instance can be deleted")
-  void stoppedInstanceCanBeDeleted() {
+  void given_stoppedInstance_should_allowDeletion() {
     assertThatCode(
             () ->
                 ConnectorInstanceService.throwIfInstanceRunning(

--- a/openaev-api/src/test/java/io/openaev/service/connector_instances/ConnectorInstanceDeletionGuardTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connector_instances/ConnectorInstanceDeletionGuardTest.java
@@ -1,0 +1,74 @@
+package io.openaev.service.connector_instances;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.openaev.database.model.ConnectorInstance;
+import io.openaev.database.model.ConnectorInstancePersisted;
+import io.openaev.rest.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A started connector instance can never be deleted (OpenCTI parity): deletion requires a stop
+ * requested (requested status stopping) or effective (current status stopped). Mirrors OpenCTI's
+ * canDeleteConnector rule for managed connectors.
+ */
+class ConnectorInstanceDeletionGuardTest {
+
+  private ConnectorInstancePersisted instance(
+      ConnectorInstance.CURRENT_STATUS_TYPE current,
+      ConnectorInstance.REQUESTED_STATUS_TYPE requested) {
+    ConnectorInstancePersisted instance = new ConnectorInstancePersisted();
+    instance.setCurrentStatus(current);
+    instance.setRequestedStatus(requested);
+    return instance;
+  }
+
+  @Test
+  @DisplayName("A started instance without a stop request cannot be deleted")
+  void startedInstanceCannotBeDeleted() {
+    assertThatThrownBy(
+            () ->
+                ConnectorInstanceService.throwIfInstanceRunning(
+                    instance(
+                        ConnectorInstance.CURRENT_STATUS_TYPE.started,
+                        ConnectorInstance.REQUESTED_STATUS_TYPE.starting)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("stop it before deleting it");
+  }
+
+  @Test
+  @DisplayName("A started instance with no requested status at all cannot be deleted")
+  void startedInstanceWithoutRequestedStatusCannotBeDeleted() {
+    assertThatThrownBy(
+            () ->
+                ConnectorInstanceService.throwIfInstanceRunning(
+                    instance(ConnectorInstance.CURRENT_STATUS_TYPE.started, null)))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("A started instance whose stop has been requested can be deleted")
+  void stopRequestedInstanceCanBeDeleted() {
+    assertThatCode(
+            () ->
+                ConnectorInstanceService.throwIfInstanceRunning(
+                    instance(
+                        ConnectorInstance.CURRENT_STATUS_TYPE.started,
+                        ConnectorInstance.REQUESTED_STATUS_TYPE.stopping)))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("A stopped instance can be deleted")
+  void stoppedInstanceCanBeDeleted() {
+    assertThatCode(
+            () ->
+                ConnectorInstanceService.throwIfInstanceRunning(
+                    instance(
+                        ConnectorInstance.CURRENT_STATUS_TYPE.stopped,
+                        ConnectorInstance.REQUESTED_STATUS_TYPE.starting)))
+        .doesNotThrowAnyException();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
@@ -87,7 +87,7 @@ class ConnectorOrchestrationServiceTest {
   @DisplayName(
       "Migrating with a collector id unknown in the current tenant fails with a 400 carrying the"
           + " real reason, not a 409 that the UI renders as 'already exists'")
-  void migrationWithUnknownCollectorIdFailsWithBadRequest() {
+  void given_migrationWithUnknownCollectorId_should_failWithBadRequest() {
     when(collectorService.collector(COLLECTOR_ID))
         .thenThrow(new ElementNotFoundException("Collector not found with id: " + COLLECTOR_ID));
 
@@ -104,7 +104,7 @@ class ConnectorOrchestrationServiceTest {
   @Test
   @DisplayName(
       "Migrating with a collector id resolvable in the current tenant creates the instance")
-  void migrationWithExistingCollectorIdCreatesInstance() {
+  void given_migrationWithExistingCollectorId_should_createInstance() {
     when(collectorService.collector(COLLECTOR_ID)).thenReturn(new Collector());
 
     CreateConnectorInstanceInput input = migrationInput(COLLECTOR_ID);
@@ -116,7 +116,7 @@ class ConnectorOrchestrationServiceTest {
 
   @Test
   @DisplayName("A plain create (no connector id in input) skips the migration existence check")
-  void plainCreateSkipsMigrationCheck() {
+  void given_plainCreateWithoutConnectorId_should_skipMigrationCheck() {
     CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();
     ConnectorOrchestrationService.CatalogConnectorWithConfigMap catalog = collectorCatalog();
 

--- a/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.database.model.CatalogConnector;
@@ -112,6 +113,22 @@ class ConnectorOrchestrationServiceTest {
     service.createConnectorInstance(catalog, input, TENANT_ID);
 
     verify(connectorInstanceService).createConnectorInstance(catalog, input, TENANT_ID);
+  }
+
+  @Test
+  @DisplayName(
+      "Migrating with a JSON null connector id fails with a 400 asking for an id, not a 500")
+  void given_migrationWithNullConnectorId_should_failWithBadRequest() {
+    CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();
+    CreateConnectorInstanceInput.ConfigurationInput idConfig =
+        new CreateConnectorInstanceInput.ConfigurationInput();
+    idConfig.setKey("COLLECTOR_ID");
+    idConfig.setValue(NullNode.getInstance());
+    input.setConfigurations(List.of(idConfig));
+
+    assertThatThrownBy(() -> service.createConnectorInstance(collectorCatalog(), input, TENANT_ID))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("A connector id is required");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
@@ -1,0 +1,128 @@
+package io.openaev.service.connectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.openaev.config.cache.LicenseCacheManager;
+import io.openaev.database.model.CatalogConnector;
+import io.openaev.database.model.Collector;
+import io.openaev.database.model.ConnectorType;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.executors.ExecutorService;
+import io.openaev.rest.collector.service.CollectorService;
+import io.openaev.rest.connector_instance.dto.CreateConnectorInstanceInput;
+import io.openaev.rest.exception.BadRequestException;
+import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.service.InjectorService;
+import io.openaev.service.catalog_connectors.CatalogConnectorService;
+import io.openaev.service.connector_instances.ConnectorInstanceLogService;
+import io.openaev.service.connector_instances.ConnectorInstanceService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectorOrchestrationServiceTest {
+
+  private static final String TENANT_ID = "2cffad3a-0001-4078-b0e2-ef74274022c3";
+  private static final String COLLECTOR_ID = "c4b850fa-6893-4b0b-bafd-ac571e502590";
+
+  @Mock private ConnectorInstanceService connectorInstanceService;
+  @Mock private XtmComposerService xtmComposerService;
+  @Mock private EnterpriseEditionService enterpriseEditionService;
+  @Mock private CatalogConnectorService catalogConnectorService;
+  @Mock private CollectorService collectorService;
+  @Mock private InjectorService injectorService;
+  @Mock private ExecutorService executorService;
+  @Mock private ConnectorInstanceLogService connectorInstanceLogService;
+  @Mock private LicenseCacheManager licenseCacheManager;
+
+  private ConnectorOrchestrationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ConnectorOrchestrationService(
+            connectorInstanceService,
+            xtmComposerService,
+            enterpriseEditionService,
+            catalogConnectorService,
+            collectorService,
+            injectorService,
+            executorService,
+            connectorInstanceLogService,
+            licenseCacheManager);
+    when(enterpriseEditionService.isLicenseActive(any())).thenReturn(true);
+  }
+
+  private ConnectorOrchestrationService.CatalogConnectorWithConfigMap collectorCatalog() {
+    CatalogConnector catalogConnector = new CatalogConnector();
+    catalogConnector.setContainerType(ConnectorType.COLLECTOR);
+    catalogConnector.setManagerSupported(false);
+    return new ConnectorOrchestrationService.CatalogConnectorWithConfigMap(
+        catalogConnector, Map.of());
+  }
+
+  private CreateConnectorInstanceInput migrationInput(String collectorId) {
+    CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();
+    CreateConnectorInstanceInput.ConfigurationInput idConfig =
+        new CreateConnectorInstanceInput.ConfigurationInput();
+    idConfig.setKey("COLLECTOR_ID");
+    idConfig.setValue(new TextNode(collectorId));
+    input.setConfigurations(List.of(idConfig));
+    return input;
+  }
+
+  @Test
+  @DisplayName(
+      "Migrating with a collector id unknown in the current tenant fails with a 400 carrying the"
+          + " real reason, not a 409 that the UI renders as 'already exists'")
+  void migrationWithUnknownCollectorIdFailsWithBadRequest() {
+    when(collectorService.collector(COLLECTOR_ID))
+        .thenThrow(new ElementNotFoundException("Collector not found with id: " + COLLECTOR_ID));
+
+    assertThatThrownBy(
+            () ->
+                service.createConnectorInstance(
+                    collectorCatalog(), migrationInput(COLLECTOR_ID), TENANT_ID))
+        .isInstanceOf(BadRequestException.class)
+        .isNotInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining(COLLECTOR_ID)
+        .hasMessageContaining("visible in the current tenant");
+  }
+
+  @Test
+  @DisplayName(
+      "Migrating with a collector id resolvable in the current tenant creates the instance")
+  void migrationWithExistingCollectorIdCreatesInstance() {
+    when(collectorService.collector(COLLECTOR_ID)).thenReturn(new Collector());
+
+    CreateConnectorInstanceInput input = migrationInput(COLLECTOR_ID);
+    ConnectorOrchestrationService.CatalogConnectorWithConfigMap catalog = collectorCatalog();
+    service.createConnectorInstance(catalog, input, TENANT_ID);
+
+    verify(connectorInstanceService).createConnectorInstance(catalog, input, TENANT_ID);
+  }
+
+  @Test
+  @DisplayName("A plain create (no connector id in input) skips the migration existence check")
+  void plainCreateSkipsMigrationCheck() {
+    CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();
+    ConnectorOrchestrationService.CatalogConnectorWithConfigMap catalog = collectorCatalog();
+
+    service.createConnectorInstance(catalog, input, TENANT_ID);
+
+    verify(connectorInstanceService).createConnectorInstance(catalog, input, TENANT_ID);
+    assertThat(input.getConfigurations()).isEmpty();
+  }
+}

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -107,7 +107,10 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
   };
 
   const canManage = ability.can(ACTIONS.MANAGE, SUBJECTS.TENANT_SETTINGS);
-  const showMigrateButton = connector?.isExternal === true && !instance && isXtmComposerUp && canManage;
+  // A catalog entry is required to migrate: the drawer posts the catalog id and
+  // needs its configuration schema, so without one the request can only fail.
+  const showMigrateButton = connector?.isExternal === true && !instance && isXtmComposerUp
+    && canManage && !!catalogConnector;
   const disabledUpdateButtons = !isEnterpriseEdition || (!isXtmComposerUp && catalogConnector?.catalog_connector_manager_supported === true);
   // A connector with no managed instance (registered directly / manually, not
   // deployed through the Integration Manager) has no instance popover, so it

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPage.tsx
@@ -120,7 +120,13 @@ const ConnectorPage = ({ extraInfoComponent }: { extraInfoComponent?: ReactNode 
   // are protected: gating on "runs in-process" instead used to strand legacy
   // rows whose implementation was dropped from the code (Caldera), leaving them
   // undeletable forever.
-  const canDeleteConnector = canManage && !instance && !!connector?.id && !isPlatformConnector(connector?.type);
+  // OpenCTI parity: a started connector can never be deleted - stop it first.
+  // For an unmanaged connector the kebab only ever contains Delete, so while
+  // the connector is running (fresh heartbeat) the kebab disappears entirely;
+  // the backend enforces the same rule.
+  const canDeleteConnector = canManage && !instance && !!connector?.id
+    && !isPlatformConnector(connector?.type)
+    && !(connector?.isExternal === true && liveliness?.started === true);
 
   const handleDeleteConnector = () => {
     if (!connector?.id) return;

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
@@ -75,7 +75,7 @@ const ConnectorPopover = ({ connectorInstanceId, connectorName, disabled = false
       action: handleDelete,
       userRight: ability.can(ACTIONS.DELETE, SUBJECTS.TENANT_SETTINGS),
       disabled: !canDeleteInstance,
-      disabledMessage: 'Stop the connector before deleting it',
+      disabledMessage: t('Stop the connector before deleting it'),
     }];
 
   return (

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
@@ -75,7 +75,8 @@ const ConnectorPopover = ({ connectorInstanceId, connectorName, disabled = false
       action: handleDelete,
       userRight: ability.can(ACTIONS.DELETE, SUBJECTS.TENANT_SETTINGS),
       disabled: !canDeleteInstance,
-      disabledMessage: t('Stop the connector before deleting it'),
+      // Raw i18n key: ButtonPopover translates disabledMessage itself (like label).
+      disabledMessage: 'Stop the connector before deleting it',
     }];
 
   return (

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
@@ -56,6 +56,13 @@ const ConnectorPopover = ({ connectorInstanceId, connectorName, disabled = false
   const onOpenUpdateConnectorInstanceDrawer = () => setOpenCreateConnectorInstanceDrawer(true);
   const onCloseUpdateConnectorInstanceDrawer = () => setOpenCreateConnectorInstanceDrawer(false);
 
+  // OpenCTI parity: a started managed connector can never be deleted. Deletion
+  // is only allowed once a stop has been requested (requested status stopping)
+  // or is effective (current status stopped); the backend enforces the same
+  // rule. The entry stays visible but disabled, with the reason as tooltip.
+  const canDeleteInstance = instance?.connector_instance_requested_status === 'stopping'
+    || instance?.connector_instance_current_status === 'stopped';
+
   // Button Popover
   const entries = [
     {
@@ -67,6 +74,8 @@ const ConnectorPopover = ({ connectorInstanceId, connectorName, disabled = false
       label: 'Delete',
       action: handleDelete,
       userRight: ability.can(ACTIONS.DELETE, SUBJECTS.TENANT_SETTINGS),
+      disabled: !canDeleteInstance,
+      disabledMessage: 'Stop the connector before deleting it',
     }];
 
   return (

--- a/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
+++ b/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
@@ -259,7 +259,6 @@ const ConnectorInstanceForm = ({
         style={{
           display: 'flex',
           flexDirection: 'column',
-          minHeight: '100%',
           gap: theme.spacing(2),
         }}
         id="connectorInstanceForm"
@@ -346,11 +345,13 @@ const ConnectorInstanceForm = ({
           </>
         )}
 
+        {/* In-flow action buttons right after the form content, like every
+            other drawer form in the app (no bottom-pinned footer). */}
         <div style={{
-          marginTop: 'auto',
           display: 'flex',
           justifyContent: 'flex-end',
           gap: theme.spacing(1),
+          marginTop: theme.spacing(1),
         }}
         >
           <Button

--- a/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
+++ b/openaev-front/src/admin/components/integrations/connector_instance/ConnectorInstanceForm.tsx
@@ -265,11 +265,16 @@ const ConnectorInstanceForm = ({
         id="connectorInstanceForm"
         onSubmit={handleSubmitWithoutDefault}
       >
+        {/* The display name is a regular catalog configuration (COLLECTOR_NAME /
+            INJECTOR_NAME / EXECUTOR_NAME): the update endpoint merges it like any
+            other config and the Integration Manager redeploys the container with
+            the new name, so it is editable - it was only ever disabled by
+            accident in the original composer feature. */}
         <TextFieldController
           name={`connector_instance_configurations.${nameFieldIndex}.configuration_value`}
           label={t('Display name')}
           required
-          disabled={disabled || isEditing}
+          disabled={disabled}
         />
         <TextField id="catalog-connector-slug" label={t('Instance name')} disabled defaultValue={catalogConnectorSlug} />
         {requiredFields.map(({ index, field, definition }) => (

--- a/openaev-front/src/admin/components/integrations/deployed/DeployedConnectors.tsx
+++ b/openaev-front/src/admin/components/integrations/deployed/DeployedConnectors.tsx
@@ -81,9 +81,13 @@ const DeployedConnectors = ({ catalogConnectors, isXtmComposerUp }: Props) => {
         const catalogMatch = connector.catalog?.catalog_connector_id
           ? catalogById.get(connector.catalog.catalog_connector_id)
           : undefined;
-        // Same clickability rule as the legacy per-type pages: collectors and
-        // executors without a catalog entry have no detail page.
-        const clickable = !(connector.catalog == null && type !== 'INJECTOR');
+        // Every registered connector gets a detail page, even without a catalog
+        // entry: the detail page is the only place offering the delete action, so
+        // gating it on the catalog stranded custom or renamed-slug connectors
+        // (no way to delete or manage them at all). Only pending, instance-only
+        // entries keep the legacy rule.
+        const clickable = connector.isExisting === true
+          || !(connector.catalog == null && type !== 'INJECTOR');
         let logoSrc: string | undefined;
         if (connector.isExisting) {
           logoSrc = config.logoUrl(connector.type);
@@ -143,6 +147,9 @@ const DeployedConnectors = ({ catalogConnectors, isXtmComposerUp }: Props) => {
     const catalogConnector = catalogConnectors.find(
       connector => connector.catalog_connector_id === deployed.connector.catalog?.catalog_connector_id,
     );
+    // Without a catalog entry the drawer would post an empty catalog id and fail
+    // with a silently-swallowed 404, looking like a dead button.
+    if (!catalogConnector) return;
     setSelectedCatalogConnector(catalogConnector);
     setMigrationSource(deployed.connector.id);
     setOpenMigrateDrawer(true);
@@ -155,7 +162,10 @@ const DeployedConnectors = ({ catalogConnectors, isXtmComposerUp }: Props) => {
     const deployed = metaById.get(item.id);
     if (!deployed) return null;
     const { connector } = deployed;
-    const canMigrate = connector.isExternal && connector.connectorInstance == null && isXtmComposerUp;
+    // A catalog entry is required to migrate: the drawer needs the catalog id and
+    // configuration schema to build the managed instance.
+    const canMigrate = connector.isExternal && connector.connectorInstance == null
+      && isXtmComposerUp && connector.catalog != null;
     const { started, lastSeen, healthy, builtIn } = computeConnectorLiveliness(connector);
     const diskColor = healthy ? theme.palette.success.main : theme.palette.error.main;
     let diskTooltip: string;

--- a/openaev-front/src/admin/components/integrations/deployed/DeployedConnectors.tsx
+++ b/openaev-front/src/admin/components/integrations/deployed/DeployedConnectors.tsx
@@ -36,6 +36,8 @@ import CreateConnectorInstanceDrawer from '../connector_instance/CreateConnector
 interface DeployedMeta {
   connector: ConnectorOutput;
   type: ConnectorItemType;
+  /** The resolved catalog entry, when the connector's catalog ref matches one. */
+  catalogConnector?: CatalogConnectorOutput;
 }
 
 interface Props {
@@ -119,6 +121,7 @@ const DeployedConnectors = ({ catalogConnectors, isXtmComposerUp }: Props) => {
         meta.set(connector.id, {
           connector,
           type,
+          catalogConnector: catalogMatch,
         });
       });
     };
@@ -144,13 +147,10 @@ const DeployedConnectors = ({ catalogConnectors, isXtmComposerUp }: Props) => {
   const onMigrateBtnClick = (e: SyntheticEvent, deployed: DeployedMeta) => {
     e.preventDefault();
     e.stopPropagation();
-    const catalogConnector = catalogConnectors.find(
-      connector => connector.catalog_connector_id === deployed.connector.catalog?.catalog_connector_id,
-    );
-    // Without a catalog entry the drawer would post an empty catalog id and fail
-    // with a silently-swallowed 404, looking like a dead button.
-    if (!catalogConnector) return;
-    setSelectedCatalogConnector(catalogConnector);
+    // The resolved catalog entry gates the button's visibility (canMigrate), so a
+    // rendered button always has one - the guard only narrows the type.
+    if (!deployed.catalogConnector) return;
+    setSelectedCatalogConnector(deployed.catalogConnector);
     setMigrationSource(deployed.connector.id);
     setOpenMigrateDrawer(true);
   };
@@ -162,10 +162,13 @@ const DeployedConnectors = ({ catalogConnectors, isXtmComposerUp }: Props) => {
     const deployed = metaById.get(item.id);
     if (!deployed) return null;
     const { connector } = deployed;
-    // A catalog entry is required to migrate: the drawer needs the catalog id and
-    // configuration schema to build the managed instance.
+    // A resolvable catalog entry is required to migrate: the drawer needs the
+    // catalog id and configuration schema to build the managed instance. Key the
+    // visibility on the entry actually resolved from the catalog list (not just
+    // the connector's embedded catalog ref) so a rendered button can never be a
+    // no-op click.
     const canMigrate = connector.isExternal && connector.connectorInstance == null
-      && isXtmComposerUp && connector.catalog != null;
+      && isXtmComposerUp && deployed.catalogConnector != null;
     const { started, lastSeen, healthy, builtIn } = computeConnectorLiveliness(connector);
     const diskColor = healthy ? theme.palette.success.main : theme.palette.error.main;
     let diskTooltip: string;

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "Schritte und Ereignisse",
   "Stop": "Anhalten",
   "Stop generating": "Nicht mehr erzeugen",
+  "Stop the connector before deleting it": "Stoppen Sie den Konnektor, bevor Sie ihn löschen",
   "stopped": "gestoppt",
   "Stopped": "Gestoppt",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "Steps & Events",
   "Stop": "Stop",
   "Stop generating": "Stop generating",
+  "Stop the connector before deleting it": "Stop the connector before deleting it",
   "stopped": "stopped",
   "Stopped": "Stopped",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "Steps & Events",
   "Stop": "Detener",
   "Stop generating": "Dejar de generar",
+  "Stop the connector before deleting it": "Detenga el conector antes de eliminarlo",
   "stopped": "detenido",
   "Stopped": "Detenido",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "Steps & Events",
   "Stop": "Arrêter",
   "Stop generating": "Cesser de générer",
+  "Stop the connector before deleting it": "Arrêtez le connecteur avant de le supprimer",
   "stopped": "stoppé",
   "Stopped": "Arrêtée",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "Steps & Events",
   "Stop": "Stop",
   "Stop generating": "Smettere di generare",
+  "Stop the connector before deleting it": "Arresta il connettore prima di eliminarlo",
   "stopped": "bloccato",
   "Stopped": "Interrotto",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "ステップとイベント",
   "Stop": "停止",
   "Stop generating": "発電停止",
+  "Stop the connector before deleting it": "削除する前にコネクターを停止してください",
   "stopped": "阻止",
   "Stopped": "停止",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "단계 및 이벤트",
   "Stop": "중지",
   "Stop generating": "생성 중지",
+  "Stop the connector before deleting it": "삭제하기 전에 커넥터를 중지하세요",
   "stopped": "차단됨",
   "Stopped": "중지됨",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "Этапы и события",
   "Stop": "Остановить",
   "Stop generating": "Прекратите генерировать",
+  "Stop the connector before deleting it": "Остановите коннектор перед удалением",
   "stopped": "остановлено",
   "Stopped": "Остановлено",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -2926,6 +2926,7 @@
   "Steps & Events": "步骤与事件",
   "Stop": "停止",
   "Stop generating": "停止生成",
+  "Stop the connector before deleting it": "删除前请先停止连接器",
   "stopped": "已阻止",
   "Stopped": "已停止",
   "Storage": "Storage",


### PR DESCRIPTION
## Summary

Fixes #7122.

Production symptom: some manually deployed collectors could not be managed at all
from the Integrations screen - cards fully locked (no click, no delete), and any
migration attempt failing with a misleading "The element already exists" toast.
This PR also aligns connector deletion with OpenCTI: a started connector can
never be deleted, it must be stopped first (both managed and unmanaged).

### Backend

- `ConnectorOrchestrationService.throwIfConnectorIdDoesNotExist` now throws
  `BadRequestException` (HTTP 400 with the real reason) instead of
  `DataIntegrityViolationException` (HTTP 409, rendered by the frontend as a
  blanket "The element already exists"). The two failure modes now read:
  - "A connector id is required to migrate an existing connector"
  - "Cannot migrate: no collector with id X is visible in the current tenant"
- `RestBehavior` gets an explicit `@ExceptionHandler(BadRequestException.class)`
  returning an `ErrorMessage` body: the class-level `@ResponseStatus` alone lets
  Spring produce the default /error body whose message field is empty unless
  `server.error.include-message=always`, so 400 reasons never reached the UI.
- Stop-before-delete enforcement (OpenCTI parity), on every delete path:
  - `ConnectorInstanceService.deleteById` rejects a started instance unless a
    stop has been requested (requested status stopping) or is effective
    (current status stopped).
  - `AbstractConnectorService.throwIfConnectorRunning` guards the connector
    entity deletes: managed connectors defer to their owning instance's status;
    unmanaged external connectors are rejected while their registration
    heartbeat is fresh (2 minute window, mirroring the frontend liveliness
    threshold - deleting an active row is futile anyway, it re-registers on the
    next heartbeat).
  - Wired into `CollectorService.deleteCollector` (new - the endpoint was a raw
    repository delete; it now also tears down the owning instance like the
    injector and executor deletes already did), `InjectorService.deleteInjector`
    and `ExecutorService.remove`.

### Frontend

- Deployed cards for registered connectors stay clickable even without a catalog
  entry. The detail page is the only place offering the Delete action for
  unmanaged connectors, so gating it on a catalog slug match stranded custom
  collectors (`vault-demo-collector`) and connectors whose type no longer matches
  any catalog slug (`openaev_tanium_threat_response`, `openaev_palo_alto_cortex_xdr`).
- The Migrate button is hidden (deployed cards and detail page) when no catalog
  entry matches: the drawer would post an empty catalog id and fail with a
  silently-swallowed 404, looking like a dead button.
- Stop-before-delete (OpenCTI parity, same rules as OpenCTI's
  canDeleteConnector):
  - unmanaged external connector: the kebab only ever contains Delete, so while
    the connector is running (fresh heartbeat) the kebab disappears entirely;
  - managed instance: the kebab stays (Update is always relevant) but Delete is
    disabled with a "Stop the connector before deleting it" tooltip until a stop
    is requested or effective.
- New translation key "Stop the connector before deleting it" added to all 9
  language files.
- The instance Display name is now editable in the Update drawer. It is a
  regular catalog configuration (COLLECTOR_NAME / INJECTOR_NAME /
  EXECUTOR_NAME): the update endpoint merges it like any other config and the
  Integration Manager redeploys the container with the new name - the field had
  been disabled by accident since the original composer feature (#4312).
- The Cancel/Create/Migrate/Update buttons of the connector instance form now
  follow the form content like every other drawer form in the app, instead of
  being pinned to the bottom of the drawer (design system alignment).

### Tests

- `ConnectorOrchestrationServiceTest`: migration with an unknown connector id
  fails with 400 (not 409); migration with a resolvable id creates the instance;
  plain create skips the check.
- `ConnectorInstanceDeletionGuardTest`: started instance rejected (with and
  without requested status), stop-requested and stopped instances allowed.
- `CollectorServiceDeleteTest`: fresh-heartbeat unmanaged collector rejected,
  stale one deleted, managed one deferred to its instance status and deleted
  through its owning instance.

## Test plan

- [ ] `mvn -pl openaev-api test -Dtest=ConnectorOrchestrationServiceTest,ConnectorInstanceDeletionGuardTest,CollectorServiceDeleteTest,ExecutorServiceTest` green (verified locally, 17 tests)
- [ ] `yarn check-ts` + eslint on changed files green (verified locally)
- [ ] On a platform with a catalog-less collector: card is clickable, detail page opens, Delete works once the collector stopped pinging
- [ ] A started collector (managed or unmanaged) cannot be deleted from UI or API; stopping it (or requesting a stop on its instance) unlocks deletion
- [ ] Migrating a collector not visible in the current tenant shows the explicit 400 message
