### PR TITLE
fix(attack-path): resolve payload argument placeholders in the frozen terminal snapshot (#7157)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.gson.*;
@@ -24,6 +25,7 @@ import io.openaev.executors.Executor;
 import io.openaev.rest.document.DocumentService;
 import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.inject.form.InjectInput;
+import io.openaev.rest.inject.service.ExecutableInjectService;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.rest.inject.service.StructuredOutputUtils;
 import io.openaev.rest.injector_contract.InjectorContractService;
@@ -45,6 +47,7 @@ import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.*;
+import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
@@ -88,6 +91,7 @@ public class InjectExecutionStep implements ActionStep {
   private final AttackPathExecutionIngestionService attackPathIngestion;
   private final AttackPathFindingIngestionService attackPathFindingIngestion;
   private final InjectExpectationService injectExpectationService;
+  private final ExecutableInjectService executableInjectService;
 
   private final InjectorContractRepository injectorContractRepository;
 
@@ -853,14 +857,23 @@ public class InjectExecutionStep implements ActionStep {
       return resolvedCommand;
     }
 
-    for (PayloadArgument arg : args) {
-      if (arg == null || arg.getKey() == null || arg.getKey().isBlank()) {
-        continue;
-      }
-      String value = arg.getDefaultValue() != null ? arg.getDefaultValue() : "";
-      resolvedCommand = resolvedCommand.replace("#{" + arg.getKey() + "}", value);
-    }
-    return resolvedCommand;
+    // Resolve each #{argumentKey} the same way a real execution does (inject content first,
+    // falling back to the payload argument's default value) — see
+    // ExecutableInjectService#replaceArgumentsByValue, also used by InjectExecutionResultService
+    // for the live terminal view (#7110). Otherwise the attack-path snapshot freezes the default
+    // value instead of what was actually run.
+    ObjectNode convertedContent = injectorContract.get().getConvertedContent();
+    JsonNode fields = convertedContent == null ? null : convertedContent.get("fields");
+    List<ObjectNode> injectorContractContentFields =
+        fields == null
+            ? List.of()
+            : StreamSupport.stream(fields.spliterator(), false)
+                .map(ObjectNode.class::cast)
+                .toList();
+    ObjectNode injectContent =
+        inject.getContent() != null ? inject.getContent() : JsonNodeFactory.instance.objectNode();
+    return executableInjectService.replaceArgumentsByValue(
+        resolvedCommand, args, injectorContractContentFields, injectContent);
   }
 
   /**


### PR DESCRIPTION
## Summary

- The attack-path finding drawer's "Terminal view" tab showed the payload's command with unresolved/default argument values (e.g. `echo localhost:22`) instead of the real value actually used at execution time (e.g. `echo 108.143.7.251:445`) — even though the Result tab and the execution output already showed the correct target.
- `InjectExecutionStep.getCommand()` builds the command frozen into the attack-path execution snapshot (`AttackPathExecution.command` → `AttackPathExecutionDetailDTO.command`) by substituting each `#{argumentKey}` placeholder with `PayloadArgument.getDefaultValue()` only, never checking the inject's actual content.
- This duplicated (and diverged from) `ExecutableInjectService.replaceArgumentsByValue`, which resolves the inject's content first, falling back to the default value only when unset — the method #7110 made public and wired into `InjectExecutionResultService` to fix the exact same class of bug for the live Terminal view (Inject details page). `InjectExecutionStep.getCommand()` was never updated to reuse it, so the attack-path snapshot kept freezing default values.
- `getCommand()` now calls `executableInjectService.replaceArgumentsByValue(...)` instead of the local default-only substitution loop, with the same null-guards as `InjectExecutionResultService` (`InjectorContract.getConvertedContent()` and `Inject.getContent()` can both be null).

Fixes #7157

## Test plan

- [x] Reviewed `InjectExecutionStepTest#given_injectWithPayloadCommands_whenGetCommand_thenResolvePayloadVariables` by hand: with no inject content set, resolution falls back to argument defaults, same result as before (`echo eva && whoami admin`).
- [ ] Manually verify: a chained inject with a `host`/`port` argument populated from a previous step's discovered output now shows the real resolved command (e.g. `echo 108.143.7.251:445`) in the attack-path drawer's Terminal view tab, instead of the payload's static default (`echo localhost:22`).