### PR TITLE
fix(attack-path): scope the focused view to the endpoint's real causal chain (#7152)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -17,7 +17,7 @@ import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import attackPathStatusColor, { attackPathChokepointColor } from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds, scopeChainFlowToEndpoint } from './attack-path-flow-helpers';
 import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
@@ -1004,10 +1004,18 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         });
         setFitNonce(n => n + 1);
       } else {
-        // The chain graph is built straight from backend node/edge ids (no `path-cl-type|...` synthetic
-        // clusters), so it's highlighted the same way a direct graph click on this finding is
-        // (openFindingFromGraph's chainMode branch): via selectedFindingId, not pathFinding.
-        setPathFinding(null);
+        // Chain view: switch into the SAME chokepoint-style scoped focus (scopeChainFlowToEndpoint
+        // filters the real graph down to this endpoint's own causal subgraph), rather than leaving
+        // the finding highlighted-but-lost in the full, possibly crowded map. type/value stay empty
+        // (chokepoint's own shape) — selectedFindingId (set below) is what seeds the walk onto the
+        // exact finding inside this now-scoped view, not the endpoint alone.
+        setPathFinding({
+          endpointNodeId: item.endpointNodeId,
+          endpointKey: item.endpointKey,
+          type: '',
+          value: '',
+        });
+        setFitNonce(n => n + 1);
       }
       // onEndpointClick itself unconditionally clears selectedFindingId/findingDetail, so both must be
       // re-set AFTER it (matches openFindingFromGraph's ordering) — setting them before it here was
@@ -1215,7 +1223,15 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         nodes: AttackPathFlowNode[];
         edges: AttackPathFlowEdge[];
       };
