### PR TITLE
fix(attack-path): resolve a payload's real target instead of its payload default (#7231)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -80,13 +80,36 @@ public class AttackPathExecutionIngestionService {
       Set.of("localhost", "127.0.0.1", "::1", "0.0.0.0", "*");
 
   /**
+   * The trimmed remote target a raw value names, or {@code null} when it names the executing
+   * machine itself (or nothing at all).
+   *
+   * <p>Every remote-target resolution goes through here, so the value that gets persisted (and
+   * keyed into {@link AttackPathIds#executionNode}) is normalized exactly once: trimmed, so two
+   * authorings of the same target differing only by stray whitespace converge on one node, while
+   * the authored case is kept for display — only the self-target comparison lowercases.
+   */
+  @Nullable
+  private static String remoteTargetOrNull(@Nullable String rawValue) {
+    if (rawValue == null) {
+      return null;
+    }
+    String value = rawValue.trim();
+    if (value.isEmpty() || SELF_TARGET_VALUES.contains(value.toLowerCase())) {
+      return null;
+    }
+    return value;
+  }
+
+  /**
    * The endpoint a Command payload targets, or {@code null} when it targets the endpoint it runs
    * on.
    *
    * <p>Reads the value <b>this inject actually uses</b> — the inject's own content overrides the
    * payload's default — because the default is authored once on the payload while the value is
    * chosen per inject. Using the default made every inject of a payload whose {@code host} argument
-   * defaults to {@code localhost} land on a discovered "localhost" node instead of its endpoint.
+   * defaults to {@code localhost} land on a discovered "localhost" node instead of its endpoint. A
+   * blank (or JSON null) override does not name a target, so it falls back to the default rather
+   * than suppressing it.
    *
    * <p>Returns {@code null} when the payload declares several endpoint-ish arguments (ambiguous,
    * the pre-existing rule) or when the value names the executing machine.
@@ -103,14 +126,13 @@ public class AttackPathExecutionIngestionService {
     PayloadArgument argument = endpointArguments.getFirst();
     JsonNode override =
         inject.getContent() == null ? null : inject.getContent().get(argument.getKey());
+    // A JSON null node must not read as the literal string "null" (asText would).
+    String overrideValue = override == null || override.isNull() ? null : override.asText();
     String value =
-        override != null && !override.asText().isEmpty()
-            ? override.asText()
+        overrideValue != null && !overrideValue.isBlank()
+            ? overrideValue
             : argument.getDefaultValue();
-    if (value == null || value.isBlank()) {
-      return null;
-    }
-    return SELF_TARGET_VALUES.contains(value.trim().toLowerCase()) ? null : value;
+    return remoteTargetOrNull(value);
   }
 
   /**
@@ -377,11 +399,7 @@ public class AttackPathExecutionIngestionService {
         }
         case NETWORK_TRAFFIC -> { // AGENT -> DISCOVERED (the destination it reached)
           NetworkTraffic networkTraffic = (NetworkTraffic) inject.getPayload().get();
-          String destination = networkTraffic.getIpDst();
-          boolean reachesAnotherHost =
-              destination != null
-                  && !destination.isBlank()
-                  && !SELF_TARGET_VALUES.contains(destination.trim().toLowerCase());
+          String destination = remoteTargetOrNull(networkTraffic.getIpDst());
           for (Agent agent : agentsAndAssetsAgentless.agents()) {
             io.openaev.database.model.Endpoint endpoint =
                 (io.openaev.database.model.Endpoint)
@@ -389,7 +407,7 @@ public class AttackPathExecutionIngestionService {
             AttackPathExecution attackPathExecution = new AttackPathExecution();
             attackPathExecution.setGlobalInformation(step, inject);
             attackPathExecution.setSourceAgentInformation(agent, endpoint);
-            if (reachesAnotherHost) {
+            if (destination != null) {
               attackPathExecution.setId(
                   AttackPathIds.executionNode(inject.getId(), destination, agent.getId()));
               attackPathExecution.setTargetDiscoveredInformation(destination);
@@ -599,10 +617,8 @@ public class AttackPathExecutionIngestionService {
         }
         case NETWORK_TRAFFIC -> { // AGENT -> DISCOVERED (the destination it reached)
           NetworkTraffic networkTraffic = (NetworkTraffic) inject.getPayload().get();
-          String destination = networkTraffic.getIpDst();
-          if (destination != null
-              && !destination.isBlank()
-              && !SELF_TARGET_VALUES.contains(destination.trim().toLowerCase())) {
+          String destination = remoteTargetOrNull(networkTraffic.getIpDst());
+          if (destination != null) {
             return AttackPathIds.executionNode(inject.getId(), destination, target);
           }
           io.openaev.database.model.Endpoint endpoint =

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -2,6 +2,7 @@ package io.openaev.service.attackpath.ingestion;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.context.TenantScopedTransaction;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
@@ -26,6 +27,7 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -124,6 +126,12 @@ public class AttackPathExecutionIngestionService {
       return null;
     }
     PayloadArgument argument = endpointArguments.getFirst();
+    // A targeted-asset field is a JSON array of endpoint ids, not a scalar: it must go through
+    // the same resolver execution uses, or reading the array as text (blank) silently falls back
+    // to the payload default.
+    if (argument.getType() == PrimitiveType.TargetedAsset) {
+      return resolveTargetedAssetTargetValue(inject, argument.getKey());
+    }
     JsonNode override =
         inject.getContent() == null ? null : inject.getContent().get(argument.getKey());
     // A JSON null node must not read as the literal string "null" (asText would).
@@ -133,6 +141,60 @@ public class AttackPathExecutionIngestionService {
             ? overrideValue
             : argument.getDefaultValue();
     return remoteTargetOrNull(value);
+  }
+
+  /**
+   * The endpoint value a targeted-asset argument resolves to, or {@code null} when it does not name
+   * exactly one remote destination.
+   *
+   * <p>Execution resolves this argument through {@link
+   * InjectService#retrieveValuesOfTargetedAssetFromInject}: the inject field holds the selected
+   * endpoint ids and a linked contract field selects which property (hostname, seen IP, local IP)
+   * is substituted into the command. Reusing that resolver here makes the graph show the value the
+   * command actually ran with instead of the payload default.
+   *
+   * <p>The row model keys exactly one row per agent — {@link #getExecutionIndex} must be able to
+   * recompute the persisted id from {@code (inject, agent)} alone — so a selection resolving to
+   * several destinations is ambiguous under the same rule as several endpoint-ish arguments, and
+   * falls back to the executing endpoint. Fanning one argument out to one row per destination needs
+   * the Phase-B index to become multi-valued first.
+   *
+   * <p>Resolution failures (contract without the linked targeted-property field, malformed content,
+   * deleted endpoints) also fall back: ingestion must degrade to the always-true "ran on its
+   * endpoint" edge rather than fail the run's write.
+   */
+  @Nullable
+  private String resolveTargetedAssetTargetValue(Inject inject, String argumentKey) {
+    try {
+      InjectorContract injectorContract = inject.getInjectorContract().orElse(null);
+      if (injectorContract == null || inject.getContent() == null) {
+        return null;
+      }
+      JsonNode fieldsNode =
+          injectorContract.getConvertedContent().get(InjectorContract.CONTRACT_CONTENT_FIELDS);
+      if (fieldsNode == null || !fieldsNode.isArray()) {
+        return null;
+      }
+      List<ObjectNode> fields =
+          StreamSupport.stream(fieldsNode.spliterator(), false)
+              .map(ObjectNode.class::cast)
+              .toList();
+      Map<String, Endpoint> destinations =
+          injectService.retrieveValuesOfTargetedAssetFromInject(
+              fields, inject.getContent(), argumentKey);
+      if (destinations.size() != 1) {
+        return null;
+      }
+      return remoteTargetOrNull(destinations.keySet().iterator().next());
+    } catch (Exception e) {
+      log.warn(
+          "Attack path: could not resolve targeted-asset argument '{}' of inject {}; attaching to"
+              + " the endpoint it ran on",
+          argumentKey,
+          inject.getId(),
+          e);
+      return null;
+    }
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionService.java
@@ -58,6 +58,62 @@ public class AttackPathExecutionIngestionService {
   private final ObjectMapper objectMapper;
 
   /**
+   * Argument types that can name an endpoint, so a Command payload carrying exactly one of them
+   * targets that value rather than the endpoint it runs on.
+   */
+  private static final Set<PrimitiveType> TARGET_ARGUMENT_TYPES =
+      Set.of(
+          PrimitiveType.IPv4,
+          PrimitiveType.IPv6,
+          PrimitiveType.TargetedAsset,
+          PrimitiveType.Host,
+          PrimitiveType.Domain,
+          PrimitiveType.IpSubnet);
+
+  /**
+   * Values that name the executing machine itself. A command targeting one of these did not reach a
+   * second endpoint, so it must stay attached to the endpoint it ran on: treating them as
+   * discovered targets both hides the real endpoint and merges every endpoint's local executions
+   * into one shared node, since the target key would be the literal value for all of them.
+   */
+  private static final Set<String> SELF_TARGET_VALUES =
+      Set.of("localhost", "127.0.0.1", "::1", "0.0.0.0", "*");
+
+  /**
+   * The endpoint a Command payload targets, or {@code null} when it targets the endpoint it runs
+   * on.
+   *
+   * <p>Reads the value <b>this inject actually uses</b> — the inject's own content overrides the
+   * payload's default — because the default is authored once on the payload while the value is
+   * chosen per inject. Using the default made every inject of a payload whose {@code host} argument
+   * defaults to {@code localhost} land on a discovered "localhost" node instead of its endpoint.
+   *
+   * <p>Returns {@code null} when the payload declares several endpoint-ish arguments (ambiguous,
+   * the pre-existing rule) or when the value names the executing machine.
+   */
+  @Nullable
+  private String resolveCommandTargetValue(Inject inject, Command payloadCommand) {
+    List<PayloadArgument> endpointArguments =
+        payloadCommand.getArguments().stream()
+            .filter(arg -> TARGET_ARGUMENT_TYPES.contains(arg.getType()))
+            .toList();
+    if (endpointArguments.size() != 1) {
+      return null;
+    }
+    PayloadArgument argument = endpointArguments.getFirst();
+    JsonNode override =
+        inject.getContent() == null ? null : inject.getContent().get(argument.getKey());
+    String value =
+        override != null && !override.asText().isEmpty()
+            ? override.asText()
+            : argument.getDefaultValue();
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    return SELF_TARGET_VALUES.contains(value.trim().toLowerCase()) ? null : value;
+  }
+
+  /**
    * Clears a simulation's attack-path rows (on simulation reset and delete). As a writer of a
    * tenant-active table it goes through Hibernate under a v2 scope, never raw JDBC (MT v2 /
    * TenantNonOrmAccessArchTest): {@code executeNew} opens a tenant-scoped REQUIRES_NEW transaction
@@ -319,26 +375,35 @@ public class AttackPathExecutionIngestionService {
             attackPathExecutions.add(attackPathExecution);
           }
         }
-        case COMMAND -> {
-          Set<PrimitiveType> typeEndpoint =
-              Set.of(
-                  PrimitiveType.IPv4,
-                  PrimitiveType.IPv6,
-                  PrimitiveType.TargetedAsset,
-                  PrimitiveType.Host,
-                  PrimitiveType.Domain,
-                  PrimitiveType.IpSubnet);
-          Command payloadCommand = (Command) inject.getPayload().get();
-          String targetArgIdentified = null;
-          List<String> targetArg =
-              payloadCommand.getArguments().stream()
-                  .filter(arg -> typeEndpoint.contains(arg.getType()))
-                  .map(PayloadArgument::getDefaultValue)
-                  .toList();
-          // IF MORE THAN 1 ARGS CAN MATCH AN ENDPOINT type WE DO NOT USED IT
-          if (targetArg.size() == 1) {
-            targetArgIdentified = targetArg.getFirst();
+        case NETWORK_TRAFFIC -> { // AGENT -> DISCOVERED (the destination it reached)
+          NetworkTraffic networkTraffic = (NetworkTraffic) inject.getPayload().get();
+          String destination = networkTraffic.getIpDst();
+          boolean reachesAnotherHost =
+              destination != null
+                  && !destination.isBlank()
+                  && !SELF_TARGET_VALUES.contains(destination.trim().toLowerCase());
+          for (Agent agent : agentsAndAssetsAgentless.agents()) {
+            io.openaev.database.model.Endpoint endpoint =
+                (io.openaev.database.model.Endpoint)
+                    org.hibernate.Hibernate.unproxy(agent.getAsset());
+            AttackPathExecution attackPathExecution = new AttackPathExecution();
+            attackPathExecution.setGlobalInformation(step, inject);
+            attackPathExecution.setSourceAgentInformation(agent, endpoint);
+            if (reachesAnotherHost) {
+              attackPathExecution.setId(
+                  AttackPathIds.executionNode(inject.getId(), destination, agent.getId()));
+              attackPathExecution.setTargetDiscoveredInformation(destination);
+            } else {
+              attackPathExecution.setId(
+                  AttackPathIds.executionNode(inject.getId(), endpoint.getId(), agent.getId()));
+              attackPathExecution.setTargetAssetInformation(endpoint);
+            }
+            attackPathExecutions.add(attackPathExecution);
           }
+        }
+        case COMMAND -> {
+          Command payloadCommand = (Command) inject.getPayload().get();
+          String targetArgIdentified = resolveCommandTargetValue(inject, payloadCommand);
 
           for (Agent agent : agentsAndAssetsAgentless.agents()) { // AGENT ->
             io.openaev.database.model.Endpoint endpoint =
@@ -360,6 +425,31 @@ public class AttackPathExecutionIngestionService {
               attackPathExecution.setTargetAssetInformation(endpoint);
               attackPathExecutions.add(attackPathExecution);
             }
+          }
+        }
+        // Safety net, not dead code: this switch is a statement, so a payload type added to the
+        // enum
+        // without a branch here compiles and silently writes no row at all - which is how
+        // NETWORK_TRAFFIC stayed invisible on the graph. Any unknown type falls back to the
+        // endpoint
+        // it ran on, the one edge that is always true of an agent-based execution.
+        default -> {
+          log.warn(
+              "Attack path: payload type '{}' has no target resolution; attaching inject {} to the "
+                  + "endpoint it ran on",
+              payloadType,
+              inject.getId());
+          for (Agent agent : agentsAndAssetsAgentless.agents()) {
+            io.openaev.database.model.Endpoint endpoint =
+                (io.openaev.database.model.Endpoint)
+                    org.hibernate.Hibernate.unproxy(agent.getAsset());
+            AttackPathExecution attackPathExecution = new AttackPathExecution();
+            attackPathExecution.setId(
+                AttackPathIds.executionNode(inject.getId(), endpoint.getId(), agent.getId()));
+            attackPathExecution.setGlobalInformation(step, inject);
+            attackPathExecution.setSourceAgentInformation(agent, endpoint);
+            attackPathExecution.setTargetAssetInformation(endpoint);
+            attackPathExecutions.add(attackPathExecution);
           }
         }
       }
@@ -507,26 +597,22 @@ public class AttackPathExecutionIngestionService {
           DnsResolution dnsResolution = (DnsResolution) inject.getPayload().get();
           return AttackPathIds.executionNode(inject.getId(), dnsResolution.getHostname(), target);
         }
-        case COMMAND -> { // AGENT ->
-          Set<PrimitiveType> typeEndpoint =
-              Set.of(
-                  PrimitiveType.IPv4,
-                  PrimitiveType.IPv6,
-                  PrimitiveType.TargetedAsset,
-                  PrimitiveType.Host,
-                  PrimitiveType.Domain,
-                  PrimitiveType.IpSubnet);
-          Command payloadCommand = (Command) inject.getPayload().get();
-          String targetArgIdentified = null;
-          List<String> targetArg =
-              payloadCommand.getArguments().stream()
-                  .filter(arg -> typeEndpoint.contains(arg.getType()))
-                  .map(PayloadArgument::getDefaultValue)
-                  .toList();
-          // IF MORE THAN 1 ARGS CAN MATCH AN ENDPOINT type WE DO NOT USED IT
-          if (targetArg.size() == 1) {
-            targetArgIdentified = targetArg.getFirst();
+        case NETWORK_TRAFFIC -> { // AGENT -> DISCOVERED (the destination it reached)
+          NetworkTraffic networkTraffic = (NetworkTraffic) inject.getPayload().get();
+          String destination = networkTraffic.getIpDst();
+          if (destination != null
+              && !destination.isBlank()
+              && !SELF_TARGET_VALUES.contains(destination.trim().toLowerCase())) {
+            return AttackPathIds.executionNode(inject.getId(), destination, target);
           }
+          io.openaev.database.model.Endpoint endpoint =
+              (io.openaev.database.model.Endpoint)
+                  org.hibernate.Hibernate.unproxy(agent.getAsset());
+          return AttackPathIds.executionNode(inject.getId(), endpoint.getId(), target);
+        }
+        case COMMAND -> { // AGENT ->
+          Command payloadCommand = (Command) inject.getPayload().get();
+          String targetArgIdentified = resolveCommandTargetValue(inject, payloadCommand);
 
           if (targetArgIdentified != null) { // DISCOVERED
             return AttackPathIds.executionNode(inject.getId(), targetArgIdentified, target);
@@ -537,6 +623,14 @@ public class AttackPathExecutionIngestionService {
                     org.hibernate.Hibernate.unproxy(agent.getAsset());
             return AttackPathIds.executionNode(inject.getId(), endpoint.getId(), target);
           }
+        }
+        // Mirrors the write side's fallback, so an unknown payload type still resolves to the id
+        // that was actually persisted for it.
+        default -> {
+          io.openaev.database.model.Endpoint endpoint =
+              (io.openaev.database.model.Endpoint)
+                  org.hibernate.Hibernate.unproxy(agent.getAsset());
+          return AttackPathIds.executionNode(inject.getId(), endpoint.getId(), target);
         }
       }
 

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -3,6 +3,7 @@ package io.openaev.service.attackpath.ingestion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.openaev.IntegrationTest;
 import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
@@ -16,7 +17,10 @@ import io.openaev.database.model.Inject;
 import io.openaev.database.model.InjectExpectationResult;
 import io.openaev.database.model.Injector;
 import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.NetworkTraffic;
 import io.openaev.database.model.Payload;
+import io.openaev.database.model.PayloadArgument;
+import io.openaev.database.model.PrimitiveType;
 import io.openaev.database.model.Step;
 import io.openaev.database.model.StepStatus;
 import io.openaev.database.model.Team;
@@ -282,6 +286,150 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(row.getAgentPrivilege()).isEqualTo("admin");
     assertThat(row.getExecutedAt()).isNotNull();
     assertThat(row.getPayloadName()).isEqualTo("crackmapexec");
+  }
+
+  /**
+   * Builds the agent/endpoint/inject triple the target-resolution tests share, so each only has to
+   * state the payload it exercises.
+   */
+  private Inject injectRunningPayload(Tenant tenant, String injectId, Payload payload) {
+    Endpoint endpoint = EndpointFixture.createEndpoint("corp-dc");
+    endpoint.setHostname("corp-dc");
+    endpoint.setIps(new String[] {"10.0.0.5"});
+    endpoint.setPlatform(Endpoint.PLATFORM_TYPE.Windows);
+    endpoint.setTenant(tenant);
+
+    Agent agent =
+        AgentFixture.createDefaultAgentSession(executorFixture.getDefaultExecutor(tenant.getId()));
+    agent.setId("agt-1");
+    agent.setAsset(endpoint);
+    agent.setExecutedByUser("agent-1");
+    endpointComposer.forEndpoint(endpoint).withAgent(agentComposer.forAgent(agent)).persist();
+
+    Exercise exercise = new Exercise();
+    exercise.setId("SIM-" + injectId);
+
+    InjectorContract contract = InjectorContractFixture.createDefaultInjectorContract();
+    contract.setNeedsExecutor(true);
+    contract.setPayload(payload);
+
+    Inject inject = InjectFixture.getDefaultInject();
+    inject.setId(injectId);
+    inject.setExercise(exercise);
+    inject.setTenant(tenant);
+    inject.setTitle(payload.getName());
+    inject.setInjectorContract(contract);
+    inject.setAssets(List.of(endpoint));
+    return inject;
+  }
+
+  private static Step stepOf(String templateId, String stepId) {
+    Step stepTemplate = StepFixture.getDefaultStepTemplate();
+    stepTemplate.setId(templateId);
+    Step step = StepFixture.getDefaultStepTemplate();
+    step.setId(stepId);
+    step.setStepTemplate(stepTemplate);
+    return step;
+  }
+
+  private static PayloadArgument argument(PrimitiveType type, String key, String defaultValue) {
+    PayloadArgument argument = new PayloadArgument();
+    argument.setType(type);
+    argument.setKey(key);
+    argument.setDefaultValue(defaultValue);
+    return argument;
+  }
+
+  @Test
+  @DisplayName(
+      "A command whose host argument names the executing machine targets its endpoint, not a"
+          + " 'localhost' node")
+  void commandTargetingLoopbackStaysOnItsEndpoint() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-loopback"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Command command =
+        (Command)
+            PayloadFixture.createDefaultCommandWithArguments(
+                List.of(
+                    argument(PrimitiveType.Host, "host", "localhost"),
+                    argument(PrimitiveType.Port, "port", "2020")));
+    command.setName("echo");
+
+    Inject inject = injectRunningPayload(tenant, "exec-loopback", command);
+    String endpointId = inject.getAssets().getFirst().getId();
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), "echo");
+
+    // Assert
+    // The command never left the machine it ran on, so it must stay attached to that endpoint.
+    // Keying it on the literal "localhost" also merged every endpoint's local runs into one node.
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("ASSET");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo(endpointId);
+    assertThat(rows.getFirst().getTargetHostname()).isEqualTo("corp-dc");
+  }
+
+  @Test
+  @DisplayName(
+      "A command's target comes from the inject's own argument value, not the payload default")
+  void commandTargetUsesInjectArgumentOverride() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-override"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Command command =
+        (Command)
+            PayloadFixture.createDefaultCommandWithArguments(
+                List.of(argument(PrimitiveType.IPv4, "target_ip", "10.9.9.9")));
+    command.setName("scan");
+
+    Inject inject = injectRunningPayload(tenant, "exec-override", command);
+    // The value this inject actually runs with, overriding the payload-level default.
+    inject.setContent(JsonNodeFactory.instance.objectNode().put("target_ip", "192.168.56.11"));
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), "scan");
+
+    // Assert
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("DISCOVERED");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo("192.168.56.11");
+  }
+
+  @Test
+  @DisplayName("A NetworkTraffic payload lands on the graph instead of writing no row at all")
+  void networkTrafficPayloadIsIngested() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-network-traffic"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    NetworkTraffic networkTraffic = new NetworkTraffic();
+    networkTraffic.setId("network-traffic-id");
+    networkTraffic.setName("beacon");
+    networkTraffic.setIpSrc("10.0.0.5");
+    networkTraffic.setIpDst("203.0.113.7");
+    networkTraffic.setPortSrc(4444);
+    networkTraffic.setPortDst(443);
+    networkTraffic.setProtocol("TCP");
+
+    Inject inject = injectRunningPayload(tenant, "exec-network", networkTraffic);
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), null);
+
+    // Assert
+    // This payload type had no branch in the resolution switch, so the step wrote nothing and the
+    // action never appeared on the attack path.
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("DISCOVERED");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo("203.0.113.7");
+    assertThat(rows.getFirst().getSourceKind()).isEqualTo("AGENT");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -371,6 +371,8 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(rows.getFirst().getTargetKind()).isEqualTo("ASSET");
     assertThat(rows.getFirst().getTargetKey()).isEqualTo(endpointId);
     assertThat(rows.getFirst().getTargetHostname()).isEqualTo("corp-dc");
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
   }
 
   @Test
