### PR TITLE
fix(threat-arsenal): rewrite embedded contract_id when importing threats (#6516)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtils.java
@@ -40,12 +40,9 @@ public class InjectorContractMigrationUtils {
       return;
     }
 
-    if (convertedContent.has(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_CONTACT_ID)) {
-      convertedContent.put(
-          InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_CONTACT_ID, contract.getId());
-      contract.setConvertedContent(convertedContent);
-      contract.setContent(convertedContent.toString());
-    }
+    convertedContent.put(
+        InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_CONTRACT_ID, contract.getId());
+    contract.setContent(convertedContent.toString());
 
     ObjectNode expectationsField =
         (ObjectNode)
@@ -91,7 +88,6 @@ public class InjectorContractMigrationUtils {
 
     expectationsField.set(InjectorContract.AVAILABLE_EXPECTATIONS, available);
     expectationsField.remove(PREDEFINED_EXPECTATIONS_OLD_LIST);
-
     contract.setContent(convertedContent.toString());
   }
 }

--- a/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtils.java
@@ -36,17 +36,18 @@ public class InjectorContractMigrationUtils {
         return;
       }
     }
-    if (!convertedContent.has("fields")) {
+    if (!convertedContent.has(InjectorContract.CONTRACT_CONTENT_FIELDS)) {
       return;
     }
 
-    convertedContent.put(
-        InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_CONTRACT_ID, contract.getId());
+    convertedContent.put(InjectorContract.CONTRACT_CONTENT_KEY_CONTRACT_ID, contract.getId());
     contract.setContent(convertedContent.toString());
 
     ObjectNode expectationsField =
         (ObjectNode)
-            StreamSupport.stream(convertedContent.get("fields").spliterator(), false)
+            StreamSupport.stream(
+                    convertedContent.get(InjectorContract.CONTRACT_CONTENT_FIELDS).spliterator(),
+                    false)
                 .filter(f -> "expectations".equals(f.path("key").asText()))
                 .findFirst()
                 .orElse(null);

--- a/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtils.java
@@ -40,6 +40,13 @@ public class InjectorContractMigrationUtils {
       return;
     }
 
+    if (convertedContent.has(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_CONTACT_ID)) {
+      convertedContent.put(
+          InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_CONTACT_ID, contract.getId());
+      contract.setConvertedContent(convertedContent);
+      contract.setContent(convertedContent.toString());
+    }
+
     ObjectNode expectationsField =
         (ObjectNode)
             StreamSupport.stream(convertedContent.get("fields").spliterator(), false)
@@ -84,6 +91,7 @@ public class InjectorContractMigrationUtils {
 
     expectationsField.set(InjectorContract.AVAILABLE_EXPECTATIONS, available);
     expectationsField.remove(PREDEFINED_EXPECTATIONS_OLD_LIST);
+
     contract.setContent(convertedContent.toString());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiImporterTest.java
@@ -148,6 +148,13 @@ class ThreatArsenalApiImporterTest extends IntegrationTest {
       // as unregistered (update / duplicate / export disabled in the arsenal).
       assertFalse(importedContract.getInjectors().isEmpty());
       assertNotNull(importedInjectorType);
+      // The contract_id embedded in the contract content must be rewritten to the
+      // persisted contract id: the inject form posts that embedded id as
+      // inject_injector_contract, so a stale exported id 404s at launch (#6516).
+      JsonNode importedContent = objectMapper.readTree(importedContract.getContent());
+      assertEquals(
+          importedActionId,
+          importedContent.get(InjectorContract.CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/injector_contract/InjectorContractMigrationUtilsTest.java
@@ -1,0 +1,116 @@
+package io.openaev.utils.injector_contract;
+
+import static io.openaev.database.model.InjectorContract.CONTRACT_CONTENT_KEY_CONTRACT_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.database.model.InjectorContract;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Injector contract migration utils")
+class InjectorContractMigrationUtilsTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String CONTRACT_ID = "d5b0b8e0-9d3a-4d9f-8f10-0f1a2b3c4d5e";
+
+  private InjectorContract buildContract(String content) {
+    InjectorContract contract = new InjectorContract();
+    contract.setId(CONTRACT_ID);
+    contract.setContent(content);
+    return contract;
+  }
+
+  private ObjectNode parseContent(InjectorContract contract) throws JsonProcessingException {
+    return (ObjectNode) MAPPER.readTree(contract.getContent());
+  }
+
+  @Test
+  @DisplayName("Should rewrite a stale embedded contract_id to the entity id")
+  void given_contentWithStaleContractId_should_rewriteToEntityId() throws Exception {
+    InjectorContract contract =
+        buildContract("{\"contract_id\":\"stale-exported-id\",\"fields\":[]}");
+
+    InjectorContractMigrationUtils.migratePredefinedExpectations(contract);
+
+    assertEquals(
+        CONTRACT_ID, parseContent(contract).get(CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
+    assertEquals(
+        CONTRACT_ID, contract.getConvertedContent().get(CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
+  }
+
+  @Test
+  @DisplayName("Should add contract_id when the content JSON has no contract_id key")
+  void given_contentWithoutContractId_should_addContractId() throws Exception {
+    InjectorContract contract = buildContract("{\"fields\":[]}");
+
+    InjectorContractMigrationUtils.migratePredefinedExpectations(contract);
+
+    assertEquals(
+        CONTRACT_ID, parseContent(contract).get(CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
+  }
+
+  @Test
+  @DisplayName("Should be idempotent when re-run on already migrated content")
+  void given_alreadyMigratedContent_should_beIdempotent() throws Exception {
+    InjectorContract contract =
+        buildContract("{\"contract_id\":\"stale-exported-id\",\"fields\":[]}");
+
+    InjectorContractMigrationUtils.migratePredefinedExpectations(contract);
+    String contentAfterFirstRun = contract.getContent();
+    InjectorContractMigrationUtils.migratePredefinedExpectations(contract);
+
+    assertEquals(contentAfterFirstRun, contract.getContent());
+    assertEquals(
+        CONTRACT_ID, parseContent(contract).get(CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
+  }
+
+  @Test
+  @DisplayName("Should leave malformed content untouched without throwing")
+  void given_malformedContent_should_leaveContentUntouched() {
+    InjectorContract contract = buildContract("not a json document");
+
+    assertDoesNotThrow(
+        () -> InjectorContractMigrationUtils.migratePredefinedExpectations(contract));
+
+    assertEquals("not a json document", contract.getContent());
+  }
+
+  @Test
+  @DisplayName("Should leave content without a fields key untouched")
+  void given_contentWithoutFields_should_leaveContentUntouched() throws Exception {
+    InjectorContract contract = buildContract("{\"contract_id\":\"stale-exported-id\"}");
+
+    InjectorContractMigrationUtils.migratePredefinedExpectations(contract);
+
+    assertEquals(
+        "stale-exported-id", parseContent(contract).get(CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
+  }
+
+  @Test
+  @DisplayName("Should rewrite contract_id while migrating legacy predefined expectations")
+  void given_legacyPredefinedExpectations_should_migrateAndRewriteContractId() throws Exception {
+    String legacyContent =
+        "{\"contract_id\":\"stale-exported-id\",\"fields\":[{\"key\":\"expectations\","
+            + "\"predefinedExpectations\":[{\"expectation_type\":\"PREVENTION\"}]}]}";
+    InjectorContract contract = buildContract(legacyContent);
+
+    InjectorContractMigrationUtils.migratePredefinedExpectations(contract);
+
+    ObjectNode content = parseContent(contract);
+    assertEquals(CONTRACT_ID, content.get(CONTRACT_CONTENT_KEY_CONTRACT_ID).asText());
+    ObjectNode expectationsField = (ObjectNode) content.get("fields").get(0);
+    assertFalse(expectationsField.has("predefinedExpectations"));
+    assertEquals(
+        "PREVENTION",
+        expectationsField
+            .get(InjectorContract.AVAILABLE_EXPECTATIONS)
+            .get(0)
+            .get("expectation_type")
+            .asText());
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
@@ -17,11 +17,7 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.audit.TenantBaseListener;
 import io.openaev.database.converter.ContentConverter;
-import io.openaev.helper.CompositeIdResolvableI;
-import io.openaev.helper.MonoIdDeserializerHelper;
-import io.openaev.helper.MonoIdSerializer;
-import io.openaev.helper.MultiIdListSerializer;
-import io.openaev.helper.MultiIdSetSerializer;
+import io.openaev.helper.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -634,6 +630,7 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   public static final String CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_PROPERTY = "targeted-property";
   public static final String CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_ASSET_SEPARATOR =
       "targeted-asset-separator";
+  public static final String CONTRACT_ELEMENT_CONTENT_KEY_CONTACT_ID = "contract_id";
 
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE_ASSET = "asset";
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE_ASSET_GROUP = "asset-group";

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
@@ -17,7 +17,11 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.audit.ModelBaseListener;
 import io.openaev.database.audit.TenantBaseListener;
 import io.openaev.database.converter.ContentConverter;
-import io.openaev.helper.*;
+import io.openaev.helper.CompositeIdResolvableI;
+import io.openaev.helper.MonoIdDeserializerHelper;
+import io.openaev.helper.MonoIdSerializer;
+import io.openaev.helper.MultiIdListSerializer;
+import io.openaev.helper.MultiIdSetSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -607,6 +611,7 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   // -- INJECTOR CONTRACT CONTENT --
 
   public static final String CONTRACT_CONTENT_FIELDS = "fields";
+  public static final String CONTRACT_CONTENT_KEY_CONTRACT_ID = "contract_id";
   public static final String CONTRACT_ELEMENT_CONTENT_KEY = "key";
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE = "type";
   public static final String CONTRACT_ELEMENT_CONTENT_CARDINALITY = "cardinality";
@@ -630,7 +635,6 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   public static final String CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_PROPERTY = "targeted-property";
   public static final String CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_ASSET_SEPARATOR =
       "targeted-asset-separator";
-  public static final String CONTRACT_ELEMENT_CONTENT_KEY_CONTRACT_ID = "contract_id";
 
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE_ASSET = "asset";
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE_ASSET_GROUP = "asset-group";

--- a/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/InjectorContract.java
@@ -630,7 +630,7 @@ public class InjectorContract implements TenantBase, CompositeIdResolvableI {
   public static final String CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_PROPERTY = "targeted-property";
   public static final String CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_ASSET_SEPARATOR =
       "targeted-asset-separator";
-  public static final String CONTRACT_ELEMENT_CONTENT_KEY_CONTACT_ID = "contract_id";
+  public static final String CONTRACT_ELEMENT_CONTENT_KEY_CONTRACT_ID = "contract_id";
 
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE_ASSET = "asset";
   public static final String CONTRACT_ELEMENT_CONTENT_TYPE_ASSET_GROUP = "asset-group";


### PR DESCRIPTION
### Proposed changes

* When a threat arsenal action (injector contract export) is imported, the import assigns a fresh contract id but previously left the `contract_id` embedded in the stored contract content JSON pointing at the exporter's original id. The inject form posts that embedded id as `inject_injector_contract` when launching, so imported actions returned 404 in atomic testing. The import migration step (`InjectorContractMigrationUtils.migratePredefinedExpectations`) now rewrites the embedded `contract_id` to the persisted contract id.
* The JSON key is exposed as the `InjectorContract.CONTRACT_CONTENT_KEY_CONTRACT_ID` constant, grouped with the other top-level content keys, and the utils reuse the existing `CONTRACT_CONTENT_FIELDS` constant instead of the `"fields"` literal.
* Added focused unit tests on `InjectorContractMigrationUtils` (stale id rewrite, add-when-missing, idempotency on re-import, lenient handling of malformed content) and an end-to-end assertion in `ThreatArsenalApiImporterTest` that the imported contract content embeds the persisted id.

### Testing Instructions

1. Export a threat arsenal action, then import it back
2. Launch an atomic test with the imported action
3. The launch succeeds (no 404); the imported contract's `injector_contract_content` embeds the new contract id

### Related issues

* Closes #6516

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

Rows imported before this fix keep their stale embedded `contract_id` and still 404 at launch; re-importing the export produces a working action. A one-shot `RuntimeMigration` (same pattern as `V20260725_Fix_starter_pack_payload_contracts`) could heal existing rows and is left as a follow-up.
