### PR TITLE
fix(chaining): stop a simulation without erasing what it produced (#7233)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -777,7 +777,7 @@ public class ExerciseService {
         && ExerciseStatus.CANCELED.equals(status)) {
       exercise.setEnd(now());
       if (previewFeatureService.isFeatureEnabled(PreviewFeature.INJECT_CHAINING)) {
-        // End WORKFLOW + STEP + delete injects + delete workflow states
+        // End WORKFLOW + STEP + delete workflow states
         List<Workflow> run = workflowService.findWorkflowRunBySimulationId(exercise.getId());
         if (!run.isEmpty()) {
           List<Step> stepsToUpdate = new ArrayList<>();
@@ -791,16 +791,21 @@ public class ExerciseService {
           stepService.saveSteps(stepsToUpdate);
           workflowService.saveAll(run);
           workflowService.deleteWorkflowStatesBySimulationId(exercise.getId());
-          List<Inject> injects = this.injectRepository.findByExerciseId(exerciseId);
-          // A manual chained simulation is reset on cancel (all injects dropped). An autonomous
-          // (AI-driven) run is different: its executed steps ARE the deliverable, so cancelling
-          // must PRESERVE what already ran - the operator keeps the executed record on the
-          // Execution screen - and only drop the never-started injects the orchestrator had queued
-          // (which are also where the duplicate-inject storms pile up).
-          boolean isAutonomous = autonomousRunRepository.existsBySimulationId(exercise.getId());
-          List<Inject> injectsToDelete =
-              isAutonomous ? injects.stream().filter(Inject::isNotExecuted).toList() : injects;
-          this.injectRepository.deleteAll(injectsToDelete);
+          // Stopping is not resetting: it ends the run and keeps its record. A manual chained
+          // simulation used to drop ALL its injects here, which emptied the Execution screen while
+          // the attack path (whose rows are only cleared on reset) still showed the same run - the
+          // simulation looked half-erased. Clearing the executed record is the explicit Reset
+          // action's job (RUNNING/FINISHED -> SCHEDULED above), not a side effect of stopping.
+          //
+          // An autonomous (AI-driven) run additionally drops the injects the orchestrator had
+          // queued but never started: they are where the duplicate-inject storms pile up, and a
+          // never-started inject is not part of the deliverable.
+          if (autonomousRunRepository.existsBySimulationId(exercise.getId())) {
+            this.injectRepository.deleteAll(
+                this.injectRepository.findByExerciseId(exerciseId).stream()
+                    .filter(Inject::isNotExecuted)
+                    .toList());
+          }
         }
       }
     }

--- a/openaev-api/src/test/java/io/openaev/service/ExerciseServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ExerciseServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import static io.openaev.utils.fixtures.TeamFixture.getTeam;
 import static io.openaev.utils.fixtures.UserFixture.getUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.when;
 
 import io.openaev.IntegrationTest;
 import io.openaev.api.url_access_token.UrlAccessTokenService;
@@ -16,10 +17,12 @@ import io.openaev.database.repository.*;
 import io.openaev.database.repository.autonomous.AutonomousRunRepository;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.rest.document.DocumentService;
+import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.rest.exercise.service.PauseExerciseService;
 import io.openaev.rest.inject.service.InjectDuplicateService;
 import io.openaev.rest.inject.service.InjectService;
+import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.attackpath.ingestion.AttackPathExecutionIngestionService;
 import io.openaev.service.chaining.StepService;
 import io.openaev.service.chaining.WorkflowService;
@@ -197,18 +200,14 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
             });
   }
 
-  @DisplayName("Stopping a chained simulation keeps the injects that already ran")
+  @DisplayName("Stopping a chained simulation keeps its injects")
   @Test
   @Transactional(rollbackFor = Exception.class)
