### PR TITLE
test(connectors): prove an absent migration id value surfaces the 400, not an NPE (#7122)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
@@ -132,6 +132,23 @@ class ConnectorOrchestrationServiceTest {
   }
 
   @Test
+  @DisplayName(
+      "Migrating with an absent (Java null) connector id value fails with a 400 asking for an id:"
+          + " Optional.map wraps the null so the isNull/asText chain is never reached")
+  void given_migrationWithAbsentConnectorIdValue_should_failWithBadRequest() {
+    CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();
+    CreateConnectorInstanceInput.ConfigurationInput idConfig =
+        new CreateConnectorInstanceInput.ConfigurationInput();
+    idConfig.setKey("COLLECTOR_ID");
+    idConfig.setValue(null);
+    input.setConfigurations(List.of(idConfig));
+
+    assertThatThrownBy(() -> service.createConnectorInstance(collectorCatalog(), input, TENANT_ID))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("A connector id is required");
+  }
+
+  @Test
   @DisplayName("A plain create (no connector id in input) skips the migration existence check")
   void given_plainCreateWithoutConnectorId_should_skipMigrationCheck() {
     CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();

--- a/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/connectors/ConnectorOrchestrationServiceTest.java
@@ -133,8 +133,8 @@ class ConnectorOrchestrationServiceTest {
 
   @Test
   @DisplayName(
-      "Migrating with an absent (Java null) connector id value fails with a 400 asking for an id:"
-          + " Optional.map wraps the null so the isNull/asText chain is never reached")
+      "Migrating with an absent (Java null) connector id value fails with a 400 asking for an id,"
+          + " not an NPE")
   void given_migrationWithAbsentConnectorIdValue_should_failWithBadRequest() {
     CreateConnectorInstanceInput input = new CreateConnectorInstanceInput();
     CreateConnectorInstanceInput.ConfigurationInput idConfig =


### PR DESCRIPTION
## Summary

Relates to #7122, follow-up to #7123.

The fifth-round Copilot review of #7123 claimed that `ConnectorOrchestrationService.throwIfConnectorIdDoesNotExist` could still throw a `NullPointerException` when the migration id configuration key is present but its value is a Java `null` (not `@NotNull` on `ConfigurationInput.value`). The claim is a false positive: the lookup chain runs on the `Optional` returned by `findFirst()`, and `Optional.map` wraps the mapper result in `ofNullable`, so a `null` value collapses to an empty `Optional` before the `isNull()`/`asText()` calls and `orElseThrow` raises the intended `BadRequestException` (400 "A connector id is required to migrate an existing connector").

#7123 was merged while this last round was being addressed, so the regression test pinning that behavior down lands in this small follow-up instead.

## Test plan

- `mvn -pl openaev-api test -Dtest=ConnectorOrchestrationServiceTest` green (5 tests, verified locally)
