### PR TITLE
fix(attack-path): stop a steady-state delta tick from wiping the live top-bar counters (#7165)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-delta-store.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-delta-store.test.ts
@@ -212,6 +212,28 @@ describe('attack-path delta store', () => {
       expect(twice.store).toBe(once.store);
     });
 
+    it('given_aSteadyStateDeltaCarryingAnExplicitNullCounters_should_keepThePreviousCounters', () => {
+      // Arrange: the backend ships a steady-state tick as an explicit JSON null (not an omitted
+      // field) meaning "nothing changed, keep what you have" — never a real reset to empty.
+      const store = fromSnapshot(snapshotV1, 1);
+      // The generated type says `counters?: AttackPathCounters` (omitted, never null) — the cast
+      // below reflects what the wire actually carries for this tick (verified against a live backend).
+      const steadyStateDelta: AttackPathDeltaDTO = {
+        ...aDelta({
+          sinceVersion: 1,
+          newVersion: 1,
+        }),
+        counters: null as unknown as AttackPathDeltaDTO['counters'],
+      };
+
+      // Act
+      const { store: next, changed } = applyDelta(store, steadyStateDelta);
+
+      // Assert: the counters a real snapshot/delta populated must survive a null tick untouched.
+      expect(changed).toBe(false);
+      expect(next.counters).toEqual(snapshotV1.counters);
+    });
+
     it('given_aDelta_should_keepTheIdentityOfUntouchedEntries', () => {
       // Arrange
       const store = fromSnapshot(snapshotV1, 1);

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-delta-store.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-delta-store.ts
@@ -349,7 +349,9 @@ export const applyDelta = (
     noteFindingType(f);
   });
 
-  const countersChanged = delta.counters !== undefined && !sameValue(store.counters, delta.counters);
+  // `null` (a steady-state tick, "keep what you have") arrives as an explicit JSON null, not an
+  // omitted field — `!== undefined` alone lets it through and wipes the last good counters.
+  const countersChanged = delta.counters != null && !sameValue(store.counters, delta.counters);
   if (!touched && !countersChanged) {
     return unchangedResult(store, version);
   }


### PR DESCRIPTION
## What

The backend ships a steady-state delta ("nothing changed since your last poll") with an explicit JSON `"counters": null`, not an omitted field — it's how it says "keep what you have" without paying two aggregate queries to recompute the same numbers (verified directly against a live backend: `{"sinceVersion":77,"newVersion":77,...,"counters":null}`).

The store's merge checked `delta.counters !== undefined`, which is also true for `null`, so the very first steady-state tick after any real update overwrote the last good counters with `null` — and it stayed `null` forever after (a null tick then compares equal to a null store, so it's never reconsidered). Discovered assets / Shares / Files / Credentials / Users / CVEs would all disappear from the attack-path top bar within ~3s of loading a live simulation, fixed only by a full page reload (which re-seeds from a fresh snapshot).

Switched the check to `!= null`, which treats `null` and `undefined` the same way. Added a regression test (`given_aSteadyStateDeltaCarryingAnExplicitNullCounters_should_keepThePreviousCounters`) that fails against the old check and passes against the fix — verified both ways.

## Test plan

- [x] Unit test added and verified to fail without the fix, pass with it.
- [ ] Open a live/ongoing simulation's attack-path graph, wait >5s, confirm the Discovered assets/Shares/Files/etc. cards stay populated instead of disappearing.