### PR TITLE
fix(chaining): snapshot asset/asset-group name onto scope rules (#7164)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/WorkflowConfigurationMapper.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/WorkflowConfigurationMapper.java
@@ -46,6 +46,7 @@ public class WorkflowConfigurationMapper {
         .selectedMode(rule.getSelectedMode())
         .ruleSource(rule.getRuleSource())
         .ruleValue(rule.getRuleValue())
+        .ruleValueLabel(rule.getRuleValueLabel())
         .build();
   }
 

--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowScopeRuleOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowScopeRuleOutput.java
@@ -27,4 +27,10 @@ public class WorkflowScopeRuleOutput {
   @Schema(description = "Selected item value")
   @JsonProperty("workflow_scope_rule_value")
   private String ruleValue;
+
+  @Schema(
+      description =
+          "Display name of the referenced asset/asset group, snapshotted when the rule was created/updated. Null for non-asset sources or if the label could not be resolved.")
+  @JsonProperty("workflow_scope_rule_value_label")
+  private String ruleValueLabel;
 }

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260804230000000__Add_workflow_scope_rule_value_label.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260804230000000__Add_workflow_scope_rule_value_label.java
@@ -1,0 +1,56 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds a snapshot label column to workflow scope rules so an asset/asset group's display name is
+ * preserved even after the referenced asset/asset group is later deleted.
+ *
+ * <p>Backfills existing ASSET/ASSET_GROUP rules from the currently live asset/asset group names
+ * where still resolvable; rules whose referenced asset has already been deleted keep a {@code NULL}
+ * label (name unrecoverable), and the frontend falls back to a generic placeholder for those.
+ *
+ * <p>The backfill resolves the owning tenant through the rule's workflow (a workflow belongs to
+ * either a simulation or a scenario, both tenant-scoped) and only copies a name when the referenced
+ * asset/asset group lives in that same tenant: assets are tenant-scoped, and raw SQL bypasses the
+ * Hibernate tenant filter, so an unconstrained id join could copy (and later expose through the
+ * API) another tenant's asset name if a rule ever referenced a foreign id.
+ */
+@Component
+public class V6_20260804230000000__Add_workflow_scope_rule_value_label extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.addBatch(
+          "ALTER TABLE workflow_scope_rules ADD COLUMN IF NOT EXISTS workflow_scope_rule_value_label varchar(255);");
+
+      statement.addBatch(
+          "UPDATE workflow_scope_rules r SET workflow_scope_rule_value_label = a.asset_name "
+              + "FROM workflows w "
+              + "LEFT JOIN exercises e ON e.exercise_id = w.workflow_simulation_id "
+              + "LEFT JOIN scenarios s ON s.scenario_id = w.workflow_scenario_id "
+              + "JOIN assets a ON a.tenant_id = COALESCE(e.tenant_id, s.tenant_id) "
+              + "WHERE r.workflow_id = w.workflow_id "
+              + "  AND r.workflow_scope_rule_source = 'ASSET' "
+              + "  AND r.workflow_scope_rule_value = a.asset_id "
+              + "  AND r.workflow_scope_rule_value_label IS NULL;");
+
+      statement.addBatch(
+          "UPDATE workflow_scope_rules r SET workflow_scope_rule_value_label = g.asset_group_name "
+              + "FROM workflows w "
+              + "LEFT JOIN exercises e ON e.exercise_id = w.workflow_simulation_id "
+              + "LEFT JOIN scenarios s ON s.scenario_id = w.workflow_scenario_id "
+              + "JOIN asset_groups g ON g.tenant_id = COALESCE(e.tenant_id, s.tenant_id) "
+              + "WHERE r.workflow_id = w.workflow_id "
+              + "  AND r.workflow_scope_rule_source = 'ASSET_GROUP' "
+              + "  AND r.workflow_scope_rule_value = g.asset_group_id "
+              + "  AND r.workflow_scope_rule_value_label IS NULL;");
+
+      statement.executeBatch();
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -4,7 +4,10 @@ import com.google.gson.Gson;
 import io.openaev.api.chaining.dto.ScopeVariableInput;
 import io.openaev.api.chaining.dto.WorkflowConfigurationInput;
 import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