@@ -399,6 +401,20 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(rows).hasSize(1);
     assertThat(rows.getFirst().getTargetKind()).isEqualTo("DISCOVERED");
     assertThat(rows.getFirst().getTargetKey()).isEqualTo("192.168.56.11");
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
+  }
+
+  private static NetworkTraffic networkTrafficTo(String ipDst) {
+    NetworkTraffic networkTraffic = new NetworkTraffic();
+    networkTraffic.setId("network-traffic-id");
+    networkTraffic.setName("beacon");
+    networkTraffic.setIpSrc("10.0.0.5");
+    networkTraffic.setIpDst(ipDst);
+    networkTraffic.setPortSrc(4444);
+    networkTraffic.setPortDst(443);
+    networkTraffic.setProtocol("TCP");
+    return networkTraffic;
   }
 
   @Test
@@ -408,16 +424,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-network-traffic"));
     TenantContext.setCurrentTenant(tenant.getId());
 
-    NetworkTraffic networkTraffic = new NetworkTraffic();
-    networkTraffic.setId("network-traffic-id");
-    networkTraffic.setName("beacon");
-    networkTraffic.setIpSrc("10.0.0.5");
-    networkTraffic.setIpDst("203.0.113.7");
-    networkTraffic.setPortSrc(4444);
-    networkTraffic.setPortDst(443);
-    networkTraffic.setProtocol("TCP");
-
-    Inject inject = injectRunningPayload(tenant, "exec-network", networkTraffic);
+    Inject inject = injectRunningPayload(tenant, "exec-network", networkTrafficTo("203.0.113.7"));
 
     // Act
     List<AttackPathExecution> rows =
