### PR TITLE
fix(chaining): fix action output as "finding" on attack path map (#5048)

### DIFF
--- a/adr/ADR-004-attack-path-sourced-from-chaining-parsed-outputs.md
+++ b/adr/ADR-004-attack-path-sourced-from-chaining-parsed-outputs.md
@@ -1,0 +1,179 @@
+# ADR-004: Source the attack path from the chaining parsed outputs
+
+## 1. Context
+
+The attack-path map visualizes what a chained simulation did: which executions ran, what
+they produced, and how one action fed the next. Today the snapshot backing this view is
+populated from `Finding` entities: on every execution event,
+`AttackPathFindingIngestionService.copyFindings` reads the inject's findings and copies them
+into `attackpath_finding` / `attackpath_execution_finding`.
+
+The chaining engine, however, does not orchestrate on findings. `WorkflowStateService`
+advances steps from the parsed outputs (`IngestionResult.parsedByType()`), persisted in
+`WorkflowState`, and never consults `Finding`. Findings are a side effect of the outputs,
+produced for the product's finding list.
+
+A capability lets an output element be marked `contract_output_element_is_finding = false`:
+it still participates in the chaining (it can trigger events consumed by later steps) but is
+intentionally not persisted as a `Finding`, to avoid polluting the finding list (gated by
+`InjectorExecutionProcessingHandler.shouldDispatch`). Because the attack path reads findings,
+these output-only values never appear on the map, even though they drive the chain — so a
+causal edge can reference data that is never rendered.
+
+## 2. Decision drivers
+
+- Fidelity to the chaining model (the map must reflect what the engine actually did).
+- No regression on existing findings (values, delta/versioning, masking, tenant isolation).
+- Effort and risk (avoid re-implementing output parsing/extraction).
+- Single source of truth (avoid two divergent extraction paths for the same outputs).
+
+## 3. Considered options
+
+### Option A: Hybrid — keep findings, add a second pass for `is_finding=false`
+
+Leave the finding-based copy untouched and add a parallel extraction of the output-only
+elements, writing them with an `is_finding=false` flag.
+
+**Pros**: smallest diff; the working finding path is untouched.
+**Cons**: the map stays a derived projection of a side effect; two code paths for the same
+data; the model still does not match the engine.
+
+### Option B: Output-based snapshot — feed the attack path from the parsed outputs
+
+Replace the finding read in the copy with consumption of the parsed outputs (the same data
+the engine uses), attributed to the frozen `AttackPathExecution` rows, with an `is_finding`
+flag distinguishing a real finding from an output-only node. All parsed output values are
+snapshotted; the flag drives the node's type/UI, not its visibility.
+
+**Pros**: the snapshot reflects the engine's source of truth; output-only values appear
+natively; a single extraction path; no re-parsing (the parsed output, its type mapping and
+its field key are already available at the copy call site).
+**Cons**: rewrites a currently working path; endpoint attribution must move from
+`finding.getAssets()` to the execution rows.
+
+### Option C: Full re-parse of the raw structured output
+
+Re-implement parsing, value extraction and type mapping inside the attack-path ingestion.
+
+Dropped: high effort and high risk of divergence from the engine, for no benefit over
+Option B which reuses the already-parsed outputs.
+
+## 4. Decision
+
+We chose a **hybrid of Option A and Option B**: the existing finding-based copy is kept
+unchanged for real findings (`is_finding=true`), and a new output-based pass adds the
+output-only values (`is_finding=false`). Pure Option B (sourcing *every* row from the parsed
+outputs) was rejected during implementation because a real finding carries precise per-value
+asset attribution (`finding.getAssets()`) that the parsed outputs cannot reproduce — moving
+findings onto execution-row attribution would regress multi-endpoint finding placement. The
+hybrid reaches the goal (all outputs on the map, correctly flagged) with zero regression on
+findings.
+
+Concretely:
+- The finding-based copy (`AttackPathFindingIngestionService.copyFindings`) is unchanged and
+  keeps writing `is_finding=true` rows with their asset-precise attribution.
+- A new `copyOutputs` pass consumes the run's parsed outputs — the execution traces available
+  in `InjectExecutionStep`'s status-update method (`extractDataFromParsed` +
+  `collectOutputElements`), passed into the ingestion — for the contract output elements
+  flagged `contract_output_element_is_finding = false`, and writes `is_finding=false` rows.
+  The persisted `WorkflowState` is NOT used by this feature; it only proves the parsed
+  outputs exist durably. As a prerequisite, `buildTypeMappingsFromInject` now uses the
+  non-filtered accessor (`InjectorContractContentUtils.getAllContractOutputs(outputParsers,
+  false)`) so non-finding outputs are type-mapped and propagate in the chaining state.
+- Each parsed output maps to the `attackpath_finding` shape `(type, field, value,
+  endpointKey)`: `field` is the output element key (the same key `FindingUtils` writes for a
+  real finding), `type` is the contract output type label, `value` is the value. One row is
+  written per value.
+- Output-only values are attributed to endpoints via the frozen `AttackPathExecution` rows
+  (`targetKey` / `targetAssetId`), using the single-endpoint fallback (skip when the step
+  targets several endpoints), since an output value carries no per-value asset.
+- Each `attackpath_finding` row carries an `is_finding` flag taken from the contract output
+  element's `contract_output_element_is_finding`. The flag drives the node's type and UI (an
+  "Output only" node, finding drawer in degraded mode), not whether it is shown — all parsed
+  output values are rendered.
+- The node + link writes (`attackpath_finding` + `attackpath_execution_finding`), the
+  deterministic id `AttackPathIds.findingRow(...)`, the `bump` / `publishChanged` versioning
+  and the secret masking are preserved unchanged.
+
+### Implementation notes
+
+- **`is_finding` origin**: read from the contract output element's
+  `contract_output_element_is_finding` flag (not inferred from the presence of a `Finding`),
+  so it is independent of finding-persistence timing.
+- **Endpoint attribution**: reuse today's `resolveTargets` fallback — attach to the step's
+  endpoint only when the step has a single endpoint, otherwise skip (no per-value signal to
+  pick one target among several).
+- **Discovered (non-asset) targets**: attribute the value to `endpointKey = targetKey`
+  (the raw target), as raw findings already do.
+- **No conflicting `is_finding` on the same id**: the id
+  `AttackPathIds.findingRow(simulationId, type, field, value, endpointKey)` does NOT include
+  `is_finding`. There is still no ambiguous upsert because `is_finding` is a property of the
+  contract output element and `field` is that element's key (`FindingUtils.createFinding`
+  sets `finding.field = element.key()`), so `is_finding` is a function of `field`. Since
+  `field` is part of the id, any two rows sharing an id share the same `field` and therefore
+  the same `is_finding`. As a defensive measure for the unlikely cross-contract case (the same
+  key declared with a different flag in another contract), the `ON CONFLICT` sets a
+  deterministic value (`is_finding = true` wins, never downgrading a real finding).
+- **No type reconciliation shortcut**: `is_finding` is orthogonal to type — an output-only
+  value can be of any type, including composite ones. The existing type reconciliation /
+  sub-field extraction (`AttackPathKeyMatcher`) MUST therefore be applied to BOTH
+  `is_finding=true` and `is_finding=false` rows.
+- **Secret masking**: applied to all rows regardless of `is_finding` (keyed by the linked
+  credential), preserving the current behavior — including composite types.
+- **Source & signature**: outputs come from the run's execution traces in
+  `InjectExecutionStep`; `copyFindings` gains the parsed output as an argument. Only
+  type-mapped outputs are snapshotted (a `NOT_CHAINABLE` / untyped output cannot form a
+  `(type, field)` row and is skipped). The output-copy currently snapshots **primitive**
+  parsed values only: a composite/tuple value (a JSON object, e.g. a `PORTSCAN` pair) has no
+  single display value and is skipped by `recordAttackPathOutputs` rather than serialized.
+- **Bounded id (conditional value hashing)**: ADR-004 lets arbitrarily long parsed outputs reach
+  `attackpath_finding` (unlike short `Finding` values), and a raw long value made the id overflow
+  its `varchar(255)` primary key (`PSQLException: value too long for type character varying(255)`).
+  `AttackPathIds.findingRow(...)` keeps the legacy raw encoding whenever it fits the column — so
+  every row copied before this change still resolves to its exact pre-upgrade id and a re-copy
+  upserts onto it instead of duplicating it — and only when the raw encoding would overflow does it
+  switch to a variant that hashes the whole `value` with SHA-256 (`CryptoHelper.hashWithSHA256`,
+  never truncated), under the distinct `FINDING_ROW_H` kind prefix so the raw and hashed namespaces
+  can never collide (no pre-existing row can carry an overflowing raw id). The same value always
+  yields the same id, preserving the idempotent upsert; the real value is kept untouched in
+  `attackpath_finding_value` (`text`) for display.
+- **Uniqueness on the primary key (no separate natural-key index)**: because the id is a
+  deterministic, injective encoding of the full natural key (`simulationId, type, field, value,
+  endpointKey`, hashing the value only on overflow as above), the same finding always resolves to
+  the same id, so the **primary key alone enforces natural-key uniqueness**. The copy therefore
+  upserts via `ON CONFLICT (attackpath_finding_id)`, and the previous partial unique index
+  `uq_ap_find_natural_key` is dropped. This also removes a latent failure: that index keyed on the
+  raw `value` (`text`), which for a long output could exceed the Postgres btree tuple limit (~2704
+  bytes) and fail the INSERT on the index. No value hash is stored or recomputed in SQL; the
+  `value` column stays `text` and un-indexed for display.
+
+## 5. Consequences
+
+### Positive
+
+- The map reflects the chaining engine's actual source of truth.
+- Output-only values (`is_finding=false`) appear on the map without special-casing.
+- One extraction path; the product finding list and the attack path cannot silently diverge.
+
+### Negative / trade-offs
+
+- A currently working path is rewritten; needs careful non-regression coverage on
+  `is_finding=true` findings.
+- Endpoint attribution logic moves to the execution rows and must be validated for the
+  single-endpoint fallback and discovered (non-asset) targets.
+- Long parsed outputs forced one schema-safety change vs short findings: the row id hashes the
+  value (only when the raw encoding would overflow) so the `varchar(255)` PK stays bounded while
+  pre-existing rows keep their legacy id. Since the id already encodes the full natural key, the
+  redundant natural-key unique index (which keyed on the raw `value`, itself a btree-overflow
+  risk) was dropped and the copy upserts on the PK. The stored `value` stays `text` for display and
+  is never indexed.
+
+### Neutral
+
+- Read contracts, counters and delta/versioning semantics are unchanged.
+- Forward-only: past simulations are not backfilled.
+
+
+
+
+

