### PR TITLE
fix(attack-path): restore focus-on-click from the table, and keep a focus always visible (#7209)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -46,6 +46,7 @@ vi.mock('../../../../../../components/i18n', () => ({
   useFormatter: () => ({
     t: (s: string) => s,
     fldt: (d: string) => d,
+    vnsdt: (d: string) => d,
   }),
 }));
 
@@ -346,11 +347,13 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     expect(await screen.findByText('CORP-HOST')).toBeTruthy();
     expect(screen.getByRole('button', { name: /Export CSV/ })).toBeTruthy();
 
-    // Clicking the row opens that endpoint's detail panel inline (its Executions section) and stays
-    // in the table view — a row click must not silently swap the whole view back to the graph.
+    // Clicking the row focuses the graph on that endpoint's own causal path (same as a chokepoint card
+    // or a search pick) and opens its detail panel: the table is a way IN to an endpoint, so it lands
+    // on the focused graph rather than leaving the analyst on the list.
     fireEvent.click(screen.getByText('CORP-HOST'));
     expect(await screen.findByText(/Executions/)).toBeTruthy();
-    expect(screen.queryByTestId('attack-path-flow')).toBeNull();
+    expect(await screen.findByTestId('attack-path-flow')).toBeTruthy();
+    expect(mocks.flowProps.current?.fitRequest ?? 0).toBeGreaterThan(0);
   });
 });
 

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -341,18 +341,28 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     setup();
     await screen.findByTestId('attack-path-flow');
 
+    // Open the endpoint's panel first (plain node click), so the row click below also proves a focus
+    // request CLOSES a panel left open — not merely that it does not open one.
+    await act(async () => {
+      mocks.flowProps.current?.onEndpointClick?.(ENDPOINT_NODE, 'host-x', 'CORP-HOST');
+    });
+    expect(await screen.findByText(/Executions/)).toBeTruthy();
+
     // Toggle to the table view; the graph is replaced by the sortable endpoint table.
     fireEvent.click(screen.getByRole('button', { name: 'Table' }));
 
     // The single exposed endpoint (score 1) is listed with its friendly hostname and total findings,
-    // and the CSV export action is available.
-    expect(await screen.findByText('CORP-HOST')).toBeTruthy();
+    // and the CSV export action is available. The hostname appears twice on purpose here: the table
+    // cell AND the still-open panel's title — the td is the row under test.
+    const rowCell = (await screen.findAllByText('CORP-HOST')).find(el => el.tagName === 'TD');
+    expect(rowCell).toBeTruthy();
     expect(screen.getByRole('button', { name: /Export CSV/ })).toBeTruthy();
 
     // Clicking the row focuses the graph on that endpoint's own causal path (same as a chokepoint card
     // or a search pick): the table is a way IN to an endpoint, so it lands on the focused graph rather
-    // than leaving the analyst on the list — and without forcing the side panel open over it.
-    fireEvent.click(screen.getByText('CORP-HOST'));
+    // than leaving the analyst on the list — and without the side panel over it: the previously open
+    // panel closes rather than lingering (stale) over the freshly focused, full-width graph.
+    fireEvent.click(rowCell as HTMLElement);
     expect(await screen.findByTestId('attack-path-flow')).toBeTruthy();
     expect(mocks.flowProps.current?.fitRequest ?? 0).toBeGreaterThan(0);
     expect(screen.queryByText(/Executions/)).toBeNull();

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../../../../../../components/i18n', () => ({
   useFormatter: () => ({
     t: (s: string) => s,
     fldt: (d: string) => d,
-    vnsdt: (d: string) => d,
+    cnsdt: (d: string) => d,
   }),
 }));
 
@@ -233,15 +233,17 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     fireEvent.click(item);
 
     // Clicking the finding refocuses the map on its attack path (fit requested) and loads the
-    // endpoint's feed for detail.
+    // endpoint's feed, whose relations label the focused layout's injector edges.
     await waitFor(() => {
       // First page of the endpoint's feed; the edges come back whole regardless.
       expect(mocks.fetchEndpointRelations).toHaveBeenCalledWith('sim-1', 'host-x', 0, 50);
       expect(mocks.flowProps.current?.fitRequest ?? 0).toBeGreaterThan(0);
     });
 
