### PR TITLE
fix(expectations): restore security platform associations for collector-filled and asset-group expectations (#7147)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260802130000000__Reindex_expectations_after_tenant_scope_indexing_fix.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260802130000000__Reindex_expectations_after_tenant_scope_indexing_fix.java
@@ -1,0 +1,37 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rebuilds the inject-expectation index after fixing the tenant-scope-less indexing sweep.
+ *
+ * <p>Since the {@code collectors} table was activated for multi-tenancy v2 filtering, the engine
+ * sync job fetched indexing rows without any tenant scope: {@code can_access_tenant} is fail-closed
+ * with no scope set, so the {@code collectors} joins of the expectation indexing query silently
+ * matched nothing. Every expectation document indexed since then carries an empty {@code
+ * base_security_platforms_side} for collector-sourced results (e.g. EDR collectors such as
+ * Microsoft Defender), which emptied the security platform posture pages and the security platform
+ * chips of asset expectation lists. Asset-sourced results (e.g. Nuclei registered as a security
+ * platform asset) were unaffected.
+ *
+ * <p>The sweep now runs under an explicit all-tenants scope; this migration converges the documents
+ * indexed while the attribution was broken. Dropping the {@code indexing_status} row of a type
+ * makes the engine driver drop, recreate and fully re-feed that index from PostgreSQL at the next
+ * startup, so only the affected type is rebuilt. Idempotent and lock-light (targeted DELETE on a
+ * tiny bookkeeping table).
+ */
+@Component
+public class V6_20260802130000000__Reindex_expectations_after_tenant_scope_indexing_fix
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "DELETE FROM indexing_status WHERE indexing_status_type = 'expectation-inject';");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJob.java
@@ -6,6 +6,8 @@ import static org.quartz.TriggerBuilder.newTrigger;
 
 import io.openaev.aop.LogExecutionTime;
 import io.openaev.config.EngineConfig;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
 import io.openaev.engine.EngineContext;
 import io.openaev.engine.EngineService;
 import io.openaev.engine.EsModel;
@@ -56,12 +58,22 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
   private final ConcurrentHashMap<String, AtomicInteger> consecutiveSkips =
       new ConcurrentHashMap<>();
 
