### PR TITLE
fix(attack-path): make expectation table scrollable, reconstruct injector command line, paginate findings/executions (#7161)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -342,7 +342,9 @@ public class AttackPathGraphService {
         maskSecrets(e.getTerminalOutput(), secrets),
         // A network injector (NetExec, Nmap…) never has its own `command` snapshot; reconstruct one
         // server-side instead of leaving the client to fetch the raw inject content itself.
-        (injectId != null && e.getPayloadId() == null && (e.getCommand() == null || e.getCommand().isBlank()))
+        (injectId != null
+                && e.getPayloadId() == null
+                && (e.getCommand() == null || e.getCommand().isBlank()))
             ? maskSecrets(injectorCommandLine(injectId), secrets)
             : null);
   }
@@ -367,8 +369,11 @@ public class AttackPathGraphService {
     if (rawCommandLine == null) {
       return null;
     }
-    ObjectNode injectContent = injectRepository.findById(injectId).map(Inject::getContent).orElse(null);
-    return injectContent == null ? rawCommandLine : unmaskCommandLine(rawCommandLine, injectContent);
+    ObjectNode injectContent =
+        injectRepository.findById(injectId).map(Inject::getContent).orElse(null);
+    return injectContent == null
+        ? rawCommandLine
+        : unmaskCommandLine(rawCommandLine, injectContent);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -1,6 +1,12 @@
 package io.openaev.service.attackpath;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.database.model.ExecutionTrace;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectStatus;
 import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.PrimitiveType;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.AttackPathExecutionRemediation;
 import io.openaev.database.model.attackpath.projection.AttackPathEdgeGroupRow;
@@ -17,6 +23,8 @@ import io.openaev.database.model.attackpath.projection.AttackPathSimSummaryRow;
 import io.openaev.database.model.attackpath.projection.AttackPathTypeCountRow;
 import io.openaev.database.repository.AssetRepository;
 import io.openaev.database.repository.ConditionRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.database.repository.InjectStatusRepository;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.StepConditionRow;
 import io.openaev.database.repository.StepRepository;
@@ -38,6 +46,7 @@ import io.openaev.service.attackpath.dto.AttackPathFindingPageDTO;
 import io.openaev.service.attackpath.dto.AttackPathFindingVerdictsDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
 import io.openaev.service.attackpath.dto.ConsumedFindingKeyDTO;
+import io.openaev.utils.PrimitiveValueMaskingUtils;
 import io.openaev.utils.mapper.PayloadMapper;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -51,6 +60,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -97,6 +108,35 @@ public class AttackPathGraphService {
   private static final String CATEGORY_CREDENTIALS = "credentials";
   private static final String CREDENTIAL_MASK = "••••";
 
+  /**
+   * Maps a redacted command-line flag to the inject content field it was resolved from, for {@link
+   * #injectorCommandLine}. Mirrors the flags NetExec/Nmap contracts expose.
+   */
+  private static final Map<String, String> COMMAND_FLAG_TO_FIELD_KEY =
+      Map.ofEntries(
+          Map.entry("-u", "username"),
+          Map.entry("--user", "username"),
+          Map.entry("--username", "username"),
+          Map.entry("-p", "password"),
+          Map.entry("--pass", "password"),
+          Map.entry("--password", "password"),
+          Map.entry("-H", "hash"),
+          Map.entry("--hash", "hash"),
+          Map.entry("--ntlm", "hash"),
+          Map.entry("-d", "domain"),
+          Map.entry("--domain", "domain"));
+
+  /** Fields partially masked (rather than shown in full) once unredacted in the command line. */
+  private static final Map<String, PrimitiveType> FIELD_KEY_TO_MASKED_TYPE =
+      Map.of(
+          "password", PrimitiveType.Password,
+          "hash", PrimitiveType.Hash);
+
+  private static final Pattern REDACTED_FLAG_PATTERN =
+      Pattern.compile("(--?[A-Za-z][A-Za-z-]*)(\\s+)(\\*+)");
+
+  private static final String PUBLISHED_TRACE_PREFIX = "the inject has been published";
+
   private static final String SHARE_TYPE = "share";
   private static final String FILE_TYPE = "file";
 
@@ -110,6 +150,8 @@ public class AttackPathGraphService {
   private final AttackPathKillChainResolver killChainResolver;
   private final ConditionRepository conditionRepository;
   private final AssetRepository assetRepository;
+  private final InjectStatusRepository injectStatusRepository;
+  private final InjectRepository injectRepository;
 
   /**
    * Above this many executions a simulation is served collapsed by default. Tied to the front
@@ -297,7 +339,87 @@ public class AttackPathGraphService {
         findings,
         securityPlatformResolver.resolve(e.getId(), e.getTenant().getId()),
         maskSecrets(e.getCommand(), secrets),
-        maskSecrets(e.getTerminalOutput(), secrets));
+        maskSecrets(e.getTerminalOutput(), secrets),
+        // A network injector (NetExec, Nmap…) never has its own `command` snapshot; reconstruct one
+        // server-side instead of leaving the client to fetch the raw inject content itself.
+        (injectId != null && e.getPayloadId() == null && (e.getCommand() == null || e.getCommand().isBlank()))
+            ? maskSecrets(injectorCommandLine(injectId), secrets)
+            : null);
+  }
+
+  /**
+   * Reconstructs a network injector's (NetExec, Nmap…) command line for display. Its own execution
+   * trace always redacts every flag value with a blanket "***" (the injector doesn't know which of
+   * its args are safe to print); this un-redacts the flags we recognize using the inject's own
+   * resolved content, applying our own partial-reveal mask (password/hash) instead of the
+   * injector's blanket one. Done entirely server-side so the raw credential value is never sent to
+   * the client, unlike reconstructing it client-side from the raw inject content.
+   *
+   * @return null when there is no matching trace or nothing to unmask
+   */
+  private String injectorCommandLine(String injectId) {
+    List<ExecutionTrace> traces =
+        injectStatusRepository
+            .findInjectStatusWithGlobalExecutionTraces(injectId)
+            .map(InjectStatus::getTraces)
+            .orElse(List.of());
+    String rawCommandLine = findCommandTraceMessage(traces);
+    if (rawCommandLine == null) {
+      return null;
+    }
+    ObjectNode injectContent = injectRepository.findById(injectId).map(Inject::getContent).orElse(null);
+    return injectContent == null ? rawCommandLine : unmaskCommandLine(rawCommandLine, injectContent);
+  }
+
+  /**
+   * The first trace is always the "published, waiting to be consumed" boilerplate; the next one is
+   * the tool invocation itself (then "executed against target…", "succeeded: …", etc.) — this
+   * ordering holds across every injector observed (NetExec, Nmap), there being no structured "this
+   * is the command" marker on a trace to key off instead.
+   */
+  private static String findCommandTraceMessage(List<ExecutionTrace> traces) {
+    if (traces.isEmpty()) {
+      return null;
+    }
+    String first = traces.get(0).getMessage();
+    boolean firstIsBoilerplate =
+        first != null && first.toLowerCase(Locale.ROOT).startsWith(PUBLISHED_TRACE_PREFIX);
+    if (!firstIsBoilerplate) {
+      return first;
+    }
+    return traces.size() > 1 ? traces.get(1).getMessage() : null;
+  }
+
+  /**
+   * Replaces each redacted "-&lt;flag&gt; ***" in the injector's own trace with the real value,
+   * partially revealed by {@link PrimitiveValueMaskingUtils} for the fields we mask, in full for
+   * every other recognized field (e.g. username). Any unrecognized flag, or a recognized flag we
+   * have no resolved value for, is left exactly as the injector logged it.
+   */
+  private static String unmaskCommandLine(String commandLine, ObjectNode injectContent) {
+    Matcher matcher = REDACTED_FLAG_PATTERN.matcher(commandLine);
+    StringBuilder result = new StringBuilder();
+    while (matcher.find()) {
+      String flag = matcher.group(1);
+      String whitespace = matcher.group(2);
+      String fieldKey = COMMAND_FLAG_TO_FIELD_KEY.get(flag);
+      JsonNode fieldValueNode = fieldKey == null ? null : injectContent.get(fieldKey);
+      String fieldValue = fieldValueNode == null ? null : fieldValueNode.asText();
+      String replacement;
+      if (fieldValue == null || fieldValue.isBlank()) {
+        replacement = matcher.group();
+      } else {
+        PrimitiveType maskedType = FIELD_KEY_TO_MASKED_TYPE.get(fieldKey);
+        String displayValue =
+            maskedType == null
+                ? fieldValue
+                : PrimitiveValueMaskingUtils.maskForDisplay(maskedType, fieldValue);
+        replacement = flag + whitespace + displayValue;
+      }
+      matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+    }
+    matcher.appendTail(result);
+    return result.toString();
   }
 
   /** The secret half of a {@code username:password} credential value (never shown in the clear). */

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -34,4 +34,8 @@ public record AttackPathExecutionDetailDTO(
     List<AttackPathSecurityPlatformDTO> securityPlatforms,
     // terminal
     String command,
-    String terminalOutput) {}
+    String terminalOutput,
+    // The reconstructed, partially-masked command line of a network injector (NetExec, Nmap…),
+    // which has no `command` snapshot of its own (see AttackPathGraphService#injectorCommandLine).
+    // Null for a Command-payload-backed execution, which already has `command`.
+    String injectorCommandLine) {}

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.IntegrationTest;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.DetectionRemediation;
+import io.openaev.database.model.ExecutionTrace;
 import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.Payload;
 import io.openaev.database.model.Step;
@@ -42,12 +45,14 @@ import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -288,5 +293,69 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
     AttackPathExecutionDetailDTO d = graphService.executionDetail(SIM, executionId);
 
     assertThat(d.detectionRemediations()).isEmpty();
+  }
+
+  // A network injector's (NetExec, Nmap…) own trace always redacts every flag with a blanket "***";
+  // injectorCommandLine() un-redacts the flags it recognizes from the inject's resolved content,
+  // partially masking password/hash rather than exposing them in full. These tests target the pure
+  // helpers directly (reflection, like InjectExecutionStepTest#getCommand) rather than seeding a full
+  // Inject/InjectStatus/ExecutionTrace tree through the ORM.
+
+  @Test
+  @DisplayName("findCommandTraceMessage skips the 'published' boilerplate trace")
+  void findCommandTraceMessageSkipsPublishedBoilerplate() {
+    ExecutionTrace published = new ExecutionTrace();
+    published.setMessage("The inject has been published, waiting to be consumed");
+    ExecutionTrace command = new ExecutionTrace();
+    command.setMessage("netexec smb 10.0.0.1 -u admin -p ***");
+
+    String result =
+        ReflectionTestUtils.invokeMethod(
+            graphService, "findCommandTraceMessage", List.of(published, command));
+
+    assertThat(result).isEqualTo("netexec smb 10.0.0.1 -u admin -p ***");
+  }
+
+  @Test
+  @DisplayName("findCommandTraceMessage returns the first trace when it is not the boilerplate")
+  void findCommandTraceMessageReturnsFirstWhenNotBoilerplate() {
+    ExecutionTrace command = new ExecutionTrace();
+    command.setMessage("nmap -p 22,80,443 10.0.0.1");
+
+    String result =
+        ReflectionTestUtils.invokeMethod(graphService, "findCommandTraceMessage", List.of(command));
+
+    assertThat(result).isEqualTo("nmap -p 22,80,443 10.0.0.1");
+  }
+
+  @Test
+  @DisplayName("unmaskCommandLine partially reveals the password and shows the username in full")
+  void unmaskCommandLineRevealsRecognizedFlags() {
+    ObjectNode content = JsonNodeFactory.instance.objectNode();
+    content.put("username", "admin");
+    content.put("password", "secret123");
+
+    String result =
+        ReflectionTestUtils.invokeMethod(
+            graphService, "unmaskCommandLine", "netexec smb 10.0.0.1 -u *** -p ***", content);
+
+    assertThat(result).isEqualTo("netexec smb 10.0.0.1 -u admin -p s*******3");
+    assertThat(result).doesNotContain("secret123");
+  }
+
+  @Test
+  @DisplayName("unmaskCommandLine leaves an unrecognized or unresolved flag exactly as redacted")
+  void unmaskCommandLineLeavesUnresolvedFlagsRedacted() {
+    ObjectNode content = JsonNodeFactory.instance.objectNode();
+    content.put("username", "admin");
+
+    String result =
+        ReflectionTestUtils.invokeMethod(
+            graphService,
+            "unmaskCommandLine",
+            "netexec smb 10.0.0.1 -u *** -p *** --unknown-flag ***",
+            content);
+
+    assertThat(result).isEqualTo("netexec smb 10.0.0.1 -u admin -p *** --unknown-flag ***");
   }
 }

