### PR TITLE
fix(chaining): fix rbac on chaining (#4824)

### DIFF
--- a/docs/docs/usage/rest-api.md
+++ b/docs/docs/usage/rest-api.md
@@ -144,6 +144,20 @@ The API uses standard HTTP status codes:
 
 Validation errors (400) return a structured body with per-field error messages. Other errors return a JSON body with a `message` field describing the issue.
 
+## Grant-scoped endpoints
+
+Global inventory endpoints such as `/api/endpoints`, `/api/asset_groups` or `/api/injector_contracts` require the corresponding platform capability (Assets, Threat Arsenal). A user who only holds a grant on a specific Simulation or Scenario can instead use resource-scoped counterparts that expose only the elements referenced by that resource. The chaining Workflow API follows this pattern:
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/workflows/{workflowId}/scope/endpoints` | Endpoints referenced by the workflow scope rules (allowlist and denylist) |
+| `POST /api/workflows/{workflowId}/scope/endpoints/find` | Same as above, restricted to the requested IDs |
+| `GET /api/workflows/{workflowId}/scope/asset-groups` | Asset groups referenced by the workflow scope rules |
+| `POST /api/workflows/{workflowId}/scope/asset-groups/find` | Same as above, restricted to the requested IDs |
+| `GET /api/workflows/{workflowId}/injector_contracts/{injectorContractId}` | An injector contract, returned only if one of the workflow steps references it |
+
+These endpoints check the caller's grant on the workflow's parent Simulation or Scenario instead of the global capabilities, so the chaining scope and logic screens work for grant-only users. IDs that are not referenced by the workflow are silently ignored, which prevents using these endpoints to read arbitrary platform data.
+
 ## Multi-tenant context
 
 When multi-tenancy is enabled, the API exposes two sets of endpoints:

--- a/openaev-api/src/main/java/io/openaev/api/chaining/WorkflowApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/WorkflowApi.java
@@ -8,10 +8,15 @@ import io.openaev.api.chaining.dto.ScopeAssetOutput;
 import io.openaev.api.chaining.dto.ScopeTeamOutput;
 import io.openaev.api.chaining.dto.WorkflowConfigurationInput;
 import io.openaev.api.chaining.dto.WorkflowConfigurationOutput;
+import io.openaev.api.chaining.dto.WorkflowInjectorContractOutput;
+import io.openaev.context.TxCtx;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
+import io.openaev.rest.asset.endpoint.form.EndpointOutput;
+import io.openaev.rest.asset_group.form.AssetGroupOutput;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.helper.RestBehavior;
+import io.openaev.rest.injector_contract.InjectorContractService;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.PreviewFeatureService;
 import io.openaev.service.chaining.ScopeService;
@@ -21,6 +26,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +45,7 @@ public class WorkflowApi extends RestBehavior {
   private final WorkflowService workflowService;
   private final ScopeService scopeService;
   private final PreviewFeatureService previewFeatureService;
+  private final InjectorContractService injectorContractService;
 
   // -- READ --
 
@@ -79,6 +86,7 @@ public class WorkflowApi extends RestBehavior {
       description = "Workflow not found or the INJECT_CHAINING feature is disabled")
   @GetMapping("/{workflowId}/valid-assets")
   @AccessControl(
+      resourceId = "#workflowId",
       actionPerformed = Action.READ,
       resourceType = ResourceType.WORKFLOW,
       isEnterpriseEdition = true)
@@ -101,11 +109,145 @@ public class WorkflowApi extends RestBehavior {
       responseCode = "404",
       description = "Workflow not found or the INJECT_CHAINING feature is disabled")
   @GetMapping("/{workflowId}/valid-teams")
-  @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.WORKFLOW)
+  @AccessControl(
+      resourceId = "#workflowId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.WORKFLOW,
+      isEnterpriseEdition = true)
   @LogExecutionTime
   public List<ScopeTeamOutput> getValidTeams(@PathVariable @NotBlank final String workflowId) {
     checkWorkflowFeatureEnabled();
     return scopeService.getValidTeams(workflowId).stream().map(ScopeTeamMapper::toOutput).toList();
+  }
+
+  @Operation(
+      summary = "Get the endpoints referenced by the scope rules of a workflow",
+      description =
+          "Returns the endpoints explicitly listed in the workflow scope rules, allowlist and "
+              + "denylist alike, so the scope screen can label every rule. Workflow-scoped "
+              + "counterpart of GET /api/endpoints: a user granted on the parent simulation or "
+              + "scenario can read them without the global asset capabilities.")
+  @Transactional(readOnly = true)
+  @ApiResponse(responseCode = "200", description = "Scope endpoints retrieved successfully")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Workflow not found or the INJECT_CHAINING feature is disabled")
+  @GetMapping("/{workflowId}/scope/endpoints")
+  @AccessControl(
+      resourceId = "#workflowId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.WORKFLOW,
+      isEnterpriseEdition = true)
+  @LogExecutionTime
+  // ctx is unused directly: the aspect reads it to scope this transaction against the v2-active
+  // executors table (each endpoint's agents eager-load their executor).
+  public List<EndpointOutput> getScopeEndpoints(
+      TxCtx ctx, @PathVariable @NotBlank final String workflowId) {
+    checkWorkflowFeatureEnabled();
+    return scopeService.getScopeEndpoints(workflowId);
+  }
+
+  @Operation(
+      summary = "Get the endpoints referenced by the scope rules of a workflow, by IDs",
+      description =
+          "Same as GET /{workflowId}/scope/endpoints, restricted to the requested IDs. IDs that "
+              + "are not referenced by the workflow scope rules are ignored.")
+  @Transactional(readOnly = true)
+  @ApiResponse(responseCode = "200", description = "Scope endpoints retrieved successfully")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Workflow not found or the INJECT_CHAINING feature is disabled")
+  @PostMapping("/{workflowId}/scope/endpoints/find")
+  @AccessControl(
+      resourceId = "#workflowId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.WORKFLOW,
+      isEnterpriseEdition = true)
+  @LogExecutionTime
+  // ctx is unused directly: the aspect reads it to scope this transaction against the v2-active
+  // executors table (each endpoint's agents eager-load their executor).
+  public List<EndpointOutput> findScopeEndpoints(
+      TxCtx ctx,
+      @PathVariable @NotBlank final String workflowId,
+      @RequestBody @Valid @NotNull final List<String> endpointIds) {
+    checkWorkflowFeatureEnabled();
+    return scopeService.getScopeEndpointsByIds(workflowId, endpointIds);
+  }
+
+  @Operation(
+      summary = "Get the asset groups referenced by the scope rules of a workflow",
+      description =
+          "Returns the asset groups explicitly listed in the workflow scope rules, allowlist and "
+              + "denylist alike. Workflow-scoped counterpart of GET /api/asset_groups.")
+  @Transactional(readOnly = true)
+  @ApiResponse(responseCode = "200", description = "Scope asset groups retrieved successfully")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Workflow not found or the INJECT_CHAINING feature is disabled")
+  @GetMapping("/{workflowId}/scope/asset-groups")
+  @AccessControl(
+      resourceId = "#workflowId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.WORKFLOW,
+      isEnterpriseEdition = true)
+  @LogExecutionTime
+  public List<AssetGroupOutput> getScopeAssetGroups(
+      @PathVariable @NotBlank final String workflowId) {
+    checkWorkflowFeatureEnabled();
+    return scopeService.getScopeAssetGroups(workflowId);
+  }
+
+  @Operation(
+      summary = "Get the asset groups referenced by the scope rules of a workflow, by IDs",
+      description =
+          "Same as GET /{workflowId}/scope/asset-groups, restricted to the requested IDs. IDs that "
+              + "are not referenced by the workflow scope rules are ignored.")
+  @Transactional(readOnly = true)
+  @ApiResponse(responseCode = "200", description = "Scope asset groups retrieved successfully")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Workflow not found or the INJECT_CHAINING feature is disabled")
+  @PostMapping("/{workflowId}/scope/asset-groups/find")
+  @AccessControl(
+      resourceId = "#workflowId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.WORKFLOW,
+      isEnterpriseEdition = true)
+  @LogExecutionTime
+  public List<AssetGroupOutput> findScopeAssetGroups(
+      @PathVariable @NotBlank final String workflowId,
+      @RequestBody @Valid @NotNull final List<String> assetGroupIds) {
+    checkWorkflowFeatureEnabled();
+    return scopeService.getScopeAssetGroupsByIds(workflowId, assetGroupIds);
+  }
+
+  @Operation(
+      summary = "Get an injector contract used by a workflow",
+      description =
+          "Returns the injector contract only if it is referenced by one of the workflow's steps. "
+              + "Chaining steps do not persist their inject before execution, so this is the only "
+              + "way for a user granted on the parent simulation or scenario to read the contracts "
+              + "displayed in the logic screen.")
+  @Transactional(readOnly = true)
+  @ApiResponse(responseCode = "200", description = "Injector contract retrieved successfully")
+  @ApiResponse(
+      responseCode = "404",
+      description =
+          "Workflow or injector contract not found, the contract is not used by the workflow, or "
+              + "the INJECT_CHAINING feature is disabled")
+  @GetMapping("/{workflowId}/injector_contracts/{injectorContractId}")
+  @AccessControl(
+      resourceId = "#workflowId",
+      actionPerformed = Action.READ,
+      resourceType = ResourceType.WORKFLOW,
+      isEnterpriseEdition = true)
+  @LogExecutionTime
+  public WorkflowInjectorContractOutput getWorkflowInjectorContract(
+      @PathVariable @NotBlank final String workflowId,
+      @PathVariable @NotBlank final String injectorContractId) {
+    checkWorkflowFeatureEnabled();
+    return WorkflowInjectorContractOutput.fromInjectorContract(
+        injectorContractService.injectorContractForWorkflow(injectorContractId, workflowId));
   }
 
   // -- UPDATE --

--- a/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowInjectorContractOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/dto/WorkflowInjectorContractOutput.java
@@ -1,0 +1,22 @@
+package io.openaev.api.chaining.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.openaev.database.model.InjectorContract;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(
+    description =
+        "Injector contract referenced by a workflow step, exposed for the logic screen. "
+            + "Only the fields needed to render the action form are returned.")
+public record WorkflowInjectorContractOutput(
+    @Schema(description = "Injector contract Id") @JsonProperty("injector_contract_id") @NotBlank
+        String id,
+    @Schema(description = "Injector contract content (serialized fields)")
+        @JsonProperty("injector_contract_content")
+        String content) {
+
+  public static WorkflowInjectorContractOutput fromInjectorContract(InjectorContract contract) {
+    return new WorkflowInjectorContractOutput(contract.getId(), contract.getContent());
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -23,6 +23,7 @@ import io.openaev.database.raw.RawInjectorsContracts;
 import io.openaev.database.repository.AttackPatternRepository;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
+import io.openaev.database.repository.StepRepository;
 import io.openaev.database.repository.TagRepository;
 import io.openaev.database.specification.InjectorContractSpecification;
 import io.openaev.injector_contract.Contract;
@@ -106,6 +107,7 @@ public class InjectorContractService implements DependenciesManager {
   private final InjectorService injectorService;
   private final OrganizationService organizationService;
   private final InjectIndexCleanupService injectIndexCleanupService;
+  private final StepRepository stepRepository;
 
   private final List<String> listDefaultInjectorContract =
       List.of(
@@ -140,6 +142,30 @@ public class InjectorContractService implements DependenciesManager {
         .findByIdOrExternalId(id, id)
         // User-facing wording: the entity is exposed as "threat arsenal item" everywhere.
         .orElseThrow(() -> new ElementNotFoundException("Threat arsenal item not found"));
+  }
+
+  /**
+   * Retrieves an injector contract by ID, only if it is referenced by one of the given workflow's
+   * steps.
+   *
+   * <p>Chaining steps do not persist their inject before execution (the inject is serialized into
+   * {@code step_data}), so contracts used by a chaining simulation/scenario cannot be resolved
+   * through the injects of the parent simulation or scenario. This workflow-scoped lookup covers
+   * both chaining contexts, and the caller's permission is checked on the workflow's parent
+   * simulation or scenario.
+   *
+   * @param injectorContractId the injector contract ID
+   * @param workflowId the ID of the workflow the contract must be referenced by
+   * @return the injector contract
+   * @throws ElementNotFoundException if not found or not referenced by the workflow
+   */
+  public InjectorContract injectorContractForWorkflow(
+      @NotBlank final String injectorContractId, @NotBlank final String workflowId) {
+    if (!stepRepository.existsInjectorContractByWorkflowIdAndInjectorContractId(
+        workflowId, injectorContractId)) {
+      throw new ElementNotFoundException("Threat arsenal item not found");
+    }
+    return injectorContract(injectorContractId);
   }
 
   // -- OTHERS --

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ScopeService.java
@@ -5,9 +5,14 @@ import static io.openaev.utils.JsonUtils.gson;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.TeamRepository;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
+import io.openaev.rest.asset.endpoint.form.EndpointOutput;
+import io.openaev.rest.asset_group.form.AssetGroupOutput;
 import io.openaev.service.AssetGroupService;
 import io.openaev.service.AssetService;
+import io.openaev.service.EndpointService;
 import io.openaev.utils.IpAddressUtils;
+import io.openaev.utils.mapper.AssetGroupMapper;
+import io.openaev.utils.mapper.EndpointMapper;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +27,95 @@ public class ScopeService {
   private final AssetGroupService assetGroupService;
   private final WorkflowStateService workflowStateService;
   private final TeamRepository teamRepository;
+  private final EndpointService endpointService;
+  private final EndpointMapper endpointMapper;
+  private final AssetGroupMapper assetGroupMapper;
+
+  /**
+   * Returns the endpoints explicitly listed in the workflow scope rules ({@code ASSET_ID} rules),
+   * whatever the rule mode.
+   *
+   * <p>Denylisted assets are included on purpose: the scope screen has to label both the allow and
+   * the deny column. This is the workflow-scoped counterpart of {@code GET /api/endpoints}, so a
+   * user granted on the parent simulation/scenario can read them without the global asset
+   * capabilities.
+   *
+   * @param workflowId the workflow whose scope rules are read
+   * @return the endpoints referenced by the scope rules
+   */
+  public List<EndpointOutput> getScopeEndpoints(final String workflowId) {
+    Set<String> assetIds = collectScopeRuleValues(workflowId, ScopeRuleValueType.ASSET_ID);
+    return resolveEndpoints(assetIds);
+  }
+
+  /**
+   * Same as {@link #getScopeEndpoints(String)} but restricted to the requested IDs. IDs that are
+   * not part of the workflow scope rules are silently ignored so the endpoint cannot be used to
+   * read arbitrary assets.
+   *
+   * @param workflowId the workflow whose scope rules are read
+   * @param endpointIds the endpoint IDs to resolve
+   * @return the matching endpoints
+   */
+  public List<EndpointOutput> getScopeEndpointsByIds(
+      final String workflowId, final List<String> endpointIds) {
+    Set<String> allowedIds = collectScopeRuleValues(workflowId, ScopeRuleValueType.ASSET_ID);
+    allowedIds.retainAll(new HashSet<>(endpointIds));
+    return resolveEndpoints(allowedIds);
+  }
+
+  /**
+   * Returns the asset groups explicitly listed in the workflow scope rules ({@code ASSET_GROUP_ID}
+   * rules), whatever the rule mode. See {@link #getScopeEndpoints(String)} for the rationale.
+   *
+   * @param workflowId the workflow whose scope rules are read
+   * @return the asset groups referenced by the scope rules
+   */
+  public List<AssetGroupOutput> getScopeAssetGroups(final String workflowId) {
+    Set<String> assetGroupIds =
+        collectScopeRuleValues(workflowId, ScopeRuleValueType.ASSET_GROUP_ID);
+    return resolveAssetGroups(assetGroupIds);
+  }
+
+  /**
+   * Same as {@link #getScopeAssetGroups(String)} but restricted to the requested IDs. IDs that are
+   * not part of the workflow scope rules are silently ignored.
+   *
+   * @param workflowId the workflow whose scope rules are read
+   * @param assetGroupIds the asset group IDs to resolve
+   * @return the matching asset groups
+   */
+  public List<AssetGroupOutput> getScopeAssetGroupsByIds(
+      final String workflowId, final List<String> assetGroupIds) {
+    Set<String> allowedIds = collectScopeRuleValues(workflowId, ScopeRuleValueType.ASSET_GROUP_ID);
+    allowedIds.retainAll(new HashSet<>(assetGroupIds));
+    return resolveAssetGroups(allowedIds);
+  }
+
+  private List<EndpointOutput> resolveEndpoints(final Set<String> endpointIds) {
+    return endpointIds.isEmpty()
+        ? List.of()
+        : endpointService.endpoints(List.copyOf(endpointIds)).stream()
+            .map(endpointMapper::toEndpointOutput)
+            .toList();
+  }
+
+  private List<AssetGroupOutput> resolveAssetGroups(final Set<String> assetGroupIds) {
+    return assetGroupIds.isEmpty()
+        ? List.of()
+        : assetGroupService.assetGroups(List.copyOf(assetGroupIds)).stream()
+            .map(assetGroupMapper::toAssetGroupOutput)
+            .toList();
+  }
+
+  private Set<String> collectScopeRuleValues(
+      final String workflowId, final ScopeRuleValueType valueType) {
+    return workflowScopeRuleRepository.findAllByWorkflowId(workflowId).stream()
+        .filter(rule -> valueType.equals(rule.getValueType()))
+        .map(WorkflowScopeRule::getRuleValue)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
 
   /**
    * Returns the assets that are in scope for the given workflow and that are not denied by a value

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
@@ -127,6 +127,10 @@ class TenantScopedEntrypointsTxCtxArchTest {
           // target search path.
           "io.openaev.rest.scenario.ScenarioApi#endpoints",
           "io.openaev.rest.scenario.ScenarioApi#endpointsByIds",
+          // workflow scope inventory (chaining RBAC, #4824): same EndpointMapper agent/executor
+          // walk as the scenario/exercise endpoint reads above.
+          "io.openaev.api.chaining.WorkflowApi#getScopeEndpoints",
+          "io.openaev.api.chaining.WorkflowApi#findScopeEndpoints",
           "io.openaev.rest.scenario.ScenarioApi#updateScenarioRecurrence",
           "io.openaev.rest.scenario.ScenarioApi#createRunningExerciseFromScenario",
           "io.openaev.rest.exercise.ExerciseApi#endpoints",

--- a/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
@@ -272,4 +272,45 @@ class StepRepositoryTest extends IntegrationTest {
     Assertions.assertTrue(resolved.contains(withInject1.getId() + "=inject-batch-1"));
     Assertions.assertTrue(resolved.contains(withInject2.getId() + "=inject-batch-2"));
   }
+
+  @Test
+  void whenExistsInjectorContractByWorkflowIdAndInjectorContractId_thenChecksBothJsonShapes() {
+    // GIVEN
+    String objectContractId = "contract-object";
+    String stringContractId = "contract-string";
+    Workflow workflow =
+        workflowComposer
+            .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+            .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+            .withStep(
+                stepComposer.forStep(
+                    Step.builder()
+                        .stepAction(StepActionClass.INJECT_EXECUTION)
+                        .status(StepStatus.TEMPLATE)
+                        .data(
+                            "{\"inject_injector_contract\": {\"injector_contract_id\": \""
+                                + objectContractId
+                                + "\"}}")
+                        .build()))
+            .withStep(
+                stepComposer.forStep(
+                    Step.builder()
+                        .stepAction(StepActionClass.INJECT_EXECUTION)
+                        .status(StepStatus.TEMPLATE)
+                        .data("{\"inject_injector_contract\": \"" + stringContractId + "\"}")
+                        .build()))
+            .persist()
+            .get();
+
+    // WHEN / THEN
+    Assertions.assertTrue(
+        stepRepository.existsInjectorContractByWorkflowIdAndInjectorContractId(
+            workflow.getId(), objectContractId));
+    Assertions.assertTrue(
+        stepRepository.existsInjectorContractByWorkflowIdAndInjectorContractId(
+            workflow.getId(), stringContractId));
+    Assertions.assertFalse(
+        stepRepository.existsInjectorContractByWorkflowIdAndInjectorContractId(
+            workflow.getId(), "contract-missing"));
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ScopeServiceTest.java
@@ -1,12 +1,18 @@
 package io.openaev.service.chaining;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.openaev.database.model.*;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
+import io.openaev.rest.asset.endpoint.form.EndpointOutput;
+import io.openaev.rest.asset_group.form.AssetGroupOutput;
 import io.openaev.service.AssetGroupService;
 import io.openaev.service.AssetService;
+import io.openaev.service.EndpointService;
+import io.openaev.utils.mapper.AssetGroupMapper;
+import io.openaev.utils.mapper.EndpointMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ScopeService - getValidAssets")
+@DisplayName("ScopeService")
 class ScopeServiceTest {
 
   private static final String WORKFLOW_ID = "workflow-1";
@@ -25,6 +31,9 @@ class ScopeServiceTest {
   @Mock private AssetService assetService;
   @Mock private AssetGroupService assetGroupService;
   @Mock private WorkflowStateService workflowStateService;
+  @Mock private EndpointService endpointService;
+  @Mock private EndpointMapper endpointMapper;
+  @Mock private AssetGroupMapper assetGroupMapper;
 
   @InjectMocks private ScopeService scopeService;
 
@@ -267,5 +276,112 @@ class ScopeServiceTest {
     List<String> result = scopeService.getValidManualTargetsFromScopeAndGlobalState(WORKFLOW_ID);
 
     assertThat(result).containsExactly("192.168.10.1", "192.168.10.2", "192.168.10.3");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scope inventory (workflow-scoped endpoint / asset group listing)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @DisplayName(
+      "Scope endpoints - ASSET_ID rules from both modes are returned, other rule types ignored")
+  void givenMixedRules_whenGettingScopeEndpoints_thenReturnsAssetIdRulesFromBothModes() {
+    Endpoint allowed = endpointWithSeenIp("asset-1", "host-1", "10.0.0.1");
+    Endpoint denied = endpointWithSeenIp("asset-2", "host-2", "10.0.0.2");
+    EndpointOutput allowedOutput = EndpointOutput.builder().id("asset-1").build();
+    EndpointOutput deniedOutput = EndpointOutput.builder().id("asset-2").build();
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                denylistRule(ScopeRuleValueType.ASSET_ID, "asset-2"),
+                allowlistRule(ScopeRuleValueType.ASSET_GROUP_ID, "group-1"),
+                allowlistRule(ScopeRuleValueType.IP, "10.0.0.9")));
+    when(endpointService.endpoints(List.of("asset-1", "asset-2")))
+        .thenReturn(List.of(allowed, denied));
+    when(endpointMapper.toEndpointOutput(allowed)).thenReturn(allowedOutput);
+    when(endpointMapper.toEndpointOutput(denied)).thenReturn(deniedOutput);
+
+    List<EndpointOutput> result = scopeService.getScopeEndpoints(WORKFLOW_ID);
+
+    assertThat(result).containsExactly(allowedOutput, deniedOutput);
+  }
+
+  @Test
+  @DisplayName("Scope endpoints - no ASSET_ID rules means no endpoint lookup at all")
+  void givenNoAssetIdRules_whenGettingScopeEndpoints_thenReturnsEmptyWithoutLookup() {
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(List.of(allowlistRule(ScopeRuleValueType.IP, "10.0.0.9")));
+
+    List<EndpointOutput> result = scopeService.getScopeEndpoints(WORKFLOW_ID);
+
+    assertThat(result).isEmpty();
+    verifyNoInteractions(endpointService);
+  }
+
+  @Test
+  @DisplayName("Scope endpoints by IDs - IDs outside the workflow scope rules are ignored")
+  void givenIdsOutsideScopeRules_whenFindingScopeEndpoints_thenOnlyScopedIdsAreResolved() {
+    Endpoint denied = endpointWithSeenIp("asset-2", "host-2", "10.0.0.2");
+    EndpointOutput deniedOutput = EndpointOutput.builder().id("asset-2").build();
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1"),
+                denylistRule(ScopeRuleValueType.ASSET_ID, "asset-2")));
+    when(endpointService.endpoints(List.of("asset-2"))).thenReturn(List.of(denied));
+    when(endpointMapper.toEndpointOutput(denied)).thenReturn(deniedOutput);
+
+    List<EndpointOutput> result =
+        scopeService.getScopeEndpointsByIds(WORKFLOW_ID, List.of("asset-2", "asset-3"));
+
+    assertThat(result).containsExactly(deniedOutput);
+  }
+
+  @Test
+  @DisplayName(
+      "Scope asset groups - ASSET_GROUP_ID rules from both modes are returned, other rule types ignored")
+  void givenMixedRules_whenGettingScopeAssetGroups_thenReturnsAssetGroupIdRulesFromBothModes() {
+    AssetGroup allowed = new AssetGroup();
+    allowed.setId("group-1");
+    AssetGroup denied = new AssetGroup();
+    denied.setId("group-2");
+    AssetGroupOutput allowedOutput = AssetGroupOutput.builder().id("group-1").build();
+    AssetGroupOutput deniedOutput = AssetGroupOutput.builder().id("group-2").build();
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(
+            List.of(
+                allowlistRule(ScopeRuleValueType.ASSET_GROUP_ID, "group-1"),
+                denylistRule(ScopeRuleValueType.ASSET_GROUP_ID, "group-2"),
+                allowlistRule(ScopeRuleValueType.ASSET_ID, "asset-1")));
+    when(assetGroupService.assetGroups(List.of("group-1", "group-2")))
+        .thenReturn(List.of(allowed, denied));
+    when(assetGroupMapper.toAssetGroupOutput(allowed)).thenReturn(allowedOutput);
+    when(assetGroupMapper.toAssetGroupOutput(denied)).thenReturn(deniedOutput);
+
+    List<AssetGroupOutput> result = scopeService.getScopeAssetGroups(WORKFLOW_ID);
+
+    assertThat(result).containsExactly(allowedOutput, deniedOutput);
+  }
+
+  @Test
+  @DisplayName("Scope asset groups by IDs - IDs outside the workflow scope rules are ignored")
+  void givenIdsOutsideScopeRules_whenFindingScopeAssetGroups_thenOnlyScopedIdsAreResolved() {
+    AssetGroup allowed = new AssetGroup();
+    allowed.setId("group-1");
+    AssetGroupOutput allowedOutput = AssetGroupOutput.builder().id("group-1").build();
+
+    when(workflowScopeRuleRepository.findAllByWorkflowId(WORKFLOW_ID))
+        .thenReturn(List.of(allowlistRule(ScopeRuleValueType.ASSET_GROUP_ID, "group-1")));
+    when(assetGroupService.assetGroups(List.of("group-1"))).thenReturn(List.of(allowed));
+    when(assetGroupMapper.toAssetGroupOutput(allowed)).thenReturn(allowedOutput);
+
+    List<AssetGroupOutput> result =
+        scopeService.getScopeAssetGroupsByIds(WORKFLOW_ID, List.of("group-1", "group-9"));
+
+    assertThat(result).containsExactly(allowedOutput);
   }
 }

--- a/openaev-front/src/actions/chaining/workflow-actions.ts
+++ b/openaev-front/src/actions/chaining/workflow-actions.ts
@@ -1,7 +1,9 @@
 import type { Dispatch } from 'redux';
 
-import { getReferential, putReferential, simpleCall } from '../../utils/Action';
+import { getReferential, putReferential, simpleCall, simplePostCall } from '../../utils/Action';
 import type { ScopeAssetOutput, ScopeTeamOutput, WorkflowConfigurationInput } from '../../utils/api-types';
+import { arrayOfAssetGroups } from '../asset_groups/assetgroup-schema';
+import { arrayOfEndpoints } from '../assets/asset-schema';
 import workflowConfigurationSchema from './workflow-schema';
 
 const WORKFLOW_URI = '/api/workflows';
@@ -24,4 +26,36 @@ export const fetchValidAssets = (workflowId: string): Promise<ScopeAssetOutput[]
 export const fetchValidTeams = (workflowId: string): Promise<ScopeTeamOutput[]> => {
   const uri = `${WORKFLOW_URI}/${workflowId}/valid-teams`;
   return simpleCall(uri).then(response => response.data);
+};
+
+// -- SCOPE INVENTORY --
+// Workflow-scoped counterparts of /api/endpoints and /api/asset_groups: they only expose the
+// assets referenced by the workflow scope rules, so a user merely granted on the parent
+// simulation or scenario can read them without the global asset capabilities.
+
+export const fetchWorkflowScopeEndpoints = (workflowId: string) => (dispatch: Dispatch) => {
+  const uri = `${WORKFLOW_URI}/${workflowId}/scope/endpoints`;
+  return getReferential(arrayOfEndpoints, uri)(dispatch);
+};
+
+export const findWorkflowScopeEndpoints = (workflowId: string, endpointIds: string[]) => {
+  const uri = `${WORKFLOW_URI}/${workflowId}/scope/endpoints/find`;
+  return simplePostCall(uri, endpointIds);
+};
+
+export const fetchWorkflowScopeAssetGroups = (workflowId: string) => (dispatch: Dispatch) => {
+  const uri = `${WORKFLOW_URI}/${workflowId}/scope/asset-groups`;
+  return getReferential(arrayOfAssetGroups, uri)(dispatch);
+};
+
+export const findWorkflowScopeAssetGroups = (workflowId: string, assetGroupIds: string[]) => {
+  const uri = `${WORKFLOW_URI}/${workflowId}/scope/asset-groups/find`;
+  return simplePostCall(uri, assetGroupIds);
+};
+
+// Injector contract used by one of the workflow's steps. Chaining steps do not persist their
+// inject before execution, so this is the only lookup that works for a user granted on the
+// parent simulation or scenario without the threat arsenal capabilities.
+export const directFetchWorkflowInjectorContract = (workflowId: string, injectorContractId: string) => {
+  return simpleCall(`${WORKFLOW_URI}/${workflowId}/injector_contracts/${injectorContractId}`);
 };

--- a/openaev-front/src/admin/components/chaining/ScopeDefinition.tsx
+++ b/openaev-front/src/admin/components/chaining/ScopeDefinition.tsx
@@ -1,11 +1,13 @@
 import { Box } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 
 import { fetchAssetGroups } from '../../../actions/asset_groups/assetgroup-action';
 import { fetchEndpoints } from '../../../actions/assets/endpoint-actions';
 import {
   fetchWorkflowConfiguration,
+  fetchWorkflowScopeAssetGroups,
+  fetchWorkflowScopeEndpoints,
   updateWorkflowConfiguration,
 } from '../../../actions/chaining/workflow-actions';
 import type { WorkflowConfigurationHelper } from '../../../actions/chaining/workflow-helper';
@@ -16,6 +18,8 @@ import type { ScopeVariableInput, WorkflowConfigurationInput, WorkflowScopeRuleI
 import { useAppDispatch } from '../../../utils/hooks';
 import useDataLoader from '../../../utils/hooks/useDataLoader';
 import useLivePolling from '../../../utils/hooks/useLivePolling';
+import { AbilityContext } from '../../../utils/permissions/permissionsContext';
+import { ACTIONS, SUBJECTS } from '../../../utils/permissions/types';
 import ScopeExecutionLimits from './ScopeExecutionLimits';
 import ScopeRules from './ScopeRules';
 import ScopeVariables from './ScopeVariables';
@@ -36,16 +40,26 @@ const ScopeDefinition = ({ workflowId, readOnly = false, autonomous = false, aut
   // Standard hooks
   const theme = useTheme();
   const dispatch = useAppDispatch();
+  const ability = useContext(AbilityContext);
+  // A user only granted on the parent simulation/scenario has no global asset capability:
+  // fall back to the workflow-scoped inventory so the scope screen still resolves asset labels.
+  const canAccessAssets = ability.can(ACTIONS.ACCESS, SUBJECTS.ASSETS);
 
   // Fetching data
   const { workflowConfiguration } = useHelper((helper: WorkflowConfigurationHelper) => ({ workflowConfiguration: helper.getWorkflowConfiguration(workflowId) }));
 
   useDataLoader(() => {
     dispatch(fetchWorkflowConfiguration(workflowId));
-    dispatch(fetchEndpoints());
-    dispatch(fetchAssetGroups());
+    dispatch(fetchWorkflowScopeEndpoints(workflowId));
+    dispatch(fetchWorkflowScopeAssetGroups(workflowId));
     dispatch(fetchTeams());
     dispatch(fetchPlayers());
+    // The global inventories require the asset capabilities: a user merely granted on the parent
+    // simulation/scenario reads the scoped lists above instead, which resolve every chip label.
+    if (canAccessAssets) {
+      dispatch(fetchEndpoints());
+      dispatch(fetchAssetGroups());
+    }
   });
 
   // Keep the Scope tab live: the AI edits the allow/deny lists, variables and limits during a run, so
@@ -131,7 +145,12 @@ const ScopeDefinition = ({ workflowId, readOnly = false, autonomous = false, aut
       aria-disabled={readOnly || undefined}
     >
       {/* Row 1: allow list | deny list (ScopeRules renders both cards as a fragment). */}
-      <ScopeRules workflowConfiguration={workflowConfiguration} onUpdate={handleUpdate} />
+      <ScopeRules
+        workflowId={workflowId}
+        workflowConfiguration={workflowConfiguration}
+        onUpdate={handleUpdate}
+        readOnly={readOnly}
+      />
       {/* Row 2: variables | combined execution limits. */}
       <ScopeVariables workflowConfiguration={workflowConfiguration} onUpdate={handleUpdate} />
       <ScopeExecutionLimits

--- a/openaev-front/src/admin/components/chaining/ScopeForm.tsx
+++ b/openaev-front/src/admin/components/chaining/ScopeForm.tsx
@@ -14,6 +14,7 @@ import {
 
 import { findAssetGroups, searchAssetGroups } from '../../../actions/asset_groups/assetgroup-action';
 import { findEndpoints, searchEndpoints } from '../../../actions/assets/endpoint-actions';
+import { findWorkflowScopeAssetGroups, findWorkflowScopeEndpoints } from '../../../actions/chaining/workflow-actions';
 import { fetchExecutors } from '../../../actions/executors/executor-action';
 import type { ExecutorHelper } from '../../../actions/executors/executor-helper';
 import { searchPlayers } from '../../../actions/players/player-actions';
@@ -56,6 +57,7 @@ interface ScopeIdOption {
 }
 
 interface ScopeFormProps {
+  workflowId?: string;
   mode: 'ALLOWLIST' | 'DENYLIST';
   selectedEndpointIds: string[];
   selectedAssetGroupIds: string[];
@@ -83,6 +85,7 @@ interface ScopeFormProps {
 }
 
 const ScopeForm: FunctionComponent<ScopeFormProps> = ({
+  workflowId,
   mode,
   selectedEndpointIds,
   selectedAssetGroupIds,
@@ -108,8 +111,14 @@ const ScopeForm: FunctionComponent<ScopeFormProps> = ({
   const dispatch = useAppDispatch();
   const ability = useContext(AbilityContext);
 
-  // Tab state
-  const [currentTab, setCurrentTab] = useState<string>('assets');
+  // Each Add tab is gated on its own capability: the asset tabs need the global asset search,
+  // the teams / persons tabs only need the teams & players capability. A user granted on the
+  // parent simulation/scenario may hold either one independently.
+  const canAccessAssets = ability.can(ACTIONS.ACCESS, SUBJECTS.ASSETS);
+  const canAccessTeamsAndPlayers = ability.can(ACTIONS.ACCESS, SUBJECTS.TEAMS_AND_PLAYERS);
+
+  // Tab state - default to the first tab the user can actually see.
+  const [currentTab, setCurrentTab] = useState<string>(canAccessAssets ? 'assets' : 'teams');
 
   const listLabel = mode === 'ALLOWLIST' ? t('Allowlisted') : t('Denylisted');
   const addLabel = mode === 'ALLOWLIST' ? t('Add assets, asset groups, teams and persons to your allowlist') : t('Add assets, asset groups, teams and persons to your denylist');
@@ -123,26 +132,34 @@ const ScopeForm: FunctionComponent<ScopeFormProps> = ({
   const { executorsMap } = useHelper((helper: ExecutorHelper) => ({ executorsMap: helper.getExecutorsMap() }));
 
   useDataLoader(() => {
-    if (ability.can(ACTIONS.ACCESS, SUBJECTS.ASSETS)) {
+    if (canAccessAssets) {
       dispatch(fetchExecutors());
     }
   });
 
+  // A user granted on the parent simulation/scenario but without the global asset capabilities
+  // resolves the selected chips through the workflow-scoped endpoints instead.
   useEffect(() => {
     if (selectedEndpointIds.length > 0) {
-      findEndpoints(selectedEndpointIds).then(result => setSelectedEndpoints(result.data));
+      const resolve = canAccessAssets || !workflowId
+        ? findEndpoints(selectedEndpointIds)
+        : findWorkflowScopeEndpoints(workflowId, selectedEndpointIds);
+      resolve.then(result => setSelectedEndpoints(result.data));
     } else {
       setSelectedEndpoints([]);
     }
-  }, [selectedEndpointIds]);
+  }, [selectedEndpointIds, canAccessAssets, workflowId]);
 
   useEffect(() => {
     if (selectedAssetGroupIds.length > 0) {
-      findAssetGroups(selectedAssetGroupIds).then(result => setSelectedAssetGroups(result.data));
+      const resolve = canAccessAssets || !workflowId
+        ? findAssetGroups(selectedAssetGroupIds)
+        : findWorkflowScopeAssetGroups(workflowId, selectedAssetGroupIds);
+      resolve.then(result => setSelectedAssetGroups(result.data));
     } else {
       setSelectedAssetGroups([]);
     }
-  }, [selectedAssetGroupIds]);
+  }, [selectedAssetGroupIds, canAccessAssets, workflowId]);
 
   useEffect(() => {
     if (selectedTeamIds.length > 0) {
@@ -561,73 +578,76 @@ const ScopeForm: FunctionComponent<ScopeFormProps> = ({
         onClearAll={handleClearAll}
       />
 
-      {/* Add section */}
-      <Box>
-        <SectionLabel>{addLabel}</SectionLabel>
-
+      {/* Add section - each tab requires its own capability: asset tabs need the global asset
+          search, teams / persons tabs need the teams & players capability. */}
+      {(canAccessAssets || canAccessTeamsAndPlayers) && (
         <Box>
-          <Tabs value={currentTab} onChange={handleTabChange}>
-            <Tab value="assets" label={t('Assets')} />
-            <Tab value="asset_groups" label={t('Asset groups')} />
-            <Tab value="teams" label={t('Teams')} />
-            <Tab value="persons" label={t('Persons')} />
-          </Tabs>
+          <SectionLabel>{addLabel}</SectionLabel>
+
+          <Box>
+            <Tabs value={currentTab} onChange={handleTabChange}>
+              {canAccessAssets && <Tab value="assets" label={t('Assets')} />}
+              {canAccessAssets && <Tab value="asset_groups" label={t('Asset groups')} />}
+              {canAccessTeamsAndPlayers && <Tab value="teams" label={t('Teams')} />}
+              {canAccessTeamsAndPlayers && <Tab value="persons" label={t('Persons')} />}
+            </Tabs>
+          </Box>
+
+          <Box sx={{ marginTop: theme.spacing(2) }}>
+            {currentTab === 'assets' && (
+              <ClickableList<EndpointOutput>
+                values={endpoints}
+                selectedIds={selectedEndpointIds}
+                elements={endpointElements}
+                onSelect={addEndpoint}
+                onDeselect={removeEndpoint}
+                paginationComponent={endpointPagination}
+                getId={el => el.asset_id}
+                isLoading={isLoadingEndpoints}
+              />
+            )}
+
+            {currentTab === 'asset_groups' && (
+              <ClickableList<AssetGroupOutput>
+                values={assetGroups}
+                selectedIds={selectedAssetGroupIds}
+                elements={assetGroupElements}
+                onSelect={addAssetGroup}
+                onDeselect={removeAssetGroup}
+                paginationComponent={assetGroupPagination}
+                getId={el => el.asset_group_id}
+                isLoading={isLoadingAssetGroups}
+              />
+            )}
+
+            {currentTab === 'teams' && (
+              <ClickableList<TeamOutput>
+                values={teams}
+                selectedIds={selectedTeamIds}
+                elements={teamElements}
+                onSelect={addTeamSelection}
+                onDeselect={removeTeamSelection}
+                paginationComponent={teamPagination}
+                getId={el => el.team_id}
+                isLoading={isLoadingTeams}
+              />
+            )}
+
+            {currentTab === 'persons' && (
+              <ClickableList<PlayerOutput>
+                values={players}
+                selectedIds={selectedPlayerIds}
+                elements={playerElements}
+                onSelect={addPlayerSelection}
+                onDeselect={removePlayerSelection}
+                paginationComponent={playerPagination}
+                getId={el => el.user_id}
+                isLoading={isLoadingPlayers}
+              />
+            )}
+          </Box>
         </Box>
-
-        <Box sx={{ marginTop: theme.spacing(2) }}>
-          {currentTab === 'assets' && (
-            <ClickableList<EndpointOutput>
-              values={endpoints}
-              selectedIds={selectedEndpointIds}
-              elements={endpointElements}
-              onSelect={addEndpoint}
-              onDeselect={removeEndpoint}
-              paginationComponent={endpointPagination}
-              getId={el => el.asset_id}
-              isLoading={isLoadingEndpoints}
-            />
-          )}
-
-          {currentTab === 'asset_groups' && (
-            <ClickableList<AssetGroupOutput>
-              values={assetGroups}
-              selectedIds={selectedAssetGroupIds}
-              elements={assetGroupElements}
-              onSelect={addAssetGroup}
-              onDeselect={removeAssetGroup}
-              paginationComponent={assetGroupPagination}
-              getId={el => el.asset_group_id}
-              isLoading={isLoadingAssetGroups}
-            />
-          )}
-
-          {currentTab === 'teams' && (
-            <ClickableList<TeamOutput>
-              values={teams}
-              selectedIds={selectedTeamIds}
-              elements={teamElements}
-              onSelect={addTeamSelection}
-              onDeselect={removeTeamSelection}
-              paginationComponent={teamPagination}
-              getId={el => el.team_id}
-              isLoading={isLoadingTeams}
-            />
-          )}
-
-          {currentTab === 'persons' && (
-            <ClickableList<PlayerOutput>
-              values={players}
-              selectedIds={selectedPlayerIds}
-              elements={playerElements}
-              onSelect={addPlayerSelection}
-              onDeselect={removePlayerSelection}
-              paginationComponent={playerPagination}
-              getId={el => el.user_id}
-              isLoading={isLoadingPlayers}
-            />
-          )}
-        </Box>
-      </Box>
+      )}
 
       {/* Footer buttons */}
       {!hideFooter && (

--- a/openaev-front/src/admin/components/chaining/ScopeRules.tsx
+++ b/openaev-front/src/admin/components/chaining/ScopeRules.tsx
@@ -30,8 +30,10 @@ const OS_PLATFORM_CATEGORIES = new Set<AssetCategory>(['HOST', 'MOBILE_DEVICE'])
 type ScopeMode = 'ALLOWLIST' | 'DENYLIST';
 
 interface ScopeRulesProps {
+  workflowId: string;
   workflowConfiguration: WorkflowConfigurationOutput | undefined;
   onUpdate: (overrides: Partial<WorkflowConfigurationInput>) => void;
+  readOnly?: boolean;
 }
 
 // Visual grouping of scope entries by kind, so a scope with many entries reads as a scannable set of
@@ -85,6 +87,7 @@ interface ScopeColumnProps {
    *  everywhere else in the app rather than a bare label. */
   resolveIcon: (rule: WorkflowScopeRuleOutput) => ReactElement;
   onAdd: () => void;
+  readOnly?: boolean;
   /** Semantic accent - green for the allow-list, red for the deny-list - for instant scanning. */
   accent: string;
   headerIcon: ReactElement;
@@ -94,7 +97,17 @@ interface ScopeColumnProps {
 
 // Each list (allow / deny) is a self-contained card: a colored top strip for instant semantic
 // scanning, a header with its typed icon + count + Add affordance, and a grouped, chip-based body.
-const ScopeColumn = ({ title, rules, resolveLabel, resolveIcon, onAdd, accent, headerIcon, infoTooltip }: ScopeColumnProps) => {
+const ScopeColumn = ({
+  title,
+  rules,
+  resolveLabel,
+  resolveIcon,
+  onAdd,
+  readOnly = false,
+  accent,
+  headerIcon,
+  infoTooltip,
+}: ScopeColumnProps) => {
   // Standard hooks
   const { t } = useFormatter();
   const theme = useTheme();
@@ -161,7 +174,7 @@ const ScopeColumn = ({ title, rules, resolveLabel, resolveIcon, onAdd, accent, h
           )}
         </Box>
 
-        <Button size="small" startIcon={<EditOutlined />} onClick={onAdd}>
+        <Button size="small" startIcon={<EditOutlined />} onClick={onAdd} disabled={readOnly}>
           {t('Define')}
         </Button>
       </Box>
@@ -243,7 +256,7 @@ const ScopeColumn = ({ title, rules, resolveLabel, resolveIcon, onAdd, accent, h
           <Typography variant="body2" sx={{ color: 'text.disabled' }}>
             {t('Nothing added yet.')}
           </Typography>
-          <Button size="small" startIcon={<EditOutlined />} onClick={onAdd}>
+          <Button size="small" startIcon={<EditOutlined />} onClick={onAdd} disabled={readOnly}>
             {t('Define')}
           </Button>
         </Box>
@@ -252,7 +265,7 @@ const ScopeColumn = ({ title, rules, resolveLabel, resolveIcon, onAdd, accent, h
   );
 };
 
-const ScopeRules = ({ workflowConfiguration, onUpdate }: ScopeRulesProps) => {
+const ScopeRules = ({ workflowId, workflowConfiguration, onUpdate, readOnly = false }: ScopeRulesProps) => {
   const { t } = useFormatter();
   const theme = useTheme();
 
@@ -273,6 +286,7 @@ const ScopeRules = ({ workflowConfiguration, onUpdate }: ScopeRulesProps) => {
   const [initialCustomRules, setInitialCustomRules] = useState<ScopeCustomRule[]>([]);
 
   const handleOpenDrawer = (mode: ScopeMode) => {
+    if (readOnly) return;
     setDrawerMode(mode);
 
     // Pre-populate with existing rules for the given mode
@@ -466,6 +480,7 @@ const ScopeRules = ({ workflowConfiguration, onUpdate }: ScopeRulesProps) => {
         resolveLabel={resolveLabel}
         resolveIcon={resolveIcon}
         onAdd={() => handleOpenDrawer('ALLOWLIST')}
+        readOnly={readOnly}
         accent={theme.palette.success.main}
         headerIcon={<TaskAltOutlined fontSize="small" />}
       />
@@ -476,6 +491,7 @@ const ScopeRules = ({ workflowConfiguration, onUpdate }: ScopeRulesProps) => {
         resolveLabel={resolveLabel}
         resolveIcon={resolveIcon}
         onAdd={() => handleOpenDrawer('DENYLIST')}
+        readOnly={readOnly}
         accent={theme.palette.error.main}
         headerIcon={<BlockOutlined fontSize="small" />}
         infoTooltip={t('Entries in the deny list always take priority over those in the allow list.')}
@@ -487,6 +503,7 @@ const ScopeRules = ({ workflowConfiguration, onUpdate }: ScopeRulesProps) => {
         title={drawerTitle}
       >
         <ScopeForm
+          workflowId={workflowId}
           mode={drawerMode}
           selectedEndpointIds={selectedEndpointIds}
           selectedAssetGroupIds={selectedAssetGroupIds}

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ComponentStepperDrawer.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ComponentStepperDrawer.tsx
@@ -426,6 +426,7 @@ const ComponentStepperDrawer = ({
         {drawerView === 'actionDetail' && (
           <InjectTargetsProvider context={context} scenarioId={scenarioId} exerciseId={exerciseId} validTeams={validTeams}>
             <ConfigureActionDetail
+              workflowId={workflowId}
               action={activeAction}
               validAssets={validAssets}
               validTeams={validTeams}

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.tsx
@@ -5,6 +5,7 @@ import { type FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 
+import { directFetchWorkflowInjectorContract } from '../../../../../actions/chaining/workflow-actions';
 import { directFetchInjectorContract } from '../../../../../actions/InjectorContracts';
 import { findTeams } from '../../../../../actions/teams/team-actions';
 import SwitchFieldController from '../../../../../components/fields/SwitchFieldController';
@@ -39,6 +40,7 @@ import FieldOutputLink, { type FieldLink } from './FieldOutputLink';
 interface ConfigureActionDetailProps {
   /** Whether the hosting drawer step is active (feeds the inject-data panel + contract fetch). */
   open?: boolean;
+  workflowId?: string;
   action: ThreatArsenalAction | null;
   validAssets: ScopeAssetOutput[];
   validTeams?: ScopeTeamOutput[];
@@ -108,6 +110,7 @@ const buildEnhancedField = (
 
 const ConfigureActionDetail: FunctionComponent<ConfigureActionDetailProps> = ({
   open = true,
+  workflowId,
   action,
   validAssets,
   validTeams = [],
@@ -170,9 +173,17 @@ const ConfigureActionDetail: FunctionComponent<ConfigureActionDetailProps> = ({
     setFieldLinks(normalizeFieldLinks(initialData?.inject_field_links));
     setContractFields(initialData?.contract_fields ?? []);
 
-    const contractId = initialData?.inject_injector_contract ?? action.injector_contract_id;
+    const existingContractId = initialData?.inject_injector_contract;
+    const contractId = existingContractId ?? action.injector_contract_id;
     setLoadingContract(true);
-    directFetchInjectorContract(contractId)
+    // A contract already referenced by a workflow step is read through the workflow-scoped
+    // endpoint, so read-granted users never need the global threat-arsenal capabilities. A newly
+    // selected action's contract is not part of the workflow yet (the scoped lookup would 404):
+    // it goes through the global lookup, which is fine because adding actions requires the
+    // manage permission and the arsenal capabilities anyway.
+    (workflowId && existingContractId
+      ? directFetchWorkflowInjectorContract(workflowId, existingContractId)
+      : directFetchInjectorContract(contractId))
       .then((res: { data: { injector_contract_content?: string } }) => {
         if (!res.data?.injector_contract_content) return;
         try {
@@ -192,7 +203,7 @@ const ConfigureActionDetail: FunctionComponent<ConfigureActionDetailProps> = ({
       })
       .catch(() => setContractFields([]))
       .finally(() => setLoadingContract(false));
-  }, [action, initialData]);
+  }, [action, initialData, workflowId]);
 
   // Auto-link action input fields with their default primitive type when available.
   // Example: field argumentType "ipv4" -> outputTypes ["ipv4"].

--- a/openaev-front/src/admin/components/chaining/logic/logic-flow-helpers.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-flow-helpers.ts
@@ -1,6 +1,6 @@
 import { type Edge, MarkerType } from '@xyflow/react';
 
-import { directFetchInjectorContract } from '../../../../actions/InjectorContracts';
+import { directFetchWorkflowInjectorContract } from '../../../../actions/chaining/workflow-actions';
 import type { ConditionOutput, EventOutput, KillChainPhase, StepOutput } from '../../../../utils/api-types';
 import type { ContractElement } from '../../../../utils/api-types-custom';
 import {
@@ -324,9 +324,14 @@ export const buildEventData = (events: EventOutput[]): { eventMetas: Record<stri
 /**
  * Fetch injector contract fields for each action that has a contract.
  * Mutates the input actionMetas in place for performance.
+ *
+ * Contracts are read through the workflow-scoped endpoint so a user who only holds a read grant
+ * on the parent simulation/scenario — and none of the threat arsenal capabilities — still gets
+ * the fields of the contracts already used by the graph.
  */
 export const enrichActionMetasWithContracts = async (
   actionMetas: Record<string, ActionMeta>,
+  workflowId: string,
 ): Promise<Record<string, ActionMeta>> => {
   const contractIds = Array.from(new Set(
     Object.values(actionMetas)
@@ -338,7 +343,7 @@ export const enrichActionMetasWithContracts = async (
 
   await Promise.all(contractIds.map(async (cid) => {
     try {
-      const res = await directFetchInjectorContract(cid) as { data: { injector_contract_content?: string } };
+      const res = await directFetchWorkflowInjectorContract(workflowId, cid) as { data: { injector_contract_content?: string } };
       if (res.data?.injector_contract_content) {
         const parsed = JSON.parse(res.data.injector_contract_content);
         contractFieldsMap[cid] = (parsed.fields ?? []) as ContractElement[];

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
@@ -159,7 +159,7 @@ const LogicGraph = ({
 
     const parsedActionMetas = buildActionMetas(stepsRes.data);
     const { eventMetas: parsedEventMetas } = buildEventData(eventsRes.data);
-    const enrichedActionMetas = await enrichActionMetasWithContracts(parsedActionMetas);
+    const enrichedActionMetas = await enrichActionMetasWithContracts(parsedActionMetas, workflowId);
 
     setActionMetas(enrichedActionMetas);
     setContextProviders(buildOutputProvidersMap(enrichedActionMetas));

--- a/openaev-front/src/admin/components/nav/LeftBar.tsx
+++ b/openaev-front/src/admin/components/nav/LeftBar.tsx
@@ -80,19 +80,19 @@ const LeftBar = () => {
           path: `/admin/scenarios`,
           icon: () => (<RouteOutlined />),
           label: 'Scenarios',
-          userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT),
+          userRight: true,
         },
         {
           path: `/admin/simulations`,
           icon: () => (<PlayCircleOutlineOutlined />),
           label: 'Simulations',
-          userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT),
+          userRight: true,
         },
         {
           path: `/admin/atomic_testings`,
           icon: () => (<Target />),
           label: 'Atomic testings',
-          userRight: ability.can(ACTIONS.ACCESS, SUBJECTS.ASSESSMENT),
+          userRight: true,
         },
         {
           path: `/admin/threat-arsenal`,

--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -115,7 +115,7 @@ const ScenarioHeader = ({
   const theme = useTheme();
   const { scenarioId } = useParams() as { scenarioId: Scenario['scenario_id'] };
   const [openScenarioAssistantQueryParam, openAiBuilderQueryParam, openAiLaunchQueryParam] = useQueryParameter(['openScenarioAssistant', 'openAiBuilder', 'openAiLaunch']);
-  const { canLaunch, canManage } = useScenarioPermissions(scenarioId);
+  const { canLaunch, canManage, canDelete } = useScenarioPermissions(scenarioId);
 
   const [openConfiguration, setOpenConfiguration] = useState(false);
   const [openScheduling, setOpenScheduling] = useState(false);
@@ -246,6 +246,9 @@ const ScenarioHeader = ({
   const scenarioPopoverActions: ('Duplicate' | 'Update' | 'Delete' | 'Export')[] = isScenarioChaining
     ? ['Update', 'Delete', 'Export']
     : ['Duplicate', 'Update', 'Delete', 'Export'];
+  // Grant-only users without any of the manage / launch / delete permissions get no overflow menu
+  // at all instead of a popover full of disabled entries.
+  const canDisplayScenarioActions = canManage || canLaunch || canDelete;
   const isScopeMissing = isScenarioChaining
     && healthchecks.some((hc: HealthCheck) => hc.type === ('SCOPE_DEFINITION' as HealthCheck['type']) && hc.detail === 'EMPTY');
 
@@ -761,12 +764,15 @@ const ScenarioHeader = ({
               {/* Launch actions (suppressed while a run is active - the lifecycle controls own the
                   hero then). Resolved into `launchActions` above to avoid nested ternaries here. */}
               {!isRunActive && canLaunch && launchActions}
-              {/* Everything else - analyze, setup, and CRUD - in one overflow menu. */}
-              <ScenarioPopover
-                scenario={scenario}
-                actions={scenarioPopoverActions}
-                onDelete={() => navigate('/admin/scenarios')}
-              />
+              {/* Everything else - analyze, setup, and CRUD - in one overflow menu. Hidden entirely
+                  for grant-only users without any manage / launch / delete permission. */}
+              {canDisplayScenarioActions && (
+                <ScenarioPopover
+                  scenario={scenario}
+                  actions={scenarioPopoverActions}
+                  onDelete={() => navigate('/admin/scenarios')}
+                />
+              )}
             </>
           )}
           stats={(

--- a/openaev-front/src/admin/components/scenarios/scenario/logic/ScenarioLogic.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/logic/ScenarioLogic.tsx
@@ -1,15 +1,26 @@
+import { useContext } from 'react';
 import { useParams } from 'react-router';
 
 import { type ScenariosHelper } from '../../../../../actions/scenarios/scenario-helper';
 import { useHelper } from '../../../../../store';
 import type { Scenario } from '../../../../../utils/api-types';
 import Logic from '../../../chaining/logic/Logic';
+import { PermissionsContext } from '../../../common/Context';
 
 const ScenarioLogic = ({ readOnly = false }: { readOnly?: boolean }) => {
   const { scenarioId } = useParams() as { scenarioId: Scenario['scenario_id'] };
   const { scenario } = useHelper((helper: ScenariosHelper) => ({ scenario: helper.getScenario(scenarioId) }));
+  const { permissions } = useContext(PermissionsContext);
+  // Scenario logic maps are never frozen: they are isolated per run by the copy performed at
+  // launch (see ADR-005). They are read-only for an autonomous run (readOnly prop) or for a user
+  // without the manage permission, in which case we just hide the edit actions without a banner.
   return (
-    <Logic workflowId={scenario?.scenario_workflow_id} context="scenario" scenarioId={scenarioId} readOnly={readOnly} />
+    <Logic
+      workflowId={scenario?.scenario_workflow_id}
+      context="scenario"
+      scenarioId={scenarioId}
+      readOnly={readOnly || !permissions.canManage}
+    />
   );
 };
 

--- a/openaev-front/src/admin/components/scenarios/scenario/scope/ScenarioScope.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/scope/ScenarioScope.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
 import type { WorkflowConfigurationHelper } from '../../../../../actions/chaining/workflow-helper';
@@ -7,6 +7,7 @@ import type { ScenariosHelper } from '../../../../../actions/scenarios/scenario-
 import { useHelper } from '../../../../../store';
 import { type HealthCheck, type Scenario } from '../../../../../utils/api-types';
 import ScopeDefinition from '../../../chaining/ScopeDefinition';
+import { PermissionsContext } from '../../../common/Context';
 import Healthchecks from '../../../common/healthchecks/Healthchecks';
 
 interface Props {
@@ -28,6 +29,8 @@ const ScenarioScope = ({ readOnly = false, autonomousTimeoutSeconds }: Props) =>
     }),
   );
 
+  const { permissions } = useContext(PermissionsContext);
+
   const [healthchecks, setHealthchecks] = useState<HealthCheck[]>([]);
 
   useEffect(() => {
@@ -39,6 +42,10 @@ const ScenarioScope = ({ readOnly = false, autonomousTimeoutSeconds }: Props) =>
   // The empty-scope shortfall is already surfaced in the hero; drop the duplicate inline banner.
   const visibleHealthchecks = healthchecks.filter(healthcheck => healthcheck.type !== 'SCOPE_DEFINITION');
 
+  // Read-only for an autonomous run (readOnly prop) or for a user without the manage permission.
+  // Scenario scopes are never frozen, so no read-only banner is shown: we just hide the actions.
+  const isReadOnly = readOnly || !permissions.canManage;
+
   return (
     <div>
       {!!visibleHealthchecks.length && (
@@ -49,7 +56,7 @@ const ScenarioScope = ({ readOnly = false, autonomousTimeoutSeconds }: Props) =>
       )}
       <ScopeDefinition
         workflowId={scenario.scenario_workflow_id}
-        readOnly={readOnly}
+        readOnly={isReadOnly}
         autonomous={readOnly}
         autonomousTimeoutSeconds={autonomousTimeoutSeconds}
       />

--- a/openaev-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
@@ -367,6 +367,7 @@ const ExerciseHeader = ({ onLoading, isLoading, autonomousRun = null }: {
   } else if (isSimulationChaining) {
     actions = ['Update', 'Export', 'Delete'];
   }
+  const canDisplaySimulationActions = permissions.canManage || permissions.canLaunch || permissions.canDelete;
 
   // Headline stats surfaced right in the hero so they are visible on every
   // tab. The hero adapts to how the simulation is actually built: injects are
@@ -581,11 +582,13 @@ const ExerciseHeader = ({ onLoading, isLoading, autonomousRun = null }: {
                 entityName={exercise.exercise_name}
               />
               {/* CRUD actions in one overflow menu. */}
-              <ExercisePopover
-                exercise={exercise}
-                actions={actions}
-                onDelete={() => navigate('/admin/simulations')}
-              />
+              {canDisplaySimulationActions && (
+                <ExercisePopover
+                  exercise={exercise}
+                  actions={actions}
+                  onDelete={() => navigate('/admin/simulations')}
+                />
+              )}
             </>
           )}
           stats={(

--- a/openaev-front/src/admin/components/simulations/simulation/logic/SimulationLogic.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/logic/SimulationLogic.tsx
@@ -4,26 +4,33 @@ import { type ExercisesHelper } from '../../../../../actions/exercises/exercise-
 import { useFormatter } from '../../../../../components/i18n';
 import { useHelper } from '../../../../../store';
 import type { Exercise } from '../../../../../utils/api-types';
+import useSimulationPermissions from '../../../../../utils/permissions/useSimulationPermissions';
 import Logic from '../../../chaining/logic/Logic';
 
 const SimulationLogic = ({ isAutonomous = false }: { isAutonomous?: boolean }) => {
   const { t } = useFormatter();
   const { exerciseId } = useParams() as { exerciseId: Exercise['exercise_id'] };
   const { exercise } = useHelper((helper: ExercisesHelper) => ({ exercise: helper.getExercise(exerciseId) }));
+  const permissions = useSimulationPermissions(exerciseId, exercise);
   // Two independent reasons the logic map is read-only: an autonomous run (the AI owns the map,
   // passed in by the router) OR a launched simulation - the map is editable only while SCHEDULED
   // (UI "Draft" / "Scheduled"), see ADR-005. While the exercise is still loading, only the incoming
   // (autonomous) flag applies, so the frozen banner never flashes before the status is known.
   const launched = !!exercise && exercise.exercise_status !== 'SCHEDULED';
-  const effectiveReadOnly = isAutonomous || launched;
+  const effectiveReadOnly = isAutonomous || launched || !permissions.canManage;
   const resolveReadOnlyMessage = () => {
     if (isAutonomous) {
       return t('This simulation is driven by the autonomous attack path. Its logic map is read-only.');
     }
-    if (exercise?.exercise_scenario) {
-      return t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it, or update the scenario and run it again.');
+    if (launched) {
+      if (exercise?.exercise_scenario) {
+        return t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it, or update the scenario and run it again.');
+      }
+      return t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it.');
     }
-    return t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it.');
+    // Read-only purely because the user lacks the manage permission: hide the edit
+    // actions without a banner (consistent with ScenarioLogic).
+    return undefined;
   };
   const readOnlyMessage = resolveReadOnlyMessage();
   return (

--- a/openaev-front/src/admin/components/simulations/simulation/scope/SimulationScope.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/scope/SimulationScope.tsx
@@ -6,6 +6,7 @@ import { searchExerciseHealthchecks } from '../../../../../actions/Exercise';
 import type { ExercisesHelper } from '../../../../../actions/exercises/exercise-helper';
 import { useHelper } from '../../../../../store';
 import { type Exercise, type HealthCheck } from '../../../../../utils/api-types';
+import useSimulationPermissions from '../../../../../utils/permissions/useSimulationPermissions';
 import ScopeDefinition from '../../../chaining/ScopeDefinition';
 import Healthchecks from '../../../common/healthchecks/Healthchecks';
 
@@ -20,6 +21,7 @@ const SimulationScope = ({ readOnly = false, autonomousTimeoutSeconds }: Props) 
   const { exerciseId } = useParams() as { exerciseId: Exercise['exercise_id'] };
 
   const { exercise } = useHelper((helper: ExercisesHelper) => ({ exercise: helper.getExercise(exerciseId) }));
+  const permissions = useSimulationPermissions(exerciseId, exercise);
   const { workflowConfiguration } = useHelper(
     (helper: WorkflowConfigurationHelper) => ({
       workflowConfiguration: exercise?.exercise_workflow_id
@@ -44,7 +46,7 @@ const SimulationScope = ({ readOnly = false, autonomousTimeoutSeconds }: Props) 
   // Read-only for two independent reasons: an autonomous run (router-provided) OR a launched
   // simulation - the scope is editable only while SCHEDULED (see ADR-005).
   const launched = exercise.exercise_status !== 'SCHEDULED';
-  const effectiveReadOnly = readOnly || launched;
+  const effectiveReadOnly = readOnly || launched || !permissions.canManage;
 
   return (
     <div>

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -12528,6 +12528,17 @@ export interface WorkflowConfigurationOutput {
   workflow_scope_variables?: ScopeVariableOutput[];
 }
 
+/** Injector contract referenced by a workflow step, exposed for the logic screen. Only the fields needed to render the action form are returned. */
+export interface WorkflowInjectorContractOutput {
+  /** Injector contract content (serialized fields) */
+  injector_contract_content?: string;
+  /**
+   * Injector contract Id
+   * @minLength 1
+   */
+  injector_contract_id: string;
+}
+
 export interface WorkflowScopeRule {
   listened?: boolean;
   /** @format date-time */

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -254,4 +254,36 @@ public interface StepRepository extends JpaRepository<Step, String> {
    * @return {@code true} if at least one run step references this template
    */
   boolean existsByStepTemplateId(String stepTemplateId);
+
+  /**
+   * Checks whether the given workflow references the given injector contract in one of its steps.
+   *
+   * <p>{@code step_data.inject_injector_contract} holds the serialized {@link
+   * io.openaev.database.model.InjectorContract} for steps created through the chaining UI, but
+   * legacy steps may only hold the contract ID as a plain string: both shapes are handled.
+   *
+   * @param workflowId the ID of the workflow whose steps are inspected
+   * @param injectorContractId the injector contract ID to look for
+   * @return {@code true} if the workflow references the injector contract
+   */
+  @Query(
+      value =
+          """
+        SELECT EXISTS (
+          SELECT 1
+          FROM steps s
+          WHERE s.step_workflow_id = :workflowId
+            AND (
+              (jsonb_typeof(s.step_data -> 'inject_injector_contract') = 'object'
+                AND s.step_data -> 'inject_injector_contract' ->> 'injector_contract_id' = :injectorContractId)
+              OR
+              (jsonb_typeof(s.step_data -> 'inject_injector_contract') = 'string'
+                AND s.step_data ->> 'inject_injector_contract' = :injectorContractId)
+            )
+        )
+        """,
+      nativeQuery = true)
+  boolean existsInjectorContractByWorkflowIdAndInjectorContractId(
+      @Param("workflowId") String workflowId,
+      @Param("injectorContractId") String injectorContractId);
 }


### PR DESCRIPTION
### Proposed changes

- Add workflow-scoped listing APIs so grant-only simulation/scenario users can use the chaining scope and logic screens without any global capability: `GET /workflows/{id}/scope/endpoints`, `POST /workflows/{id}/scope/endpoints/find`, `GET /workflows/{id}/scope/asset-groups`, `POST /workflows/{id}/scope/asset-groups/find` and `GET /workflows/{id}/injector_contracts/{contractId}`. Each endpoint only exposes elements already referenced by the workflow (scope rules or steps), and the RBAC check runs against the workflow's parent simulation/scenario grant.
- The workflow contract lookup returns a dedicated `WorkflowInjectorContractOutput` DTO (id + content) and uses an O(1) jsonb EXISTS query on `step_data` (both serialized-object and plain-string contract shapes are handled).
- Frontend chaining views (scope definition, scope form, logic graph, action drawer) read through the workflow-scoped endpoints when the user lacks the global ASSETS capability, so no 403 shows up on the network.
- The scope form Add section gates each tab on its own capability: Assets / Asset groups on ASSETS, Teams / Persons on TEAMS_AND_PLAYERS.
- Action buttons are hidden or disabled when the user is not granted or lacks the capability: scenario/simulation header popovers, scope Define buttons, and the logic map switches to read-only without the manage permission.
- Scenarios / Simulations / Atomic testings menu entries are always visible so grant-only users can reach their granted resources.
- Unit tests cover the new ScopeService scope-inventory methods and the jsonb step lookup; the new grant-scoped endpoints are documented in `docs/docs/usage/rest-api.md`.

### Testing Instructions

1. Create a simulation/scenario with chaining
2. Create a new group and add a new user to it
3. Grant the simulation/scenario to that group
4. Open the network tab
5. Go to the scope and logic pages as the granted user
6. No 403 error should show up on the network and the action buttons should be hidden or disabled

### Related issues

- Related to #4824 (chaining engine epic - not closed by this PR)
