### PR TITLE
fix(attack-path): surface whether an execution actually ran, not just its verdict (#7194)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.test.tsx
@@ -1,0 +1,140 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ExecutionResultTerminalPanel from '../../../../../../admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel';
+import type { AttackPathExecutionDetailDTO } from '../../../../../../utils/api-types';
+
+// The Result tab's new execution-status badge (issue 244) is what these tests pin down: an
+// execution that technically failed must be distinguishable from one that ran cleanly but simply
+// went undetected. Stub the action layer (the badge resolves its data itself) and i18n.
+const mocks = vi.hoisted(() => ({
+  searchTargets: vi.fn(),
+  getInjectStatusWithGlobalExecutionTraces: vi.fn(),
+  fetchInjectExecutionResult: vi.fn(),
+  fetchExecutionDetail: vi.fn(),
+}));
+
+vi.mock('../../../../../../actions/injects/inject-action', () => ({
+  searchTargets: mocks.searchTargets,
+  getInjectStatusWithGlobalExecutionTraces: mocks.getInjectStatusWithGlobalExecutionTraces,
+}));
+
+vi.mock('../../../../../../actions/inject_status/inject-status-action', () => ({ fetchInjectExecutionResult: mocks.fetchInjectExecutionResult }));
+
+vi.mock('../../../../../../actions/attack-path/attack-path-actions', () => ({ fetchExecutionDetail: mocks.fetchExecutionDetail }));
+
+vi.mock('../../../../../../actions/findings/finding-actions', () => ({ searchDistinctFindingsForInjects: vi.fn() }));
+
+vi.mock('../../../../../../components/i18n', () => ({
+  useFormatter: () => ({
+    t: (s: string) => s,
+    fldt: (d: string) => d,
+    du: (d: number) => String(d),
+  }),
+}));
+
+// Licence validated so the EE attribution chip stays out of the Result tab under test.
+vi.mock('../../../../../../utils/hooks/useEnterpriseEdition', () => ({ default: () => ({ isValidated: true }) }));
+
+// Heavy list machinery (queryable pagination + local storage) irrelevant to the badge under test.
+vi.mock('../../../../../../admin/components/findings/FindingList', () => ({ default: () => null }));
+
+const renderPanel = (detail: AttackPathExecutionDetailDTO, endpointLabel?: string) => render(
+  <ThemeProvider theme={createTheme()}>
+    <ExecutionResultTerminalPanel
+      loading={false}
+      detail={detail}
+      onClose={() => {}}
+      endpointLabel={endpointLabel}
+    />
+  </ThemeProvider>,
+);
+
+describe('ExecutionResultTerminalPanel execution-status badge', () => {
+  beforeEach(() => {
+    mocks.searchTargets.mockResolvedValue({ data: { content: [] } });
+    mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({ data: null });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({ data: null });
+    mocks.fetchExecutionDetail.mockResolvedValue({ data: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows the inject-level status chip for a network-injector execution', async () => {
+    mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({
+      data: {
+        status_id: 'status-1',
+        status_name: 'ERROR',
+      },
+    });
+
+    renderPanel({
+      injectId: 'inject-1',
+      endpointKey: 'ep-1',
+      payloadName: 'Nmap scan',
+    } as AttackPathExecutionDetailDTO, 'CORP-HOST');
+
+    // The technical verdict surfaces in the Result tab even though the run produced no
+    // prevention/detection rows at all.
+    expect(await screen.findByText('ERROR')).toBeDefined();
+    expect(mocks.getInjectStatusWithGlobalExecutionTraces).toHaveBeenCalledWith('inject-1');
+    // A network injector never goes through the per-target payload pipeline.
+    expect(mocks.fetchInjectExecutionResult).not.toHaveBeenCalled();
+  });
+
+  it('shows the per-target trace status chip for a payload-backed execution', async () => {
+    mocks.searchTargets.mockResolvedValue({
+      data: {
+        content: [{
+          target_id: 'target-1',
+          target_type: 'ASSETS',
+          target_name: 'CORP-HOST',
+        }],
+      },
+    });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({
+      data: {
+        execution_traces: {
+          'target-1': [{
+            execution_action: 'COMPLETE',
+            execution_status: 'ACCESS_DENIED',
+            execution_time: '2026-01-01T00:00:00Z',
+          }],
+        },
+      },
+    });
+
+    renderPanel({
+      injectId: 'inject-2',
+      payloadId: 'payload-1',
+      endpointKey: 'ep-2',
+      targetHostname: 'CORP-HOST',
+    } as AttackPathExecutionDetailDTO, 'CORP-HOST');
+
+    // ACCESS_DENIED reads as "Access denied" — the run was technically blocked, which the
+    // detection verdicts alone would have flattened into a plain "not detected".
+    expect(await screen.findByText('Access denied')).toBeDefined();
+    // The per-target fetch fires only once the target is resolved (never with a placeholder).
+    expect(mocks.fetchInjectExecutionResult).toHaveBeenCalledWith('inject-2', 'target-1', 'ASSETS');
+    expect(mocks.getInjectStatusWithGlobalExecutionTraces).not.toHaveBeenCalled();
+  });
+
+  it('renders no badge and fires no fetch for a seeded snapshot without an inject', async () => {
+    renderPanel({
+      endpointKey: 'ep-3',
+      command: 'whoami',
+      terminalOutput: 'root',
+    } as AttackPathExecutionDetailDTO, 'CORP-HOST');
+
+    expect(await screen.findByText('CORP-HOST')).toBeDefined();
+    await waitFor(() => {
+      expect(mocks.searchTargets).not.toHaveBeenCalled();
+      expect(mocks.getInjectStatusWithGlobalExecutionTraces).not.toHaveBeenCalled();
+      expect(mocks.fetchInjectExecutionResult).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
@@ -1,0 +1,103 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExecutionRowStatusBadge } from '../../../../../../admin/components/simulations/simulation/attack_path/ExecutionStatusBadge';
+
+// The endpoint/injector list rows only carry an execution ref — the badge has to resolve the
+// inject/payload ids first, then delegate to the same payload/injector badges the Result tab uses.
+const mocks = vi.hoisted(() => ({
+  fetchExecutionDetail: vi.fn(),
+  searchTargets: vi.fn(),
+  getInjectStatusWithGlobalExecutionTraces: vi.fn(),
+  fetchInjectExecutionResult: vi.fn(),
+}));
+
+vi.mock('../../../../../../actions/attack-path/attack-path-actions', () => ({ fetchExecutionDetail: mocks.fetchExecutionDetail }));
+
+vi.mock('../../../../../../actions/injects/inject-action', () => ({
+  searchTargets: mocks.searchTargets,
+  getInjectStatusWithGlobalExecutionTraces: mocks.getInjectStatusWithGlobalExecutionTraces,
+}));
+
+vi.mock('../../../../../../actions/inject_status/inject-status-action', () => ({ fetchInjectExecutionResult: mocks.fetchInjectExecutionResult }));
+
+vi.mock('../../../../../../components/i18n', () => ({ useFormatter: () => ({ t: (s: string) => s }) }));
+
+const renderWithTheme = (element: ReactElement) => render(
+  <ThemeProvider theme={createTheme()}>{element}</ThemeProvider>,
+);
+
+describe('ExecutionRowStatusBadge', () => {
+  beforeEach(() => {
+    mocks.fetchExecutionDetail.mockResolvedValue({ data: null });
+    mocks.searchTargets.mockResolvedValue({ data: { content: [] } });
+    mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({ data: null });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({ data: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('resolves the row ref then shows the per-target chip for a payload-backed execution', async () => {
+    mocks.fetchExecutionDetail.mockResolvedValue({
+      data: {
+        injectId: 'inject-1',
+        payloadId: 'payload-1',
+      },
+    });
+    mocks.searchTargets.mockResolvedValue({
+      data: {
+        content: [{
+          target_id: 'target-1',
+          target_type: 'ASSETS',
+          target_name: 'CORP-HOST',
+        }],
+      },
+    });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({
+      data: {
+        execution_traces: {
+          'target-1': [{
+            execution_action: 'COMPLETE',
+            execution_status: 'TIMEOUT',
+            execution_time: '2026-01-01T00:00:00Z',
+          }],
+        },
+      },
+    });
+
+    renderWithTheme(<ExecutionRowStatusBadge simulationId="sim-1" executionRef="exec-ref-1" endpointName="CORP-HOST" />);
+
+    expect(await screen.findByText('Timeout')).toBeDefined();
+    expect(mocks.fetchExecutionDetail).toHaveBeenCalledWith('sim-1', 'exec-ref-1');
+    expect(mocks.fetchInjectExecutionResult).toHaveBeenCalledWith('inject-1', 'target-1', 'ASSETS');
+  });
+
+  it('shows the inject-level chip for a network-injector execution', async () => {
+    mocks.fetchExecutionDetail.mockResolvedValue({ data: { injectId: 'inject-2' } });
+    mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({
+      data: {
+        status_id: 'status-1',
+        status_name: 'EXECUTED',
+      },
+    });
+
+    renderWithTheme(<ExecutionRowStatusBadge simulationId="sim-1" executionRef="exec-ref-2" />);
+
+    expect(await screen.findByText('EXECUTED')).toBeDefined();
+    expect(mocks.searchTargets).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing and fires no resolution without an execution ref', async () => {
+    const { container } = renderWithTheme(<ExecutionRowStatusBadge simulationId="sim-1" />);
+
+    await waitFor(() => {
+      expect(mocks.fetchExecutionDetail).not.toHaveBeenCalled();
+    });
+    expect(container.textContent).toBe('');
+  });
+});

--- a/openaev-front/src/actions/inject_status/useFetchInjectExecutionResult.tsx
+++ b/openaev-front/src/actions/inject_status/useFetchInjectExecutionResult.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 import type { InjectResultPayloadExecutionOutput, InjectTarget } from '../../utils/api-types';
 import { fetchInjectExecutionResult } from './inject-status-action';
 
-const useFetchInjectExecutionResult = (injectId: string, target: InjectTarget) => {
+// `target` may be null while the caller is still resolving which target to show
+// (e.g. the attack-path panel resolves it from a search): the fetch simply waits
+// until a target with an id and type is provided.
+const useFetchInjectExecutionResult = (injectId: string, target: InjectTarget | null) => {
   const [injectExecutionResult, setInjectExecutionResult] = useState<InjectResultPayloadExecutionOutput>();
   const [loading, setLoading] = useState(false);
   const fetch = async () => {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -298,13 +298,32 @@ const EndpointDetailPanel = ({
                     </Typography>
                   </Box>
                   {/* Whether this execution actually ran at all (issue 244), at a glance in the list —
-                      the verdict pill beside it only answers whether it was caught. */}
-                  <ExecutionRowStatusBadge
-                    simulationId={simulationId}
-                    executionRef={e.ref}
-                    endpointName={e.hostname}
-                  />
-                  <AttackPathVerdictPill label={status} status={e.status} />
+                      the verdict pill beside it only answers whether it was caught. Both sit in
+                      fixed-width slots: their labels vary in length ("Executed"/"Timeout",
+                      "DETECTED"/"UNDETECTED"), so intrinsic widths made every row's pair land on a
+                      different x and the column read as ragged. */}
+                  <Box sx={{
+                    flexShrink: 0,
+                    width: 92,
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                  }}
+                  >
+                    <ExecutionRowStatusBadge
+                      simulationId={simulationId}
+                      executionRef={e.ref}
+                      endpointName={e.hostname}
+                    />
+                  </Box>
+                  <Box sx={{
+                    flexShrink: 0,
+                    width: 104,
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                  }}
+                  >
+                    <AttackPathVerdictPill label={status} status={e.status} />
+                  </Box>
                 </Box>
               );
             })}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -9,6 +9,7 @@ import Loader from '../../../../../components/Loader';
 import type { AttackPathNodeDTO } from '../../../../../utils/api-types';
 import InjectFormSection from '../../../common/injects/form/InjectFormSection';
 import AttackPathVerdictPill from './AttackPathVerdictPill';
+import { ExecutionRowStatusBadge } from './ExecutionStatusBadge';
 
 interface FindingGroup {
   type: string;
@@ -43,6 +44,7 @@ const PageSizeSelect = ({ value, onChange }: {
 };
 
 interface Props {
+  simulationId: string;
   endpointLabel: string;
   endpointSub?: string;
   findingsLoading: boolean;
@@ -80,6 +82,7 @@ interface Props {
 // InjectFormSection sections, FindingIcon on each finding group and a verdict pill per execution.
 // Mirrors FindingDetailPanel / ExecutionResultTerminalPanel so the three side panels are consistent.
 const EndpointDetailPanel = ({
+  simulationId,
   endpointLabel,
   endpointSub,
   findingsLoading,
@@ -294,6 +297,13 @@ const EndpointDetailPanel = ({
                       {[e.agentName, e.privilege].filter(Boolean).join(' · ')}
                     </Typography>
                   </Box>
+                  {/* Whether this execution actually ran at all (issue 244), at a glance in the list —
+                      the verdict pill beside it only answers whether it was caught. */}
+                  <ExecutionRowStatusBadge
+                    simulationId={simulationId}
+                    executionRef={e.ref}
+                    endpointName={e.hostname}
+                  />
                   <AttackPathVerdictPill label={status} status={e.status} />
                 </Box>
               );

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -6,14 +6,14 @@ import DOMPurify from 'dompurify';
 import { useContext, useEffect, useRef, useState } from 'react';
 
 import { searchDistinctFindingsForInjects } from '../../../../../actions/findings/finding-actions';
-import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
+import { getInjectStatusWithGlobalExecutionTraces } from '../../../../../actions/injects/inject-action';
 import AttackPatternChip from '../../../../../components/AttackPatternChip';
 import Tabs from '../../../../../components/common/tabs/Tabs';
 import useTabs from '../../../../../components/common/tabs/useTabs';
 import Terminal, { type TerminalLine } from '../../../../../components/common/terminal/Terminal';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
-import type { AttackPathExecutionDetailDTO, AttackPathSecurityPlatformDTO, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
+import type { AttackPathExecutionDetailDTO, AttackPathSecurityPlatformDTO, InjectStatusOutput } from '../../../../../utils/api-types';
 import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../../utils/permissions/types';
@@ -31,6 +31,7 @@ import ExpectationPlatformsTable, {
   type ExpectationPlatformRow,
 } from './ExpectationPlatformsTable';
 import ImageWithFallback from './ImageWithFallback';
+import useResolvedAssetTarget from './useResolvedAssetTarget';
 
 interface Props {
   loading: boolean;
@@ -267,41 +268,14 @@ const CollectorByIdLogo = ({ collectorId, label }: {
 
 // Live terminal for a real execution: the attack-path DTO only carries `command`/`terminalOutput` on
 // seeded runs, so for a real inject we reuse the shared `TerminalViewTab`, fed by the live
-// `execution_traces` — exactly like the inject detail view. The DTO exposes `injectId` but not the
-// executed target, so we resolve the inject's asset targets and pick the one matching this execution's
-// endpoint (falling back to the first asset), then hand it to `TerminalViewTab`.
+// `execution_traces` — exactly like the inject detail view. The executed target is resolved by the
+// shared hook (also used by the payload execution-status badge), then handed to `TerminalViewTab`.
 const LiveExecutionTerminal = ({ injectId, endpointName }: {
   injectId: string;
   endpointName?: string;
 }) => {
   const { t } = useFormatter();
-  const [target, setTarget] = useState<InjectTarget | null>(null);
-  const [loading, setLoading] = useState(true);
-  useEffect(() => {
-    let active = true;
-    setLoading(true);
-    searchTargets(injectId, 'ASSETS', {
-      filterGroup: {
-        mode: 'and',
-        filters: [],
-      },
-      size: 50,
-      page: 0,
-    })
-      .then((response) => {
-        if (!active) {
-          return;
-        }
-        const targets: InjectTarget[] = response.data?.content ?? [];
-        const match = targets.find(tg => tg.target_name && tg.target_name === endpointName);
-        setTarget(match ?? targets[0] ?? null);
-      })
-      .catch(() => active && setTarget(null))
-      .finally(() => active && setLoading(false));
-    return () => {
-      active = false;
-    };
-  }, [injectId, endpointName]);
+  const { target, loading } = useResolvedAssetTarget(injectId, endpointName);
 
   if (loading) {
     return <Loader variant="inElement" size="sm" />;

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -3,10 +3,9 @@ import { Box, Button, IconButton, Paper, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 // eslint-disable-next-line import/no-named-as-default
 import DOMPurify from 'dompurify';
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 
 import { searchDistinctFindingsForInjects } from '../../../../../actions/findings/finding-actions';
-import useFetchInjectExecutionResult from '../../../../../actions/inject_status/useFetchInjectExecutionResult';
 import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
 import AttackPatternChip from '../../../../../components/AttackPatternChip';
 import Tabs from '../../../../../components/common/tabs/Tabs';
@@ -14,7 +13,7 @@ import useTabs from '../../../../../components/common/tabs/useTabs';
 import Terminal, { type TerminalLine } from '../../../../../components/common/terminal/Terminal';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
-import type { AttackPathExecutionDetailDTO, AttackPathSecurityPlatformDTO, InjectStatus as InjectStatusType, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
+import type { AttackPathExecutionDetailDTO, AttackPathSecurityPlatformDTO, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
 import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../../utils/permissions/types';
@@ -23,12 +22,10 @@ import { buildTenantApiPath } from '../../../../../utils/url-helper';
 import StatusPill from '../../../atomic_testings/atomic_testing/target_result/StatusPill';
 import EEChip from '../../../common/entreprise_edition/EEChip';
 import expectationIconByType from '../../../common/ExpectationIconByType';
-import InjectStatus from '../../../common/injects/status/InjectStatus';
 import GlobalExecutionTraces from '../../../common/injects/status/traces/GlobalExecutionTraces';
 import TerminalViewTab from '../../../common/injects/status/traces/TerminalViewTab';
-import TraceStatusChip from '../../../common/injects/status/traces/TraceStatusChip';
-import useAgentStatus from '../../../common/injects/status/traces/useAgentStatus';
 import FindingList from '../../../findings/FindingList';
+import { InjectorExecutionStatusBadge, PayloadExecutionStatusBadge } from './ExecutionStatusBadge';
 import ExpectationPlatformsTable, {
   type ExpectationPlatformAlert,
   type ExpectationPlatformRow,
@@ -315,52 +312,6 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
   return <TerminalViewTab injectId={injectId} target={target} />;
 };
 
-// Per-target execution status for a payload-backed execution (issue 244): the Result tab's
-// prevention/detection verdicts answer "was it caught?", never "did it run at all?" — a technical
-// failure (timeout, access denied…) and a clean run that simply went undetected previously looked
-// identical there. Resolves the same target + traces LiveExecutionTerminal does for the terminal
-// (a second, independent fetch — the two tabs render independently of one another), and renders
-// nothing once resolved without any real traces (a seeded/demo snapshot has no live target to match).
-const PayloadExecutionStatusBadge = ({ injectId, endpointName }: {
-  injectId: string;
-  endpointName?: string;
-}) => {
-  const [target, setTarget] = useState<InjectTarget | null>(null);
-  useEffect(() => {
-    let active = true;
-    searchTargets(injectId, 'ASSETS', {
-      filterGroup: {
-        mode: 'and',
-        filters: [],
-      },
-      size: 50,
-      page: 0,
-    })
-      .then((response) => {
-        if (!active) {
-          return;
-        }
-        const targets: InjectTarget[] = response.data?.content ?? [];
-        const match = targets.find(tg => tg.target_name && tg.target_name === endpointName);
-        setTarget(match ?? targets[0] ?? null);
-      })
-      .catch(() => active && setTarget(null));
-    return () => {
-      active = false;
-    };
-  }, [injectId, endpointName]);
-  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target ?? ({} as InjectTarget));
-  const allTraces = useMemo(
-    () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
-    [injectExecutionResult],
-  );
-  const agentStatus = useAgentStatus(allTraces);
-  if (allTraces.length === 0) {
-    return null;
-  }
-  return <TraceStatusChip status={agentStatus.statusName} />;
-};
-
 // A network injector (NetExec, Nmap…) has no single shell command on the DTO — `command` is only ever
 // resolved for Command-payload-backed injects (see InjectExecutionStep#getCommand on the backend).
 // What it actually ran is instead reconstructed and partially masked server-side (see
@@ -411,28 +362,6 @@ const InjectorExecutionTraces = ({ injectId }: { injectId: string }) => {
     return <Typography variant="body2" color="text.secondary">{t('No data available')}</Typography>;
   }
   return <GlobalExecutionTraces injectStatus={injectStatus} />;
-};
-
-// Inject-level execution status for a network injector (NetExec, Nmap…) (issue 244): its own traces have
-// no `execution_agent` (no deployed agent), so GlobalExecutionTraces above routes them through
-// MainTraces, which — unlike AgentTraces — renders no status chip at all. Fetched independently (the
-// Result tab renders regardless of which other tab is active) and rendered in the Result tab instead of
-// alongside the traces, matching where the equivalent payload-side badge above lives.
-const InjectorExecutionStatusBadge = ({ injectId }: { injectId: string }) => {
-  const [statusName, setStatusName] = useState<string | null>(null);
-  useEffect(() => {
-    let active = true;
-    getInjectStatusWithGlobalExecutionTraces(injectId)
-      .then((response: { data: InjectStatusOutput }) => active && setStatusName(response.data?.status_name ?? null))
-      .catch(() => active && setStatusName(null));
-    return () => {
-      active = false;
-    };
-  }, [injectId]);
-  if (!statusName) {
-    return null;
-  }
-  return <InjectStatus status={statusName as InjectStatusType['status_name']} />;
 };
 
 // The Result & Terminal panel for one execution (issue 5048): an in-flow panel between the execution
@@ -828,24 +757,50 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
                 gap: theme.spacing(2),
               }}
               >
-                <div>
+                <Box sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1,
+                }}
+                >
                   {/* The friendly endpoint name (kingslanding), not the raw endpoint key/UUID, to stay
                        consistent with the graph node; fall back to the IP only when no name is known. */}
                   <Typography variant="subtitle2">{endpointLabel || detail.targetHostname || detail.targetIp || detail.endpointKey}</Typography>
-                </div>
-                {/* Whether the action actually ran at all (issue 244), ahead of the prevention/detection
-                    verdicts below: those answer "was it caught?", never "did it run?" — a technical
-                    failure and a clean-but-undetected run previously looked identical. */}
-                {detail.injectId && (
-                  detail.payloadId
-                    ? (
-                        <PayloadExecutionStatusBadge
-                          injectId={detail.injectId}
-                          endpointName={endpointLabel || detail.targetHostname || detail.endpointKey}
-                        />
-                      )
-                    : <InjectorExecutionStatusBadge injectId={detail.injectId} />
-                )}
+                  {/* Whether the action actually ran at all (issue 244): those verdicts below answer "was
+                      it caught?", never "did it run?" — a technical failure and a clean-but-undetected run
+                      previously looked identical. Sits beside the endpoint name (not its own row) to save
+                      vertical space. */}
+                  {detail.injectId && (
+                    <Box sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.75,
+                      flexShrink: 0,
+                    }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.06em',
+                        }}
+                      >
+                        {t('Status')}
+                        :
+                      </Typography>
+                      {detail.payloadId
+                        ? (
+                            <PayloadExecutionStatusBadge
+                              injectId={detail.injectId}
+                              endpointName={endpointLabel || detail.targetHostname || detail.endpointKey}
+                            />
+                          )
+                        : <InjectorExecutionStatusBadge injectId={detail.injectId} />}
+                    </Box>
+                  )}
+                </Box>
                 {/* Enterprise gate on the attribution itself, not on the verdicts: one chip for the
                     section, offering the upsell path instead of a dead-end sentence per row. Only
                     clickable for a user who could act on the dialog — the licence form it opens

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -306,33 +306,59 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
     };
   }, [injectId, endpointName]);
 
-  // Whether the payload itself actually ran (issue 244): the prevention/detection verdicts above answer
-  // "was it caught?", never "did it run at all?" — a technical failure (timeout, access denied…) and a
-  // clean run that simply went undetected previously looked identical. Fetched regardless of `target`
-  // (the hook no-ops until target._target_id is set) to keep this a single unconditional hook call.
-  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target ?? ({} as InjectTarget));
-  const allTraces = useMemo(
-    () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
-    [injectExecutionResult],
-  );
-  const agentStatus = useAgentStatus(allTraces);
-
   if (loading) {
     return <Loader variant="inElement" size="sm" />;
   }
   if (!target?.target_id || !target.target_type) {
     return <Typography variant="body2" color="text.secondary">{t('No traces on this target.')}</Typography>;
   }
-  return (
-    <>
-      {allTraces.length > 0 && (
-        <Box sx={{ mb: 1.5 }}>
-          <TraceStatusChip status={agentStatus.statusName} />
-        </Box>
-      )}
-      <TerminalViewTab injectId={injectId} target={target} />
-    </>
+  return <TerminalViewTab injectId={injectId} target={target} />;
+};
+
+// Per-target execution status for a payload-backed execution (issue 244): the Result tab's
+// prevention/detection verdicts answer "was it caught?", never "did it run at all?" — a technical
+// failure (timeout, access denied…) and a clean run that simply went undetected previously looked
+// identical there. Resolves the same target + traces LiveExecutionTerminal does for the terminal
+// (a second, independent fetch — the two tabs render independently of one another), and renders
+// nothing once resolved without any real traces (a seeded/demo snapshot has no live target to match).
+const PayloadExecutionStatusBadge = ({ injectId, endpointName }: {
+  injectId: string;
+  endpointName?: string;
+}) => {
+  const [target, setTarget] = useState<InjectTarget | null>(null);
+  useEffect(() => {
+    let active = true;
+    searchTargets(injectId, 'ASSETS', {
+      filterGroup: {
+        mode: 'and',
+        filters: [],
+      },
+      size: 50,
+      page: 0,
+    })
+      .then((response) => {
+        if (!active) {
+          return;
+        }
+        const targets: InjectTarget[] = response.data?.content ?? [];
+        const match = targets.find(tg => tg.target_name && tg.target_name === endpointName);
+        setTarget(match ?? targets[0] ?? null);
+      })
+      .catch(() => active && setTarget(null));
+    return () => {
+      active = false;
+    };
+  }, [injectId, endpointName]);
+  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target ?? ({} as InjectTarget));
+  const allTraces = useMemo(
+    () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
+    [injectExecutionResult],
   );
+  const agentStatus = useAgentStatus(allTraces);
+  if (allTraces.length === 0) {
+    return null;
+  }
+  return <TraceStatusChip status={agentStatus.statusName} />;
 };
 
 // A network injector (NetExec, Nmap…) has no single shell command on the DTO — `command` is only ever
@@ -384,19 +410,29 @@ const InjectorExecutionTraces = ({ injectId }: { injectId: string }) => {
   if (!injectStatus) {
     return <Typography variant="body2" color="text.secondary">{t('No data available')}</Typography>;
   }
-  return (
-    <>
-      {/* Whether the inject itself actually ran (issue 244): its own traces have no `execution_agent`
-          (a network injector like NetExec/Nmap has no deployed agent), so GlobalExecutionTraces routes
-          them through MainTraces, which — unlike AgentTraces — renders no status chip at all. Same gap
-          as LiveExecutionTerminal's payload case above, fixed with the inject's own top-level status
-          instead of a per-target one. */}
-      <Box sx={{ mb: 1.5 }}>
-        <InjectStatus status={injectStatus.status_name as InjectStatusType['status_name']} />
-      </Box>
-      <GlobalExecutionTraces injectStatus={injectStatus} />
-    </>
-  );
+  return <GlobalExecutionTraces injectStatus={injectStatus} />;
+};
+
+// Inject-level execution status for a network injector (NetExec, Nmap…) (issue 244): its own traces have
+// no `execution_agent` (no deployed agent), so GlobalExecutionTraces above routes them through
+// MainTraces, which — unlike AgentTraces — renders no status chip at all. Fetched independently (the
+// Result tab renders regardless of which other tab is active) and rendered in the Result tab instead of
+// alongside the traces, matching where the equivalent payload-side badge above lives.
+const InjectorExecutionStatusBadge = ({ injectId }: { injectId: string }) => {
+  const [statusName, setStatusName] = useState<string | null>(null);
+  useEffect(() => {
+    let active = true;
+    getInjectStatusWithGlobalExecutionTraces(injectId)
+      .then((response: { data: InjectStatusOutput }) => active && setStatusName(response.data?.status_name ?? null))
+      .catch(() => active && setStatusName(null));
+    return () => {
+      active = false;
+    };
+  }, [injectId]);
+  if (!statusName) {
+    return null;
+  }
+  return <InjectStatus status={statusName as InjectStatusType['status_name']} />;
 };
 
 // The Result & Terminal panel for one execution (issue 5048): an in-flow panel between the execution
@@ -797,6 +833,19 @@ const ExecutionResultTerminalPanel = ({ loading, detail, onClose, onBack, onOpen
                        consistent with the graph node; fall back to the IP only when no name is known. */}
                   <Typography variant="subtitle2">{endpointLabel || detail.targetHostname || detail.targetIp || detail.endpointKey}</Typography>
                 </div>
+                {/* Whether the action actually ran at all (issue 244), ahead of the prevention/detection
+                    verdicts below: those answer "was it caught?", never "did it run?" — a technical
+                    failure and a clean-but-undetected run previously looked identical. */}
+                {detail.injectId && (
+                  detail.payloadId
+                    ? (
+                        <PayloadExecutionStatusBadge
+                          injectId={detail.injectId}
+                          endpointName={endpointLabel || detail.targetHostname || detail.endpointKey}
+                        />
+                      )
+                    : <InjectorExecutionStatusBadge injectId={detail.injectId} />
+                )}
                 {/* Enterprise gate on the attribution itself, not on the verdicts: one chip for the
                     section, offering the upsell path instead of a dead-end sentence per row. Only
                     clickable for a user who could act on the dialog — the licence form it opens

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionResultTerminalPanel.tsx
@@ -3,9 +3,10 @@ import { Box, Button, IconButton, Paper, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 // eslint-disable-next-line import/no-named-as-default
 import DOMPurify from 'dompurify';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { searchDistinctFindingsForInjects } from '../../../../../actions/findings/finding-actions';
+import useFetchInjectExecutionResult from '../../../../../actions/inject_status/useFetchInjectExecutionResult';
 import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
 import AttackPatternChip from '../../../../../components/AttackPatternChip';
 import Tabs from '../../../../../components/common/tabs/Tabs';
@@ -13,7 +14,7 @@ import useTabs from '../../../../../components/common/tabs/useTabs';
 import Terminal, { type TerminalLine } from '../../../../../components/common/terminal/Terminal';
 import { useFormatter } from '../../../../../components/i18n';
 import Loader from '../../../../../components/Loader';
-import type { AttackPathExecutionDetailDTO, AttackPathSecurityPlatformDTO, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
+import type { AttackPathExecutionDetailDTO, AttackPathSecurityPlatformDTO, InjectStatus as InjectStatusType, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
 import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../../utils/permissions/types';
@@ -22,8 +23,11 @@ import { buildTenantApiPath } from '../../../../../utils/url-helper';
 import StatusPill from '../../../atomic_testings/atomic_testing/target_result/StatusPill';
 import EEChip from '../../../common/entreprise_edition/EEChip';
 import expectationIconByType from '../../../common/ExpectationIconByType';
+import InjectStatus from '../../../common/injects/status/InjectStatus';
 import GlobalExecutionTraces from '../../../common/injects/status/traces/GlobalExecutionTraces';
 import TerminalViewTab from '../../../common/injects/status/traces/TerminalViewTab';
+import TraceStatusChip from '../../../common/injects/status/traces/TraceStatusChip';
+import useAgentStatus from '../../../common/injects/status/traces/useAgentStatus';
 import FindingList from '../../../findings/FindingList';
 import ExpectationPlatformsTable, {
   type ExpectationPlatformAlert,
@@ -302,13 +306,33 @@ const LiveExecutionTerminal = ({ injectId, endpointName }: {
     };
   }, [injectId, endpointName]);
 
+  // Whether the payload itself actually ran (issue 244): the prevention/detection verdicts above answer
+  // "was it caught?", never "did it run at all?" — a technical failure (timeout, access denied…) and a
+  // clean run that simply went undetected previously looked identical. Fetched regardless of `target`
+  // (the hook no-ops until target._target_id is set) to keep this a single unconditional hook call.
+  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target ?? ({} as InjectTarget));
+  const allTraces = useMemo(
+    () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
+    [injectExecutionResult],
+  );
+  const agentStatus = useAgentStatus(allTraces);
+
   if (loading) {
     return <Loader variant="inElement" size="sm" />;
   }
   if (!target?.target_id || !target.target_type) {
     return <Typography variant="body2" color="text.secondary">{t('No traces on this target.')}</Typography>;
   }
-  return <TerminalViewTab injectId={injectId} target={target} />;
+  return (
+    <>
+      {allTraces.length > 0 && (
+        <Box sx={{ mb: 1.5 }}>
+          <TraceStatusChip status={agentStatus.statusName} />
+        </Box>
+      )}
+      <TerminalViewTab injectId={injectId} target={target} />
+    </>
+  );
 };
 
 // A network injector (NetExec, Nmap…) has no single shell command on the DTO — `command` is only ever
@@ -360,7 +384,19 @@ const InjectorExecutionTraces = ({ injectId }: { injectId: string }) => {
   if (!injectStatus) {
     return <Typography variant="body2" color="text.secondary">{t('No data available')}</Typography>;
   }
-  return <GlobalExecutionTraces injectStatus={injectStatus} />;
+  return (
+    <>
+      {/* Whether the inject itself actually ran (issue 244): its own traces have no `execution_agent`
+          (a network injector like NetExec/Nmap has no deployed agent), so GlobalExecutionTraces routes
+          them through MainTraces, which — unlike AgentTraces — renders no status chip at all. Same gap
+          as LiveExecutionTerminal's payload case above, fixed with the inject's own top-level status
+          instead of a per-target one. */}
+      <Box sx={{ mb: 1.5 }}>
+        <InjectStatus status={injectStatus.status_name as InjectStatusType['status_name']} />
+      </Box>
+      <GlobalExecutionTraces injectStatus={injectStatus} />
+    </>
+  );
 };
 
 // The Result & Terminal panel for one execution (issue 5048): an in-flow panel between the execution

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { fetchExecutionDetail } from '../../../../../actions/attack-path/attack-path-actions';
+import useFetchInjectExecutionResult from '../../../../../actions/inject_status/useFetchInjectExecutionResult';
+import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
+import type { InjectStatus as InjectStatusType, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
+import InjectStatus from '../../../common/injects/status/InjectStatus';
+import TraceStatusChip from '../../../common/injects/status/traces/TraceStatusChip';
+import useAgentStatus from '../../../common/injects/status/traces/useAgentStatus';
+
+// Per-target execution status for a payload-backed execution (issue 244): the prevention/detection
+// verdicts shown elsewhere answer "was it caught?", never "did it run at all?" — a technical failure
+// (timeout, access denied…) and a clean run that simply went undetected previously looked identical.
+// Resolves the same target + traces the live terminal view does (a second, independent fetch — this
+// badge and that view render independently of one another), and renders nothing once resolved without
+// any real traces (a seeded/demo snapshot has no live target to match).
+export const PayloadExecutionStatusBadge = ({ injectId, endpointName }: {
+  injectId: string;
+  endpointName?: string;
+}) => {
+  const [target, setTarget] = useState<InjectTarget | null>(null);
+  useEffect(() => {
+    let active = true;
+    searchTargets(injectId, 'ASSETS', {
+      filterGroup: {
+        mode: 'and',
+        filters: [],
+      },
+      size: 50,
+      page: 0,
+    })
+      .then((response) => {
+        if (!active) {
+          return;
+        }
+        const targets: InjectTarget[] = response.data?.content ?? [];
+        const match = targets.find(tg => tg.target_name && tg.target_name === endpointName);
+        setTarget(match ?? targets[0] ?? null);
+      })
+      .catch(() => active && setTarget(null));
+    return () => {
+      active = false;
+    };
+  }, [injectId, endpointName]);
+  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target ?? ({} as InjectTarget));
+  const allTraces = useMemo(
+    () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
+    [injectExecutionResult],
+  );
+  const agentStatus = useAgentStatus(allTraces);
+  if (allTraces.length === 0) {
+    return null;
+  }
+  return <TraceStatusChip status={agentStatus.statusName} />;
+};
+
+// Inject-level execution status for a network injector (NetExec, Nmap…) (issue 244): its own traces have
+// no `execution_agent` (no deployed agent), so the shared traces view routes them through a plain trace
+// list with no status chip of its own. Fetched independently and rendered wherever this execution's
+// status needs to be visible at a glance.
+export const InjectorExecutionStatusBadge = ({ injectId }: { injectId: string }) => {
+  const [statusName, setStatusName] = useState<string | null>(null);
+  useEffect(() => {
+    let active = true;
+    getInjectStatusWithGlobalExecutionTraces(injectId)
+      .then((response: { data: InjectStatusOutput }) => active && setStatusName(response.data?.status_name ?? null))
+      .catch(() => active && setStatusName(null));
+    return () => {
+      active = false;
+    };
+  }, [injectId]);
+  if (!statusName) {
+    return null;
+  }
+  return <InjectStatus status={statusName as InjectStatusType['status_name']} />;
+};
+
+// One execution row (endpoint/injector panel list) rarely has its injectId/payloadId already loaded —
+// those live on the execution DETAIL DTO, not the lightweight graph row — so this resolves them first
+// (a small extra fetch per visible row) before delegating to the same two badges the Result tab uses,
+// so every place an execution shows up agrees on the same "did it actually run" status.
+export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointName }: {
+  simulationId: string;
+  executionRef?: string;
+  endpointName?: string;
+}) => {
+  const [detail, setDetail] = useState<{
+    injectId?: string;
+    payloadId?: string;
+  } | null>(null);
+  useEffect(() => {
+    let active = true;
+    if (!executionRef) {
+      setDetail(null);
+      return () => {
+        active = false;
+      };
+    }
+    fetchExecutionDetail(simulationId, executionRef)
+      .then(r => active && setDetail(r.data))
+      .catch(() => active && setDetail(null));
+    return () => {
+      active = false;
+    };
+  }, [simulationId, executionRef]);
+  if (!detail?.injectId) {
+    return null;
+  }
+  return detail.payloadId
+    ? <PayloadExecutionStatusBadge injectId={detail.injectId} endpointName={endpointName} />
+    : <InjectorExecutionStatusBadge injectId={detail.injectId} />;
+};

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -2,11 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { fetchExecutionDetail } from '../../../../../actions/attack-path/attack-path-actions';
 import useFetchInjectExecutionResult from '../../../../../actions/inject_status/useFetchInjectExecutionResult';
-import { getInjectStatusWithGlobalExecutionTraces, searchTargets } from '../../../../../actions/injects/inject-action';
-import type { InjectStatus as InjectStatusType, InjectStatusOutput, InjectTarget } from '../../../../../utils/api-types';
+import { getInjectStatusWithGlobalExecutionTraces } from '../../../../../actions/injects/inject-action';
+import type { InjectStatus as InjectStatusType, InjectStatusOutput } from '../../../../../utils/api-types';
 import InjectStatus from '../../../common/injects/status/InjectStatus';
 import TraceStatusChip from '../../../common/injects/status/traces/TraceStatusChip';
 import useAgentStatus from '../../../common/injects/status/traces/useAgentStatus';
+import useResolvedAssetTarget from './useResolvedAssetTarget';
 
 // Per-target execution status for a payload-backed execution (issue 244): the prevention/detection
 // verdicts shown elsewhere answer "was it caught?", never "did it run at all?" — a technical failure
@@ -18,31 +19,8 @@ export const PayloadExecutionStatusBadge = ({ injectId, endpointName }: {
   injectId: string;
   endpointName?: string;
 }) => {
-  const [target, setTarget] = useState<InjectTarget | null>(null);
-  useEffect(() => {
-    let active = true;
-    searchTargets(injectId, 'ASSETS', {
-      filterGroup: {
-        mode: 'and',
-        filters: [],
-      },
-      size: 50,
-      page: 0,
-    })
-      .then((response) => {
-        if (!active) {
-          return;
-        }
-        const targets: InjectTarget[] = response.data?.content ?? [];
-        const match = targets.find(tg => tg.target_name && tg.target_name === endpointName);
-        setTarget(match ?? targets[0] ?? null);
-      })
-      .catch(() => active && setTarget(null));
-    return () => {
-      active = false;
-    };
-  }, [injectId, endpointName]);
-  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target ?? ({} as InjectTarget));
+  const { target } = useResolvedAssetTarget(injectId, endpointName);
+  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target);
   const allTraces = useMemo(
     () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
     [injectExecutionResult],

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2762,6 +2762,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
 
               {!findingDetail && selectedNodeId && !detailExecutionId && (
                 <EndpointDetailPanel
+                  simulationId={simulationId}
                   endpointLabel={selectedLabel || t('Endpoint')}
                   emptyFindingsLabel={selectedTargetEmptyFindingsLabel}
                   findingsLoading={endpointFindingsLoading}
@@ -2792,6 +2793,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
                 Result / Execution details / Remediation detail (the global command it ran). */}
               {!pathFinding && !findingDetail && !selectedNodeId && selectedInjectorId && !detailExecutionId && (
                 <EndpointDetailPanel
+                  simulationId={simulationId}
                   endpointLabel={injectorPanelLabel || t('Injector')}
                   emptyFindingsLabel={t('No findings from this action')}
                   findingsLoading={injectorFindingsLoading}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/useResolvedAssetTarget.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/useResolvedAssetTarget.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import { searchTargets } from '../../../../../actions/injects/inject-action';
+import type { InjectTarget } from '../../../../../utils/api-types';
+
+// The attack-path DTOs expose `injectId` but not the executed target, so resolve the inject's asset
+// targets and pick the one matching this execution's endpoint (falling back to the first asset).
+// Shared by the live terminal view and the payload execution-status badge — each mounts
+// independently, so each resolution runs when its consumer renders.
+const useResolvedAssetTarget = (injectId: string, endpointName?: string) => {
+  const [target, setTarget] = useState<InjectTarget | null>(null);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    searchTargets(injectId, 'ASSETS', {
+      filterGroup: {
+        mode: 'and',
+        filters: [],
+      },
+      size: 50,
+      page: 0,
+    })
+      .then((response) => {
+        if (!active) {
+          return;
+        }
+        const targets: InjectTarget[] = response.data?.content ?? [];
+        const match = targets.find(tg => tg.target_name && tg.target_name === endpointName);
+        setTarget(match ?? targets[0] ?? null);
+      })
+      .catch(() => active && setTarget(null))
+      .finally(() => active && setLoading(false));
+    return () => {
+      active = false;
+    };
+  }, [injectId, endpointName]);
+  return {
+    target,
+    loading,
+  };
+};
+
+export default useResolvedAssetTarget;


### PR DESCRIPTION
## Summary
- The Result & Terminal panel showed prevention/detection verdicts but nothing about whether the action technically ran at all: an execution that errored out (timeout, access denied, platform incompatibility...) and one that ran cleanly but simply went undetected were visually indistinguishable, both reading as a plain red "not detected".
- Reuses the same status-chip components already shown elsewhere in the app for this exact distinction, per the issue's own reference screenshots: `InjectStatus` (the inject-level Executed/Error/Partial chip from the inject's own hero page) for a network injector's execution, and `TraceStatusChip` (the per-agent chip already used on the target-result detail page) for a payload-backed execution.
- The badge sits next to the endpoint name in the Result tab (with a "Status:" label), and every execution row in the endpoint/injector list panel now shows its own badge too, so whether everything actually ran is visible at a glance without opening each execution. The two status-resolving components live in a shared `ExecutionStatusBadge.tsx`; a row badge resolves its execution ref to the inject/payload ids first, then delegates to the same two badges so every surface agrees on the status.
- Review follow-ups: `useFetchInjectExecutionResult` now accepts `InjectTarget | null` instead of call sites passing a type-unsafe `{} as InjectTarget` sentinel, and the target-resolution effect shared by the live terminal and the payload badge is deduplicated into a `useResolvedAssetTarget` hook.
- Scope: the attack-path panels only, per discussion - the graph node/edge coloring and the executions feed are untouched for now.

Fixes OpenAEV-Platform/filigran-private#244

## Test plan
- [x] `eslint` and `tsc --noEmit` clean on the changed files.
- [x] Unit tests (vitest) cover the badge behavior: a network-injector execution shows the inject-level chip, a payload-backed execution shows the per-target trace chip and only fetches once the target is resolved, a seeded snapshot without an inject shows no badge and fires no fetch, and the list-row badge resolves its execution ref before delegating. Full attack-path suite green (105 tests).
- [ ] Manual verification in a live simulation: a network-injector execution (e.g. NetExec/Nmap) shows the inject-level status chip; a payload-backed execution shows the per-target trace status chip; execution rows in the endpoint/injector panel show their own badges.
