### PR TITLE
fix(attack-path): only spend the live camera budget on real growth (#7205)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -540,4 +540,55 @@ describe('SimulationAttackPath live delta updates', () => {
     expect(screen.getByText('Reconnecting…')).toBeTruthy();
     expect(screen.getByTestId('attack-path-flow')).toBeTruthy();
   });
+
+  it('re-frames the camera when a live delta grows the graph, then hands over to pursuit', async () => {
+    // One growth delta per tick, each introducing a distinct endpoint so every one is real growth.
+    const growthDelta = (version: number, host: string) => ({
+      data: {
+        sinceVersion: version - 1,
+        newVersion: version,
+        attackPathNodes: [{
+          id: `NODE_ENDPOINT|${host}`,
+          type: 'ASSET',
+          label: host,
+          hostname: host,
+          ref: host,
+          findingCounts: {},
+        }],
+        attackPathEdges: [{
+          edgeId: `edge-nmap-${host}`,
+          edgeSourceId: 'NODE_INJECTOR|nmap',
+          edgeTargetId: `NODE_ENDPOINT|${host}`,
+          type: 'EDGE_EXECUTIONS',
+          count: 1,
+        }],
+      },
+    });
+
+    setup();
+    // Both initial reads must settle: the collapsed seed AND the causal overlay merged in after it
+    // each bump the structural nonce, and neither is live growth — they are the initial framing.
+    await mounted();
+    await mounted();
+    const afterInitialLoad = mocks.flowProps.current?.fitRequest ?? 0;
+
+    // A live delta introduces an endpoint. It lands outside the framed viewport, so the camera must
+    // re-frame — otherwise the run draws itself off-screen until the user pans by hand.
+    mocks.fetchAttackPathGraphDelta.mockResolvedValue(growthDelta(11, 'host-a'));
+    await tick();
+    const afterFirstGrowth = mocks.flowProps.current?.fitRequest ?? 0;
+    expect(afterFirstGrowth).toBeGreaterThan(afterInitialLoad);
+
+    // The framing budget is AP_MAX_LIVE_FITS (2) LIVE deltas, so the second one still re-frames.
+    mocks.fetchAttackPathGraphDelta.mockResolvedValue(growthDelta(12, 'host-b'));
+    await tick();
+    const afterSecondGrowth = mocks.flowProps.current?.fitRequest ?? 0;
+    expect(afterSecondGrowth).toBeGreaterThan(afterFirstGrowth);
+
+    // Budget spent: the camera now CHASES the newest nodes at the current zoom instead of pulling
+    // back on every delta — so no further re-fit, and the new nodes are handed to pursuit instead.
+    mocks.fetchAttackPathGraphDelta.mockResolvedValue(growthDelta(13, 'host-c'));
+    await tick();
+    expect(mocks.flowProps.current?.fitRequest ?? 0).toBe(afterSecondGrowth);
+  });
 });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -380,11 +380,18 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
           nonce: structuralNonce,
         });
       } else {
-        liveFitCount.current += 1;
         setFitNonce(n => n + 1);
+        // Only LIVE growth spends the framing budget. The initial load also bumps the structural
+        // nonce — once for the collapsed seed, once for the causal overlay merged in after it — and
+        // those carry no batch. Counting them exhausted the budget before the first delta ever
+        // arrived, so pursuit engaged immediately and every growth re-fit was suppressed for the
+        // rest of the run (the graph then drew itself off-screen until the user panned by hand).
         // Only a run still producing deltas graduates to pursuit; a terminal run loads once and fits.
-        if (!runTerminal && liveFitCount.current >= AP_MAX_LIVE_FITS) {
-          setPursuitActive(true);
+        if (newNodeIds.length > 0) {
+          liveFitCount.current += 1;
+          if (!runTerminal && liveFitCount.current >= AP_MAX_LIVE_FITS) {
+            setPursuitActive(true);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

During a running simulation the Attack path graph stopped re-framing itself as new nodes were drawn — the run drew itself progressively off-screen and the user had to pan/zoom by hand.

`AP_MAX_LIVE_FITS = 2` (`SimulationAttackPath.tsx:61`) is documented as a budget for *"the first structural **deltas**"*, but it was spent by anything that bumped `structuralNonce` — and the **initial load** bumps it twice before any delta arrives:

| bump | source | effect |
|---|---|---|
| 1 | `useAttackPathLiveGraph.ts:181` — collapsed snapshot seed | `liveFitCount = 1` |
| 2 | `useAttackPathLiveGraph.ts:225` — causal/full graph merged in | `liveFitCount = 2` → `setPursuitActive(true)` |
| 3+ | the first (and every) real live delta | pursuit already active → no re-fit, ever |

`AttackPathCanvas.tsx:240` (`firstFit || !pursuitActiveRef.current`) then suppresses every growth re-fit for the rest of the run, so live growth got **zero** re-fits instead of the intended 1-2. Both initial bumps happen on any normal small run (`fullEligible` is true when the run is absent from the summary list or under the size ceiling, `SimulationAttackPath.tsx:220-228`).

**Fix:** only spend the budget on bumps that actually carried new node ids. The seed and the full merge carry no batch — they still frame the graph on load, but no longer graduate the camera to pursuit before the run has produced anything.

Fixes #7205

## Test plan

- [x] Regression test added on the existing `SimulationAttackPath` harness (it captures the `fitRequest` prop handed to the canvas). Verified it **fails without the fix** (`AssertionError: expected 2 to be greater than 2`) and passes with it.
- [x] The same test also pins the intended hand-over, so the fix restores re-framing without disabling pursuit: delta 1 re-frames, delta 2 re-frames, delta 3 does not (pursuit owns the camera).
- [x] `yarn vitest run src/__tests__/.../attack_path/` — 100 tests / 4 files pass.
- [x] `yarn eslint` on both changed files, and `yarn check-ts`, both clean.

## Not covered by this PR

The other half of the reported symptom — the live view only catching up after ~45 s instead of ~3 s — is a **separate** issue and is deliberately left out. Mechanism: `useAttackPathLiveGraph.ts:339-345` picks the 45 s safety net whenever `isStreamHealthy()` is true, but that helper (`useDataLoader.js:364-369`) only measures the shared stream's 1 s ping — never whether `attack-path-version` nudges actually arrive. So any nudge-delivery failure silently degrades the cadence to 45 s while the LIVE badge stays green.

Changing that policy would contradict the existing, deliberate `given_aHealthyStream_should_pollOnlyAsASafetyNet` test (spec 003 FR6), and would mask the nudge failure rather than fix it — so it needs its own issue and a root-cause pass on why the nudges stop (candidates: `StreamApi.listenAttackPathVersion` is a `@TransactionalEventListener` without `fallbackExecution`, and the `streamExecutor` pool's `DiscardOldestPolicy`, which `AttackPathVersionService`'s own javadoc flags as a flooding risk).