--- a/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/attackpath/AttackPathExecutionDetailTest.java
@@ -298,7 +298,8 @@ class AttackPathExecutionDetailTest extends IntegrationTest {
   // A network injector's (NetExec, Nmap…) own trace always redacts every flag with a blanket "***";
   // injectorCommandLine() un-redacts the flags it recognizes from the inject's resolved content,
   // partially masking password/hash rather than exposing them in full. These tests target the pure
-  // helpers directly (reflection, like InjectExecutionStepTest#getCommand) rather than seeding a full
+  // helpers directly (reflection, like InjectExecutionStepTest#getCommand) rather than seeding a
+  // full
   // Inject/InjectStatus/ExecutionTrace tree through the ORM.
 
   @Test

--- a/openaev-front/src/actions/injects/inject-action.ts
+++ b/openaev-front/src/actions/injects/inject-action.ts
@@ -33,6 +33,11 @@ export const exportInject = (injectId: string, data: InjectIndividualExportReque
   });
 };
 
+export const getInjectSimple = (injectId: string) => {
+  const uri = `${INJECT_URI}/${injectId}`;
+  return simpleCall(uri);
+};
+
 // -- TARGETS --
 
 export const searchTargets = (injectId: string, targetType: string, searchPaginationInput: SearchPaginationInput) => {

--- a/openaev-front/src/actions/injects/inject-action.ts
+++ b/openaev-front/src/actions/injects/inject-action.ts
@@ -33,11 +33,6 @@ export const exportInject = (injectId: string, data: InjectIndividualExportReque
   });
 };
 
