### PR TITLE
fix(attack-path): truncate a finding panel's list items to one line (#7204)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/CategoryFindingsPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/CategoryFindingsPanel.tsx
@@ -186,9 +186,8 @@ const CategoryFindingsPanel = ({
                     flex: 1,
                   }}
                   >
-                    {/* A single line, ellipsised (never the multi-line wall of text a long output value —
-                        e.g. a captured nmap XML report — would otherwise render as, same as the graph's
-                        own node label): the full value stays available in the title tooltip below. */}
+                    {/* One ellipsised line even for huge values (e.g. a raw action output); the
+                        title tooltip keeps the full (masked) value, like the graph's node labels. */}
                     <Typography variant="body2" noWrap title={maskedValue}>{maskedValue}</Typography>
                     {endpointName && (
                       <Typography variant="caption" color="text.secondary" noWrap title={endpointName} sx={{ display: 'block' }}>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/CategoryFindingsPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/CategoryFindingsPanel.tsx
@@ -186,7 +186,10 @@ const CategoryFindingsPanel = ({
                     flex: 1,
                   }}
                   >
-                    <Typography variant="body2" title={maskedValue} sx={{ wordBreak: 'break-all' }}>{maskedValue}</Typography>
+                    {/* A single line, ellipsised (never the multi-line wall of text a long output value —
+                        e.g. a captured nmap XML report — would otherwise render as, same as the graph's
+                        own node label): the full value stays available in the title tooltip below. */}
+                    <Typography variant="body2" noWrap title={maskedValue}>{maskedValue}</Typography>
                     {endpointName && (
                       <Typography variant="caption" color="text.secondary" noWrap title={endpointName} sx={{ display: 'block' }}>
                         {endpointName}


### PR DESCRIPTION
## Summary

- A long output value (e.g. a captured nmap XML report shown as an "Action output" finding) rendered as a wall of wrapped text spanning dozens of lines in the finding category panel's item list, instead of a single-line, ellipsised label like the graph's own finding nodes already show for the same kind of value.
- Switched the item's `Typography` to `noWrap` (single line + ellipsis) instead of `wordBreak: 'break-all'`. The full (masked) value is unchanged - still available via the existing `title` tooltip and the detail panel.

## Test plan

- [x] `eslint` clean on the changed file.
- [x] `yarn check-ts` clean on the full frontend.

Closes #7204
