### PR TITLE
fix(attack-path): scope a finding's focus on itself, and stop truncating the causal walk (#7156)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -17,7 +17,7 @@ import { SIMULATION_BASE_URL } from '../../../../../constants/BaseUrls';
 import type { AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingItemDTO, AttackPathFindingPageDTO, AttackPathNodeDTO, AttackPathSimSummaryRow, ExerciseSimple } from '../../../../../utils/api-types';
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import attackPathStatusColor, { attackPathChokepointColor } from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds, scopeChainFlowToEndpoint } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from './attack-path-flow-helpers';
 import AttackPathFlow, { type AttackPathFocusRequest } from './AttackPathFlow';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
@@ -1224,13 +1224,15 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         edges: AttackPathFlowEdge[];
       };
       if (pathFinding && chainMode && fullDto) {
-        // Chain mode has the real kill chain already built for the whole run — scope THAT down to
-        // this endpoint instead of falling back to buildFindingPathFlow's flatter, non-causal
-        // layout, so the focused view keeps the causal ("Triggered ...") structure between actions.
-        raw = scopeChainFlowToEndpoint(
-          buildCausalChainFlow(fullDto, t, expandedFindingClusters, endpointClusterBatch),
-          pathFinding.endpointNodeId,
-        );
+        // Chain mode has the real kill chain already built for the whole run — scope THAT down
+        // instead of falling back to buildFindingPathFlow's flatter, non-causal layout, so the
+        // focused view keeps the causal ("Triggered ...") structure between actions. A specific
+        // finding (selectedFindingId) seeds on itself for a tighter focus that skips the endpoint's
+        // unrelated siblings; the plain endpoint-only focus (chokepoint click) seeds on the endpoint.
+        const fullChain = buildCausalChainFlow(fullDto, t, expandedFindingClusters, endpointClusterBatch);
+        raw = selectedFindingId
+          ? scopeChainFlowToSeeds(fullChain, new Set([selectedFindingId]))
+          : scopeChainFlowToEndpoint(fullChain, pathFinding.endpointNodeId);
       } else if (pathFinding) {
         raw = buildFindingPathFlow(dto, pathFinding, t, pathContractLabelByInjector, {
           expanded: expandedFindingClusters,
@@ -1264,7 +1266,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       };
     },
     [
-      dto, chainMode, fullDto, pathFinding, pathContractLabelByInjector, endpointBatch,
+      dto, chainMode, fullDto, pathFinding, selectedFindingId, pathContractLabelByInjector, endpointBatch,
       expandedFindingClusters, endpointClusterBatch, findingsByCluster, findingBatch, chokepointRankById, pivotNodeIds, t,
     ],
   );
@@ -1692,8 +1694,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
         activeId = selectedFindingId ?? defaultId;
         // Only the injector(s) that actually produced the focused finding light up — not every injector
         // that merely reached the endpoint — so the highlighted path stays scoped to the finding the
