### PR TITLE
fix(dashboard): return 400 instead of 500 for inverted date ranges (#4388)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/utilstest/ElasticUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/ElasticUtilsTest.java
@@ -1,0 +1,51 @@
+package io.openaev.utilstest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.openaev.exception.InvalidDateRangeException;
+import io.openaev.utils.ElasticUtils;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Elastic Utils tests")
+class ElasticUtilsTest {
+
+  @Test
+  @DisplayName("buildDateRangeQuery should accept a valid date range")
+  void buildDateRangeQuery_whenStartBeforeEnd_thenReturnsQuery() {
+    // -- PREPARE --
+    Instant start = Instant.parse("2025-01-01T00:00:00Z");
+    Instant end = Instant.parse("2025-01-31T00:00:00Z");
+
+    // -- EXECUTE & ASSERT --
+    assertDoesNotThrow(() -> ElasticUtils.buildDateRangeQuery("created_at", start, end));
+  }
+
+  @Test
+  @DisplayName("buildDateRangeQuery should throw InvalidDateRangeException when start is after end")
+  void buildDateRangeQuery_whenStartAfterEnd_thenThrowsInvalidDateRangeException() {
+    // -- PREPARE --
+    Instant start = Instant.parse("2025-01-31T00:00:00Z");
+    Instant end = Instant.parse("2025-01-01T00:00:00Z");
+
+    // -- EXECUTE & ASSERT --
+    InvalidDateRangeException exception =
+        assertThrows(
+            InvalidDateRangeException.class,
+            () -> ElasticUtils.buildDateRangeQuery("created_at", start, end));
+    assertEquals("Start date must be before end date", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("buildDateRangeQuery should throw InvalidDateRangeException when start equals end")
+  void buildDateRangeQuery_whenStartEqualsEnd_thenThrowsInvalidDateRangeException() {
+    // -- PREPARE --
+    Instant date = Instant.parse("2025-01-15T00:00:00Z");
+
+    // -- EXECUTE & ASSERT --
+    assertThrows(
+        InvalidDateRangeException.class,
+        () -> ElasticUtils.buildDateRangeQuery("created_at", date, date));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utilstest/OpenSearchUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/OpenSearchUtilsTest.java
@@ -1,0 +1,51 @@
+package io.openaev.utilstest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.openaev.exception.InvalidDateRangeException;
+import io.openaev.utils.OpenSearchUtils;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OpenSearch Utils tests")
+class OpenSearchUtilsTest {
+
+  @Test
+  @DisplayName("buildDateRangeQuery should accept a valid date range")
+  void buildDateRangeQuery_whenStartBeforeEnd_thenReturnsQuery() {
+    // -- PREPARE --
+    Instant start = Instant.parse("2025-01-01T00:00:00Z");
+    Instant end = Instant.parse("2025-01-31T00:00:00Z");
+
+    // -- EXECUTE & ASSERT --
+    assertDoesNotThrow(() -> OpenSearchUtils.buildDateRangeQuery("created_at", start, end));
+  }
+
+  @Test
+  @DisplayName("buildDateRangeQuery should throw InvalidDateRangeException when start is after end")
+  void buildDateRangeQuery_whenStartAfterEnd_thenThrowsInvalidDateRangeException() {
+    // -- PREPARE --
+    Instant start = Instant.parse("2025-01-31T00:00:00Z");
+    Instant end = Instant.parse("2025-01-01T00:00:00Z");
+
+    // -- EXECUTE & ASSERT --
+    InvalidDateRangeException exception =
+        assertThrows(
+            InvalidDateRangeException.class,
+            () -> OpenSearchUtils.buildDateRangeQuery("created_at", start, end));
+    assertEquals("Start date must be before end date", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("buildDateRangeQuery should throw InvalidDateRangeException when start equals end")
+  void buildDateRangeQuery_whenStartEqualsEnd_thenThrowsInvalidDateRangeException() {
+    // -- PREPARE --
+    Instant date = Instant.parse("2025-01-15T00:00:00Z");
+
+    // -- EXECUTE & ASSERT --
+    assertThrows(
+        InvalidDateRangeException.class,
+        () -> OpenSearchUtils.buildDateRangeQuery("created_at", date, date));
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/exception/InvalidDateRangeException.java
+++ b/openaev-model/src/main/java/io/openaev/exception/InvalidDateRangeException.java
@@ -1,0 +1,18 @@
+package io.openaev.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a date range is invalid (e.g. start date is after end date).
+ *
+ * <p>Maps to HTTP 400 Bad Request so that callers receive a clear validation error instead of a 500
+ * from the search engine.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidDateRangeException extends RuntimeException {
+
+  public InvalidDateRangeException(String message) {
+    super(message);
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/utils/ElasticUtils.java
+++ b/openaev-model/src/main/java/io/openaev/utils/ElasticUtils.java
@@ -8,6 +8,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.FieldDateMath;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import io.openaev.database.model.Filters;
 import io.openaev.engine.api.HistogramInterval;
+import io.openaev.exception.InvalidDateRangeException;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -42,6 +43,9 @@ public class ElasticUtils {
    */
   public static Query buildDateRangeQuery(
       @NotBlank final String field, @NotNull final Instant start, @NotNull final Instant end) {
+    if (!start.isBefore(end)) {
+      throw new InvalidDateRangeException("Start date must be before end date");
+    }
     return DateRangeQuery.of(d -> d.field(field).gt(String.valueOf(start)).lt(String.valueOf(end)))
         ._toRangeQuery()
         ._toQuery();

--- a/openaev-model/src/main/java/io/openaev/utils/OpenSearchUtils.java
+++ b/openaev-model/src/main/java/io/openaev/utils/OpenSearchUtils.java
@@ -2,6 +2,7 @@ package io.openaev.utils;
 
 import io.openaev.database.model.Filters;
 import io.openaev.engine.api.HistogramInterval;
+import io.openaev.exception.InvalidDateRangeException;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
@@ -68,6 +69,9 @@ public class OpenSearchUtils {
    */
   public static Query buildDateRangeQuery(
       @NotBlank final String field, @NotNull final Instant start, @NotNull final Instant end) {
+    if (!start.isBefore(end)) {
+      throw new InvalidDateRangeException("Start date must be before end date");
+    }
     return RangeQuery.of(d -> d.field(field).gt(JsonData.of(start)).lt(JsonData.of(end))).toQuery();
   }
 


### PR DESCRIPTION
## Summary

- Validate `start < end` in `buildDateRangeQuery` (both `ElasticUtils` and `OpenSearchUtils`) before sending the query to the search engine
- Throw a new `InvalidDateRangeException` annotated with `@ResponseStatus(BAD_REQUEST)` so Spring returns HTTP 400 with a clear message instead of letting the search engine crash with a 500

Closes #4388