### PR TITLE
fix(chaining): show the MITRE tactic only on the column, not on every card (#7229)

### DIFF
--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphActionCard.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphActionCard.tsx
@@ -17,7 +17,10 @@ export interface GraphActionCardProps {
   injectorType?: string;
   payloadType?: string;
   isPayload?: boolean;
-  /** MITRE tactic this action belongs to (shown as a chip). */
+  /**
+   * MITRE tactic this action belongs to. Surfaced in the tooltip only: the canvas already groups the
+   * cards under a per-tactic hull whose header names the tactic, so a chip on the card would repeat it.
+   */
   tacticLabel?: string;
   /** Finding/output types this action produces (feeds triggers). */
   outputTypes?: string[];
@@ -226,29 +229,9 @@ const GraphActionCard = ({
           >
             {typeLabel}
           </Typography>
-          {tacticLabel && (
-            <Box
-              component="span"
-              sx={{
-                flexShrink: 0,
-                maxWidth: 96,
-                fontSize: '0.5625rem',
-                fontWeight: 700,
-                letterSpacing: '0.03em',
-                textTransform: 'uppercase',
-                color: theme.palette.primary.main,
-                backgroundColor: `${theme.palette.primary.main}1f`,
-                borderRadius: 0.5,
-                paddingInline: 0.5,
-                paddingBlock: '1px',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {tacticLabel}
-            </Box>
-          )}
+          {/* No tactic chip here: the canvas draws a hull around the cards sharing a tactic and puts
+              the tactic name in its header, so repeating it per card was pure duplication. The tactic
+              stays reachable in the tooltip above. */}
           {!readOnly && (
             <IconButton
               size="small"


### PR DESCRIPTION
Fixes #7229 (reported as OpenAEV-Platform/filigran-private#256).

The logic map already groups action cards under a per-MITRE-tactic hull whose header names the tactic. Every card inside that hull also rendered the same tactic as a chip, so a hull labelled `DISCOVERY` contained N cards each repeating `DISCOVERY`. The chip additionally competed with the injector/payload type label for the card's header row.

### Change

One removal in `GraphActionCard`: the `tacticLabel` chip. The prop stays and keeps feeding the hover tooltip's "Tactic" row — a transient surface, so it is not a duplication of the hull header, and the information remains reachable per card.

### Verification

Probed the `AD_ASSESMENT (action_output QA)` scenario's Logic page (7 action cards, hulls `Discovery` + `Other`) before and after, reading each card's rendered text:

| | card text |
|---|---|
| before | `OPENAEV NMAP` · **`OTHER`** · `Nmap - TCP Connect Scan` · `5 output(s)` |
| after | `OPENAEV NMAP` · `Nmap - TCP Connect Scan` · `5 output(s)` |

The hull headers still read `Discovery` / `Other`, so no tactic information is lost from the canvas.

- 548 front unit tests pass (32 files)
- `tsc` unchanged from the `main` baseline (2 pre-existing errors in `ChainedTimeline.tsx`, none in `logic-graph`)
- ESLint clean on the touched file

