### PR TITLE
fix(chaining): keep a field's defined value when a type is also linked (#7210)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapFieldLinksToStepConditions } from '../../../../../../admin/components/chaining/logic/drawer/ConfigureActionDetail.utils';
+import type { ActionDetailData } from '../../../../../../admin/components/chaining/logic/types';
+
+// Minimal ActionDetailData carrying only what mapFieldLinksToStepConditions reads.
+const data = (over: Partial<ActionDetailData>): ActionDetailData => ({
+  inject_title: 'a',
+  inject_injector_contract: 'c',
+  inject_assets: [],
+  inject_asset_groups: [],
+  inject_teams: [],
+  inject_all_teams: false,
+  inject_documents: [],
+  inject_content: {},
+  inject_field_links: {},
+  contract_fields: [],
+  ...over,
+});
+
+describe('mapFieldLinksToStepConditions', () => {
+  it('carries a linked field’s defined value into condition_value alongside its type', () => {
+    // The field "target" is linked to the "host" output type AND has a defined value typed in.
+    const conditions = mapFieldLinksToStepConditions(data({
+      inject_content: { target: '10.0.0.5' },
+      inject_field_links: {
+        target: {
+          outputTypes: ['host'],
+          localScope: false,
+        },
+      },
+    }));
+
+    expect(conditions).toHaveLength(1);
+    expect(conditions[0]).toMatchObject({
+      condition_type: 'MAPPER',
+      condition_key: 'target',
+      condition_key_types: ['host'],
+      condition_value: '10.0.0.5', // the defined value is NOT dropped once a type is linked
+      condition_mapping_type: 'GLOBAL',
+    });
+  });
+
+  it('omits condition_value when the field has no defined value', () => {
+    const conditions = mapFieldLinksToStepConditions(data({
+      inject_content: {},
+      inject_field_links: {
+        target: {
+          outputTypes: ['host'],
+          localScope: true,
+        },
+      },
+    }));
+
+    expect(conditions[0].condition_value).toBeUndefined();
+    expect(conditions[0].condition_mapping_type).toBe('LOCAL');
+  });
+
+  it('falls back to a text key type for a link that carries no output type', () => {
+    // Degenerate case: a link with no output types must never serialize empty keyTypes, or the
+    // backend drops the whole step's execution batches.
+    const conditions = mapFieldLinksToStepConditions(data({
+      inject_content: { target: 'literal' },
+      inject_field_links: {
+        target: {
+          outputTypes: [],
+          localScope: false,
+        },
+      },
+    }));
+
+    expect(conditions[0].condition_key_types).toEqual(['text']);
+    expect(conditions[0].condition_value).toBe('literal');
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.test.ts
@@ -19,7 +19,7 @@ const data = (over: Partial<ActionDetailData>): ActionDetailData => ({
 });
 
 describe('mapFieldLinksToStepConditions', () => {
-  it('carries a linked field’s defined value into condition_value alongside its type', () => {
+  it(`carries a linked field's defined value into condition_value alongside its type`, () => {
     // The field "target" is linked to the "host" output type AND has a defined value typed in.
     const conditions = mapFieldLinksToStepConditions(data({
       inject_content: { target: '10.0.0.5' },
@@ -71,5 +71,53 @@ describe('mapFieldLinksToStepConditions', () => {
 
     expect(conditions[0].condition_key_types).toEqual(['text']);
     expect(conditions[0].condition_value).toBe('literal');
+  });
+
+  it('coerces a numeric defined value to its string form', () => {
+    const conditions = mapFieldLinksToStepConditions(data({
+      inject_content: { port: 8080 },
+      inject_field_links: {
+        port: {
+          outputTypes: ['port'],
+          localScope: false,
+        },
+      },
+    }));
+
+    expect(conditions[0].condition_value).toBe('8080');
+  });
+
+  it('omits condition_value for non-scalar content (array or object)', () => {
+    // A multi-cardinality select stores an array; String() would coerce it into a meaningless
+    // "a,b" candidate. Only scalar values are carried into condition_value.
+    const conditions = mapFieldLinksToStepConditions(data({
+      inject_content: {
+        multi: ['a', 'b'],
+        obj: { nested: true },
+      },
+      inject_field_links: {
+        multi: {
+          outputTypes: ['text'],
+          localScope: false,
+        },
+        obj: {
+          outputTypes: ['text'],
+          localScope: false,
+        },
+      },
+    }));
+
+    expect(conditions).toHaveLength(2);
+    expect(conditions[0].condition_value).toBeUndefined();
+    expect(conditions[1].condition_value).toBeUndefined();
+  });
+
+  it('produces no conditions for fields that are not linked', () => {
+    const conditions = mapFieldLinksToStepConditions(data({
+      inject_content: { free_text: 'kept in inject_content only' },
+      inject_field_links: {},
+    }));
+
+    expect(conditions).toEqual([]);
   });
 });

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ComponentStepperDrawer.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ComponentStepperDrawer.tsx
@@ -30,6 +30,7 @@ import { resolveConditionKeyTypes } from '../logic-flow-helpers';
 import type { ActionDetailData, ActionMeta, EventMeta } from '../types';
 import AddActionList from './AddActionList';
 import ConfigureActionDetail from './ConfigureActionDetail';
+import { mapFieldLinksToStepConditions } from './ConfigureActionDetail.utils';
 import InjectTargetsProvider from './InjectTargetsProvider';
 
 /**
@@ -273,16 +274,10 @@ const ComponentStepperDrawer = ({
 
   const handleSaveActionDetail = async (data: ActionDetailData) => {
     if (!workflowId) return;
-    const stepConditions: ConditionCreateInput[] = Object.entries(data.inject_field_links).map(([fieldKey, link], i) => {
-      const keyTypes = link.outputTypes && link.outputTypes.length > 0 ? link.outputTypes : ['text'];
-      return {
-        condition_temporary_id: String(i),
-        condition_type: 'MAPPER' as const,
-        condition_key_types: keyTypes as ConditionCreateInput['condition_key_types'],
-        condition_key: fieldKey,
-        condition_mapping_type: (link.localScope ? 'LOCAL' : 'GLOBAL') as ConditionCreateInput['condition_mapping_type'],
-      };
-    });
+    // Carries each linked field's own defined value into condition_value alongside its linked
+    // type(s), so a value typed before linking a type is no longer dropped (the backend keeps it as
+    // an extra candidate — ConditionService#resolveMapperPairs).
+    const stepConditions: ConditionCreateInput[] = mapFieldLinksToStepConditions(data);
 
     const stepPayload = {
       step_workflow_id: workflowId,

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.tsx
@@ -350,7 +350,11 @@ const ConfigureActionDetail: FunctionComponent<ConfigureActionDetailProps> = ({
 
     return (
       <Box key={ef.key}>
-        {!link && <InjectContentFieldComponent field={ef} />}
+        {/* The defined-value input stays available even once a type is linked: the two are not
+            mutually exclusive — the backend keeps the defined value as one more candidate alongside
+            the linked type's resolved pool (ConditionService#resolveMapperPairs). Only auto-linked
+            fields (e.g. targeted-asset) are system-managed and hide it. */}
+        {!isAutoLinked && <InjectContentFieldComponent field={ef} />}
         {showLink && (
           <FieldOutputLink
             panelOpen={open}

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.ts
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.ts
@@ -65,9 +65,12 @@ export const mapFieldLinksToStepConditions = (
     // Carry over the field's own typed value as the MAPPER condition's defined value,
     // so it keeps participating in the generated input combinations as an extra
     // candidate alongside the linked type's resolved pool, instead of being dropped
-    // once a primitive type is linked.
+    // once a primitive type is linked. Only scalar values are carried: an array (e.g. a
+    // multi-cardinality select) or object would be coerced into a meaningless string
+    // ("a,b", "[object Object]") and injected as a bogus runtime candidate.
     const rawValue = data.inject_content[fieldKey];
-    const definedValue = rawValue != null && String(rawValue).trim() !== ''
+    const isScalar = typeof rawValue === 'string' || typeof rawValue === 'number' || typeof rawValue === 'boolean';
+    const definedValue = isScalar && String(rawValue).trim() !== ''
       ? String(rawValue)
       : undefined;
 

--- a/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.ts
+++ b/openaev-front/src/admin/components/chaining/logic/drawer/ConfigureActionDetail.utils.ts
@@ -57,7 +57,10 @@ export const mapFieldLinksToStepConditions = (
   const fieldLinks: Record<string, FieldLink> = data.inject_field_links;
   return Object.entries(fieldLinks).map(([fieldKey, link], index) => {
     const outputTypes = link.outputTypes ?? [];
-    const keyTypes = outputTypes.length > 0 ? outputTypes : [];
+    // A linked field always carries at least one output type; the 'text' fallback only guards the
+    // degenerate "link with no type" case so the backend never sees a mapper with empty keyTypes
+    // (which would drop the whole step's execution batches — ConditionService line ~1086).
+    const keyTypes = outputTypes.length > 0 ? outputTypes : ['text'];
 
     // Carry over the field's own typed value as the MAPPER condition's defined value,
     // so it keeps participating in the generated input combinations as an extra


### PR DESCRIPTION
## Summary

In the chaining **Configure action** drawer, a payload/contract argument could be given a **defined value** OR bound to an upstream **output type**, but not both - once a type was linked the value was silently ignored.

- `ConfigureActionDetail.tsx` rendered the defined-value input only when there was no link, so linking a type hid it.
- `ComponentStepperDrawer.tsx` built the step `MAPPER` conditions inline and never set `condition_value`, so the typed value never reached the backend.
- A purpose-built helper `mapFieldLinksToStepConditions` (carries `inject_content[key]` into `condition_value`, comment: "instead of being dropped once a primitive type is linked") existed but was **dead code**.

The backend already supports both together - `ConditionService#resolveMapperPairs` adds the mapper's defined value as one more candidate alongside the linked type's resolved pool, "never silently discarded just because the mapper is no longer MappingType.DEFAULT". So the fix is frontend-only.

## Changes

- Show the defined-value input whenever the field is **not auto-linked** (auto-linked system fields like `targeted-asset` still hide it), so a value stays available alongside a manually linked type.
- Serialize step conditions through `mapFieldLinksToStepConditions` (removing the inline mapping that dropped `condition_value`), and align its keyTypes fallback with the previous inline behaviour (`'text'` for the degenerate no-type link, so the backend never gets empty keyTypes and drops the step's execution batches).
- Only carry **scalar** defined values (string/number/boolean) into `condition_value`: an array (multi-cardinality select) or object would otherwise be coerced into a meaningless string ("a,b", "[object Object]") and injected as a bogus runtime candidate.

Fixes #7210

## Test plan

- [x] Unit tests on `mapFieldLinksToStepConditions` (6): defined value carried into `condition_value` alongside its type; `condition_value` omitted when no value; `'text'` keyTypes fallback for a link with no type; numeric value coerced to string; non-scalar content (array/object) skipped; unlinked fields produce no conditions. 6/6 pass.
- [x] `yarn eslint` (changed files) + `yarn check-ts` clean.
- [ ] Manual: type a defined value on a payload argument, then link an output type - both persist; at run time the defined value participates as an extra candidate.