+  /**
+   * The indexing sweep is genuinely-global background work: it must read rows from every tenant to
+   * build the search documents. Without an explicit scope, {@code can_access_tenant} is fail-closed
+   * and every tenant-activated table (e.g. {@code collectors}) silently reads empty, which dropped
+   * the collector-to-security-platform attribution from every indexed expectation.
+   */
+  private final TenantScopedTransaction tenantTx;
+
   protected EngineSyncExecutionJob(
       Scheduler scheduler,
       EngineService engineService,
       EngineContext engineContext,
-      EngineConfig engineConfig) {
+      EngineConfig engineConfig,
+      TenantScopedTransaction tenantTx) {
     super(scheduler, engineService, engineContext);
+    this.tenantTx = tenantTx;
     // Clamp to at least 1: zero (or negative) permits would silently disable engine sync
     // altogether, which is never what a tuning knob should do.
     int maxConcurrentModels = engineConfig.getIndexingMaxConcurrentModels();
@@ -116,7 +128,10 @@ public class EngineSyncExecutionJob extends SelfConfiguredPlatformJob {
       consecutiveSkips.remove(modelName);
       try {
         log.info("Executing engine sync for model {}", modelName);
-        engineService.bulkProcessing(Stream.of(model.get()));
+        // allTenants(): the sweep indexes every tenant's rows; the primitive resolves it into an
+        // explicit tenant list for can_access_tenant (see TxCtx#allTenants).
+        tenantTx.execute(
+            TxCtx.allTenants(), () -> engineService.bulkProcessing(Stream.of(model.get())));
       } finally {
         concurrentSyncs.release();
       }

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -61,6 +61,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -1269,7 +1270,10 @@ public class InjectExpectationService {
                 targetId,
                 injectExpectationRepository.findAllByInjectAndAsset(injectId, targetId));
         case ASSETS_GROUPS ->
-            injectExpectationRepository.findAllByInjectAndAssetGroup(injectId, targetId);
+            enrichAssetGroupExpectationsWithChildrenSecurityPlatforms(
+                injectId,
+                targetId,
+                injectExpectationRepository.findAllByInjectAndAssetGroup(injectId, targetId));
         default ->
             throw new RuntimeException(
                 "Target type "
@@ -1304,22 +1308,81 @@ public class InjectExpectationService {
       // Agentless asset (AI target, agentless endpoint): the asset expectation is filled directly.
       return assetExpectations;
     }
+    return enrichExpectationsWithChildrenSecurityPlatforms(
+        assetExpectations,
+        agentExpectations,
+        // Prefer an answered result over a pending one for the same source.
+        expectation ->
+            (existing, candidate) -> existing.getResult() != null ? existing : candidate);
+  }
+
+  /**
+   * Makes the asset-group target-results view show the security platforms of its underlying assets.
+   * Asset-group detection/prevention expectations are scored by rolling up their asset children
+   * and, on the collector path, never carry the per-security-platform result rows that the agent /
+   * asset expectations hold (only direct writes - e.g. an assessment injector like Nuclei
+   * concluding the group row itself - do). For display we merge, per expectation type, the union of
+   * the children's (agent and asset levels) security-platform results onto a DETACHED clone of each
+   * group expectation, so the change never persists. Per platform, the displayed result reflects
+   * the platform's overall verdict under the group's validation rule (see {@link
+   * #pickGroupPlatformVerdict}). Groups without children rows are returned unchanged.
+   *
+   * @param injectId the inject ID
+   * @param assetGroupId the asset group ID
+   * @param assetGroupExpectations the group-level expectations for the inject
+   * @return detached group expectations enriched with their children's security-platform results
+   */
+  private List<BaseInjectExpectation> enrichAssetGroupExpectationsWithChildrenSecurityPlatforms(
+      final String injectId,
+      final String assetGroupId,
+      final List<BaseInjectExpectation> assetGroupExpectations) {
+    List<BaseInjectExpectation> childExpectations =
+        injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+            injectId, assetGroupId);
+    if (childExpectations.isEmpty()) {
+      return assetGroupExpectations;
+    }
+    return enrichExpectationsWithChildrenSecurityPlatforms(
+        assetGroupExpectations,
+        childExpectations,
+        expectation ->
+            (existing, candidate) -> pickGroupPlatformVerdict(expectation, existing, candidate));
+  }
+
+  /**
+   * Merges the children's security-platform (collector) results onto a DETACHED clone of each
+   * parent expectation of the same type, de-duplicated by source. The parent's OWN direct results
+   * (e.g. a security platform that answered the parent level directly) are kept in the union: a
+   * result persisted on the row must stay visible, silently dropping it would hide what drove the
+   * score. Display-only: the persistent entities are never modified.
+   *
+   * @param parentExpectations the parent expectations to enrich (asset or asset-group level)
+   * @param childExpectations the children carrying the security-platform results
+   * @param mergePreferenceFor picks, per parent expectation, which of two results of the same
+   *     source the merged view keeps
+   * @return detached parent expectations enriched with their children's security-platform results
+   */
+  private static List<BaseInjectExpectation> enrichExpectationsWithChildrenSecurityPlatforms(
+      final List<BaseInjectExpectation> parentExpectations,
+      final List<BaseInjectExpectation> childExpectations,
+      final Function<BaseInjectExpectation, BinaryOperator<InjectExpectationResult>>
+          mergePreferenceFor) {
     // Union of security-platform / collector results per expectation type, de-duplicated by source.
     Map<BaseInjectExpectation.EXPECTATION_TYPE, List<InjectExpectationResult>> resultsByType =
         new HashMap<>();
-    for (BaseInjectExpectation agentExpectation : agentExpectations) {
+    for (BaseInjectExpectation childExpectation : childExpectations) {
       List<InjectExpectationResult> platformResults =
-          agentExpectation.getResults().stream()
+          childExpectation.getResults().stream()
               .filter(
                   r ->
                       COLLECTOR.equals(r.getSourceType())
                           || SECURITY_PLATFORM.equals(r.getSourceType()))
               .toList();
       resultsByType
-          .computeIfAbsent(agentExpectation.getType(), k -> new ArrayList<>())
+          .computeIfAbsent(childExpectation.getType(), k -> new ArrayList<>())
           .addAll(platformResults);
     }
-    return assetExpectations.stream()
+    return parentExpectations.stream()
         .map(
             expectation -> {
               List<InjectExpectationResult> platformResults =
@@ -1328,10 +1391,10 @@ public class InjectExpectationService {
                 return expectation;
               }
               BaseInjectExpectation clone = expectation.clone();
+              BinaryOperator<InjectExpectationResult> mergePreference =
+                  mergePreferenceFor.apply(expectation);
               Map<String, InjectExpectationResult> bySource = new LinkedHashMap<>();
-              // Agents' results first, then the asset expectation's OWN direct results (e.g. a
-              // security platform that answered the asset level directly): a result persisted on
-              // the row must stay visible, silently dropping it would hide what drove the score.
+              // Children's results first, then the parent expectation's OWN direct results.
               Stream.concat(
                       platformResults.stream(),
                       expectation.getResults().stream()
@@ -1339,18 +1402,10 @@ public class InjectExpectationService {
                               r ->
                                   COLLECTOR.equals(r.getSourceType())
                                       || SECURITY_PLATFORM.equals(r.getSourceType())))
-                  .forEach(
-                      r ->
-                          bySource.merge(
-                              mergeSourceKey(r),
-                              r,
-                              (existing, candidate) ->
-                                  // Prefer an answered result over a pending one for the same
-                                  // source.
-                                  existing.getResult() != null ? existing : candidate));
+                  .forEach(r -> bySource.merge(mergeSourceKey(r), r, mergePreference));
               // A VULNERABILITY row a genuine platform already answered needs no expiration entry
-              // in the merged display either: the union pulls the agents' expiration rows (the
-              // vulnerability default "Not vulnerable") onto the asset view, where they render as
+              // in the merged display either: the union pulls the children's expiration rows (the
+              // vulnerability default "Not vulnerable") onto the parent view, where they render as
               // redundant - or contradictory - entries next to the real scan verdict. Same rule as
               // the write path (InjectExpectationUtils.computeScores): the expiration default is
               // the absence-of-signal fallback, a real answer supersedes it.
@@ -1378,6 +1433,43 @@ public class InjectExpectationService {
               return clone;
             })
         .toList();
+  }
+
+  /**
+   * Per-platform verdict aggregation for the asset-group view: the same security platform typically
+   * answered several assets of the group with different verdicts (e.g. detected on one endpoint,
+   * missed on another). The displayed row must reflect the platform's OVERALL verdict under the
+   * group's validation rule: with the default "all assets must validate" rule one failure fails the
+   * platform overall (keep the worst-scored result), with the "at least one asset" rule one success
+   * validates it (keep the best-scored result). An answered result always beats a pending one.
+   *
+   * @param groupExpectation the group expectation whose validation rule drives the choice
+   * @param existing the result currently kept for this source
+   * @param candidate the competing result of the same source
+   * @return the result the merged view keeps
+   */
+  private static InjectExpectationResult pickGroupPlatformVerdict(
+      final BaseInjectExpectation groupExpectation,
+      final InjectExpectationResult existing,
+      final InjectExpectationResult candidate) {
+    boolean existingAnswered = isAnsweredResult(existing);
+    boolean candidateAnswered = isAnsweredResult(candidate);
+    if (existingAnswered != candidateAnswered) {
+      return existingAnswered ? existing : candidate;
+    }
+    Double existingScore = existing.getScore();
+    Double candidateScore = candidate.getScore();
+    if (existingScore == null || candidateScore == null) {
+      return existing;
+    }
+    if (groupExpectation.isExpectationGroup()) {
+      return candidateScore > existingScore ? candidate : existing;
+    }
+    return candidateScore < existingScore ? candidate : existing;
+  }
+
+  private static boolean isAnsweredResult(final InjectExpectationResult result) {
+    return result.getResult() != null && !result.getResult().isBlank();
   }
 
   private static String mergeSourceKey(InjectExpectationResult result) {

--- a/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
@@ -174,6 +174,32 @@ class TenantStatementInspectorTest {
     assertTrue(out.contains("jsonb_array_elements"), out);
   }
 
+  @Test
+  @DisplayName("the expectation indexing query has its collectors joins tenant-filtered")
+  void expectationIndexingQueryCollectorsJoinsAreFilteredWithCollectorsActive() throws Exception {
+    // #6751 activated collectors, which pulled findForIndexing into rewriting: both collectors
+    // joins of the security-platform attribution CTEs are wrapped in a can_access_tenant
+    // sub-query. Pin the real production SQL against an inspector with collectors active (strict:
+    // collectors.tenant_id is part of the composite primary key, so it is NOT NULL). This is why
+    // the engine sync sweep MUST run under an explicit tenant scope: with no scope set,
+    // can_access_tenant is fail-closed and every collector-sourced security platform attribution
+    // silently indexes empty.
+    String sql =
+        io.openaev.database.repository.InjectExpectationRepository.class
+            .getMethod("findForIndexing", java.time.Instant.class, int.class)
+            .getAnnotation(org.springframework.data.jpa.repository.Query.class)
+            .value();
+    TenantStatementInspector collectorsActive =
+        new TenantStatementInspector(new TenantTables(Set.of("collectors"), Set.of()));
+    String out = collectorsActive.inspect(sql).replaceAll("\\s+", " ").trim();
+    // The sp_self join (this expectation's own results)...
+    assertTrue(out.contains("can_access_tenant(c.tenant_id)"), out);
+    // ...and the agent_security_platforms join (agent-level children's results) are both filtered.
+    assertTrue(out.contains("can_access_tenant(child_c.tenant_id)"), out);
+    // The lateral jsonb unnests survive the rewrite instead of being refused.
+    assertTrue(out.contains("jsonb_array_elements"), out);
+  }
+
   // --- Single table --------------------------------------------------------
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingTenantScopeRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingTenantScopeRegressionTest.java
@@ -1,0 +1,311 @@
+package io.openaev.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.BaseInjectExpectation;
+import io.openaev.database.model.Collector;
+import io.openaev.database.model.DetectionInjectExpectation;
+import io.openaev.database.model.InjectExpectationResult;
+import io.openaev.database.model.Tenant;
+import io.openaev.engine.model.injectexpectation.EsInjectExpectation;
+import io.openaev.engine.model.injectexpectation.InjectExpectationHandler;
+import io.openaev.utils.fixtures.AgentFixture;
+import io.openaev.utils.fixtures.CollectorFixture;
+import io.openaev.utils.fixtures.EndpointFixture;
+import io.openaev.utils.fixtures.InjectExpectationFixture;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.ScenarioFixture;
+import io.openaev.utils.fixtures.SecurityPlatformFixture;
+import io.openaev.utils.fixtures.composers.CollectorComposer;
+import io.openaev.utils.fixtures.composers.EndpointComposer;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectExpectationComposer;
+import io.openaev.utils.fixtures.composers.ScenarioComposer;
+import io.openaev.utils.fixtures.composers.SecurityPlatformComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import io.openaev.utilstest.RabbitMQTestListener;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Regression tests for the expectation indexing query under multi-tenancy v2 filtering, with the
+ * {@code collectors} table activated as in production.
+ *
+ * <p>The default test profile activates no table, so the whole indexing pipeline runs with the
+ * tenant statement inspector inert — which is exactly how the production regression slipped
+ * through: with {@code collectors} active, {@code findForIndexing}'s collector joins are wrapped in
+ * {@code can_access_tenant}, and the (then scope-less) engine sync sweep silently indexed every
+ * collector-sourced security platform attribution as empty. Asset-sourced attributions (e.g. a
+ * scanner registered as a security platform asset) kept working, which is why only collector-backed
+ * platforms (EDRs such as Microsoft Defender) went dark.
+ *
+ * <p>These tests pin the two halves of the fix: the sweep must run under an explicit tenant scope
+ * (the fail-closed test), and the collector joins must be tenant-correlated because built-in
+ * collectors share the same {@code collector_id} across tenants (the cross-tenant test).
+ */
+@Transactional
+@WithMockUser
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(properties = "openaev.tenant.active-tables=collectors")
+@TestExecutionListeners(
+    value = {RabbitMQTestListener.class},
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@DisplayName("findForIndexing under tenant filtering (collectors active)")
+class IndexingTenantScopeRegressionTest extends IntegrationTest {
+
+  @Autowired private InjectExpectationHandler injectExpectationHandler;
+
+  @Autowired private CollectorComposer collectorComposer;
+  @Autowired private EndpointComposer endpointComposer;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectExpectationComposer injectExpectationComposer;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private SecurityPlatformComposer securityPlatformComposer;
+
+  /** A point in time used as the {@code :from} parameter — 1 hour ago. */
+  private static final Instant FROM = Instant.now().minus(1, ChronoUnit.HOURS);
+
+  @BeforeEach
+  void setUp() {
+    collectorComposer.reset();
+    endpointComposer.reset();
+    injectComposer.reset();
+    injectExpectationComposer.reset();
+    scenarioComposer.reset();
+    securityPlatformComposer.reset();
+  }
+
+  /**
+   * Sets the transaction-local tenant scope, simulating what the tenant-scoped transaction
+   * primitive does when the engine sync job opens its {@code allTenants()} sweep (the intention is
+   * resolved into an explicit tenant list).
+   */
+  private void setScope(String scope) {
+    entityManager
+        .createNativeQuery("SELECT set_config('app.current_tenants', :scope, true)")
+        .setParameter("scope", scope)
+        .getSingleResult();
+  }
+
+  /**
+   * Persists an agentless detection expectation (under scenario/inject/endpoint) carrying a
+   * collector-sourced result, and returns its id. The collector itself is created by the caller.
+   */
+  private String persistExpectationFilledByCollector(Collector collector) {
+    EndpointComposer.Composer endpointWrapper =
+        endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+    endpointWrapper.persist();
+
+    BaseInjectExpectation expectation =
+        InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+    expectation.setResults(
+        List.of(
+            InjectExpectationResult.builder()
+                .sourceId(collector.getId())
+                .sourceType("collector")
+                .sourceName(collector.getName())
+                .result("detected")
+                .score(100.0)
+                .build()));
+    InjectExpectationComposer.Composer expectationWrapper =
+        injectExpectationComposer.forExpectation(expectation).withEndpoint(endpointWrapper);
+
+    InjectComposer.Composer injectWrapper =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withExpectation(expectationWrapper);
+    scenarioComposer
+        .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+        .withInject(injectWrapper)
+        .persist();
+    entityManager.flush();
+    entityManager.clear();
+    return expectation.getId();
+  }
+
+  private EsInjectExpectation fetchDoc(String expectationId) {
+    return injectExpectationHandler.fetch(FROM, 5000).stream()
+        .filter(es -> es.getBase_id().equals(expectationId))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  @Test
+  @DisplayName("a scoped sweep attributes the collector's security platform")
+  void given_collectorFilledExpectation_when_sweepIsScoped_should_attributeSecurityPlatform() {
+    setScope(Tenant.DEFAULT_TENANT_UUID);
+
+    SecurityPlatformComposer.Composer securityPlatform =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR scoped", "EDR"))
+            .persist();
+    Collector collector =
+        collectorComposer
+            .forCollector(CollectorFixture.createDefaultCollector("collector-edr-scoped"))
+            .withSecurityPlatform(securityPlatform)
+            .persist()
+            .get();
+
+    String expectationId = persistExpectationFilledByCollector(collector);
+
+    assertThat(fetchDoc(expectationId).getBase_security_platforms_side())
+        .contains(securityPlatform.get().getId());
+  }
+
+  @Test
+  @DisplayName("a scope-less sweep silently loses the attribution (the production incident shape)")
+  void given_collectorFilledExpectation_when_sweepIsNotScoped_should_loseAttribution() {
+    // Arrange with a scope so the composers can write the collector row...
+    setScope(Tenant.DEFAULT_TENANT_UUID);
+    SecurityPlatformComposer.Composer securityPlatform =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR unscoped", "EDR"))
+            .persist();
+    Collector collector =
+        collectorComposer
+            .forCollector(CollectorFixture.createDefaultCollector("collector-edr-unscoped"))
+            .withSecurityPlatform(securityPlatform)
+            .persist()
+            .get();
+    String expectationId = persistExpectationFilledByCollector(collector);
+
+    // ...then drop the scope, as the engine sync sweep did before it carried allTenants():
+    // can_access_tenant is fail-closed, the collectors join reads empty, the document indexes
+    // with no security platform. This is the exact production incident shape.
+    setScope("");
+
+    assertThat(fetchDoc(expectationId).getBase_security_platforms_side()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("an all-tenant sweep does not attribute another tenant's security platform")
+  void given_sameCollectorIdInAnotherTenant_should_notAttributeForeignSecurityPlatform() {
+    String tenantB = UUID.randomUUID().toString();
+    // The sweep sees every tenant at once (resolved allTenants() scope).
+    setScope(Tenant.DEFAULT_TENANT_UUID + "," + tenantB);
+
+    SecurityPlatformComposer.Composer platformA =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR tenant A", "EDR"))
+            .persist();
+    SecurityPlatformComposer.Composer platformB =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR tenant B", "EDR"))
+            .persist();
+    Collector collector =
+        collectorComposer
+            .forCollector(CollectorFixture.createDefaultCollector("collector-edr-shared"))
+            .withSecurityPlatform(platformA)
+            .persist()
+            .get();
+    // Built-in collectors share the same collector_id across tenants (composite PK
+    // (collector_id, tenant_id)): create the same collector id under another tenant, pointing at
+    // that tenant's own security platform.
+    entityManager
+        .createNativeQuery("INSERT INTO tenants (tenant_id, tenant_name) VALUES (:id, :name)")
+        .setParameter("id", tenantB)
+        .setParameter("name", "tenant-b-" + tenantB)
+        .executeUpdate();
+    entityManager
+        .createNativeQuery(
+            "INSERT INTO collectors (collector_id, tenant_id, collector_name, collector_type,"
+                + " collector_period, collector_external, collector_security_platform)"
+                + " VALUES (:id, :tenant, :name, :type, 60, true, :platform)")
+        .setParameter("id", collector.getId())
+        .setParameter("tenant", tenantB)
+        .setParameter("name", collector.getName())
+        .setParameter("type", "collector-edr-shared-tenant-b")
+        .setParameter("platform", platformB.get().getId())
+        .executeUpdate();
+
+    String expectationId = persistExpectationFilledByCollector(collector);
+
+    // The expectation belongs to the default tenant: only that tenant's collector row may
+    // attribute its platform, even though the other tenant's row shares the collector id and is
+    // visible to the all-tenant sweep.
+    assertThat(fetchDoc(expectationId).getBase_security_platforms_side())
+        .contains(platformA.get().getId())
+        .doesNotContain(platformB.get().getId());
+  }
+
+  /**
+   * Agent-level children contribute their collector-sourced results to the parent (agentless)
+   * document through the {@code agent_security_platforms} CTE, whose collectors join must be
+   * tenant-correlated exactly like the {@code sp_self} one.
+   */
+  @Test
+  @DisplayName("agent-level child results are attributed through the same tenant-correlated join")
+  void given_agentChildFilledByCollector_when_sweepIsScoped_should_attributeSecurityPlatform() {
+    setScope(Tenant.DEFAULT_TENANT_UUID);
+
+    SecurityPlatformComposer.Composer securityPlatform =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR child", "EDR"))
+            .persist();
+    Collector collector =
+        collectorComposer
+            .forCollector(CollectorFixture.createDefaultCollector("collector-edr-child"))
+            .withSecurityPlatform(securityPlatform)
+            .persist()
+            .get();
+
+    EndpointComposer.Composer endpointWrapper =
+        endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+    endpointWrapper.persist();
+
+    BaseInjectExpectation agentlessExpectation =
+        InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+    InjectExpectationComposer.Composer agentlessExpectationWrapper =
+        injectExpectationComposer
+            .forExpectation(agentlessExpectation)
+            .withEndpoint(endpointWrapper);
+
+    Agent agent = AgentFixture.createDefaultAgentService();
+    agent.setAsset(endpointWrapper.get());
+    entityManager.persist(agent);
+    entityManager.flush();
+    Agent persistedAgent = entityManager.getReference(Agent.class, agent.getId());
+
+    DetectionInjectExpectation agentExpectation =
+        InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+    agentExpectation.setAgent(persistedAgent);
+    agentExpectation.setResults(
+        List.of(
+            InjectExpectationResult.builder()
+                .sourceId(collector.getId())
+                .sourceType("collector")
+                .sourceName(collector.getName())
+                .result("detected")
+                .score(100.0)
+                .build()));
+    InjectExpectationComposer.Composer agentExpectationWrapper =
+        injectExpectationComposer.forExpectation(agentExpectation).withEndpoint(endpointWrapper);
+
+    InjectComposer.Composer injectWrapper =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withExpectation(agentlessExpectationWrapper)
+            .withExpectation(agentExpectationWrapper);
+    scenarioComposer
+        .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+        .withInject(injectWrapper)
+        .persist();
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(fetchDoc(agentlessExpectation.getId()).getBase_security_platforms_side())
+        .contains(securityPlatform.get().getId());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/engine/IndexingTenantScopeRegressionTest.java
+++ b/openaev-api/src/test/java/io/openaev/engine/IndexingTenantScopeRegressionTest.java
@@ -12,12 +12,14 @@ import io.openaev.database.model.Tenant;
 import io.openaev.engine.model.injectexpectation.EsInjectExpectation;
 import io.openaev.engine.model.injectexpectation.InjectExpectationHandler;
 import io.openaev.utils.fixtures.AgentFixture;
+import io.openaev.utils.fixtures.AssetGroupFixture;
 import io.openaev.utils.fixtures.CollectorFixture;
 import io.openaev.utils.fixtures.EndpointFixture;
 import io.openaev.utils.fixtures.InjectExpectationFixture;
 import io.openaev.utils.fixtures.InjectFixture;
 import io.openaev.utils.fixtures.ScenarioFixture;
 import io.openaev.utils.fixtures.SecurityPlatformFixture;
+import io.openaev.utils.fixtures.composers.AssetGroupComposer;
 import io.openaev.utils.fixtures.composers.CollectorComposer;
 import io.openaev.utils.fixtures.composers.EndpointComposer;
 import io.openaev.utils.fixtures.composers.InjectComposer;
@@ -67,6 +69,7 @@ class IndexingTenantScopeRegressionTest extends IntegrationTest {
 
   @Autowired private InjectExpectationHandler injectExpectationHandler;
 
+  @Autowired private AssetGroupComposer assetGroupComposer;
   @Autowired private CollectorComposer collectorComposer;
   @Autowired private EndpointComposer endpointComposer;
   @Autowired private InjectComposer injectComposer;
@@ -79,6 +82,7 @@ class IndexingTenantScopeRegressionTest extends IntegrationTest {
 
   @BeforeEach
   void setUp() {
+    assetGroupComposer.reset();
     collectorComposer.reset();
     endpointComposer.reset();
     injectComposer.reset();
@@ -307,5 +311,100 @@ class IndexingTenantScopeRegressionTest extends IntegrationTest {
 
     assertThat(fetchDoc(agentlessExpectation.getId()).getBase_security_platforms_side())
         .contains(securityPlatform.get().getId());
+  }
+
+  /**
+   * Asset-group parent documents roll their agent-level children's platforms up too, but only the
+   * children of THEIR OWN group: an inject targeting two asset groups must not cross-attribute one
+   * group's platforms onto the other group's synthesis document.
+   */
+  @Test
+  @DisplayName("asset-group docs roll up their own group's children platforms only")
+  void given_assetGroupExpectation_should_attributeOwnGroupChildrenPlatformsOnly() {
+    setScope(Tenant.DEFAULT_TENANT_UUID);
+
+    SecurityPlatformComposer.Composer platformOwnGroup =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR own group", "EDR"))
+            .persist();
+    SecurityPlatformComposer.Composer platformOtherGroup =
+        securityPlatformComposer
+            .forSecurityPlatform(SecurityPlatformFixture.createDefault("EDR other group", "EDR"))
+            .persist();
+    Collector ownCollector =
+        collectorComposer
+            .forCollector(CollectorFixture.createDefaultCollector("collector-edr-own-group"))
+            .withSecurityPlatform(platformOwnGroup)
+            .persist()
+            .get();
+    Collector otherCollector =
+        collectorComposer
+            .forCollector(CollectorFixture.createDefaultCollector("collector-edr-other-group"))
+            .withSecurityPlatform(platformOtherGroup)
+            .persist()
+            .get();
+
+    AssetGroupComposer.Composer ownGroup =
+        assetGroupComposer.forAssetGroup(AssetGroupFixture.createDefaultAssetGroup("own-group"));
+    AssetGroupComposer.Composer otherGroup =
+        assetGroupComposer.forAssetGroup(AssetGroupFixture.createDefaultAssetGroup("other-group"));
+
+    // The group-level synthesis expectation of the OWN group (no asset, no agent).
+    BaseInjectExpectation groupExpectation =
+        InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+    InjectExpectationComposer.Composer groupExpectationWrapper =
+        injectExpectationComposer.forExpectation(groupExpectation).withAssetGroup(ownGroup);
+
+    InjectComposer.Composer injectWrapper =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withExpectation(groupExpectationWrapper)
+            .withExpectation(agentChildExpectation(ownCollector, ownGroup, "endpoint-own-group"))
+            .withExpectation(
+                agentChildExpectation(otherCollector, otherGroup, "endpoint-other-group"));
+    scenarioComposer
+        .forScenario(ScenarioFixture.createDefaultIncidentResponseScenario())
+        .withInject(injectWrapper)
+        .persist();
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(fetchDoc(groupExpectation.getId()).getBase_security_platforms_side())
+        .contains(platformOwnGroup.get().getId())
+        .doesNotContain(platformOtherGroup.get().getId());
+  }
+
+  /**
+   * Builds an agent-level detection expectation bound to the given asset group and filled by the
+   * given collector, on a fresh endpoint carrying a fresh agent.
+   */
+  private InjectExpectationComposer.Composer agentChildExpectation(
+      Collector collector, AssetGroupComposer.Composer group, String endpointKey) {
+    EndpointComposer.Composer endpointWrapper =
+        endpointComposer.forEndpoint(EndpointFixture.createEndpoint());
+    endpointWrapper.persist();
+
+    Agent agent = AgentFixture.createDefaultAgentService();
+    agent.setAsset(endpointWrapper.get());
+    entityManager.persist(agent);
+    entityManager.flush();
+    Agent persistedAgent = entityManager.getReference(Agent.class, agent.getId());
+
+    DetectionInjectExpectation agentExpectation =
+        InjectExpectationFixture.createDefaultDetectionInjectExpectation();
+    agentExpectation.setAgent(persistedAgent);
+    agentExpectation.setResults(
+        List.of(
+            InjectExpectationResult.builder()
+                .sourceId(collector.getId())
+                .sourceType("collector")
+                .sourceName(collector.getName())
+                .result("detected")
+                .score(100.0)
+                .build()));
+    return injectExpectationComposer
+        .forExpectation(agentExpectation)
+        .withEndpoint(endpointWrapper)
+        .withAssetGroup(group);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/engine_sync/EngineSyncExecutionJobTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.openaev.config.EngineConfig;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
 import io.openaev.engine.EngineContext;
 import io.openaev.engine.EngineService;
 import io.openaev.engine.EsModel;
@@ -36,6 +38,7 @@ class EngineSyncExecutionJobTest {
   @Mock private EngineContext engineContext;
   @Mock private EsModel<EsBase> esModel;
   @Mock private JobExecutionContext jobExecutionContext;
+  @Mock private TenantScopedTransaction tenantTx;
 
   private EngineConfig engineConfig;
 
@@ -47,10 +50,21 @@ class EngineSyncExecutionJobTest {
     JobDataMap jobDataMap = new JobDataMap();
     jobDataMap.put("modelName", MODEL_NAME);
     lenient().when(jobExecutionContext.getMergedJobDataMap()).thenReturn(jobDataMap);
+    // The tenant-scoped primitive runs the work it is given; the transaction plumbing itself is
+    // covered by TenantScopedTransaction's own tests.
+    lenient()
+        .doAnswer(
+            invocation -> {
+              invocation.getArgument(1, Runnable.class).run();
+              return null;
+            })
+        .when(tenantTx)
+        .execute(any(TxCtx.class), any(Runnable.class));
   }
 
   private EngineSyncExecutionJob buildJob() throws Exception {
-    return new EngineSyncExecutionJob(scheduler, engineService, engineContext, engineConfig);
+    return new EngineSyncExecutionJob(
+        scheduler, engineService, engineContext, engineConfig, tenantTx);
   }
 
   @Test
@@ -190,5 +204,23 @@ class EngineSyncExecutionJobTest {
 
     assertThrows(JobExecutionException.class, () -> pass.execute(jobExecutionContext));
     verify(engineService, never()).bulkProcessing(any());
+  }
+
+  @Test
+  @DisplayName("Runs the sync pass inside an all-tenants scoped transaction")
+  void given_syncPass_should_runInsideAllTenantsScope() throws Exception {
+    // The indexing sweep reads tenant-activated tables (e.g. collectors) to build the search
+    // documents, and can_access_tenant is fail-closed: a scope-less sweep silently reads those
+    // tables empty and drops the collector-to-security-platform attribution from every indexed
+    // expectation. The sweep must therefore always carry the allTenants() intention.
+    engineConfig.setIndexingMaxConcurrentModels(1);
+    EngineSyncExecutionJob job = buildJob();
+
+    job.new Job().execute(jobExecutionContext);
+
+    ArgumentCaptor<TxCtx> scope = ArgumentCaptor.forClass(TxCtx.class);
+    verify(tenantTx).execute(scope.capture(), any(Runnable.class));
+    assertEquals(TxCtx.allTenants(), scope.getValue(), "the sweep must carry the allTenants scope");
+    verify(engineService).bulkProcessing(any());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -1185,4 +1185,177 @@ class InjectExpectationServiceTest {
       assertEquals(List.of(assetExpectation), merged);
     }
   }
+
+  @Nested
+  @DisplayName("findMergedExpectationsByInjectAndTargetAndTargetType for asset groups")
+  class AssetGroupSecurityPlatformEnrichmentTests {
+
+    private InjectExpectationResult collectorResult(String result, Double score) {
+      return InjectExpectationResult.builder()
+          .sourceId("collector-1")
+          .sourceType("collector")
+          .sourceName("Microsoft Defender")
+          .result(result)
+          .score(score)
+          .build();
+    }
+
+    private List<? extends BaseInjectExpectation> merge() {
+      return injectExpectationService.findMergedExpectationsByInjectAndTargetAndTargetType(
+          "inject-id", "group-id", "parent-id", "ASSETS_GROUPS");
+    }
+
+    @Test
+    @DisplayName("Asset-group expectations mirror their children's security-platform results")
+    void assetGroupExpectationsAreEnrichedWithChildrenSecurityPlatformResults() {
+      // Regression (second half of #7147): the collector path writes its per-platform results on
+      // the agent rows only, so the group synthesis row displayed NO security platform at all
+      // while every underlying asset showed e.g. "Microsoft Defender - Not Prevented".
+      DetectionInjectExpectation groupExpectation = new DetectionInjectExpectation();
+      groupExpectation.setId("group-expectation");
+      DetectionInjectExpectation agentExpectation = new DetectionInjectExpectation();
+      agentExpectation.setId("agent-expectation");
+      InjectExpectationResult defenderResult = collectorResult("Not Detected", 0.0);
+      agentExpectation.setResults(new ArrayList<>(List.of(defenderResult)));
+      when(injectExpectationRepository.findAllByInjectAndAssetGroup("inject-id", "group-id"))
+          .thenReturn(List.of(groupExpectation));
+      when(injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+              "inject-id", "group-id"))
+          .thenReturn(List.of(agentExpectation));
+
+      List<? extends BaseInjectExpectation> merged = merge();
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(defenderResult), merged.get(0).getResults());
+      // The enrichment must stay display-only: the persistent entity is untouched.
+      assertTrue(groupExpectation.getResults().isEmpty());
+    }
+
+    @Test
+    @DisplayName("A platform's group row keeps its worst verdict under the default all-assets rule")
+    void assetGroupPlatformRowKeepsWorstVerdictUnderAllAssetsRule() {
+      // Default validation rule ("all assets must validate"): one missed asset fails the group,
+      // so the platform's overall verdict is its worst result across the group's children.
+      DetectionInjectExpectation groupExpectation = new DetectionInjectExpectation();
+      groupExpectation.setId("group-expectation");
+      groupExpectation.setExpectationGroup(false);
+      groupExpectation.setExpectedScore(100.0);
+      DetectionInjectExpectation detectedChild = new DetectionInjectExpectation();
+      detectedChild.setId("agent-detected");
+      detectedChild.setResults(new ArrayList<>(List.of(collectorResult("Detected", 100.0))));
+      DetectionInjectExpectation missedChild = new DetectionInjectExpectation();
+      missedChild.setId("agent-missed");
+      InjectExpectationResult missedResult = collectorResult("Not Detected", 0.0);
+      missedChild.setResults(new ArrayList<>(List.of(missedResult)));
+      when(injectExpectationRepository.findAllByInjectAndAssetGroup("inject-id", "group-id"))
+          .thenReturn(List.of(groupExpectation));
+      when(injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+              "inject-id", "group-id"))
+          .thenReturn(List.of(detectedChild, missedChild));
+
+      List<? extends BaseInjectExpectation> merged = merge();
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(missedResult), merged.get(0).getResults());
+    }
+
+    @Test
+    @DisplayName("A platform's group row keeps its best verdict under the at-least-one rule")
+    void assetGroupPlatformRowKeepsBestVerdictUnderAtLeastOneRule() {
+      DetectionInjectExpectation groupExpectation = new DetectionInjectExpectation();
+      groupExpectation.setId("group-expectation");
+      groupExpectation.setExpectationGroup(true);
+      groupExpectation.setExpectedScore(100.0);
+      DetectionInjectExpectation detectedChild = new DetectionInjectExpectation();
+      detectedChild.setId("agent-detected");
+      InjectExpectationResult detectedResult = collectorResult("Detected", 100.0);
+      detectedChild.setResults(new ArrayList<>(List.of(detectedResult)));
+      DetectionInjectExpectation missedChild = new DetectionInjectExpectation();
+      missedChild.setId("agent-missed");
+      missedChild.setResults(new ArrayList<>(List.of(collectorResult("Not Detected", 0.0))));
+      when(injectExpectationRepository.findAllByInjectAndAssetGroup("inject-id", "group-id"))
+          .thenReturn(List.of(groupExpectation));
+      when(injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+              "inject-id", "group-id"))
+          .thenReturn(List.of(detectedChild, missedChild));
+
+      List<? extends BaseInjectExpectation> merged = merge();
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(detectedResult), merged.get(0).getResults());
+    }
+
+    @Test
+    @DisplayName("An answered child result beats a pending one for the same platform")
+    void answeredChildResultBeatsPendingOne() {
+      DetectionInjectExpectation groupExpectation = new DetectionInjectExpectation();
+      groupExpectation.setId("group-expectation");
+      groupExpectation.setExpectationGroup(false);
+      DetectionInjectExpectation pendingChild = new DetectionInjectExpectation();
+      pendingChild.setId("agent-pending");
+      pendingChild.setResults(new ArrayList<>(List.of(collectorResult(null, null))));
+      DetectionInjectExpectation answeredChild = new DetectionInjectExpectation();
+      answeredChild.setId("agent-answered");
+      InjectExpectationResult answeredResult = collectorResult("Not Detected", 0.0);
+      answeredChild.setResults(new ArrayList<>(List.of(answeredResult)));
+      when(injectExpectationRepository.findAllByInjectAndAssetGroup("inject-id", "group-id"))
+          .thenReturn(List.of(groupExpectation));
+      when(injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+              "inject-id", "group-id"))
+          .thenReturn(List.of(pendingChild, answeredChild));
+
+      List<? extends BaseInjectExpectation> merged = merge();
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(answeredResult), merged.get(0).getResults());
+    }
+
+    @Test
+    @DisplayName("A direct result persisted on the group row itself stays visible")
+    void directGroupResultStaysVisible() {
+      // Assessment injectors (e.g. Nuclei) write their verdict directly on the group row: the
+      // display union must keep it next to the children's platforms.
+      DetectionInjectExpectation groupExpectation = new DetectionInjectExpectation();
+      groupExpectation.setId("group-expectation");
+      InjectExpectationResult directResult =
+          InjectExpectationResult.builder()
+              .sourceId("nuclei-security-platform")
+              .sourceType("security-platform")
+              .sourceName("Nuclei")
+              .result("Detected")
+              .score(100.0)
+              .build();
+      groupExpectation.setResults(new ArrayList<>(List.of(directResult)));
+      DetectionInjectExpectation agentExpectation = new DetectionInjectExpectation();
+      agentExpectation.setId("agent-expectation");
+      InjectExpectationResult defenderResult = collectorResult("Not Detected", 0.0);
+      agentExpectation.setResults(new ArrayList<>(List.of(defenderResult)));
+      when(injectExpectationRepository.findAllByInjectAndAssetGroup("inject-id", "group-id"))
+          .thenReturn(List.of(groupExpectation));
+      when(injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+              "inject-id", "group-id"))
+          .thenReturn(List.of(agentExpectation));
+
+      List<? extends BaseInjectExpectation> merged = merge();
+
+      assertEquals(1, merged.size());
+      assertEquals(List.of(defenderResult, directResult), merged.get(0).getResults());
+    }
+
+    @Test
+    @DisplayName("Asset groups without children rows are returned unchanged")
+    void assetGroupsWithoutChildrenAreReturnedUnchanged() {
+      DetectionInjectExpectation groupExpectation = new DetectionInjectExpectation();
+      groupExpectation.setId("group-expectation");
+      when(injectExpectationRepository.findAllByInjectAndAssetGroup("inject-id", "group-id"))
+          .thenReturn(List.of(groupExpectation));
+      when(injectExpectationRepository.findAllChildExpectationsByInjectAndAssetGroup(
+              "inject-id", "group-id"))
+          .thenReturn(List.of());
+
+      List<? extends BaseInjectExpectation> merged = merge();
+
+      assertEquals(List.of(groupExpectation), merged);
+    }
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -339,6 +339,19 @@ public interface InjectExpectationRepository
       @Param("injectId") @NotBlank final String injectId,
       @Param("assetGroupId") @NotBlank final String assetGroupId);
 
+  // Child expectation rows (asset AND agent levels) of an asset group. Used to mirror
+  // the children's security-platform results onto the asset-group target-results view.
+  @Query(
+      value =
+          "SELECT i FROM InjectExpectation i "
+              + "WHERE i.inject.id = :injectId "
+              + "AND i.assetGroup.id = :assetGroupId "
+              + "AND (i.asset IS NOT NULL OR i.agent IS NOT NULL) "
+              + "ORDER BY i.type, i.createdAt")
+  List<BaseInjectExpectation> findAllChildExpectationsByInjectAndAssetGroup(
+      @Param("injectId") @NotBlank final String injectId,
+      @Param("assetGroupId") @NotBlank final String assetGroupId);
+
   @Query(
       value =
           "SELECT "
@@ -509,10 +522,11 @@ public interface InjectExpectationRepository
     ),
     agent_security_platforms AS (
         -- Security platforms contributed by agent-level children, scoped to the SAME expectation
-        -- type and (when the parent is asset-level) the SAME asset as the parent doc. Keyed per
-        -- parent expectation: joining only on inject_id would attribute every platform that
-        -- returned any result for any expectation of the inject (e.g. blame a platform that
-        -- detected for a prevention miss on another asset).
+        -- type and (when the parent is asset-level) the SAME asset - or (when the parent is
+        -- asset-group-level) the SAME asset group - as the parent doc. Keyed per parent
+        -- expectation: joining only on inject_id would attribute every platform that returned
+        -- any result for any expectation of the inject (e.g. blame a platform that detected for
+        -- a prevention miss on another asset, or on an asset of another targeted group).
         SELECT b.inject_expectation_id,
                COALESCE(array_agg(DISTINCT child_c.collector_security_platform::text) FILTER (WHERE child_c.collector_security_platform IS NOT NULL), ARRAY[]::text[])
                || COALESCE(array_agg(DISTINCT child_a.asset_id::text) FILTER (WHERE child_a.asset_id IS NOT NULL), ARRAY[]::text[]) AS security_platform_ids
@@ -522,6 +536,7 @@ public interface InjectExpectationRepository
          AND child_ie.agent_id IS NOT NULL
          AND child_ie.inject_expectation_type = b.inject_expectation_type
          AND (b.asset_id IS NULL OR child_ie.asset_id = b.asset_id)
+         AND (b.asset_group_id IS NULL OR child_ie.asset_group_id = b.asset_group_id)
         LEFT JOIN LATERAL jsonb_array_elements(child_ie.inject_expectation_results::jsonb) AS child_r(elem) ON true
         LEFT JOIN collectors child_c ON child_r.elem->>'sourceId' = child_c.collector_id::text
                                     AND child_c.tenant_id = b.tenant_id

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectExpectationRepository.java
@@ -494,12 +494,16 @@ public interface InjectExpectationRepository
     ),
     sp_self AS (
         -- Collectors / assets referenced in THIS expectation own results.
+        -- The collectors join is tenant-correlated: the indexing sweep runs under an all-tenant
+        -- scope (multi-tenancy v2), and built-in collectors share the same collector_id across
+        -- tenants, so a bare sourceId join would attribute the security platform of another tenant.
         SELECT b.inject_expectation_id,
                COALESCE(array_agg(DISTINCT c.collector_security_platform::text) FILTER (WHERE c.collector_security_platform IS NOT NULL), ARRAY[]::text[])
                || COALESCE(array_agg(DISTINCT a.asset_id::text) FILTER (WHERE a.asset_id IS NOT NULL), ARRAY[]::text[]) AS ids
         FROM base b
         LEFT JOIN LATERAL jsonb_array_elements(b.inject_expectation_results::jsonb) AS r(elem) ON true
         LEFT JOIN collectors c ON r.elem->>'sourceId' = c.collector_id::text
+                              AND c.tenant_id = b.tenant_id
         LEFT JOIN assets a ON r.elem->>'sourceId' = a.asset_id::text
         GROUP BY b.inject_expectation_id
     ),
@@ -520,6 +524,7 @@ public interface InjectExpectationRepository
          AND (b.asset_id IS NULL OR child_ie.asset_id = b.asset_id)
         LEFT JOIN LATERAL jsonb_array_elements(child_ie.inject_expectation_results::jsonb) AS child_r(elem) ON true
         LEFT JOIN collectors child_c ON child_r.elem->>'sourceId' = child_c.collector_id::text
+                                    AND child_c.tenant_id = b.tenant_id
         LEFT JOIN assets child_a ON child_r.elem->>'sourceId' = child_a.asset_id::text
         GROUP BY b.inject_expectation_id
     )


### PR DESCRIPTION
## Summary

Fixes #7147 - two related losses of the expectation-to-security-platform association for collector-backed platforms (Microsoft Defender and every other collector-backed EDR).

### Bug 1 - search index: collector attributions indexed empty

Collector-filled expectations were indexed with an empty `base_security_platforms_side`, so the security platform pages and the asset expectation lists lost the association everywhere the UI relies on the search engine.

Root cause: the engine sync Quartz job ran `bulkProcessing` with no tenant scope. Under multi-tenancy v2 the `collectors` table is tenant-activated, so the tenant statement inspector wraps the collector joins of `findForIndexing` in `can_access_tenant(...)` - which is fail-closed. With `app.current_tenants` unset, the collectors join silently read empty and every collector-to-security-platform attribution was dropped. Assets are not tenant-activated, which is why asset-sourced attributions (Nuclei) kept working.

Three-part fix:

- **Scope the sweep**: `EngineSyncExecutionJob` now runs `bulkProcessing` through `TenantScopedTransaction` with the `allTenants()` intention, as the ES indexing sweep is genuinely-global background work.
- **Tenant-correlate the collector joins**: built-in collectors share the same `collector_id` across tenants (composite PK `(collector_id, tenant_id)`), so an all-tenant sweep with a bare `sourceId` join would attribute the security platform of another tenant. Both collector joins in `findForIndexing` (`sp_self` and `agent_security_platforms` CTEs) are now correlated on `tenant_id = b.tenant_id`.
- **Reindex migration**: deletes the `expectation-inject` row from `indexing_status` so the next engine sync rebuilds every expectation document with the correct attributions.

### Bug 2 - asset-group target results: no security platforms on the synthesis row

In the inject "Results by target" view, every underlying asset correctly showed e.g. "Microsoft Defender - Not Prevented", but the asset-group synthesis card showed NO security platform at all (only the validation rule).

Root cause: the collector path writes its per-platform results on the AGENT rows only; parents are only re-scored. The asset target-results view compensates by merging the agent children's platform results onto a detached clone of the asset expectation for display, but the `ASSETS_GROUPS` branch returned the raw group rows with no such enrichment. Only direct writes on the group row (e.g. Nuclei assessing the group itself) were visible - matching the report that Nuclei group rows were fine while Defender ones were empty.

Fix:

- **Enrich the asset-group view like the asset view**: the `ASSETS_GROUPS` branch of `findMergedExpectationsByInjectAndTargetAndTargetType` now merges the security-platform results of the group's children (agent AND asset levels, via a new `findAllChildExpectationsByInjectAndAssetGroup` query) onto a detached clone of each group expectation. The shared merge core is extracted from the existing asset enrichment; display-only, nothing is persisted.
- **Rule-aware per-platform verdict**: the same platform typically answered several assets with different verdicts. The group row reflects the platform's OVERALL verdict under the group's validation rule: worst result under the default "all assets must validate" rule, best result under "at least one asset"; an answered result always beats a pending one. Direct results persisted on the group row itself stay visible.
- **Group-scope the indexing rollup**: the `agent_security_platforms` CTE of `findForIndexing` now also correlates children on the parent's `asset_group_id`, so an inject targeting two asset groups no longer cross-attributes one group's platforms onto the other group's document.

## Tests

- `IndexingTenantScopeRegressionTest` (integration, runs with `openaev.tenant.active-tables=collectors` as in production): a scoped sweep attributes the collector's platform; a scope-less sweep loses it (the exact production incident shape); an all-tenant sweep does not attribute another tenant's platform for a shared collector id; agent-level children are attributed through the same tenant-correlated join; NEW - asset-group docs roll up their own group's children platforms only.
- `EngineSyncExecutionJobTest`: new case asserting the sweep carries the `allTenants()` scope (existing 6 cases adapted to the new constructor).
- `TenantStatementInspectorTest`: new case asserting the `findForIndexing` collector joins are wrapped in `can_access_tenant` when `collectors` is active.
- `InjectExpectationServiceTest` (NEW nested suite for asset groups): group expectations mirror their children's security-platform results (display-only, entity untouched); worst verdict kept under the all-assets rule; best verdict kept under the at-least-one rule; answered beats pending; direct group-row results stay visible; groups without children returned unchanged.

## Test plan

- [x] `mvn spotless:apply` clean
- [x] Unit tests green (inspector + job + expectation service incl. the new asset-group suite)
- [x] Integration regression tests: 5/5 green against dockerized Postgres + Elasticsearch
- [ ] CI green
