### PR TITLE
fix(chaining): lay the logic graph out in MITRE-tactic columns (#7218)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
@@ -81,6 +81,68 @@ describe('buildLogicGraphLayout tactic columns', () => {
     }
   });
 
+  it('cascades events sharing a lane down without overlapping', () => {
+    // e1 and e2 both gate a1: same lane, same anchor. The first is centered on a1, the second must
+    // cascade below it (align, then de-overlap) instead of stacking on the same Y.
+    const { nodeById } = buildLogicGraphLayout({
+      actionMetas: { a1: action(['e1', 'e2']) },
+      eventMetas: {
+        e1: event(),
+        e2: event(),
+      },
+      outputProviders: {},
+      tacticForStep: { a1: 'Discovery' },
+      tacticOrder: { Discovery: 1 },
+    });
+    expect(nodeById.e1.x).toBe(nodeById.e2.x);
+    const [first, second] = [nodeById.e1, nodeById.e2].sort((a, b) => a.y - b.y);
+    expect(second.y).toBeGreaterThanOrEqual(first.y + first.height);
+  });
+
+  it('sorts a tactic missing from the order map after the known ones', () => {
+    const { columns } = buildLogicGraphLayout({
+      actionMetas: {
+        a1: action(),
+        a2: action(),
+      },
+      eventMetas: {},
+      outputProviders: {},
+      tacticForStep: {
+        a1: 'Alpha Unknown',
+        a2: 'Lateral Movement',
+      },
+      // 'Alpha Unknown' is absent from the order map: it must fall to the end even though it would
+      // come first alphabetically.
+      tacticOrder: { 'Lateral Movement': 8 },
+    });
+    expect(columns.map(c => c.tactic)).toEqual(['Lateral Movement', 'Alpha Unknown']);
+  });
+
+  it('puts an event gating actions in several columns in the leftmost lane', () => {
+    // e1 gates both a2 (second column) and a1 (first column): it must take the FIRST column's lane
+    // (left of a1), keeping the graph reading left to right.
+    const { nodeById } = buildLogicGraphLayout({
+      actionMetas: {
+        a1: action(['e1']),
+        a2: action(['e1']),
+      },
+      eventMetas: { e1: event() },
+      outputProviders: {},
+      tacticForStep: {
+        a1: 'Discovery',
+        a2: 'Lateral Movement',
+      },
+      tacticOrder: {
+        'Discovery': 1,
+        'Lateral Movement': 2,
+      },
+    });
+    expect(nodeById.e1.x).toBeLessThan(nodeById.a1.x);
+    const e1Center = nodeById.e1.y + nodeById.e1.height / 2;
+    const a1Center = nodeById.a1.y + nodeById.a1.height / 2;
+    expect(Math.round(e1Center)).toBe(Math.round(a1Center));
+  });
+
   it('returns an empty layout (no columns) for an empty graph', () => {
     const empty = buildLogicGraphLayout({
       actionMetas: {},

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLogicGraphLayout } from '../../../../../../admin/components/chaining/logic/logic-graph/layout';
+import type { ActionMeta, EventMeta } from '../../../../../../admin/components/chaining/logic/types';
+
+// Minimal metas: the layout only reads step_condition_ids on actions and formData.conditionGroups
+// on events (for the inferred edges), plus the tactic inputs. Cast the rest away.
+const action = (stepConditionIds: string[] = []): ActionMeta =>
+  ({ step_condition_ids: stepConditionIds } as unknown as ActionMeta);
+const event = (): EventMeta =>
+  ({ formData: { conditionGroups: [] } } as unknown as EventMeta);
+
+// Two tactics (Discovery before Lateral Movement); a1+a2 in Discovery, a3 in Lateral Movement.
+// e1 gates a1, e2 gates a3.
+const build = () => buildLogicGraphLayout({
+  actionMetas: {
+    a1: action(['e1']),
+    a2: action([]),
+    a3: action(['e2']),
+  },
+  eventMetas: {
+    e1: event(),
+    e2: event(),
+  },
+  outputProviders: {},
+  tacticForStep: {
+    a1: 'Discovery',
+    a2: 'Discovery',
+    a3: 'Lateral Movement',
+  },
+  tacticOrder: {
+    'Discovery': 1,
+    'Lateral Movement': 2,
+  },
+});
+
+describe('buildLogicGraphLayout tactic columns', () => {
+  it('groups actions of the same tactic into one column, ordered by phase', () => {
+    const { nodeById, columns } = build();
+
+    // a1 and a2 share the Discovery column; a3 is in a later (further-right) column.
+    expect(nodeById.a1.x).toBe(nodeById.a2.x);
+    expect(nodeById.a3.x).toBeGreaterThan(nodeById.a1.x);
+    // Stacked vertically within the shared column.
+    expect(nodeById.a1.y).not.toBe(nodeById.a2.y);
+
+    // Columns follow the MITRE phase order, each a sized band.
+    expect(columns.map(c => c.tactic)).toEqual(['Discovery', 'Lateral Movement']);
+    expect(columns[0].x).toBeLessThan(columns[1].x);
+    expect(columns[0].height).toBeGreaterThan(0);
+    // Each action sits inside its tactic's band.
+    expect(nodeById.a1.x).toBeGreaterThanOrEqual(columns[0].x);
+    expect(nodeById.a1.x + nodeById.a1.width).toBeLessThanOrEqual(columns[0].x + columns[0].width);
+    expect(nodeById.a3.x).toBeGreaterThanOrEqual(columns[1].x);
+  });
+
+  it('places each gating event just left of its action, vertically aligned', () => {
+    const { nodeById } = build();
+
+    // e1 sits left of the action it gates (a1) and is centered on it.
+    expect(nodeById.e1.x).toBeLessThan(nodeById.a1.x);
+    const e1Center = nodeById.e1.y + nodeById.e1.height / 2;
+    const a1Center = nodeById.a1.y + nodeById.a1.height / 2;
+    expect(Math.round(e1Center)).toBe(Math.round(a1Center));
+
+    // e2 gates a3 (second column), so it sits in that column's lane — left of a3 but right of the
+    // first column's actions, not dumped in the far-left lane.
+    expect(nodeById.e2.x).toBeLessThan(nodeById.a3.x);
+    expect(nodeById.e2.x).toBeGreaterThan(nodeById.a1.x);
+  });
+
+  it('keeps events outside the tactic bands (only actions carry a TTP)', () => {
+    const { nodeById, columns } = build();
+    // Every event lies fully to the left of every tactic band (no event overlaps a band's x-range).
+    for (const eventId of ['e1', 'e2']) {
+      const ev = nodeById[eventId];
+      for (const col of columns) {
+        const insideBand = ev.x + ev.width > col.x && ev.x < col.x + col.width;
+        expect(insideBand).toBe(false);
+      }
+    }
+  });
+
+  it('returns an empty layout (no columns) for an empty graph', () => {
+    const empty = buildLogicGraphLayout({
+      actionMetas: {},
+      eventMetas: {},
+      outputProviders: {},
+      tacticForStep: {},
+      tacticOrder: {},
+    });
+    expect(empty.nodes).toHaveLength(0);
+    expect(empty.columns).toHaveLength(0);
+  });
+});

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -180,13 +180,28 @@ const LogicGraph = ({
     [actionMetas],
   );
 
+  // Tactic name -> kill-chain phase order, so the layout orders the tactic columns by MITRE phase
+  // (keeping the lowest order when a tactic maps to several phases).
+  const tacticOrder = useMemo(() => {
+    const order: Record<string, number> = {};
+    for (const phase of Object.values(killChainPhasesMap as Record<string, KillChainPhase>)) {
+      const name = phase.phase_name;
+      if (!name) continue;
+      const value = phase.phase_order ?? 99;
+      if (order[name] === undefined || value < order[name]) order[name] = value;
+    }
+    return order;
+  }, [killChainPhasesMap]);
+
   const layout = useMemo(
     () => buildLogicGraphLayout({
       actionMetas,
       eventMetas,
       outputProviders,
+      tacticForStep,
+      tacticOrder,
     }),
-    [actionMetas, eventMetas, outputProviders],
+    [actionMetas, eventMetas, outputProviders, tacticForStep, tacticOrder],
   );
 
   // Apply manual overrides on top of the auto-layout positions.
@@ -482,6 +497,46 @@ const LogicGraph = ({
           onDeleteEdge={handleDeleteEdge}
           readOnly={readOnly}
         />
+        {/* MITRE-tactic column bands: a faint coloured rectangle behind each column's nodes, with the
+            tactic name as a header, so it reads which nodes belong to which tactic. */}
+        {layout.columns.map(col => (
+          <div
+            key={`tactic-col-${col.tactic}`}
+            style={{
+              position: 'absolute',
+              left: col.x,
+              top: col.top,
+              width: col.width,
+              height: col.height,
+              pointerEvents: 'none',
+              borderRadius: 8,
+              backgroundColor: alpha(theme.palette.primary.main, 0.05),
+              border: `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: col.headerY - col.top,
+                left: 0,
+                width: '100%',
+                textAlign: 'center',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                padding: '0 8px',
+                boxSizing: 'border-box',
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: theme.palette.text.secondary,
+              }}
+            >
+              {col.tactic || t('Other')}
+            </div>
+          </div>
+        ))}
         {positionedNodes.map((node) => {
           const dimmed = isDimmed(node.id);
           if (node.kind === 'action') {

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/PanZoom.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/PanZoom.tsx
@@ -104,9 +104,15 @@ const PanZoom = ({
     const initial = Math.min(INITIAL_MAX_ZOOM, Math.max(INITIAL_MIN_ZOOM, raw));
     const next = clampZoom(initial);
     setZoom(next);
+    // Anchor on the top-left (with padding) whenever the content is larger than the viewport at this
+    // zoom, so the top of the graph — the tactic column headers — is always in view after a fit; only
+    // content that fully fits is centered. Centering a taller-than-viewport graph pushed its top
+    // (the headers) off-screen.
+    const scaledW = contentWidth * next;
+    const scaledH = contentHeight * next;
     setPan({
-      x: (el.clientWidth - contentWidth * next) / 2,
-      y: (el.clientHeight - contentHeight * next) / 2,
+      x: scaledW > el.clientWidth ? FIT_PADDING : (el.clientWidth - scaledW) / 2,
+      y: scaledH > el.clientHeight ? FIT_PADDING : (el.clientHeight - scaledH) / 2,
     });
     hasFitted.current = true;
   }, [contentWidth, contentHeight, clampZoom]);

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
@@ -7,10 +7,21 @@ export const NODE_WIDTH = 248;
 export const ACTION_NODE_HEIGHT = 112;
 export const TRIGGER_NODE_HEIGHT = 76;
 
-// Column / row separation. Denser when the chain is large (mirrors XTM One's
-// node-count-driven `dynNodeSep` / `dynRankSep`) so big graphs stay compact.
-const columnGap = (nodeCount: number) => (nodeCount > 14 ? 84 : 120);
-const rowGap = (nodeCount: number) => (nodeCount > 14 ? 18 : 30);
+// Tactic-column layout tokens (px). Actions are grouped into one column per MITRE tactic (ordered by
+// kill-chain phase), and each gating event sits in a lane immediately to the left of its action's
+// column. See buildLogicGraphLayout.
+const EVENT_TO_COL_GAP = 60; // gap between an event lane and the action column it feeds
+const INTER_COLUMN_GAP = 90; // gap between one tactic column and the next column's event lane
+const ACTION_ROW_GAP = 40; // vertical gap between stacked actions in a column
+const EVENT_ROW_GAP = 24; // vertical gap when de-overlapping events sharing a lane
+const COLUMN_TOP_MARGIN = 56; // room above the top node for the tactic column header
+const COLUMN_HEADER_Y = 22; // Y of the tactic column header label (within the top margin)
+const BAND_TOP = 8; // top of the tactic column background band
+const BAND_PADDING_BOTTOM = 20; // padding below the last node inside the column band
+// One tactic column spans its event lane + gap + action column; the next starts a stride further.
+const COLUMN_STRIDE = NODE_WIDTH + EVENT_TO_COL_GAP + NODE_WIDTH + INTER_COLUMN_GAP;
+const eventLaneX = (col: number) => col * COLUMN_STRIDE;
+const actionColX = (col: number) => col * COLUMN_STRIDE + NODE_WIDTH + EVENT_TO_COL_GAP;
 
 export type LogicGraphNodeKind = 'action' | 'trigger';
 
@@ -48,9 +59,22 @@ export interface LogicGraphBBox {
   height: number;
 }
 
+/** One MITRE-tactic column: its header label and the coloured band its nodes sit in. */
+export interface LogicGraphColumn {
+  tactic: string;
+  /** The band rectangle (world coords): spans the event lane + the action column. */
+  x: number;
+  width: number;
+  top: number;
+  height: number;
+  /** Y of the column header label (centered over the band). */
+  headerY: number;
+}
+
 export interface LogicGraphLayout {
   nodes: LogicGraphNode[];
   edges: LogicGraphEdge[];
+  columns: LogicGraphColumn[];
   bbox: LogicGraphBBox;
   nodeById: Record<string, LogicGraphNode>;
 }
@@ -85,6 +109,10 @@ interface BuildLayoutInput {
   eventMetas: Record<string, EventMeta>;
   /** Inverted "output type -> provider actions" map (see buildOutputProvidersMap). */
   outputProviders: Record<string, OutputProviderEntry[]>;
+  /** Resolved MITRE tactic name per action step id (see buildTacticForStep). */
+  tacticForStep: Record<string, string>;
+  /** Tactic name -> kill-chain phase order, so columns follow the MITRE order (lower = leftmost). */
+  tacticOrder: Record<string, number>;
 }
 
 interface RawEdge {
@@ -235,6 +263,8 @@ export const buildLogicGraphLayout = ({
   actionMetas,
   eventMetas,
   outputProviders,
+  tacticForStep,
+  tacticOrder,
 }: BuildLayoutInput): LogicGraphLayout => {
   const kindById: Record<string, LogicGraphNodeKind> = {};
   for (const id of Object.keys(actionMetas)) kindById[id] = 'action';
@@ -277,79 +307,130 @@ export const buildLogicGraphLayout = ({
   }
   const graphEdges = [...prunedInferred, ...nonInferred];
 
-  const preds: Record<string, string[]> = {};
-  for (const edge of graphEdges) (preds[edge.target] ??= []).push(edge.source);
+  // -- Tactic-column positioning ------------------------------------------------------------------
+  // Actions are grouped into one column per MITRE tactic, columns ordered by kill-chain phase. Each
+  // gating event sits in a lane immediately to the LEFT of its action's column, vertically aligned
+  // to the action it gates (so the event -> action arrow stays horizontal). This restores the
+  // tactic-column reading of the logic view (the dependency-depth layering it replaced put the whole
+  // chain on a single alternating row). The graphEdges above are still used only for rendering.
+  const actionIds = nodeIds.filter(id => kindById[id] === 'action');
+  const eventIds = nodeIds.filter(id => kindById[id] === 'trigger');
 
-  const layer = computeLayers(nodeIds, graphEdges);
-
-  // Bucket nodes per layer, keeping a stable initial order.
-  const layers: Record<number, string[]> = {};
-  for (const id of nodeIds) (layers[layer[id]] ??= []).push(id);
-  const layerKeys = Object.keys(layers).map(Number).sort((a, b) => a - b);
-
-  // Barycenter ordering (single downward pass) to reduce edge crossings: order each layer by the
-  // average row of its predecessors in the previous layer.
-  const orderIndex: Record<string, number> = {};
-  layerKeys.forEach((layerKey, layerIdx) => {
-    const ids = layers[layerKey];
-    if (layerIdx === 0) {
-      ids.forEach((id, i) => {
-        orderIndex[id] = i;
-      });
-      return;
-    }
-    const withKey = ids.map((id) => {
-      const parents = (preds[id] ?? []).filter(p => orderIndex[p] !== undefined);
-      const key = parents.length > 0
-        ? parents.reduce((sum, p) => sum + orderIndex[p], 0) / parents.length
-        : Number.MAX_SAFE_INTEGER;
-      return {
-        id,
-        key,
-      };
-    });
-    withKey.sort((a, b) => a.key - b.key);
-    layers[layerKey] = withKey.map(w => w.id);
-    layers[layerKey].forEach((id, i) => {
-      orderIndex[id] = i;
-    });
+  // The tactic columns present in THIS workflow, ordered by phase (unknown tactics sort last, then
+  // by name for determinism).
+  const uniqueTactics = Array.from(new Set(actionIds.map(id => tacticForStep[id] ?? '')));
+  uniqueTactics.sort((a, b) => {
+    const oa = tacticOrder[a] ?? 99;
+    const ob = tacticOrder[b] ?? 99;
+    return oa !== ob ? oa - ob : a.localeCompare(b);
   });
+  const colByTactic: Record<string, number> = {};
+  uniqueTactics.forEach((tactic, i) => {
+    colByTactic[tactic] = i;
+  });
+  const colOfAction = (id: string) => colByTactic[tacticForStep[id] ?? ''] ?? 0;
 
-  const nodeCount = nodeIds.length;
-  const colGap = columnGap(nodeCount);
-  const rGap = rowGap(nodeCount);
-  const heightOf = (id: string) =>
-    (kindById[id] === 'action' ? ACTION_NODE_HEIGHT : TRIGGER_NODE_HEIGHT);
+  // Actions per column, in a stable order.
+  const actionsByCol: Record<number, string[]> = {};
+  for (const id of actionIds) (actionsByCol[colOfAction(id)] ??= []).push(id);
 
-  // Vertically center each column around a shared midline so the chain reads as balanced rather
-  // than top-left heavy.
-  const colHeight: Record<number, number> = {};
-  for (const layerKey of layerKeys) {
-    const ids = layers[layerKey];
-    colHeight[layerKey] = ids.reduce((sum, id) => sum + heightOf(id), 0)
-      + Math.max(0, ids.length - 1) * rGap;
-  }
-  const maxColHeight = Math.max(0, ...Object.values(colHeight));
-
+  // Actions are top-aligned within their column (like a table): every column starts at the same top,
+  // just under its header, so headers stay attached to their nodes. `colActionBottomY` tracks each
+  // column's lowest ACTION so its background band can be sized to fit — only actions carry a TTP, so
+  // only actions belong to a tactic column; events sit outside the band (see below).
   const nodes: LogicGraphNode[] = [];
-  for (const layerKey of layerKeys) {
-    const ids = layers[layerKey];
-    let y = (maxColHeight - colHeight[layerKey]) / 2;
-    const x = layerKey * (NODE_WIDTH + colGap);
+  const actionCenterY: Record<string, number> = {};
+  const colActionBottomY: Record<number, number> = {};
+  uniqueTactics.forEach((_tactic, col) => {
+    const ids = actionsByCol[col] ?? [];
+    let y = COLUMN_TOP_MARGIN;
     for (const id of ids) {
-      const height = heightOf(id);
       nodes.push({
         id,
-        kind: kindById[id],
-        layer: layerKey,
-        x,
+        kind: 'action',
+        layer: col,
+        x: actionColX(col),
         y,
         width: NODE_WIDTH,
-        height,
+        height: ACTION_NODE_HEIGHT,
       });
-      y += height + rGap;
+      actionCenterY[id] = y + ACTION_NODE_HEIGHT / 2;
+      colActionBottomY[col] = y + ACTION_NODE_HEIGHT;
+      y += ACTION_NODE_HEIGHT + ACTION_ROW_GAP;
+    }
+  });
+
+  // Resolve, per event, the column it sits left of and the Y to align to: the leftmost tactic among
+  // the actions it gates, aligned to that action's center (topmost when it gates several).
+  const eventPlacement: Record<string, {
+    col: number;
+    anchorY: number;
+  }> = {};
+  for (const [stepId, meta] of Object.entries(actionMetas)) {
+    if (actionCenterY[stepId] === undefined) continue;
+    const col = colOfAction(stepId);
+    const y = actionCenterY[stepId];
+    for (const eventId of meta.step_condition_ids) {
+      if (!eventMetas[eventId]) continue;
+      const cur = eventPlacement[eventId];
+      if (!cur || col < cur.col || (col === cur.col && y < cur.anchorY)) {
+        eventPlacement[eventId] = {
+          col,
+          anchorY: y,
+        };
+      }
     }
   }
+
+  // Bucket events per lane X (orphan events, gating nothing, share column 0's lane), then align each
+  // to its anchor and cascade down only to resolve overlaps ("align, then de-overlap").
+  const eventLanes: Record<number, {
+    id: string;
+    anchorY: number | null;
+  }[]> = {};
+  for (const id of eventIds) {
+    const p = eventPlacement[id];
+    const laneX = eventLaneX(p ? p.col : 0);
+    (eventLanes[laneX] ??= []).push({
+      id,
+      anchorY: p ? p.anchorY : null,
+    });
+  }
+  for (const [laneXStr, items] of Object.entries(eventLanes)) {
+    const laneX = Number(laneXStr);
+    items.sort(
+      (a, b) => (a.anchorY ?? Number.POSITIVE_INFINITY) - (b.anchorY ?? Number.POSITIVE_INFINITY),
+    );
+    let cursor = COLUMN_TOP_MARGIN;
+    for (const { id, anchorY } of items) {
+      const desiredTop = anchorY === null ? cursor : anchorY - TRIGGER_NODE_HEIGHT / 2;
+      const y = Math.max(desiredTop, cursor);
+      nodes.push({
+        id,
+        kind: 'trigger',
+        layer: 0,
+        x: laneX,
+        y,
+        width: NODE_WIDTH,
+        height: TRIGGER_NODE_HEIGHT,
+      });
+      cursor = y + TRIGGER_NODE_HEIGHT + EVENT_ROW_GAP;
+    }
+  }
+
+  // One coloured band per column, covering the ACTION column only (events have no TTP, so they sit
+  // in the lane to the left of the band, outside any tactic). Sized to the column's actions.
+  const columns: LogicGraphColumn[] = uniqueTactics.map((tactic, col) => {
+    const bottom = colActionBottomY[col] ?? COLUMN_TOP_MARGIN;
+    return {
+      tactic,
+      x: actionColX(col),
+      width: NODE_WIDTH,
+      top: BAND_TOP,
+      height: bottom + BAND_PADDING_BOTTOM - BAND_TOP,
+      headerY: COLUMN_HEADER_Y,
+    };
+  });
 
   const nodeById: Record<string, LogicGraphNode> = Object.fromEntries(
     nodes.map(n => [n.id, n]),
@@ -368,7 +449,8 @@ export const buildLogicGraphLayout = ({
   });
 
   let minX = Infinity;
-  let minY = Infinity;
+  // Start at the band top so the column headers/bands above the topmost node are never framed out.
+  let minY = columns.length > 0 ? BAND_TOP : Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
   for (const node of nodes) {
@@ -387,6 +469,7 @@ export const buildLogicGraphLayout = ({
   return {
     nodes,
     edges,
+    columns,
     bbox: {
       minX,
       minY,

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
@@ -62,7 +62,10 @@ export interface LogicGraphBBox {
 /** One MITRE-tactic column: its header label and the coloured band its nodes sit in. */
 export interface LogicGraphColumn {
   tactic: string;
-  /** The band rectangle (world coords): spans the event lane + the action column. */
+  /**
+   * The coloured band rectangle (world coords). Covers the ACTION column only: events carry no TTP,
+   * so they sit in the lane to the LEFT of this band, outside any tactic (see buildLogicGraphLayout).
+   */
   x: number;
   width: number;
   top: number;


### PR DESCRIPTION
## Summary

The **Logic** view lost its per-MITRE-tactic column layout in the #7099 canvas rewrite: the dependency-depth layering that replaced it puts the whole chain on a single alternating `action -> event -> action` row, which is unreadable beyond a trivial chain.

This restores the tactic reading in `buildLogicGraphLayout` (layout-only; the edge set is unchanged):

- **Columns by tactic** - actions grouped into one column per MITRE tactic, columns ordered by kill-chain phase, actions top-aligned within a column (like a table).
- **Events left of their action** - each gating event sits in a lane immediately to the left of its action's column, aligned to the action's center (horizontal `event -> action` arrow). Events sharing a lane de-overlap by cascading down; orphan events fall to the far-left lane; an event gating actions in several columns takes the leftmost column's lane.
- **Coloured column bands** covering the **action column only** - only actions carry a TTP, so events are positioned outside any tactic band - with the tactic name as the column header. The `LogicGraphColumn` JSDoc documents exactly that geometry.
- **Fit anchoring** (`PanZoom`) - a tall column layout no longer scrolls its column headers off-screen: the fit anchors on the top-left when the graph exceeds the viewport in that axis (on load and on auto-organize); content that fully fits stays centered. `PanZoom` is only consumed by the Logic view, so no other canvas is affected.

`tacticForStep` + a tactic->phase-order map are threaded into the layout. The tactic data already flows through `ActionMeta`/`buildTacticForStep` (unknown tactics fall back to "Other" and sort after the mapped phases); no backend change.

Fixes #7218

## Test plan

- [x] `layout.test.ts` (7 tests): actions of a tactic share a column ordered by phase; each action sits inside its tactic band; each gating event is left of its action and vertically centered on it; **events are never inside a tactic band** (only actions carry a TTP); events sharing a lane cascade down without overlapping; a tactic missing from the order map sorts after the known ones; an event gating actions in several columns takes the leftmost lane; empty graph -> no columns.
- [x] `yarn check-ts` + `yarn eslint` (touched files) clean.
- [x] Manually verified on a real workflow (nmap/netexec AD scenario): columns per tactic with headers, events left of their actions outside the bands, and column headers visible after fit / auto-organize.

## Related

Third of the chaining QA PRs: #7211 (defined value + type link), #7213 (action->event link guard + event labels + remove action "+"), and this. These three touch adjacent chaining/logic code but are independent; merge order does not matter (only #7213 and this both touch `logic-graph/`, in non-overlapping ways - connect handles/labels vs. layout).