-        // analyst opened, even after expanding its cluster.
-        const restrictInjectors = producingInjectorIds.size > 0;
+        // analyst opened, even after expanding its cluster. Chain mode is exempt: producingInjectorIds
+        // is only ever the finding's DIRECT (one-hop) producer, so applying it here cut the walk short
+        // at the second injector hop back — every EARLIER action in the causal chain (e.g. the "NetExec
+        // SMB - Share Listing" that ran before the "spider_plus" pass that actually captured the file)
+        // never got added, staying dimmed despite being genuinely on the path. Chain mode has no
+        // shared-hub ambiguity to guard against (unlike the clustered view this restriction was written
+        // for), so there's nothing to lose by walking every hop back.
+        const restrictInjectors = !chainMode && producingInjectorIds.size > 0;
         pathSet.add(activeId);
         for (let pass = 0; pass < 8; pass += 1) {
           for (const e of baseFlow.edges) {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -2047,33 +2047,39 @@ export const buildCausalChainFlow = (
   };
 };
 
-// Filters a causal-chain flow (already built for the WHOLE run) down to one endpoint's own
-// subgraph: its causal ancestry (every action/finding that led to it, walked backward through
-// BOTH production and causal edges — same rule as the page's own selectedNodeId&&chainMode
-// highlight walk) plus its own direct findings (one hop forward from the endpoint, so what it
-// discovered still shows even though nothing consumed it further). Used for the focused
-// single-endpoint view (chokepoint click, endpoint drill-down) so that view keeps the real kill
-// chain instead of falling back to the flatter, non-causal buildFindingPathFlow layout.
+// Filters a causal-chain flow (already built for the WHOLE run) down to the subgraph reachable
+// from a set of seed nodes: their causal ancestry (every action/finding that led to them, walked
+// backward through BOTH production and causal edges — same rule as the page's own
+// selectedNodeId&&chainMode highlight walk) plus their own direct children (one hop forward, so
+// what a seed itself discovered/led to still shows even though nothing consumed it further). Used
+// for the focused view (chokepoint/endpoint click seeds on the endpoint; a finding click seeds on
+// the finding itself instead, for a tighter focus that doesn't pull in the endpoint's unrelated
+// siblings) so that view keeps the real kill chain instead of falling back to the flatter,
+// non-causal buildFindingPathFlow layout.
+//
+// Known limitation (deferred pending a backend change): a shared action that fans out to several
+// targets from different upstream triggers (e.g. one credential-yielding finding per endpoint, all
+// feeding the same shared "NetExec SMB" node) still pulls in every trigger feeding that shared node,
+// including ones for OTHER, unrelated endpoints — the backend currently records causal
+// dependencies per injector, not per specific (injector, target) execution, so the frontend has no
+// way to tell which specific trigger produced which specific execution.
 //
 // Node positions are left untouched (still their absolute coordinates from the full-graph layout,
 // not re-flowed for the smaller subgraph) — ReactFlow's fitView still frames whatever is rendered,
 // so the result is correctly scoped even if not as compact as a purpose-built focused layout.
-export const scopeChainFlowToEndpoint = (
+export const scopeChainFlowToSeeds = (
   chainFlow: {
     nodes: AttackPathFlowNode[];
     edges: AttackPathFlowEdge[];
   },
-  endpointId: string,
+  seedIds: Set<string>,
 ): {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
 } => {
   const { nodes, edges } = chainFlow;
-  const seedIds = new Set(
-    nodes.filter(n => n.id.startsWith('chain-ep|') && n.id.endsWith(`|${endpointId}`)).map(n => n.id),
-  );
-  // The endpoint never executed anything in the causal chain yet (e.g. no full-graph data): show
-  // the whole thing rather than an empty focus.
+  // None of the seeds exist in the causal chain yet (e.g. no full-graph data, or a finding whose
+  // type cluster is still collapsed): show the whole thing rather than an empty focus.
   if (seedIds.size === 0) {
     return chainFlow;
   }
@@ -2097,3 +2103,22 @@ export const scopeChainFlowToEndpoint = (
     edges: edges.filter(e => scope.has(e.source) && scope.has(e.target)),
   };
 };
+
+// scopeChainFlowToSeeds, seeded on every depth-instance of one endpoint (the causal chain lays the
+// same physical endpoint out again at each depth it's touched, each a distinct `chain-ep|depth|id`
+// node) — the endpoint-focus case (chokepoint click, endpoint drill-down with no specific finding).
+export const scopeChainFlowToEndpoint = (
+  chainFlow: {
+    nodes: AttackPathFlowNode[];
+    edges: AttackPathFlowEdge[];
+  },
+  endpointId: string,
+): {
+  nodes: AttackPathFlowNode[];
+  edges: AttackPathFlowEdge[];
+} => scopeChainFlowToSeeds(
+  chainFlow,
+  new Set(
+    chainFlow.nodes.filter(n => n.id.startsWith('chain-ep|') && n.id.endsWith(`|${endpointId}`)).map(n => n.id),
+  ),
+);


### PR DESCRIPTION
## Summary

Two follow-ups to the endpoint-focus scoping added in #7152:

- Clicking a finding scoped the focused view to its whole **endpoint**, pulling in the endpoint's unrelated siblings (other findings/branches on the same host that don't lead to the clicked one). Generalized `scopeChainFlowToEndpoint` into `scopeChainFlowToSeeds` and seed on the finding itself when one is selected, for a tighter focus. The endpoint-only case (chokepoint click, no specific finding) keeps its existing behavior unchanged.
- Even scoped correctly, part of the causal path stayed unhighlighted: the "activeId" highlight walk applies `producingInjectorIds` as a restriction meant for the clustered (non-chain) shared-hub case, which only ever contains a finding's DIRECT (one-hop) producer. In chain mode this cut the walk short at the second injector hop back — every earlier action in the chain (e.g. the recon step that ran before the one that actually captured a file) stayed dimmed despite being genuinely on the path. Chain mode has no shared-hub ambiguity to guard against, so the restriction is now skipped there.

## Known, documented limitation (unchanged, deferred pending a backend change)

A shared action fanning out to several targets from different upstream triggers (e.g. one credential finding per endpoint all feeding the same shared injector node) still pulls in every trigger feeding that shared node, including ones for unrelated endpoints — the backend records causal dependencies per injector, not per specific (injector, target) execution, so the frontend can't yet tell which trigger produced which specific execution. Documented directly in `scopeChainFlowToSeeds`'s comment.

## Review notes
- Pure refactor + two targeted, minimal-diff behavior changes — no new attack surface, no new network calls, no unvalidated user input.
- Same bounded-pass closure algorithm as #7152, just seeded differently.

## Test plan
- [x] `yarn check-ts` clean
- [x] `yarn eslint` clean on the changed files
- [x] `yarn vitest run` on the attack-path test suite: 96/96 passing, no regressions
- [ ] Manual: click a finding several hops into a causal chain (e.g. a file dropped after multiple recon/lateral-movement steps) — the focused view should show ONLY that finding's own path (no unrelated endpoint siblings), fully highlighted back to the first action