### PR TITLE
fix(front): hide Ask Ariane button when XTM One is not configured (#7129)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/ariane/AskArianeButton.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/ariane/AskArianeButton.test.tsx
@@ -1,0 +1,105 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AskArianeButton from '../../../../admin/components/ariane/AskArianeButton';
+import { ChatbotContext, type ChatbotContextType } from '../../../../admin/components/ariane/chatbotContext';
+import { type PlatformSettings, type User } from '../../../../utils/api-types';
+import { UserContext, type UserContextType } from '../../../../utils/hooks/useAuth';
+import { type AppAbility } from '../../../../utils/permissions/ability';
+import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
+
+const theme = createTheme({
+  palette: {
+    ai: {
+      main: '#9575ff',
+      light: '#c4b5fd',
+    },
+  },
+});
+
+const LABEL = 'Ask Ariane';
+
+const DEFAULT_SETTINGS: Partial<PlatformSettings> = {
+  platform_xtm_one_configured: true,
+  platform_xtm_one_url: 'https://xtmone.example.com',
+  filigran_chatbot_ai_cgu_status: 'enabled',
+  platform_license: { license_is_validated: true },
+};
+
+const chatbotContext: ChatbotContextType = {
+  isOpen: false,
+  mode: 'sidebar',
+  sidebarWidth: 400,
+  isResizing: false,
+  openChat: vi.fn(),
+  closeChat: vi.fn(),
+  toggleChat: vi.fn(),
+  setMode: vi.fn(),
+  setSidebarWidth: vi.fn(),
+  setIsResizing: vi.fn(),
+};
+
+const ability = { can: () => true } as unknown as AppAbility;
+
+const renderButton = (settingsOverrides: Partial<PlatformSettings> = {}) => {
+  const userContext: UserContextType = {
+    me: { user_id: 'user-1' } as User,
+    settings: {
+      ...DEFAULT_SETTINGS,
+      ...settingsOverrides,
+    } as PlatformSettings,
+    isXTMHubAccessible: true,
+    userTenants: [],
+    currentUserTenant: null,
+    switchUserTenant: vi.fn(),
+    reloadUserTenants: vi.fn(),
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ThemeProvider theme={theme}>
+      <IntlProvider locale="en" defaultLocale="en" onError={() => {}}>
+        <UserContext.Provider value={userContext}>
+          <AbilityContext.Provider value={ability}>
+            <ChatbotContext.Provider value={chatbotContext}>
+              {children}
+            </ChatbotContext.Provider>
+          </AbilityContext.Provider>
+        </UserContext.Provider>
+      </IntlProvider>
+    </ThemeProvider>
+  );
+
+  return render(<AskArianeButton />, { wrapper });
+};
+
+describe('AskArianeButton', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe('Visibility', () => {
+    it('renders the button when XTM One is configured and the AI is enabled', () => {
+      renderButton();
+      expect(screen.getByText(LABEL)).toBeDefined();
+    });
+
+    it('renders nothing when the agentic AI is disabled', () => {
+      const { container } = renderButton({ filigran_chatbot_ai_cgu_status: 'disabled' });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when XTM One is not configured', () => {
+      const { container } = renderButton({ platform_xtm_one_configured: false });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when the XTM One configuration flag is absent', () => {
+      const { container } = renderButton({ platform_xtm_one_configured: undefined });
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/ariane/AskArianeButton.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/ariane/AskArianeButton.test.tsx
@@ -101,5 +101,15 @@ describe('AskArianeButton', () => {
       const { container } = renderButton({ platform_xtm_one_configured: undefined });
       expect(container.firstChild).toBeNull();
     });
+
+    it('renders nothing when the XTM One URL is missing', () => {
+      const { container } = renderButton({ platform_xtm_one_url: undefined });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when the XTM One URL is not an http(s) URL', () => {
+      const { container } = renderButton({ platform_xtm_one_url: 'javascript:alert(1)' });
+      expect(container.firstChild).toBeNull();
+    });
   });
 });

--- a/openaev-front/src/admin/components/ariane/AskArianeButton.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianeButton.tsx
@@ -28,8 +28,11 @@ const AskArianeButton = () => {
   const chatbotCguStatus = settings.filigran_chatbot_ai_cgu_status;
   const isCguPending = chatbotCguStatus === 'pending' || chatbotCguStatus === undefined;
 
-  // Hide if chatbot has been explicitly disabled
-  if (chatbotCguStatus === 'disabled') {
+  // Hide if chatbot has been explicitly disabled, or if XTM One is not
+  // configured (url + token): the chat proxy (`/api/xtmone/chat/*`) rejects
+  // every call in that case, so the button cannot lead anywhere. Same gating
+  // as the CTEM Command Center shortcut next to it.
+  if (chatbotCguStatus === 'disabled' || settings.platform_xtm_one_configured !== true) {
     return null;
   }
 

--- a/openaev-front/src/admin/components/ariane/AskArianeButton.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianeButton.tsx
@@ -11,6 +11,7 @@ import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
 import EEChip from '../common/entreprise_edition/EEChip';
 import FiligranAiCguDialog from './FiligranAiCguDialog';
 import { useChatbot } from './useChatbotHooks';
+import isXtmOneAvailable from './xtmOneAvailability';
 
 const AskArianeButton = () => {
   const theme = useTheme();
@@ -28,11 +29,12 @@ const AskArianeButton = () => {
   const chatbotCguStatus = settings.filigran_chatbot_ai_cgu_status;
   const isCguPending = chatbotCguStatus === 'pending' || chatbotCguStatus === undefined;
 
-  // Hide if chatbot has been explicitly disabled, or if XTM One is not
-  // configured (url + token): the chat proxy (`/api/xtmone/chat/*`) rejects
-  // every call in that case, so the button cannot lead anywhere. Same gating
-  // as the CTEM Command Center shortcut next to it.
-  if (chatbotCguStatus === 'disabled' || settings.platform_xtm_one_configured !== true) {
+  // Hide if the chatbot has been explicitly disabled, or if XTM One is not
+  // connected properly (configured url + token, valid http(s) URL): the chat
+  // proxy (`/api/xtmone/chat/*`) rejects every call in that case, so the
+  // button cannot lead anywhere. Same gating as the CTEM Command Center
+  // shortcut next to it (shared `isXtmOneAvailable` predicate).
+  if (!isXtmOneAvailable(settings)) {
     return null;
   }
 

--- a/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
+++ b/openaev-front/src/admin/components/ariane/AskArianePanel.tsx
@@ -13,6 +13,7 @@ import { api } from '../../../network';
 import { computeBannerSettings } from '../../../public/components/systembanners/utils';
 import { MESSAGING$ } from '../../../utils/Environment';
 import useAuth from '../../../utils/hooks/useAuth';
+import { toHttpUrl } from '../../../utils/url-helper';
 import installChatbotCsrf from './installChatbotCsrf';
 
 interface AskArianePanelProps {
@@ -48,7 +49,10 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
   const topOffset = 64 + bannerHeightNumber;
   const firstName = me.user_email?.split('@')[0] ?? 'User';
   const accentColor = theme.palette.ai?.main ?? '#B286FF';
-  const xtmOneUrl = settings.platform_xtm_one_url || '';
+  // Guarded by the shared http(s)-only helper: the URL is forwarded to the
+  // chatbot widget as `agentDashboardUrl` (an anchor href), so a misconfigured
+  // scheme must never reach it.
+  const xtmOneUrl = toHttpUrl(settings.platform_xtm_one_url) || '';
   const isDarkMode = theme.palette.mode === 'dark';
 
   const logoIcon = (

--- a/openaev-front/src/admin/components/ariane/CtemCommandCenterButton.tsx
+++ b/openaev-front/src/admin/components/ariane/CtemCommandCenterButton.tsx
@@ -5,27 +5,26 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
 import { toHttpUrl } from '../../../utils/url-helper';
+import isXtmOneAvailable from './xtmOneAvailability';
 
 /**
  * Top-bar shortcut to the XTM One CTEM Command Center (the cross-product exposure
  * posture dashboard / XTM One home). Opens the XTM One URL in a new tab.
  *
- * Shown only when XTM One is connected properly (`platform_xtm_one_configured`
- * with `platform_xtm_one_url` set, guarded by the shared http(s)-only helper)
- * and the agentic AI is not disabled. NOT Enterprise-gated: the CTEM Command
- * Center is also available in full CE (metrics only).
+ * Shown only when XTM One is available (shared `isXtmOneAvailable` predicate:
+ * `platform_xtm_one_configured` with a valid http(s) `platform_xtm_one_url`,
+ * agentic AI not disabled). NOT Enterprise-gated: the CTEM Command Center is
+ * also available in full CE (metrics only).
  */
 const CtemCommandCenterButton = () => {
   const theme = useTheme();
   const { t } = useFormatter();
   const { settings } = useAuth();
 
+  // `!xtmOneUrl` is implied by `isXtmOneAvailable` but kept for type narrowing
+  // of the anchor href below.
   const xtmOneUrl = toHttpUrl(settings.platform_xtm_one_url);
-  if (
-    settings.filigran_chatbot_ai_cgu_status === 'disabled'
-    || settings.platform_xtm_one_configured !== true
-    || !xtmOneUrl
-  ) {
+  if (!isXtmOneAvailable(settings) || !xtmOneUrl) {
     return null;
   }
 

--- a/openaev-front/src/admin/components/ariane/xtmOneAvailability.ts
+++ b/openaev-front/src/admin/components/ariane/xtmOneAvailability.ts
@@ -1,0 +1,22 @@
+import { type PlatformSettings } from '../../../utils/api-types';
+import { toHttpUrl } from '../../../utils/url-helper';
+
+/**
+ * Single source of truth for the visibility of the XTM One (agentic AI)
+ * surface: the Ask Ariane button, the CTEM Command Center shortcut, the
+ * divider grouping them in the top bar, and the chat panel itself.
+ *
+ * XTM One is available when the agentic AI has not been explicitly disabled
+ * and the platform is connected to XTM One: `platform_xtm_one_configured`
+ * (url + token set on the backend) with a syntactically valid http(s)
+ * `platform_xtm_one_url` (guarded by the shared http(s)-only helper, since
+ * the URL ends up in anchor hrefs). Without that, every `/api/xtmone/chat/*`
+ * proxy call is rejected, so no XTM One entry point can lead anywhere.
+ */
+const isXtmOneAvailable = (settings: PlatformSettings): boolean => (
+  settings.filigran_chatbot_ai_cgu_status !== 'disabled'
+  && settings.platform_xtm_one_configured === true
+  && toHttpUrl(settings.platform_xtm_one_url) !== undefined
+);
+
+export default isXtmOneAvailable;

--- a/openaev-front/src/admin/components/nav/TopBar.tsx
+++ b/openaev-front/src/admin/components/nav/TopBar.tsx
@@ -16,6 +16,7 @@ import AskArianeButton from '../ariane/AskArianeButton';
 import AskArianePanel from '../ariane/AskArianePanel';
 import CtemCommandCenterButton from '../ariane/CtemCommandCenterButton';
 import { useChatbot } from '../ariane/useChatbotHooks';
+import isXtmOneAvailable from '../ariane/xtmOneAvailability';
 import BulkOperationsIndicator from './BulkOperationsIndicator';
 import TopBarNotifications from './TopBarNotifications';
 
@@ -151,12 +152,11 @@ const TopBar: FunctionComponent = () => {
           </Stack>
           <div>
             <Stack direction="row" gap={1} alignItems="center">
-              {/* XTM One (agentic AI) block: only when XTM One is configured
-                  and the chatbot has not been explicitly disabled — the same
-                  gating the buttons apply themselves, repeated here so the
+              {/* XTM One (agentic AI) block: only when XTM One is available
+                  (configured, valid URL, AI not disabled) - the exact same
+                  predicate the buttons apply themselves, shared so the
                   divider never renders as an orphan. */}
-              {settings.filigran_chatbot_ai_cgu_status !== 'disabled'
-                && settings.platform_xtm_one_configured === true && (
+              {isXtmOneAvailable(settings) && (
                 <>
                   <AskArianeButton />
                   <CtemCommandCenterButton />
@@ -221,7 +221,7 @@ const TopBar: FunctionComponent = () => {
           </div>
         </Toolbar>
       </AppBar>
-      {settings.platform_xtm_one_configured && isArianeChatOpen && (
+      {isXtmOneAvailable(settings) && isArianeChatOpen && (
         <AskArianePanel
           mode={arianeChatMode}
           onClose={closeChat}

--- a/openaev-front/src/admin/components/nav/TopBar.tsx
+++ b/openaev-front/src/admin/components/nav/TopBar.tsx
@@ -151,7 +151,12 @@ const TopBar: FunctionComponent = () => {
           </Stack>
           <div>
             <Stack direction="row" gap={1} alignItems="center">
-              {settings.filigran_chatbot_ai_cgu_status !== 'disabled' && (
+              {/* XTM One (agentic AI) block: only when XTM One is configured
+                  and the chatbot has not been explicitly disabled — the same
+                  gating the buttons apply themselves, repeated here so the
+                  divider never renders as an orphan. */}
+              {settings.filigran_chatbot_ai_cgu_status !== 'disabled'
+                && settings.platform_xtm_one_configured === true && (
                 <>
                   <AskArianeButton />
                   <CtemCommandCenterButton />


### PR DESCRIPTION
## Summary

- Hide the "Ask Ariane" top-bar button when XTM One is not available. Without XTM One, every `/api/xtmone/chat/*` proxy endpoint short-circuits (`XtmOneChatApi` returns empty lists / 400), so the button could only lead to a dead chat panel or an EE upsell for a feature that cannot work.
- Introduce a single shared `isXtmOneAvailable(settings)` predicate (`ariane/xtmOneAvailability.ts`): agentic AI not explicitly disabled, `platform_xtm_one_configured === true` (url + token set on the backend), and a syntactically valid http(s) `platform_xtm_one_url` (shared `toHttpUrl` helper). It is used by `AskArianeButton`, `CtemCommandCenterButton`, the `TopBar` XTM One block (buttons + vertical divider) and the `AskArianePanel` render, so the gates can never diverge and the divider never renders as an orphan.
- Guard `agentDashboardUrl` in `AskArianePanel` with `toHttpUrl` as well (defense in depth: the value ends up in an anchor href inside the chatbot widget).
- Add visibility tests for `AskArianeButton` (enabled, AI disabled, not configured, flag absent, URL missing, non-http(s) URL), mirroring the existing `CtemCommandCenterButton` suite.

## Test plan

- [x] `yarn vitest run src/__tests__/admin/components/ariane/` - 12 tests passed (6 new)
- [x] `yarn vitest run src/__tests__/admin/components/profile/XtmOneMcpAccess.test.tsx` - 7 tests passed (unchanged consumer of the same settings)
- [x] `yarn check-ts` - clean
- [x] `yarn eslint` on the six touched files - clean

Closes #7129
