### PR TITLE
fix(injector-contract): dedupe attack patterns/tags/domains on the search endpoint (#7189)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -746,12 +746,32 @@ public class InjectorContractService implements DependenciesManager {
         tuple.get("payload_type", String.class),
         tuple.get("collector_type", String.class),
         tuple.get("injector_contract_injector_type", String.class),
-        tuple.get("injector_contract_attack_patterns", String[].class),
-        tuple.get("injector_contract_tags", String[].class),
-        tuple.get("injector_contract_domains", String[].class),
+        dedupePreservingOrder(tuple.get("injector_contract_attack_patterns", String[].class)),
+        dedupePreservingOrder(tuple.get("injector_contract_tags", String[].class)),
+        dedupePreservingOrder(tuple.get("injector_contract_domains", String[].class)),
         tuple.get("injector_contract_updated_at", Instant.class),
         tuple.get("payload_execution_arch", Payload.PAYLOAD_EXECUTION_ARCH.class),
         injectorNames);
+  }
+
+  /**
+   * Deduplicates an array of IDs while preserving first-seen order.
+   *
+   * <p>{@code buildCommonInjectorContractContext} aggregates several independent collections
+   * (domains, attack patterns, tags) via parallel LEFT JOINs under a single GROUP BY that doesn't
+   * cover any of them; when a contract has more than one row in one of those collections, the
+   * cartesian product duplicates every value from the others. Deduplicating here is a query-shape
+   * workaround, not a data fix: the underlying rows are correct, only their cartesian-product
+   * expansion isn't.
+   *
+   * @param values the raw (possibly duplicate-laden) array, or {@code null}
+   * @return a deduplicated array, or {@code null} if the input was {@code null}
+   */
+  private static String[] dedupePreservingOrder(String[] values) {
+    if (values == null) {
+      return null;
+    }
+    return Arrays.stream(values).distinct().toArray(String[]::new);
   }
 
   /**
@@ -931,11 +951,11 @@ public class InjectorContractService implements DependenciesManager {
         tuple.get("injector_contract_updated_at", Instant.class),
         tuple.get("injector_contract_labels", Map.class),
         tuple.get("injector_contract_injector_type", String.class),
-        tuple.get("injector_contract_domains", String[].class),
+        dedupePreservingOrder(tuple.get("injector_contract_domains", String[].class)),
         tuple.get("injector_contract_platforms", Endpoint.PLATFORM_TYPE[].class),
-        tuple.get("injector_contract_tags", String[].class),
+        dedupePreservingOrder(tuple.get("injector_contract_tags", String[].class)),
         payload,
-        tuple.get("injector_contract_attack_patterns", String[].class),
+        dedupePreservingOrder(tuple.get("injector_contract_attack_patterns", String[].class)),
         tuple.get("injector_contract_payload_author", String.class),
         tuple.get("injector_contract_payload_author_name", String.class),
         tuple.get("injector_contract_payload_author_type", String.class));

--- a/openaev-api/src/test/java/io/openaev/rest/injector_contract/InjectorContractApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/injector_contract/InjectorContractApiTest.java
@@ -1470,7 +1470,8 @@ public class InjectorContractApiTest extends IntegrationTest {
       em.flush();
       em.clear();
 
-      InjectorContractSearchPaginationInput searchInput = new InjectorContractSearchPaginationInput();
+      InjectorContractSearchPaginationInput searchInput =
+          new InjectorContractSearchPaginationInput();
       searchInput.setIncludeFullDetails(true);
       searchInput.setInjectorContractIdsToProcess(List.of(taggedContract.getId()));
 

--- a/openaev-api/src/test/java/io/openaev/rest/injector_contract/InjectorContractApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/injector_contract/InjectorContractApiTest.java
@@ -75,6 +75,7 @@ public class InjectorContractApiTest extends IntegrationTest {
   @Autowired private DomainComposer domainComposer;
   @Autowired private PayloadComposer payloadComposer;
   @Autowired private DomainRepository domainRepository;
+  @Autowired private TagComposer tagComposer;
 
   @Autowired private UserComposer userComposer;
   @Autowired private TenantGroupComposer tenantGroupComposer;
@@ -94,6 +95,7 @@ public class InjectorContractApiTest extends IntegrationTest {
     tenantRoleComposer.reset();
     grantComposer.reset();
     domainComposer.reset();
+    tagComposer.reset();
   }
 
   @Nested
@@ -1443,6 +1445,50 @@ public class InjectorContractApiTest extends IntegrationTest {
         result.andExpect(
             jsonPath("$.totalElements", equalTo(preExistingContractsCount + grantedActionNumber)));
       }
+    }
+
+    @Test
+    @DisplayName(
+        "A contract with one attack pattern and several tags returns that attack pattern only once")
+    void searchDoesNotDuplicateAttackPatternsWhenContractHasSeveralTags() throws Exception {
+      // buildCommonInjectorContractContext aggregates domains/attackPatterns/tags via parallel
+      // LEFT JOINs under a single GROUP BY that covers none of them; more than one tag on the
+      // contract used to fan out the cartesian product and duplicate the single attack pattern.
+      AttackPatternComposer.Composer attackPatternWrapper =
+          attackPatternComposer
+              .forAttackPattern(AttackPatternFixture.createDefaultAttackPattern())
+              .persist();
+      InjectorContract taggedContract =
+          injectorContractComposer
+              .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+              .withInjector(injectorFixture.getWellKnownOaevImplantInjector())
+              .withAttackPattern(attackPatternWrapper)
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("tag-one")).persist())
+              .withTag(tagComposer.forTag(TagFixture.getTagWithText("tag-two")).persist())
+              .persist()
+              .get();
+      em.flush();
+      em.clear();
+
+      InjectorContractSearchPaginationInput searchInput = new InjectorContractSearchPaginationInput();
+      searchInput.setIncludeFullDetails(true);
+      searchInput.setInjectorContractIdsToProcess(List.of(taggedContract.getId()));
+
+      String response =
+          mvc.perform(
+                  post(INJECTOR_CONTRACT_URL + "/search")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(mapper.writeValueAsString(searchInput))
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      assertThatJson(response)
+          .node("content[0].injector_contract_attack_patterns")
+          .isArray()
+          .isEqualTo(mapper.writeValueAsString(List.of(attackPatternWrapper.get().getId())));
     }
   }
 

--- a/openaev-front/src/admin/components/integrations/injectors/InjectorContracts.jsx
+++ b/openaev-front/src/admin/components/integrations/injectors/InjectorContracts.jsx
@@ -322,7 +322,7 @@ const InjectorContracts = () => {
                     style={inlineStyles.attack_patterns}
                   >
                     {injectorContract.injector_contract_attack_patterns?.length
-                      ? injectorContract.injector_contract_attack_patterns
+                      ? Array.from(new Set(injectorContract.injector_contract_attack_patterns))
                           .map((n) => {
                             const pattern = attackPatternsMap[n];
                             return pattern


### PR DESCRIPTION
## Summary
`buildCommonInjectorContractContext()` aggregates domains, attack patterns, and tags via three independent LEFT JOINs under a single `GROUP BY` that covers none of them. When a contract has more than one row in one of those collections (e.g. several tags), the cartesian product duplicates every value from the others — visible in the UI as the same MITRE ATT&CK technique listed twice in the "Attack patterns" column.

The underlying data was never wrong (confirmed directly: `injectors_contracts_attack_patterns` has exactly one row per real mapping); only the join's cartesian-product expansion was.

**Backend**: dedupe the three aggregated arrays in the two mappers that read them (`mapFull`, `mapThreatArsenal`) rather than fighting Hibernate's Criteria API for a `DISTINCT` inside `array_agg` (no such option exists in this Hibernate version's `arrayAgg` overloads — only `countDistinct` is special-cased).

**Frontend**: `InjectorContracts.jsx` rendered `injector_contract_attack_patterns` directly with no dedup, unlike the sibling kill-chain-phases block just above it which already wraps its derived list in a `Set`. Added the same `Set`-based dedup as a second line of defense.

Verified against a rebuilt image: scanned 5000 real contracts via the search endpoint (the one the frontend list page uses) — zero duplicates in attack_patterns/tags/domains, including contracts with several tags that previously exhibited the bug.

Fixes #7189

## Test plan
- [x] `mvn install -DskipTests -pl openaev-api -am` — compiles clean
- [x] New regression test (`searchDoesNotDuplicateAttackPatternsWhenContractHasSeveralTags`) reproducing the exact trigger condition (one attack pattern + two tags on the same contract) — passes in CI
- [x] End-to-end: scanned 5000 real contracts post-fix, zero duplicates
- [x] Full CI suite green (API Tests, E2E chrome/webkit, Spotless, etc.)