@@ -430,6 +437,90 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     assertThat(rows.getFirst().getTargetKind()).isEqualTo("DISCOVERED");
     assertThat(rows.getFirst().getTargetKey()).isEqualTo("203.0.113.7");
     assertThat(rows.getFirst().getSourceKind()).isEqualTo("AGENT");
+    // The recomputed index must name the row that was persisted, or verdicts and terminal
+    // traces written later through getExecutionIndex would miss it.
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
+  }
+
+  @Test
+  @DisplayName("A NetworkTraffic payload whose destination is loopback stays on its endpoint")
+  void networkTrafficLoopbackStaysOnItsEndpoint() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-network-loopback"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Inject inject =
+        injectRunningPayload(tenant, "exec-network-loop", networkTrafficTo("127.0.0.1"));
+    String endpointId = inject.getAssets().getFirst().getId();
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), null);
+
+    // Assert
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("ASSET");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo(endpointId);
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
+  }
+
+  @Test
+  @DisplayName("A blank inject override does not name a target: the payload default still applies")
+  void commandBlankOverrideFallsBackToPayloadDefault() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-blank"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Command command =
+        (Command)
+            PayloadFixture.createDefaultCommandWithArguments(
+                List.of(argument(PrimitiveType.IPv4, "target_ip", "10.9.9.9")));
+    command.setName("scan");
+
+    Inject inject = injectRunningPayload(tenant, "exec-blank", command);
+    // A whitespace-only value names nothing, so it must not suppress the payload default.
+    inject.setContent(JsonNodeFactory.instance.objectNode().put("target_ip", "   "));
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), "scan");
+
+    // Assert
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("DISCOVERED");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo("10.9.9.9");
+  }
+
+  @Test
+  @DisplayName(
+      "The persisted target value is trimmed, so stray whitespace never forks a second node")
+  void commandTargetValueIsTrimmedBeforePersisting() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-trim"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Command command =
+        (Command)
+            PayloadFixture.createDefaultCommandWithArguments(
+                List.of(argument(PrimitiveType.IPv4, "target_ip", "10.9.9.9")));
+    command.setName("scan");
+
+    Inject inject = injectRunningPayload(tenant, "exec-trim", command);
+    inject.setContent(JsonNodeFactory.instance.objectNode().put("target_ip", " 192.168.56.11  "));
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), "scan");
+
+    // Assert
+    // The id is keyed on the target value: an untrimmed " 192.168.56.11  " would be a distinct
+    // node from "192.168.56.11", and would diverge from the loopback check, which trims.
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo("192.168.56.11");
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/ingestion/AttackPathExecutionIngestionServiceTest.java
@@ -31,6 +31,7 @@ import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.AttackPathExecutionRemediation;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRemediationRepository;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRepository;
+import io.openaev.injector_contract.ContractTargetedProperty;
 import io.openaev.service.attackpath.AttackPathIds;
 import io.openaev.utils.fixtures.AgentFixture;
 import io.openaev.utils.fixtures.DetectionRemediationFixture;
