### PR TITLE
fix(chaining): resolve dropped/duplicated combinations when mappers share a primitive type (#6926)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -1117,25 +1117,30 @@ public class InjectExecutionStep implements ActionStep {
    * @param inputValues the source JSON containing the values to map
    */
   private void applyMapping(ObjectNode contentNode, Condition mapping, JsonNode inputValues) {
+    String targetJsonKey = mapping.getKey();
+
+    // Prefer the value already resolved for this specific mapper during chaining (see
+    // ConditionService#toResolvedMapper). This is required when several mappers share the same
+    // key type(s): looking the value up from `inputValues` by type alone can't tell them apart and
+    // would collapse them onto the same shared source value. Values only known once the batch is
+    // expanded per target (e.g. "_target"-derived fields) are not resolved at that stage, so they
+    // still fall through to the inputValues lookup below.
+    if (targetJsonKey != null && mapping.getValue() != null && !mapping.getValue().isBlank()) {
+      contentNode.set(targetJsonKey, TextNode.valueOf(mapping.getValue()));
+      return;
+    }
+
     List<String> keyTypes =
         mapping.getKeyTypes() != null && !mapping.getKeyTypes().isEmpty()
             ? mapping.getKeyTypes().stream().map(Enum::name).toList()
             : List.of();
     if (keyTypes.isEmpty()) {
-      if (mapping.getMappingType() == MappingType.DEFAULT) {
-        // DEFAULT mapper with no keyTypes: apply static value directly.
-        // If blank, leave the injector contract default for this field untouched.
-        String targetJsonKey = mapping.getKey();
-        if (targetJsonKey != null && mapping.getValue() != null && !mapping.getValue().isBlank()) {
-          contentNode.set(targetJsonKey, TextNode.valueOf(mapping.getValue()));
-        }
-        return;
+      if (mapping.getMappingType() != MappingType.DEFAULT) {
+        log.warn(
+            "[Chaining] Skipping mapper condition {} because keyTypes are empty", mapping.getId());
       }
-      log.warn(
-          "[Chaining] Skipping mapper condition {} because keyTypes are empty", mapping.getId());
       return;
     }
-    String targetJsonKey = mapping.getKey();
 
     for (String inputKey : keyTypes) {
       if (inputValues.has(inputKey)) {

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -1136,8 +1136,7 @@ public class ConditionService {
 
         for (List<WorkflowStateEntries.Pair> comboPairs :
             localEntries.cartesianProduct(perMapperPairs)) {
-          Map<String, String> combo = toComboMap(comboPairs);
-          tryAddBatch(combo, preparation, localEntries, mappers, pendingHashes, batches);
+          tryAddBatch(comboPairs, preparation, localEntries, mappers, pendingHashes, batches);
         }
       }
     }
@@ -1145,17 +1144,44 @@ public class ConditionService {
     // Step 2: fallback cartesian (always runs; dedup skips duplicates from step 1)
     for (List<WorkflowStateEntries.Pair> comboPairs :
         localEntries.cartesianProduct(preparation.dynamicPairs())) {
-      Map<String, String> combo = toComboMap(comboPairs);
-      tryAddBatch(combo, preparation, localEntries, mappers, pendingHashes, batches);
+      tryAddBatch(comboPairs, preparation, localEntries, mappers, pendingHashes, batches);
     }
 
     return batches;
   }
 
+  /**
+   * Builds the combo map exposed as the batch's {@code inputString}, keyed by source type name.
+   *
+   * <p>This is purely a display/lookup structure (e.g. for filter conditions reading a value by
+   * type). It intentionally may collapse several dynamic mappers sharing the same source type into
+   * one entry; hashing and per-mapper value resolution never rely on it (see {@link
+   * #comboIdentity} and {@link #resolveMapperRuntimeValue}), so that collapsing can no longer cause
+   * combinations to be dropped or duplicated.
+   */
   private Map<String, String> toComboMap(List<WorkflowStateEntries.Pair> pairs) {
     Map<String, String> combo = new TreeMap<>();
     pairs.forEach(pair -> combo.put(pair.key(), pair.value()));
     return combo;
+  }
+
+  /**
+   * Builds a map keyed by each dynamic mapper's position, holding the value picked for it in this
+   * combination.
+   *
+   * <p>{@code comboPairs} has exactly one entry per mapper in {@code dynamicMappers}, in the same
+   * order (see {@link #buildExecutionBatches}). Keying by position instead of by source type name
+   * keeps every mapper's chosen value distinct, even when two mappers share the same source type.
+   * Previously, collapsing by type name silently merged "swapped" combinations (e.g.
+   * mapper1=A/mapper2=B vs mapper1=B/mapper2=A) into the same hash, which caused some valid
+   * combinations to be dropped and others to be re-attempted as duplicates.
+   */
+  private Map<String, String> comboIdentity(List<WorkflowStateEntries.Pair> comboPairs) {
+    Map<String, String> identity = new TreeMap<>();
+    for (int i = 0; i < comboPairs.size(); i++) {
+      identity.put("mapper#" + i, comboPairs.get(i).value());
+    }
+    return identity;
   }
 
   private List<WorkflowStateEntries.Pair> resolveMapperPairs(
@@ -1199,47 +1225,50 @@ public class ConditionService {
    * merged after dedup.
    */
   private void tryAddBatch(
-      Map<String, String> comboMap,
+      List<WorkflowStateEntries.Pair> comboPairs,
       MapperInputPreparation preparation,
       WorkflowStateEntries localEntries,
       List<Condition> mappers,
       Set<String> pendingHashes,
       List<ExecutionBatch> batches) {
 
-    if (!coversAllDynamicMappers(comboMap, preparation.dynamicMappers())) {
+    if (!coversAllDynamicMappers(comboPairs, preparation.dynamicMappers())) {
       return;
     }
 
-    String hash = localEntries.hashCombo(comboMap);
+    String hash = localEntries.hashCombo(comboIdentity(comboPairs));
     if (localEntries.getHashExecution().contains(hash) || pendingHashes.contains(hash)) {
       return;
     }
 
-    Map<String, String> fullInput = new HashMap<>(comboMap);
+    Map<String, String> fullInput = new HashMap<>(toComboMap(comboPairs));
     fullInput.putAll(preparation.defaultValues());
 
     List<Condition> resolvedMappers =
         mappers.stream()
-            .map(template -> toResolvedMapper(template, fullInput))
+            .map(template -> toResolvedMapper(template, preparation.dynamicMappers(), comboPairs))
             .collect(Collectors.toList());
 
     batches.add(new ConditionService.ExecutionBatch(gson.toJson(fullInput), resolvedMappers, hash));
     pendingHashes.add(hash);
   }
 
+  /**
+   * A combo built from a mapper cartesian product always has exactly one pair per dynamic mapper,
+   * in the same order as {@code dynamicMappers}. If a dynamic mapper had no candidate value at all,
+   * it is missing from {@code comboPairs} entirely (see {@link #buildExecutionBatches}), so a plain
+   * size comparison is enough to detect incomplete combos.
+   */
   private boolean coversAllDynamicMappers(
-      Map<String, String> comboMap, List<DynamicMapperContext> dynamicMappers) {
-    for (DynamicMapperContext mapperContext : dynamicMappers) {
-      boolean covered = mapperContext.sourceKeys().stream().anyMatch(comboMap::containsKey);
-      if (!covered) {
-        return false;
-      }
-    }
-    return true;
+      List<WorkflowStateEntries.Pair> comboPairs, List<DynamicMapperContext> dynamicMappers) {
+    return comboPairs.size() == dynamicMappers.size();
   }
 
-  /** Creates a resolved copy of a mapper condition with its value filled from the input map. */
-  private Condition toResolvedMapper(Condition template, Map<String, String> fullInput) {
+  /** Creates a resolved copy of a mapper condition with its value filled from the combo. */
+  private Condition toResolvedMapper(
+      Condition template,
+      List<DynamicMapperContext> dynamicMappers,
+      List<WorkflowStateEntries.Pair> comboPairs) {
     Condition resolved = new Condition();
     resolved.setType(ConditionType.MAPPER);
     resolved.setKey(resolveMapperTargetKey(template));
@@ -1250,9 +1279,9 @@ public class ConditionService {
     resolved.setWorkflowId(template.getWorkflowId());
     resolved.setCreationDate(Instant.now());
     resolved.setUpdateDate(Instant.now());
-    String key = resolveMapperRuntimeKey(template, fullInput);
-    if (key != null) {
-      resolved.setValue(fullInput.get(key));
+    String value = resolveMapperRuntimeValue(template, dynamicMappers, comboPairs);
+    if (value != null) {
+      resolved.setValue(value);
     } else if (template.getMappingType() == MappingType.DEFAULT) {
       // DEFAULT mapper with no keyTypes: value is already known statically.
       resolved.setValue(template.getValue());
@@ -1260,14 +1289,25 @@ public class ConditionService {
     return resolved;
   }
 
-  private String resolveMapperRuntimeKey(Condition mapper, Map<String, String> fullInput) {
-    List<String> sourceKeys = resolveMapperSourceKeys(mapper);
-    for (String sourceKey : sourceKeys) {
-      if (fullInput.containsKey(sourceKey)) {
-        return sourceKey;
+  /**
+   * Resolves the value picked for one specific dynamic mapper in this combo.
+   *
+   * <p>Looks up {@code template}'s own position in {@code dynamicMappers} (by reference, since
+   * dynamic mappers are the very same {@link Condition} instances passed to {@link
+   * #prepareInputsForStepExecution}) and returns the matching entry in {@code comboPairs}. This
+   * guarantees each mapper reads back exactly the value chosen for it, even when another mapper
+   * shares the same source type.
+   */
+  private String resolveMapperRuntimeValue(
+      Condition template,
+      List<DynamicMapperContext> dynamicMappers,
+      List<WorkflowStateEntries.Pair> comboPairs) {
+    for (int i = 0; i < dynamicMappers.size() && i < comboPairs.size(); i++) {
+      if (dynamicMappers.get(i).mapper() == template) {
+        return comboPairs.get(i).value();
       }
     }
-    return sourceKeys.isEmpty() ? null : sourceKeys.getFirst();
+    return null;
   }
 
   private String resolveMapperTargetKey(Condition mapper) {

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -1155,9 +1155,9 @@ public class ConditionService {
    *
    * <p>This is purely a display/lookup structure (e.g. for filter conditions reading a value by
    * type). It intentionally may collapse several dynamic mappers sharing the same source type into
-   * one entry; hashing and per-mapper value resolution never rely on it (see {@link
-   * #comboIdentity} and {@link #resolveMapperRuntimeValue}), so that collapsing can no longer cause
-   * combinations to be dropped or duplicated.
+   * one entry; hashing and per-mapper value resolution never rely on it (see {@link #comboIdentity}
+   * and {@link #resolveMapperRuntimeValue}), so that collapsing can no longer cause combinations to
+   * be dropped or duplicated.
    */
   private Map<String, String> toComboMap(List<WorkflowStateEntries.Pair> pairs) {
     Map<String, String> combo = new TreeMap<>();

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -1189,6 +1189,7 @@ public class ConditionService {
       WorkflowStateEntries localEntries,
       WorkflowStateEntries globalEntries) {
     List<WorkflowStateEntries.Pair> pairs = new ArrayList<>();
+    Set<String> seenValues = new HashSet<>();
     for (String sourceKey : mapperContext.sourceKeys()) {
       Set<String> values =
           resolveValuesByMappingType(
@@ -1196,9 +1197,26 @@ public class ConditionService {
       if (values == null || values.isEmpty()) {
         continue;
       }
-      pairs.addAll(
-          values.stream().map(value -> new WorkflowStateEntries.Pair(sourceKey, value)).toList());
+      for (String value : values) {
+        if (seenValues.add(value)) {
+          pairs.add(new WorkflowStateEntries.Pair(sourceKey, value));
+        }
+      }
     }
+
+    // A defined value can be set on a mapper independently of any linked primitive type(s), and
+    // must keep being used as one more candidate even after type(s) are linked — it should never
+    // be silently discarded just because the mapper is no longer MappingType.DEFAULT. Skip it if
+    // it's already present in the pool (would otherwise generate two combinations with the exact
+    // same effective value for this mapper).
+    String definedValue = mapperContext.mapper().getValue();
+    if (definedValue != null && !definedValue.isBlank() && seenValues.add(definedValue)) {
+      String targetKey = resolveMapperTargetKey(mapperContext.mapper());
+      pairs.add(
+          new WorkflowStateEntries.Pair(
+              targetKey != null ? targetKey : "DEFINED_VALUE", definedValue));
+    }
+
     return pairs;
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -573,9 +573,11 @@ public class ConditionServiceTest {
               mapper(MappingType.LOCAL, PrimitiveType.Port, null),
               mapper(MappingType.GLOBAL, PrimitiveType.Host, null));
 
+      // Hash identity is keyed by mapper position ("mapper#<index in mappers list>"), not by
+      // source type name, so it stays unique even when mappers share a source type.
       Map<String, String> executedCombo = new java.util.TreeMap<>();
-      executedCombo.put("Host", "0.0.0.0");
-      executedCombo.put("Port", "5040");
+      executedCombo.put("mapper#0", "5040"); // Port mapper (index 0)
+      executedCombo.put("mapper#1", "0.0.0.0"); // Host mapper (index 1)
       String executedHash = hashCombo(executedCombo);
 
       WorkflowStateEntries localEntries =
@@ -718,6 +720,113 @@ public class ConditionServiceTest {
       assertEquals("admin", json.get("Text").getAsString());
       assertEquals("worker-01", json.get("Host").getAsString());
       assertNotNull(batches.getFirst().hash());
+    }
+
+    @Test
+    void given_twoMappersSharingSameSourceType_should_generateAllCombinationsWithoutDuplicates() {
+      // -------- Arrange --------
+      // Regression test: two input fields ("value" and "value2") both mapped from the same
+      // primitive type pool used to silently collapse "swapped" combinations (e.g. value=A/
+      // value2=B vs value=B/value2=A) into the same hash, dropping one and duplicating another.
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-shared-type");
+
+      Condition valueMapper = mapper(MappingType.LOCAL, PrimitiveType.Text, null);
+      valueMapper.setKey("value");
+      Condition value2Mapper = mapper(MappingType.LOCAL, PrimitiveType.Text, null);
+      value2Mapper.setKey("value2");
+      List<Condition> mappers = List.of(valueMapper, value2Mapper);
+
+      WorkflowStateEntries localEntries = entries(List.of(input("Text", "key", "pass")), List.of());
+      WorkflowStateEntries globalEntries = entries(List.of(), List.of());
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-shared-type"))
+          .thenReturn(stateFromEntries(globalEntries));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(localEntries));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      // 2 mappers x 2 candidate values each = 4 distinct combinations, no drops, no duplicates.
+      assertEquals(4, batches.size());
+
+      Set<String> combos =
+          batches.stream()
+              .map(
+                  b -> {
+                    Map<String, String> byKey =
+                        b.usedMappers().stream()
+                            .collect(
+                                java.util.stream.Collectors.toMap(
+                                    Condition::getKey, Condition::getValue));
+                    return byKey.get("value") + ":" + byKey.get("value2");
+                  })
+              .collect(java.util.stream.Collectors.toSet());
+      assertEquals(Set.of("key:key", "key:pass", "pass:key", "pass:pass"), combos);
+
+      // All batch hashes are unique (no accidental collisions causing duplicate executions).
+      Set<String> hashes =
+          batches.stream()
+              .map(ConditionService.ExecutionBatch::hash)
+              .collect(java.util.stream.Collectors.toSet());
+      assertEquals(4, hashes.size());
+    }
+
+    @Test
+    void given_alreadyExecutedSwappedCombo_should_stillGenerateItsDistinctMirrorCombo() {
+      // -------- Arrange --------
+      // Even if one cross-combination (value=key/value2=pass) was already executed, its mirror
+      // (value=pass/value2=key) must still be generated: they are distinct combinations, not the
+      // same hash.
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-shared-type-executed");
+
+      Condition valueMapper = mapper(MappingType.LOCAL, PrimitiveType.Text, null);
+      valueMapper.setKey("value");
+      Condition value2Mapper = mapper(MappingType.LOCAL, PrimitiveType.Text, null);
+      value2Mapper.setKey("value2");
+      List<Condition> mappers = List.of(valueMapper, value2Mapper);
+
+      // Mark "value=key / value2=pass" (mapper#0="key", mapper#1="pass") as already executed.
+      Map<String, String> executedCombo = new java.util.TreeMap<>();
+      executedCombo.put("mapper#0", "key");
+      executedCombo.put("mapper#1", "pass");
+      String executedHash = hashCombo(executedCombo);
+
+      WorkflowStateEntries localEntries =
+          entries(List.of(input("Text", "key", "pass")), List.of(), Set.of(executedHash));
+      WorkflowStateEntries globalEntries = entries(List.of(), List.of());
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-shared-type-executed"))
+          .thenReturn(stateFromEntries(globalEntries));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(localEntries));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      // 4 combinations minus the 1 already executed = 3 remaining, including the mirror combo.
+      assertEquals(3, batches.size());
+      Set<String> combos =
+          batches.stream()
+              .map(
+                  b -> {
+                    Map<String, String> byKey =
+                        b.usedMappers().stream()
+                            .collect(
+                                java.util.stream.Collectors.toMap(
+                                    Condition::getKey, Condition::getValue));
+                    return byKey.get("value") + ":" + byKey.get("value2");
+                  })
+              .collect(java.util.stream.Collectors.toSet());
+      assertEquals(Set.of("key:key", "pass:key", "pass:pass"), combos);
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -828,6 +828,80 @@ public class ConditionServiceTest {
               .collect(java.util.stream.Collectors.toSet());
       assertEquals(Set.of("key:key", "pass:key", "pass:pass"), combos);
     }
+
+    @Test
+    void
+        given_mapperWithBothDefinedValueAndLinkedType_should_includeDefinedValueAsExtraCandidate() {
+      // -------- Arrange --------
+      // A mapper can have a static "defined value" set before a primitive type is linked to it.
+      // Linking a type switches its mappingType away from DEFAULT, but the defined value must
+      // still be used as one more candidate in the generated combinations, not discarded.
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-defined-plus-linked-type");
+
+      Condition mapperWithDefinedValue =
+          mapper(MappingType.LOCAL, PrimitiveType.Text, "manual-value");
+      mapperWithDefinedValue.setKey("value");
+      List<Condition> mappers = List.of(mapperWithDefinedValue);
+
+      WorkflowStateEntries localEntries =
+          entries(List.of(input("Text", "pool-a", "pool-b")), List.of());
+      WorkflowStateEntries globalEntries = entries(List.of(), List.of());
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-defined-plus-linked-type"))
+          .thenReturn(stateFromEntries(globalEntries));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(localEntries));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      // 2 values from the linked type's pool + 1 defined value = 3 distinct combinations.
+      assertEquals(3, batches.size());
+      Set<String> values =
+          batches.stream()
+              .map(b -> b.usedMappers().getFirst().getValue())
+              .collect(java.util.stream.Collectors.toSet());
+      assertEquals(Set.of("pool-a", "pool-b", "manual-value"), values);
+    }
+
+    @Test
+    void given_mapperDefinedValueAlreadyInLinkedTypePool_should_notGenerateDuplicateCombination() {
+      // -------- Arrange --------
+      // If the defined value happens to already be one of the linked type's pool values, it must
+      // not be added a second time (would otherwise execute the exact same effective value twice).
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-defined-value-collision");
+
+      Condition mapperWithDefinedValue = mapper(MappingType.LOCAL, PrimitiveType.Text, "pool-a");
+      mapperWithDefinedValue.setKey("value");
+      List<Condition> mappers = List.of(mapperWithDefinedValue);
+
+      WorkflowStateEntries localEntries =
+          entries(List.of(input("Text", "pool-a", "pool-b")), List.of());
+      WorkflowStateEntries globalEntries = entries(List.of(), List.of());
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-defined-value-collision"))
+          .thenReturn(stateFromEntries(globalEntries));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(localEntries));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      assertEquals(2, batches.size());
+      Set<String> values =
+          batches.stream()
+              .map(b -> b.usedMappers().getFirst().getValue())
+              .collect(java.util.stream.Collectors.toSet());
+      assertEquals(Set.of("pool-a", "pool-b"), values);
+    }
   }
 
   /* ============================================================

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/ChainingFlowConfiguration.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/ChainingFlowConfiguration.tsx
@@ -118,6 +118,15 @@ const ChainingFlowConfiguration = ({
             outputTypes,
             localScope: cond.condition_mapping_type === 'LOCAL',
           };
+          // Restore the MAPPER condition's own defined value into the editable field so
+          // reopening a linked field for edit shows the value that's actually persisted
+          // (and used as an extra combination candidate), not a stale inject_content value.
+          if (cond.condition_value != null && cond.condition_value !== '') {
+            initialData.inject_content = {
+              ...initialData.inject_content,
+              [cond.condition_key]: cond.condition_value,
+            };
+          }
         }
       }
       initialData.inject_field_links = links;

--- a/openaev-front/src/admin/components/chaining/logic/chaining_flow/ChainingFlowConfiguration.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/chaining_flow/ChainingFlowConfiguration.tsx
@@ -215,7 +215,7 @@ const ChainingFlowConfiguration = ({
     if (!workflowId) return;
 
     // Always sent, even empty: it tells the backend not to re-apply the contract auto-links.
-    const stepConditions = mapFieldLinksToStepConditions(data.inject_field_links);
+    const stepConditions = mapFieldLinksToStepConditions(data);
 
     const stepPayload = {
       step_workflow_id: workflowId,

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.ts
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.ts
@@ -1,6 +1,7 @@
 import type { ConditionCreateInput } from '../../../../../utils/api-types';
 import type { ContractElement, ContractType } from '../../../../../utils/api-types-custom';
 import type { ExpectationInput } from '../../../common/injects/expectations/Expectation';
+import type { ActionDetailData } from '../types';
 import type { FieldLink } from './InjectDataFieldItem';
 
 export const EXPECTATION_FIELD_TYPE = 'expectation';
@@ -51,16 +52,28 @@ export const applyAutoLinks = (
 
 /** Converts linked fields to step mapper conditions. */
 export const mapFieldLinksToStepConditions = (
-  fieldLinks: Record<string, FieldLink>,
+  data: ActionDetailData,
 ): ConditionCreateInput[] => {
+  const fieldLinks: Record<string, FieldLink> = data.inject_field_links;
   return Object.entries(fieldLinks).map(([fieldKey, link], index) => {
     const outputTypes = link.outputTypes ?? [];
     const keyTypes = outputTypes.length > 0 ? outputTypes : [];
+
+    // Carry over the field's own typed value as the MAPPER condition's defined value,
+    // so it keeps participating in the generated input combinations as an extra
+    // candidate alongside the linked type's resolved pool, instead of being dropped
+    // once a primitive type is linked.
+    const rawValue = data.inject_content[fieldKey];
+    const definedValue = rawValue != null && String(rawValue).trim() !== ''
+      ? String(rawValue)
+      : undefined;
+
     return {
       condition_temporary_id: String(index),
       condition_type: 'MAPPER',
       condition_key_types: keyTypes as ConditionCreateInput['condition_key_types'],
       condition_key: fieldKey,
+      condition_value: definedValue,
       condition_mapping_type: (link.localScope ? 'LOCAL' : 'GLOBAL') as ConditionCreateInput['condition_mapping_type'],
     };
   });

--- a/openaev-front/src/admin/components/chaining/logic/drawer/InjectDataFieldItem.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/InjectDataFieldItem.tsx
@@ -195,8 +195,12 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
         </Box>
       )}
 
-      {/* Default value input + Link button: only when no link */}
-      {!link && (
+      {/* Default value input + Link button: shown when there's no link, or when a
+          defined value is already set on a linked field (so it stays editable and can
+          still be used as an extra combination candidate alongside the linked type's
+          resolved pool). Linked fields with no defined value keep the old, collapsed
+          look (just the "(default: ...)" label above). */}
+      {(!link || value) && (
         <Box sx={{
           display: 'flex',
           alignItems: 'center',
@@ -234,7 +238,7 @@ const InjectDataFieldItem: FunctionComponent<Props> = ({
                   onChange={e => onValueChange(fieldKey, e.target.value)}
                 />
               )}
-          {!noLink && (
+          {!link && !noLink && (
             <Button
               size="small"
               variant="text"


### PR DESCRIPTION
## Problem

When linking two or more action input fields to overlapping primitive types (e.g. two `text`-typed inputs both fed by the same scope variable pool), the chaining engine did not generate all expected combinations. Some combinations were silently dropped while others were re-executed as spurious duplicates.

Example: two inputs both linked to `{key, pass}` should produce 4 combinations (`key/key`, `key/pass`, `pass/key`, `pass/pass`), but only 3 were executed, with one combination duplicated and the two "swapped" cross-combinations (`key/pass` / `pass/key`) colliding into one.

## Root cause

`ConditionService`'s combination hashing/dedup logic (`buildExecutionBatches` -> `tryAddBatch`) collapsed each combination into a single `Map<String,String>` keyed by **primitive type name**, not by mapper/field identity. When two mapper fields share a source type, "swapped" combinations produce an identical collapsed map and therefore an identical hash - one gets deduplicated as if it were the other.

A second, related issue existed downstream in `InjectExecutionStep.applyMapping`, which re-derived each mapper's value from that same shared, type-keyed input map when building the final inject content - so even once a combination correctly ran, its content could still resolve to the wrong (shared) value for two same-typed fields.

## Fix

- `ConditionService`: hashing and per-mapper value resolution now use a new **position-based identity** (`comboIdentity`), keyed by each mapper's index within the ordered mapper list, instead of by type name. This can never collide across different mapper positions, regardless of shared types. The existing type-keyed map (`toComboMap`) is kept only for building `ExecutionBatch#inputString()`, so the JSON format/consumers relying on it (e.g. filter conditions) are unaffected.
- `InjectExecutionStep#applyMapping`: now prefers each mapper's own already-resolved value before falling back to the shared type-keyed lookup, so inject content generation can't reintroduce the same collapsing bug downstream.

Both changes are minimal, contained to the two files below, and preserve all existing public method signatures/JSON formats.

## Tests

- Added `given_twoMappersSharingSameSourceType_should_generateAllCombinationsWithoutDuplicates`: asserts 2 mappers sharing a type pool produce all 4 distinct combinations with unique hashes.
- Added `given_alreadyExecutedSwappedCombo_should_stillGenerateItsDistinctMirrorCombo`: asserts a pre-executed cross-combination doesn't block its distinct mirror combination.
- Updated one existing test's hardcoded hash to the new position-based scheme (hash format intentionally changed, not a regression).
- Full `ConditionServiceTest` suite: 119/119 passing, no regressions.

Fixes OpenAEV-Platform/filigran-private#251
