### PR TITLE
fix(connector): only check jwks for connector tied to requested tenant (#7180)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
@@ -1,7 +1,6 @@
 package io.openaev.config;
 
 import static io.openaev.config.SessionHelper.ANONYMOUS_USER;
-import static io.openaev.config.TenantUriUtils.TENANT_ID_PATH_VARIABLE;
 
 import io.openaev.aop.AccessControl;
 import io.openaev.config.cache.TenantMembershipCacheManager;
@@ -10,9 +9,6 @@ import io.openaev.database.model.ResourceType;
 import io.openaev.rest.exception.TenantAccessDeniedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Map;
-import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Interceptor that automatically extracts the {@code tenantId} path variable from any request
@@ -49,22 +46,26 @@ public class TenantInterceptor implements AsyncHandlerInterceptor {
   @SuppressWarnings("unchecked")
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    tenantUriUtils.getTenantIdFromRequestUrl(request).ifPresent(tenantId -> {
-      if (!targetsTenantResource(handler)) {
-        // Validate the authenticated user belongs to this tenant
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null
-                && authentication.isAuthenticated()
-                && !ANONYMOUS_USER.equals(authentication.getPrincipal())) {
-          OpenAEVPrincipal principal = (OpenAEVPrincipal) authentication.getPrincipal();
-          if (!tenantMembershipCacheManager.existsByUserIdAndTenantId(
-                  principal.getId(), tenantId)) {
-            throw new TenantAccessDeniedException(tenantId);
-          }
-        }
-      }
-      TenantContext.setCurrentTenant(tenantId);
-    });
+    tenantUriUtils
+        .getTenantIdFromRequestUrl(request)
+        .ifPresent(
+            tenantId -> {
+              if (!targetsTenantResource(handler)) {
+                // Validate the authenticated user belongs to this tenant
+                Authentication authentication =
+                    SecurityContextHolder.getContext().getAuthentication();
+                if (authentication != null
+                    && authentication.isAuthenticated()
+                    && !ANONYMOUS_USER.equals(authentication.getPrincipal())) {
+                  OpenAEVPrincipal principal = (OpenAEVPrincipal) authentication.getPrincipal();
+                  if (!tenantMembershipCacheManager.existsByUserIdAndTenantId(
+                      principal.getId(), tenantId)) {
+                    throw new TenantAccessDeniedException(tenantId);
+                  }
+                }
+              }
+              TenantContext.setCurrentTenant(tenantId);
+            });
     return true;
   }
 

--- a/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
@@ -15,8 +15,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
-import org.springframework.web.servlet.HandlerMapping;
-import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Interceptor that automatically extracts the {@code tenantId} path variable from any request

