### PR TITLE
docs(injector-contract): clarify is_atomic_testing semantics (#5345)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/form/InjectorContractAddInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/form/InjectorContractAddInput.java
@@ -49,6 +49,7 @@ public class InjectorContractAddInput {
   @JsonProperty("contract_content")
   private String content;
 
+  // Indicates whether this contract can be used to create an atomic testing inject.
   // Fixes a bug due to a new version of jackson and lombok
   // cf: https://github.com/projectlombok/lombok/issues/3978
   @Getter(onMethod_ = @JsonProperty("is_atomic_testing"))

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/form/InjectorContractInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/form/InjectorContractInput.java
@@ -30,6 +30,7 @@ public class InjectorContractInput {
   @JsonProperty("contract_content")
   private String content;
 
+  // Indicates whether this contract can be used to create an atomic testing inject.
   @JsonProperty("is_atomic_testing")
   // Fixes a bug due to a new version of jackson and lombok
   // cf: https://github.com/projectlombok/lombok/issues/3978

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/form/InjectorContractUpdateInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/form/InjectorContractUpdateInput.java
@@ -33,6 +33,7 @@ public class InjectorContractUpdateInput {
   @JsonProperty("contract_content")
   private String content;
 
+  // Indicates whether this contract can be used to create an atomic testing inject.
   @JsonProperty("is_atomic_testing")
   // Fixes a bug due to a new version of jackson and lombok
   // cf: https://github.com/projectlombok/lombok/issues/3978

--- a/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
+++ b/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
@@ -82,7 +82,7 @@ public class Contract {
   @JsonProperty("contract_attack_patterns_external_ids")
   private List<String> attackPatternsExternalIds = new ArrayList<>();
 
-  /** Whether this contract can be used for atomic testing. */
+  /** Whether this contract can be used to create an atomic testing inject. */
   @Setter
   @JsonProperty("is_atomic_testing")
   private boolean isAtomicTesting = true;

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
@@ -461,6 +461,7 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
     this.vulnerabilities = vulnerabilities;
   }
 
+  // Indicates whether this contract can be used to create an atomic testing inject.
   // Fixes a bug due to a new version of jackson and lombok
   // cf: https://github.com/projectlombok/lombok/issues/3978
   @Getter(onMethod_ = @JsonProperty("injector_contract_atomic_testing"))
@@ -469,6 +470,7 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   @Queryable(filterable = true)
   private boolean isAtomicTesting;
 
+  // Exposes the contract capability used to decide if atomic testing creation is allowed.
   @JsonProperty("injector_contract_atomic_testing")
   public boolean getAtomicTestingEffective() {
     return Boolean.TRUE.equals(isAtomicTesting);


### PR DESCRIPTION
### Proposed changes

* Documentation-only change: add explicit code comments clarifying the semantics of `is_atomic_testing` (contract input DTOs and framework `Contract`) and `injector_contract_atomic_testing` (the `InjectorContract` entity). No behavior is modified.
* These properties are injector contract capability flags: they indicate whether the contract CAN be used to create an atomic testing inject. They do not indicate that an inject created from the contract IS an atomic test.

### Context and relationship to the reported bug

Issue #5345 reports that injects created on a Scenario or Simulation carry `is_atomic_testing` / `injector_contract_atomic_testing` set to `true`. Investigation shows these values come from the embedded injector contract serialization and are expected: whether an inject IS an atomic test is derived from its creation context, not from the contract flag (`Inject.isAtomicTesting()` is true only when the inject has neither a scenario nor an exercise, mirrored by `InjectSpecification.isAtomicTesting()`, and that derived state is `@JsonIgnore`, so no inject-level atomic-testing field is exposed by the API). The frontend contract picker uses `injector_contract_atomic_testing = true` only as a filter when creating an atomic test. The behavior therefore works as designed, and this PR adds comments so the capability semantics are not mistaken for inject state again.

### Testing Instructions

1. No functional change to test (comments and Javadoc only).
2. CI on the head commit is green: backend compile, Spotless, API tests, E2E and codecov all pass.

### Related issues

* Relates to #5345 (not "Closes": the reported behavior is by design, so the issue should be closed as such by maintainers if they agree with this reading rather than by this PR)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
