### PR TITLE
fix(chaining): keep a preserved event's whole tree when saving a step (#7236)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -436,10 +436,11 @@ public class ConditionService {
    * Deletes conditions linked to a given step, excluding specific condition IDs. Rules: - Always
    * remove the current condition-step link for this step. - Delete the condition only if, after
    * unlinking, it has no more condition-step links and no children. - Conditions whose IDs are in
-   * {@code excludedConditionIds} are unlinked but never deleted, so they can be re-linked later.
+   * {@code excludedConditionIds}, and every descendant of those, are left completely untouched: not
+   * unlinked, not saved, not deleted.
    *
    * @param stepId step identifier
-   * @param excludedConditionIds condition IDs to preserve (unlink only, never delete)
+   * @param excludedConditionIds root condition IDs to preserve, subtree included
    */
   public void deleteAllConditionsByStepId(String stepId, List<String> excludedConditionIds) {
     List<Condition> conditions = findAllConditionsByStepId(stepId);
@@ -456,7 +457,9 @@ public class ConditionService {
       // ROOT ids it keeps. Unlinking a leaf and then deleting it (it has no other link and no
       // children of its own) left the surviving parent referencing a deleted instance, and the step
       // merge that follows failed the whole save with ObjectDeletedException.
-      if (preserved.contains(condition.getId())) {
+      // Guard the id explicitly: `preserved` may be an immutable Set, whose contains(null) throws.
+      // A condition with no id was never persisted, so no caller can have named it as preserved.
+      if (condition.getId() != null && preserved.contains(condition.getId())) {
         continue;
       }
 
@@ -486,10 +489,13 @@ public class ConditionService {
       return Set.of();
     }
     Set<String> preserved = new HashSet<>();
-    Deque<String> pending = new ArrayDeque<>(rootIds);
+    // Nulls are filtered on the way IN, not on pop: the caller's list is API input and may carry a
+    // null entry, and ArrayDeque rejects nulls on insertion.
+    Deque<String> pending =
+        rootIds.stream().filter(Objects::nonNull).collect(Collectors.toCollection(ArrayDeque::new));
     while (!pending.isEmpty()) {
       String id = pending.pop();
-      if (id == null || !preserved.add(id)) {
+      if (!preserved.add(id)) {
         continue;
       }
       conditionRepository
@@ -497,7 +503,10 @@ public class ConditionService {
           .filter(condition -> condition.getConditionChildren() != null)
           .ifPresent(
               condition ->
-                  condition.getConditionChildren().forEach(child -> pending.push(child.getId())));
+                  condition.getConditionChildren().stream()
+                      .map(Condition::getId)
+                      .filter(Objects::nonNull)
+                      .forEach(pending::push));
     }
     return preserved;
   }

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -447,16 +447,21 @@ public class ConditionService {
       return;
     }
 
-    Set<String> excluded =
-        excludedConditionIds == null ? Set.of() : new HashSet<>(excludedConditionIds);
+    Set<String> preserved = withDescendants(excludedConditionIds);
 
     for (Condition condition : conditions) {
-      unlinkFromStep(condition, stepId);
-      Condition persisted = conditionRepository.save(condition);
-
-      if (excluded.contains(persisted.getId())) {
+      // A preserved condition is left completely untouched, subtree included. Its children are
+      // linked to this step too - createConditionTree links every node of an event's tree, the root
+      // with is_root=true and the leaves with is_root=false - while the caller only ever names the
+      // ROOT ids it keeps. Unlinking a leaf and then deleting it (it has no other link and no
+      // children of its own) left the surviving parent referencing a deleted instance, and the step
+      // merge that follows failed the whole save with ObjectDeletedException.
+      if (preserved.contains(condition.getId())) {
         continue;
       }
+
+      unlinkFromStep(condition, stepId);
+      Condition persisted = conditionRepository.save(condition);
 
       boolean hasNoStepLinks =
           persisted.getConditionSteps() == null || persisted.getConditionSteps().isEmpty();
@@ -466,6 +471,35 @@ public class ConditionService {
         conditionRepository.delete(persisted);
       }
     }
+  }
+
+  /**
+   * The given condition ids plus every descendant of them, so preserving a condition preserves the
+   * whole tree hanging off it.
+   *
+   * <p>Callers name the ROOT conditions they keep (a step's {@code step_condition_ids}), but an
+   * event's leaves are separate rows linked to the same step, so they have to be derived here
+   * rather than trusted from the input.
+   */
+  private Set<String> withDescendants(List<String> rootIds) {
+    if (rootIds == null || rootIds.isEmpty()) {
+      return Set.of();
+    }
+    Set<String> preserved = new HashSet<>();
+    Deque<String> pending = new ArrayDeque<>(rootIds);
+    while (!pending.isEmpty()) {
+      String id = pending.pop();
+      if (id == null || !preserved.add(id)) {
+        continue;
+      }
+      conditionRepository
+          .findById(id)
+          .filter(condition -> condition.getConditionChildren() != null)
+          .ifPresent(
+              condition ->
+                  condition.getConditionChildren().forEach(child -> pending.push(child.getId())));
+    }
+    return preserved;
   }
 
   // -- CONDITION PERSISTENCE HELPERS --

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -448,7 +448,11 @@ public class ConditionService {
       return;
     }
 
-    Set<String> preserved = withDescendants(excludedConditionIds);
+    // Null entries are dropped defensively: the caller's list is API input.
+    Set<String> excluded =
+        excludedConditionIds == null
+            ? Set.of()
+            : excludedConditionIds.stream().filter(Objects::nonNull).collect(Collectors.toSet());
 
     for (Condition condition : conditions) {
       // A preserved condition is left completely untouched, subtree included. Its children are
@@ -457,9 +461,7 @@ public class ConditionService {
       // ROOT ids it keeps. Unlinking a leaf and then deleting it (it has no other link and no
       // children of its own) left the surviving parent referencing a deleted instance, and the step
       // merge that follows failed the whole save with ObjectDeletedException.
-      // Guard the id explicitly: `preserved` may be an immutable Set, whose contains(null) throws.
-      // A condition with no id was never persisted, so no caller can have named it as preserved.
-      if (condition.getId() != null && preserved.contains(condition.getId())) {
+      if (isPreserved(condition, excluded)) {
         continue;
       }
 
@@ -477,38 +479,30 @@ public class ConditionService {
   }
 
   /**
-   * The given condition ids plus every descendant of them, so preserving a condition preserves the
-   * whole tree hanging off it.
+   * Whether the condition is named in the excluded ids, or descends from a condition that is, so
+   * preserving a condition preserves the whole tree hanging off it.
    *
    * <p>Callers name the ROOT conditions they keep (a step's {@code step_condition_ids}), but an
-   * event's leaves are separate rows linked to the same step, so they have to be derived here
-   * rather than trusted from the input.
+   * event's leaves are separate rows linked to the same step, so preservation has to be derived by
+   * walking up the parent chain rather than trusted from the input. The walk stays on entities
+   * already in the persistence context (every node of a linked tree is linked to the step itself,
+   * and reading a lazy parent's id does not initialize its proxy), so no per-node repository lookup
+   * is needed. The visited set makes the walk terminate even on a corrupted parent chain forming a
+   * cycle.
    */
-  private Set<String> withDescendants(List<String> rootIds) {
-    if (rootIds == null || rootIds.isEmpty()) {
-      return Set.of();
+  private boolean isPreserved(Condition condition, Set<String> excludedConditionIds) {
+    if (excludedConditionIds.isEmpty()) {
+      return false;
     }
-    Set<String> preserved = new HashSet<>();
-    // Nulls are filtered on the way IN, not on pop: the caller's list is API input and may carry a
-    // null entry, and ArrayDeque rejects nulls on insertion.
-    Deque<String> pending =
-        rootIds.stream().filter(Objects::nonNull).collect(Collectors.toCollection(ArrayDeque::new));
-    while (!pending.isEmpty()) {
-      String id = pending.pop();
-      if (!preserved.add(id)) {
-        continue;
+    Set<String> visited = new HashSet<>();
+    for (Condition current = condition;
+        current != null && current.getId() != null && visited.add(current.getId());
+        current = current.getConditionParent()) {
+      if (excludedConditionIds.contains(current.getId())) {
+        return true;
       }
-      conditionRepository
-          .findById(id)
-          .filter(condition -> condition.getConditionChildren() != null)
-          .ifPresent(
-              condition ->
-                  condition.getConditionChildren().stream()
-                      .map(Condition::getId)
-                      .filter(Objects::nonNull)
-                      .forEach(pending::push));
     }
-    return preserved;
+    return false;
   }
 
   // -- CONDITION PERSISTENCE HELPERS --

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -18,6 +18,7 @@ import io.openaev.rest.exception.WorkflowNotEditableException;
 import io.openaev.utils.ConditionUtils;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -1450,7 +1451,7 @@ public class ConditionServiceTest {
     }
 
     @Test
-    void shouldPreserveExcludedCondition_whenUnlinkedButInExclusionList() {
+    void shouldLeaveExcludedConditionUntouched_whenInExclusionList() {
       String removedStepId = "step-A";
 
       Condition condition = new Condition();
@@ -1460,14 +1461,67 @@ public class ConditionServiceTest {
       conditionService.linkToStep(condition, stepA, true);
 
       when(conditionRepository.findAllLinkedToStepId(removedStepId)).thenReturn(List.of(condition));
-      when(conditionRepository.save(any(Condition.class)))
-          .thenAnswer(invocation -> invocation.getArgument(0));
+      when(conditionRepository.findById("cond-excluded")).thenReturn(Optional.of(condition));
 
       conditionService.deleteAllConditionsByStepId(removedStepId, List.of("cond-excluded"));
 
-      verify(conditionRepository).save(condition);
+      // Untouched means untouched: not unlinked, not saved, not deleted. Unlinking a preserved node
+      // and saving it is what left a surviving parent pointing at a deleted child, failing the step
+      // merge with ObjectDeletedException.
+      verify(conditionRepository, never()).save(any());
       verify(conditionRepository, never()).delete(any());
-      assertTrue(condition.getConditionSteps().isEmpty());
+      assertEquals(1, condition.getConditionSteps().size());
+      assertEquals(removedStepId, condition.getConditionSteps().getFirst().getStep().getId());
+    }
+
+    @Test
+    void shouldLeaveTheChildrenOfAnExcludedConditionUntouched_whenOnlyItsRootIsNamed() {
+      String removedStepId = "step-A";
+      Step stepA = new Step();
+      stepA.setId(removedStepId);
+
+      // createConditionTree links EVERY node of an event's tree to the step, but the caller only
+      // ever
+      // names the ROOT it keeps, so the child has to be derived from the root.
+      Condition root = new Condition();
+      root.setId("cond-root");
+      Condition child = new Condition();
+      child.setId("cond-child");
+      child.setConditionParent(root);
+      root.setConditionChildren(List.of(child));
+      conditionService.linkToStep(root, stepA, true);
+      conditionService.linkToStep(child, stepA, false);
+
+      when(conditionRepository.findAllLinkedToStepId(removedStepId))
+          .thenReturn(List.of(root, child));
+      when(conditionRepository.findById("cond-root")).thenReturn(Optional.of(root));
+      when(conditionRepository.findById("cond-child")).thenReturn(Optional.of(child));
+
+      conditionService.deleteAllConditionsByStepId(removedStepId, List.of("cond-root"));
+
+      verify(conditionRepository, never()).save(any());
+      verify(conditionRepository, never()).delete(any());
+      assertEquals(1, child.getConditionSteps().size());
+    }
+
+    @Test
+    void shouldTolerateANullEntryInTheExclusionList() {
+      String removedStepId = "step-A";
+
+      Condition condition = new Condition();
+      condition.setId("cond-deleted");
+      Step stepA = new Step();
+      stepA.setId(removedStepId);
+      conditionService.linkToStep(condition, stepA, true);
+
+      when(conditionRepository.findAllLinkedToStepId(removedStepId)).thenReturn(List.of(condition));
+      when(conditionRepository.save(any(Condition.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      conditionService.deleteAllConditionsByStepId(
+          removedStepId, Arrays.asList(null, "cond-other"));
+
+      verify(conditionRepository).delete(condition);
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -1461,7 +1461,6 @@ public class ConditionServiceTest {
       conditionService.linkToStep(condition, stepA, true);
 
       when(conditionRepository.findAllLinkedToStepId(removedStepId)).thenReturn(List.of(condition));
-      when(conditionRepository.findById("cond-excluded")).thenReturn(Optional.of(condition));
 
       conditionService.deleteAllConditionsByStepId(removedStepId, List.of("cond-excluded"));
 
@@ -1482,7 +1481,8 @@ public class ConditionServiceTest {
 
       // createConditionTree links EVERY node of an event's tree to the step, but the caller only
       // ever
-      // names the ROOT it keeps, so the child has to be derived from the root.
+      // names the ROOT it keeps, so the child's preservation has to be derived from its parent
+      // chain.
       Condition root = new Condition();
       root.setId("cond-root");
       Condition child = new Condition();
@@ -1494,14 +1494,57 @@ public class ConditionServiceTest {
 
       when(conditionRepository.findAllLinkedToStepId(removedStepId))
           .thenReturn(List.of(root, child));
-      when(conditionRepository.findById("cond-root")).thenReturn(Optional.of(root));
-      when(conditionRepository.findById("cond-child")).thenReturn(Optional.of(child));
 
       conditionService.deleteAllConditionsByStepId(removedStepId, List.of("cond-root"));
 
       verify(conditionRepository, never()).save(any());
       verify(conditionRepository, never()).delete(any());
       assertEquals(1, child.getConditionSteps().size());
+    }
+
+    @Test
+    void shouldTerminate_whenACorruptedParentChainFormsACycle() {
+      String removedStepId = "step-A";
+      Step stepA = new Step();
+      stepA.setId(removedStepId);
+
+      // Corrupted data: two conditions each claiming the other as parent. The preservation walk
+      // must terminate instead of looping forever, and neither matches the exclusion list.
+      Condition a = new Condition();
+      a.setId("cond-a");
+      Condition b = new Condition();
+      b.setId("cond-b");
+      a.setConditionParent(b);
+      b.setConditionParent(a);
+      conditionService.linkToStep(a, stepA, true);
+      conditionService.linkToStep(b, stepA, false);
+
+      when(conditionRepository.findAllLinkedToStepId(removedStepId)).thenReturn(List.of(a, b));
+      when(conditionRepository.save(any(Condition.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      conditionService.deleteAllConditionsByStepId(removedStepId, List.of("cond-unrelated"));
+
+      verify(conditionRepository, times(2)).save(any(Condition.class));
+    }
+
+    @Test
+    void shouldNotPreserveACondition_whenItHasNoIdYet() {
+      String removedStepId = "step-A";
+      Step stepA = new Step();
+      stepA.setId(removedStepId);
+
+      // A condition with no id was never persisted, so no caller can have named it as preserved.
+      Condition condition = new Condition();
+      conditionService.linkToStep(condition, stepA, true);
+
+      when(conditionRepository.findAllLinkedToStepId(removedStepId)).thenReturn(List.of(condition));
+      when(conditionRepository.save(any(Condition.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      conditionService.deleteAllConditionsByStepId(removedStepId, List.of("cond-excluded"));
+
+      verify(conditionRepository).delete(condition);
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
@@ -9,8 +9,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.IntegrationTest;
 import io.openaev.api.chaining.dto.ConditionCreateInput;
+import io.openaev.api.chaining.dto.StepInput;
 import io.openaev.api.chaining.dto.StepsCreateInput;
 import io.openaev.database.model.*;
+import io.openaev.database.repository.ConditionRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
@@ -48,7 +50,7 @@ class StepServiceIntegrationTest extends IntegrationTest {
 
   @Autowired private StepRepository stepRepository;
   @Autowired private ConditionService conditionService;
-  @Autowired private io.openaev.database.repository.ConditionRepository conditionRepository;
+  @Autowired private ConditionRepository conditionRepository;
   @Autowired private WorkflowComposer workflowComposer;
   @Autowired private ExerciseComposer simulationComposer;
   @MockitoBean private InjectorContractService injectorContractService;
@@ -271,8 +273,8 @@ class StepServiceIntegrationTest extends IntegrationTest {
     // does.
     // The child used to be unlinked and then deleted while its preserved parent still referenced
     // it, and the step merge that followed failed the save with ObjectDeletedException.
-    io.openaev.api.chaining.dto.StepInput updateInput =
-        io.openaev.api.chaining.dto.StepInput.builder()
+    StepInput updateInput =
+        StepInput.builder()
             .workflowId(workflow.getId())
             .stepAction(StepActionClass.INJECT_EXECUTION)
             .conditionIds(List.of(rootId))

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
@@ -47,6 +47,8 @@ class StepServiceIntegrationTest extends IntegrationTest {
   @MockitoSpyBean private StepService spyStepService;
 
   @Autowired private StepRepository stepRepository;
+  @Autowired private ConditionService conditionService;
+  @Autowired private io.openaev.database.repository.ConditionRepository conditionRepository;
   @Autowired private WorkflowComposer workflowComposer;
   @Autowired private ExerciseComposer simulationComposer;
   @MockitoBean private InjectorContractService injectorContractService;
@@ -236,6 +238,54 @@ class StepServiceIntegrationTest extends IntegrationTest {
 
     verify(spyStepService, atLeastOnce()).saveStep(any());
     assertTrue(TestTransaction.isFlaggedForRollback());
+  }
+
+  @Test
+  void should_update_a_step_whose_preserved_condition_tree_has_children()
+      throws JsonProcessingException, ChainingException {
+    // -- PREPARE --
+    // A step gated by an event: createConditionTree links EVERY node of the tree to the step - the
+    // root with is_root=true, its leaves with is_root=false.
+    InjectInput injectInput = mapper.readValue(injectInputJson, InjectInput.class);
+    Workflow workflow =
+        workflowComposer
+            .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+            .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+            .persist()
+            .get();
+    StepsCreateInput.StepInput createInput = buildInvalidInput(); // root + one child
+    createInput.setDataStep(injectInput);
+    Step step = spyStepService.createStepTemplate(workflow, createInput);
+
+    List<Condition> linked = conditionService.findAllConditionsByStepId(step.getId());
+    String rootId =
+        linked.stream()
+            .filter(c -> c.getConditionParent() == null)
+            .map(Condition::getId)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(2, linked.size(), "the tree's root AND its child are linked to the step");
+
+    // -- EXECUTE --
+    // Editing the action preserves that tree by naming its ROOT only, exactly as the logic map
+    // does.
+    // The child used to be unlinked and then deleted while its preserved parent still referenced
+    // it, and the step merge that followed failed the save with ObjectDeletedException.
+    io.openaev.api.chaining.dto.StepInput updateInput =
+        io.openaev.api.chaining.dto.StepInput.builder()
+            .workflowId(workflow.getId())
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .conditionIds(List.of(rootId))
+            .dataStep(injectInput)
+            .build();
+
+    Step updated = spyStepService.updateStepTemplate(step.getId(), updateInput);
+
+    // -- ASSERT --
+    assertNotNull(updated);
+    Condition survivingRoot = conditionRepository.findById(rootId).orElse(null);
+    assertNotNull(survivingRoot, "the preserved event survives");
+    assertEquals(1, survivingRoot.getConditionChildren().size(), "and keeps its child");
   }
 
   private StepsCreateInput.StepInput buildInvalidInputCondition() {


### PR DESCRIPTION
Fixes #7236 (reported as OpenAEV-Platform/filigran-private#258).

### Scope is wider than reported

Reported as *"after simulation reset user can not edit logic"*. The reset turns out to be incidental - I reproduced the identical failure against the live API on a **scenario that was never run**:

| case | result |
|---|---|
| action whose gating event has a **leaf** condition linked to it | **400** `ObjectDeletedException` |
| action whose event has only its root linked | 200 |
| action with no event | 200 |

So **any action gated by a non-trivial event was unsaveable**, on scenarios and simulations alike. A reset is just a moment where people go back and edit the logic.

### Root cause

`createConditionTree` links **every node** of an event's tree to the step - root `is_root=true`, leaves `is_root=false` - but a client can only name the **root** ids it keeps (`step_condition_ids`).

`deleteAllConditionsByStepId` then unlinks each linked condition and deletes any that ends up with no step link and no children. A leaf of a *preserved* event matches both, so it was deleted - while its preserved parent still held it in `conditionChildren`. The `saveStep` that follows cascades a merge onto that parent, reaches the deleted child, and Hibernate aborts the whole save.

### Fix

Preserve the whole subtree of a preserved condition, and leave it entirely untouched - not even unlinked, since `linkExistingConditionsToStep` re-links only roots and `linkToStep` is idempotent, making the unlink/re-link round trip a no-op. The step's own MAPPER conditions are still fully replaced, which is what the update intends.

Following review, preservation is derived fully in memory: instead of one `findById` (plus a lazy children load) per node of the preserved trees, each linked condition walks its `conditionParent` chain - the parents of a linked leaf are linked to the step themselves, so they are already in the persistence context and the walk issues no extra query. A visited set keeps the walk terminating even if a corrupted parent chain forms a cycle.

### Verification

Integration test added, run against the code **with and without** the fix:

| | result |
|---|---|
| without the fix | `ObjectDeletedException: deleted instance passed to merge: [Condition#<null>]` - the same error the live API returned |
| with the fix | whole class green |

The test asserts both that the save succeeds and that the preserved event still has its child afterwards, so the fix cannot regress into silently dropping the leaf. Unit tests additionally cover: a preserved root's child left untouched, a null entry in the exclusion list, a corrupted parent-chain cycle, and a never-persisted condition (null id).

The branch was rebased onto current main (the interim merge commit was flattened); all commits are signed.