--- a/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
@@ -43,7 +43,6 @@ public class TenantInterceptor implements AsyncHandlerInterceptor {
   private final TenantUriUtils tenantUriUtils;
 
   @Override
-  @SuppressWarnings("unchecked")
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
     tenantUriUtils

--- a/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantInterceptor.java
@@ -11,6 +11,8 @@ import io.openaev.rest.exception.TenantAccessDeniedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,32 +43,28 @@ import org.springframework.web.servlet.HandlerMapping;
 public class TenantInterceptor implements AsyncHandlerInterceptor {
 
   private final TenantMembershipCacheManager tenantMembershipCacheManager;
+  private final TenantUriUtils tenantUriUtils;
 
   @Override
   @SuppressWarnings("unchecked")
   public boolean preHandle(
       HttpServletRequest request, HttpServletResponse response, Object handler) {
-    Map<String, String> pathVariables =
-        (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-    if (pathVariables != null && pathVariables.containsKey(TENANT_ID_PATH_VARIABLE)) {
-      String tenantId = pathVariables.get(TENANT_ID_PATH_VARIABLE);
-
+    tenantUriUtils.getTenantIdFromRequestUrl(request).ifPresent(tenantId -> {
       if (!targetsTenantResource(handler)) {
         // Validate the authenticated user belongs to this tenant
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null
-            && authentication.isAuthenticated()
-            && !ANONYMOUS_USER.equals(authentication.getPrincipal())) {
+                && authentication.isAuthenticated()
+                && !ANONYMOUS_USER.equals(authentication.getPrincipal())) {
           OpenAEVPrincipal principal = (OpenAEVPrincipal) authentication.getPrincipal();
           if (!tenantMembershipCacheManager.existsByUserIdAndTenantId(
-              principal.getId(), tenantId)) {
+                  principal.getId(), tenantId)) {
             throw new TenantAccessDeniedException(tenantId);
           }
         }
       }
-
       TenantContext.setCurrentTenant(tenantId);
-    }
+    });
     return true;
   }
 

--- a/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
@@ -10,12 +10,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerMapping;
 
 @Component
+@SuppressWarnings("unchecked")
 public final class TenantUriUtils {
 
   public static final String TENANT_ID_PATH_VARIABLE = "tenantId";
   public static final String TENANT_BASE_PATH = "/api/tenants/";
   public static final String TENANT_PREFIX = TENANT_BASE_PATH + "{" + TENANT_ID_PATH_VARIABLE + "}";
-  private final Pattern tenantPattern = Pattern.compile(TENANT_BASE_PATH + "([A-Fa-f0-9-]+)/?");
+  private final Pattern tenantPattern =
+      Pattern.compile("^" + TENANT_BASE_PATH + "([A-Fa-f0-9-]+)/?");
 
   public Optional<String> getTenantIdFromRequestUrl(HttpServletRequest request) {
     Map<String, String> pathVariables =

--- a/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
@@ -1,10 +1,26 @@
 package io.openaev.config;
 
+import io.openaev.utils.FilterUtilsJpa;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
 public final class TenantUriUtils {
 
   public static final String TENANT_ID_PATH_VARIABLE = "tenantId";
   public static final String TENANT_BASE_PATH = "/api/tenants/";
   public static final String TENANT_PREFIX = TENANT_BASE_PATH + "{" + TENANT_ID_PATH_VARIABLE + "}";
 
-  private TenantUriUtils() {}
+  public Optional<String> getTenantIdFromRequestUrl(HttpServletRequest request) {
+    Map<String, String> pathVariables =
+            (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+    if (pathVariables != null && pathVariables.containsKey(TENANT_ID_PATH_VARIABLE)) {
+      return Optional.of(pathVariables.get(TENANT_ID_PATH_VARIABLE));
+    }
+    return Optional.empty();
+  }
 }

--- a/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
@@ -1,12 +1,13 @@
 package io.openaev.config;
 
-import io.openaev.utils.FilterUtilsJpa;
+import io.openaev.utils.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerMapping;
-
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
 
 @Component
 public final class TenantUriUtils {
@@ -14,13 +15,24 @@ public final class TenantUriUtils {
   public static final String TENANT_ID_PATH_VARIABLE = "tenantId";
   public static final String TENANT_BASE_PATH = "/api/tenants/";
   public static final String TENANT_PREFIX = TENANT_BASE_PATH + "{" + TENANT_ID_PATH_VARIABLE + "}";
+  private final Pattern tenantPattern = Pattern.compile(TENANT_BASE_PATH + "([A-Fa-f0-9-]+)/?");
 
   public Optional<String> getTenantIdFromRequestUrl(HttpServletRequest request) {
     Map<String, String> pathVariables =
-            (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
     if (pathVariables != null && pathVariables.containsKey(TENANT_ID_PATH_VARIABLE)) {
       return Optional.of(pathVariables.get(TENANT_ID_PATH_VARIABLE));
     }
+
+    // second attempt
+    String uri = request.getRequestURI();
+    if (!StringUtils.isBlank(uri)) {
+      Matcher matcher = tenantPattern.matcher(request.getRequestURI());
+      if (matcher.find()) {
+        return Optional.of(matcher.group(1));
+      }
+    }
+
     return Optional.empty();
   }
 }

--- a/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
@@ -35,8 +35,14 @@ public final class TenantUriUtils {
 
     // Fallback for callers running before handler mapping populated the path variables
     // (e.g. authentication filters): parse the tenant id straight from the request URI.
+    // getRequestURI() includes the servlet context path, so strip it first to keep the
+    // anchored pattern working for deployments served under a non-root context path.
     String uri = request.getRequestURI();
     if (!StringUtils.isBlank(uri)) {
+      String contextPath = request.getContextPath();
+      if (!StringUtils.isBlank(contextPath) && uri.startsWith(contextPath)) {
+        uri = uri.substring(contextPath.length());
+      }
       Matcher matcher = tenantPattern.matcher(uri);
       if (matcher.find()) {
         return Optional.of(matcher.group(1));

--- a/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantUriUtils.java
@@ -10,26 +10,34 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerMapping;
 
 @Component
-@SuppressWarnings("unchecked")
 public final class TenantUriUtils {
 
   public static final String TENANT_ID_PATH_VARIABLE = "tenantId";
   public static final String TENANT_BASE_PATH = "/api/tenants/";
   public static final String TENANT_PREFIX = TENANT_BASE_PATH + "{" + TENANT_ID_PATH_VARIABLE + "}";
+
+  private static final String UUID_REGEX =
+      "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+
+  // Tenant detection feeds security decisions (connector JWT verification), so the
+  // fallback regex is strict: the tenant segment must be a full UUID and must end at a
+  // path-segment boundary to avoid extracting a truncated id from a malformed URI.
   private final Pattern tenantPattern =
-      Pattern.compile("^" + TENANT_BASE_PATH + "([A-Fa-f0-9-]+)/?");
+      Pattern.compile("^" + TENANT_BASE_PATH + "(" + UUID_REGEX + ")(?:/|$)");
 
   public Optional<String> getTenantIdFromRequestUrl(HttpServletRequest request) {
-    Map<String, String> pathVariables =
-        (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-    if (pathVariables != null && pathVariables.containsKey(TENANT_ID_PATH_VARIABLE)) {
-      return Optional.of(pathVariables.get(TENANT_ID_PATH_VARIABLE));
+    Object pathVariablesAttribute =
+        request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+    if (pathVariablesAttribute instanceof Map<?, ?> pathVariables
+        && pathVariables.get(TENANT_ID_PATH_VARIABLE) instanceof String tenantId) {
+      return Optional.of(tenantId);
     }
 
-    // second attempt
+    // Fallback for callers running before handler mapping populated the path variables
+    // (e.g. authentication filters): parse the tenant id straight from the request URI.
     String uri = request.getRequestURI();
     if (!StringUtils.isBlank(uri)) {
-      Matcher matcher = tenantPattern.matcher(request.getRequestURI());
+      Matcher matcher = tenantPattern.matcher(uri);
       if (matcher.find()) {
         return Optional.of(matcher.group(1));
       }

--- a/openaev-api/src/main/java/io/openaev/security/TokenAuthenticationFilter.java
+++ b/openaev-api/src/main/java/io/openaev/security/TokenAuthenticationFilter.java
@@ -54,7 +54,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     this.plainTokenExtractor = plainTokenExtractor;
   }
 
-  private Optional<User> getAuthedUserFromAuthorizationHeader(String value, HttpServletRequest request) {
+  private Optional<User> getAuthedUserFromAuthorizationHeader(
+      String value, HttpServletRequest request) {
     Set<ExtractorBase> extractors =
         Set.of(this.connectorJwtExtractor, this.xtmJwksExtractor, this.plainTokenExtractor);
 

--- a/openaev-api/src/main/java/io/openaev/security/TokenAuthenticationFilter.java
+++ b/openaev-api/src/main/java/io/openaev/security/TokenAuthenticationFilter.java
@@ -54,18 +54,18 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     this.plainTokenExtractor = plainTokenExtractor;
   }
 
-  private Optional<User> getAuthedUserFromAuthorizationHeader(String value) {
+  private Optional<User> getAuthedUserFromAuthorizationHeader(String value, HttpServletRequest request) {
     Set<ExtractorBase> extractors =
         Set.of(this.connectorJwtExtractor, this.xtmJwksExtractor, this.plainTokenExtractor);
 
     if (!value.toLowerCase().startsWith(BEARER_PREFIX)) {
-      return this.plainTokenExtractor.authUser(value);
+      return this.plainTokenExtractor.authUser(value, request);
     }
 
     String candidateToken = value.substring(BEARER_PREFIX.length());
     for (ExtractorBase extractor : extractors) {
       try {
-        Optional<User> candidateUser = extractor.authUser(candidateToken);
+        Optional<User> candidateUser = extractor.authUser(candidateToken, request);
         if (candidateUser.isPresent()) {
           return candidateUser;
         }
@@ -82,9 +82,9 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     Optional<Cookie> defaultCookie =
         Arrays.stream(cookies).filter(cookie -> COOKIE_NAME.equals(cookie.getName())).findFirst();
     return hasLength(header)
-        ? getAuthedUserFromAuthorizationHeader(header)
+        ? getAuthedUserFromAuthorizationHeader(header, request)
         : this.plainTokenExtractor.authUser(
-            defaultCookie.orElseGet(() -> new Cookie(COOKIE_NAME, null)).getValue());
+            defaultCookie.orElseGet(() -> new Cookie(COOKIE_NAME, null)).getValue(), request);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
@@ -1,5 +1,7 @@
 package io.openaev.security.token;
 
+import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
+
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Jwks;
@@ -14,8 +16,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
-import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
 
 @Component
 @Slf4j

--- a/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
@@ -28,16 +28,13 @@ public class ConnectorJwtExtractor implements ExtractorBase {
   @Override
   public Optional<User> authUser(String value, HttpServletRequest request)
       throws ConnectorError, JwtException {
-    Optional<String> tenantId = tenantUriUtils.getTenantIdFromRequestUrl(request);
-    if (tenantId.isEmpty()) {
-      // if no tenant can be found,
-      // backwards compatibility fallback to default tenant ID
-      tenantId = Optional.of(DEFAULT_TENANT_UUID);
-    }
+    // if no tenant can be found in the request URL,
+    // backwards compatibility fallback to default tenant ID
+    String tenantId = tenantUriUtils.getTenantIdFromRequestUrl(request).orElse(DEFAULT_TENANT_UUID);
 
-    Optional<ConnectorBase> connector = openCTIConnectorService.getConnectorBase(tenantId.get());
+    Optional<ConnectorBase> connector = openCTIConnectorService.getConnectorBase(tenantId);
     if (connector.isEmpty()) {
-      throw new ConnectorError("Connector for tenant '%s' not found".formatted(tenantId.get()));
+      throw new ConnectorError("Connector for tenant '%s' not found".formatted(tenantId));
     }
 
     try {
@@ -58,7 +55,7 @@ public class ConnectorJwtExtractor implements ExtractorBase {
       return userService.findByTokenAndTenantId(
           connector.get().getToken(), connector.get().getTenantId());
     } catch (Exception e) {
-      // No exception needed here because thrown above
+      log.debug("Connector JWT verification failed for tenant {}", tenantId, e);
     }
 
     throw new ConnectorError("Token or JWT not valid");

--- a/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
@@ -4,16 +4,13 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Jwks;
 import io.openaev.config.TenantUriUtils;
-import io.openaev.database.model.Tenant;
 import io.openaev.database.model.User;
 import io.openaev.opencti.connectors.ConnectorBase;
 import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
 import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.service.UserService;
-import java.util.List;
-import java.util.Optional;
-
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -27,9 +24,10 @@ public class ConnectorJwtExtractor implements ExtractorBase {
   private final TenantUriUtils tenantUriUtils;
 
   @Override
-  public Optional<User> authUser(String value, HttpServletRequest request) throws ConnectorError, JwtException {
+  public Optional<User> authUser(String value, HttpServletRequest request)
+      throws ConnectorError, JwtException {
     Optional<String> tenantId = tenantUriUtils.getTenantIdFromRequestUrl(request);
-    if(tenantId.isEmpty()) {
+    if (tenantId.isEmpty()) {
       throw new ConnectorError("Cannot locate a connector without a tenant ID in the request.");
     }
 
@@ -53,7 +51,8 @@ public class ConnectorJwtExtractor implements ExtractorBase {
               })
           .build()
           .parseSignedClaims(value);
-      return userService.findByTokenAndTenantId(connector.get().getToken(), connector.get().getTenantId());
+      return userService.findByTokenAndTenantId(
+          connector.get().getToken(), connector.get().getTenantId());
     } catch (Exception e) {
       // No exception needed here because thrown above
     }

--- a/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
@@ -3,6 +3,8 @@ package io.openaev.security.token;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Jwks;
+import io.openaev.config.TenantUriUtils;
+import io.openaev.database.model.Tenant;
 import io.openaev.database.model.User;
 import io.openaev.opencti.connectors.ConnectorBase;
 import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
@@ -10,6 +12,8 @@ import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.service.UserService;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,34 +24,40 @@ import org.springframework.stereotype.Component;
 public class ConnectorJwtExtractor implements ExtractorBase {
   private final OpenCTIConnectorService openCTIConnectorService;
   private final UserService userService;
+  private final TenantUriUtils tenantUriUtils;
 
   @Override
-  public Optional<User> authUser(String value) throws ConnectorError, JwtException {
-    List<ConnectorBase> connectors = openCTIConnectorService.getRegisterConnectors();
-    if (connectors.isEmpty()) {
-      throw new ConnectorError("Connectors not found");
+  public Optional<User> authUser(String value, HttpServletRequest request) throws ConnectorError, JwtException {
+    Optional<String> tenantId = tenantUriUtils.getTenantIdFromRequestUrl(request);
+    if(tenantId.isEmpty()) {
+      throw new ConnectorError("Cannot locate a connector without a tenant ID in the request.");
     }
-    for (ConnectorBase connector : connectors) {
-      try {
-        Jwts.parser()
-            .requireIssuer("opencti")
-            .requireSubject("connector")
-            .keyLocator(
-                header -> {
-                  String kid = (String) header.get("kid");
-                  return Jwks.setParser().build().parse(connector.getJwks()).getKeys().stream()
-                      .filter(k -> kid.equals(k.getId()))
-                      .findFirst()
-                      .orElseThrow()
-                      .toKey();
-                })
-            .build()
-            .parseSignedClaims(value);
-        return userService.findByTokenAndTenantId(connector.getToken(), connector.getTenantId());
-      } catch (Exception e) {
-        // No exception needed here because thrown above
-      }
+
+    Optional<ConnectorBase> connector = openCTIConnectorService.getConnectorBase(tenantId.get());
+    if (connector.isEmpty()) {
+      throw new ConnectorError("Connector for tenant '%s' not found".formatted(tenantId.get()));
     }
+
+    try {
+      Jwts.parser()
+          .requireIssuer("opencti")
+          .requireSubject("connector")
+          .keyLocator(
+              header -> {
+                String kid = (String) header.get("kid");
+                return Jwks.setParser().build().parse(connector.get().getJwks()).getKeys().stream()
+                    .filter(k -> kid.equals(k.getId()))
+                    .findFirst()
+                    .orElseThrow()
+                    .toKey();
+              })
+          .build()
+          .parseSignedClaims(value);
+      return userService.findByTokenAndTenantId(connector.get().getToken(), connector.get().getTenantId());
+    } catch (Exception e) {
+      // No exception needed here because thrown above
+    }
+
     throw new ConnectorError("Token or JWT not valid");
   }
 }

--- a/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ConnectorJwtExtractor.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -28,7 +30,9 @@ public class ConnectorJwtExtractor implements ExtractorBase {
       throws ConnectorError, JwtException {
     Optional<String> tenantId = tenantUriUtils.getTenantIdFromRequestUrl(request);
     if (tenantId.isEmpty()) {
-      throw new ConnectorError("Cannot locate a connector without a tenant ID in the request.");
+      // if no tenant can be found,
+      // backwards compatibility fallback to default tenant ID
+      tenantId = Optional.of(DEFAULT_TENANT_UUID);
     }
 
     Optional<ConnectorBase> connector = openCTIConnectorService.getConnectorBase(tenantId.get());

--- a/openaev-api/src/main/java/io/openaev/security/token/ExtractorBase.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ExtractorBase.java
@@ -5,9 +5,9 @@ import io.openaev.database.model.User;
 import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.security.error.AuthenticationError;
 import jakarta.servlet.http.HttpServletRequest;
-
 import java.util.Optional;
 
 public interface ExtractorBase {
-  Optional<User> authUser(String value, HttpServletRequest request) throws ConnectorError, JwtException, AuthenticationError;
+  Optional<User> authUser(String value, HttpServletRequest request)
+      throws ConnectorError, JwtException, AuthenticationError;
 }

--- a/openaev-api/src/main/java/io/openaev/security/token/ExtractorBase.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/ExtractorBase.java
@@ -4,8 +4,10 @@ import io.jsonwebtoken.JwtException;
 import io.openaev.database.model.User;
 import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.security.error.AuthenticationError;
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.Optional;
 
 public interface ExtractorBase {
-  Optional<User> authUser(String value) throws ConnectorError, JwtException, AuthenticationError;
+  Optional<User> authUser(String value, HttpServletRequest request) throws ConnectorError, JwtException, AuthenticationError;
 }

--- a/openaev-api/src/main/java/io/openaev/security/token/PlainTokenExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/PlainTokenExtractor.java
@@ -2,9 +2,8 @@ package io.openaev.security.token;
 
 import io.openaev.database.model.User;
 import io.openaev.service.UserService;
-import java.util.Optional;
-
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/openaev-api/src/main/java/io/openaev/security/token/PlainTokenExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/PlainTokenExtractor.java
@@ -3,6 +3,8 @@ package io.openaev.security.token;
 import io.openaev.database.model.User;
 import io.openaev.service.UserService;
 import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,7 +17,7 @@ public class PlainTokenExtractor implements ExtractorBase {
   private final UserService userService;
 
   @Override
-  public Optional<User> authUser(String value) {
+  public Optional<User> authUser(String value, HttpServletRequest _request) {
     return userService.findByToken(value);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/security/token/XtmJwksExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/XtmJwksExtractor.java
@@ -11,6 +11,7 @@ import io.openaev.security.error.AuthenticationError;
 import io.openaev.service.UserService;
 import io.openaev.utils.StringUtils;
 import io.openaev.xtmone.XtmOneConfig;
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Duration;
@@ -21,8 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
-
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -64,7 +63,8 @@ public class XtmJwksExtractor implements ExtractorBase {
   private record CachedJwks(Instant fetchedAt, String jwksJson) {}
 
   @Override
-  public Optional<User> authUser(String value, HttpServletRequest _request) throws JwtException, AuthenticationError {
+  public Optional<User> authUser(String value, HttpServletRequest _request)
+      throws JwtException, AuthenticationError {
     if (value == null) {
       throw new AuthenticationError("No bearer token found");
     }

--- a/openaev-api/src/main/java/io/openaev/security/token/XtmJwksExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/XtmJwksExtractor.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -62,7 +64,7 @@ public class XtmJwksExtractor implements ExtractorBase {
   private record CachedJwks(Instant fetchedAt, String jwksJson) {}
 
   @Override
-  public Optional<User> authUser(String value) throws JwtException, AuthenticationError {
+  public Optional<User> authUser(String value, HttpServletRequest _request) throws JwtException, AuthenticationError {
     if (value == null) {
       throw new AuthenticationError("No bearer token found");
     }

--- a/openaev-api/src/test/java/io/openaev/config/TenantInterceptorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantInterceptorTest.java
@@ -17,8 +17,10 @@ import org.springframework.web.servlet.HandlerMapping;
 @DisplayName("TenantInterceptor")
 class TenantInterceptorTest {
 
-  private final TenantInterceptor interceptor =
-      new TenantInterceptor(mock(TenantMembershipCacheManager.class));
+  private final TenantMembershipCacheManager tenantMembershipCacheManager =
+      mock(TenantMembershipCacheManager.class);
+  private final TenantUriUtils tenantUriUtils = new TenantUriUtils();
+  private final TenantInterceptor interceptor = new TenantInterceptor(tenantMembershipCacheManager, tenantUriUtils);
 
   @AfterEach
   void cleanup() {

--- a/openaev-api/src/test/java/io/openaev/config/TenantInterceptorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantInterceptorTest.java
@@ -20,7 +20,8 @@ class TenantInterceptorTest {
   private final TenantMembershipCacheManager tenantMembershipCacheManager =
       mock(TenantMembershipCacheManager.class);
   private final TenantUriUtils tenantUriUtils = new TenantUriUtils();
-  private final TenantInterceptor interceptor = new TenantInterceptor(tenantMembershipCacheManager, tenantUriUtils);
+  private final TenantInterceptor interceptor =
+      new TenantInterceptor(tenantMembershipCacheManager, tenantUriUtils);
 
   @AfterEach
   void cleanup() {

--- a/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
+++ b/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -156,5 +157,44 @@ public class OpenCTIJwtAuthenticationTest extends IntegrationTest {
     } else {
       mvc.perform(request).andExpect(status().isUnauthorized());
     }
+  }
+
+  @Test
+  void processBundle_withServletContextPath_authorizesConnectorJwtForUrlTenant() throws Exception {
+    JwtFixture.Bundle validJwtJwk = JwtFixture.generateConnectorJwtBundle(false);
+    String tenantId = TenantContext.getCurrentTenant();
+
+    SecurityCoverageConnector c = new SecurityCoverageConnector();
+    c.setJwks(validJwtJwk.jwks());
+    c.setOpenCTIConfig(openCTIConfig.getOpencti().get(tenantId));
+    c.setTenantId(tenantId);
+    Mockito.doReturn(Optional.of(c)).when(openCTIConnectorService).getConnectorBase(tenantId);
+
+    User user =
+        userComposer
+            .forUser(UserFixture.getUserWithDefaultEmail())
+            .withToken(tokenComposer.forToken(TokenFixture.getTokenWithValue("auth token")))
+            .persist()
+            .get();
+    tenantRepository.addUserToTenant(user.getId(), Tenant.DEFAULT_TENANT_UUID);
+    entityManager.flush();
+
+    String contextPath = "/openaev";
+    String urlPrefix = TENANT_STIX_URI.replaceAll("\\{" + TENANT_ID_PATH_VARIABLE + "}", tenantId);
+
+    // the tenant resolution used for connector JWT auth must still work when the
+    // application is deployed under a non-root servlet context path
+    var request =
+        post(contextPath + urlPrefix + "/process-bundle")
+            .contextPath(contextPath)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("")
+            .with(csrf())
+            .header("Authorization", "Bearer " + validJwtJwk.jwtToken());
+
+    mvc.perform(request)
+        .andExpect(
+            result ->
+                assertNotEquals(HttpStatus.UNAUTHORIZED.value(), result.getResponse().getStatus()));
   }
 }

--- a/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
+++ b/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
@@ -71,7 +71,7 @@ public class OpenCTIJwtAuthenticationTest extends IntegrationTest {
             "Bearer " + validJwtJwk.jwtToken(),
             validJwtJwk.jwks(),
             true,
-            "Given valid JWT should authorized"),
+            "Given valid JWT should authorize"),
         Arguments.of(
             "Bearer " + expiredJwtJwk.jwtToken(),
             expiredJwtJwk.jwks(),
@@ -91,7 +91,6 @@ public class OpenCTIJwtAuthenticationTest extends IntegrationTest {
       Mockito.doReturn(Optional.of(c))
           .when(openCTIConnectorService)
           .getConnectorBase(TenantContext.getCurrentTenant());
-      Mockito.doReturn(List.of(c)).when(openCTIConnectorService).getRegisterConnectors();
     }
 
     User user =

--- a/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
+++ b/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
@@ -1,6 +1,7 @@
 package io.openaev.security;
 
-import static io.openaev.api.stix_process.StixApi.STIX_URI;
+import static io.openaev.api.stix_process.StixApi.TENANT_STIX_URI;
+import static io.openaev.config.TenantUriUtils.TENANT_ID_PATH_VARIABLE;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -22,6 +23,7 @@ import io.openaev.utils.fixtures.composers.TokenComposer;
 import io.openaev.utils.fixtures.composers.UserComposer;
 import io.openaev.utils.mockConfig.WithMockOpenCTIConfig;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
@@ -62,35 +64,69 @@ public class OpenCTIJwtAuthenticationTest extends IntegrationTest {
   private Stream<Arguments> authorizationOpenCTI() throws Exception {
     JwtFixture.Bundle validJwtJwk = JwtFixture.generateConnectorJwtBundle(false);
     JwtFixture.Bundle expiredJwtJwk = JwtFixture.generateConnectorJwtBundle(true);
+    String configuredTenantId = TenantContext.getCurrentTenant();
+    String otherTenantId = UUID.randomUUID().toString();
 
     return Stream.of(
-        Arguments.of(null, null, false, "Given no token should get 401 Unauthorized status"),
-        Arguments.of(adminToken, null, true, "Given Admin token should be authorized"),
+        Arguments.of(
+            null,
+            null,
+            false,
+            "Given no token should get 401 Unauthorized status",
+            configuredTenantId,
+            configuredTenantId),
+        Arguments.of(
+            adminToken,
+            null,
+            true,
+            "Given Admin token should be authorized",
+            configuredTenantId,
+            configuredTenantId),
         Arguments.of(
             "Bearer " + validJwtJwk.jwtToken(),
             validJwtJwk.jwks(),
             true,
-            "Given valid JWT should authorize"),
+            "Given valid JWT should authorize",
+            configuredTenantId,
+            configuredTenantId),
+        Arguments.of(
+            "Bearer " + validJwtJwk.jwtToken(),
+            validJwtJwk.jwks(),
+            false,
+            "Given valid JWT for configured tenant, requesting other tenant should fail",
+            configuredTenantId,
+            otherTenantId),
         Arguments.of(
             "Bearer " + expiredJwtJwk.jwtToken(),
             expiredJwtJwk.jwks(),
             false,
-            "Given expired valid JWT should not authorize"));
+            "Given expired valid JWT should not authorize",
+            configuredTenantId,
+            configuredTenantId));
   }
 
   @ParameterizedTest(name = "{3}")
   @MethodSource("authorizationOpenCTI")
   void processBundle_authorizationOpenCti(
-      String authHeader, String jwks, Boolean isAuthorized, String displayName) throws Exception {
+      String authHeader,
+      String jwks,
+      Boolean isAuthorized,
+      String displayName,
+      String configuredTenantId,
+      String requestedTenantId)
+      throws Exception {
     if (jwks != null) {
       SecurityCoverageConnector c = new SecurityCoverageConnector();
       c.setJwks(jwks);
-      c.setOpenCTIConfig(openCTIConfig.getOpencti().get(TenantContext.getCurrentTenant()));
-      c.setTenantId(TenantContext.getCurrentTenant());
+      c.setOpenCTIConfig(openCTIConfig.getOpencti().get(configuredTenantId));
+      c.setTenantId(configuredTenantId);
       Mockito.doReturn(Optional.of(c))
           .when(openCTIConnectorService)
-          .getConnectorBase(TenantContext.getCurrentTenant());
+          .getConnectorBase(configuredTenantId);
     }
+
+    String urlPrefix =
+        TENANT_STIX_URI.replaceAll("\\{" + TENANT_ID_PATH_VARIABLE + "}", requestedTenantId);
 
     User user =
         userComposer
@@ -102,7 +138,7 @@ public class OpenCTIJwtAuthenticationTest extends IntegrationTest {
     entityManager.flush();
 
     var request =
-        post(STIX_URI + "/process-bundle")
+        post(urlPrefix + "/process-bundle")
             .contentType(MediaType.APPLICATION_JSON)
             .content("")
             .with(csrf());

--- a/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
+++ b/openaev-api/src/test/java/io/openaev/security/OpenCTIJwtAuthenticationTest.java
@@ -21,7 +21,6 @@ import io.openaev.utils.fixtures.UserFixture;
 import io.openaev.utils.fixtures.composers.TokenComposer;
 import io.openaev.utils.fixtures.composers.UserComposer;
 import io.openaev.utils.mockConfig.WithMockOpenCTIConfig;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;

--- a/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
@@ -1,0 +1,80 @@
+package io.openaev.utilstest;
+
+import static io.openaev.config.TenantUriUtils.TENANT_BASE_PATH;
+import static io.openaev.config.TenantUriUtils.TENANT_ID_PATH_VARIABLE;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.openaev.config.TenantUriUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.HandlerMapping;
+
+@ExtendWith(MockitoExtension.class)
+public class TenantUriUtilsTest {
+  private final TenantUriUtils tenantUriUtils = new TenantUriUtils();
+  @Mock private HttpServletRequest mockRequest;
+
+  static final String tenantId = "c078ce91-d4b8-4d29-a17e-b8fea925dc2c";
+
+  static String generateTenantUri(String tenantId) {
+    return generateTenantUri(tenantId, "");
+  }
+
+  static String generateTenantUri(String tenantId, String subpath) {
+    return TENANT_BASE_PATH + tenantId + subpath;
+  }
+
+  @Nested
+  @DisplayName("When there is no URI_TEMPLATE_VARIABLES_ATTRIBUTE")
+  public class NoUriTemplateAttributes {
+    static Stream<Arguments> uris() {
+      return Stream.of(
+          Arguments.of(generateTenantUri(tenantId), Optional.of(tenantId)),
+          Arguments.of(null, Optional.empty()),
+          Arguments.of(generateTenantUri(tenantId, "/more"), Optional.of(tenantId)),
+          Arguments.of(generateTenantUri("subpath/" + tenantId, "/more"), Optional.empty()),
+          Arguments.of("/generic/" + tenantId, Optional.empty()));
+    }
+
+    @ParameterizedTest(name = "given uri={0} should return {1}")
+    @MethodSource("uris")
+    void matchTest(String uri, Optional<String> outcome) {
+      when(mockRequest.getRequestURI()).thenReturn(uri);
+      assertThat(tenantUriUtils.getTenantIdFromRequestUrl(mockRequest)).isEqualTo(outcome);
+    }
+  }
+
+  @Nested
+  @DisplayName("When there is URI_TEMPLATE_VARIABLES_ATTRIBUTE")
+  public class WithUriTemplateAttributes {
+    @Test
+    @DisplayName("given tenant part is found, then return tenantId")
+    void given_tenantPartIsFound_then_returnTenantId() {
+      when(mockRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+          .thenReturn(Map.of(TENANT_ID_PATH_VARIABLE, tenantId));
+      assertThat(tenantUriUtils.getTenantIdFromRequestUrl(mockRequest))
+          .isEqualTo(Optional.of(tenantId));
+    }
+
+    @Test
+    @DisplayName("given tenant part is not found, then return empty")
+    void given_tenantPartIsNotFound_then_returnEmpty() {
+      when(mockRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+          .thenReturn(Map.of());
+      when(mockRequest.getRequestURI()).thenReturn("");
+      assertThat(tenantUriUtils.getTenantIdFromRequestUrl(mockRequest)).isEmpty();
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
@@ -45,7 +45,8 @@ public class TenantUriUtilsTest {
           Arguments.of(null, Optional.empty()),
           Arguments.of(generateTenantUri(tenantId, "/more"), Optional.of(tenantId)),
           Arguments.of(generateTenantUri("subpath/" + tenantId, "/more"), Optional.empty()),
-          Arguments.of("/generic/" + tenantId, Optional.empty()));
+          Arguments.of("/generic/" + tenantId, Optional.empty()),
+          Arguments.of("/generic/api/tenants/" + tenantId, Optional.empty()));
     }
 
     @ParameterizedTest(name = "given uri={0} should return {1}")

--- a/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
@@ -59,6 +59,29 @@ public class TenantUriUtilsTest {
       when(mockRequest.getRequestURI()).thenReturn(uri);
       assertThat(tenantUriUtils.getTenantIdFromRequestUrl(mockRequest)).isEqualTo(outcome);
     }
+
+    static Stream<Arguments> contextPathUris() {
+      return Stream.of(
+          // context path is stripped before matching the anchored pattern
+          Arguments.of(
+              "/openaev" + generateTenantUri(tenantId, "/more"), "/openaev", Optional.of(tenantId)),
+          Arguments.of("/openaev" + generateTenantUri(tenantId), "/openaev", Optional.of(tenantId)),
+          // root context path (empty string) leaves the URI untouched
+          Arguments.of(generateTenantUri(tenantId, "/more"), "", Optional.of(tenantId)),
+          // URI not under the context path is matched as-is
+          Arguments.of(generateTenantUri(tenantId), "/other", Optional.of(tenantId)),
+          // a tenant-looking path nested under another prefix still does not match
+          Arguments.of(
+              "/openaev/generic" + generateTenantUri(tenantId), "/openaev", Optional.empty()));
+    }
+
+    @ParameterizedTest(name = "given uri={0} and contextPath={1} should return {2}")
+    @MethodSource("contextPathUris")
+    void contextPathMatchTest(String uri, String contextPath, Optional<String> outcome) {
+      when(mockRequest.getRequestURI()).thenReturn(uri);
+      when(mockRequest.getContextPath()).thenReturn(contextPath);
+      assertThat(tenantUriUtils.getTenantIdFromRequestUrl(mockRequest)).isEqualTo(outcome);
+    }
   }
 
   @Nested

--- a/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/TenantUriUtilsTest.java
@@ -46,7 +46,11 @@ public class TenantUriUtilsTest {
           Arguments.of(generateTenantUri(tenantId, "/more"), Optional.of(tenantId)),
           Arguments.of(generateTenantUri("subpath/" + tenantId, "/more"), Optional.empty()),
           Arguments.of("/generic/" + tenantId, Optional.empty()),
-          Arguments.of("/generic/api/tenants/" + tenantId, Optional.empty()));
+          Arguments.of("/generic/api/tenants/" + tenantId, Optional.empty()),
+          // tenant segment must be a full UUID ending at a path-segment boundary
+          Arguments.of(generateTenantUri(tenantId + "garbage", "/more"), Optional.empty()),
+          Arguments.of(generateTenantUri("deadbeef", "/more"), Optional.empty()),
+          Arguments.of(generateTenantUri("not-a-uuid"), Optional.empty()));
     }
 
     @ParameterizedTest(name = "given uri={0} should return {1}")


### PR DESCRIPTION
### Proposed changes

* Only look up the JWKS of the connector belonging to the tenant of the requested URL when verifying OpenCTI connector JWTs, instead of iterating every registered connector. This prevents a JWT issued for one tenant's connector from authenticating requests against another tenant.
* Thread `HttpServletRequest` through `TokenAuthenticationFilter` -> `ExtractorBase` so token extractors can resolve the tenant from the incoming URL.
* Introduce `TenantUriUtils.getTenantIdFromRequestUrl` (path variables first, strict URI regex fallback) and reuse it from both `TenantInterceptor` and `ConnectorJwtExtractor`. The regex fallback only accepts a full UUID ending at a path-segment boundary, since the token filter runs before handler mapping and this parsing is security-relevant.
* Requests without a tenant in the URL fall back to the default tenant for backwards compatibility.

### Testing Instructions

1. Set up two tenants
2. Connect two connectors to different OpenCTI instances
3. Get a connector JWT from the first OpenCTI instance
4. Submit a STIX bundle to the second OpenAEV tenant (related to the second OpenCTI) using the JWT from the first OpenCTI instance for auth
5. The bundle should be rejected

Automated coverage: `OpenCTIJwtAuthenticationTest` includes a cross-tenant regression case (valid JWT for tenant A requesting tenant B's URL must get 401), and `TenantUriUtilsTest` covers tenant-id extraction including malformed and truncated tenant segments.

### Related issues

* Closes #7180

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
