### PR TITLE
fix(chaining): addback lock banner on logic map and fix issue blocking edit after reset (#5045)

### DIFF
--- a/openaev-front/src/admin/components/chaining/logic/Logic.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/Logic.tsx
@@ -17,6 +17,7 @@ import useRemainingViewportHeight from '../../../../utils/hooks/useRemainingView
 import { type LogicContext } from './AddComponentButton';
 import ComponentStepperDrawer, { type DrawerView } from './drawer/ComponentStepperDrawer';
 import LogicGraph from './logic-graph/LogicGraph';
+import LogicReadOnlyBanner from './LogicReadOnlyBanner';
 import LogicTopBar from './LogicTopBar';
 import OutputProvidersProvider from './OutputProvidersContext';
 import type { ActionMeta, EventMeta } from './types';
@@ -32,9 +33,12 @@ interface LogicProps {
    *  authoring affordances (top bar, add-component, node edit/delete) are hidden while pan/zoom
    *  and the trigger spotlight stay available. */
   readOnly?: boolean;
+  /** Message shown in the read-only banner explaining WHY the map is frozen. When omitted, no
+   *  banner is rendered (the read-only affordances are still hidden). */
+  readOnlyMessage?: string;
 }
 
-const Logic = ({ workflowId, context, scenarioId, exerciseId, readOnly = false }: LogicProps) => {
+const Logic = ({ workflowId, context, scenarioId, exerciseId, readOnly = false, readOnlyMessage }: LogicProps) => {
   const { t } = useFormatter();
   // The canvas sizes itself to the exact space left under the page chrome (no page scrollbar).
   const [graphContainerRef, graphHeight] = useRemainingViewportHeight();
@@ -212,6 +216,7 @@ const Logic = ({ workflowId, context, scenarioId, exerciseId, readOnly = false }
 
   return (
     <OutputProvidersProvider>
+      {readOnly && readOnlyMessage && <LogicReadOnlyBanner message={readOnlyMessage} />}
       <div
         ref={graphContainerRef}
         style={{

--- a/openaev-front/src/admin/components/chaining/logic/LogicReadOnlyBanner.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/LogicReadOnlyBanner.tsx
@@ -1,0 +1,35 @@
+import { Lock } from '@mui/icons-material';
+import { Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { type FunctionComponent } from 'react';
+
+import { useFormatter } from '../../../../components/i18n';
+import AlertBanner from '../../common/AlertBanner';
+
+/**
+ * Read-only banner shown on a launched simulation. A launched simulation is frozen:
+ * its logic map / scope can only be edited while the simulation is in Draft (see ADR-005).
+ */
+interface Props { message?: string }
+
+const LogicReadOnlyBanner: FunctionComponent<Props> = ({ message }) => {
+  const { t } = useFormatter();
+  const theme = useTheme();
+  return (
+    <AlertBanner color={theme.palette.info.main} title={t('Read only')}>
+      <div style={{
+        alignItems: 'center',
+        display: 'flex',
+        gap: theme.spacing(1),
+      }}
+      >
+        <Lock fontSize="small" />
+        <Typography variant="body2">
+          {message ?? t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it, or update the scenario and run it again.')}
+        </Typography>
+      </div>
+    </AlertBanner>
+  );
+};
+
+export default LogicReadOnlyBanner;

--- a/openaev-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/Index.tsx
@@ -138,7 +138,7 @@ const IndexComponent: FunctionComponent<{
                       autonomousTimeoutSeconds: autonomousRun?.autonomous_run_timeout_seconds,
                     }) : errorWrapper(SimulationScope)()}
                   />
-                  <Route path="logic" element={isAutonomous ? errorWrapper(SimulationLogic)({ readOnly: true }) : errorWrapper(SimulationLogic)()} />
+                  <Route path="logic" element={isAutonomous ? errorWrapper(SimulationLogic)({ isAutonomous: true }) : errorWrapper(SimulationLogic)()} />
                   {/* Not found */}
                   <Route path="*" element={<NotFound />} />
                 </Routes>

--- a/openaev-front/src/admin/components/simulations/simulation/logic/SimulationLogic.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/logic/SimulationLogic.tsx
@@ -6,7 +6,7 @@ import { useHelper } from '../../../../../store';
 import type { Exercise } from '../../../../../utils/api-types';
 import Logic from '../../../chaining/logic/Logic';
 
-const SimulationLogic = ({ readOnly = false }: { readOnly?: boolean }) => {
+const SimulationLogic = ({ isAutonomous = false }: { isAutonomous?: boolean }) => {
   const { t } = useFormatter();
   const { exerciseId } = useParams() as { exerciseId: Exercise['exercise_id'] };
   const { exercise } = useHelper((helper: ExercisesHelper) => ({ exercise: helper.getExercise(exerciseId) }));
@@ -15,9 +15,9 @@ const SimulationLogic = ({ readOnly = false }: { readOnly?: boolean }) => {
   // (UI "Draft" / "Scheduled"), see ADR-005. While the exercise is still loading, only the incoming
   // (autonomous) flag applies, so the frozen banner never flashes before the status is known.
   const launched = !!exercise && exercise.exercise_status !== 'SCHEDULED';
-  const effectiveReadOnly = readOnly || launched;
+  const effectiveReadOnly = isAutonomous || launched;
   const resolveReadOnlyMessage = () => {
-    if (readOnly) {
+    if (isAutonomous) {
       return t('This simulation is driven by the autonomous attack path. Its logic map is read-only.');
     }
     if (exercise?.exercise_scenario) {

--- a/openaev-front/src/admin/components/simulations/simulation/logic/SimulationLogic.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/logic/SimulationLogic.tsx
@@ -1,25 +1,38 @@
 import { useParams } from 'react-router';
 
 import { type ExercisesHelper } from '../../../../../actions/exercises/exercise-helper';
+import { useFormatter } from '../../../../../components/i18n';
 import { useHelper } from '../../../../../store';
 import type { Exercise } from '../../../../../utils/api-types';
 import Logic from '../../../chaining/logic/Logic';
 
 const SimulationLogic = ({ readOnly = false }: { readOnly?: boolean }) => {
+  const { t } = useFormatter();
   const { exerciseId } = useParams() as { exerciseId: Exercise['exercise_id'] };
   const { exercise } = useHelper((helper: ExercisesHelper) => ({ exercise: helper.getExercise(exerciseId) }));
   // Two independent reasons the logic map is read-only: an autonomous run (the AI owns the map,
   // passed in by the router) OR a launched simulation - the map is editable only while SCHEDULED
   // (UI "Draft" / "Scheduled"), see ADR-005. While the exercise is still loading, only the incoming
-  // (autonomous) flag applies.
+  // (autonomous) flag applies, so the frozen banner never flashes before the status is known.
   const launched = !!exercise && exercise.exercise_status !== 'SCHEDULED';
   const effectiveReadOnly = readOnly || launched;
+  const resolveReadOnlyMessage = () => {
+    if (readOnly) {
+      return t('This simulation is driven by the autonomous attack path. Its logic map is read-only.');
+    }
+    if (exercise?.exercise_scenario) {
+      return t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it, or update the scenario and run it again.');
+    }
+    return t('This simulation has been launched. Its logic map is read-only. Reset the simulation to edit it.');
+  };
+  const readOnlyMessage = resolveReadOnlyMessage();
   return (
     <Logic
       workflowId={exercise?.exercise_workflow_id}
       context="simulation"
       exerciseId={exerciseId}
       readOnly={effectiveReadOnly}
+      readOnlyMessage={effectiveReadOnly ? readOnlyMessage : undefined}
     />
   );
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Bring back the lock banner and fix the issue with the logic not editable after reset


### Testing Instructions

1. Start a simulation launch/stop/reset
2. Logic map should lock with a banner and should unlock after reset

### Related issues

* Closes #5045 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [NA] I wrote test cases for the relevant uses case
- [NA] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