--- a/adr/ADR-004-attack-path-sourced-from-chaining-parsed-outputs.md
+++ b/adr/ADR-004-attack-path-sourced-from-chaining-parsed-outputs.md
@@ -133,10 +133,12 @@ Concretely:
   every row copied before this change still resolves to its exact pre-upgrade id and a re-copy
   upserts onto it instead of duplicating it — and only when the raw encoding would overflow does it
   switch to a variant that hashes the whole `value` with SHA-256 (`CryptoHelper.hashWithSHA256`,
-  never truncated), under the distinct `FINDING_ROW_H` kind prefix so the raw and hashed namespaces
-  can never collide (no pre-existing row can carry an overflowing raw id). The same value always
-  yields the same id, preserving the idempotent upsert; the real value is kept untouched in
-  `attackpath_finding_value` (`text`) for display.
+  never truncated), under the distinct `FINDING_ROW_H` kind prefix. If that variant still
+  overflows (the excess length comes from another component, e.g. a very long endpoint key), the
+  last resort hashes the whole raw id under the fixed-size `FINDING_ROW_F` kind. The three kind
+  prefixes are distinct, so the namespaces can never collide (and no pre-existing row can carry an
+  overflowing raw id). The same natural key always yields the same id, preserving the idempotent
+  upsert; the real value is kept untouched in `attackpath_finding_value` (`text`) for display.
 - **Uniqueness on the primary key (no separate natural-key index)**: because the id is a
   deterministic, injective encoding of the full natural key (`simulationId, type, field, value,
   endpointKey`, hashing the value only on overflow as above), the same finding always resolves to

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -286,6 +286,86 @@ public class InjectExecutionStep implements ActionStep {
     }
   }
 