-      if (pathFinding) {
+      if (pathFinding && chainMode && fullDto) {
+        // Chain mode has the real kill chain already built for the whole run — scope THAT down to
+        // this endpoint instead of falling back to buildFindingPathFlow's flatter, non-causal
+        // layout, so the focused view keeps the causal ("Triggered ...") structure between actions.
+        raw = scopeChainFlowToEndpoint(
+          buildCausalChainFlow(fullDto, t, expandedFindingClusters, endpointClusterBatch),
+          pathFinding.endpointNodeId,
+        );
+      } else if (pathFinding) {
         raw = buildFindingPathFlow(dto, pathFinding, t, pathContractLabelByInjector, {
           expanded: expandedFindingClusters,
           findingsByCluster,
@@ -1369,8 +1385,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         type,
         value,
       });
-      setFitNonce(n => n + 1);
+    } else {
+      // Chain view: same chokepoint-style scoped focus as a drawer pick (scopeChainFlowToEndpoint
+      // filters the real causal graph down to this endpoint), not a plain in-place highlight on the
+      // possibly crowded full map. type/value stay empty (chokepoint's own shape); selectedFindingId
+      // (set below) is what seeds the walk onto the exact finding inside this now-scoped view.
+      setPathFinding({
+        endpointNodeId: assetNodeId,
+        endpointKey,
+        type: '',
+        value: '',
+      });
     }
+    setFitNonce(n => n + 1);
     // Loads the endpoint feed (executions + relations) so producing actions resolve. It also resets
     // findingDetail + highlightedExecutionIds + selectedFindingId, so all are set right after in the batch.
     onEndpointClick(assetNodeId, endpointKey, label);
@@ -1614,10 +1641,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       // the focused endpoint is "selected" (blue); its injectors, edges and finding clusters keep their
       // verdict colour (green/orange/red) so blue means "what I picked", not "the whole subgraph".
       if (!pathFinding.type && !selectedInjectorId && !selectedFindingId) {
+        // The endpoint's own node id in the scoped chain graph is `chain-ep|depth|<raw id>`, not the
+        // raw id itself (that's the non-chain buildFindingPathFlow layout's scheme) — match either.
+        const isFocusedEndpoint = (nodeId: string) => nodeId === pathFinding.endpointNodeId
+          || (nodeId.startsWith('chain-ep|') && nodeId.endsWith(`|${pathFinding.endpointNodeId}`));
         return {
           nodes: baseFlow.nodes.map(n => ({
             ...n,
-            selected: n.id === pathFinding.endpointNodeId,
+            selected: isFocusedEndpoint(n.id),
             data: {
               ...(n.data ?? {}),
               dimmed: false,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -2046,3 +2046,54 @@ export const buildCausalChainFlow = (
     edges,
   };
 };
+
+// Filters a causal-chain flow (already built for the WHOLE run) down to one endpoint's own
+// subgraph: its causal ancestry (every action/finding that led to it, walked backward through
+// BOTH production and causal edges — same rule as the page's own selectedNodeId&&chainMode
+// highlight walk) plus its own direct findings (one hop forward from the endpoint, so what it
+// discovered still shows even though nothing consumed it further). Used for the focused
+// single-endpoint view (chokepoint click, endpoint drill-down) so that view keeps the real kill
+// chain instead of falling back to the flatter, non-causal buildFindingPathFlow layout.
+//
+// Node positions are left untouched (still their absolute coordinates from the full-graph layout,
+// not re-flowed for the smaller subgraph) — ReactFlow's fitView still frames whatever is rendered,
+// so the result is correctly scoped even if not as compact as a purpose-built focused layout.
+export const scopeChainFlowToEndpoint = (
+  chainFlow: {
+    nodes: AttackPathFlowNode[];
+    edges: AttackPathFlowEdge[];
+  },
+  endpointId: string,
+): {
+  nodes: AttackPathFlowNode[];
+  edges: AttackPathFlowEdge[];
+} => {
+  const { nodes, edges } = chainFlow;
+  const seedIds = new Set(
+    nodes.filter(n => n.id.startsWith('chain-ep|') && n.id.endsWith(`|${endpointId}`)).map(n => n.id),
+  );
+  // The endpoint never executed anything in the causal chain yet (e.g. no full-graph data): show
+  // the whole thing rather than an empty focus.
+  if (seedIds.size === 0) {
+    return chainFlow;
+  }
+  const scope = new Set(seedIds);
+  for (let pass = 0; pass < 8; pass += 1) {
+    for (const e of edges) {
+      if (e.source && e.target && scope.has(e.target) && !scope.has(e.source)) {
+        scope.add(e.source);
+      }
+    }
+  }
+  for (let pass = 0; pass < 3; pass += 1) {
+    for (const e of edges) {
+      if (e.source && e.target && seedIds.has(e.source) && !scope.has(e.target)) {
+        scope.add(e.target);
+      }
+    }
+  }
+  return {
+    nodes: nodes.filter(n => scope.has(n.id)),
+    edges: edges.filter(e => scope.has(e.source) && scope.has(e.target)),
+  };
+};


### PR DESCRIPTION
## Summary

Two related UX gaps in the causal-chain (chain mode) attack-path view:

- Clicking an endpoint via "Top chokepoints" always rendered the focus through `buildFindingPathFlow`'s flat layout (injectors → endpoint → finding-type clusters), even in chain mode — losing the causal ("Triggered ...") relationships between actions that the full graph shows. Added `scopeChainFlowToEndpoint`, which filters the real `buildCausalChainFlow` output down to one endpoint's own causal ancestry (+ its direct findings) instead, so the focused view keeps the real kill chain.
- Clicking a finding (from the drawer, or directly in the graph) in chain mode only highlighted it in place on the full map — easy to lose track of on a crowded graph. Both entry points now switch into the same chokepoint-style scoped focus (via the finding's origin endpoint), with the finding itself seeding the highlight walk inside that now-scoped view, instead of a plain highlight-in-place.
- Fixed the "endpoint focus, nothing sub-selected" case to match the chain graph's own `chain-ep|depth|<id>` node ids (previously only matched `buildFindingPathFlow`'s raw ids, so the focused endpoint never rendered as selected in chain mode).

## Review notes

- No new attack surface: no new network calls, no unfiltered user input, no auth/permission logic touched. Purely filters data already fetched and already rendered elsewhere in the same session — no additional data exposure.
- Bounded-pass closure walk (8 ancestor passes + 3 descendant passes), consistent with the existing highlight-walk patterns already in this file. No unbounded loops.
- Known residual risk (not fully verified live): scoping assumes `pathFinding.endpointNodeId` (set from either the drawer or a direct graph click) matches the raw id format `buildCausalChainFlow` embeds in its `chain-ep|...` node ids. If they ever diverge, the fallback is silent — `scopeChainFlowToEndpoint` returns the unfiltered graph rather than crashing or showing an empty focus.

## Test plan
- [x] `yarn check-ts` clean
- [x] `yarn eslint` clean on the changed files
- [x] `yarn vitest run` on the attack-path test suite: 96/96 passing, no regressions
- [ ] Manual: click "Top chokepoints" → an endpoint in a run with recorded executions — the focused view should show actions/events/findings with their causal ("Triggered ...") edges, not a flat list
- [ ] Manual: click a finding (drawer row, or directly in the graph) in the same run — should switch into the same kind of scoped focus around that finding's endpoint, with the finding itself highlighted inside it