### PR TITLE
fix(attack-path): fall back to the full chain when a scoped seed is collapsed (#7175)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -1223,6 +1223,73 @@ describe('buildCausalChainFlow', () => {
     const nodeIds = new Set(nodes.map(n => n.id));
     expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE && e.target === 'ep-1')).toHaveLength(0);
     expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+});
+
+describe('scopeChainFlowToSeeds', () => {
+  // Same "5 shares > cap of 4" shape as the buildCausalChainFlow collapse test above: the 5 findings
+  // never render individually, only their `chain-fc|...` cluster does.
+  const fids = ['a', 'b', 'c', 'd', 'e'];
+  const collapsed: AttackPathDTO = {
+    ...chainDto,
+    attackPathNodes: [
+      {
+        id: 'inj-A',
+        type: 'INJECTOR',
+        label: 'A',
+      },
+      {
+        id: 'ep-1',
+        type: 'ASSET',
+        label: 'EP1',
+        ip: '10.0.0.1',
+      },
+      ...fids.map(v => ({
+        id: `NODE_FINDING|share|${v}`,
+        type: 'FINDING' as const,
+        typeFindings: 'share',
+        value: v,
+        label: v,
+      })),
+    ],
+    attackPathExecutions: [
+      {
+        id: 'xA',
+        type: 'EXECUTION',
+        ref: 'exec-A',
+        stepTemplateId: 'step-A',
+        findingsNodeIds: fids.map(v => `NODE_FINDING|share|${v}`),
+        dependsOn: [],
+      },
+    ],
+    attackPathEdges: [
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'inj-A',
+        edgeTargetId: 'ep-1',
+        executionIds: ['exec-A'],
+      },
+    ],
+  };
+
+  it('falls back to the full chain rather than an empty focus when the seed is a collapsed finding', () => {
+    const chainFlow = buildCausalChainFlow(collapsed, tt);
+    // The seed is one of the 5 collapsed findings — it has no node of its own, only its cluster does.
+    const scoped = scopeChainFlowToSeeds(chainFlow, new Set(['NODE_FINDING|share|a']));
+
+    expect(scoped.nodes).not.toHaveLength(0);
+    expect(scoped.nodes).toEqual(chainFlow.nodes);
+    expect(scoped.edges).toEqual(chainFlow.edges);
+  });
+
+  it('scopes down to the seed and its connected nodes when the seed is actually rendered', () => {
+    const chainFlow = buildCausalChainFlow(collapsed, tt);
+    const injectorNode = chainFlow.nodes.find(n => n.id === 'inj-A');
+
+    const scoped = scopeChainFlowToSeeds(chainFlow, new Set(['inj-A']));
+
+    expect(scoped.nodes).toContainEqual(injectorNode);
+    expect(scoped.nodes.length).toBeLessThan(chainFlow.nodes.length);
   });
 });
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -2106,12 +2106,17 @@ export const scopeChainFlowToSeeds = (
   edges: AttackPathFlowEdge[];
 } => {
   const { nodes, edges } = chainFlow;
-  // None of the seeds exist in the causal chain yet (e.g. no full-graph data, or a finding whose
-  // type cluster is still collapsed): show the whole thing rather than an empty focus.
-  if (seedIds.size === 0) {
+  // Keep only the seeds that are actually rendered: a finding whose type cluster is still collapsed
+  // (more than CHAIN_FINDINGS_MAX_PER_TYPE on that endpoint) has no node of its own — only its
+  // `chain-fc|...` cluster does — so seeding on the raw finding id would scope to nothing.
+  const nodeIds = new Set(nodes.map(n => n.id));
+  const presentSeedIds = new Set([...seedIds].filter(id => nodeIds.has(id)));
+  // None of the seeds exist in the causal chain yet (e.g. no full-graph data, or every seed's
+  // cluster is still collapsed): show the whole thing rather than an empty focus.
+  if (presentSeedIds.size === 0) {
     return chainFlow;
   }
-  const scope = new Set(seedIds);
+  const scope = new Set(presentSeedIds);
   for (let pass = 0; pass < 8; pass += 1) {
     for (const e of edges) {
       if (e.source && e.target && scope.has(e.target) && !scope.has(e.source)) {
@@ -2121,7 +2126,7 @@ export const scopeChainFlowToSeeds = (
   }
   for (let pass = 0; pass < 3; pass += 1) {
     for (const e of edges) {
-      if (e.source && e.target && seedIds.has(e.source) && !scope.has(e.target)) {
+      if (e.source && e.target && presentSeedIds.has(e.source) && !scope.has(e.target)) {
         scope.add(e.target);
       }
     }


### PR DESCRIPTION
## Summary

- In the Attack path tab's causal-chain view, clicking the "Portscan" chip and selecting one specific discovered port (e.g. one among 16 open ports found on an endpoint) emptied the graph canvas entirely — "No attack-path data for this simulation..." — even though a simulation was clearly selected and the right-side detail panel still rendered correctly.
- Root cause: `buildCausalChainFlow` collapses more than `CHAIN_FINDINGS_MAX_PER_TYPE` (4) same-type findings on one endpoint into a single `chain-fc|<depth>|<endpoint>|<type>` cluster node, without emitting the individual finding nodes. `scopeChainFlowToSeeds` (#7156) seeds the focused view on the raw finding id — which, once collapsed, has no node of its own. Its own comment already documents the intent for this exact case ("a finding whose type cluster is still collapsed: show the whole thing rather than an empty focus"), but the code only guarded the trivially-empty `seedIds.size === 0` case, not a non-empty seed set that is simply absent from the rendered nodes.
- Fix: intersect the requested seeds with the ids actually present in the chain flow's nodes before scoping, and fall back to the full flow (matching the already-documented intent) when none of the seeds survive.

Fixes #7175

## Test plan

- [x] Added `scopeChainFlowToSeeds` unit tests: falls back to the full flow when the seed is a collapsed finding; scopes down correctly when the seed is actually rendered.
- [ ] Manually verify: on a simulation with a "Portscan" (or any finding type) collapsed past the cluster cap, clicking one specific finding no longer empties the graph.