-export const getInjectSimple = (injectId: string) => {
-  const uri = `${INJECT_URI}/${injectId}`;
-  return simpleCall(uri);
-};
-
 // -- TARGETS --
 
 export const searchTargets = (injectId: string, targetType: string, searchPaginationInput: SearchPaginationInput) => {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { Close } from '@mui/icons-material';
-import { Box, Button, IconButton, Paper, Typography } from '@mui/material';
+import { Box, Button, IconButton, MenuItem, Pagination, Paper, Select, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import { useState } from 'react';
 
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
@@ -11,6 +12,33 @@ interface FindingGroup {
   type: string;
   values: string[];
 }
+
+const PAGE_SIZE_OPTIONS = [5, 10, 25, 50];
+const DEFAULT_PAGE_SIZE = 10;
+
+// A compact "N / page" selector next to a section title — shared by the Findings groups and the
+// Executions list so both windowed lists offer the same control.
+const PageSizeSelect = ({ value, onChange }: {
+  value: number;
+  onChange: (value: number) => void;
+}) => {
+  const { t } = useFormatter();
+  return (
+    <Select
+      size="small"
+      variant="standard"
+      value={value}
+      onChange={e => onChange(Number(e.target.value))}
+      sx={{ fontSize: 12 }}
+    >
+      {PAGE_SIZE_OPTIONS.map(size => (
+        <MenuItem key={size} value={size} sx={{ fontSize: 12 }}>
+          {t('{count} / page', { count: size })}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+};
 
 interface Props {
   endpointLabel: string;
@@ -60,6 +88,20 @@ const EndpointDetailPanel = ({
 }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
+  // One page per finding-type group (all values are already loaded — this just windows the display);
+  // the page size is shared by every group, like a single control for the whole Findings section.
+  const [groupPages, setGroupPages] = useState<Record<string, number>>({});
+  const [findingsPageSize, setFindingsPageSize] = useState(DEFAULT_PAGE_SIZE);
+  // Executions are windowed the same way. `executions` itself may still be a server-paginated subset
+  // (see totalExecutions/onShowMore below) — this only windows whatever is currently loaded.
+  const [executionsPage, setExecutionsPage] = useState(1);
+  const [executionsPageSize, setExecutionsPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const executionsPageCount = Math.max(1, Math.ceil(executions.length / executionsPageSize));
+  const currentExecutionsPage = Math.min(executionsPage, executionsPageCount);
+  const pagedExecutions = executions.slice(
+    (currentExecutionsPage - 1) * executionsPageSize,
+    currentExecutionsPage * executionsPageSize,
+  );
 
   return (
     <Paper
@@ -94,9 +136,20 @@ const EndpointDetailPanel = ({
       <div style={{ padding: theme.spacing(0, 2.5, 2) }}>
         {!hideFindings && (
           <>
-            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-              {t('Findings')}
-            </Typography>
+            <Box sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1,
+            }}
+            >
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                {t('Findings')}
+              </Typography>
+              {findingGroups.some(g => g.values.length > PAGE_SIZE_OPTIONS[0]) && (
+                <PageSizeSelect value={findingsPageSize} onChange={setFindingsPageSize} />
+              )}
+            </Box>
             {findingsLoading && (
               <Box sx={{ minHeight: 60 }}>
                 <Loader variant="inElement" size="sm" />
@@ -114,34 +167,72 @@ const EndpointDetailPanel = ({
                 {t('No findings on this endpoint')}
               </Typography>
             )}
-            {!findingsLoading && findingGroups.map(g => (
-              <Box key={g.type} sx={{ mb: 1 }}>
-                <Typography
-                  variant="caption"
-                  sx={{
-                    display: 'block',
-                    fontWeight: 600,
-                    color: 'text.secondary',
-                    textTransform: 'uppercase',
-                    letterSpacing: 0.4,
-                  }}
-                >
-                  {`${g.type} (${g.values.length})`}
-                </Typography>
-                {g.values.map((v, i) => (
-                  <Typography key={`${g.type}-${i}`} variant="body2" noWrap title={v}>
-                    {v}
+            {!findingsLoading && findingGroups.map((g) => {
+              const pageCount = Math.max(1, Math.ceil(g.values.length / findingsPageSize));
+              const page = Math.min(groupPages[g.type] ?? 1, pageCount);
+              const pageValues = g.values.slice(
+                (page - 1) * findingsPageSize,
+                page * findingsPageSize,
+              );
+              return (
+                <Box key={g.type} sx={{ mb: 1 }}>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      display: 'block',
+                      fontWeight: 700,
+                      color: 'text.primary',
+                      textTransform: 'uppercase',
+                      letterSpacing: 0.4,
+                    }}
+                  >
+                    {`${g.type} (${g.values.length})`}
                   </Typography>
-                ))}
-              </Box>
-            ))}
+                  {pageValues.map((v, i) => (
+                    <Typography key={`${g.type}-${i}`} variant="body2" noWrap title={v}>
+                      {v}
+                    </Typography>
+                  ))}
+                  {pageCount > 1 && (
+                    <Pagination
+                      size="small"
+                      count={pageCount}
+                      page={page}
+                      onChange={(_, value) => setGroupPages(prev => ({
+                        ...prev,
+                        [g.type]: value,
+                      }))}
+                      sx={{ mt: 0.5 }}
+                    />
+                  )}
+                </Box>
+              );
+            })}
           </>
         )}
 
-        <Typography variant="subtitle2" color="text.secondary" gutterBottom sx={{ mt: hideFindings ? 0 : 1 }}>
-          {`${t('Executions')} (${executions.length})`}
-        </Typography>
-        {executions.map((e) => {
+        <Box sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 1,
+          mt: hideFindings ? 0 : 1,
+        }}
+        >
+          <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+            {`${t('Executions')} (${executions.length})`}
+          </Typography>
+          {executions.length > PAGE_SIZE_OPTIONS[0] && (
+            <PageSizeSelect
+              value={executionsPageSize}
+              onChange={(value) => {
+                setExecutionsPageSize(value);
+                setExecutionsPage(1);
+              }}
+            />
+          )}
+        </Box>
+        {pagedExecutions.map((e) => {
           const status = execStatusLabel(e.status);
           const highlighted = !!e.ref && highlightedExecutionIds.has(e.ref);
           return (
@@ -201,6 +292,15 @@ const EndpointDetailPanel = ({
             </Box>
           );
         })}
+        {executionsPageCount > 1 && (
+          <Pagination
+            size="small"
+            count={executionsPageCount}
+            page={currentExecutionsPage}
+            onChange={(_, value) => setExecutionsPage(value)}
+            sx={{ mt: 0.5 }}
+          />
+        )}
         {/* The list holds one page, so reaching the rest must be an action rather than a dead caption:
             same slot, a text button that fetches the next page (See More precedent). Where the caller
             cannot fetch more (the injector panel reads a bounded set in one go), say what is not shown

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -6,7 +6,7 @@ import DOMPurify from 'dompurify';
 import { useContext, useEffect, useRef, useState } from 'react';
 
 import { searchDistinctFindingsForInjects } from '../../../../../actions/findings/finding-actions';
-import { getInjectSimple, getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
+import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
 import AttackPatternChip from '../../../../../components/AttackPatternChip';
 import Tabs from '../../../../../components/common/tabs/Tabs';
 import useTabs from '../../../../../components/common/tabs/useTabs';
@@ -311,113 +311,13 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
   return <TerminalViewTab injectId={injectId} target={target} />;
 };
 
-// Same prefix/suffix reveal rule as the backend's PrimitiveValueMaskingUtils (used for the workflow
-// Scope's own credential variables): a password shows only its first and last character, a
-// hash/key shows three on each side. Any other field is shown as-is (this is what makes the
-// username legible, with no special-casing needed).
-const maskCommandValue = (key: string, value: string): string => {
-  const normalizedKey = key.toLowerCase();
-  let prefixLength = 0;
-  let suffixLength = 0;
-  if (normalizedKey.includes('password') || normalizedKey.includes('secret')) {
-    prefixLength = 1;
-    suffixLength = 1;
-  } else if (normalizedKey === 'hash' || normalizedKey === 'key') {
-    prefixLength = 3;
-    suffixLength = 3;
-  } else {
-    return value;
-  }
-  if (value.length <= prefixLength + suffixLength) {
-    return '*'.repeat(value.length);
-  }
-  return value.slice(0, prefixLength)
-    + '*'.repeat(value.length - prefixLength - suffixLength)
-    + value.slice(value.length - suffixLength);
-};
-
 // A network injector (NetExec, Nmap…) has no single shell command on the DTO — `command` is only ever
-// resolved for Command-payload-backed injects (see InjectExecutionStep#getCommand on the backend). What
-// it actually ran is instead logged as one of its own execution traces — always fully redacted
-// ("-u *** -p ***"), since the injector doesn't know which of its args are safe to print. This
-// un-redacts it using the inject's own resolved field values (fetched separately, since the trace
-// carries no structured field data), applying our own partial-reveal rule rather than the injector's
-// blanket one.
-const COMMAND_FLAG_TO_FIELD_KEY: Record<string, string> = {
-  '-u': 'username',
-  '--user': 'username',
-  '--username': 'username',
-  '-p': 'password',
-  '--pass': 'password',
-  '--password': 'password',
-  '-H': 'hash',
-  '--hash': 'hash',
-  '--ntlm': 'hash',
-  '-d': 'domain',
-  '--domain': 'domain',
-};
-
-// The first trace is always the "published, waiting to be consumed" boilerplate; the next one is the
-// tool invocation itself (then come "executed against target…", "succeeded: …", etc.) — this ordering
-// holds across every injector observed (NetExec, Nmap), there being no structured "this is the command"
-// marker on a trace to key off instead.
-const findCommandTraceMessage = (traces: { execution_message: string }[]): string | undefined => {
-  if (traces.length === 0) {
-    return undefined;
-  }
-  return /^The inject has been published/i.test(traces[0].execution_message)
-    ? traces[1]?.execution_message
-    : traces[0].execution_message;
-};
-
-// Replaces each redacted "-<flag> ***" in the injector's own trace with the real value, partially
-// revealed by us (maskCommandValue), for every flag we recognize and have a resolved value for. Any
-// unrecognized flag/token — including a plain "***" for a field we don't know — is left exactly as the
-// injector logged it, rather than guessed at.
-const unmaskCommandLine = (commandLine: string, content: Record<string, unknown>): string => commandLine.replace(
-  /(--?[A-Za-z][A-Za-z-]*)(\s+)(\*+)/g,
-  (fullMatch, flag: string, whitespace: string) => {
-    const fieldKey = COMMAND_FLAG_TO_FIELD_KEY[flag];
-    const fieldValue = fieldKey ? content[fieldKey] : undefined;
-    if (typeof fieldValue !== 'string' || fieldValue.trim().length === 0) {
-      return fullMatch;
-    }
-    return `${flag}${whitespace}${maskCommandValue(fieldKey, fieldValue)}`;
-  },
-);
-
-const InjectorCommandParams = ({ injectId }: { injectId: string }) => {
+// resolved for Command-payload-backed injects (see InjectExecutionStep#getCommand on the backend).
+// What it actually ran is instead reconstructed and partially masked server-side (see
+// AttackPathGraphService#injectorCommandLine) from its own redacted execution trace and the inject's
+// resolved content — never sent to the client in the clear, unlike reconstructing it here would.
+const InjectorCommandLine = ({ commandLine }: { commandLine: string }) => {
   const { t } = useFormatter();
-  const [commandLine, setCommandLine] = useState<string | null | undefined>(undefined);
-  useEffect(() => {
-    let active = true;
-    setCommandLine(undefined);
-    Promise.all([
-      getInjectSimple(injectId),
-      getInjectStatusWithGlobalExecutionTraces(injectId),
-    ]).then(([injectResponse, statusResponse]: [
-      { data: { inject_content?: Record<string, unknown> } },
-      { data: InjectStatusOutput },
-    ]) => {
-      if (!active) {
-        return;
-      }
-      const content = injectResponse.data.inject_content ?? {};
-      const rawCommandLine = findCommandTraceMessage(statusResponse.data.status_main_traces ?? []);
-      setCommandLine(rawCommandLine ? unmaskCommandLine(rawCommandLine, content) : null);
-    }).catch(() => active && setCommandLine(null));
-    return () => {
-      active = false;
-    };
-  }, [injectId]);
-
-  if (commandLine === undefined) {
-    return <Loader variant="inElement" size="sm" />;
-  }
-  if (commandLine === null) {
-    return null;
-  }
-
   return (
     <Box sx={{ mb: 2 }}>
       <Typography variant="subtitle2" gutterBottom>{t('Command')}</Typography>
@@ -501,11 +401,12 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
   // is rendered live from execution traces instead (see hasSnapshot below).
   const hasSnapshot = Boolean(detail?.command || detail?.terminalOutput);
   // A network injector (NetExec, Nmap…) never has a `command` — regardless of whether its terminalOutput
-  // snapshot is populated — so its resolved parameters render as an extra block ahead of the
+  // snapshot is populated — so its reconstructed command line (server-side, see
+  // AttackPathGraphService#injectorCommandLine) renders as an extra block ahead of the
   // traces/snapshot. That extra block isn't accounted for by the snapshot Terminal's own fixed,
   // internally-scrolling height, so this case must use the outer box's scroll instead (see
   // injectorTracesView below) to avoid clipping it.
-  const showsCommandParams = !detail?.command && !!detail?.injectId && !detail?.payloadId;
+  const showsCommandParams = !!detail?.injectorCommandLine;
   // On the terminal tab a network injector shows its execution traces (a plain list that grows) and/or
   // its command params, unlike the snapshot/payload `Terminal` which is sized to fill and scrolls
   // internally. Both need the outer box to scroll, otherwise their content is clipped.
@@ -883,8 +784,8 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
                 {/* A network injector (NetExec, Nmap…) has no `command` regardless of whether its
                     terminalOutput snapshot is populated — show what was actually sent either way,
                     ahead of whichever traces/output view renders below. */}
-                {!detail.command && !!detail.injectId && !detail.payloadId && (
-                  <InjectorCommandParams injectId={detail.injectId} />
+                {detail.injectorCommandLine && (
+                  <InjectorCommandLine commandLine={detail.injectorCommandLine} />
                 )}
                 {(() => {
                   // Seeded runs show their frozen snapshot. For a real inject: a payload-backed execution

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -1,12 +1,12 @@
 import { ArrowBack, Close, OpenInNew, ShieldOutlined } from '@mui/icons-material';
-import { Button, IconButton, Paper, Typography } from '@mui/material';
+import { Box, Button, IconButton, Paper, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 // eslint-disable-next-line import/no-named-as-default
 import DOMPurify from 'dompurify';
 import { useContext, useEffect, useRef, useState } from 'react';
 
 import { searchDistinctFindingsForInjects } from '../../../../../actions/findings/finding-actions';
-import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
+import { getInjectSimple, getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
 import AttackPatternChip from '../../../../../components/AttackPatternChip';
 import Tabs from '../../../../../components/common/tabs/Tabs';
 import useTabs from '../../../../../components/common/tabs/useTabs';
@@ -311,6 +311,130 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
   return <TerminalViewTab injectId={injectId} target={target} />;
 };
 
+// Same prefix/suffix reveal rule as the backend's PrimitiveValueMaskingUtils (used for the workflow
+// Scope's own credential variables): a password shows only its first and last character, a
+// hash/key shows three on each side. Any other field is shown as-is (this is what makes the
+// username legible, with no special-casing needed).
+const maskCommandValue = (key: string, value: string): string => {
+  const normalizedKey = key.toLowerCase();
+  let prefixLength = 0;
+  let suffixLength = 0;
+  if (normalizedKey.includes('password') || normalizedKey.includes('secret')) {
+    prefixLength = 1;
+    suffixLength = 1;
+  } else if (normalizedKey === 'hash' || normalizedKey === 'key') {
+    prefixLength = 3;
+    suffixLength = 3;
+  } else {
+    return value;
+  }
+  if (value.length <= prefixLength + suffixLength) {
+    return '*'.repeat(value.length);
+  }
+  return value.slice(0, prefixLength)
+    + '*'.repeat(value.length - prefixLength - suffixLength)
+    + value.slice(value.length - suffixLength);
+};
+
+// A network injector (NetExec, Nmap…) has no single shell command on the DTO — `command` is only ever
+// resolved for Command-payload-backed injects (see InjectExecutionStep#getCommand on the backend). What
+// it actually ran is instead logged as one of its own execution traces — always fully redacted
+// ("-u *** -p ***"), since the injector doesn't know which of its args are safe to print. This
+// un-redacts it using the inject's own resolved field values (fetched separately, since the trace
+// carries no structured field data), applying our own partial-reveal rule rather than the injector's
+// blanket one.
+const COMMAND_FLAG_TO_FIELD_KEY: Record<string, string> = {
+  '-u': 'username',
+  '--user': 'username',
+  '--username': 'username',
+  '-p': 'password',
+  '--pass': 'password',
+  '--password': 'password',
+  '-H': 'hash',
+  '--hash': 'hash',
+  '--ntlm': 'hash',
+  '-d': 'domain',
+  '--domain': 'domain',
+};
+
+// The first trace is always the "published, waiting to be consumed" boilerplate; the next one is the
+// tool invocation itself (then come "executed against target…", "succeeded: …", etc.) — this ordering
+// holds across every injector observed (NetExec, Nmap), there being no structured "this is the command"
+// marker on a trace to key off instead.
+const findCommandTraceMessage = (traces: { execution_message: string }[]): string | undefined => {
+  if (traces.length === 0) {
+    return undefined;
+  }
+  return /^The inject has been published/i.test(traces[0].execution_message)
+    ? traces[1]?.execution_message
+    : traces[0].execution_message;
+};
+
+// Replaces each redacted "-<flag> ***" in the injector's own trace with the real value, partially
+// revealed by us (maskCommandValue), for every flag we recognize and have a resolved value for. Any
+// unrecognized flag/token — including a plain "***" for a field we don't know — is left exactly as the
+// injector logged it, rather than guessed at.
+const unmaskCommandLine = (commandLine: string, content: Record<string, unknown>): string => commandLine.replace(
+  /(--?[A-Za-z][A-Za-z-]*)(\s+)(\*+)/g,
+  (fullMatch, flag: string, whitespace: string) => {
+    const fieldKey = COMMAND_FLAG_TO_FIELD_KEY[flag];
+    const fieldValue = fieldKey ? content[fieldKey] : undefined;
+    if (typeof fieldValue !== 'string' || fieldValue.trim().length === 0) {
+      return fullMatch;
+    }
+    return `${flag}${whitespace}${maskCommandValue(fieldKey, fieldValue)}`;
+  },
+);
+
+const InjectorCommandParams = ({ injectId }: { injectId: string }) => {
+  const { t } = useFormatter();
+  const [commandLine, setCommandLine] = useState<string | null | undefined>(undefined);
+  useEffect(() => {
+    let active = true;
+    setCommandLine(undefined);
+    Promise.all([
+      getInjectSimple(injectId),
+      getInjectStatusWithGlobalExecutionTraces(injectId),
+    ]).then(([injectResponse, statusResponse]: [
+      { data: { inject_content?: Record<string, unknown> } },
+      { data: InjectStatusOutput },
+    ]) => {
+      if (!active) {
+        return;
+      }
+      const content = injectResponse.data.inject_content ?? {};
+      const rawCommandLine = findCommandTraceMessage(statusResponse.data.status_main_traces ?? []);
+      setCommandLine(rawCommandLine ? unmaskCommandLine(rawCommandLine, content) : null);
+    }).catch(() => active && setCommandLine(null));
+    return () => {
+      active = false;
+    };
+  }, [injectId]);
+
+  if (commandLine === undefined) {
+    return <Loader variant="inElement" size="sm" />;
+  }
+  if (commandLine === null) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="subtitle2" gutterBottom>{t('Command')}</Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          fontFamily: 'monospace',
+          wordBreak: 'break-all',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {commandLine}
+      </Typography>
+    </Box>
+  );
+};
+
 // Terminal for a network injector's execution (NetExec, Nmap…): these have no per-agent terminal, so the
 // per-target `TerminalViewTab` above shows nothing. Instead render the inject's global execution traces —
 // the very same "Traces" the inject execution-details page shows (the "<tool> succeeded: …" output).
@@ -376,10 +500,16 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
   // Seeded runs carry a frozen command/output snapshot on the DTO; a real inject leaves them empty and
   // is rendered live from execution traces instead (see hasSnapshot below).
   const hasSnapshot = Boolean(detail?.command || detail?.terminalOutput);
-  // On the terminal tab a network injector shows its execution traces (a plain list that grows), unlike
-  // the snapshot/payload `Terminal` which is sized to fill and scrolls internally. The list needs the
-  // outer box to scroll, otherwise long traces are clipped.
-  const injectorTracesView = !hasSnapshot && !!detail?.injectId && !detail?.payloadId;
+  // A network injector (NetExec, Nmap…) never has a `command` — regardless of whether its terminalOutput
+  // snapshot is populated — so its resolved parameters render as an extra block ahead of the
+  // traces/snapshot. That extra block isn't accounted for by the snapshot Terminal's own fixed,
+  // internally-scrolling height, so this case must use the outer box's scroll instead (see
+  // injectorTracesView below) to avoid clipping it.
+  const showsCommandParams = !detail?.command && !!detail?.injectId && !detail?.payloadId;
+  // On the terminal tab a network injector shows its execution traces (a plain list that grows) and/or
+  // its command params, unlike the snapshot/payload `Terminal` which is sized to fill and scrolls
+  // internally. Both need the outer box to scroll, otherwise their content is clipped.
+  const injectorTracesView = (!hasSnapshot || showsCommandParams) && !!detail?.injectId && !detail?.payloadId;
   const terminalLines: TerminalLine[] = [];
   if (detail?.command) {
     terminalLines.push({
@@ -748,17 +878,27 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
               </div>
             )}
 
-            {currentTab === TERMINAL_TAB && (() => {
-              // Seeded runs show their frozen snapshot. For a real inject: a payload-backed execution runs
-              // on an agent and has a per-target terminal (keep it); a network injector (NetExec, Nmap…)
-              // has none, so show its global execution traces instead.
-              if (hasSnapshot || !detail.injectId) {
-                return <Terminal lines={terminalLines} maxHeight={terminalMaxHeight} />;
-              }
-              return detail.payloadId
-                ? <LiveExecutionTerminal injectId={detail.injectId} endpointName={endpointLabel || detail.targetHostname || detail.endpointKey} />
-                : <InjectorExecutionTraces injectId={detail.injectId} />;
-            })()}
+            {currentTab === TERMINAL_TAB && (
+              <>
+                {/* A network injector (NetExec, Nmap…) has no `command` regardless of whether its
+                    terminalOutput snapshot is populated — show what was actually sent either way,
+                    ahead of whichever traces/output view renders below. */}
+                {!detail.command && !!detail.injectId && !detail.payloadId && (
+                  <InjectorCommandParams injectId={detail.injectId} />
+                )}
+                {(() => {
+                  // Seeded runs show their frozen snapshot. For a real inject: a payload-backed execution
+                  // runs on an agent and has a per-target terminal (keep it); a network injector has none,
+                  // so show its global execution traces instead.
+                  if (hasSnapshot || !detail.injectId) {
+                    return <Terminal lines={terminalLines} maxHeight={terminalMaxHeight} />;
+                  }
+                  return detail.payloadId
+                    ? <LiveExecutionTerminal injectId={detail.injectId} endpointName={endpointLabel || detail.targetHostname || detail.endpointKey} />
+                    : <InjectorExecutionTraces injectId={detail.injectId} />;
+                })()}
+              </>
+            )}
 
             {currentTab === FINDINGS_TAB && detail.injectId && (
               <FindingList

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -184,6 +184,7 @@ const toPlatformRows = (
           id: a.id ?? `${bucket}-alert-${index}-${i}`,
           title: a.title ?? 'Alert',
           date: a.date,
+          link: a.link,
         })),
       };
     });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExpectationPlatformsTable.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExpectationPlatformsTable.tsx
@@ -1,4 +1,5 @@
-import { Popover, Typography } from '@mui/material';
+import { OpenInNew } from '@mui/icons-material';
+import { Box, Popover, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { type ReactNode, useState } from 'react';
 
@@ -10,6 +11,7 @@ export interface ExpectationPlatformAlert {
   id: string;
   title: string;
   date?: string | null;
+  link?: string | null;
 }
 
 export interface ExpectationPlatformRow {
@@ -48,7 +50,20 @@ const ExpectationPlatformsTable = ({ rows }: Props) => {
   } as const;
 
   return (
-    <div style={{ overflowX: 'auto' }}>
+    <Box
+      sx={{
+        'overflowX': 'auto',
+        'scrollbarWidth': 'thin',
+        // Webkit/Chromium hide overlay scrollbars until the user scrolls this exact element, which on a
+        // narrow drawer (the "Detection time"/"Alerts" columns routinely overflow) leaves no visual hint
+        // the row is scrollable at all. Force the thumb to always render, matching IconBar's pattern.
+        '&::-webkit-scrollbar': { height: 8 },
+        '&::-webkit-scrollbar-thumb': {
+          backgroundColor: theme.palette.action.focus,
+          borderRadius: 1,
+        },
+      }}
+    >
       <div style={{ minWidth: ROW_MIN_WIDTH }}>
         <div
           style={{
@@ -178,22 +193,48 @@ const ExpectationPlatformsTable = ({ rows }: Props) => {
             {`${t('Alerts')} (${popover?.row.alerts.length ?? 0})`}
           </Typography>
           {(popover?.row.alerts ?? []).map(alert => (
-            <div
+            <Box
               key={alert.id}
-              style={{
+              {...(alert.link
+                ? {
+                    component: 'a',
+                    href: alert.link,
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                  }
+                : {})}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing(1),
                 padding: '4px 0',
                 borderBottom: `1px solid ${theme.palette.divider}`,
+                textDecoration: 'none',
+                color: 'inherit',
+                ...(alert.link && {
+                  'cursor': 'pointer',
+                  '&:hover': { color: 'primary.main' },
+                }),
               }}
             >
-              <Typography variant="body2">{alert.title}</Typography>
-              {alert.date && (
-                <Typography variant="caption" color="text.secondary">{fldt(alert.date)}</Typography>
+              <div style={{ flex: 1 }}>
+                <Typography variant="body2">{alert.title}</Typography>
+                {alert.date && (
+                  <Typography variant="caption" color="text.secondary">{fldt(alert.date)}</Typography>
+                )}
+              </div>
+              {alert.link && (
+                <OpenInNew sx={{
+                  fontSize: 15,
+                  flexShrink: 0,
+                }}
+                />
               )}
-            </div>
+            </Box>
           ))}
         </div>
       </Popover>
-    </div>
+    </Box>
   );
 };
 

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1025,6 +1025,7 @@ export interface AttackPathExecutionDetailDTO {
   executedAt?: string;
   findings?: AttackPathExecutionFindingItemDTO[];
   injectId?: string;
+  injectorCommandLine?: string;
   payloadId?: string;
   payloadName?: string;
   preventionStatus?: string;

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -12,6 +12,7 @@
   ".": ".",
   "(last 180 days)": "(last 180 days)",
   "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Lessons learned questionnaire",
+  "{count} / page": "{count} / page",
   "{count} action(s) added successfully.": "{count} action(s) added successfully.",
   "{count} actions available": "{count} actions available",
   "{count} actions selected": "{count} actions selected",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -12,6 +12,7 @@
   ".": ".",
   "(last 180 days)": "(180 derniers jours)",
   "[{exerciseName}] Lessons learned questionnaire": "[{exerciseName}] Questionnaire de retour d'expérience",
+  "{count} / page": "{count} / page",
   "{count} action(s) added successfully.": "{count} action(s) ajoutée(s) avec succès.",
   "{count} actions available": "{count} actions disponibles",
   "{count} actions selected": "{count} actions sélectionnées",


### PR DESCRIPTION
## What

- The security-platform expectation table (Prevention/Detection/Vulnerability) had a horizontal scroll container with no visible scrollbar, leaving the "Detection time"/"Alerts" columns unreachable on Chromium/WebKit at the drawer's default width. The scrollbar thumb now always renders.
- Each alert's `link` field (already resolved by `AttackPathSecurityPlatformResolver`, but dropped in the frontend mapping) is now threaded through to the alerts popover, rendered as a real clickable link.
- The Terminal view had no visibility into what a network injector (NetExec, Nmap…) actually sent — it has no `command` on the DTO (only resolved for Command-payload-backed injects). It's now reconstructed from the injector's own execution trace (always redacted with `***`) by un-redacting the recognized flags using the inject's resolved field values, applying our own partial-reveal masking (password/hash) instead of a blanket `***`.
- The endpoint/injector panel's Findings groups and Executions list now have numbered pagination with a page-size selector (5/10/25/50, default 10), replacing the unbounded/fixed-5-per-page display.

## Test plan

- [ ] Open an execution's Terminal view for a network-injector action (e.g. NetExec SMB) and confirm the "Command" block shows the reconstructed line with the username visible and the password partially masked.
- [ ] Open an execution's Result tab, confirm the platform table's scrollbar is visible and the Alerts column is reachable; click an alert count and confirm a link opens.
- [ ] Open an endpoint/injector panel with many findings/executions and confirm pagination + page-size selector work.