### PR TITLE
fix(autonomous): allow restarting a run from any state (#7220)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -227,11 +227,11 @@ public class AutonomousRunApi extends RestBehavior {
   }
 
   @Operation(
-      summary = "Restart a terminal run in place",
+      summary = "Restart a run in place (hard reset, valid from any status)",
       description =
-          "Reuses the same scenario: tears the old simulation down, provisions a fresh one, resets"
-              + " the run's timeline / directives to CREATED. The caller then starts it again. No"
-              + " new scenario is ever created on restart.")
+          "Reuses the same scenario: stops the orchestrator, tears the old simulation down,"
+              + " provisions a fresh one, resets the run's timeline / directives to CREATED. The"
+              + " caller then starts it again. No new scenario is ever created on restart.")
   @PostMapping("/{runId}/restart")
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -668,14 +668,21 @@ public class AutonomousRunService {
    * which reads this CANCELED status - OpenAEV is the source of truth for the run lifecycle - so a
    * userless cross-tenant HTTP push from the watchdog is not needed to clean XTM One up.
    *
-   * <p>The terminal flip is claimed through the same atomic conditional UPDATE as the read-path
+   * <p>The terminal flip is claimed through an atomic conditional UPDATE, like the read-path
    * reconcile: an operator Stop, a racing reconcile and this watchdog can all reach a run at its
    * deadline, and only the claimer narrates the stop - so the timeline gets exactly one terminal
    * event, never a "Run canceled" plus a "Run timed out" for the same run.
+   *
+   * <p>The watchdog's flip is restricted to the two live statuses its decision was based on
+   * (RUNNING / WAITING_INPUT), not merely "not yet terminal": the deadline was read in this
+   * transaction, but the UPDATE may land after a concurrent transition committed. A restart (valid
+   * from any status) resets the run to CREATED with a fresh simulation, and a pause parks it -
+   * neither must be hard-stopped by a stale deadline claim, so a lost race is a silent no-op here
+   * too.
    */
   private void timeoutRun(AutonomousRun run) {
     int changed =
-        runRepository.settleTerminalStatusIfActive(
+        runRepository.settleTerminalStatusIfLive(
             run.getId(), run.getTenant().getId(), AutonomousRunStatus.CANCELED, now());
     if (changed == 0) {
       // Someone else (operator Stop, reconcile) already settled it; nothing left to narrate.
@@ -757,31 +764,28 @@ public class AutonomousRunService {
   // endregion
 
   /**
-   * Restarts a settled run <b>in place</b>: reuses the SAME scenario, tears down the previous
-   * simulation (attack-path rows included) and the run's decision timeline + steering directives,
-   * provisions a fresh simulation from that scenario, and resets the run to {@code CREATED}. The
-   * caller then {@link #start}s it again. This keeps the invariant "one scenario == one run == one
-   * live simulation" instead of spawning a brand-new scenario on every restart, and gives the
-   * cockpit (overview, attack-path graph, reasoning panel) a clean slate to animate from scratch.
+   * Restarts a run <b>in place</b>, from ANY status: reuses the SAME scenario, tears down the
+   * previous simulation (attack-path rows included) and the run's decision timeline + steering
+   * directives, provisions a fresh simulation from that scenario, and resets the run to {@code
+   * CREATED}. The caller then {@link #start}s it again. This keeps the invariant "one scenario ==
+   * one run == one live simulation" instead of spawning a brand-new scenario on every restart, and
+   * gives the cockpit (overview, attack-path graph, reasoning panel) a clean slate to animate from
+   * scratch.
    *
-   * <p>Allowed once a run has settled: a terminal live run (COMPLETED / FAILED / CANCELED) or a
-   * settled dry-run plan (PLANNED). Re-planning a settled plan (e.g. after the operator filled a
-   * capability gap or steered the scope) is the same reset - a plan-mode restart re-provisions the
-   * TEMPLATE workflow so the AI rebuilds the plan from scratch.
+   * <p>Restart is a deliberate, operator-triggered HARD RESET, so it is valid from any status, not
+   * just a settled one: the teardown stops an active run cleanly, and restarting a live run is
+   * simply a stop-then-restart - which is what the operator expects when they click Restart. The
+   * previous "settled only" guard rejected any non-terminal status with a 409, which the cockpit
+   * surfaced as the misleading "The element already exists" toast whenever Restart was offered on a
+   * run the backend still considered active (parked in WAITING_INPUT / RUNNING, or a status desync
+   * after repeated start/stop cycles). Re-planning a settled dry-run plan (e.g. after the operator
+   * filled a capability gap or steered the scope) is the same reset - a plan-mode restart
+   * re-provisions the TEMPLATE workflow so the AI rebuilds the plan from scratch.
    */
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun restart(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
-    // Restart is a deliberate, operator-triggered HARD RESET: it stops the orchestrator, tears the
-    // current simulation + decision timeline + steering down and re-provisions a fresh simulation
-    // from the same scenario. It is therefore valid from ANY state, not just a settled one - the
-    // teardown below already stops an active run cleanly. The previous "settled only" guard rejected
-    // any non-terminal status with a 409, which the cockpit surfaced as the misleading "The element
-    // already exists" toast whenever the operator's view offered Restart on a run the backend still
-    // considered active (a run parked in WAITING_INPUT / RUNNING, or a status desync after repeated
-    // start/stop cycles) - the exact "Restart does nothing / errors out" report. Restarting a live
-    // run is simply a stop-then-restart, which is what the operator expects when they click Restart.
     // Stop the previous XTM One orchestration before tearing its simulation down, so a lingering
     // decision cycle can't dispatch injects against the simulation we are about to delete. The
     // subsequent start() re-engages the run cleanly (upstream start resets the same execution).
@@ -830,6 +834,12 @@ public class AutonomousRunService {
     run.setStatus(AutonomousRunStatus.CREATED);
     run.setLastError(null);
     run.setXtmSessionId(null);
+    // The previous live window's time budget is void after a hard reset: the follow-up start()
+    // stamps a fresh one, and a CREATED run must never sit with a stale (possibly past) deadline
+    // from the life it just shed.
+    run.setStartedAt(null);
+    run.setDeadlineAt(null);
+    run.setWinddownPhase(null);
     AutonomousRun saved = runRepository.save(run);
     eventService.append(
         saved.getId(),

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -773,13 +773,15 @@ public class AutonomousRunService {
   public AutonomousRun restart(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
-    if (run.getStatus() != AutonomousRunStatus.COMPLETED
-        && run.getStatus() != AutonomousRunStatus.FAILED
-        && run.getStatus() != AutonomousRunStatus.CANCELED
-        && run.getStatus() != AutonomousRunStatus.PLANNED) {
-      throw new ResponseStatusException(
-          HttpStatus.CONFLICT, "Run can only be restarted once it has settled");
-    }
+    // Restart is a deliberate, operator-triggered HARD RESET: it stops the orchestrator, tears the
+    // current simulation + decision timeline + steering down and re-provisions a fresh simulation
+    // from the same scenario. It is therefore valid from ANY state, not just a settled one - the
+    // teardown below already stops an active run cleanly. The previous "settled only" guard rejected
+    // any non-terminal status with a 409, which the cockpit surfaced as the misleading "The element
+    // already exists" toast whenever the operator's view offered Restart on a run the backend still
+    // considered active (a run parked in WAITING_INPUT / RUNNING, or a status desync after repeated
+    // start/stop cycles) - the exact "Restart does nothing / errors out" report. Restarting a live
+    // run is simply a stop-then-restart, which is what the operator expects when they click Restart.
     // Stop the previous XTM One orchestration before tearing its simulation down, so a lingering
     // decision cycle can't dispatch injects against the simulation we are about to delete. The
     // subsequent start() re-engages the run cleanly (upstream start resets the same execution).

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -11,7 +11,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.openaev.database.model.Exercise;
 import io.openaev.database.model.ExerciseStatus;
+import io.openaev.database.model.Scenario;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.autonomous.AutonomousDirective;
 import io.openaev.database.model.autonomous.AutonomousEventType;
@@ -21,7 +23,10 @@ import io.openaev.database.repository.autonomous.AutonomousDirectiveRepository;
 import io.openaev.database.repository.autonomous.AutonomousRunRepository;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.service.PreviewFeatureService;
+import io.openaev.service.ScenarioToExerciseService;
 import io.openaev.service.chaining.WorkflowService;
+import io.openaev.service.scenario.ScenarioService;
+import io.openaev.xtmone.XtmOneClient;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -33,11 +38,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
- * Focused unit tests for the dry-run ("plan mode") branches and the OpenAEV-owned timeout policy
- * (deadline stamping, winddown nudges, hard stop) of {@link AutonomousRunService}. Kept as a plain
- * Mockito unit test (no Spring context / Docker) so it verifies the suppression + guard logic in
- * isolation: a plan run never dispatches, only a settled plan can be promoted, each winddown phase
- * fires at most once, and the hard stop is claimed exactly once.
+ * Focused unit tests for the dry-run ("plan mode") branches, the OpenAEV-owned timeout policy
+ * (deadline stamping, winddown nudges, hard stop) and the restart hard-reset contract of {@link
+ * AutonomousRunService}. Kept as a plain Mockito unit test (no Spring context / Docker) so it
+ * verifies the suppression + guard logic in isolation: a plan run never dispatches, only a settled
+ * plan can be promoted, each winddown phase fires at most once, the hard stop is claimed exactly
+ * once, and restart is valid from any status (teardown + fresh simulation + reset to CREATED).
  */
 @ExtendWith(MockitoExtension.class)
 class AutonomousRunServiceTest {
@@ -48,6 +54,9 @@ class AutonomousRunServiceTest {
   @Mock private WorkflowService workflowService;
   @Mock private ExerciseService exerciseService;
   @Mock private PreviewFeatureService previewFeatureService;
+  @Mock private ScenarioService scenarioService;
+  @Mock private ScenarioToExerciseService scenarioToExerciseService;
+  @Mock private XtmOneClient xtmOneClient;
 
   @InjectMocks private AutonomousRunService service;
 
@@ -211,7 +220,7 @@ class AutonomousRunServiceTest {
   void enforceDeadlineHardStopsPastDeadline() throws Exception {
     AutonomousRun run = liveRun(Instant.now().minusSeconds(5));
     when(runRepository.findByIdAndTenantId("run-1", "tenant-1")).thenReturn(Optional.of(run));
-    when(runRepository.settleTerminalStatusIfActive(
+    when(runRepository.settleTerminalStatusIfLive(
             eq("run-1"), eq("tenant-1"), eq(AutonomousRunStatus.CANCELED), any(Instant.class)))
         .thenReturn(1);
 
@@ -234,15 +243,123 @@ class AutonomousRunServiceTest {
   void enforceDeadlineHardStopClaimedOnce() {
     AutonomousRun run = liveRun(Instant.now().minusSeconds(5));
     when(runRepository.findByIdAndTenantId("run-1", "tenant-1")).thenReturn(Optional.of(run));
-    // An operator Stop or a read-path reconcile settled the run first: the conditional UPDATE
-    // matches no row, so this watchdog must not narrate a second terminal event.
-    when(runRepository.settleTerminalStatusIfActive(
+    // An operator Stop / restart or a read-path reconcile moved the run first: the conditional
+    // UPDATE (restricted to the live statuses the sweep acts on) matches no row, so this watchdog
+    // must not narrate a second terminal event nor cancel a freshly-restarted run.
+    when(runRepository.settleTerminalStatusIfLive(
             eq("run-1"), eq("tenant-1"), eq(AutonomousRunStatus.CANCELED), any(Instant.class)))
         .thenReturn(0);
 
     service.enforceDeadline("run-1", "tenant-1");
 
     verifyNoInteractions(eventService, exerciseService, directiveRepository);
+  }
+
+  // endregion
+
+  // region restart: an operator-triggered hard reset, valid from ANY status
+
+  private AutonomousRun restartableRun(AutonomousRunStatus status) {
+    AutonomousRun run = new AutonomousRun();
+    run.setId("run-1");
+    run.setScenarioId("scenario-1");
+    run.setSimulationId("sim-old");
+    run.setStatus(status);
+    run.setPlanMode(false);
+    return run;
+  }
+
+  /** Stubs the collaborators the restart teardown + re-provisioning path touches. */
+  private void stubRestartCollaborators() {
+    when(previewFeatureService.isAutonomousAttackPathEnabled()).thenReturn(true);
+    Scenario scenario = new Scenario();
+    when(scenarioService.scenario("scenario-1")).thenReturn(scenario);
+    Exercise freshSimulation = new Exercise();
+    freshSimulation.setId("sim-new");
+    when(scenarioToExerciseService.toExercise(eq(scenario), any(Instant.class), eq(true)))
+        .thenReturn(freshSimulation);
+    when(runRepository.save(any(AutonomousRun.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @Test
+  @DisplayName("restart from RUNNING is a hard reset: stop, teardown, fresh simulation, CREATED")
+  void restartFromRunningIsAHardReset() throws Exception {
+    AutonomousRun run = restartableRun(AutonomousRunStatus.RUNNING);
+    // Leftovers from the live window that must not survive the reset.
+    run.setLastError("previous failure");
+    run.setXtmSessionId("xtm-session-1");
+    run.setStartedAt(Instant.now().minusSeconds(600));
+    run.setDeadlineAt(Instant.now().minusSeconds(5));
+    run.setWinddownPhase("WINDDOWN_1M");
+    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    stubRestartCollaborators();
+
+    AutonomousRun restarted = service.restart("run-1");
+
+    // The previous orchestration is stopped (and its coordination state purged) and the previous
+    // simulation torn down before the fresh one is provisioned from the SAME scenario.
+    verify(xtmOneClient).cancelAutonomousRun(eq("run-1"), anyString(), eq(true));
+    verify(exerciseService).deleteById("sim-old");
+    verify(workflowService).startWorkflowByScenarioIdAndSimulation(eq("scenario-1"), any());
+    // Decision timeline + steering reset so the cockpit starts clean.
+    verify(directiveRepository).deleteByRunId("run-1");
+    verify(eventService).deleteByRun("run-1");
+    assertThat(restarted.getStatus()).isEqualTo(AutonomousRunStatus.CREATED);
+    assertThat(restarted.getSimulationId()).isEqualTo("sim-new");
+    assertThat(restarted.getLastError()).isNull();
+    assertThat(restarted.getXtmSessionId()).isNull();
+    // The stale time budget is void: the follow-up start() stamps a fresh deadline, and the
+    // watchdog must never see a CREATED run carrying the previous window's (past) deadline.
+    assertThat(restarted.getStartedAt()).isNull();
+    assertThat(restarted.getDeadlineAt()).isNull();
+    assertThat(restarted.getWinddownPhase()).isNull();
+  }
+
+  @Test
+  @DisplayName("restart from WAITING_INPUT no longer 409s: the parked run is reset like any other")
+  void restartFromWaitingInputIsAllowed() throws Exception {
+    AutonomousRun run = restartableRun(AutonomousRunStatus.WAITING_INPUT);
+    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    stubRestartCollaborators();
+
+    AutonomousRun restarted = service.restart("run-1");
+
+    verify(xtmOneClient).cancelAutonomousRun(eq("run-1"), anyString(), eq(true));
+    verify(exerciseService).deleteById("sim-old");
+    verify(workflowService).startWorkflowByScenarioIdAndSimulation(eq("scenario-1"), any());
+    assertThat(restarted.getStatus()).isEqualTo(AutonomousRunStatus.CREATED);
+    assertThat(restarted.getSimulationId()).isEqualTo("sim-new");
+  }
+
+  @Test
+  @DisplayName("restart from a settled status keeps working exactly as before")
+  void restartFromSettledStatusStillWorks() throws Exception {
+    AutonomousRun run = restartableRun(AutonomousRunStatus.COMPLETED);
+    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    stubRestartCollaborators();
+
+    AutonomousRun restarted = service.restart("run-1");
+
+    verify(exerciseService).deleteById("sim-old");
+    verify(workflowService).startWorkflowByScenarioIdAndSimulation(eq("scenario-1"), any());
+    assertThat(restarted.getStatus()).isEqualTo(AutonomousRunStatus.CREATED);
+    assertThat(restarted.getSimulationId()).isEqualTo("sim-new");
+  }
+
+  @Test
+  @DisplayName("plan-mode restart re-provisions the TEMPLATE workflow only (nothing executes)")
+  void restartOfPlanModeReprovisionsTemplateOnly() throws Exception {
+    AutonomousRun run = restartableRun(AutonomousRunStatus.PLANNED);
+    run.setPlanMode(true);
+    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    stubRestartCollaborators();
+
+    AutonomousRun restarted = service.restart("run-1");
+
+    verify(workflowService).provisionSimulationTemplateWorkflow(eq("scenario-1"), any());
+    verify(workflowService, never()).startWorkflowByScenarioIdAndSimulation(anyString(), any());
+    assertThat(restarted.getStatus()).isEqualTo(AutonomousRunStatus.CREATED);
   }
 
   // endregion

--- a/openaev-front/src/admin/components/autonomous/AutonomousAttackCreation.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousAttackCreation.tsx
@@ -635,7 +635,7 @@ const AutonomousAttackCreation: FunctionComponent<AutonomousAttackCreationProps>
                       },
                     }}
                     helperText={t('Maximum run duration. OpenAEV steers the orchestrator to converge a few minutes before this deadline, then hard-stops the run. Default is 24 hours.')}
-                    sx={{ width: 240 }}
+                    fullWidth
                   />
                 </Box>
               </>

--- a/openaev-front/src/utils/error/ErrorHandler.tsx
+++ b/openaev-front/src/utils/error/ErrorHandler.tsx
@@ -25,7 +25,12 @@ const ErrorHandler = () => {
       } else if (error.status === 403 && error.message === 'WORKFLOW_NOT_EDITABLE') {
         MESSAGING$.notifyError(t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it.'));
       } else if (error.status === 409) {
-        MESSAGING$.notifyError(t('The element already exists'));
+        // A 409 is not always a duplicate: several endpoints raise a CONFLICT with an explanatory
+        // reason (e.g. a lifecycle guard). Surface that reason when the backend provides one and
+        // only fall back to the generic "already exists" for a bare conflict, so a real cause is
+        // never masked by a misleading "The element already exists".
+        const conflictMessage = error.message && error.message !== 'Conflict' ? error.message : null;
+        MESSAGING$.notifyError(conflictMessage ? t(conflictMessage) : t('The element already exists'));
       } else if (error.status === 400) {
         if (error.message) {
           MESSAGING$.notifyError(t(error.message));

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
@@ -83,4 +83,26 @@ public interface AutonomousRunRepository extends JpaRepository<AutonomousRun, St
       @Param("tenantId") String tenantId,
       @Param("target") AutonomousRunStatus target,
       @Param("now") Instant now);
+
+  /**
+   * Watchdog variant of {@link #settleTerminalStatusIfActive}: atomically settles a run to a
+   * terminal status ONLY while it is still in one of the two live statuses the deadline sweep acts
+   * on (RUNNING / WAITING_INPUT). The timeout decision is made on a row read earlier in the
+   * watchdog's transaction and this flip may land after a concurrent transition committed, so the
+   * UPDATE re-asserts the statuses the decision was based on: an operator restart (which resets the
+   * run to CREATED around a fresh simulation) or a pause must not be flipped to CANCELED by a stale
+   * deadline claim. Returns 1 when this call performed the flip, 0 when the run moved on (settled,
+   * restarted, paused), belongs to another tenant, or no longer exists.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE AutonomousRun r SET r.status = :target, r.updatedAt = :now "
+          + "WHERE r.id = :id AND r.tenant.id = :tenantId "
+          + "AND (r.status = io.openaev.database.model.autonomous.AutonomousRunStatus.RUNNING "
+          + "OR r.status = io.openaev.database.model.autonomous.AutonomousRunStatus.WAITING_INPUT)")
+  int settleTerminalStatusIfLive(
+      @Param("id") String id,
+      @Param("tenantId") String tenantId,
+      @Param("target") AutonomousRunStatus target,
+      @Param("now") Instant now);
 }


### PR DESCRIPTION
## Summary

Fixes #7220 - restarting an autonomous attack-path run no longer fails with a misleading "The element already exists" conflict.

- Backend: `AutonomousRunService.restart(...)` is now valid from any run status. Restart is a deliberate hard reset that already stops the orchestrator, tears the current simulation + decision timeline + steering down and re-provisions a fresh simulation from the same scenario, so restricting it to a "settled only" status set was wrong. The old guard threw `409 Conflict` whenever the cockpit offered Restart on a run the backend still considered active (parked in `WAITING_INPUT`/`RUNNING`, or a status desync after repeated start/stop cycles). Restarting a live run is simply a stop-then-restart. The JavaDoc and the Swagger operation summary now document the any-status contract.
- Backend (hardening): now that restart is valid from live states, the timeout watchdog's hard-stop is restricted to the live statuses its decision was based on (`RUNNING`/`WAITING_INPUT`) via a dedicated conditional UPDATE (`settleTerminalStatusIfLive`). Without it, a deadline claim read before a concurrent restart committed could flip the freshly reset `CREATED` run to `CANCELED` (and narrate a stray "Run timed out" on the fresh timeline). `restart(...)` also clears the previous window's `startedAt`/`deadlineAt`/`winddownPhase` - the follow-up `start()` stamps a fresh budget, and a `CREATED` run must never carry a stale (possibly past) deadline.
- Frontend: `ErrorHandler` no longer maps every `409` to the blanket "The element already exists". It surfaces the backend conflict reason when one is provided and only falls back to the generic message for a bare conflict, so a real cause is never masked again.
- Frontend (cosmetic): the time budget field in the autonomous launch drawer is now `fullWidth`, matching its sibling fields.

## Why the 409 was a status guard, not a duplicate row

The response body on the wire is Spring's default `/error` shape (`{timestamp, status: 409, error: "Conflict", path}`), which only happens for an unhandled `ResponseStatusException(CONFLICT)`. A DB `DataIntegrityViolationException` would instead be rendered by `RestBehavior` as a `ViolationErrorBag` (`type`/`message`, no `timestamp`/`path`). `restart(...)` raised exactly one `ResponseStatusException(CONFLICT)`: the "Run can only be restarted once it has settled" guard. Its reason phrase is suppressed by Spring's default `server.error.include-message=never`, so the operator only ever saw the generic "already exists".

Note on the `ErrorHandler` change's reach: with `include-message=never` (the platform does not override it), `ResponseStatusException` reason phrases still never reach the frontend - the default `/error` body carries no `message` field, so those conflicts keep the generic fallback. The improvement is real for the 409s that DO ship a body message today (`RestBehavior`'s `ViolationErrorBag` for integrity/lock conflicts), and the misleading toast reported in #7220 is fixed at the source by removing the guard. Follow-up (out of scope here): render `ResponseStatusException` through a `RestBehavior` handler (or revisit `include-message`) so lifecycle-guard reasons like "A plan can only be run for real once planning has settled" become visible to operators too.

## Test plan

- [x] Unit tests (`AutonomousRunServiceTest`, Mockito, no Docker): restart from `RUNNING` and `WAITING_INPUT` stops the orchestration (purge included), tears the old simulation down, re-provisions from the same scenario and resets to `CREATED` with the stale time budget cleared; restart from a settled status still works; a plan-mode restart re-provisions the TEMPLATE workflow only; the watchdog hard-stop claims through the live-status UPDATE and stays silent when it loses the race.
- [ ] Launch an autonomous run, Stop it, click Restart -> a fresh simulation is provisioned and the run re-engages (no 409, no "already exists" toast).
- [ ] Restart a run parked in WAITING_INPUT or RUNNING -> hard reset, no 409.
- [ ] Repeat several start/stop cycles, then Restart -> still works.
- [ ] Redo plan on a dry-run (plan mode) -> still works.
- [ ] Any genuine duplicate 409 elsewhere still shows a sensible message.