+  /**
+   * Copies the run's output-only values (contract outputs flagged {@code
+   * contract_output_element_is_finding = false}) onto the attack-path snapshot, so the map shows
+   * every output the chaining used, not only the ones persisted as findings (ADR-004). Flag-gated
+   * and non-fatal, mirroring {@link #recordAttackPathFindings}.
+   */
+  private void recordAttackPathOutputs(
+      Step stepRun, Inject inject, List<Map<String, JsonElement>> output) {
+    if (!previewFeatureService.isFeatureEnabled(PreviewFeature.ATTACK_PATH)) {
+      return;
+    }
+    try {
+      JsonObject parsed = extractDataFromParsed(output);
+      if (parsed.size() == 0) {
+        return;
+      }
+      Map<String, io.openaev.database.model.ContractOutputType> typeByKey = new HashMap<>();
+      Map<String, Boolean> isFindingByKey = new HashMap<>();
+      collectOutputElements(inject, typeByKey, isFindingByKey);
+
+      List<AttackPathFindingIngestionService.OutputValue> values = new ArrayList<>();
+      for (String key : parsed.keySet()) {
+        Boolean isFinding = isFindingByKey.get(key);
+        io.openaev.database.model.ContractOutputType type = typeByKey.get(key);
+        // Only output-only (is_finding=false), typed outputs form a row; findings are handled by
+        // the finding copy, untyped outputs cannot form a (type, field) row.
+        if (isFinding == null || isFinding || type == null) {
+          continue;
+        }
+        JsonElement valuesNode = parsed.get(key);
+        if (valuesNode == null || !valuesNode.isJsonArray()) {
+          continue;
+        }
+        for (JsonElement value : valuesNode.getAsJsonArray()) {
+          if (value == null || value.isJsonNull() || !value.isJsonPrimitive()) {
+            continue;
+          }
+          values.add(
+              new AttackPathFindingIngestionService.OutputValue(
+                  type.getLabel(), key, value.getAsString()));
+        }
+      }
+      if (!values.isEmpty()) {
+        attackPathFindingIngestion.copyOutputs(inject, stepRun, values);
+      }
+    } catch (Exception e) {
+      log.warn("Attack-path outputs copy skipped for inject {} (non-fatal)", inject.getId(), e);
+    }
+  }
+
+  /**
+   * Collects the inject's contract output elements, indexing their contract output type and their
+   * {@code is_finding} flag by output key. Mirrors {@link #buildTypeMappingsFromInject}: the
+   * payload path uses the non-filtered accessor (so non-finding outputs are included), the
+   * injector-contract path uses {@code isFindingCompatible} as the flag.
+   */
+  private void collectOutputElements(
+      Inject inject,
+      Map<String, io.openaev.database.model.ContractOutputType> typeByKey,
+      Map<String, Boolean> isFindingByKey) {
+    if (inject.getPayload().isPresent()) {
+      Set<OutputParser> outputParsers = structuredOutputUtils.extractOutputParsers(inject);
+      injectorContractContentUtils
+          .getAllContractOutputs(outputParsers, false)
+          .forEach(
+              out -> {
+                typeByKey.put(out.getKey(), out.getType());
+                isFindingByKey.put(out.getKey(), out.isFinding());
+              });
+    } else if (inject.getInjectorContract().isPresent()) {
+      injectorContractContentUtils
+          .getAllContractOutputs(inject.getInjectorContract().get())
+          .forEach(
+              out -> {
+                typeByKey.put(out.getField(), out.getType());
+                isFindingByKey.put(out.getField(), out.isFindingCompatible());
+              });
+    }
+  }
+
   /** Loads the concrete payload subtype (Command, Executable, etc.) into the injector contract. */
   private void prepareGetStatusPayloadFromInject(InjectorContract injectorContract) {
     if (injectorContract.getPayload() == null) {
@@ -360,6 +440,8 @@ public class InjectExecutionStep implements ActionStep {
       stepRun.setOutput(jsonObject.toString());
       // PROPAGATE state changes into engine if parsed output is present
       processOutputAndStateSync(stepRun, output, inject);
+      // COPY output-only values (is_finding=false) onto the attack-path snapshot
+      recordAttackPathOutputs(stepRun, inject, output);
 
       return Optional.of(stepRun);
     }

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260803000000000__Add_attackpath_finding_is_finding.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260803000000000__Add_attackpath_finding_is_finding.java
@@ -1,0 +1,25 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds {@code attackpath_finding_is_finding} so the attack-path snapshot can distinguish a real
+ * finding ({@code true}) from an output-only value ({@code false}) produced by the chaining but not
+ * persisted as a {@link io.openaev.database.model.Finding} (ADR-004). Defaults to {@code true} so
+ * pre-existing and seed rows keep their current meaning. Additive and idempotent.
+ */
+@Component
+public class V6_20260803000000000__Add_attackpath_finding_is_finding extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "ALTER TABLE attackpath_finding ADD COLUMN IF NOT EXISTS"
+              + " attackpath_finding_is_finding BOOLEAN NOT NULL DEFAULT true;");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260804093000000__Drop_attackpath_finding_natural_key_index.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260804093000000__Drop_attackpath_finding_natural_key_index.java
@@ -1,0 +1,34 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Drops the natural-key unique index {@code uq_ap_find_natural_key} on {@code attackpath_finding}.
+ *
+ * <p>It is redundant: the primary key {@code attackpath_finding_id} is a deterministic, injective
+ * encoding of the same natural key ({@code simulationId, type, field, value, endpointKey}, see
+ * {@code AttackPathIds.findingRow}; the value is hashed only when its raw encoding would overflow
+ * the column, so pre-existing rows keep their legacy id), so the same finding always resolves to
+ * the same id and the PK alone enforces natural-key uniqueness. The findings copy now upserts via
+ * {@code ON CONFLICT (attackpath_finding_id)}.
+ *
+ * <p>Dropping it also removes a latent failure: that index keyed on the raw {@code value} ({@code
+ * text}), which for a long parsed output (ADR-004) could exceed the Postgres btree tuple limit
+ * (~2704 bytes) and fail the INSERT on the index. The PK stays bounded because a long value is
+ * hashed inside the id; the {@code value} column stays {@code text} (un-indexed) for display.
+ * Idempotent.
+ */
+@Component
+public class V6_20260804093000000__Drop_attackpath_finding_natural_key_index
+    extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute("DROP INDEX IF EXISTS uq_ap_find_natural_key;");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -583,8 +583,13 @@ public class AttackPathGraphService {
       String typeNodeId = AttackPathIds.findingTypeNode(f.type(), endpointKey);
       typeNodes.computeIfAbsent(typeNodeId, id -> findingTypeNode(id, f.type(), assetNodeId));
       String findingNodeId = AttackPathIds.findingNode(f.type(), f.value());
-      findingNodes.computeIfAbsent(
-          findingNodeId, id -> findingNode(id, f.type(), f.value(), typeNodeId, assetNodeId));
+      AttackPathNodeDTO findingDrawerNode =
+          findingNodes.computeIfAbsent(
+              findingNodeId, id -> findingNode(id, f.type(), f.value(), typeNodeId, assetNodeId));
+      // A real finding among the (type, value) producers wins over an output-only one (ADR-004).
+      if (f.isFinding()) {
+        findingDrawerNode.setIsFinding(true);
+      }
       producersByFinding
           .computeIfAbsent(findingNodeId, id -> new ArrayList<>())
           .add(
@@ -721,6 +726,11 @@ public class AttackPathGraphService {
               findingNodeId, id -> findingNode(id, f.type(), f.value(), typeNodeId, assetNodeId));
       if (seenFindingNodes.add(findingNodeId)) {
         staticFindings.add(findingNode);
+      }
+      // A node dedups (type, value) across endpoints and both flags: a real finding among its
+      // producers wins over an output-only one (ADR-004).
+      if (f.isFinding()) {
+        findingNode.setIsFinding(true);
       }
 
       // Accumulate each producing execution's verdict for the cross-endpoint worst-of on the node.
@@ -1466,6 +1476,8 @@ public class AttackPathGraphService {
     node.setTypeFindings(type);
     node.setFindingsTypeNodeId(typeNodeId);
     node.setAssetNodeId(assetNodeId);
+    // Default to output-only; a real finding among the node's producers flips it to true (OR).
+    node.setIsFinding(false);
     return node;
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
@@ -1,5 +1,7 @@
 package io.openaev.service.attackpath;
 
+import static io.openaev.helper.CryptoHelper.hashWithSHA256;
+
 /**
  * Deterministic, collision-safe IDs for the attack-path graph (issue 6647). Every node and edge
  * carries a stable string ID built from its columns, so the same inputs always produce the same ID
@@ -14,6 +16,13 @@ package io.openaev.service.attackpath;
 public final class AttackPathIds {
 
   private static final char DELIMITER = '|';
+
+  /**
+   * Capacity of the {@code attackpath_finding_id} column ({@code varchar(255)}): a raw {@code
+   * FINDING_ROW} id at most this long keeps its legacy (un-hashed) form, so ids computed before the
+   * value hashing was introduced stay stable across upgrades.
+   */
+  private static final int FINDING_ROW_ID_MAX_LENGTH = 255;
 
   /**
    * Prefix of a synthetic seed simulation id ({@code AttackPathSeedService} builds ids as {@code
@@ -89,10 +98,30 @@ public final class AttackPathIds {
    * simulationId}, {@code type}, {@code field}, {@code value}, {@code endpointKey}). Deterministic,
    * so re-copying the same finding lands on the same row; the simulation is part of the id, so the
    * same finding in two runs never collides.
+   *
+   * <p>ADR-004 lets arbitrarily long parsed outputs reach {@code attackpath_finding} (unlike short
+   * {@link io.openaev.database.model.Finding} values), and a raw long value overflowed the {@code
+   * varchar(255)} primary key. When the raw encoding fits the column, it is kept as-is - so every
+   * row copied before the hashing was introduced still resolves to its legacy id, and a re-copy
+   * upserts onto the existing row instead of duplicating it. Only when the raw encoding would
+   * overflow does the id switch to a variant that hashes the whole {@code value} with SHA-256
+   * (never truncated), under the distinct {@code FINDING_ROW_H} kind so the two namespaces can
+   * never collide (no pre-existing row can carry an overflowing raw id). The real value is kept
+   * untouched in {@code attackpath_finding_value} ({@code text}) for display.
    */
   public static String findingRow(
       String simulationId, String type, String field, String value, String endpointKey) {
-    return encode("FINDING_ROW", simulationId, type, field, value, endpointKey);
+    String rawId = encode("FINDING_ROW", simulationId, type, field, value, endpointKey);
+    if (rawId.length() <= FINDING_ROW_ID_MAX_LENGTH) {
+      return rawId;
+    }
+    return encode(
+        "FINDING_ROW_H",
+        simulationId,
+        type,
+        field,
+        value == null ? null : hashWithSHA256(value),
+        endpointKey);
   }
 
   /** {@code EDGE_ENDPOINT_FINDINGS_TYPE}: an endpoint to one of its finding-type nodes. */

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathIds.java
@@ -105,9 +105,13 @@ public final class AttackPathIds {
    * row copied before the hashing was introduced still resolves to its legacy id, and a re-copy
    * upserts onto the existing row instead of duplicating it. Only when the raw encoding would
    * overflow does the id switch to a variant that hashes the whole {@code value} with SHA-256
-   * (never truncated), under the distinct {@code FINDING_ROW_H} kind so the two namespaces can
-   * never collide (no pre-existing row can carry an overflowing raw id). The real value is kept
-   * untouched in {@code attackpath_finding_value} ({@code text}) for display.
+   * (never truncated), under the distinct {@code FINDING_ROW_H} kind. If that variant still
+   * overflows (the excess length comes from another component, e.g. a very long {@code
+   * endpointKey}), the last resort hashes the whole raw id under the {@code FINDING_ROW_F} kind,
+   * whose length is a constant 78 chars. The three kinds are distinct, so the namespaces can never
+   * collide (and no pre-existing row can carry an overflowing raw id: those inserts failed). Every
+   * variant is a deterministic, collision-free function of the same natural key; the real value is
+   * kept untouched in {@code attackpath_finding_value} ({@code text}) for display.
    */
   public static String findingRow(
       String simulationId, String type, String field, String value, String endpointKey) {
@@ -115,13 +119,20 @@ public final class AttackPathIds {
     if (rawId.length() <= FINDING_ROW_ID_MAX_LENGTH) {
       return rawId;
     }
-    return encode(
-        "FINDING_ROW_H",
-        simulationId,
-        type,
-        field,
-        value == null ? null : hashWithSHA256(value),
-        endpointKey);
+    String hashedValueId =
+        encode(
+            "FINDING_ROW_H",
+            simulationId,
+            type,
+            field,
+            value == null ? null : hashWithSHA256(value),
+            endpointKey);
+    if (hashedValueId.length() <= FINDING_ROW_ID_MAX_LENGTH) {
+      return hashedValueId;
+    }
+    // The overflow comes from another component: hashing the full raw id (already an injective
+    // encoding of the natural key) yields a fixed-size id that can never overflow.
+    return encode("FINDING_ROW_F", hashWithSHA256(rawId));
   }
 
   /** {@code EDGE_ENDPOINT_FINDINGS_TYPE}: an endpoint to one of its finding-type nodes. */

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
@@ -80,4 +80,8 @@ public class AttackPathNodeDTO {
   // FINDING only: the per-finding verdict triple, worst-of aggregated across the producing
   // executions. Null on every other node type (omitted from the JSON).
   private AttackPathFindingVerdictsDTO verdicts;
+  // FINDING only: false when the node is an output-only value (a chaining output not persisted as a
+  // Finding, ADR-004), true for a real finding. Drives the "Output only" rendering and the degraded
+  // drawer. Null on every other node type (omitted from the JSON).
+  private Boolean isFinding;
 }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathFindingIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathFindingIngestionService.java
@@ -53,6 +53,88 @@ public class AttackPathFindingIngestionService {
         () -> copy(inject.getId(), step.getId(), simulationId, tenantId));
   }
 
+  /**
+   * One output-only value produced by the chaining and NOT persisted as a {@link Finding} ({@code
+   * contract_output_element_is_finding = false}, ADR-004). {@code type} is the contract output type
+   * label, {@code field} the output element key (never blank, so the row carries the full natural
+   * key its deterministic id is derived from).
+   */
+  public record OutputValue(String type, String field, String value) {}
+
+  /**
+   * Copies the run's output-only values onto the attack-path snapshot with {@code is_finding =
+   * false}, so the map shows every output the chaining used, not only the ones persisted as
+   * findings. Same tenant-scoped REQUIRES_NEW boundary, versioning and idempotent writes as {@link
+   * #copyFindings}; a failure here is non-fatal to the run.
+   */
+  public void copyOutputs(Inject inject, Step step, List<OutputValue> outputs) {
+    if (inject.getExercise() == null || outputs.isEmpty()) {
+      return;
+    }
+    String simulationId = inject.getExercise().getId();
+    String tenantId = inject.getTenant().getId();
+    tenantTx.executeNew(
+        TxCtx.forTenant(tenantId),
+        () -> copyOutputsTx(step.getId(), simulationId, tenantId, outputs));
+  }
+
+  private void copyOutputsTx(
+      String stepId, String simulationId, String tenantId, List<OutputValue> outputs) {
+    List<AttackPathExecution> rows = executionRepository.findByStepIdAndTenantId(stepId, tenantId);
+    if (rows.isEmpty()) {
+      return; // no frozen endpoint to attribute an output to yet
+    }
+    // An output value carries no per-value asset, so attribute it only when the step targets a
+    // single endpoint - otherwise there is no signal to pick the right one (as the finding copy's
+    // no-match fallback does).
+    long distinctEndpoints =
+        rows.stream().map(AttackPathExecution::getTargetKey).distinct().count();
+    if (distinctEndpoints != 1) {
+      return;
+    }
+
+    List<FindingRow> findingRows = new ArrayList<>();
+    List<Link> links = new ArrayList<>();
+    Set<String> seenRows = new HashSet<>();
+    Set<String> seenLinks = new HashSet<>();
+
+    for (OutputValue out : outputs) {
+      for (AttackPathExecution row : rows) {
+        String endpointKey = row.getTargetKey();
+        String endpointId = row.getTargetAssetId();
+        String endpointRaw = endpointId != null ? null : endpointKey;
+        String id =
+            AttackPathIds.findingRow(
+                simulationId, out.type(), out.field(), out.value(), endpointKey);
+        if (seenRows.add(id)) {
+          findingRows.add(
+              new FindingRow(
+                  id,
+                  tenantId,
+                  simulationId,
+                  out.type(),
+                  out.field(),
+                  out.value(),
+                  endpointId,
+                  endpointRaw,
+                  endpointKey,
+                  false));
+        }
+        if (seenLinks.add(row.getId() + '\u0000' + id)) {
+          links.add(new Link(row.getId(), id));
+        }
+      }
+    }
+
+    if (findingRows.isEmpty() && links.isEmpty()) {
+      return;
+    }
+    long version = versionService.bump(simulationId, tenantId);
+    findingWriter.insertFindings(findingRows, version);
+    findingWriter.insertLinks(links);
+    versionService.publishChanged(simulationId, tenantId, version);
+  }
+
   private void copy(String injectId, String stepId, String simulationId, String tenantId) {
     List<AttackPathExecution> rows = executionRepository.findByStepIdAndTenantId(stepId, tenantId);
     if (rows.isEmpty()) {
@@ -97,7 +179,8 @@ public class AttackPathFindingIngestionService {
                   value,
                   endpointId,
                   endpointRaw,
-                  endpointKey));
+                  endpointKey,
+                  true));
         }
         if (seenLinks.add(row.getId() + '\u0000' + id)) {
           links.add(new Link(row.getId(), id));

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathFindingWriter.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathFindingWriter.java
@@ -34,10 +34,17 @@ public class AttackPathFindingWriter {
   private final JdbcTemplate jdbcTemplate;
 
   /**
-   * One snapshot finding row to copy. {@code field} must be non-null: the partial unique index that
-   * makes the copy idempotent only covers rows that have one, so a null field would escape the
-   * dedup and could duplicate. A copied finding always carries one ({@code Finding.field} is
-   * {@code @NotBlank}). {@code endpointId} may be null (a discovered target has no asset id).
+   * One snapshot finding row to copy. {@code field} must be non-null: a copied finding always
+   * carries one ({@code Finding.field} is {@code @NotBlank}). {@code endpointId} may be null (a
+   * discovered target has no asset id).
+   *
+   * <p>The row {@code id} is a deterministic, injective encoding of the full natural key ({@code
+   * simulationId, type, field, value, endpointKey}, see {@code AttackPathIds.findingRow}), so the
+   * primary key alone enforces natural-key uniqueness: the same finding always resolves to the same
+   * id. A short value keeps the legacy raw encoding (stable across upgrades); only a value whose
+   * raw encoding would overflow the {@code varchar(255)} primary key is hashed inside the id
+   * (ADR-004 lets arbitrarily long parsed outputs reach this table); {@code value} stays {@code
+   * text} for display and is never indexed.
    */
   public record FindingRow(
       String id,
@@ -48,7 +55,8 @@ public class AttackPathFindingWriter {
       String value,
       String endpointId,
       String endpointRaw,
-      String endpointKey) {}
+      String endpointKey,
+      boolean isFinding) {}
 
   /** One (execution, finding) link. */
   public record Link(String executionId, String findingId) {}
@@ -68,10 +76,12 @@ public class AttackPathFindingWriter {
    * otherwise identical row costs one redundant upsert in a client's next delta, which is
    * idempotent.
    *
-   * <p>One constraint the caller must keep: a batch must not carry the same natural key twice,
-   * since {@code DO UPDATE} cannot touch a row twice in one statement (the previous {@code DO
-   * NOTHING} tolerated it). The ingestion dedupes on the row id, which is derived from that very
-   * natural key.
+   * <p>Conflict is resolved on the primary key {@code attackpath_finding_id}, which is a
+   * deterministic, injective encoding of the natural key (hashing the value only when its raw
+   * encoding would overflow the column), so a re-copied finding always collides with itself,
+   * including rows written before the hashing existed. A batch must not carry the same id twice,
+   * since {@code DO UPDATE} cannot touch a row twice in one statement; the ingestion dedupes on the
+   * row id before calling this.
    */
   public void insertFindings(List<FindingRow> rows, long rowVersion) {
     for (int from = 0; from < rows.size(); from += CHUNK) {
@@ -81,15 +91,15 @@ public class AttackPathFindingWriter {
               + " attackpath_finding_simulation_id, attackpath_finding_type,"
               + " attackpath_finding_field, attackpath_finding_value, attackpath_finding_endpoint_id,"
               + " attackpath_finding_endpoint_raw, attackpath_finding_endpoint_key,"
-              + " attackpath_finding_row_version) VALUES "
+              + " attackpath_finding_is_finding, attackpath_finding_row_version) VALUES "
               + String.join(
-                  ", ", Collections.nCopies(chunk.size(), "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))
-              + " ON CONFLICT (attackpath_finding_simulation_id, attackpath_finding_type,"
-              + " attackpath_finding_field, attackpath_finding_value,"
-              + " attackpath_finding_endpoint_key) WHERE attackpath_finding_field IS NOT NULL"
+                  ", ", Collections.nCopies(chunk.size(), "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))
+              + " ON CONFLICT (attackpath_finding_id)"
               + " DO UPDATE SET attackpath_finding_row_version ="
-              + " EXCLUDED.attackpath_finding_row_version";
-      List<Object> args = new ArrayList<>(chunk.size() * 10);
+              + " EXCLUDED.attackpath_finding_row_version,"
+              + " attackpath_finding_is_finding = attackpath_finding.attackpath_finding_is_finding"
+              + " OR EXCLUDED.attackpath_finding_is_finding";
+      List<Object> args = new ArrayList<>(chunk.size() * 11);
       for (FindingRow r : chunk) {
         args.add(r.id());
         args.add(r.tenantId());
@@ -100,6 +110,7 @@ public class AttackPathFindingWriter {
         args.add(r.endpointId());
         args.add(r.endpointRaw());
         args.add(r.endpointKey());
+        args.add(r.isFinding());
         args.add(rowVersion);
       }
       jdbcTemplate.update(sql, args.toArray());

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
@@ -668,6 +668,45 @@ class AttackPathGraphServiceTest extends IntegrationTest {
         .persist();
   }
 
+  @Test
+  @DisplayName("A real finding node is flagged is_finding=true")
+  void realFinding_node_isFinding_true() {
+    AttackPathDTO dto = service.buildGraph(SIM);
+    AttackPathNodeDTO node =
+        nodeById(dto, AttackPathIds.findingNode("credentials", "admin:secret"));
+    assertThat(node.getIsFinding()).isTrue();
+  }
+
+  @Test
+  @DisplayName(
+      "An output-only value (is_finding=false) is rendered as a node flagged is_finding=false")
+  void outputOnly_node_isFinding_false() {
+    // A chaining output not persisted as a Finding (ADR-004): still on the map, flagged
+    // output-only.
+    finding("service_banner", "OpenSSH 9.0", "dc-01", exec1Id, false);
+    entityManager.flush();
+
+    AttackPathDTO dto = service.buildGraph(SIM);
+    AttackPathNodeDTO node =
+        nodeById(dto, AttackPathIds.findingNode("service_banner", "OpenSSH 9.0"));
+    assertThat(node.getType()).isEqualTo("FINDING");
+    assertThat(node.getIsFinding()).isFalse();
+  }
+
+  @Test
+  @DisplayName("A (type,value) produced both as a finding and as an output keeps is_finding=true")
+  void mixed_finding_and_output_node_isFinding_true() {
+    // The same (type, value) is produced once as a real finding and once as an output-only value:
+    // the deduped node keeps is_finding=true (a real finding wins, ADR-004).
+    finding("port", "22", "dc-01", exec1Id, true);
+    finding("port", "22", "app-01", exec2Id, false);
+    entityManager.flush();
+
+    AttackPathDTO dto = service.buildGraph(SIM);
+    AttackPathNodeDTO node = nodeById(dto, AttackPathIds.findingNode("port", "22"));
+    assertThat(node.getIsFinding()).isTrue();
+  }
+
   /** An injector run carrying the frozen contract external id and injector type. */
   private String seedInjectorRun(
       String injector,
@@ -763,6 +802,11 @@ class AttackPathGraphServiceTest extends IntegrationTest {
   }
 
   private void finding(String type, String value, String endpointKey, String executionId) {
+    finding(type, value, endpointKey, executionId, true);
+  }
+
+  private void finding(
+      String type, String value, String endpointKey, String executionId, boolean isFinding) {
     AttackPathFinding f = new AttackPathFinding();
     f.setTenant(tenant);
     f.setSimulationId(SIM);
@@ -770,6 +814,7 @@ class AttackPathGraphServiceTest extends IntegrationTest {
     f.setValue(value);
     f.setEndpointId(endpointKey);
     f.setEndpointKey(endpointKey);
+    f.setFinding(isFinding);
     String findingId = findingRepository.save(f).getId();
 
     AttackPathExecutionFinding link = new AttackPathExecutionFinding();

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
@@ -115,6 +115,26 @@ class AttackPathIdsTest {
   }
 
   @Test
+  @DisplayName("A finding row id stays bounded when the overflow comes from another component")
+  void finding_row_id_is_bounded_when_other_components_overflow() {
+    // Hashing the value cannot shrink an id whose excess length comes from, e.g., a very long
+    // endpoint key: the last resort hashes the whole raw id into the fixed-size FINDING_ROW_F
+    // form, which stays deterministic and distinct per natural key.
+    String longEndpointKey = "k".repeat(300);
+    String id = AttackPathIds.findingRow("sim-1", "port", "text_field", "22", longEndpointKey);
+
+    assertThat(id.length()).isLessThanOrEqualTo(255);
+    assertThat(id).startsWith("FINDING_ROW_F|");
+    assertThat(id)
+        .isEqualTo(AttackPathIds.findingRow("sim-1", "port", "text_field", "22", longEndpointKey));
+    assertThat(id)
+        .isNotEqualTo(
+            AttackPathIds.findingRow("sim-1", "port", "text_field", "23", longEndpointKey))
+        .isNotEqualTo(
+            AttackPathIds.findingRow("sim-1", "port", "text_field", "22", longEndpointKey + "k"));
+  }
+
+  @Test
   @DisplayName("The delimiter inside a component cannot cause a collision (injective encoding)")
   void delimiter_in_component_is_safe() {
     // Without escaping, both would encode to "NODE_FINDING|a|b|c".

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathIdsTest.java
@@ -78,6 +78,43 @@ class AttackPathIdsTest {
   }
 
   @Test
+  @DisplayName("A short finding row id keeps its legacy (un-hashed) form across upgrades")
+  void finding_row_id_keeps_legacy_form_for_short_values() {
+    // Rows copied before the value hashing was introduced carry the raw-value id; a short value
+    // must keep resolving to that exact id so a post-upgrade re-copy upserts onto the existing row
+    // instead of inserting a duplicate (the natural-key index was dropped, the PK is the dedup).
+    assertThat(AttackPathIds.findingRow("sim-1", "cve", "text_field", "CVE-1", "asset-1"))
+        .isEqualTo("FINDING_ROW|sim-1|cve|text_field|CVE-1|asset-1");
+  }
+
+  @Test
+  @DisplayName("A finding row id stays bounded and deterministic even for a very long value")
+  void finding_row_id_is_bounded_for_long_values() {
+    // ADR-004 lets arbitrarily long parsed outputs reach attackpath_finding; when the raw encoding
+    // would overflow the varchar(255) primary key, the value is hashed (FINDING_ROW_H namespace).
+    String longValue = "x".repeat(10_000);
+    String id = AttackPathIds.findingRow("sim-1", "output", "text_field", longValue, "asset-1");
+
+    assertThat(id.length()).isLessThanOrEqualTo(255);
+    assertThat(id).startsWith("FINDING_ROW_H|");
+    // Deterministic: the same long value always yields the same id.
+    assertThat(id)
+        .isEqualTo(AttackPathIds.findingRow("sim-1", "output", "text_field", longValue, "asset-1"));
+    // Two different long values (even sharing a long prefix) yield different ids: the whole value
+    // is hashed, never truncated.
+    assertThat(id)
+        .isNotEqualTo(
+            AttackPathIds.findingRow("sim-1", "output", "text_field", longValue + "y", "asset-1"));
+    // The hashed namespace can never collide with a raw id: a short value crafted to look like the
+    // long value's hashed component still lives under the FINDING_ROW kind.
+    String hashedComponent = id.substring("FINDING_ROW_H|".length());
+    assertThat(
+            AttackPathIds.findingRow("sim-1", "output", "text_field", hashedComponent, "asset-1"))
+        .startsWith("FINDING_ROW|")
+        .isNotEqualTo(id);
+  }
+
+  @Test
   @DisplayName("The delimiter inside a component cannot cause a collision (injective encoding)")
   void delimiter_in_component_is_safe() {
     // Without escaping, both would encode to "NODE_FINDING|a|b|c".

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathKeyMatcherTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathKeyMatcherTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class AttackPathKeyMatcherTest {
 
   private static AttackPathFindingRow finding(String type, String value) {
-    return new AttackPathFindingRow("f-id", type, value, null, null, "ep", "exec");
+    return new AttackPathFindingRow("f-id", type, value, null, null, "ep", "exec", true);
   }
 
   private static ConsumedFindingKeyDTO key(String keyType, String operator, String value) {

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathFindingWriterTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathFindingWriterTest.java
@@ -21,12 +21,13 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 
 /**
- * The batched snapshot inserts are idempotent. A finding row is deduped on its natural key
- * (simulation, type, field, value, endpoint_key), not only on its id, so replaying a copy with a
- * different id resolution still writes no duplicate; a link is deduped on its composite key. What a
- * replay does change is the row version, and only that: it is what lets a re-discovered finding's
- * new link reach a polling client. Read back through raw JDBC; not {@code @Transactional} (the
- * inserts are asserted after they commit).
+ * The batched snapshot inserts are idempotent. A finding row is deduped on its primary key, which
+ * is a deterministic, injective encoding of its natural key (simulation, type, field, value,
+ * endpoint_key; the value is hashed inside the id only when its raw encoding would overflow the
+ * column), so re-copying the same finding always collides with itself; a link is deduped on its
+ * composite key. What a replay does change is the row version, and only that: it is what lets a
+ * re-discovered finding's new link reach a polling client. Read back through raw JDBC; not
+ * {@code @Transactional} (the inserts are asserted after they commit).
  */
 @TestPropertySource(
     properties = {
@@ -63,19 +64,21 @@ class AttackPathFindingWriterTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("a finding row is deduped on its natural key, not only on its id")
-  void findingInsertIsIdempotentOnTheNaturalKey() {
+  @DisplayName("a finding row is deduped on its id (a deterministic encoding of its natural key)")
+  void findingInsertIsIdempotentOnItsId() {
     String id = AttackPathIds.findingRow(SIM, "cve", "text_field", "CVE-1", "asset-1");
     insertFinding(id, "cve", "text_field", "CVE-1", "asset-1");
     assertThat(findingCount()).isEqualTo(1);
 
-    // Same batch again: the id conflict is skipped.
+    // Same batch again: the PK conflict is skipped.
     insertFinding(id, "cve", "text_field", "CVE-1", "asset-1");
     assertThat(findingCount()).isEqualTo(1);
 
-    // Same natural key, a different id (a perturbed resolution): the natural-key index rejects it,
-    // so no duplicate and the original row is kept.
-    insertFinding("other-id", "cve", "text_field", "CVE-1", "asset-1");
+    // The same natural key always resolves to the same id (a deterministic encoding of it), so a
+    // re-copy collides with itself on the PK — no duplicate, the original row is kept.
+    String sameId = AttackPathIds.findingRow(SIM, "cve", "text_field", "CVE-1", "asset-1");
+    assertThat(sameId).isEqualTo(id);
+    insertFinding(sameId, "cve", "text_field", "CVE-1", "asset-1");
     assertThat(findingCount()).isEqualTo(1);
     assertThat(theOnlyFindingId()).isEqualTo(id);
   }
@@ -108,6 +111,42 @@ class AttackPathFindingWriterTest extends IntegrationTest {
     assertThat(linkCount("exec-1")).isEqualTo(1);
   }
 
+  @Test
+  @DisplayName("on a PK conflict, is_finding is never downgraded: a real finding wins")
+  void isFindingIsNeverDowngradedOnConflict() {
+    String id = AttackPathIds.findingRow(SIM, "port", "text_field", "22", "asset-1");
+    // First seen as an output-only value...
+    insertFinding(id, "port", "text_field", "22", "asset-1", 1L, false);
+    assertThat(isFindingOf(id)).isFalse();
+
+    // ...then re-copied as a real finding: the flag flips to true (true wins).
+    insertFinding(id, "port", "text_field", "22", "asset-1", 2L, true);
+    assertThat(findingCount()).isEqualTo(1);
+    assertThat(isFindingOf(id)).isTrue();
+
+    // A later output-only re-copy must NOT downgrade it back to false.
+    insertFinding(id, "port", "text_field", "22", "asset-1", 3L, false);
+    assertThat(isFindingOf(id)).isTrue();
+  }
+
+  @Test
+  @DisplayName("a very long value inserts without overflowing the id, idempotently")
+  void longValueInsertsAndIsIdempotent() {
+    // ADR-004 lets arbitrarily long parsed outputs reach attackpath_finding. The value is hashed
+    // inside the id, so the varchar(255) PK stays bounded and the value (text, un-indexed) is never
+    // indexed — a 10 KB value must insert and dedup on the PK like any other.
+    String longValue = "x".repeat(10_000);
+    String id = AttackPathIds.findingRow(SIM, "output", "text_field", longValue, "asset-1");
+
+    insertFinding(id, "output", "text_field", longValue, "asset-1");
+    assertThat(findingCount()).isEqualTo(1);
+
+    // Re-copied: same value -> same id, PK conflict skipped, no duplicate.
+    insertFinding(id, "output", "text_field", longValue, "asset-1");
+    assertThat(findingCount()).isEqualTo(1);
+    assertThat(theOnlyFindingId()).isEqualTo(id);
+  }
+
   private void insertFinding(
       String id, String type, String field, String value, String endpointKey) {
     insertFinding(id, type, field, value, endpointKey, 1L);
@@ -115,11 +154,40 @@ class AttackPathFindingWriterTest extends IntegrationTest {
 
   private void insertFinding(
       String id, String type, String field, String value, String endpointKey, long rowVersion) {
+    insertFinding(id, type, field, value, endpointKey, rowVersion, true);
+  }
+
+  private void insertFinding(
+      String id,
+      String type,
+      String field,
+      String value,
+      String endpointKey,
+      long rowVersion,
+      boolean isFinding) {
     findingWriter.insertFindings(
         List.of(
             new FindingRow(
-                id, tenant.getId(), SIM, type, field, value, endpointKey, null, endpointKey)),
+                id,
+                tenant.getId(),
+                SIM,
+                type,
+                field,
+                value,
+                endpointKey,
+                null,
+                endpointKey,
+                isFinding)),
         rowVersion);
+  }
+
+  private boolean isFindingOf(String findingId) {
+    return Boolean.TRUE.equals(
+        jdbc.queryForObject(
+            "SELECT attackpath_finding_is_finding FROM attackpath_finding"
+                + " WHERE attackpath_finding_id = ?",
+            Boolean.class,
+            findingId));
   }
 
   private long rowVersion(String findingId) {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
@@ -31,6 +31,9 @@ interface Props {
   expectations?: FindingExpectations;
   actions: ProducingAction[];
   activeRef: string | null;
+  // false when the node is an output-only value (a chaining output not persisted as a Finding,
+  // ADR-004): the panel renders a degraded banner and omits finding-only affordances. Defaults true.
+  isFinding?: boolean;
   onSelect: (ref: string) => void;
   onClose: () => void;
 }
@@ -42,9 +45,10 @@ const EXPECTATION_ORDER: (keyof FindingExpectations)[] = ['prevention', 'detecti
 // Selecting a producing action opens the Result & Terminal panel next to it, so the finding, its path
 // (highlighted on the map) and the raw execution result can all be inspected at once. All values are
 // rendered as inert text (secrets are masked upstream); nothing here is injected as HTML.
-const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectations, actions, activeRef, onSelect, onClose }: Props) => {
+const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectations, actions, activeRef, isFinding = true, onSelect, onClose }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
+  const isOutputOnly = isFinding === false;
 
   // Colour a verdict per its expectation type: a successful prevention is green, a successful
   // detection is orange, a failed verdict is red, and an unknown one is muted.
@@ -112,6 +116,11 @@ const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectati
       </div>
 
       <div style={{ padding: theme.spacing(0, 2.5, 2) }}>
+        {isOutputOnly && (
+          <Alert severity="info" sx={{ mt: 1 }}>
+            {t('This is an output-only value used by the chaining and not recorded as a finding.')}
+          </Alert>
+        )}
         <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 1 }}>
           {t('Discovered on')}
         </Typography>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -240,6 +240,32 @@ interface SimulationAttackPathProps {
   scenarioId?: string;
 }
 
+// Resolves the attack-path node backing a finding detail across the candidate node pools: prefer a
+// direct id match (selectedFindingId), else match by (type, value); return the first node the caller
+// accepts. Shared by the verdicts and is-finding lookups, which only differ by their accept test.
+const findFindingNode = (
+  pools: (AttackPathNodeDTO[] | undefined)[],
+  selectedFindingId: string | undefined,
+  type?: string | null,
+  value?: string | null,
+  accept: (n: AttackPathNodeDTO) => boolean = () => true,
+): AttackPathNodeDTO | undefined => {
+  const matchByTypeValue = (n: AttackPathNodeDTO) => n.type === 'FINDING'
+    && n.typeFindings === type
+    && (n.value ?? n.label) === value;
+  for (const pool of pools) {
+    if (!pool) {
+      continue;
+    }
+    const node = (selectedFindingId ? pool.find(n => n.id === selectedFindingId) : undefined)
+      ?? pool.find(matchByTypeValue);
+    if (node && accept(node)) {
+      return node;
+    }
+  }
+  return undefined;
+};
+
 const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAttackPathProps) => {
   const { exerciseId } = useParams() as { exerciseId?: string };
   // Scenario context lists several runs to pick from; simulation context is locked to its own run.
@@ -350,6 +376,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     // `focusedEndpoint` to fall back on, so we carry the origin endpoint here to resolve the panel's
     // "Discovered on" label (else it degraded to the literal word "Endpoint").
     endpointNodeId?: string;
+    // false when the node is an output-only value (a chaining output not persisted as a Finding,
+    // ADR-004): the panel renders in degraded mode. Absent/true for a real finding.
+    isFinding?: boolean;
   } | null>(null);
   const [executions, setExecutions] = useState<AttackPathNodeDTO[]>([]);
   // The clicked injector's own executions (its contracts across every endpoint it reached), listed in
@@ -2013,20 +2042,13 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     if (!findingDetail) {
       return undefined;
     }
-    const matchByTypeValue = (n: AttackPathNodeDTO) => n.type === 'FINDING'
-      && n.typeFindings === findingDetail.type
-      && (n.value ?? n.label) === findingDetail.value;
-    let node: AttackPathNodeDTO | undefined;
-    for (const pool of [fullDto?.attackPathNodes, dto?.staticAttackPathFindings, dto?.attackPathNodes]) {
-      if (!pool) {
-        continue;
-      }
-      node = (selectedFindingId ? pool.find(n => n.id === selectedFindingId) : undefined)
-        ?? pool.find(matchByTypeValue);
-      if (node?.verdicts) {
-        break;
-      }
-    }
+    const node = findFindingNode(
+      [fullDto?.attackPathNodes, dto?.staticAttackPathFindings, dto?.attackPathNodes],
+      selectedFindingId ?? undefined,
+      findingDetail.type,
+      findingDetail.value,
+      n => !!n.verdicts,
+    );
     const norm = (s?: string): ExpectationVerdict => (s === 'success' || s === 'failed' ? s : 'unknown');
     const v = node?.verdicts;
     return {
@@ -2034,6 +2056,23 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       detection: norm(v?.detection),
       vulnerability: norm(v?.vulnerability),
     };
+  }, [findingDetail, selectedFindingId, fullDto?.attackPathNodes, dto?.staticAttackPathFindings, dto?.attackPathNodes]);
+
+  // Whether the selected finding node is a real finding or an output-only value (a chaining output
+  // not persisted as a Finding, ADR-004): read from the same node pools as the verdicts, so the panel
+  // can render its degraded mode. Defaults to true (real finding) when no node resolves.
+  const findingIsFinding = useMemo((): boolean => {
+    if (!findingDetail) {
+      return true;
+    }
+    const node = findFindingNode(
+      [fullDto?.attackPathNodes, dto?.staticAttackPathFindings, dto?.attackPathNodes],
+      selectedFindingId ?? undefined,
+      findingDetail.type,
+      findingDetail.value,
+      n => n.isFinding !== undefined,
+    );
+    return node?.isFinding ?? true;
   }, [findingDetail, selectedFindingId, fullDto?.attackPathNodes, dto?.staticAttackPathFindings, dto?.attackPathNodes]);
 
   // The clicked endpoint's findings grouped by type for the side panel; secrets (credentials) masked.
@@ -2900,6 +2939,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
                       expectations={findingExpectations}
                       actions={producingActions}
                       activeRef={detailExecutionId}
+                      isFinding={findingIsFinding}
                       onSelect={openExecutionDetail}
                       onClose={() => {
                         // Clicking a finding in the clustered view also selects its endpoint (to load the

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -77,6 +77,10 @@ export interface AttackPathFlowNodeData {
   // For a finding node: the id of the endpoint (ASSET) node it was discovered on, so a direct click
   // on the finding can open its details panel by focusing that endpoint's path.
   assetNodeId?: string;
+  // For a finding node: false when the node is an output-only value (a chaining output not persisted
+  // as a Finding, ADR-004), true for a real finding. Drives the "Output only" badge and the degraded
+  // drawer. Absent on non-finding nodes.
+  isFinding?: boolean;
   // For an endpoint (ASSET) node: its 1-based rank among the top chokepoints (most findings), used to
   // badge the most-exposed endpoints. Absent when the endpoint is not a top chokepoint.
   chokepointRank?: number;
@@ -147,6 +151,8 @@ const nodeData = (n: AttackPathNodeDTO): AttackPathFlowNodeData => ({
   stepTemplateId: n.stepTemplateId,
   injectorType: n.injectorType,
   attackPatterns: n.attackPatterns,
+  assetNodeId: n.assetNodeId,
+  isFinding: n.isFinding,
 });
 
 const EDGE_EXECUTIONS = 'EDGE_EXECUTIONS';

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/nodes/FindingNode.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/nodes/FindingNode.tsx
@@ -4,19 +4,34 @@ import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { memo } from 'react';
 
 import FindingIcon from '../../../../../../components/FindingIcon';
+import { useFormatter } from '../../../../../../components/i18n';
 import attackPathStatusColor from '../attack-path-colors';
 import { type AttackPathFlowNode, maskFindingValue } from '../attack-path-flow-helpers';
 import { AP_FINDING_SIZE } from './node-sizes';
+
+// Findings whose displayed value exceeds this many characters are hard-truncated on the map (the
+// full value stays available in the node's tooltip), so a long output value (ADR-004) never renders
+// as a sprawling one-line label across the graph.
+const FINDING_LABEL_MAX_LENGTH = 16;
 
 // A leaf finding node: the type icon with the discovered value ABOVE it (only the value, no type name),
 // kept off the horizontal path so the incoming/outgoing edges never overlap the label. The handles sit on
 // the icon so the edges reach it with no gap.
 const FindingNode = ({ data, selected }: NodeProps<AttackPathFlowNode>) => {
   const theme = useTheme();
+  const { t } = useFormatter();
   // Verdict colour (green/orange/red) by default; blue only when this finding is the selected path.
   const verdict = data.status ? attackPathStatusColor(theme, data.status) : theme.palette.divider;
   const color = selected ? theme.palette.primary.main : verdict;
   const value = maskFindingValue(data.typeFindings, data.label);
+  // Hard-truncate what is rendered on the map (no word-boundary trimming, so it always keeps 16
+  // characters); the full value stays in the tooltip below.
+  const displayValue = value.length > FINDING_LABEL_MAX_LENGTH
+    ? `${value.slice(0, FINDING_LABEL_MAX_LENGTH)}...`
+    : value;
+  // Output-only value (a chaining output not persisted as a Finding, ADR-004): flagged so the analyst
+  // can tell it apart from a real finding and knows its drawer is in a degraded (details-less) mode.
+  const isOutputOnly = data.isFinding === false;
   return (
     <div
       style={{
@@ -38,7 +53,7 @@ const FindingNode = ({ data, selected }: NodeProps<AttackPathFlowNode>) => {
           label or the neighbouring rows. */}
       <Typography
         variant="caption"
-        title={value}
+        title={isOutputOnly ? `${value} — ${t('Output only')}` : value}
         sx={{
           position: 'absolute',
           bottom: '100%',
@@ -49,9 +64,26 @@ const FindingNode = ({ data, selected }: NodeProps<AttackPathFlowNode>) => {
           color,
         }}
       >
-        {value}
+        {displayValue}
       </Typography>
       <FindingIcon findingType={data.typeFindings ?? ''} />
+      {isOutputOnly && (
+        <Typography
+          variant="caption"
+          sx={{
+            position: 'absolute',
+            top: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            mt: 0.25,
+            whiteSpace: 'nowrap',
+            fontStyle: 'italic',
+            color: theme.palette.text.secondary,
+          }}
+        >
+          {t('Output only')}
+        </Typography>
+      )}
       <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
     </div>
   );

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1091,6 +1091,7 @@ export interface AttackPathNodeDTO {
   id?: string;
   injectorType?: string;
   ip?: string;
+  isFinding?: boolean;
   label?: string;
   payloadName?: string;
   platform?: string;

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -938,6 +938,8 @@
   "Discovered on": "Entdeckt am",
   "Discovered Shares": "Entdeckte Freigaben",
   "Discovered Users": "Entdeckte Benutzer",
+  "Output only": "Nur Ausgabe",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "Dies ist ein reiner Ausgabewert, der von der Verkettung verwendet und nicht als Finding erfasst wird.",
   "Dismiss": "Verwerfen",
   "Display legend": "Legende anzeigen",
   "Display list": "Liste anzeigen",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -939,6 +939,8 @@
   "Discovered on": "Discovered on",
   "Discovered Shares": "Discovered Shares",
   "Discovered Users": "Discovered Users",
+  "Output only": "Output only",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "This is an output-only value used by the chaining and not recorded as a finding.",
   "Dismiss": "Dismiss",
   "Display legend": "Display legend",
   "Display list": "Display list",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -938,6 +938,8 @@
   "Discovered on": "Descubierto el",
   "Discovered Shares": "Recursos compartidos descubiertos",
   "Discovered Users": "Usuarios descubiertos",
+  "Output only": "Solo salida",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "Este es un valor de solo salida utilizado por el encadenamiento y no registrado como finding.",
   "Dismiss": "Descartar",
   "Display legend": "Mostrar leyenda",
   "Display list": "Mostrar lista",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -939,6 +939,8 @@
   "Discovered on": "Découvert sur",
   "Discovered Shares": "Partages découverts",
   "Discovered Users": "Utilisateurs découverts",
+  "Output only": "Sortie uniquement",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "Il s'agit d'une valeur de sortie utilisée par le chaînage et non enregistrée comme finding.",
   "Dismiss": "Ignorer",
   "Display legend": "Afficher la légende",
   "Display list": "Liste d'affichage",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -938,6 +938,8 @@
   "Discovered on": "Scoperto il",
   "Discovered Shares": "Condivisioni rilevate",
   "Discovered Users": "Utenti scoperti",
+  "Output only": "Solo output",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "Questo è un valore di solo output utilizzato dal concatenamento e non registrato come finding.",
   "Dismiss": "Ignora",
   "Display legend": "Visualizza la legenda",
   "Display list": "Visualizza elenco",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -938,6 +938,8 @@
   "Discovered on": "発見日時",
   "Discovered Shares": "検出された共有",
   "Discovered Users": "発見されたユーザー",
+  "Output only": "出力のみ",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "これはチェーンで使用される出力専用の値であり、finding として記録されません。",
   "Dismiss": "却下",
   "Display legend": "凡例を表示",
   "Display list": "リストを表示する",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -938,6 +938,8 @@
   "Discovered on": "발견 일시",
   "Discovered Shares": "발견된 공유",
   "Discovered Users": "발견된 사용자",
+  "Output only": "출력 전용",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "체이닝에서 사용되는 출력 전용 값이며 finding으로 기록되지 않습니다.",
   "Dismiss": "무시",
   "Display legend": "범례 표시",
   "Display list": "목록 표시",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -938,6 +938,8 @@
   "Discovered on": "Дата обнаружения",
   "Discovered Shares": "Обнаруженные общие ресурсы",
   "Discovered Users": "Обнаруженные пользователи",
+  "Output only": "Только вывод",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "Это значение, используемое только для вывода в цепочке и не записываемое как finding.",
   "Dismiss": "Скрыть",
   "Display legend": "Отображение легенды",
   "Display list": "Отобразить список",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -938,6 +938,8 @@
   "Discovered on": "发现时间",
   "Discovered Shares": "发现的共享",
   "Discovered Users": "发现的用户",
+  "Output only": "仅输出",
+  "This is an output-only value used by the chaining and not recorded as a finding.": "这是链式处理使用的仅输出值，不会记录为 finding。",
   "Dismiss": "忽略",
   "Display legend": "显示图例",
   "Display list": "显示列表",

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathFinding.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/AttackPathFinding.java
@@ -61,6 +61,15 @@ public class AttackPathFinding implements TenantBase {
   private String endpointKey;
 
   /**
+   * Whether this row is a real finding ({@code true}) or an output-only value ({@code false})
+   * produced by the chaining but not persisted as a {@link io.openaev.database.model.Finding}
+   * (ADR-004). Driven by the contract output element's {@code contract_output_element_is_finding}.
+   * The flag drives the rendered node's type/UI, not its visibility.
+   */
+  @Column(name = "attackpath_finding_is_finding", nullable = false)
+  private boolean isFinding = true;
+
+  /**
    * The simulation's {@link AttackPathGraphVersion} value at the write that created this row,
    * stamped in the same transaction as the bump so the delta read is a cursor over {@code
    * (simulation_id, row_version)}. The copy's conflict branch re-stamps it on a re-discovered

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEndpointFindingVerdictRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathEndpointFindingVerdictRow.java
@@ -11,4 +11,5 @@ public record AttackPathEndpointFindingVerdictRow(
     String value,
     String preventionStatus,
     String detectionStatus,
-    String vulnerabilityStatus) {}
+    String vulnerabilityStatus,
+    boolean isFinding) {}

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathFindingRow.java
@@ -12,4 +12,5 @@ public record AttackPathFindingRow(
     String endpointId,
     String endpointRaw,
     String endpointKey,
-    String executionId) {}
+    String executionId,
+    boolean isFinding) {}

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathFindingRepository.java
@@ -25,7 +25,7 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingRow("
-          + "f.id, f.type, f.value, f.endpointId, f.endpointRaw, f.endpointKey, ef.executionId) "
+          + "f.id, f.type, f.value, f.endpointId, f.endpointRaw, f.endpointKey, ef.executionId, f.isFinding) "
           + "FROM AttackPathFinding f "
           + "JOIN AttackPathExecutionFinding ef ON ef.findingId = f.id "
           + "WHERE f.simulationId = :simulationId")
@@ -40,7 +40,7 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingRow("
-          + "f.id, f.type, f.value, f.endpointId, f.endpointRaw, f.endpointKey, ef.executionId) "
+          + "f.id, f.type, f.value, f.endpointId, f.endpointRaw, f.endpointKey, ef.executionId, f.isFinding) "
           + "FROM AttackPathFinding f "
           + "JOIN AttackPathExecutionFinding ef ON ef.findingId = f.id "
           + "WHERE f.simulationId = :simulationId AND f.rowVersion > :since")
@@ -60,7 +60,7 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathFindingRow("
-          + "f.id, f.type, f.value, f.endpointId, f.endpointRaw, f.endpointKey, ef.executionId) "
+          + "f.id, f.type, f.value, f.endpointId, f.endpointRaw, f.endpointKey, ef.executionId, f.isFinding) "
           + "FROM AttackPathFinding f "
           + "JOIN AttackPathExecutionFinding ef ON ef.findingId = f.id "
           + "WHERE f.simulationId = :simulationId AND f.type IN :types")
@@ -109,7 +109,7 @@ public interface AttackPathFindingRepository extends CrudRepository<AttackPathFi
    */
   @Query(
       "SELECT new io.openaev.database.model.attackpath.projection.AttackPathEndpointFindingVerdictRow("
-          + "f.type, f.value, e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus) "
+          + "f.type, f.value, e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, f.isFinding) "
           + "FROM AttackPathFinding f "
           + "JOIN AttackPathExecutionFinding ef ON ef.findingId = f.id "
           + "JOIN AttackPathExecution e ON e.id = ef.executionId "


### PR DESCRIPTION
### Proposed changes

- Show chaining **output-only values** (`contract_output_element_is_finding = false`) on the attack path map. These outputs drive the chaining (they trigger events) but are never persisted as `Finding` entities, so until now they never appeared on the attack path, which was sourced exclusively from `Finding` entities (see `ADR-004`).
- Fix a chaining bug where `is_finding=false` outputs were dropped before type-mapping: `buildTypeMappingsFromInject` now uses the non-filtered accessor `InjectorContractContentUtils.getAllContractOutputs(outputParsers, false)` on the payload path, so non-finding outputs are type-mapped and propagate in the chaining state. The filtered accessor is kept for the finding-generation paths.
- Persist an `is_finding` flag on attack-path nodes: new `attackpath_finding_is_finding` column (Flyway migration, default `true`), carried through the entity, writer, projections, repository queries, DTO and graph service. `ON CONFLICT` is **true-wins** (`is_finding = existing OR excluded`) so a real finding is never downgraded by an output-only re-copy.
- **Hybrid write path**: keep the existing finding-copy for `is_finding=true` (preserves precise multi-endpoint attribution via `finding.getAssets()`), and add an output-copy (`copyOutputs`) for `is_finding=false` values, attributed via the step's executions with a single-endpoint fallback. The output-copy snapshots primitive parsed values only; composite/tuple values are skipped.
- **Bounded row id, upgrade-safe**: `AttackPathIds.findingRow` keeps the legacy raw-value id whenever it fits the `varchar(255)` primary key, so rows copied before the upgrade keep resolving to their existing id and a re-copy upserts instead of duplicating. Only a value whose raw encoding would overflow is hashed (SHA-256, never truncated) under the distinct `FINDING_ROW_H` namespace. The redundant natural-key unique index (a btree-overflow risk on long values) is dropped in favour of the PK upsert.
- **Frontend**: output-only nodes are rendered with an "Output only" badge; the finding drawer is reused in a degraded (read-only) mode with an info banner; finding-only actions are disabled. Added the `isFinding` flag through the API types, flow helpers, `FindingNode`, `FindingDetailPanel` and `SimulationAttackPath`, plus i18n keys for all languages.

Notes:

- Forward-only - no backfill of existing rows (they default to `is_finding=true`).
- Secret masking is preserved for both `is_finding=true` and `is_finding=false` values.

### Testing Instructions

1. Run an inject whose contract exposes at least one output element with `is_finding=false` (an output-only value used by the chaining) and at least one real finding.
2. Open the simulation's **Attack path**:
   - the real finding appears as a normal finding node;
   - the output-only value appears as a node with an "Output only" badge;
   - clicking the output-only node opens the finding drawer in **degraded mode** (info banner, finding-only actions disabled).
3. Verify counters are unchanged and that an endpoint producing **both** a finding and an output-only value shows both.

### Related issues

- Relates to #5048

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

The attack path was historically sourced from `Finding` entities, which excluded output-only values even though the chaining engine orchestrates purely on outputs (`IngestionResult.parsedByType()`), never on findings. Two options were considered: (A) fully re-source the attack path from chaining parsed outputs, or (B) a hybrid approach. We chose the **hybrid** approach (documented in `ADR-004`) because a pure output-sourcing would regress the precise multi-endpoint finding attribution provided by `finding.getAssets()`. The hybrid keeps the finding-copy untouched for real findings and adds an output-copy for output-only values, giving full map coverage without any attribution regression.

The branch was rebased onto `main` and squashed into a single signed commit (original 11 commits included three merge commits; authorship preserved via a co-author trailer).
