### PR TITLE
feat(attack-path): causal seed generator (#6855)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/attackpath/AttackPathApi.java
@@ -10,20 +10,24 @@ import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.PreviewFeatureService;
 import io.openaev.service.attackpath.AttackPathAccessControl;
+import io.openaev.service.attackpath.AttackPathCausalSeedService;
 import io.openaev.service.attackpath.AttackPathDeltaService;
 import io.openaev.service.attackpath.AttackPathGraphService;
 import io.openaev.service.attackpath.AttackPathSeedService;
+import io.openaev.service.attackpath.dto.AttackPathCausalSeedResultDTO;
 import io.openaev.service.attackpath.dto.AttackPathDTO;
 import io.openaev.service.attackpath.dto.AttackPathDeltaDTO;
 import io.openaev.service.attackpath.dto.AttackPathEndpointRelationsDTO;
 import io.openaev.service.attackpath.dto.AttackPathExecutionDetailDTO;
 import io.openaev.service.attackpath.dto.AttackPathExpandDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
+import io.openaev.service.attackpath.dto.AttackPathReplayStepDTO;
 import io.openaev.service.attackpath.dto.AttackPathSeedInput;
 import io.openaev.service.attackpath.dto.AttackPathSeedResultDTO;
 import io.openaev.service.attackpath.ingestion.AttackPathVersionService;
 import io.openaev.utils.TxCtxScopeUtils;
 import jakarta.validation.constraints.Min;
+import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -64,6 +68,7 @@ public class AttackPathApi extends RestBehavior {
   private final AttackPathDeltaService deltaService;
   private final AttackPathVersionService versionService;
   private final AttackPathSeedService seedService;
+  private final AttackPathCausalSeedService causalSeedService;
   private final PreviewFeatureService previewFeatureService;
   private final AttackPathAccessControl attackPathAccessControl;
 
@@ -72,6 +77,20 @@ public class AttackPathApi extends RestBehavior {
     if (!previewFeatureService.isFeatureEnabled(PreviewFeature.ATTACK_PATH)) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
+  }
+
+  /**
+   * The single tenant the seed writes under. Seeding is a one-tenant operation, so a scope that
+   * does not resolve to exactly one tenant (none, or several from a multi-tenant header) is
+   * rejected rather than silently picking one and seeding the wrong tenant.
+   */
+  private String requireSingleTenant(TxCtx ctx) {
+    Collection<String> tenants = TxCtxScopeUtils.tenantIdsFromHTTPCtx(ctx);
+    if (tenants.size() != 1) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "seed under exactly one tenant: use the /tenant/{id}/ route");
+    }
+    return tenants.iterator().next();
   }
 
   /**
@@ -243,5 +262,73 @@ public class AttackPathApi extends RestBehavior {
     }
     AttackPathSeedInput params = input != null ? input : new AttackPathSeedInput(null, null, null);
     return seedService.generate(params.toParams(), params.tenantId());
+  }
+
+  /**
+   * Generate a causal attack-path scenario under the request's tenant, for developing and demoing
+   * the causal view at will: {@code scenario=realistic} (default) is one deep recon-to-DC chain,
+   * {@code scenario=scaled} is {@code footholds} independent paths converging on one DC chokepoint,
+   * {@code scenario=intrusion} is a deep host-to-host targeted intrusion that reads left to right,
+   * and {@code scenario=ransomware} is a deep-and-wide kill chain (phishing to DCSync to
+   * domain-wide impact) whose workstation tier and impacted fleet are both sized by {@code
+   * footholds}. Admin-only and only reachable when the feature flag is on, like {@link #seed}.
+   * Returns the id of the created simulation, whose Attack path tab renders the seeded graph.
+   *
+   * <p>With {@code scenario=ransomware&live=step} the simulation is created empty and its kill
+   * chain is landed one stage at a time by {@link #replayNextStage}, so an open view shows it build
+   * up.
+   *
+   * <p>TODO(#6647): a development data generator; remove before production.
+   */
+  @PostMapping("/seed/causal")
+  @Transactional
+  @AccessControl(skipRBAC = true)
+  public AttackPathCausalSeedResultDTO seedCausal(
+      TxCtx ctx,
+      @RequestParam(required = false, defaultValue = "realistic") String scenario,
+      @RequestParam(required = false, defaultValue = "20") int footholds,
+      @RequestParam(required = false, defaultValue = "") String live) {
+    requireAttackPathFeature();
+    if (!SessionHelper.currentUser().isAdmin()) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Attack path seeding is admin-only");
+    }
+    String tenantId = requireSingleTenant(ctx);
+    String simulationId =
+        switch (scenario) {
+          case "realistic" -> causalSeedService.seedRealisticChain(tenantId);
+          case "scaled" -> causalSeedService.seedScaledChain(tenantId, footholds);
+          case "intrusion" -> causalSeedService.seedDeepIntrusion(tenantId, footholds);
+          case "ransomware" ->
+              "step".equals(live)
+                  ? causalSeedService.createRansomwareSimulation(tenantId)
+                  : causalSeedService.seedRansomwareChain(tenantId, footholds);
+          default ->
+              throw new ResponseStatusException(
+                  HttpStatus.BAD_REQUEST, "unknown scenario: " + scenario);
+        };
+    return new AttackPathCausalSeedResultDTO(simulationId);
+  }
+
+  /**
+   * Play the next stage of a live ransomware replay onto the simulation created with {@code
+   * live=step}, and report which stage ran and whether the replay is complete. Admin-only and
+   * feature-gated like {@link #seedCausal}. Call it repeatedly, or on a timer, to watch the kill
+   * chain build up stage by stage in the Attack path tab.
+   *
+   * <p>TODO(#6647): a development data generator; remove before production.
+   */
+  @PostMapping("/simulations/{simulationId}/replay")
+  @Transactional
+  @AccessControl(skipRBAC = true)
+  public AttackPathReplayStepDTO replayNextStage(
+      TxCtx ctx,
+      @PathVariable String simulationId,
+      @RequestParam(required = false, defaultValue = "20") int footholds) {
+    requireAttackPathFeature();
+    if (!SessionHelper.currentUser().isAdmin()) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Attack path seeding is admin-only");
+    }
+    String tenantId = requireSingleTenant(ctx);
+    return causalSeedService.replayRansomwareNextStage(simulationId, tenantId, footholds);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathCausalSeedService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathCausalSeedService.java
@@ -1,0 +1,1341 @@
+package io.openaev.service.attackpath;
+
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.Condition;
+import io.openaev.database.model.ConditionType;
+import io.openaev.database.model.Endpoint;
+import io.openaev.database.model.Exercise;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Injector;
+import io.openaev.database.model.PrimitiveType;
+import io.openaev.database.model.Step;
+import io.openaev.database.model.StepActionClass;
+import io.openaev.database.model.StepStatus;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.Workflow;
+import io.openaev.database.model.WorkflowStatus;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.repository.ConditionRepository;
+import io.openaev.database.repository.ExerciseRepository;
+import io.openaev.database.repository.StepRepository;
+import io.openaev.database.repository.TenantRepository;
+import io.openaev.database.repository.WorkflowRepository;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.service.attackpath.dto.AttackPathReplayStepDTO;
+import io.openaev.service.attackpath.ingestion.AttackPathFindingWriter;
+import io.openaev.service.attackpath.ingestion.AttackPathVersionService;
+import io.openaev.service.chaining.ConditionService;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Byte-faithful, causal, live-capable attack-path seed. Writes through the engine's OWN mechanisms
+ * (AttackPathExecution entities built via the ingestion setters, AttackPathFindingWriter, and the
+ * chaining condition model) so the rendered graph is identical to a real run. Distinct from the
+ * static {@link AttackPathSeedService}, which keeps feeding the aggregated view.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = Exception.class)
+public class AttackPathCausalSeedService {
+
+  private final ExerciseRepository exerciseRepository;
+  private final WorkflowRepository workflowRepository;
+  private final StepRepository stepRepository;
+  private final ConditionRepository conditionRepository;
+  private final ConditionService conditionService;
+  private final AttackPathExecutionRepository executionRepository;
+  private final AttackPathFindingWriter findingWriter;
+  private final AttackPathVersionService versionService;
+  private final TenantRepository tenantRepository;
+  private final EntityManager entityManager;
+
+  /** The number of kill-chain stages the ransomware scenario replays, one version bump each. */
+  private static final int RANSOMWARE_STAGES = 8;
+
+  /**
+   * Create the minimal condition model (a step template carrying a {@code port EQ 445} condition)
+   * and one execution referencing it, under the given simulation + tenant, so {@code buildGraph}
+   * resolves that step's consumed key onto the execution: the {@code step_template_id} &lt;-&gt;
+   * condition linkage the rest of the seed relies on.
+   */
+  public void seedCausalMinimal(String simulationId, String tenantId) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Step template =
+        conditionedTemplate(tenant, simulationId, PrimitiveType.Port, ConditionType.EQ, "445");
+
+    AttackPathExecution execution = new AttackPathExecution();
+    execution.setTenant(tenant);
+    execution.setSimulationId(simulationId);
+    execution.setStepTemplateId(template.getId());
+    execution.setSourceKind("INJECTOR");
+    execution.setSourceInjector("nmap");
+    execution.setTargetKind("ASSET");
+    execution.setTargetKey("ep-dc-01");
+    execution.setTargetAssetId("ep-dc-01");
+    execution.setExecutedAt(Instant.now());
+    execution.setRowVersion(1L);
+    executionRepository.save(execution);
+  }
+
+  /**
+   * Build ONE byte-faithful execution through the engine's OWN setters (deterministic {@code
+   * AttackPathIds} id + frozen columns computed by production code), under the given simulation +
+   * tenant.
+   */
+  public void seedFaithfulExecution(String simulationId, String tenantId) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Inject inject =
+        inject(
+            simulationId + "-inject-nmap-castelback",
+            "Nmap portscan",
+            tenant,
+            simulationId,
+            injector("nmap", "Nmap", "openbas_nmap"));
+    Step template = new Step();
+    template.setId(simulationId + "-template-nmap");
+    Endpoint endpoint =
+        endpoint(simulationId + "-endpoint-castelback", "castelback", "20.224.192.102");
+    executionRepository.save(
+        injectorToAssetExecution(
+            inject, stepInstance(simulationId + "-step-nmap", template), endpoint, 1L));
+  }
+
+  /**
+   * Seed the minimal causal chain: a recon execution that produces a portscan finding, and the
+   * exploit execution that consumes {@code port EQ 445} as an agent pivot, so buildGraph resolves
+   * the finding as the exploit's matched producer (the connected source-to-destination edge).
+   */
+  public void seedMinimalCausalChain(String simulationId, String tenantId) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    long version = versionService.bump(simulationId, tenantId);
+
+    Endpoint castelback =
+        endpoint(simulationId + "-endpoint-castelback", "castelback", "20.224.192.102");
+    Endpoint winterfell = endpoint(simulationId + "-endpoint-winterfell", "winterfell", "10.0.0.7");
+    // Producer strictly before consumer: what buildGraph requires to draw the causal edge.
+    Instant reconAt = Instant.now().minusSeconds(60);
+    Instant exploitAt = reconAt.plusSeconds(1);
+
+    // Recon: an injector portscan of castelback, on its own step template (no condition consumed).
+    Step reconTemplate = new Step();
+    reconTemplate.setId(simulationId + "-recon-template");
+    Inject reconInject =
+        inject(
+            simulationId + "-inject-nmap",
+            "Nmap portscan",
+            tenant,
+            simulationId,
+            injector("nmap", "Nmap", "openbas_nmap"));
+    AttackPathExecution recon =
+        injectorToAssetExecution(
+            reconInject,
+            stepInstance(simulationId + "-recon-step", reconTemplate),
+            castelback,
+            version);
+    recon.setExecutedAt(reconAt);
+
+    // Exploit: NetExec launched FROM castelback's agent, gated by `port EQ 445`, reaching
+    // winterfell. Its template is a distinct, conditioned one, so it consumes the key the recon
+    // finding satisfies, and castelback (recon target + exploit source) collapses to one node.
+    Step exploitTemplate =
+        conditionedTemplate(tenant, simulationId, PrimitiveType.Port, ConditionType.EQ, "445");
+    Inject exploitInject =
+        inject(
+            simulationId + "-inject-netexec",
+            "NetExec SMB - Share Listing",
+            tenant,
+            simulationId,
+            injector("netexec", "NetExec", "openbas_netexec"));
+    Agent agent = agentOn(castelback, simulationId + "-agent-castelback");
+    AttackPathExecution exploit =
+        agentPivotExecution(
+            exploitInject,
+            stepInstance(simulationId + "-exploit-step", exploitTemplate),
+            agent,
+            castelback,
+            winterfell,
+            version);
+    exploit.setExecutedAt(exploitAt);
+
+    executionRepository.save(recon);
+    executionRepository.save(exploit);
+    // Push the JPA inserts (tenant + executions) to the DB before the raw-JDBC finding/link writes,
+    // whose foreign keys (tenant_id, execution_id) would otherwise not see them in this
+    // transaction.
+    entityManager.flush();
+
+    // The produced portscan finding, linked to the recon execution that produced it.
+    String value = AttackPathSeedFindingValues.portscan("20.224.192.102", 445, "microsoft-ds");
+    String findingId =
+        AttackPathIds.findingRow(simulationId, "portscan", "portscan", value, castelback.getId());
+    findingWriter.insertFindings(
+        List.of(
+            new AttackPathFindingWriter.FindingRow(
+                findingId,
+                tenantId,
+                simulationId,
+                "portscan",
+                "portscan",
+                value,
+                castelback.getId(),
+                null,
+                castelback.getId(),
+                true)),
+        version);
+    findingWriter.insertLinks(List.of(new AttackPathFindingWriter.Link(recon.getId(), findingId)));
+  }
+
+  /**
+   * Seed a realistic multi-hop chain (recon -&gt; SMB exploit -&gt; credential dump -&gt; lateral
+   * movement -&gt; DC): each pivot hop consumes the finding the previous hop produced, so
+   * buildGraph draws one connected source-to-destination path across several endpoints.
+   */
+  public String seedRealisticChain(String tenantId) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Workflow workflow = demoSimulationWorkflow(tenant, "Attack path demo - recon to DC");
+    String simulationId = workflow.getSimulation().getId();
+    long version = versionService.bump(simulationId, tenantId);
+    Instant base = Instant.now().minusSeconds(300);
+
+    Endpoint castelback = endpoint(simulationId + "-ep-castelback", "castelback", "20.224.192.102");
+    Endpoint winterfell = endpoint(simulationId + "-ep-winterfell", "winterfell", "10.0.0.7");
+    Endpoint kingslanding = endpoint(simulationId + "-ep-kingslanding", "kingslanding", "10.0.0.9");
+    Endpoint dc = endpoint(simulationId + "-ep-dc01", "dc01", "10.0.0.10");
+
+    List<AttackPathExecution> executions = new ArrayList<>();
+    List<AttackPathFindingWriter.FindingRow> findingRows = new ArrayList<>();
+    List<AttackPathFindingWriter.Link> links = new ArrayList<>();
+
+    // Hop 0 (recon): an injector portscan of castelback, producing the port-445 finding the first
+    // pivot waits on. Its template carries no condition (nothing to consume yet).
+    Step reconTemplate = new Step();
+    reconTemplate.setId(simulationId + "-tmpl-recon");
+    Inject nmapInject =
+        inject(
+            simulationId + "-inject-nmap",
+            "Nmap portscan",
+            tenant,
+            simulationId,
+            injector("nmap", "Nmap", "openbas_nmap"));
+    AttackPathExecution recon =
+        injectorToAssetExecution(
+            nmapInject,
+            stepInstance(simulationId + "-step-recon", reconTemplate),
+            castelback,
+            version);
+    recon.setExecutedAt(base);
+    executions.add(recon);
+    addFinding(
+        findingRows,
+        links,
+        recon,
+        simulationId,
+        tenantId,
+        "portscan",
+        AttackPathSeedFindingValues.portscan("20.224.192.102", 445, "microsoft-ds"),
+        castelback);
+
+    // Hop 1 (SMB exploit): from castelback to winterfell, gated on `port EQ 445`, producing a
+    // share.
+    AttackPathExecution exploit =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(60),
+            injector("netexec", "NetExec", "openbas_netexec"),
+            "NetExec SMB - Share Listing",
+            castelback,
+            winterfell,
+            PrimitiveType.Port,
+            ConditionType.EQ,
+            "445",
+            "exploit");
+    executions.add(exploit);
+    addFinding(
+        findingRows,
+        links,
+        exploit,
+        simulationId,
+        tenantId,
+        "share",
+        AttackPathSeedFindingValues.share("winterfell", "C$", "READ,WRITE"),
+        winterfell);
+
+    // Hop 2 (credential dump): from winterfell to kingslanding, gated on the share, producing
+    // creds.
+    AttackPathExecution credDump =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(120),
+            injector("impacket", "Impacket", "openbas_impacket"),
+            "Impacket - secretsdump",
+            winterfell,
+            kingslanding,
+            PrimitiveType.ShareName,
+            ConditionType.EQ,
+            "C$",
+            "creddump");
+    executions.add(credDump);
+    addFinding(
+        findingRows,
+        links,
+        credDump,
+        simulationId,
+        tenantId,
+        "credentials",
+        AttackPathSeedFindingValues.credentials("administrator", "P@ssw0rd!"),
+        kingslanding);
+
+    // Hop 3 (lateral movement): from kingslanding to the DC, gated on the dumped credentials.
+    AttackPathExecution lateral =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(180),
+            injector("impacket", "Impacket", "openbas_impacket"),
+            "Impacket - psexec (lateral movement)",
+            kingslanding,
+            dc,
+            PrimitiveType.Username,
+            ConditionType.EQ,
+            "administrator",
+            "lateral");
+    executions.add(lateral);
+
+    executionRepository.saveAll(executions);
+    // Flush the JPA executions + tenant before the raw-JDBC finding/link writes, whose foreign keys
+    // (tenant_id, execution_id) would otherwise not see them in this transaction.
+    entityManager.flush();
+    findingWriter.insertFindings(findingRows, version);
+    findingWriter.insertLinks(links);
+    return simulationId;
+  }
+
+  /**
+   * Seed a deep, mostly linear targeted intrusion that reads left to right: the attacker pivots
+   * host to host across the estate (workstation, app server, file server, database, jump host, an
+   * admin's workstation, then the domain controller) and finally detonates ransomware on a few
+   * critical servers. Each hop lands on a NEW host and consumes the finding the previous host
+   * yielded, so the graph lays out as one long horizontal kill chain rather than a wide fan-out.
+   * Exercises all six finding types.
+   */
+  public String seedDeepIntrusion(String tenantId, int hops) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Workflow workflow = demoSimulationWorkflow(tenant, "Attack path demo - targeted intrusion");
+    String simulationId = workflow.getSimulation().getId();
+    long version = versionService.bump(simulationId, tenantId);
+    // `hops` intermediate lateral pivots. A past timeline long enough that even a deep chain keeps
+    // every hop strictly ordered and in the past.
+    int lateralHops = Math.max(1, hops);
+    Instant base = Instant.now().minusSeconds(120L + 60L * (lateralHops + 8L));
+
+    Endpoint ws = endpoint(simulationId + "-ep-ws01", "ws-user-01", "10.0.2.11");
+    Endpoint app = endpoint(simulationId + "-ep-appsrv", "app-srv", "10.0.0.5");
+    Endpoint file = endpoint(simulationId + "-ep-filesrv", "file-srv", "10.0.0.20");
+    Endpoint dc = endpoint(simulationId + "-ep-dc01", "dc01", "10.0.0.10");
+
+    List<AttackPathExecution> executions = new ArrayList<>();
+    List<AttackPathFindingWriter.FindingRow> findingRows = new ArrayList<>();
+    List<AttackPathFindingWriter.Link> links = new ArrayList<>();
+
+    // Initial access: phishing drops a macro document on the user's workstation.
+    Step phishTemplate = new Step();
+    phishTemplate.setId(simulationId + "-tmpl-phish");
+    Inject phishInject =
+        inject(
+            simulationId + "-inject-phish",
+            "Phishing - macro document",
+            tenant,
+            simulationId,
+            injector("email", "Email", "openbas_email"));
+    AttackPathExecution phishing =
+        injectorToAssetExecution(
+            phishInject, stepInstance(simulationId + "-step-phish", phishTemplate), ws, version);
+    phishing.setExecutedAt(base);
+    executions.add(phishing);
+    addFinding(
+        findingRows,
+        links,
+        phishing,
+        simulationId,
+        tenantId,
+        "file",
+        AttackPathSeedFindingValues.file("ws-user-01", "C$", "Users\\Public", "invoice.docm"),
+        ws);
+
+    // Discovery: the implant scans and finds RDP open on the app server.
+    AttackPathExecution recon =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(120),
+            injector("nmap", "Nmap", "openbas_nmap"),
+            "Nmap - network discovery",
+            ws,
+            app,
+            PrimitiveType.FileName,
+            ConditionType.EQ,
+            "invoice.docm",
+            "recon");
+    executions.add(recon);
+    addFinding(
+        findingRows,
+        links,
+        recon,
+        simulationId,
+        tenantId,
+        "portscan",
+        AttackPathSeedFindingValues.portscan("10.0.0.5", 3389, "ms-wbt-server"),
+        app);
+
+    // Exploitation: an RDP CVE on the app server.
+    AttackPathExecution exploit =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(240),
+            injector("metasploit", "Metasploit", "openbas_metasploit"),
+            "RDP exploit (BlueKeep)",
+            ws,
+            app,
+            PrimitiveType.Port,
+            ConditionType.EQ,
+            "3389",
+            "exploit");
+    executions.add(exploit);
+    addFinding(
+        findingRows,
+        links,
+        exploit,
+        simulationId,
+        tenantId,
+        "cve",
+        AttackPathSeedFindingValues.cve("CVE-2019-0708"),
+        app);
+
+    // Foothold: dump the first service account on the file server and expose a share.
+    String svcBackup = "svc-backup";
+    AttackPathExecution toFile =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(360),
+            injector("impacket", "Impacket", "openbas_impacket"),
+            "Impacket - lateral movement + secretsdump",
+            app,
+            file,
+            PrimitiveType.CVE,
+            ConditionType.EQ,
+            "CVE-2019-0708",
+            "to-file");
+    executions.add(toFile);
+    addFinding(
+        findingRows,
+        links,
+        toFile,
+        simulationId,
+        tenantId,
+        "credentials",
+        AttackPathSeedFindingValues.credentials(svcBackup, "B@ckup2024"),
+        file);
+    addFinding(
+        findingRows,
+        links,
+        toFile,
+        simulationId,
+        tenantId,
+        "username",
+        AttackPathSeedFindingValues.username("CONTOSO", svcBackup),
+        file);
+    addFinding(
+        findingRows,
+        links,
+        toFile,
+        simulationId,
+        tenantId,
+        "share",
+        AttackPathSeedFindingValues.share("file-srv", "Data", "READ,WRITE"),
+        file);
+
+    // Lateral movement across the estate: `hops` host-to-host pivots, each launched with the
+    // credential the previous host yielded. Landing on a NEW host each hop is what makes the chain
+    // long and horizontal (the graph groups executions by their source host).
+    String[] tools = {"crackmapexec", "impacket", "evil-winrm", "psexec", "wmiexec"};
+    String[] toolNames = {"CrackMapExec", "Impacket", "Evil-WinRM", "PsExec", "WMIExec"};
+    int[] subnetPorts = {445, 3389, 5985};
+    String[] subnetServices = {"microsoft-ds", "ms-wbt-server", "wsman"};
+    Endpoint prev = file;
+    String prevUser = svcBackup;
+    for (int i = 0; i < lateralHops; i++) {
+      Endpoint next =
+          endpoint(
+              simulationId + "-ep-host-" + i,
+              "host-" + i,
+              "10.1." + (i / 250) + "." + (i % 250 + 1));
+      String user = "user-" + i;
+      AttackPathExecution lateral =
+          pivotHop(
+              simulationId,
+              tenant,
+              workflow,
+              version,
+              base.plusSeconds(420L + i * 30L),
+              injector(tools[i % 5], toolNames[i % 5], "openbas_" + tools[i % 5]),
+              toolNames[i % 5] + " - lateral movement",
+              prev,
+              next,
+              PrimitiveType.Username,
+              ConditionType.EQ,
+              prevUser,
+              "lat-" + i);
+      executions.add(lateral);
+      addFinding(
+          findingRows,
+          links,
+          lateral,
+          simulationId,
+          tenantId,
+          "credentials",
+          AttackPathSeedFindingValues.credentials(user, "P@ss-" + i),
+          next);
+      addFinding(
+          findingRows,
+          links,
+          lateral,
+          simulationId,
+          tenantId,
+          "username",
+          AttackPathSeedFindingValues.username("CONTOSO", user),
+          next);
+      // Breadth on this host, collapsing into expandable "+N" clusters in the causal view: the
+      // subnet it scanned, the accounts it dumped, and the shares it could read. None of these are
+      // consumed by the chain (the next hop keys on `user`), so they add depth of detail without
+      // branching the path.
+      for (int k = 0; k < 20; k++) {
+        addFinding(
+            findingRows,
+            links,
+            lateral,
+            simulationId,
+            tenantId,
+            "portscan",
+            AttackPathSeedFindingValues.portscan(
+                "10.9." + (i % 250) + "." + (k + 1), subnetPorts[k % 3], subnetServices[k % 3]),
+            next);
+      }
+      for (int k = 0; k < 8; k++) {
+        addFinding(
+            findingRows,
+            links,
+            lateral,
+            simulationId,
+            tenantId,
+            "credentials",
+            AttackPathSeedFindingValues.credentials("svc-" + i + "-" + k, "Pw-" + i + "-" + k),
+            next);
+      }
+      for (int k = 0; k < 5; k++) {
+        addFinding(
+            findingRows,
+            links,
+            lateral,
+            simulationId,
+            tenantId,
+            "share",
+            AttackPathSeedFindingValues.share("host-" + i, "Share-" + k, "READ"),
+            next);
+      }
+      prev = next;
+      prevUser = user;
+    }
+
+    // DCSync from the last compromised host: full domain compromise.
+    String domainKey = "krbtgt";
+    AttackPathExecution dcSync =
+        pivotHop(
+            simulationId,
+            tenant,
+            workflow,
+            version,
+            base.plusSeconds(420L + lateralHops * 30L),
+            injector("mimikatz", "Mimikatz", "openbas_mimikatz"),
+            "Mimikatz - DCSync (domain compromise)",
+            prev,
+            dc,
+            PrimitiveType.Username,
+            ConditionType.EQ,
+            prevUser,
+            "dcsync");
+    executions.add(dcSync);
+    addFinding(
+        findingRows,
+        links,
+        dcSync,
+        simulationId,
+        tenantId,
+        "credentials",
+        AttackPathSeedFindingValues.credentials(domainKey, "e3b0c44298fc"),
+        dc);
+
+    // Impact: ransomware detonated on a few critical servers from the DC.
+    String[] crown = {"srv-finance", "srv-hr", "srv-ops"};
+    for (int j = 0; j < crown.length; j++) {
+      Endpoint target = endpoint(simulationId + "-ep-crown-" + j, crown[j], "10.0.4." + (10 + j));
+      AttackPathExecution impact =
+          pivotHop(
+              simulationId,
+              tenant,
+              workflow,
+              version,
+              base.plusSeconds(450L + lateralHops * 30L),
+              injector("ransomware", "Ransomware", "openbas_impacket"),
+              "Ransomware deployment",
+              dc,
+              target,
+              PrimitiveType.Username,
+              ConditionType.EQ,
+              domainKey,
+              "impact-" + j);
+      executions.add(impact);
+    }
+
+    executionRepository.saveAll(executions);
+    entityManager.flush();
+    findingWriter.insertFindings(findingRows, version);
+    findingWriter.insertLinks(links);
+    return simulationId;
+  }
+
+  /**
+   * Fan out {@code footholdCount} independent attack paths converging on one DC: each foothold is
+   * compromised (its own unique credential) and then laterally moved to the same DC. Each path keys
+   * its consumed condition on its own credential, so the paths stay separate (no cross-match) and
+   * the DC renders as the shared chokepoint the whole estate funnels into.
+   */
+  public String seedScaledChain(String tenantId, int footholdCount) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Workflow workflow = demoSimulationWorkflow(tenant, "Attack path demo - fan-out to DC");
+    String simulationId = workflow.getSimulation().getId();
+    long version = versionService.bump(simulationId, tenantId);
+    Instant base = Instant.now().minusSeconds(600);
+
+    Endpoint dc = endpoint(simulationId + "-ep-dc01", "dc01", "10.0.0.254");
+    // The compromise action shares one condition-less template across footholds; only the lateral
+    // hops carry a per-foothold condition, so each path is keyed by its own credential.
+    Step compromiseTemplate = new Step();
+    compromiseTemplate.setId(simulationId + "-tmpl-compromise");
+
+    List<AttackPathExecution> executions = new ArrayList<>();
+    List<AttackPathFindingWriter.FindingRow> findingRows = new ArrayList<>();
+    List<AttackPathFindingWriter.Link> links = new ArrayList<>();
+
+    for (int i = 0; i < footholdCount; i++) {
+      Endpoint foothold =
+          endpoint(simulationId + "-ep-foothold-" + i, "workstation-" + i, "10.0.1." + (10 + i));
+      String user = "admin-" + i;
+
+      // Compromise: an injector run that lands on the foothold and dumps its local credential.
+      Inject compromiseInject =
+          inject(
+              simulationId + "-inject-compromise-" + i,
+              "CrackMapExec - credential dump",
+              tenant,
+              simulationId,
+              injector("crackmapexec", "CrackMapExec", "openbas_crackmapexec"));
+      AttackPathExecution compromise =
+          injectorToAssetExecution(
+              compromiseInject,
+              stepInstance(simulationId + "-step-compromise-" + i, compromiseTemplate),
+              foothold,
+              version);
+      compromise.setExecutedAt(base);
+      executions.add(compromise);
+      addFinding(
+          findingRows,
+          links,
+          compromise,
+          simulationId,
+          tenantId,
+          "credentials",
+          AttackPathSeedFindingValues.credentials(user, "P@ssw0rd-" + i),
+          foothold);
+
+      // Lateral: pivot from the foothold to the shared DC, gated on THIS foothold's credential, so
+      // every path funnels into the one DC chokepoint.
+      AttackPathExecution lateral =
+          pivotHop(
+              simulationId,
+              tenant,
+              workflow,
+              version,
+              base.plusSeconds(60),
+              injector("impacket", "Impacket", "openbas_impacket"),
+              "Impacket - psexec (lateral to DC)",
+              foothold,
+              dc,
+              PrimitiveType.Username,
+              ConditionType.EQ,
+              user,
+              "lateral-" + i);
+      executions.add(lateral);
+    }
+
+    executionRepository.saveAll(executions);
+    entityManager.flush();
+    findingWriter.insertFindings(findingRows, version);
+    findingWriter.insertLinks(links);
+    return simulationId;
+  }
+
+  /**
+   * Seed a deep AND wide kill chain (the "ransomware" scenario). An initial-access spine (phishing,
+   * discovery, SMB exploit, credential dump) lands a reused local admin on the file server. From
+   * there two things happen: the local admin is sprayed across a workstation tier, each host
+   * dumping its own domain user and then moving laterally to the domain controller; and, in
+   * parallel, a readable share leaks a service account that Kerberoasting cracks and a DCSync turns
+   * into the domain key. Every path converges on the one DC, which then fans out a final time as
+   * domain-wide ransomware. Each hop consumes the finding the previous hop produced, and the tiers
+   * key their conditions on distinct credentials, so the DC renders as the chokepoint the whole
+   * estate funnels through. {@code spread} sizes both the workstation tier and the impacted fleet.
+   */
+  public String seedRansomwareChain(String tenantId, int spread) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Workflow workflow = demoSimulationWorkflow(tenant, "Attack path demo - ransomware intrusion");
+    String simulationId = workflow.getSimulation().getId();
+    // Write every stage in the caller's one transaction: the whole chain lands at once, through the
+    // same per-stage writer the live replay commits one stage at a time.
+    for (int stage = 0; stage < RANSOMWARE_STAGES; stage++) {
+      writeRansomwareStage(simulationId, tenantId, tenant, workflow, spread, stage);
+    }
+    return simulationId;
+  }
+
+  /**
+   * Create the ransomware demo's simulation (a real Exercise plus one workflow to host its
+   * conditioned templates) with no graph yet, and return its id. The live replay then lands the
+   * kill chain onto it one stage at a time, so an open Attack path tab shows the intrusion build
+   * up.
+   */
+  public String createRansomwareSimulation(String tenantId) {
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Workflow workflow = demoSimulationWorkflow(tenant, "Attack path demo - ransomware (live)");
+    return workflow.getSimulation().getId();
+  }
+
+  /**
+   * Play the next un-played stage of the ransomware kill chain onto an existing simulation, in the
+   * caller's transaction. The next stage is the simulation's current version (each stage bumps it
+   * once), so a client drives the replay by calling this repeatedly, no state to track.
+   */
+  public AttackPathReplayStepDTO replayRansomwareNextStage(
+      String simulationId, String tenantId, int spread) {
+    int stage =
+        versionService.current(simulationId, List.of(tenantId)).map(Long::intValue).orElse(0);
+    if (stage >= RANSOMWARE_STAGES) {
+      return new AttackPathReplayStepDTO(
+          RANSOMWARE_STAGES, RANSOMWARE_STAGES, true, "Replay complete");
+    }
+    Tenant tenant = tenantRepository.getReferenceById(tenantId);
+    Workflow workflow =
+        workflowRepository.findAllBySimulation_Id(simulationId).stream()
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No workflow to replay for simulation " + simulationId));
+    String label = writeRansomwareStage(simulationId, tenantId, tenant, workflow, spread, stage);
+    return new AttackPathReplayStepDTO(
+        stage, RANSOMWARE_STAGES, stage + 1 >= RANSOMWARE_STAGES, label);
+  }
+
+  /**
+   * Build and commit ONE stage of the ransomware kill chain (its conditioned templates, executions
+   * and findings) in the caller's transaction, then bump the version and nudge open views. Each
+   * stage consumes findings earlier stages already committed, so it renders as a causal step. The
+   * stages in order: phishing, discovery, exploitation, credential dump, lateral spray, convergence
+   * on the DC, privilege escalation (Kerberoast + DCSync), domain-wide impact.
+   */
+  private String writeRansomwareStage(
+      String simulationId,
+      String tenantId,
+      Tenant tenant,
+      Workflow workflow,
+      int spread,
+      int stage) {
+    long version = versionService.bump(simulationId, tenantId);
+    // Past, per-stage timeline: a later stage is written later so its base is greater, and the
+    // offsets keep a producer before the consumer that reads it, within and across stages.
+    Instant base = Instant.now().minusSeconds(900);
+    Endpoint entry = endpoint(simulationId + "-ep-ws01", "ws-user-01", "10.0.2.11");
+    Endpoint fileServer = endpoint(simulationId + "-ep-filesrv", "file-srv", "10.0.0.20");
+    Endpoint dc = endpoint(simulationId + "-ep-dc01", "dc01", "10.0.0.10");
+    String localAdmin = "localadmin";
+    String serviceAccount = "svc_sql";
+    String domainKey = "krbtgt";
+
+    List<AttackPathExecution> executions = new ArrayList<>();
+    List<AttackPathFindingWriter.FindingRow> findingRows = new ArrayList<>();
+    List<AttackPathFindingWriter.Link> links = new ArrayList<>();
+    String label;
+
+    switch (stage) {
+      case 0 -> {
+        label = "Initial access - phishing";
+        // Phishing drops an implant on the entry workstation (no condition, the chain starts here),
+        // producing the file the discovery hop waits on.
+        Step phishTemplate = new Step();
+        phishTemplate.setId(simulationId + "-tmpl-phish");
+        Inject phishInject =
+            inject(
+                simulationId + "-inject-phish",
+                "Phishing - malicious attachment",
+                tenant,
+                simulationId,
+                injector("email", "Email", "openbas_email"));
+        AttackPathExecution phishing =
+            injectorToAssetExecution(
+                phishInject,
+                stepInstance(simulationId + "-step-phish", phishTemplate),
+                entry,
+                version);
+        phishing.setExecutedAt(base);
+        executions.add(phishing);
+        addFinding(
+            findingRows,
+            links,
+            phishing,
+            simulationId,
+            tenantId,
+            "file",
+            AttackPathSeedFindingValues.file("ws-user-01", "C$", "Users\\Public", "invoice.exe"),
+            entry);
+      }
+      case 1 -> {
+        label = "Discovery - subnet portscan";
+        AttackPathExecution discovery =
+            pivotHop(
+                simulationId,
+                tenant,
+                workflow,
+                version,
+                base.plusSeconds(60),
+                injector("nmap", "Nmap", "openbas_nmap"),
+                "Nmap - subnet discovery",
+                entry,
+                fileServer,
+                PrimitiveType.FileName,
+                ConditionType.EQ,
+                "invoice.exe",
+                "discovery");
+        executions.add(discovery);
+        addFinding(
+            findingRows,
+            links,
+            discovery,
+            simulationId,
+            tenantId,
+            "portscan",
+            AttackPathSeedFindingValues.portscan("10.0.0.20", 445, "microsoft-ds"),
+            fileServer);
+      }
+      case 2 -> {
+        label = "Exploitation - SMB CVE";
+        AttackPathExecution exploit =
+            pivotHop(
+                simulationId,
+                tenant,
+                workflow,
+                version,
+                base.plusSeconds(120),
+                injector("netexec", "NetExec", "openbas_netexec"),
+                "NetExec - SMB exploitation",
+                entry,
+                fileServer,
+                PrimitiveType.Port,
+                ConditionType.EQ,
+                "445",
+                "exploit");
+        executions.add(exploit);
+        addFinding(
+            findingRows,
+            links,
+            exploit,
+            simulationId,
+            tenantId,
+            "cve",
+            AttackPathSeedFindingValues.cve("CVE-2017-0144"),
+            fileServer);
+      }
+      case 3 -> {
+        label = "Credential access - LSASS dump";
+        AttackPathExecution credDump =
+            pivotHop(
+                simulationId,
+                tenant,
+                workflow,
+                version,
+                base.plusSeconds(180),
+                injector("impacket", "Impacket", "openbas_impacket"),
+                "Impacket - secretsdump (LSASS)",
+                fileServer,
+                fileServer,
+                PrimitiveType.CVE,
+                ConditionType.EQ,
+                "CVE-2017-0144",
+                "creddump");
+        executions.add(credDump);
+        addFinding(
+            findingRows,
+            links,
+            credDump,
+            simulationId,
+            tenantId,
+            "credentials",
+            AttackPathSeedFindingValues.credentials(localAdmin, "aad3b435b51404ee"),
+            fileServer);
+      }
+      case 4 -> {
+        label = "Lateral movement - pass-the-hash spray";
+        // The reused local admin is sprayed across the workstation tier, each host dumping its own
+        // domain user.
+        for (int i = 0; i < spread; i++) {
+          Endpoint workstation =
+              endpoint(simulationId + "-ep-ws-" + i, "workstation-" + i, "10.0.2." + (20 + i));
+          AttackPathExecution spray =
+              pivotHop(
+                  simulationId,
+                  tenant,
+                  workflow,
+                  version,
+                  base.plusSeconds(240),
+                  injector("crackmapexec", "CrackMapExec", "openbas_crackmapexec"),
+                  "CrackMapExec - pass-the-hash",
+                  fileServer,
+                  workstation,
+                  PrimitiveType.Username,
+                  ConditionType.EQ,
+                  localAdmin,
+                  "spray-" + i);
+          executions.add(spray);
+          addFinding(
+              findingRows,
+              links,
+              spray,
+              simulationId,
+              tenantId,
+              "credentials",
+              AttackPathSeedFindingValues.credentials("user-" + i, "P@ssw0rd-" + i),
+              workstation);
+        }
+      }
+      case 5 -> {
+        label = "Convergence - lateral movement to the DC";
+        // Each compromised workstation moves laterally to the shared DC on its own credential.
+        for (int i = 0; i < spread; i++) {
+          Endpoint workstation =
+              endpoint(simulationId + "-ep-ws-" + i, "workstation-" + i, "10.0.2." + (20 + i));
+          AttackPathExecution converge =
+              pivotHop(
+                  simulationId,
+                  tenant,
+                  workflow,
+                  version,
+                  base.plusSeconds(300),
+                  injector("impacket", "Impacket", "openbas_impacket"),
+                  "Impacket - psexec (lateral to DC)",
+                  workstation,
+                  dc,
+                  PrimitiveType.Username,
+                  ConditionType.EQ,
+                  "user-" + i,
+                  "converge-" + i);
+          executions.add(converge);
+        }
+      }
+      case 6 -> {
+        label = "Privilege escalation - Kerberoast and DCSync";
+        // From the file-server foothold a readable share leaks a service account, Kerberoasting
+        // cracks it, and a DCSync against the DC yields the domain key.
+        AttackPathExecution shareEnum =
+            pivotHop(
+                simulationId,
+                tenant,
+                workflow,
+                version,
+                base.plusSeconds(360),
+                injector("crackmapexec", "CrackMapExec", "openbas_crackmapexec"),
+                "CrackMapExec - share enumeration",
+                fileServer,
+                fileServer,
+                PrimitiveType.Username,
+                ConditionType.EQ,
+                localAdmin,
+                "shareenum");
+        executions.add(shareEnum);
+        addFinding(
+            findingRows,
+            links,
+            shareEnum,
+            simulationId,
+            tenantId,
+            "share",
+            AttackPathSeedFindingValues.share("file-srv", "SYSVOL", "READ"),
+            fileServer);
+        addFinding(
+            findingRows,
+            links,
+            shareEnum,
+            simulationId,
+            tenantId,
+            "file",
+            AttackPathSeedFindingValues.file("file-srv", "SYSVOL", "policies", "Groups.xml"),
+            fileServer);
+        AttackPathExecution kerberoast =
+            pivotHop(
+                simulationId,
+                tenant,
+                workflow,
+                version,
+                base.plusSeconds(370),
+                injector("impacket", "Impacket", "openbas_impacket"),
+                "Impacket - GetUserSPNs (Kerberoast)",
+                fileServer,
+                fileServer,
+                PrimitiveType.ShareName,
+                ConditionType.EQ,
+                "SYSVOL",
+                "kerberoast");
+        executions.add(kerberoast);
+        addFinding(
+            findingRows,
+            links,
+            kerberoast,
+            simulationId,
+            tenantId,
+            "credentials",
+            AttackPathSeedFindingValues.credentials(serviceAccount, "Summer2024!"),
+            fileServer);
+        addFinding(
+            findingRows,
+            links,
+            kerberoast,
+            simulationId,
+            tenantId,
+            "username",
+            AttackPathSeedFindingValues.username("CONTOSO", serviceAccount),
+            fileServer);
+        AttackPathExecution dcSync =
+            pivotHop(
+                simulationId,
+                tenant,
+                workflow,
+                version,
+                base.plusSeconds(380),
+                injector("impacket", "Impacket", "openbas_impacket"),
+                "Impacket - secretsdump (DCSync)",
+                fileServer,
+                dc,
+                PrimitiveType.Username,
+                ConditionType.EQ,
+                serviceAccount,
+                "dcsync");
+        executions.add(dcSync);
+        addFinding(
+            findingRows,
+            links,
+            dcSync,
+            simulationId,
+            tenantId,
+            "credentials",
+            AttackPathSeedFindingValues.credentials(domainKey, "e3b0c44298fc1c14"),
+            dc);
+      }
+      case 7 -> {
+        label = "Impact - domain-wide ransomware";
+        // Ransomware pushed from the DC to the whole fleet.
+        for (int j = 0; j < spread; j++) {
+          Endpoint fleetHost =
+              endpoint(simulationId + "-ep-fleet-" + j, "fleet-" + j, "10.0.3." + (20 + j));
+          AttackPathExecution impact =
+              pivotHop(
+                  simulationId,
+                  tenant,
+                  workflow,
+                  version,
+                  base.plusSeconds(420),
+                  injector("impacket", "Impacket", "openbas_impacket"),
+                  "Impacket - psexec (ransomware deployment)",
+                  dc,
+                  fleetHost,
+                  PrimitiveType.Username,
+                  ConditionType.EQ,
+                  domainKey,
+                  "impact-" + j);
+          executions.add(impact);
+        }
+      }
+      default -> throw new IllegalArgumentException("Unknown ransomware stage: " + stage);
+    }
+
+    executionRepository.saveAll(executions);
+    entityManager.flush();
+    findingWriter.insertFindings(findingRows, version);
+    findingWriter.insertLinks(links);
+    versionService.publishChanged(simulationId, tenantId, version);
+    return label;
+  }
+
+  /**
+   * One pivot hop: an agent action launched from {@code source} against {@code target}, whose
+   * conditioned template consumes {@code (keyType op value)} so buildGraph resolves the finding the
+   * previous hop produced as its matched producer. {@code label} keys the hop's deterministic ids.
+   */
+  private AttackPathExecution pivotHop(
+      String simulationId,
+      Tenant tenant,
+      Workflow workflow,
+      long version,
+      Instant executedAt,
+      Injector injector,
+      String actionTitle,
+      Endpoint source,
+      Endpoint target,
+      PrimitiveType keyType,
+      ConditionType operator,
+      String value,
+      String label) {
+    Step template = conditionedTemplateIn(workflow, keyType, operator, value);
+    Inject inject =
+        inject(simulationId + "-inject-" + label, actionTitle, tenant, simulationId, injector);
+    Agent agent = agentOn(source, simulationId + "-agent-" + label);
+    AttackPathExecution execution =
+        agentPivotExecution(
+            inject,
+            stepInstance(simulationId + "-step-" + label, template),
+            agent,
+            source,
+            target,
+            version);
+    execution.setExecutedAt(executedAt);
+    return execution;
+  }
+
+  /** Records a finding produced on {@code endpoint} and links it to its producing execution. */
+  private void addFinding(
+      List<AttackPathFindingWriter.FindingRow> rows,
+      List<AttackPathFindingWriter.Link> links,
+      AttackPathExecution producer,
+      String simulationId,
+      String tenantId,
+      String type,
+      String value,
+      Endpoint endpoint) {
+    String id = AttackPathIds.findingRow(simulationId, type, type, value, endpoint.getId());
+    rows.add(
+        new AttackPathFindingWriter.FindingRow(
+            id,
+            tenantId,
+            simulationId,
+            type,
+            type,
+            value,
+            endpoint.getId(),
+            null,
+            endpoint.getId(),
+            true));
+    links.add(new AttackPathFindingWriter.Link(producer.getId(), id));
+  }
+
+  /**
+   * The injector -&gt; asset execution recipe, byte-identical to {@code
+   * AttackPathExecutionIngestionService.setSourceInjectorTargetAsset}: the deterministic {@code
+   * executionNode} id, then the engine setters that freeze the identity/source/target columns. The
+   * domain objects are transient (the execution freezes their values into plain columns; only
+   * {@code tenant} is a real FK), so nothing but the execution row is persisted.
+   */
+  private AttackPathExecution injectorToAssetExecution(
+      Inject inject, Step step, Endpoint endpoint, long rowVersion) {
+    AttackPathExecution execution = new AttackPathExecution();
+    execution.setId(
+        AttackPathIds.executionNode(
+            inject.getId(), endpoint.getId(), inject.getInjector().getId()));
+    execution.setGlobalInformation(step, inject);
+    execution.setSourceInjectorInformation(inject.getInjector());
+    execution.setTargetAssetInformation(endpoint);
+    execution.setRowVersion(rowVersion);
+    return execution;
+  }
+
+  /**
+   * The agent -&gt; asset (pivot) execution recipe, byte-identical to the agent branch of {@code
+   * AttackPathExecutionIngestionService}: the source is an agent on {@code sourceEndpoint}, so that
+   * endpoint renders as both a reached target and a pivot source in the graph.
+   */
+  private AttackPathExecution agentPivotExecution(
+      Inject inject,
+      Step step,
+      Agent agent,
+      Endpoint sourceEndpoint,
+      Endpoint targetEndpoint,
+      long rowVersion) {
+    AttackPathExecution execution = new AttackPathExecution();
+    execution.setId(
+        AttackPathIds.executionNode(inject.getId(), targetEndpoint.getId(), agent.getId()));
+    execution.setGlobalInformation(step, inject);
+    execution.setSourceAgentInformation(agent, sourceEndpoint);
+    execution.setTargetAssetInformation(targetEndpoint);
+    execution.setRowVersion(rowVersion);
+    return execution;
+  }
+
+  /**
+   * A persisted step template (in a workflow of a simulation) carrying one filter condition, so
+   * buildGraph resolves it as a consumed key on the executions that ran it. The workflow needs a
+   * simulation (or scenario) per chk_workflow_simulation_or_scenario; the executions carry the
+   * simulation id as a frozen string, so the two are decoupled.
+   */
+  private Step conditionedTemplate(
+      Tenant tenant, String label, PrimitiveType keyType, ConditionType operator, String value) {
+    Exercise simulation = new Exercise();
+    simulation.setName("Causal seed " + label);
+    simulation.setFrom("causal-seed@openaev.io");
+    simulation.setTenant(tenant);
+    exerciseRepository.save(simulation);
+    Workflow workflow = workflowTemplate();
+    workflow.setSimulation(simulation);
+    workflowRepository.save(workflow);
+    Step template = stepTemplate(workflow);
+    stepRepository.save(template);
+    Condition condition = new Condition();
+    condition.setKeyTypes(List.of(keyType));
+    condition.setType(operator);
+    condition.setValue(value);
+    conditionService.linkToStep(condition, template, true);
+    conditionRepository.save(condition);
+    return template;
+  }
+
+  /**
+   * Create the demo simulation the front navigates to (a real Exercise) plus one workflow to host
+   * all of its conditioned step templates, and return the workflow. The attack-path rows are
+   * written under {@code workflow.getSimulation().getId()} so that simulation's Attack path tab
+   * renders them.
+   */
+  private Workflow demoSimulationWorkflow(Tenant tenant, String name) {
+    Exercise simulation = new Exercise();
+    simulation.setName(name);
+    simulation.setFrom("causal-seed@openaev.io");
+    simulation.setTenant(tenant);
+    exerciseRepository.save(simulation);
+    Workflow workflow = workflowTemplate();
+    workflow.setSimulation(simulation);
+    workflowRepository.save(workflow);
+    return workflow;
+  }
+
+  /** A conditioned step template hosted in the given (shared) workflow. */
+  private Step conditionedTemplateIn(
+      Workflow workflow, PrimitiveType keyType, ConditionType operator, String value) {
+    Step template = stepTemplate(workflow);
+    stepRepository.save(template);
+    Condition condition = new Condition();
+    condition.setKeyTypes(List.of(keyType));
+    condition.setType(operator);
+    condition.setValue(value);
+    conditionService.linkToStep(condition, template, true);
+    conditionRepository.save(condition);
+    return template;
+  }
+
+  private Endpoint endpoint(String id, String name, String ip) {
+    Endpoint endpoint = new Endpoint();
+    endpoint.setId(id);
+    endpoint.setName(name);
+    endpoint.setHostname(name);
+    endpoint.setIps(new String[] {ip});
+    endpoint.setPlatform(Endpoint.PLATFORM_TYPE.Windows);
+    return endpoint;
+  }
+
+  private Injector injector(String id, String name, String type) {
+    Injector injector = new Injector();
+    injector.setId(id);
+    injector.setName(name);
+    injector.setType(type);
+    return injector;
+  }
+
+  private Inject inject(
+      String id, String title, Tenant tenant, String simulationId, Injector injector) {
+    Exercise simulation = new Exercise();
+    simulation.setId(simulationId);
+    Inject inject = new Inject();
+    inject.setId(id);
+    inject.setTitle(title);
+    inject.setTenant(tenant);
+    inject.setExercise(simulation);
+    inject.setInjector(injector);
+    return inject;
+  }
+
+  private Agent agentOn(Endpoint endpoint, String id) {
+    Agent agent = new Agent();
+    agent.setId(id);
+    agent.setAsset(endpoint);
+    agent.setPrivilege(Agent.PRIVILEGE.admin);
+    return agent;
+  }
+
+  private static Step stepInstance(String id, Step template) {
+    Step step = new Step();
+    step.setId(id);
+    step.setStepTemplate(template);
+    return step;
+  }
+
+  private static Workflow workflowTemplate() {
+    Workflow workflow = new Workflow();
+    workflow.setStatus(WorkflowStatus.TEMPLATE);
+    workflow.setVersion(1);
+    workflow.setEdited(false);
+    workflow.setWorkflowCreatedAt(Instant.now());
+    workflow.setWorkflowUpdatedAt(Instant.now());
+    workflow.setWorkflowTemplate(null);
+    workflow.setWorkflowsExecuted(new ArrayList<>());
+    workflow.setSteps(new ArrayList<>());
+    return workflow;
+  }
+
+  private static Step stepTemplate(Workflow workflow) {
+    Step step = new Step();
+    step.setWorkflow(workflow);
+    step.setStepAction(StepActionClass.INJECT_EXECUTION);
+    step.setOutput("{}");
+    step.setOutputParser("{}");
+    step.setInput("{}");
+    step.setData("{}");
+    step.setLimitExecution(1);
+    step.setConditionExecuted("true");
+    step.setStatus(StepStatus.TEMPLATE);
+    return step;
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathSeedFindingValues.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathSeedFindingValues.java
@@ -1,0 +1,69 @@
+package io.openaev.service.attackpath;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Produces attack-path finding VALUES in the exact byte formats the OutputProcessors emit (the
+ * inverse of {@link AttackPathKeyMatcher}'s sub-field extractors), so a seeded finding is matched
+ * by a consumed key exactly like a real one. Kept as one small pure helper so the seed and its
+ * tests share a single source of truth for the formats.
+ */
+public final class AttackPathSeedFindingValues {
+
+  private AttackPathSeedFindingValues() {}
+
+  /** portscan: {@code host:port (service)}, service dropped when blank. */
+  public static String portscan(String host, int port, String service) {
+    return host + ":" + port + (isBlank(service) ? "" : " (" + service + ")");
+  }
+
+  /** credentials: {@code username:password} (split on the first colon). */
+  public static String credentials(String username, String password) {
+    return username + ":" + password;
+  }
+
+  /**
+   * share: the ShareOutputProcessor form; the UNC host prefix is dropped when the host is blank.
+   */
+  public static String share(String host, String shareName, String permissions) {
+    String value = shareName + " (" + permissions + ")";
+    return isBlank(host) ? value : "\\\\" + host + "\\" + value;
+  }
+
+  /**
+   * file: the FileOutputProcessor form. A UNC path ({@code \\host\share\dir\file}) on a share,
+   * {@code host:/path} otherwise, or the bare relative path when the host is blank. The basename is
+   * the matched sub-field.
+   */
+  public static String file(String host, String share, String path, String fileName) {
+    String relative =
+        Stream.of(share, path, fileName).filter(s -> !isBlank(s)).collect(Collectors.joining("/"));
+    if (isBlank(host)) {
+      return relative;
+    }
+    if (!isBlank(share)) {
+      return "\\\\" + host + "\\" + relative.replace('/', '\\');
+    }
+    return host + ":" + (relative.startsWith("/") ? relative : "/" + relative);
+  }
+
+  /** username: the UsernameOutputProcessor form; the domain prefix is dropped when it is blank. */
+  public static String username(String domain, String user) {
+    return isBlank(domain) ? user : domain + "\\" + user;
+  }
+
+  /** cve: the identifier itself (whole-value match). */
+  public static String cve(String cveId) {
+    return cveId;
+  }
+
+  /** bare port: the port number as text (whole-value match). */
+  public static String port(int port) {
+    return Integer.toString(port);
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathCausalSeedResultDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathCausalSeedResultDTO.java
@@ -1,0 +1,4 @@
+package io.openaev.service.attackpath.dto;
+
+/** Result of a causal seed run: the synthetic seed simulation id the chain was written under. */
+public record AttackPathCausalSeedResultDTO(String simulationId) {}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathReplayStepDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathReplayStepDTO.java
@@ -1,0 +1,7 @@
+package io.openaev.service.attackpath.dto;
+
+/**
+ * The outcome of playing one stage of a live seed replay: which stage was played, how many there
+ * are in total, whether the replay is now complete, and a human label for the stage.
+ */
+public record AttackPathReplayStepDTO(int stage, int totalStages, boolean done, String label) {}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiDisabledTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathApiDisabledTest.java
@@ -1,6 +1,8 @@
 package io.openaev.api.attackpath;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.openaev.IntegrationTest;
@@ -24,6 +26,13 @@ class AttackPathApiDisabledTest extends IntegrationTest {
   @DisplayName("The graph endpoint returns 404 when the attack-path preview feature is off")
   void graph_endpoint_is_404_when_feature_off() throws Exception {
     mvc.perform(get(AttackPathApi.ATTACK_PATH_URI + "/simulations/any/graph"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("The causal seed endpoint returns 404 when the attack-path preview feature is off")
+  void causal_seed_endpoint_is_404_when_feature_off() throws Exception {
+    mvc.perform(post(AttackPathApi.ATTACK_PATH_URI + "/seed/causal").with(csrf()))
         .andExpect(status().isNotFound());
   }
 

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathCausalSeedApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathCausalSeedApiTest.java
@@ -1,0 +1,97 @@
+package io.openaev.api.attackpath;
+
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.utils.mockUser.WithMockUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The causal seed entrypoint: admin-only and gated behind the ATTACK_PATH feature, it creates a
+ * simulation, writes a causal chain under it, and returns its id; the seeded graph is then readable
+ * through the graph endpoint for that simulation.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@TestPropertySource(properties = "openaev.enabled-dev-features=INJECT_CHAINING,ATTACK_PATH")
+class AttackPathCausalSeedApiTest extends IntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Test
+  @DisplayName("POST /seed/causal seeds a chain an admin then reads via the graph endpoint")
+  void admin_seeds_causal_chain_visible_via_graph() throws Exception {
+    String body =
+        mvc.perform(post(tenantUri(TENANT_PREFIX + "/attack-path/seed/causal")).with(csrf()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.simulationId").isNotEmpty())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String sim = JsonPath.read(body, "$.simulationId");
+
+    mvc.perform(get(tenantUri(TENANT_PREFIX + "/attack-path/simulations/" + sim + "/graph")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.attackPathExecutions").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("POST /seed/causal is forbidden for a non-admin")
+  @WithMockUser(isAdmin = false)
+  void non_admin_is_forbidden() throws Exception {
+    mvc.perform(post(tenantUri(TENANT_PREFIX + "/attack-path/seed/causal")).with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("POST /seed/causal?scenario=scaled fans out N footholds converging on the DC")
+  void admin_seeds_the_scaled_fanout() throws Exception {
+    String body =
+        mvc.perform(
+                post(tenantUri(TENANT_PREFIX + "/attack-path/seed/causal"))
+                    .with(csrf())
+                    .param("scenario", "scaled")
+                    .param("footholds", "5"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String sim = JsonPath.read(body, "$.simulationId");
+
+    // 5 footholds plus the shared DC they all funnel into.
+    mvc.perform(get(tenantUri(TENANT_PREFIX + "/attack-path/simulations/" + sim + "/graph")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.counters.endpoints").value(6));
+  }
+
+  @Test
+  @DisplayName("POST /seed/causal?scenario=ransomware builds the deep-and-wide kill chain")
+  void admin_seeds_the_ransomware_chain() throws Exception {
+    String body =
+        mvc.perform(
+                post(tenantUri(TENANT_PREFIX + "/attack-path/seed/causal"))
+                    .with(csrf())
+                    .param("scenario", "ransomware")
+                    .param("footholds", "4"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String sim = JsonPath.read(body, "$.simulationId");
+
+    mvc.perform(get(tenantUri(TENANT_PREFIX + "/attack-path/simulations/" + sim + "/graph")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.attackPathExecutions").isNotEmpty());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantActiveTableAccessArchTest.java
@@ -47,6 +47,7 @@ import io.openaev.rest.vulnerability.service.VulnerabilityService;
 import io.openaev.service.EndpointService;
 import io.openaev.service.InjectExpectationTraceService;
 import io.openaev.service.MapperService;
+import io.openaev.service.attackpath.AttackPathCausalSeedService;
 import io.openaev.service.attackpath.AttackPathDeltaService;
 import io.openaev.service.attackpath.AttackPathGraphService;
 import io.openaev.service.attackpath.ingestion.AttackPathExecutionIngestionService;
@@ -311,7 +312,13 @@ class TenantActiveTableAccessArchTest {
               // Scoped reader: reads the step's execution rows inside its own executeNew (the
               // inject's tenant) with an explicit tenantId predicate, to attribute copied findings.
               // Pinned by AttackPathFindingIngestionServiceTest:
-              AttackPathFindingIngestionService.class)
+              AttackPathFindingIngestionService.class,
+              // Seed generator, scoped: the admin flag-gated endpoint carries the TxCtx tenant
+              // scope
+              // (pinned by TenantScopedEntrypointsTxCtxArchTest) and the service only writes
+              // executions with an explicit tenant on every row; its reads go through
+              // AttackPathGraphService. Pinned by AttackPathCausalSeedApiTest:
+              AttackPathCausalSeedService.class)
           .should()
           .dependOnClassesThat()
           .areAssignableTo(AttackPathExecutionRepository.class)

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedChainTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedChainTest.java
@@ -1,0 +1,70 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.service.attackpath.dto.AttackPathDTO;
+import io.openaev.service.attackpath.ingestion.AttackPathVersionService;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The minimal causal chain must render as a connected source-to-destination path: a recon execution
+ * produces a portscan finding, and the exploit execution that consumes {@code port EQ 445} resolves
+ * that finding as its matched producer, so buildGraph carries a non-empty {@code matchedFindingIds}
+ * (the causal edge) on the consumer.
+ */
+@Transactional
+@DisplayName("causal seed: the minimal chain renders a connected causal edge")
+class AttackPathCausalSeedChainTest extends IntegrationTest {
+
+  private static final String SIM = "ap-seed-causal-chain";
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+  @Autowired private AttackPathVersionService versionService;
+
+  @Test
+  @DisplayName("the exploit's port key resolves the recon's portscan finding as its producer")
+  void chain_renders_a_causal_edge() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-seed-causal-chain-tenant"));
+
+    causalSeedService.seedMinimalCausalChain(SIM, tenant.getId());
+
+    AttackPathDTO dto = graphService.buildGraph(SIM);
+
+    assertThat(dto.attackPathExecutions())
+        .as("a consumer execution's consumed key resolves to a produced finding (causal edge)")
+        .anySatisfy(
+            node ->
+                assertThat(node.getConsumedFindingKeys())
+                    .anySatisfy(key -> assertThat(key.matchedFindingIds()).isNotEmpty()));
+  }
+
+  @Test
+  @DisplayName("the chain writes a graph version and stamps every execution at or below it")
+  void chain_stamps_a_coherent_version() {
+    Tenant tenant =
+        tenantRepository.save(TenantFixture.getTenant("ap-seed-causal-chain-version-tenant"));
+
+    causalSeedService.seedMinimalCausalChain(SIM, tenant.getId());
+
+    long version = versionService.current(SIM, List.of(tenant.getId())).orElse(0L);
+    assertThat(version).as("a graph version was bumped for the simulation").isPositive();
+    assertThat(
+            StreamSupport.stream(executionRepository.findAll().spliterator(), false)
+                .filter(e -> SIM.equals(e.getSimulationId()))
+                .toList())
+        .as("every seeded execution is stamped at or below the current graph version")
+        .isNotEmpty()
+        .allSatisfy(e -> assertThat(e.getRowVersion()).isLessThanOrEqualTo(version));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedDeepIntrusionTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedDeepIntrusionTest.java
@@ -1,0 +1,52 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.attackpath.dto.AttackPathDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The deep intrusion is a long, mostly linear kill chain: the attacker pivots host to host across
+ * the estate to the domain controller, each hop consuming the finding the previous host yielded, so
+ * buildGraph resolves a matched producer on every hop of the chain (not just the first).
+ */
+@Transactional
+@DisplayName("causal seed: the deep intrusion pivots host to host to the DC")
+class AttackPathCausalSeedDeepIntrusionTest extends IntegrationTest {
+
+  private static final int HOPS = 12;
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+
+  @Test
+  @DisplayName("every host-to-host hop resolves the prior host's finding")
+  void deep_intrusion_pivots_host_to_host() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-intrusion-tenant"));
+
+    String sim = causalSeedService.seedDeepIntrusion(tenant.getId(), HOPS);
+
+    AttackPathDTO dto = graphService.buildGraph(sim);
+
+    long causalHops =
+        dto.attackPathExecutions().stream()
+            .filter(
+                node ->
+                    node.getConsumedFindingKeys() != null
+                        && node.getConsumedFindingKeys().stream()
+                            .anyMatch(key -> !key.matchedFindingIds().isEmpty()))
+            .count();
+
+    // recon, exploit and the file-server foothold, then HOPS lateral pivots, then DCSync, plus the
+    // three-way ransomware impact.
+    assertThat(causalHops)
+        .as("a long host-to-host chain: each pivot consumes the finding of the host before it")
+        .isGreaterThanOrEqualTo(HOPS + 7);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedFidelityTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedFidelityTest.java
@@ -1,0 +1,63 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.attackpath.AttackPathExecution;
+import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * A seeded execution must be byte-faithful to what the real engine writes: the deterministic {@code
+ * NODE_EXECUTION|...} id, the frozen identity keys ({@code injector_type}, {@code
+ * step_template_id}), the source/target shape (INJECTOR + ASSET, {@code target_asset_id ==
+ * target_key}) and {@code payload_name = inject title}. Built through the engine's OWN setters so
+ * the columns are computed by production code, not re-derived here.
+ */
+@Transactional
+@DisplayName("causal seed: a seeded execution matches the real engine's column shape")
+class AttackPathCausalSeedFidelityTest extends IntegrationTest {
+
+  private static final String SIM = "ap-seed-causal-fidelity";
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathExecutionRepository executionRepository;
+
+  @Test
+  @DisplayName("the seeded execution carries the engine's deterministic id and frozen columns")
+  void seeded_execution_matches_the_engine_column_shape() {
+    Tenant tenant =
+        tenantRepository.save(TenantFixture.getTenant("ap-seed-causal-fidelity-tenant"));
+
+    causalSeedService.seedFaithfulExecution(SIM, tenant.getId());
+
+    List<AttackPathExecution> rows =
+        StreamSupport.stream(executionRepository.findAll().spliterator(), false)
+            .filter(e -> SIM.equals(e.getSimulationId()))
+            .toList();
+    assertThat(rows).hasSize(1);
+    AttackPathExecution e = rows.get(0);
+
+    assertThat(e.getId()).as("deterministic engine id").startsWith("NODE_EXECUTION|");
+    assertThat(e.getStepTemplateId())
+        .as("frozen step template id (kill-chain linkage)")
+        .isNotNull();
+    assertThat(e.getInjectorType()).as("frozen injector type").isNotBlank();
+    assertThat(e.getSourceKind()).isEqualTo("INJECTOR");
+    assertThat(e.getSourceInjector()).as("injector name").isNotBlank();
+    assertThat(e.getTargetKind()).isEqualTo("ASSET");
+    assertThat(e.getTargetAssetId())
+        .as("ASSET target: asset id == target key")
+        .isEqualTo(e.getTargetKey());
+    assertThat(e.getPayloadName()).as("payload_name = inject title").isNotBlank();
+    assertThat(e.getExecutedAt()).isNotNull();
+    assertThat(e.getRowVersion()).isNotNull();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedLinkageTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedLinkageTest.java
@@ -1,0 +1,47 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.attackpath.dto.AttackPathDTO;
+import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Proves the causal seed's step-template &lt;-&gt; condition linkage, the one silent-failure risk:
+ * a seeded execution whose {@code step_template_id} is a conditioned step's id must make {@code
+ * buildGraph} resolve that step's consumed key ({@code port EQ 445}) onto the execution feed node.
+ * If the linkage is wrong the graph builds with an empty {@code consumedFindingKeys} and NO error,
+ * so this is pinned before any breadth.
+ */
+@Transactional
+@DisplayName("causal seed: an execution's step_template_id resolves the step's consumed keys")
+class AttackPathCausalSeedLinkageTest extends IntegrationTest {
+
+  private static final String SIM = "ap-seed-causal-linkage";
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+
+  @Test
+  @DisplayName("buildGraph surfaces (port, EQ, 445) on the execution that ran the conditioned step")
+  void execution_step_template_id_resolves_the_step_conditions() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-seed-causal-linkage-tenant"));
+
+    causalSeedService.seedCausalMinimal(SIM, tenant.getId());
+
+    AttackPathDTO dto = graphService.buildGraph(SIM);
+
+    assertThat(dto.attackPathExecutions())
+        .as("the execution feed node carries the step's resolved consumed key")
+        .anySatisfy(
+            node ->
+                assertThat(node.getConsumedFindingKeys())
+                    .contains(new ConsumedFindingKeyDTO("port", "EQ", "445", null)));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedRansomwareChainTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedRansomwareChainTest.java
@@ -1,0 +1,56 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.attackpath.dto.AttackPathDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The ransomware chain is a deep AND wide kill chain: a multi-hop initial-access spine (phishing,
+ * discovery, SMB exploit, credential dump) lands a reused local admin, which fans out across a
+ * workstation tier, converges on the domain controller through a share/Kerberoast/DCSync
+ * escalation, and finally fans out again as domain-wide impact. Every hop consumes the prior hop's
+ * finding, so buildGraph resolves a matched producer on all of them: the spine, both fan-outs and
+ * the convergence.
+ */
+@Transactional
+@DisplayName("causal seed: the ransomware chain is deep and wide, converging on the DC")
+class AttackPathCausalSeedRansomwareChainTest extends IntegrationTest {
+
+  private static final int SPREAD = 5;
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+
+  @Test
+  @DisplayName("every spine, fan-out and convergence hop resolves its producer")
+  void ransomware_chain_is_deep_and_wide() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-seed-ransomware-tenant"));
+
+    String sim = causalSeedService.seedRansomwareChain(tenant.getId(), SPREAD);
+
+    AttackPathDTO dto = graphService.buildGraph(sim);
+
+    long causalHops =
+        dto.attackPathExecutions().stream()
+            .filter(
+                node ->
+                    node.getConsumedFindingKeys() != null
+                        && node.getConsumedFindingKeys().stream()
+                            .anyMatch(key -> !key.matchedFindingIds().isEmpty()))
+            .count();
+
+    // Initial-access spine (discovery, exploit, dump) + workstation spray (SPREAD) + privileged
+    // spine (share, Kerberoast, DCSync) + workstation-to-DC convergence (SPREAD) + domain-wide
+    // impact (SPREAD). If any deep hop failed to resolve its producer, the count drops below this.
+    assertThat(causalHops)
+        .as("the whole kill chain resolves: spine, both fan-outs and the convergence")
+        .isGreaterThanOrEqualTo(3L + SPREAD + 3L + SPREAD + SPREAD);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedRansomwareReplayTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedRansomwareReplayTest.java
@@ -1,0 +1,73 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.attackpath.dto.AttackPathReplayStepDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The live replay lands the ransomware kill chain one stage at a time onto an existing simulation:
+ * each call plays the next un-played stage (tracked by the simulation's version), the graph grows
+ * by that stage, and the fully replayed graph carries every causal hop the one-shot seed does.
+ */
+@Transactional
+@DisplayName("causal seed: the ransomware replay lands the kill chain stage by stage")
+class AttackPathCausalSeedRansomwareReplayTest extends IntegrationTest {
+
+  // The ransomware scenario replays eight kill-chain stages.
+  private static final int STAGES = 8;
+  private static final int SPREAD = 4;
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+
+  @Test
+  @DisplayName("each call plays the next stage; the completed graph carries every causal hop")
+  void replay_lands_the_kill_chain_one_stage_at_a_time() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-ransomware-replay-tenant"));
+    String sim = causalSeedService.createRansomwareSimulation(tenant.getId());
+
+    // Created empty: the intrusion has not started yet.
+    assertThat(graphService.buildGraph(sim).attackPathExecutions()).isEmpty();
+
+    // First stage: phishing lands one execution.
+    AttackPathReplayStepDTO first =
+        causalSeedService.replayRansomwareNextStage(sim, tenant.getId(), SPREAD);
+    assertThat(first.stage()).isZero();
+    assertThat(first.done()).isFalse();
+    assertThat(graphService.buildGraph(sim).attackPathExecutions()).hasSize(1);
+
+    // Each further call advances exactly one stage, up to the last.
+    AttackPathReplayStepDTO step = first;
+    for (int expected = 1; expected < STAGES; expected++) {
+      step = causalSeedService.replayRansomwareNextStage(sim, tenant.getId(), SPREAD);
+      assertThat(step.stage()).isEqualTo(expected);
+    }
+    assertThat(step.done()).as("the final stage completes the replay").isTrue();
+
+    // The fully replayed graph is the whole kill chain: spine, both fan-outs and the convergence.
+    long causalHops =
+        graphService.buildGraph(sim).attackPathExecutions().stream()
+            .filter(
+                node ->
+                    node.getConsumedFindingKeys() != null
+                        && node.getConsumedFindingKeys().stream()
+                            .anyMatch(key -> !key.matchedFindingIds().isEmpty()))
+            .count();
+    assertThat(causalHops)
+        .as("replaying the stages resolves the same causal hops as the one-shot seed")
+        .isGreaterThanOrEqualTo(3L + SPREAD + 3L + SPREAD + SPREAD);
+
+    // Replaying past the end is a no-op.
+    AttackPathReplayStepDTO afterEnd =
+        causalSeedService.replayRansomwareNextStage(sim, tenant.getId(), SPREAD);
+    assertThat(afterEnd.done()).isTrue();
+    assertThat(afterEnd.stage()).isEqualTo(STAGES);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedRealisticChainTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedRealisticChainTest.java
@@ -1,0 +1,49 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.attackpath.dto.AttackPathDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The realistic chain must be a connected multi-hop path: several pivot hops each consume the
+ * finding the previous hop produced (port then share then credentials), so buildGraph resolves a
+ * matched producer on every consumer, not just the first edge.
+ */
+@Transactional
+@DisplayName("causal seed: the realistic chain connects multiple hops end to end")
+class AttackPathCausalSeedRealisticChainTest extends IntegrationTest {
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+
+  @Test
+  @DisplayName("every pivot hop resolves the prior hop's finding (>= 3 causal edges)")
+  void realistic_chain_connects_multiple_hops() {
+    Tenant tenant =
+        tenantRepository.save(TenantFixture.getTenant("ap-seed-causal-realistic-tenant"));
+
+    String sim = causalSeedService.seedRealisticChain(tenant.getId());
+
+    AttackPathDTO dto = graphService.buildGraph(sim);
+
+    long causalHops =
+        dto.attackPathExecutions().stream()
+            .filter(
+                node ->
+                    node.getConsumedFindingKeys() != null
+                        && node.getConsumedFindingKeys().stream()
+                            .anyMatch(key -> !key.matchedFindingIds().isEmpty()))
+            .count();
+
+    assertThat(causalHops)
+        .as("a multi-hop chain: each pivot consumes the finding of the hop before it")
+        .isGreaterThanOrEqualTo(3);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedScaledChainTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathCausalSeedScaledChainTest.java
@@ -1,0 +1,50 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Tenant;
+import io.openaev.service.attackpath.dto.AttackPathDTO;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The scaled seed must fan out into many independent paths that converge on the DC: each foothold
+ * consumes its OWN credential (no cross-match between paths), so buildGraph resolves a matched
+ * producer on every foothold's lateral hop, one per foothold.
+ */
+@Transactional
+@DisplayName("causal seed: the scaled chain fans out into converging paths")
+class AttackPathCausalSeedScaledChainTest extends IntegrationTest {
+
+  private static final int FOOTHOLDS = 8;
+
+  @Autowired private AttackPathCausalSeedService causalSeedService;
+  @Autowired private AttackPathGraphService graphService;
+
+  @Test
+  @DisplayName("each foothold resolves its own credential into a lateral hop (>= N causal paths)")
+  void scaled_chain_fans_out_into_converging_paths() {
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-seed-causal-scaled-tenant"));
+
+    String sim = causalSeedService.seedScaledChain(tenant.getId(), FOOTHOLDS);
+
+    AttackPathDTO dto = graphService.buildGraph(sim);
+
+    long convergingPaths =
+        dto.attackPathExecutions().stream()
+            .filter(
+                node ->
+                    node.getConsumedFindingKeys() != null
+                        && node.getConsumedFindingKeys().stream()
+                            .anyMatch(key -> !key.matchedFindingIds().isEmpty()))
+            .count();
+
+    assertThat(convergingPaths)
+        .as("one converging causal path per foothold, each on its own credential")
+        .isGreaterThanOrEqualTo(FOOTHOLDS);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathSeedFindingValuesTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathSeedFindingValuesTest.java
@@ -1,0 +1,96 @@
+package io.openaev.service.attackpath;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.database.model.attackpath.projection.AttackPathFindingRow;
+import io.openaev.output_processor.PortScanOutputProcessor;
+import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A seeded finding value must be re-extracted by the real {@link AttackPathKeyMatcher} exactly as a
+ * produced key consumes it, so the causal chain's {@code matchedFindingIds} resolve on seeded rows
+ * identically to real ones. Pure by design: the matcher is a static function over {@link
+ * AttackPathFindingRow}, so no DB/Spring is needed to pin the format.
+ */
+@DisplayName("causal seed: finding values match the real key matcher")
+class AttackPathSeedFindingValuesTest {
+
+  private static AttackPathFindingRow row(String type, String value) {
+    return new AttackPathFindingRow("f", type, value, null, null, null, null, true);
+  }
+
+  private static boolean matchesEq(String type, String value, String keyType, String keyValue) {
+    return AttackPathKeyMatcher.matches(
+        row(type, value), new ConsumedFindingKeyDTO(keyType, "EQ", keyValue, null));
+  }
+
+  @Test
+  @DisplayName("portscan value exposes its port sub-field to a port EQ key")
+  void portscanMatchesPort() {
+    String value = AttackPathSeedFindingValues.portscan("20.224.192.102", 445, "microsoft-ds");
+    assertThat(matchesEq("portscan", value, "port", "445")).isTrue();
+  }
+
+  @Test
+  @DisplayName("portscan value is byte-identical to PortScanOutputProcessor.toFindingValue")
+  void portscanIsByteIdenticalToProcessor() {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode node = mapper.createObjectNode();
+    node.put("host", "20.224.192.102");
+    node.put("port", 445);
+    node.put("service", "microsoft-ds");
+    String produced = new PortScanOutputProcessor(null).toFindingValue(node);
+    assertThat(AttackPathSeedFindingValues.portscan("20.224.192.102", 445, "microsoft-ds"))
+        .isEqualTo(produced);
+  }
+
+  @Test
+  @DisplayName(
+      "credentials value exposes username and password sub-fields (password keeps its colon)")
+  void credentialsMatchesUsernameAndPassword() {
+    String value = AttackPathSeedFindingValues.credentials("administrator", "P@ss:w0rd");
+    assertThat(matchesEq("credentials", value, "username", "administrator")).isTrue();
+    assertThat(matchesEq("credentials", value, "password", "P@ss:w0rd")).isTrue();
+  }
+
+  @Test
+  @DisplayName("share value exposes its share_name sub-field")
+  void shareMatchesShareName() {
+    String value = AttackPathSeedFindingValues.share("winterfell", "C$", "READ,WRITE");
+    assertThat(matchesEq("share", value, "share_name", "C$")).isTrue();
+  }
+
+  @Test
+  @DisplayName("file value exposes its file_name basename")
+  void fileMatchesFileName() {
+    String value =
+        AttackPathSeedFindingValues.file("winterfell", "C$", "Users/admin", "secret.txt");
+    assertThat(matchesEq("file", value, "file_name", "secret.txt")).isTrue();
+  }
+
+  @Test
+  @DisplayName("username value exposes its username and domain sub-fields")
+  void usernameMatchesUserAndDomain() {
+    String value = AttackPathSeedFindingValues.username("CORP", "administrator");
+    assertThat(matchesEq("username", value, "username", "administrator")).isTrue();
+    assertThat(matchesEq("username", value, "domain", "CORP")).isTrue();
+  }
+
+  @Test
+  @DisplayName("cve value matches a cve EQ key on the whole value")
+  void cveMatchesWholeValue() {
+    String value = AttackPathSeedFindingValues.cve("CVE-2021-34527");
+    assertThat(matchesEq("cve", value, "cve", "CVE-2021-34527")).isTrue();
+  }
+
+  @Test
+  @DisplayName("bare port value matches a port EQ key on the whole value")
+  void barePortMatchesWholeValue() {
+    String value = AttackPathSeedFindingValues.port(445);
+    assertThat(matchesEq("port", value, "port", "445")).isTrue();
+  }
+}

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -973,6 +973,10 @@ export interface AttackPathAttackPatternDTO {
   name?: string;
 }
 
+export interface AttackPathCausalSeedResultDTO {
+  simulationId?: string;
+}
+
 export interface AttackPathCounters {
   /** @format int64 */
   credentials?: number;
@@ -1127,6 +1131,15 @@ export interface AttackPathNodeDTO {
   typeFindings?: string;
   value?: string;
   verdicts?: AttackPathFindingVerdictsDTO;
+}
+
+export interface AttackPathReplayStepDTO {
+  done?: boolean;
+  label?: string;
+  /** @format int32 */
+  stage?: number;
+  /** @format int32 */
+  totalStages?: number;
 }
 
 export interface AttackPathSecurityPlatformDTO {


### PR DESCRIPTION
## Summary

A development and demo generator for the causal attack-path view. It exposes an admin, flag-gated
endpoint that writes a byte-faithful causal graph straight into the attack-path store, so the causal
view can be exercised and demoed without deploying agents or running a real workflow.

What it adds:

- Four scenarios: `realistic` (a short recon-to-DC chain), `scaled` (N footholds converging on one DC
  chokepoint), `intrusion` (a long host-to-host intrusion that scales by depth, each host carrying
  expandable finding clusters), and `ransomware` (a deep-and-wide kill chain).
- A live, stage-by-stage replay of the ransomware kill chain, so an open Attack path tab shows the
  intrusion build up.
- Scales to tens of thousands of executions, with the graph served full below the collapse threshold
  and aggregated above it.

The generator is admin-only, behind the `ATTACK_PATH` feature flag, and tracked for removal before
production. Part of #6855 (attack path - part 1), following the #6647 POC.

The full usage guide follows.

---

# Attack path causal seed API

A development and demo endpoint that generates a ready-to-view causal attack path. Each call creates
a real, navigable simulation and writes a full causal graph under it, so the result shows up directly
in that simulation's **Attack path** tab. No injects to run, no agents to deploy.

## What it is for

The causal attack-path view (chain mode) needs a chain of executions where each action consumes a
finding the previous action produced. Building that by hand (deploy agents, run a workflow, wait for
findings) is slow. This endpoint writes such a chain straight into the graph store, faithfully enough
that the front renders it exactly like a real run: causal edges, chokepoints, finding cards, live
overlay.

## Prerequisites

- The `ATTACK_PATH` feature flag must be enabled on the environment.
- You need an **admin** API token (the endpoint is admin-only).
- You need the **tenant id** you want to seed under.

## Endpoint

```
POST /api/attack-path/seed/causal
```

Query parameters:

| Parameter   | Values                              | Default     | Meaning                                                              |
|-------------|-------------------------------------|-------------|---------------------------------------------------------------------|
| `scenario`  | `realistic` \| `scaled` \| `intrusion` \| `ransomware` | `realistic` | Which shape to generate (see below).                    |
| `footholds` | integer                             | `20`        | Ignored by `realistic`. Fan-out width for `scaled` / `ransomware`, chain DEPTH (number of lateral hops) for `intrusion`. |
| `live`      | empty \| `step`                     | empty       | `ransomware` only. `step` creates the simulation empty for a live replay (see below); empty writes the whole graph at once. |

Response:

```json
{ "simulationId": "6c2b04ea-a837-44aa-9501-551174616c74" }
```

The returned id is a real simulation. Open it in the front, or find it in the simulations list by name.

## Authentication and headers

Authenticate with a bearer token and select the tenant with a header. A bearer-token request does not
need the CSRF handshake.

```
Authorization: Bearer <ADMIN_TOKEN>
X-Tenant-Ids: <TENANT_ID>
```

## Usage

Set your environment once:

```bash
BASE=https://<your-environment>          # the platform base URL
TOKEN=<ADMIN_TOKEN>
TID=<TENANT_ID>
H=(-H "Authorization: Bearer $TOKEN" -H "X-Tenant-Ids: $TID")
```

Then call whichever scenario you want:

```bash
# realistic: one deep recon-to-DC chain
curl -s "${H[@]}" -X POST "$BASE/api/attack-path/seed/causal"

# scaled: N independent paths converging on one DC chokepoint
curl -s "${H[@]}" -X POST "$BASE/api/attack-path/seed/causal?scenario=scaled&footholds=20"

# ransomware: a deep AND wide kill chain
curl -s "${H[@]}" -X POST "$BASE/api/attack-path/seed/causal?scenario=ransomware&footholds=10"
```

Each call returns a `simulationId`. Open it in the front:

```
<your-environment>/admin/simulations/<simulationId>/attack-path
```

## The scenarios

### `realistic`

One connected source-to-destination path across four endpoints: a portscan finds SMB, an SMB action
lists a share, a credential dump reads the share, and a lateral move to the DC consumes the dumped
credential. Small and easy to read. Good for checking the causal view renders and edges connect.

### `scaled`

`footholds` independent paths that all converge on a single DC. Each foothold is compromised on its
own unique credential (no cross-match between paths) and then moved laterally to the same DC, so the
DC renders as the one chokepoint the whole estate funnels into. Good for showing convergence at width.

### `intrusion`

A long, mostly linear targeted intrusion that reads left to right: phishing, an RDP exploit, a
foothold on the file server, then `footholds` lateral pivots each landing on a NEW machine on the
credential the previous host yielded, a DCSync against the domain controller, and finally ransomware
on a few critical servers. Here `footholds` sets the DEPTH (the number of lateral hops), not the
width, so it lays out as one long horizontal kill chain rather than a fan-out and stays in full
causal mode. Exercises all six finding types. Best for telling a realistic end-to-end story.

Each host along the way also carries a batch of findings (the subnet it scanned, the accounts it
dumped, the shares it could read), which the causal view collapses into expandable "+N" clusters on
that host. So the chain scales in two directions that both stay displayable: longer (more
`footholds`) and deeper per host (unfold a cluster), rather than a wide fan-out that freezes the
render.

The front's causal layout groups executions by their source endpoint and clusters findings (not
endpoints), so a host-to-host chain with rich per-host findings reads horizontally and unfolds
vertically, while a wide fan-out (`scaled` / `ransomware`) stacks endpoints and needs the aggregate
view at scale (see Scale).

### `ransomware`

A full kill chain that is both deep and wide, the closest to a real intrusion:

1. **Initial access.** Phishing drops an implant on a workstation (a `file` finding).
2. **Discovery.** The implant scans the subnet and exposes SMB on a file server (a `portscan` finding).
3. **Exploitation.** An SMB CVE is used against the file server (a `cve` finding).
4. **Credential access.** An LSASS dump yields a reused local admin (a `credentials` finding).
5. **Lateral spray (fan-out).** The local admin is sprayed across `footholds` workstations, each one
   dumping its own domain user.
6. **Convergence.** Every sprayed workstation moves laterally to the domain controller on its own
   credential.
7. **Privilege escalation (parallel deep path).** From the file server, a readable share leaks a
   service account (`share` + `file`), Kerberoasting cracks it (`credentials` + `username`), and a
   DCSync against the DC yields the domain key.
8. **Domain-wide impact (fan-out).** From the DC, ransomware is pushed to the whole fleet.

The domain controller is the single point every path funnels through and the launch point of the
impact, so it stands out as the chokepoint. The scenario exercises all six finding types (`file`,
`portscan`, `cve`, `credentials`, `username`, `share`), so every finding card lights up.

With `footholds=N` the graph has `2N + 3` endpoints (entry workstation, file server, DC, `N`
workstations, `N` fleet hosts).

## Live replay (watch the kill chain build)

The ransomware scenario can be landed one stage at a time instead of all at once, so an open Attack
path tab shows the intrusion build up live (the "live" badge stays lit as each stage lands).

Two steps: create the simulation empty, then play its stages.

Create it empty and note the id:

```bash
SIM=$(curl -s "${H[@]}" -X POST "$BASE/api/attack-path/seed/causal?scenario=ransomware&live=step" \
  | python3 -c "import sys,json;print(json.load(sys.stdin)['simulationId'])")
echo "Open: $BASE_FRONT/admin/simulations/$SIM/attack-path"
```

Open that URL. The graph is empty and the view is live. Then play the stages, one every few seconds:

```bash
for i in $(seq 8); do
  curl -s "${H[@]}" -X POST "$BASE/api/attack-path/simulations/$SIM/replay?footholds=8"
  echo
  sleep 3
done
```

Each `POST /replay` plays the next un-played stage and returns which one ran:

```json
{ "stage": 4, "totalStages": 8, "done": false, "label": "Lateral movement - pass-the-hash spray" }
```

The server tracks progress on the simulation itself (its attack-path version), so you just call
`/replay` again for the next stage, no state to pass. `done` turns true on the last stage, and any
further call is a no-op. The stages, in order: phishing, discovery, exploitation, credential dump,
lateral spray, convergence on the DC, privilege escalation (Kerberoast + DCSync), domain-wide impact.

Run the loop faster or slower by changing the `sleep`, and pause between calls to narrate a stage.

## Scale

`footholds` drives the size: it sizes the fan-out for `scaled` and both tiers for `ransomware`
(`realistic` and `intrusion` are fixed-size). The write scales linearly at roughly 6 to 7 ms per
foothold (the cost is one persisted conditioned template per hop); the read grows with the payload:

| footholds | executions | endpoints | write  | read   | mode |
|-----------|------------|-----------|--------|--------|------|
| 200       | 400        | 201       | ~1.4 s | ~0.2 s | full |
| 1000      | 2000       | 1001      | ~6.7 s | ~0.2 s | full |
| 3000      | 6000       | 3001      | ~19 s  | ~1.0 s | full |
| 8000      | 16000      | 8001      | ~45 s  | ~5 s   | full |
| 500 (ransomware) | 1507 | 1003      | ~5.3 s | ~0.3 s | full |

### Generate a large-scale attack path

Pick a fan-out scenario and a large `footholds`. A massive estate converging on one domain controller:

```bash
SIM=$(curl -s "${H[@]}" -X POST "$BASE/api/attack-path/seed/causal?scenario=scaled&footholds=8000" \
  | python3 -c "import sys,json;print(json.load(sys.stdin)['simulationId'])")
echo "Open: $BASE_FRONT/admin/simulations/$SIM/attack-path"
```

That seeds 16000 executions across 8001 endpoints in about 45 seconds, once. Use `scenario=ransomware`
instead for the same scale with the richer hourglass shape.

### Two regimes, one threshold

How many executions the simulation has decides how the graph is both served and drawn, at one shared
ceiling (`openaev.attackpath.collapse-threshold`, default 20000, matched by the front's own cap):

- **Below 20000 executions: the full causal graph.** Every hop is rendered. This is the view for the
  causal story, but the front draws every node, so a few thousand endpoints stay smooth while tens of
  thousands make the browser crawl. Keep it to a few thousand for a readable causal view.
- **At or above 20000 executions: the aggregated graph.** The backend serves the collapsed topology
  (endpoints, chokepoints, counts) and the front stops fetching the full chain, so a very large run
  stays responsive but drops the per-hop detail. This is the view for scale: `scaled&footholds=11000`
  (22000 executions) and up.

So aim for a few thousand footholds for a legible causal demo, or well past 10000 for a smooth
scale/topology view. The awkward middle (roughly 5000 to 10000 endpoints, still full mode) is the
heaviest on the browser: correct, but slow to draw.

## Notes

- Each call creates one new simulation. Calling twice gives you two independent simulations.
- The graph is served in full causal mode below the collapse threshold
  (`openaev.attackpath.collapse-threshold`, default 20000 executions) and as an aggregated topology
  at or above it (see Scale). Fixed-size scenarios (`realistic`, `intrusion`) stay well under it.
- This is a development generator. It is gated behind the feature flag and admin only, and is tracked
  for removal before production (#6647).