+import io.openaev.database.repository.AssetGroupRepository;
+import io.openaev.database.repository.AssetRepository;
 import io.openaev.database.repository.ScopeVariableRepository;
 import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
@@ -45,6 +48,8 @@ public class WorkflowService {
   private final WorkflowRepository workflowRepository;
   private final WorkflowScopeRuleRepository workflowScopeRuleRepository;
   private final ScopeVariableRepository scopeVariableRepository;
+  private final AssetRepository assetRepository;
+  private final AssetGroupRepository assetGroupRepository;
 
   private final ScopeMetricCollector scopeMetricCollector;
   private final ChainingSafetyPolicyMetricCollector chainingSafetyPolicyMetricCollector;
@@ -715,6 +720,7 @@ public class WorkflowService {
     existing.setRuleSource(input.getRuleSource());
     existing.setRuleValue(input.getRuleValue());
     existing.setValueType(detectValueType(input));
+    existing.setRuleValueLabel(resolveValueLabel(input));
   }
 
   private WorkflowScopeRule buildScopeRule(WorkflowScopeRuleInput input, Workflow workflow) {
@@ -722,9 +728,41 @@ public class WorkflowService {
         .selectedMode(input.getSelectedMode())
         .ruleSource(input.getRuleSource())
         .ruleValue(input.getRuleValue())
+        .ruleValueLabel(resolveValueLabel(input))
         .valueType(detectValueType(input))
         .workflow(workflow)
         .build();
+  }
+
+  /**
+   * Resolves the current display name of an ASSET/ASSET_GROUP rule's referenced entity, so it can
+   * be snapshotted onto the rule. Returns {@code null} for non-asset sources, or if the referenced
+   * asset/asset group can no longer be found (e.g. already deleted) — the frontend then falls back
+   * to a generic placeholder rather than showing a raw ID.
+   *
+   * <p>The lookup is explicitly constrained to the caller's tenant: Hibernate's {@code
+   * tenantFilter} does not apply to primary-key loads, so a plain {@code findById} on a
+   * user-supplied id could snapshot (and later expose) another tenant's asset name. This runs on
+   * the request thread ({@code WorkflowApi}), where {@code TenantInterceptor} has set the tenant.
+   */
+  private String resolveValueLabel(WorkflowScopeRuleInput input) {
+    if (input.getRuleSource() == null || input.getRuleValue() == null) {
+      return null;
+    }
+    String tenantId = TenantContext.getCurrentTenant();
+    return switch (input.getRuleSource()) {
+      case ASSET ->
+          assetRepository
+              .findByIdAndTenantId(input.getRuleValue(), tenantId)
+              .map(Asset::getName)
+              .orElse(null);
+      case ASSET_GROUP ->
+          assetGroupRepository
+              .findByIdAndTenantId(input.getRuleValue(), tenantId)
+              .map(AssetGroup::getName)
+              .orElse(null);
+      default -> null;
+    };
   }
 
   private ScopeRuleValueType detectValueType(WorkflowScopeRuleInput input) {

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -8,7 +8,10 @@ import com.google.gson.JsonObject;
 import io.openaev.api.chaining.dto.ScopeVariableInput;
 import io.openaev.api.chaining.dto.WorkflowConfigurationInput;
 import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
+import io.openaev.database.repository.AssetGroupRepository;
+import io.openaev.database.repository.AssetRepository;
 import io.openaev.database.repository.ScopeVariableRepository;
 import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
@@ -42,6 +45,8 @@ class WorkflowServiceTest {
   @Mock private WorkflowRepository workflowRepository;
   @Mock private WorkflowScopeRuleRepository workflowScopeRuleRepository;
   @Mock private ScopeVariableRepository scopeVariableRepository;
+  @Mock private AssetRepository assetRepository;
+  @Mock private AssetGroupRepository assetGroupRepository;
   @Mock private PreviewFeatureService previewFeatureService;
   @Mock private StepService stepService;
   @Mock private StepDelayQueueService stepDelayQueueService;
@@ -786,6 +791,136 @@ class WorkflowServiceTest {
               .orElseThrow();
       assertEquals(ScopeRuleValueType.ASSET_GROUP_ID, mappedAssetGroupRule.getValueType());
     }
+
+    @Test
+    @DisplayName("should snapshot tenant-scoped asset/asset-group names as rule value labels")
+    void shouldSnapshotRuleValueLabelsTenantScoped() {
+      String tenantId = UUID.randomUUID().toString();
+      TenantContext.setCurrentTenant(tenantId);
+      try {
+        String workflowId = UUID.randomUUID().toString();
+        Workflow workflow =
+            Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+
+        WorkflowConfigurationInput input = new WorkflowConfigurationInput();
+        input.setWorkflowScopeRules(WorkflowFixture.getDefaultWorkflowScopeRuleInputList());
+
+        Asset asset = new Asset();
+        asset.setName("Endpoint A");
+        AssetGroup assetGroup = new AssetGroup();
+        assetGroup.setName("Group A");
+        // The lookup must be constrained to the caller's tenant: findById would bypass the
+        // Hibernate tenant filter (never applied to primary-key loads).
+        when(assetRepository.findByIdAndTenantId("asset-123", tenantId))
+            .thenReturn(Optional.of(asset));
+        when(assetGroupRepository.findByIdAndTenantId("asset-group-1", tenantId))
+            .thenReturn(Optional.of(assetGroup));
+
+        when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
+            .thenReturn(Optional.of(workflow));
+        when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+
+        Workflow result = workflowService.updateWorkflowConfiguration(workflowId, input);
+
+        WorkflowScopeRule assetRule =
+            result.getWorkflowScopeRules().stream()
+                .filter(r -> "asset-123".equals(r.getRuleValue()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Endpoint A", assetRule.getRuleValueLabel());
+
+        WorkflowScopeRule assetGroupRule =
+            result.getWorkflowScopeRules().stream()
+                .filter(r -> "asset-group-1".equals(r.getRuleValue()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("Group A", assetGroupRule.getRuleValueLabel());
+
+        // Non-asset sources never get a label
+        WorkflowScopeRule manualRule =
+            result.getWorkflowScopeRules().stream()
+                .filter(r -> "10.10.10.10".equals(r.getRuleValue()))
+                .findFirst()
+                .orElseThrow();
+        assertNull(manualRule.getRuleValueLabel());
+      } finally {
+        TenantContext.clearCurrentTenant();
+      }
+    }
+
+    @Test
+    @DisplayName("should refresh the snapshotted label when an existing rule is updated")
+    void shouldRefreshLabelOnRuleUpdate() {
+      String workflowId = UUID.randomUUID().toString();
+      Workflow workflow =
+          Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+
+      WorkflowScopeRule existingRule =
+          WorkflowScopeRule.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-old")
+              .ruleValueLabel("Old name")
+              .valueType(ScopeRuleValueType.ASSET_ID)
+              .workflow(workflow)
+              .build();
+      String ruleId = UUID.randomUUID().toString();
+      org.springframework.test.util.ReflectionTestUtils.setField(existingRule, "id", ruleId);
+      workflow.getWorkflowScopeRules().add(existingRule);
+
+      WorkflowScopeRuleInput ruleInput =
+          WorkflowScopeRuleInput.builder()
+              .id(ruleId)
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-new")
+              .build();
+      WorkflowConfigurationInput input = new WorkflowConfigurationInput();
+      input.setWorkflowScopeRules(List.of(ruleInput));
+
+      Asset asset = new Asset();
+      asset.setName("New name");
+      when(assetRepository.findByIdAndTenantId(eq("asset-new"), anyString()))
+          .thenReturn(Optional.of(asset));
+      when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
+          .thenReturn(Optional.of(workflow));
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+
+      Workflow result = workflowService.updateWorkflowConfiguration(workflowId, input);
+
+      assertEquals(1, result.getWorkflowScopeRules().size());
+      WorkflowScopeRule updated = result.getWorkflowScopeRules().getFirst();
+      assertSame(existingRule, updated);
+      assertEquals("New name", updated.getRuleValueLabel());
+    }
+
+    @Test
+    @DisplayName("should leave the label null when the referenced asset is not in the tenant")
+    void shouldLeaveLabelNullWhenAssetUnresolvable() {
+      String workflowId = UUID.randomUUID().toString();
+      Workflow workflow =
+          Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+
+      WorkflowScopeRuleInput ruleInput =
+          WorkflowScopeRuleInput.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-of-another-tenant")
+              .build();
+      WorkflowConfigurationInput input = new WorkflowConfigurationInput();
+      input.setWorkflowScopeRules(List.of(ruleInput));
+
+      when(assetRepository.findByIdAndTenantId(eq("asset-of-another-tenant"), anyString()))
+          .thenReturn(Optional.empty());
+      when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
+          .thenReturn(Optional.of(workflow));
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+
+      Workflow result = workflowService.updateWorkflowConfiguration(workflowId, input);
+
+      assertEquals(1, result.getWorkflowScopeRules().size());
+      assertNull(result.getWorkflowScopeRules().getFirst().getRuleValueLabel());
+    }
   }
 
   @Nested
@@ -969,6 +1104,8 @@ class WorkflowServiceTest {
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
+              assetRepository,
+              assetGroupRepository,
               scopeMetricCollector,
               chainingSafetyPolicyMetricCollector,
               resultsMetricCollector);
@@ -1246,6 +1383,8 @@ class WorkflowServiceTest {
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
+              assetRepository,
+              assetGroupRepository,
               scopeMetricCollector,
               chainingSafetyPolicyMetricCollector,
               resultsMetricCollector);
@@ -1427,6 +1566,8 @@ class WorkflowServiceTest {
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
+              assetRepository,
+              assetGroupRepository,
               scopeMetricCollector,
               chainingSafetyPolicyMetricCollector,
               resultsMetricCollector);

--- a/openaev-front/src/admin/components/chaining/ScopeRules.tsx
+++ b/openaev-front/src/admin/components/chaining/ScopeRules.tsx
@@ -191,19 +191,21 @@ const ScopeRules = ({ workflowConfiguration, onUpdate, readOnly = false }: Scope
 
   const resolveLabel = (rule: WorkflowScopeRuleOutput): string => {
     const value = rule.workflow_scope_rule_value ?? '';
-    const unresolvedLabel = t('Loading...');
+    const snapshotLabel = rule.workflow_scope_rule_value_label;
 
     switch (rule.workflow_scope_rule_source) {
       case 'ASSET': {
         const endpoint = endpointsMap[value];
-        return endpoint?.asset_name ?? unresolvedLabel;
+        // Prefer the live asset name (keeps up with renames); fall back to the name
+        // snapshotted on the rule, which stays available even after the asset is deleted.
+        return endpoint?.asset_name ?? snapshotLabel ?? t('Deleted asset');
       }
       case 'ASSET_GROUP': {
         const group = assetGroupsMap[value];
-        return group?.asset_group_name ?? unresolvedLabel;
+        return group?.asset_group_name ?? snapshotLabel ?? t('Deleted asset group');
       }
       default:
-        return value || unresolvedLabel;
+        return value || t('Loading...');
     }
   };
 

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -11551,6 +11551,8 @@ export interface WorkflowScopeRuleOutput {
   workflow_scope_rule_source?: "ASSET" | "ASSET_GROUP" | "MANUAL" | "CSV";
   /** Selected item value */
   workflow_scope_rule_value?: string;
+  /** Display name of the referenced asset/asset group, snapshotted when the rule was created/updated. Null for non-asset sources or if the label could not be resolved. */
+  workflow_scope_rule_value_label?: string;
 }
 
 export interface XtmComposerInstanceOutput {

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "Löschen von Tenant",
   "DELETE_THREAT_ARSENALS": "Bedrohungsarsenal löschen",
   "Deleted": "Gelöscht",
+  "Deleted asset": "Gelöschtes Asset",
+  "Deleted asset group": "Gelöschte Asset-Gruppe",
   "Deleting actions": "Aktionen werden gelöscht",
   "Deleting asset groups": "Anlagengruppen werden gelöscht",
   "Deleting assets": "Assets werden gelöscht",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -876,6 +876,8 @@
   "DELETE_TENANTS": "Delete tenants",
   "DELETE_THREAT_ARSENALS": "Delete threat arsenal",
   "Deleted": "Deleted",
+  "Deleted asset": "Deleted asset",
+  "Deleted asset group": "Deleted asset group",
   "Deleting actions": "Deleting actions",
   "Deleting asset groups": "Deleting asset groups",
   "Deleting assets": "Deleting assets",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "Borrar tenants",
   "DELETE_THREAT_ARSENALS": "Borrar arsenal de amenazas",
   "Deleted": "Borrado",
+  "Deleted asset": "Activo eliminado",
+  "Deleted asset group": "Grupo de activos eliminado",
   "Deleting actions": "Eliminando acciones",
   "Deleting asset groups": "Eliminando grupos de activos",
   "Deleting assets": "Eliminando activos",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -876,6 +876,8 @@
   "DELETE_TENANTS": "Supprimer les tenants",
   "DELETE_THREAT_ARSENALS": "Supprimer les actions de l'arsenal",
   "Deleted": "Supprimé",
+  "Deleted asset": "Actif supprimé",
+  "Deleted asset group": "Groupe d'actifs supprimé",
   "Deleting actions": "Suppression des actions",
   "Deleting asset groups": "Suppression des groupes d'actifs",
   "Deleting assets": "Suppression des actifs",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "Eliminare gli tenant",
   "DELETE_THREAT_ARSENALS": "Cancellare l'arsenale delle minacce",
   "Deleted": "Eliminato",
+  "Deleted asset": "Asset eliminato",
+  "Deleted asset group": "Gruppo di asset eliminato",
   "Deleting actions": "Eliminazione delle azioni",
   "Deleting asset groups": "Eliminazione dei gruppi di attività",
   "Deleting assets": "Eliminazione delle attività",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "Tenantの削除",
   "DELETE_THREAT_ARSENALS": "脅威兵器庫の削除",
   "Deleted": "削除",
+  "Deleted asset": "削除されたアセット",
+  "Deleted asset group": "削除されたアセットグループ",
   "Deleting actions": "アクションを削除中",
   "Deleting asset groups": "アセットグループを削除中",
   "Deleting assets": "アセットを削除中",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "Tenant 삭제",
   "DELETE_THREAT_ARSENALS": "위협 무기고 삭제",
   "Deleted": "삭제됨",
+  "Deleted asset": "삭제된 자산",
+  "Deleted asset group": "삭제된 자산 그룹",
   "Deleting actions": "액션 삭제 중",
   "Deleting asset groups": "자산 그룹 삭제 중",
   "Deleting assets": "자산 삭제 중",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "Удалить tenant",
   "DELETE_THREAT_ARSENALS": "Удалить арсенал угроз",
   "Deleted": "Удалено",
+  "Deleted asset": "Удалённый актив",
+  "Deleted asset group": "Удалённая группа активов",
   "Deleting actions": "Удаление действий",
   "Deleting asset groups": "Удаление групп активов",
   "Deleting assets": "Удаление активов",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -875,6 +875,8 @@
   "DELETE_TENANTS": "删除Tenant",
   "DELETE_THREAT_ARSENALS": "删除威胁库",
   "Deleted": "已删除",
+  "Deleted asset": "已删除的资产",
+  "Deleted asset group": "已删除的资产组",
   "Deleting actions": "正在删除动作",
   "Deleting asset groups": "正在删除资产组",
   "Deleting assets": "正在删除资产",

--- a/openaev-model/src/main/java/io/openaev/database/model/WorkflowScopeRule.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/WorkflowScopeRule.java
@@ -49,6 +49,15 @@ public class WorkflowScopeRule implements Base {
   @JsonProperty("workflow_scope_rule_value")
   private String ruleValue;
 
+  /**
+   * Display name of the referenced asset/asset group, snapshotted at the time the rule was
+   * created/updated. Kept so the UI can still show a meaningful label if the referenced asset/asset
+   * group is later deleted. Null for non-asset rule sources (MANUAL, CSV).
+   */
+  @Column(name = "workflow_scope_rule_value_label")
+  @JsonProperty("workflow_scope_rule_value_label")
+  private String ruleValueLabel;
+
   @Column(name = "workflow_scope_rule_value_type")
   @Enumerated(EnumType.STRING)
   @JdbcTypeCode(SqlTypes.NAMED_ENUM)
@@ -75,6 +84,7 @@ public class WorkflowScopeRule implements Base {
         .selectedMode(source.getSelectedMode())
         .ruleSource(source.getRuleSource())
         .ruleValue(source.getRuleValue())
+        .ruleValueLabel(source.getRuleValueLabel())
         .valueType(source.getValueType())
         .workflow(target)
         .build();

--- a/openaev-model/src/main/java/io/openaev/database/repository/AssetRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/AssetRepository.java
@@ -3,8 +3,10 @@ package io.openaev.database.repository;
 import io.openaev.database.model.Asset;
 import io.openaev.database.model.AssetType;
 import io.openaev.database.raw.RawIndexedAsset;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -16,6 +18,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AssetRepository
     extends CrudRepository<Asset, String>, JpaSpecificationExecutor<Asset> {
+
+  /**
+   * Tenant-scoped primary-key lookup. Hibernate's {@code tenantFilter} does not apply to {@code
+   * findById} (filters never apply to primary-key loads), so callers resolving an id received from
+   * user input must use this method to avoid reading another tenant's asset.
+   */
+  Optional<Asset> findByIdAndTenantId(@NotNull String id, @NotNull String tenantId);
 
   /**
    * Feeds the {@code asset} search index with the whole asset inventory: every asset type except


### PR DESCRIPTION
## Problem

When an asset or asset group referenced by a scope rule was deleted, the scope rule allow/deny list in **past simulations** permanently showed a "Loading..." placeholder instead of the asset's name - even though the simulation's scope rule (referencing the asset/group ID) was correctly preserved as an immutable per-run snapshot at the database level.

## Root cause

The scope rule's *display name* was never persisted anywhere. The frontend always resolved it by looking up the referenced asset/group ID against the **live**, current asset list (`ScopeRules.tsx`'s `resolveLabel()`). Once the asset was deleted, that lookup returned nothing and the UI fell back to a hardcoded "Loading..." label forever - misleadingly implying data loss, when in fact the scope rule reference itself was intact.

## Fix

- Added a nullable `workflow_scope_rule_value_label` column to `workflow_scope_rules` (Flyway migration), snapshotting the asset/asset-group **name** at the time the rule is created or updated (`WorkflowService`).
- The name is resolved through a **tenant-scoped lookup** (`findByIdAndTenantId` + `TenantContext`): Hibernate's tenant filter does not apply to primary-key loads, so a plain `findById` on a user-supplied id could snapshot (and later expose) another tenant's asset name. Ids that do not resolve within the caller's tenant stay unresolved (`null` label).
- The migration backfills the label for existing rules, joining through the rule's workflow to its simulation/scenario **tenant** so labels are only copied from assets of the owning tenant. The migration is numbered `V6_20260804230000000` so it sorts after the latest migration on `main` (out-of-order execution is disabled by default, an older version would be skipped on already-upgraded environments).
- Propagated the label through the entity (`WorkflowScopeRule`), DTO (`WorkflowScopeRuleOutput`), and mapper (`WorkflowConfigurationMapper`) so it's returned by the API and correctly copied over when a RUN workflow snapshots its scope rules from the TEMPLATE (`WorkflowScopeRule.copyOf()`).
- Frontend (`ScopeRules.tsx`) now: (1) prefers the live asset name (keeps up with renames, unchanged behaviour), (2) falls back to the snapshotted label when the asset has been deleted, (3) shows a generic "Deleted asset" / "Deleted asset group" message - never the raw ID - if neither is available (pre-migration rows whose asset was already deleted). The two translation keys are added to all 9 locale files.

## Tests

- `WorkflowServiceTest` covers the tenant-scoped label snapshot on rule creation (asset, asset group, and `null` for MANUAL rules), the label refresh on rule update, and the unresolvable-id (cross-tenant or deleted) case.

Fixes OpenAEV-Platform/filigran-private#252