-    // The feed panel is titled with the endpoint's friendly hostname, not the raw key.
-    expect(await screen.findByText(/CORP-HOST/)).toBeTruthy();
+    // No side panel is forced open: the click is about the focused graph, and a panel would take back
+    // the width the focus just revealed. The graph stays rendered, the detail is one node click away.
+    expect(await screen.findByTestId('attack-path-flow')).toBeTruthy();
+    expect(screen.queryByText(/Executions/)).toBeNull();
   });
 
   it('opens the result & terminal panel for a clicked execution and focuses its endpoint on the map', async () => {
@@ -348,12 +350,12 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     expect(screen.getByRole('button', { name: /Export CSV/ })).toBeTruthy();
 
     // Clicking the row focuses the graph on that endpoint's own causal path (same as a chokepoint card
-    // or a search pick) and opens its detail panel: the table is a way IN to an endpoint, so it lands
-    // on the focused graph rather than leaving the analyst on the list.
+    // or a search pick): the table is a way IN to an endpoint, so it lands on the focused graph rather
+    // than leaving the analyst on the list — and without forcing the side panel open over it.
     fireEvent.click(screen.getByText('CORP-HOST'));
-    expect(await screen.findByText(/Executions/)).toBeTruthy();
     expect(await screen.findByTestId('attack-path-flow')).toBeTruthy();
     expect(mocks.flowProps.current?.fitRequest ?? 0).toBeGreaterThan(0);
+    expect(screen.queryByText(/Executions/)).toBeNull();
   });
 });
 

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -1371,6 +1371,78 @@ describe('scopeChainFlowToSeeds', () => {
     const scoped = scopeChainFlowToSeeds(chainFlow, new Set([resolvedSeed!]));
 
     expect(scoped.nodes.map(n => n.id).sort()).toEqual(['chain-ep|0|ep-1', 'inj-A', resolvedSeed].sort());
+  });
+});
+
+describe('scopeChainFlowToEndpoint', () => {
+  // An endpoint whose execution edge keys it by its REF, not by its graph node id — the shape a
+  // raw-value / re-resolved target takes. The focus click still only knows the node id.
+  const REF = 'ep-ref-1';
+  const NODE_ID = 'NODE_ENDPOINT|ep-ref-1';
+  const refKeyed: AttackPathDTO = {
+    ...chainDto,
+    attackPathNodes: [
+      {
+        id: 'inj-A',
+        type: 'INJECTOR',
+        label: 'A',
+      },
+      {
+        id: NODE_ID,
+        ref: REF,
+        type: 'ASSET',
+        label: 'EP1',
+        ip: '10.0.0.1',
+      },
+      {
+        id: 'NODE_FINDING|share|s1',
+        type: 'FINDING',
+        typeFindings: 'share',
+        value: 's1',
+        label: 's1',
+      },
+    ],
+    attackPathExecutions: [
+      {
+        id: 'xA',
+        type: 'EXECUTION',
+        ref: 'exec-A',
+        stepTemplateId: 'step-A',
+        findingsNodeIds: ['NODE_FINDING|share|s1'],
+        dependsOn: [],
+      },
+    ],
+    attackPathEdges: [
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'inj-A',
+        // Keyed by ref — so the chain endpoint node is `chain-ep|0|ep-ref-1`, not `…|NODE_ENDPOINT|…`.
+        edgeTargetId: REF,
+        executionIds: ['exec-A'],
+      },
+    ],
+  };
+
+  it('resolves a ref-keyed endpoint from its node id, keeping the causal chain scoped', () => {
+    const chainFlow = buildCausalChainFlow(refKeyed, tt);
+    // Passing both identifiers (as the focus does) must resolve, so the focus really scopes down
+    // instead of silently returning the whole chain — which would read as "nothing happened".
+    const scoped = scopeChainFlowToEndpoint(chainFlow, [NODE_ID, REF]);
+
+    expect(scoped.nodes.some(n => n.id === `chain-ep|0|${REF}`)).toBe(true);
+    // The producing injector stays in scope: the causal structure is preserved, not flattened away.
+    expect(scoped.nodes.some(n => n.id === 'inj-A')).toBe(true);
+    expect(scoped.edges.length).toBeGreaterThan(0);
+  });
+
+  it('still resolves when only the matching identifier is supplied, and tolerates undefined ones', () => {
+    const chainFlow = buildCausalChainFlow(refKeyed, tt);
+
+    expect(scopeChainFlowToEndpoint(chainFlow, [undefined, REF]).nodes
+      .some(n => n.id === `chain-ep|0|${REF}`)).toBe(true);
+    // A single string keeps working (the original signature).
+    expect(scopeChainFlowToEndpoint(chainFlow, REF).nodes
+      .some(n => n.id === `chain-ep|0|${REF}`)).toBe(true);
   });
 });
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathHeader.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathHeader.tsx
@@ -270,8 +270,20 @@ const AttackPathHeader: FunctionComponent<Props> = ({
             );
           }}
           renderInput={params => <TextField {...params} label={t('Simulation')} />}