@@ -344,7 +345,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
   @DisplayName(
       "A command whose host argument names the executing machine targets its endpoint, not a"
           + " 'localhost' node")
-  void commandTargetingLoopbackStaysOnItsEndpoint() {
+  void given_commandWithLoopbackHostArgument_should_targetItsOwnEndpoint() {
     // Arrange
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-loopback"));
     TenantContext.setCurrentTenant(tenant.getId());
@@ -378,7 +379,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
   @Test
   @DisplayName(
       "A command's target comes from the inject's own argument value, not the payload default")
-  void commandTargetUsesInjectArgumentOverride() {
+  void given_injectArgumentOverride_should_targetTheOverriddenValue() {
     // Arrange
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-override"));
     TenantContext.setCurrentTenant(tenant.getId());
@@ -419,7 +420,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
 
   @Test
   @DisplayName("A NetworkTraffic payload lands on the graph instead of writing no row at all")
-  void networkTrafficPayloadIsIngested() {
+  void given_networkTrafficPayload_should_ingestOneExecutionRow() {
     // Arrange
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-network-traffic"));
     TenantContext.setCurrentTenant(tenant.getId());
@@ -445,7 +446,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
 
   @Test
   @DisplayName("A NetworkTraffic payload whose destination is loopback stays on its endpoint")
-  void networkTrafficLoopbackStaysOnItsEndpoint() {
+  void given_loopbackNetworkTrafficDestination_should_targetItsOwnEndpoint() {
     // Arrange
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-network-loopback"));
     TenantContext.setCurrentTenant(tenant.getId());
@@ -468,7 +469,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
 
   @Test
   @DisplayName("A blank inject override does not name a target: the payload default still applies")
-  void commandBlankOverrideFallsBackToPayloadDefault() {
+  void given_blankInjectOverride_should_fallBackToPayloadDefault() {
     // Arrange
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-blank"));
     TenantContext.setCurrentTenant(tenant.getId());
@@ -496,7 +497,7 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
   @Test
   @DisplayName(
       "The persisted target value is trimmed, so stray whitespace never forks a second node")
-  void commandTargetValueIsTrimmedBeforePersisting() {
+  void given_paddedTargetValue_should_persistTheTrimmedValue() {
     // Arrange
     Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-trim"));
     TenantContext.setCurrentTenant(tenant.getId());
@@ -519,6 +520,102 @@ class AttackPathExecutionIngestionServiceTest extends IntegrationTest {
     // node from "192.168.56.11", and would diverge from the loopback check, which trims.
     assertThat(rows).hasSize(1);
     assertThat(rows.getFirst().getTargetKey()).isEqualTo("192.168.56.11");
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
+  }
+
+  /** A second endpoint the targeted-asset tests select as the command's destination. */
+  private Endpoint persistTargetedEndpoint(Tenant tenant, String hostname, String ip) {
+    Endpoint targeted = EndpointFixture.createEndpoint(hostname);
+    targeted.setHostname(hostname);
+    targeted.setIps(new String[] {ip});
+    targeted.setPlatform(Endpoint.PLATFORM_TYPE.Linux);
+    targeted.setTenant(tenant);
+    endpointComposer.forEndpoint(targeted).persist();
+    return targeted;
+  }
+
+  @Test
+  @DisplayName(
+      "A targeted-asset argument resolves to the selected endpoint's property value, like"
+          + " execution does, not to the payload default")
+  void given_targetedAssetArgument_should_targetTheResolvedEndpointValue() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-targeted-asset"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Command command =
+        (Command)
+            PayloadFixture.createDefaultCommandWithArguments(
+                List.of(argument(PrimitiveType.TargetedAsset, "asset-key", null)));
+    command.setName("lateral");
+
+    Inject inject = injectRunningPayload(tenant, "exec-targeted-asset", command);
+    // The contract carries the targeted-asset field and its linked targeted-property selector
+    // (hostname), exactly what InjectService#retrieveValuesOfTargetedAssetFromInject reads.
+    InjectorContractFixture.addTargetedAssetFields(
+        inject.getInjectorContract().orElseThrow(), "asset-key", ContractTargetedProperty.hostname);
+
+    Endpoint targeted = persistTargetedEndpoint(tenant, "db-server", "10.0.0.9");
+    inject.setContent(
+        JsonNodeFactory.instance
+            .objectNode()
+            .set("asset-key", JsonNodeFactory.instance.arrayNode().add(targeted.getId())));
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), "lateral");
+
+    // Assert
+    // The inject field is an array of endpoint ids: read as text it is blank, which used to fall
+    // back to the payload default. The resolved property value is what the command ran with.
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("DISCOVERED");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo("db-server");
+    assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
+        .isEqualTo(rows.getFirst().getId());
+  }
+
+  @Test
+  @DisplayName(
+      "A targeted-asset selection resolving to several destinations is ambiguous and stays on the"
+          + " executing endpoint")
+  void given_targetedAssetArgumentWithSeveralEndpoints_should_fallBackToExecutingEndpoint() {
+    // Arrange
+    Tenant tenant = tenantRepository.save(TenantFixture.getTenant("ap-cmd-targeted-multi"));
+    TenantContext.setCurrentTenant(tenant.getId());
+
+    Command command =
+        (Command)
+            PayloadFixture.createDefaultCommandWithArguments(
+                List.of(argument(PrimitiveType.TargetedAsset, "asset-key", null)));
+    command.setName("sweep");
+
+    Inject inject = injectRunningPayload(tenant, "exec-targeted-multi", command);
+    InjectorContractFixture.addTargetedAssetFields(
+        inject.getInjectorContract().orElseThrow(), "asset-key", ContractTargetedProperty.hostname);
+
+    Endpoint first = persistTargetedEndpoint(tenant, "db-server", "10.0.0.9");
+    Endpoint second = persistTargetedEndpoint(tenant, "web-server", "10.0.0.10");
+    String executingEndpointId = inject.getAssets().getFirst().getId();
+    inject.setContent(
+        JsonNodeFactory.instance
+            .objectNode()
+            .set(
+                "asset-key",
+                JsonNodeFactory.instance.arrayNode().add(first.getId()).add(second.getId())));
+
+    // Act
+    List<AttackPathExecution> rows =
+        ingestionService.getAttackPathExecution(inject, stepOf("tmpl-1", "step-1"), "sweep");
+
+    // Assert
+    // One row per agent, recomputable from (inject, agent): several destinations cannot key that
+    // one row, so the edge falls back to the endpoint the command ran on (same ambiguity rule as
+    // several endpoint-ish arguments).
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getTargetKind()).isEqualTo("ASSET");
+    assertThat(rows.getFirst().getTargetKey()).isEqualTo(executingEndpointId);
     assertThat(ingestionService.getExecutionIndex(inject, "agt-1"))
         .isEqualTo(rows.getFirst().getId());
   }


### PR DESCRIPTION
Fixes #7231 (reported as OpenAEV-Platform/filigran-private#259 and OpenAEV-Platform/filigran-private#260 - same root area, one switch).

### 1. Payloads attached to a shared `localhost` node instead of their endpoint

`AttackPathExecutionIngestionService` resolved a `COMMAND` payload's target from the argument's **default value** rather than the value the inject actually runs with. So an inject overriding `target_ip` still landed on the payload default, and - far more visibly - a `host` argument defaulting to `localhost` produced a `DISCOVERED` node literally named `localhost`. The target key *is* that raw value, so every endpoint's local executions collapsed onto one shared node and the endpoint that ran the payload disappeared from the chain.

This is not hypothetical: a payload in the local dataset (`echo seb`) has exactly one endpoint-typed argument - `host`, defaulting to `localhost`.

Now: read the inject's own value, fall back to the payload default, and treat loopback (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`, `*`) as "the endpoint it ran on".

### 2. `NetworkTraffic` payloads never appeared at all

`PayloadType` has six values; the resolution switch handled five. It is a `switch` **statement**, so the missing `NETWORK_TRAFFIC` branch compiled silently and wrote **zero rows** - the action never landed on the map, while its endpoint was still drawn by other executions. That is exactly the reported "endpoints with no payload card". Verified against the current tip of `main`: `PayloadType.NETWORK_TRAFFIC` and the `NetworkTraffic` entity are both present and actively used (`PayloadService`, `InjectUtils`, `PayloadCreateInput`, frontend type mappings), so the gap is real today.

Now: `NETWORK_TRAFFIC` targets its `ip_dst`, mirroring how `DNS_RESOLUTION` targets its hostname, falling back to the executing endpoint when the destination is absent or loopback. Both switches also gained a `default` branch so a payload type added to (or later removed from) the enum can never again silently write nothing.

`getExecutionIndex` duplicated the same resolution and carried both defects identically - it must agree with the write path since it recomputes the persisted id. Both now share one helper.

Review note (#1191): the network-traffic *attack capability* (an executor that generates the traffic) was never implemented - #1191 tracks that feature and is still open - but the payload type is creatable today (`PayloadCreateInput`, `PayloadService`), so an inject carrying one must not silently write zero attack-path rows. If the type is ever removed as part of that feature decision, the `default` branch added here keeps the graph safe through the removal, and dropping the `case NETWORK_TRAFFIC` is a one-line mechanical follow-up. On the "payloads hidden when target == source" design (filigran-private#239): that was the previous design; per the team the new design shows payloads and injectors on the map, which is what the loopback-to-ASSET behavior here implements.

### 3. Review hardening: normalize the target value exactly once

All remote-target resolution (Command argument value, NetworkTraffic `ip_dst`) flows through a single `remoteTargetOrNull` helper: the persisted value / id key is trimmed once, so stray whitespace can never fork a second discovered node (the authored case is kept for display; only the loopback comparison lowercases). A blank or JSON-null inject override falls back to the payload default instead of suppressing it, and a JSON null node no longer reads as the literal string "null". `DNS_RESOLUTION` is deliberately untouched: its hostname is fixed on the payload (not argument-driven), there is no reported defect there, and re-keying it would churn existing DNS node ids for no benefit.

### 4. Review follow-up: targeted-asset arguments resolve like execution does

A `TargetedAsset` inject field is a JSON array of endpoint ids, not a scalar: reading it as text yields blank, which fell back to the payload default (the pre-existing behavior). It now goes through the same resolver execution uses (`InjectService#retrieveValuesOfTargetedAssetFromInject`), so the row carries the property value (hostname / seen IP / local IP) the command actually ran with. The row model keys exactly one row per `(inject, agent)` - `getExecutionIndex` must recompute the persisted id from that pair alone, which is how Phase-B verdicts, traces, and collector snapshots find their row - so a selection resolving to several destinations stays ambiguous (same rule as several endpoint-ish arguments) and falls back to the executing endpoint; fanning out to one row per destination needs the Phase-B index to become multi-valued first, an explicit follow-up. Resolution failures degrade to the executing-endpoint edge rather than failing the run's write.

### Verification

Three integration tests from the original fix, each run against the code **with and without** the fix:

| test | without the fix |
|---|---|
| command whose host argument is loopback | `expected "ASSET" but was "DISCOVERED"` |
| command target from the inject's argument | `expected "192.168.56.11" but was "10.9.9.9"` |
| NetworkTraffic payload is ingested | `Expected size: 1 but was: 0` |

Six review additions: a blank override falls back to the payload default, the persisted target value is trimmed, a loopback NetworkTraffic destination stays on its endpoint, a targeted-asset argument resolves to the selected endpoint's property value, a multi-endpoint selection falls back to the executing endpoint, and the recomputed execution index equals the persisted row id on every touched branch. The tests introduced by this PR follow the `given_X_should_Y` naming convention. Full test class: `Tests run: 18, Failures: 0, Errors: 0`. Branch rebased onto current `main` (clean, no conflicts; all commits signed); Spotless applied.