-  void stoppingChainedSimulationKeepsItsInjects()
-      throws io.openaev.rest.exception.ChainingException {
+  void given_runningChainedSimulation_should_keepInjectsOnStop() throws ChainingException {
     // -- PREPARE --
     // Stopping used to delete every inject of a manual chained simulation, which emptied the
     // Execution screen while the attack path (cleared only on reset) still showed the same run.
-    org.mockito.Mockito.when(
-            previewFeatureService.isFeatureEnabled(
-                io.openaev.rest.settings.PreviewFeature.INJECT_CHAINING))
-        .thenReturn(true);
+    when(previewFeatureService.isFeatureEnabled(PreviewFeature.INJECT_CHAINING)).thenReturn(true);
 
     Exercise exercise = ExerciseFixture.getExercise();
     exercise.setFrom("test@test.com");
@@ -220,10 +219,12 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
     workflowRun.setSimulation(exerciseSaved);
     this.workflowRepository.save(workflowRun);
 
+    // The inject has no status yet (pending): stop must keep it too - only Reset clears the
+    // record, and the autonomous-only carve-out is exactly about pending injects like this one.
     InjectorContract injectorContract = injectorContractFixture.getWellKnownSingleEmailContract();
-    Inject executedInject = getInjectForEmailContract(injectorContract);
-    executedInject.setExercise(exerciseSaved);
-    Inject executedInjectSaved = this.injectRepository.save(executedInject);
+    Inject pendingInject = getInjectForEmailContract(injectorContract);
+    pendingInject.setExercise(exerciseSaved);
+    Inject pendingInjectSaved = this.injectRepository.save(pendingInject);
     entityManager.flush();
 
     // -- EXECUTE --
@@ -232,7 +233,7 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
 
     // -- ASSERT --
     assertEquals(
-        List.of(executedInjectSaved.getId()),
+        List.of(pendingInjectSaved.getId()),
         this.injectRepository.findByExerciseId(exerciseSaved.getId()).stream()
             .map(Inject::getId)
             .toList());

--- a/openaev-api/src/test/java/io/openaev/service/ExerciseServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ExerciseServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import io.openaev.utils.ResultUtils;
 import io.openaev.utils.fixtures.ExerciseFixture;
 import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.WorkflowFixture;
 import io.openaev.utils.mapper.ExerciseMapper;
 import io.openaev.utils.mapper.InjectExpectationMapper;
 import io.openaev.utils.mapper.InjectMapper;
@@ -92,6 +93,7 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
   @Autowired private UrlAccessTokenService urlAccessTokenService;
 
   @Autowired private WorkflowService workflowService;
+  @Autowired private WorkflowRepository workflowRepository;
   @Autowired private io.openaev.healthcheck.utils.HealthCheckUtils healthCheckUtils;
   @Autowired private ApplicationEventPublisher eventPublisher;
   @Autowired private AttackPathExecutionIngestionService attackPathExecutionService;
@@ -193,6 +195,47 @@ class ExerciseServiceIntegrationTest extends IntegrationTest {
                 assertEquals(noContextualTeam.getId(), team.getId());
               }
             });
