### PR TITLE
fix(dashboards): drill security-coverage widgets into every declared series (#7137)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/custom_dashboard/WidgetService.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -363,10 +364,18 @@ public class WidgetService {
    */
   public ListConfiguration convertSecurityCoverageWidgetToListConfiguration(
       Widget widget, Map<String, List<String>> attackPatternFilterValues) {
-    // The matrix scores success against failure, so it drills both of its series. Naming
-    // them beats re-stating their statuses here: the union is then whatever the widget
-    // declares, and cannot fall out of step with it (#7079).
-    return this.convertWidgetToListConfiguration(widget, List.of(0, 1), attackPatternFilterValues);
+    // The matrix drills EVERY series the widget declares: both success and failure for
+    // stored two-series widgets (#7079), the single scope series for the synthetic
+    // overview drill-downs (#7137). Enumerating the declared series beats hardcoding
+    // their indexes here: the union is then whatever the widget declares, and cannot
+    // fall out of step with it.
+    List<WidgetConfigurationWithSeries.Series> series =
+        widget.getWidgetConfiguration() instanceof WidgetConfigurationWithSeries config
+                && config.getSeries() != null
+            ? config.getSeries()
+            : List.of();
+    List<Integer> seriesIndexes = IntStream.range(0, series.size()).boxed().toList();
+    return this.convertWidgetToListConfiguration(widget, seriesIndexes, attackPatternFilterValues);
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/rest/custom_dashboard/WidgetServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/custom_dashboard/WidgetServiceTest.java
@@ -1,0 +1,122 @@
+package io.openaev.rest.custom_dashboard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.database.model.BaseInjectExpectation;
+import io.openaev.database.model.Filters;
+import io.openaev.database.model.Widget;
+import io.openaev.database.model.WidgetLayout;
+import io.openaev.engine.api.ListConfiguration;
+import io.openaev.engine.api.StructuralHistogramWidget;
+import io.openaev.engine.api.WidgetConfigurationWithSeries;
+import io.openaev.engine.api.WidgetType;
+import io.openaev.utils.CustomDashboardTimeRange;
+import io.openaev.utils.fixtures.WidgetFixture;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WidgetService unit tests")
+class WidgetServiceTest {
+
+  // Conversion methods only transform the widget configuration; they never touch the
+  // repositories or the metric collector, so the service is instantiated bare.
+  private final WidgetService widgetService = new WidgetService(null, null, null);
+
+  private static final String SCENARIO_ID = "scenario-id";
+  private static final String ATTACK_PATTERN_ID = "attack-pattern-id";
+
+  /**
+   * Mirrors the synthetic contextual widgets the overview pages build for their kill chain and
+   * posture drill-downs: a security-coverage widget declaring a single series that carries the
+   * whole scope (base_entity plus the scenario/simulation side filter).
+   */
+  private static Widget createSingleSeriesSecurityCoverageWidget() {
+    Widget widget = new Widget();
+    widget.setType(WidgetType.SECURITY_COVERAGE_CHART);
+    StructuralHistogramWidget widgetConfig = new StructuralHistogramWidget();
+    WidgetConfigurationWithSeries.Series series = new WidgetConfigurationWithSeries.Series();
+    series.setName("");
+    Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+    filterGroup.setMode(Filters.FilterMode.and);
+    filterGroup.setFilters(
+        new ArrayList<>(
+            List.of(
+                createFilter("base_entity", List.of("expectation-inject")),
+                createFilter("base_scenario_side", List.of(SCENARIO_ID)))));
+    series.setFilter(filterGroup);
+    widgetConfig.setSeries(List.of(series));
+    widgetConfig.setTitle("Kill chain results");
+    widgetConfig.setField("base_attack_patterns_side");
+    widgetConfig.setDateAttribute("base_created_at");
+    widgetConfig.setTimeRange(CustomDashboardTimeRange.ALL_TIME);
+    widget.setWidgetConfiguration(widgetConfig);
+    widget.setLayout(new WidgetLayout());
+    return widget;
+  }
+
+  private static Filters.Filter createFilter(String key, List<String> values) {
+    Filters.Filter filter = new Filters.Filter();
+    filter.setKey(key);
+    filter.setMode(Filters.FilterMode.or);
+    filter.setOperator(Filters.FilterOperator.eq);
+    filter.setValues(values);
+    return filter;
+  }
+
+  private static Optional<Filters.Filter> findFilter(Filters.FilterGroup group, String key) {
+    return group.getFilters().stream().filter(f -> key.equals(f.getKey())).findFirst();
+  }
+
+  @Test
+  @DisplayName(
+      "Security coverage drill-down succeeds on a widget declaring a single series and keeps its"
+          + " scope")
+  void givenSingleSeriesSecurityCoverageWidget_whenConverting_thenPerspectiveCarriesSeriesScope() {
+    Widget widget = createSingleSeriesSecurityCoverageWidget();
+
+    ListConfiguration listConfiguration =
+        widgetService.convertSecurityCoverageWidgetToListConfiguration(
+            widget, Map.of("base_attack_patterns_side", List.of(ATTACK_PATTERN_ID)));
+
+    Filters.FilterGroup perspectiveFilter = listConfiguration.getPerspective().getFilter();
+    assertThat(findFilter(perspectiveFilter, "base_entity"))
+        .hasValueSatisfying(
+            filter -> assertThat(filter.getValues()).containsExactly("expectation-inject"));
+    assertThat(findFilter(perspectiveFilter, "base_scenario_side"))
+        .hasValueSatisfying(filter -> assertThat(filter.getValues()).containsExactly(SCENARIO_ID));
+    assertThat(findFilter(perspectiveFilter, "base_attack_patterns_side"))
+        .hasValueSatisfying(
+            filter -> assertThat(filter.getValues()).containsExactly(ATTACK_PATTERN_ID));
+  }
+
+  @Test
+  @DisplayName(
+      "Security coverage drill-down unions the status values of a two-series widget (#7079)")
+  void givenTwoSeriesSecurityCoverageWidget_whenConverting_thenPerspectiveUnionsStatusValues() {
+    Widget widget =
+        WidgetFixture.createSecurityConverageWidget(
+            CustomDashboardTimeRange.ALL_TIME,
+            "base_created_at",
+            BaseInjectExpectation.EXPECTATION_TYPE.PREVENTION);
+
+    ListConfiguration listConfiguration =
+        widgetService.convertSecurityCoverageWidgetToListConfiguration(
+            widget, Map.of("base_attack_patterns_side", List.of(ATTACK_PATTERN_ID)));
+
+    Filters.FilterGroup perspectiveFilter = listConfiguration.getPerspective().getFilter();
+    assertThat(findFilter(perspectiveFilter, "inject_expectation_status"))
+        .hasValueSatisfying(
+            filter ->
+                assertThat(filter.getValues())
+                    .containsExactlyInAnyOrder(
+                        BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS.name(),
+                        BaseInjectExpectation.EXPECTATION_STATUS.FAILED.name()));
+    assertThat(findFilter(perspectiveFilter, "base_entity"))
+        .hasValueSatisfying(
+            filter -> assertThat(filter.getValues()).containsExactly("expectation-inject"));
+  }
+}


### PR DESCRIPTION
## Summary

Clicking a technique tile in the "Kill chain results" widget or a "Latest run posture" gauge on scenario/simulation Overview pages always failed with a 400 "Cannot drill down into series [0, 1]: the widget declares 1 series".

- Root cause: `WidgetService.convertSecurityCoverageWidgetToListConfiguration` hardcoded the drilled series indexes as `[0, 1]`, assuming every security-coverage widget declares two series (success/failure, #7079). The synthetic (non-persisted) drill-down widgets the overview pages build declare a single series carrying the whole scope, so index 1 does not exist and `mergeSeries` rejects the request.
- Fix: compute the indexes of every series the widget actually declares and drill all of them. Stored two-series widgets keep the success/failure union behavior from #7079; the single-series synthetic widgets now resolve with their own scope. A series-less widget still gets a clean 400 from `mergeSeries`.

Fixes #7137

## Test plan

- New unit test `WidgetServiceTest` (plain JUnit, no Spring context):
  - a security-coverage widget declaring one series (mirroring the synthetic contextual widget: structural-histogram, field `base_attack_patterns_side`, scope filters `base_entity=expectation-inject` and `base_scenario_side=<id>`) converts successfully and the perspective filter carries the series scope plus the attack pattern drill-down filter;
  - a security-coverage widget declaring two series (success/failure) converts successfully and the perspective filter unions the `inject_expectation_status` values (preserves #7079).
- `mvn -pl openaev-api -am test -Dtest=WidgetServiceTest`: 2 tests, 0 failures.
- `mvn spotless:apply` run; only the touched files changed.