+          // The closed field only ever shows a compact date (08/05/26, 04:06 PM), so it is sized for
+          // that instead of the old 300px that also had to fit the simulation name. The dropdown is
+          // let out of that width: its rows carry the date AND the endpoint/exec counts, which would
+          // otherwise be crushed into the narrower field.
+          slotProps={{
+            paper: {
+              sx: {
+                width: 'max-content',
+                minWidth: '100%',
+              },
+            },
+          }}
           sx={{
-            'width': 300,
+            'width': 200,
             '& .MuiOutlinedInput-root': {
               height: CONTROL_HEIGHT,
               paddingBlock: 0,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathTableView.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/AttackPathTableView.tsx
@@ -33,9 +33,10 @@ interface Props {
   typeColumns: string[];
   // Rank threshold (top-N) used to flag chokepoints with the flame, matching the graph badges.
   chokepointTopN: number;
-  // Open the endpoint's detail panel inline (same right slot as the graph), WITHOUT leaving the
-  // table — a row click must not silently switch the whole view to the graph.
-  onRowOpen: (row: AttackPathEndpointRow) => void;
+  // Focus the graph on that endpoint's own attack path (its injectors, and the findings they produced
+  // on it) and open its detail panel — the table is a way IN to an endpoint, so a row click lands on
+  // the same focused causal view a chokepoint card or a search pick does.
+  onRowFocus: (row: AttackPathEndpointRow) => void;
 }
 
 type SortKey = 'label' | 'ip' | 'score' | 'chokepoint' | 'criticality' | `type:${string}`;
@@ -74,8 +75,8 @@ const csvField = (v: string | number): string => `"${String(v).replace(/"/g, '""
 
 // A table alternative to the node-link graph: the most-exposed endpoints (chokepoints) and their
 // per-type finding breakdown, sortable and exportable to CSV. Reuses the already-loaded endpoint data
-// (no extra fetch); clicking a row opens that endpoint's detail panel next to the table (no view swap).
-const AttackPathTableView = ({ rows, typeColumns, chokepointTopN, onRowOpen }: Props) => {
+// (no extra fetch); clicking a row focuses the graph on that endpoint's own causal path.
+const AttackPathTableView = ({ rows, typeColumns, chokepointTopN, onRowFocus }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
   const [sortKey, setSortKey] = useState<SortKey>('chokepoint');
@@ -212,7 +213,7 @@ const AttackPathTableView = ({ rows, typeColumns, chokepointTopN, onRowOpen }: P
                   <TableRow
                     key={r.nodeId}
                     hover
-                    onClick={() => onRowOpen(r)}
+                    onClick={() => onRowFocus(r)}
                     sx={{ cursor: 'pointer' }}
                   >
                     <TableCell>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -200,7 +200,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   // Scenario context lists several runs to pick from; simulation context is locked to its own run.
   const showPicker = scenarioExerciseIds !== undefined;
   const theme = useTheme();
-  const { t, fldt } = useFormatter();
+  const { t, fldt, vnsdt } = useFormatter();
   const navigate = useNavigate();
 
   // The view sizes itself to the exact space left under the page chrome (no page scrollbar).
@@ -530,6 +530,8 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   }, [exerciseId, scenarioExerciseIds, showPicker]);
 
   // Readable label for a simulation id: "date · name" for real simulations, raw id for seeds/unknowns.
+  // The date is the compact numeric form (05/08/2026 14:54 in fr, locale-adapted elsewhere) rather than
+  // the long prose one ("August 5, 2026 at 2:54:00 PM"), which crowded the picker out of the header.
   const labelFor = useCallback((simId?: string): string => {
     if (!simId) {
       return '';
@@ -537,11 +539,11 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     const meta = metaById.get(simId);
     if (meta?.exercise_name) {
       return meta.exercise_start_date
-        ? `${fldt(meta.exercise_start_date)} · ${meta.exercise_name}`
+        ? `${vnsdt(meta.exercise_start_date)} · ${meta.exercise_name}`
         : meta.exercise_name;
     }
     return simId;
-  }, [metaById, fldt]);
+  }, [metaById, vnsdt]);
 
   // Click a real endpoint (only visible once its injector cluster is expanded): load its own findings
   // (grouped in the side panel) and its executions. Stale responses are dropped.
@@ -1260,9 +1262,23 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         }
         // The plain endpoint-only focus (chokepoint click, no finding/action selected) seeds on the
         // endpoint itself.
-        raw = seeds
+        const scoped = seeds
           ? scopeChainFlowToSeeds(fullChain, seeds)
           : scopeChainFlowToEndpoint(fullChain, pathFinding.endpointNodeId);
+        // Both scopers deliberately return the WHOLE chain when none of their seeds is a rendered node,
+        // rather than an empty canvas. That safety net is right for the canvas but wrong for a focus
+        // request: the graph comes back byte-identical, so the click reads as "nothing happened" (an
+        // endpoint reached only through a path the chain layout does not lay out — e.g. a raw-value
+        // target, or a step whose source is not an injector — hits exactly that). Degrade to the flatter
+        // buildFindingPathFlow layout instead: it always renders a genuinely focused view for the
+        // endpoint, losing the causal edges but never the focus itself.
+        raw = scoped.nodes.length === fullChain.nodes.length
+          ? buildFindingPathFlow(dto, pathFinding, t, pathContractLabelByInjector, {
+              expanded: expandedFindingClusters,
+              findingsByCluster,
+              batch: findingBatch,
+            })
+          : scoped;
       } else if (pathFinding) {
         raw = buildFindingPathFlow(dto, pathFinding, t, pathContractLabelByInjector, {
           expanded: expandedFindingClusters,
@@ -2633,7 +2649,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
               rows={tableRows}
               typeColumns={endpointTypeColumns}
               chokepointTopN={CHOKEPOINT_TOP_N}
-              onRowOpen={row => onEndpointClick(row.nodeId, row.ref, row.label)}
+              onRowFocus={row => focusChokepoint(row)}
             />
           </Paper>
         )}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -200,7 +200,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   // Scenario context lists several runs to pick from; simulation context is locked to its own run.
   const showPicker = scenarioExerciseIds !== undefined;
   const theme = useTheme();
-  const { t, fldt, vnsdt } = useFormatter();
+  const { t, fldt, cnsdt } = useFormatter();
   const navigate = useNavigate();
 
   // The view sizes itself to the exact space left under the page chrome (no page scrollbar).
@@ -539,16 +539,24 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     const meta = metaById.get(simId);
     if (meta?.exercise_name) {
       return meta.exercise_start_date
-        ? `${vnsdt(meta.exercise_start_date)} · ${meta.exercise_name}`
+        ? `${cnsdt(meta.exercise_start_date)} · ${meta.exercise_name}`
         : meta.exercise_name;
     }
     return simId;
-  }, [metaById, vnsdt]);
+  }, [metaById, cnsdt]);
 
   // Click a real endpoint (only visible once its injector cluster is expanded): load its own findings
   // (grouped in the side panel) and its executions. Stale responses are dropped.
-  const onEndpointClick = useCallback((nodeId: string, ref?: string, label?: string) => {
-    setSelectedNodeId(nodeId);
+  //
+  // `openPanel: false` loads the endpoint's data WITHOUT selecting it, so the side panel stays closed.
+  // A focus request (table row, chokepoint, search pick, finding pick) wants the whole width for the
+  // graph it just focused — opening the panel on top of it immediately narrows the view the click was
+  // meant to reveal. The data is still fetched: the focused layout labels its injector edges from those
+  // relations, and the panel is one node click away once the analyst wants the detail.
+  const onEndpointClick = useCallback((nodeId: string, ref?: string, label?: string, opts?: { openPanel?: boolean }) => {
+    if (opts?.openPanel !== false) {
+      setSelectedNodeId(nodeId);
+    }
     setSelectedFindingId(null);
     setSelectedInjectorId(null);
     setFindingDetail(null);
@@ -1017,15 +1025,12 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       // onEndpointClick itself unconditionally clears selectedFindingId/findingDetail, so both must be
       // re-set AFTER it (matches openFindingFromGraph's ordering) — setting them before it here was
       // the bug: onEndpointClick silently clobbered the canonical id back to null on every click.
-      onEndpointClick(item.endpointNodeId, item.endpointKey, label);
+      // No side panel: like every other focus entry point, the click is about the focused graph, and a
+      // panel opening on top of it takes back the width the focus just revealed.
+      onEndpointClick(item.endpointNodeId, item.endpointKey, label, { openPanel: false });
       if (chainMode) {
         setSelectedFindingId(canonicalId ?? null);
       }
-      setFindingDetail({
-        type: item.type ?? '',
-        value: item.value ?? '',
-        endpointNodeId: item.endpointNodeId,
-      });
       setHighlightedExecutionIds(new Set(item.executionIds ?? []));
     },
     [onEndpointClick, dto?.attackPathNodes, fullDto?.attackPathNodes, chainMode],
@@ -2367,8 +2372,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   const [searchInput, setSearchInput] = useState('');
 
   // Focus a chokepoint endpoint: redraw the graph as the focused endpoint path (injectors -> endpoint
-  // -> its finding clusters) and open its side panel (findings + executions). Uses the endpoint-focus
-  // mode of buildFindingPathFlow (empty finding type/value).
+  // -> its finding clusters). Shared by the table rows, the chokepoint dialog and the search picks.
+  // The side panel is deliberately NOT opened: the point of the click is the focused graph, and the
+  // panel would immediately take a third of the width back. It stays one node click away.
   const focusChokepoint = (c: {
     nodeId: string;
     ref: string;
@@ -2390,7 +2396,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       value: '',
     });
     setFitNonce(n => n + 1);
-    onEndpointClick(c.nodeId, c.ref, c.label);
+    onEndpointClick(c.nodeId, c.ref, c.label, { openPanel: false });
   };
 
   // Keep the selected value in the options so MUI does not warn when the current simulation has no

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1261,24 +1261,15 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
           seeds = new Set([selectedInjectorId]);
         }
         // The plain endpoint-only focus (chokepoint click, no finding/action selected) seeds on the
-        // endpoint itself.
-        const scoped = seeds
+        // endpoint itself, matched on EVERY identifier it is known by — its graph node id AND its ref —
+        // because a chain endpoint node is keyed by whatever form its execution edge carried, which is
+        // not always the same form the click hands us. Matching on the node id alone left a
+        // ref-keyed endpoint unresolvable, and an unresolvable seed makes the scoper return the whole
+        // chain (its no-empty-canvas safety net), so the graph came back identical and the click read
+        // as "nothing happened".
+        raw = seeds
           ? scopeChainFlowToSeeds(fullChain, seeds)
-          : scopeChainFlowToEndpoint(fullChain, pathFinding.endpointNodeId);
-        // Both scopers deliberately return the WHOLE chain when none of their seeds is a rendered node,
-        // rather than an empty canvas. That safety net is right for the canvas but wrong for a focus
-        // request: the graph comes back byte-identical, so the click reads as "nothing happened" (an
-        // endpoint reached only through a path the chain layout does not lay out — e.g. a raw-value
-        // target, or a step whose source is not an injector — hits exactly that). Degrade to the flatter
-        // buildFindingPathFlow layout instead: it always renders a genuinely focused view for the
-        // endpoint, losing the causal edges but never the focus itself.
-        raw = scoped.nodes.length === fullChain.nodes.length
-          ? buildFindingPathFlow(dto, pathFinding, t, pathContractLabelByInjector, {
-              expanded: expandedFindingClusters,
-              findingsByCluster,
-              batch: findingBatch,
-            })
-          : scoped;
+          : scopeChainFlowToEndpoint(fullChain, [pathFinding.endpointNodeId, pathFinding.endpointKey]);
       } else if (pathFinding) {
         raw = buildFindingPathFlow(dto, pathFinding, t, pathContractLabelByInjector, {
           expanded: expandedFindingClusters,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -530,19 +530,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   }, [exerciseId, scenarioExerciseIds, showPicker]);
 
   // Readable label for a simulation id: "date · name" for real simulations, raw id for seeds/unknowns.
-  // The date is the compact numeric form (05/08/2026 14:54 in fr, locale-adapted elsewhere) rather than
-  // the long prose one ("August 5, 2026 at 2:54:00 PM"), which crowded the picker out of the header.
+  // The date alone identifies the run here: the simulation's name is already on the page header above
+  // the tabs, so repeating it only widened the picker. Compact numeric form (05/08/26 16:06 in fr,
+  // locale-adapted elsewhere) rather than the long prose one ("August 5, 2026 at 4:06:00 PM"). A run
+  // with no start date has nothing to show but its name, so that case still falls back to it.
   const labelFor = useCallback((simId?: string): string => {
     if (!simId) {
       return '';
     }
     const meta = metaById.get(simId);
-    if (meta?.exercise_name) {
-      return meta.exercise_start_date
-        ? `${cnsdt(meta.exercise_start_date)} · ${meta.exercise_name}`
-        : meta.exercise_name;
+    if (meta?.exercise_start_date) {
+      return cnsdt(meta.exercise_start_date);
     }
-    return simId;
+    return meta?.exercise_name || simId;
   }, [metaById, cnsdt]);
 
   // Click a real endpoint (only visible once its injector cluster is expanded): load its own findings

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -554,9 +554,10 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   // meant to reveal. The data is still fetched: the focused layout labels its injector edges from those
   // relations, and the panel is one node click away once the analyst wants the detail.
   const onEndpointClick = useCallback((nodeId: string, ref?: string, label?: string, opts?: { openPanel?: boolean }) => {
-    if (opts?.openPanel !== false) {
-      setSelectedNodeId(nodeId);
-    }
+    // On a focus request, CLOSE any panel a previous node click left open (not just skip opening one):
+    // a stale panel would keep covering the freshly focused graph, showing the new endpoint's data
+    // under the old node's selection highlight.
+    setSelectedNodeId(opts?.openPanel !== false ? nodeId : null);
     setSelectedFindingId(null);
     setSelectedInjectorId(null);
     setFindingDetail(null);

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -2200,18 +2200,30 @@ export const scopeChainFlowToSeeds = (
 // scopeChainFlowToSeeds, seeded on every depth-instance of one endpoint (the causal chain lays the
 // same physical endpoint out again at each depth it's touched, each a distinct `chain-ep|depth|id`
 // node) — the endpoint-focus case (chokepoint click, endpoint drill-down with no specific finding).
+//
+// `endpointIds` takes every identifier the endpoint is known by (its graph node id AND its ref): a
+// chain endpoint node is keyed by whatever form its execution edge carried, which is not always the
+// form the caller holds. Accepting only one of them left a ref-keyed endpoint unresolvable, and an
+// unresolvable seed falls through to the whole-chain safety net below — the graph comes back
+// unchanged, so the focus click reads as "nothing happened".
 export const scopeChainFlowToEndpoint = (
   chainFlow: {
     nodes: AttackPathFlowNode[];
     edges: AttackPathFlowEdge[];
   },
-  endpointId: string,
+  endpointIds: string | ReadonlyArray<string | undefined>,
 ): {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
-} => scopeChainFlowToSeeds(
-  chainFlow,
-  new Set(
-    chainFlow.nodes.filter(n => n.id.startsWith('chain-ep|') && n.id.endsWith(`|${endpointId}`)).map(n => n.id),
-  ),
-);
+} => {
+  const candidates = (typeof endpointIds === 'string' ? [endpointIds] : endpointIds)
+    .filter((id): id is string => !!id);
+  return scopeChainFlowToSeeds(
+    chainFlow,
+    new Set(
+      chainFlow.nodes
+        .filter(n => n.id.startsWith('chain-ep|') && candidates.some(id => n.id.endsWith(`|${id}`)))
+        .map(n => n.id),
+    ),
+  );
+};

--- a/openaev-front/src/components/i18n.tsx
+++ b/openaev-front/src/components/i18n.tsx
@@ -265,6 +265,22 @@ export const useFormatter = () => {
       year: 'numeric',
     });
   };
+  // The tightest date+time that still carries the year (05/08/26 11:25 in fr), for space-constrained
+  // spots such as a picker label sharing its line with a name. Every part is 2-digit so the width is
+  // stable across values, and the year is kept 2-digit rather than dropped: a scenario accumulates
+  // simulations over months, so "05/08" alone would be ambiguous across years.
+  const compactNumericDateTime = (date: Parameters<IntlShape['formatDate']>[0]) => {
+    if (isNone(date)) {
+      return translate('None');
+    }
+    return intl.formatDate(date, {
+      minute: '2-digit',
+      hour: '2-digit',
+      day: '2-digit',
+      month: '2-digit',
+      year: '2-digit',
+    });
+  };
   const time = (date: Parameters<IntlShape['formatDate']>[0]) => {
     return intl.formatTime(date, {
       second: 'numeric',
@@ -341,6 +357,7 @@ export const useFormatter = () => {
     nsd: shortNumericDate,
     nsdt: shortNumericDateTime,
     vnsdt: veryShortNumericDateTime,
+    cnsdt: compactNumericDateTime,
     fndt: fullNumericDateTime,
     ft: time,
     fd: standardDate,


### PR DESCRIPTION
## Summary

Closes #7209

Three fixes to the attack-path view.

**1. Table row click focuses the graph again (regression)**

Clicking a row in "MOST EXPOSED ASSETS" used to focus the graph on that endpoint's own causal path. It was rewired in #7098/#7099 to only open the side panel while staying on the list (`onRowOpen` -> `onEndpointClick`). Restored: the table is a way *in* to an endpoint, so a row click lands on the same focused causal view a chokepoint card or a search pick does (prop renamed back to `onRowFocus` -> `focusChokepoint`).

The side panel is deliberately NOT forced open by any focus entry point (table row, chokepoint dialog, search pick, finding pick): the click is about the focused path, and a panel would immediately take back a third of the width it just revealed. The endpoint's data is still fetched (the focused layout labels its injector edges from those relations), so the panel is one node click away - and a panel left open by a previous node click is closed rather than lingering (stale) over the freshly focused graph (`openPanel: false` on `onEndpointClick`).

**2. A focus request never silently no-ops - without losing the causal links**

`scopeChainFlowToSeeds` / `scopeChainFlowToEndpoint` deliberately return the **whole** chain when none of their seeds is a rendered node, rather than an empty canvas. That safety net is right for the canvas but wrong for a focus request: the graph comes back byte-identical, so the click reads as "nothing happened".

The cause is seed resolution, not the layout: a chain endpoint node is keyed by whatever form its execution edge carried, which is not always the form the click hands us - a **ref-keyed** endpoint was unresolvable from its node id alone. Endpoint focus now matches on **every identifier the endpoint is known by** (graph node id AND ref): `scopeChainFlowToEndpoint` accepts a list of candidate identifiers (the single-string signature still works). The causal chain stays the layout in every focused case: the focused view exists to show the "Triggered ..." edges, so it must never degrade to the flat non-causal layout.

Rebased on main after #7187 merged: the collapsed-finding seed now goes through #7187's `causalSourceByFinding` map (which resolves a collapsed finding to the node that actually represents it, so the key-form problem cannot arise there), and this PR's multi-identifier matching covers the endpoint-focus path.

**3. Compact simulation date in the picker**

The picker label is now the date alone in a dedicated all-2-digit `cnsdt` formatter (new in `i18n.tsx`; `vnsdt` is shared by four other components and left untouched): `August 5, 2026 at 2:54:00 PM · test` -> `05/08/26 14:54` (fr), locale-adapted elsewhere via `Intl.DateTimeFormat` - no new i18n strings. The simulation name is dropped from the label (it is already on the page header above the tabs); a run with no start date still falls back to its name. The 2-digit year is kept rather than dropped: a scenario accumulates simulations over months, so a day/month alone would be ambiguous across years.

## Test plan

- [x] Updated the table-view test: a row click now asserts the graph is focused (`fitRequest > 0`) and that a previously open side panel CLOSES (not merely "does not open"), instead of "stays in the table view".
- [x] Added two `scopeChainFlowToEndpoint` tests: a ref-keyed endpoint resolves from its node id **and the producing injector stays in scope** (causal structure preserved, not flattened); plus undefined-tolerance and the original single-string signature.
- [x] Full `attack_path` suite passes (103/103, including the tests merged with #7187).
- [x] `tsc --noEmit` and `eslint` clean.
- [x] Date rendering verified per locale against `Intl.DateTimeFormat` for fr/en/de/es/it/ja/ko/zh/ru.
- [ ] Manual: table row, chokepoint card, finding pick and search-bar pick each focus the endpoint **keeping the causal links**, at full width.