+  }
+
+  @DisplayName("Stopping a chained simulation keeps the injects that already ran")
+  @Test
+  @Transactional(rollbackFor = Exception.class)
+  void stoppingChainedSimulationKeepsItsInjects()
+      throws io.openaev.rest.exception.ChainingException {
+    // -- PREPARE --
+    // Stopping used to delete every inject of a manual chained simulation, which emptied the
+    // Execution screen while the attack path (cleared only on reset) still showed the same run.
+    org.mockito.Mockito.when(
+            previewFeatureService.isFeatureEnabled(
+                io.openaev.rest.settings.PreviewFeature.INJECT_CHAINING))
+        .thenReturn(true);
+
+    Exercise exercise = ExerciseFixture.getExercise();
+    exercise.setFrom("test@test.com");
+    exercise.setStatus(ExerciseStatus.RUNNING);
+    Exercise exerciseSaved = this.exerciseRepository.save(exercise);
+
+    // The cancel path only touches injects when the simulation has a RUN workflow.
+    Workflow workflowRun = WorkflowFixture.getDefaultWorkflowExecution(WorkflowStatus.RUN);
+    workflowRun.setSimulation(exerciseSaved);
+    this.workflowRepository.save(workflowRun);
+
+    InjectorContract injectorContract = injectorContractFixture.getWellKnownSingleEmailContract();
+    Inject executedInject = getInjectForEmailContract(injectorContract);
+    executedInject.setExercise(exerciseSaved);
+    Inject executedInjectSaved = this.injectRepository.save(executedInject);
+    entityManager.flush();
+
+    // -- EXECUTE --
+    this.exerciseService.changeExerciseStatus(ExerciseStatus.CANCELED, exerciseSaved.getId());
+    entityManager.flush();
+
+    // -- ASSERT --
+    assertEquals(
+        List.of(executedInjectSaved.getId()),
+        this.injectRepository.findByExerciseId(exerciseSaved.getId()).stream()
+            .map(Inject::getId)
+            .toList());
   }
 
   @DisplayName("Should remove team from exercise")

--- a/openaev-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
@@ -197,8 +197,10 @@ const Buttons = ({ exerciseId, exerciseStatus, exerciseName, onLoading, isLoadin
         return `${t('Injects will be paused, do you want to continue?')}`;
       case 'SCHEDULED':
         return `${exerciseName} ${t('data will be reset, do you want to restart?')}`;
+      // Stopping keeps everything that ran - only Reset clears it - so this must not borrow the
+      // reset wording, which had users expecting their results to be wiped by a stop.
       case 'CANCELED':
-        return `${exerciseName} ${t('data will be reset, do you want to restart?')}`;
+        return `${exerciseName} ${t('will be stopped, collected results are kept. Do you want to continue?')}`;
       default:
         return 'Do you want to change the status of this simulation?';
     }

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "Wer sendet?",
   "Who receives this inject.": "Wer diese Injektion erhalt.",
   "will be started, do you want to continue?": "wird gestartet, wollen Sie fortfahren?",
+  "will be stopped, collected results are kept. Do you want to continue?": "wird gestoppt, die bereits erfassten Ergebnisse bleiben erhalten. Möchten Sie fortfahren?",
   "Windows": "Windows",
   "Windows Command Line": "Windows Kommandozeile",
   "Windows documentation.": "Windows-Dokumentation.",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "Who is sending?",
   "Who receives this inject.": "Who receives this inject.",
   "will be started, do you want to continue?": "will be started, do you want to continue?",
+  "will be stopped, collected results are kept. Do you want to continue?": "will be stopped, collected results are kept. Do you want to continue?",
   "Windows": "Windows",
   "Windows Command Line": "Windows Command Line",
   "Windows documentation.": "Windows documentation.",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "¿Quién envía?",
   "Who receives this inject.": "Quien recibe esta inyeccion.",
   "will be started, do you want to continue?": "se iniciará, ¿desea continuar?",
+  "will be stopped, collected results are kept. Do you want to continue?": "se detendrá, los resultados ya recopilados se conservan. ¿Desea continuar?",
   "Windows": "Windows",
   "Windows Command Line": "Línea de comandos de Windows",
   "Windows documentation.": "Documentación de Windows.",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "Qui envoie ?",
   "Who receives this inject.": "Qui recoit cette injection.",
   "will be started, do you want to continue?": "va démarrer, voulez-vous continuer ?",
+  "will be stopped, collected results are kept. Do you want to continue?": "sera arrêtée, les résultats déjà collectés sont conservés. Souhaitez-vous continuer ?",
   "Windows": "Windows",
   "Windows Command Line": "Ligne de commande Windows",
   "Windows documentation.": "Documentation Windows.",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "Chi sta inviando?",
   "Who receives this inject.": "Chi riceve questa iniezione.",
   "will be started, do you want to continue?": "sarà avviato, volete continuare?",
+  "will be stopped, collected results are kept. Do you want to continue?": "verrà interrotta, i risultati già raccolti vengono conservati. Vuoi continuare?",
   "Windows": "Windows",
   "Windows Command Line": "Riga di comando di Windows",
   "Windows documentation.": "Documentazione Windows.",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "誰が送る？",
   "Who receives this inject.": "このインジェクトを受け取る対象。",
   "will be started, do you want to continue?": "が始まりますが続けますか？",
+  "will be stopped, collected results are kept. Do you want to continue?": "を停止します。収集済みの結果は保持されます。続行しますか？",
   "Windows": "ウィンドウズ",
   "Windows Command Line": "Windows コマンドライン",
   "Windows documentation.": "Windows ドキュメント",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "누가 보내는 사람인가요?",
   "Who receives this inject.": "이 인젝트를 받는 대상.",
   "will be started, do you want to continue?": "가 시작됩니다. 계속하시겠습니까?",
+  "will be stopped, collected results are kept. Do you want to continue?": "이(가) 중지됩니다. 이미 수집된 결과는 유지됩니다. 계속하시겠습니까?",
   "Windows": "Windows",
   "Windows Command Line": "Windows 명령줄",
   "Windows documentation.": "Windows 문서.",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "Кто отправляет?",
   "Who receives this inject.": "Кто получает эту инъекцию.",
   "will be started, do you want to continue?": "начнется, хотите ли вы продолжить?",
+  "will be stopped, collected results are kept. Do you want to continue?": "будет остановлена, уже собранные результаты сохранятся. Продолжить?",
   "Windows": "Windows",
   "Windows Command Line": "Командная строка Windows",
   "Windows documentation.": "Документация по Windows.",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3700,6 +3700,7 @@
   "Who is sending?": "谁在发送？",
   "Who receives this inject.": "谁接收此注入。",
   "will be started, do you want to continue?": "将要开始,你想要继续么?",
+  "will be stopped, collected results are kept. Do you want to continue?": "将被停止，已收集的结果将保留。是否继续？",
   "Windows": "Windows",
   "Windows Command Line": "Windows命令行",
   "Windows documentation.": "Windows 文档。",


### PR DESCRIPTION
Fixes #7233 (reported as OpenAEV-Platform/filigran-private#261).

Stopping a chained simulation both erased its execution record and announced itself with the *reset* warning, so a stop looked and behaved like a reset.

### 1. Stop deleted every inject

`ExerciseService.changeExerciseStatus`, on `RUNNING -> CANCELED`, dropped **all** injects of a manual chained simulation. The Execution tab is built from injects, so it went empty — while the attack path kept its rows, since those are only cleared on reset (`CANCELED/FINISHED -> SCHEDULED`). The simulation was left half-erased: an attack path describing a run whose execution record had vanished.

Stop now deletes nothing. The autonomous carve-out is preserved exactly as it was — an autonomous run still drops the never-started injects its orchestrator had queued, which is where the duplicate-inject storms pile up.

### 2. The stop dialog used the reset wording

`CANCELED` mapped to the same text as `SCHEDULED` — *"data will be reset, do you want to restart?"* — displayed right next to a **Reset** button. It now says the collected results are kept.

### Verification

Integration test added, run against the code **with and without** the fix:

| | result |
|---|---|
| without the fix | `expected: <[52e0b387-…]> but was: <[]>` — the inject is deleted by the stop |
| with the fix | `Tests run: 1, Failures: 0, Errors: 0` |

Front: 548 unit tests pass, ESLint clean, `i18n-checker` passes (the new string is added to all 9 languages and the files re-sorted with `sort-translation-files.js`).

### One behaviour worth calling out

Injects that were queued but never ran now remain visible as **pending** after a stop, where they used to disappear with everything else. That is the accurate record of a run stopped mid-flight, and Reset still clears them — but it is a visible change on the Execution tab, so flagging it explicitly.

