### PR TITLE
fix(chaining): lay the logic map back out as one column per MITRE tactic (#7240)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { OutputProviderEntry } from '../../../../../../admin/components/chaining/logic/logic-flow-helpers';
 import {
   ACTION_NODE_HEIGHT,
   buildLogicGraphLayout,
@@ -14,6 +15,16 @@ const action = (stepConditionIds: string[] = []): ActionMeta =>
   ({ step_condition_ids: stepConditionIds } as unknown as ActionMeta);
 const event = (): EventMeta =>
   ({ formData: { conditionGroups: [] } } as unknown as EventMeta);
+/** An event listening on one finding field, so `outputProviders` can wire an inferred producer edge. */
+const eventOn = (field: string): EventMeta =>
+  ({
+    formData: {
+      conditionGroups: [{
+        conditions: [{ field }],
+        subGroups: [],
+      }],
+    },
+  } as unknown as EventMeta);
 
 /** Do two boxes share any surface? Touching edges do NOT count as overlapping. */
 const overlaps = (
@@ -279,23 +290,53 @@ describe('buildLogicGraphLayout tactic columns', () => {
     expect(ungatedGap).toBeLessThan(nodeById.gate.width);
   });
 
-  it('stacks a column\'s cards in causal order (dependency depth first)', () => {
-    // late is gated by a trigger fed by early, so it sits below early in their shared column.
+  it('stacks a column\'s gated cards on top, ungated ones at the bottom', () => {
+    // Only `gated` has a trigger to align with, so it goes first and the lane's card stays near the
+    // top of the canvas instead of hanging under a stack of ungated cards.
     const { nodeById } = buildLogicGraphLayout({
       actionMetas: {
-        late: action(['gate']),
-        early: action(),
+        ungated1: action(),
+        gated: action(['gate']),
+        ungated2: action(),
       },
       eventMetas: { gate: event() },
       outputProviders: {},
       tacticForStep: {
-        late: 'Discovery',
-        early: 'Discovery',
+        ungated1: 'Discovery',
+        gated: 'Discovery',
+        ungated2: 'Discovery',
       },
       tacticOrder: { Discovery: 1 },
     });
-    expect(nodeById.late.x).toBe(nodeById.early.x);
-    expect(nodeById.early.y).toBeLessThan(nodeById.late.y);
+    expect(nodeById.gated.x).toBe(nodeById.ungated1.x);
+    expect(nodeById.gated.y).toBeLessThan(nodeById.ungated1.y);
+    expect(nodeById.gated.y).toBeLessThan(nodeById.ungated2.y);
+    // Which is the point: the trigger sits level with the topmost row, not far below it.
+    expect(nodeById.gate.y + nodeById.gate.height / 2)
+      .toBe(nodeById.gated.y + nodeById.gated.height / 2);
+    expect(nodeById.gate.y).toBeLessThan(nodeById.ungated1.y);
+  });
+
+  it('orders the gated cards among themselves by dependency depth', () => {
+    // deep is gated by `late`, a trigger fed by shallow's "port" output, so it comes after shallow.
+    const { nodeById } = buildLogicGraphLayout({
+      actionMetas: {
+        deep: action(['late']),
+        shallow: action(['first']),
+      },
+      eventMetas: {
+        first: event(),
+        late: eventOn('port'),
+      },
+      outputProviders: { port: [{ stepId: 'shallow' } as unknown as OutputProviderEntry] },
+      tacticForStep: {
+        deep: 'Discovery',
+        shallow: 'Discovery',
+      },
+      tacticOrder: { Discovery: 1 },
+    });
+    expect(nodeById.deep.x).toBe(nodeById.shallow.x);
+    expect(nodeById.shallow.y).toBeLessThan(nodeById.deep.y);
   });
 
   it('falls a tactic missing from the order map to the end (after the known ones)', () => {

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
@@ -209,6 +209,76 @@ describe('buildLogicGraphLayout tactic columns', () => {
     expect(nodeById.smbFound.x).toBeLessThan(nodeById.exec2.x);
   });
 
+  it('collapses the event lane of a tactic that has no event, tightening the bands', () => {
+    // Three tactics, no event anywhere: nothing has to be routed between the bands, so none of them
+    // may reserve an event card's worth of empty canvas.
+    const { columns, nodeById } = buildLogicGraphLayout({
+      actionMetas: {
+        a1: action(),
+        a2: action(),
+        a3: action(),
+      },
+      eventMetas: {},
+      outputProviders: {},
+      tacticForStep: {
+        a1: 'Discovery',
+        a2: 'Lateral Movement',
+        a3: 'Impact',
+      },
+      tacticOrder: {
+        'Discovery': 1,
+        'Lateral Movement': 2,
+        'Impact': 3,
+      },
+    });
+    expect(columns).toHaveLength(3);
+    // The first band starts at the origin: no empty lane pushes it right.
+    expect(columns[0].x).toBe(0);
+    for (let i = 1; i < columns.length; i += 1) {
+      const gap = columns[i].x - (columns[i - 1].x + columns[i - 1].width);
+      expect(gap).toBeGreaterThan(0); // still non-overlapping
+      expect(gap).toBeLessThan(nodeById.a1.width); // but too tight to hide an unused card slot
+    }
+  });
+
+  it('keeps lane room only where an event actually sits', () => {
+    // Only the second tactic is gated: its lane must be wide enough for the trigger card, while the
+    // first tactic (no event) stays flush against it.
+    const { columns, nodeById } = buildLogicGraphLayout({
+      actionMetas: {
+        a1: action(),
+        a2: action(['gate']),
+        a3: action(),
+      },
+      eventMetas: { gate: event() },
+      outputProviders: {},
+      tacticForStep: {
+        a1: 'Discovery',
+        a2: 'Lateral Movement',
+        a3: 'Impact',
+      },
+      tacticOrder: {
+        'Discovery': 1,
+        'Lateral Movement': 2,
+        'Impact': 3,
+      },
+    });
+    const [discovery, lateral, impact] = columns;
+
+    // Lane present between Discovery and Lateral Movement: the gap fits the trigger card, and the
+    // trigger sits inside it (outside both bands).
+    const gatedGap = lateral.x - (discovery.x + discovery.width);
+    expect(gatedGap).toBeGreaterThanOrEqual(nodeById.gate.width);
+    expect(nodeById.gate.x).toBeGreaterThanOrEqual(discovery.x + discovery.width);
+    expect(nodeById.gate.x + nodeById.gate.width).toBeLessThanOrEqual(lateral.x);
+
+    // No lane between Lateral Movement and Impact: that gap stays tight.
+    const ungatedGap = impact.x - (lateral.x + lateral.width);
+    expect(ungatedGap).toBeGreaterThan(0);
+    expect(ungatedGap).toBeLessThan(gatedGap);
+    expect(ungatedGap).toBeLessThan(nodeById.gate.width);
+  });
+
   it('stacks a column\'s cards in causal order (dependency depth first)', () => {
     // late is gated by a trigger fed by early, so it sits below early in their shared column.
     const { nodeById } = buildLogicGraphLayout({

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   ACTION_NODE_HEIGHT,
   buildLogicGraphLayout,
+  type LogicGraphColumn,
+  type LogicGraphNode,
 } from '../../../../../../admin/components/chaining/logic/logic-graph/layout';
 import type { ActionMeta, EventMeta } from '../../../../../../admin/components/chaining/logic/types';
 
@@ -13,8 +15,24 @@ const action = (stepConditionIds: string[] = []): ActionMeta =>
 const event = (): EventMeta =>
   ({ formData: { conditionGroups: [] } } as unknown as EventMeta);
 
-// A three-step chain: e1 gates a1, a1 -> e2 (inferred, elided here) ... a2 gated by e2, a3 gated by
-// e3. Discovery = a1 + a2, Lateral Movement = a3.
+/** Do two boxes share any surface? Touching edges do NOT count as overlapping. */
+const overlaps = (
+  a: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  },
+  b: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  },
+) => a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height;
+
+// A three-step chain: e1 gates a1, a2 is gated by e2, a3 by e3. Discovery = a1 + a2, Lateral
+// Movement = a3.
 const build = () => buildLogicGraphLayout({
   actionMetas: {
     a1: action(['e1']),
@@ -38,54 +56,57 @@ const build = () => buildLogicGraphLayout({
   },
 });
 
-describe('buildLogicGraphLayout dependency-depth layout', () => {
-  it('lays nodes out left-to-right by dependency depth, NOT by tactic', () => {
+describe('buildLogicGraphLayout tactic-column layout', () => {
+  it('puts every action of a tactic in that tactic\'s column, ordered by kill-chain phase', () => {
     const { nodeById } = build();
 
-    // A gating trigger sits strictly left of the action it gates (the causal wave reads L-to-R).
+    // Same tactic -> same column, stacked; different tactic -> a column further right (phase order).
+    expect(nodeById.a1.x).toBe(nodeById.a2.x);
+    expect(nodeById.a1.y).not.toBe(nodeById.a2.y);
+    expect(nodeById.a3.x).toBeGreaterThan(nodeById.a1.x);
+  });
+
+  it('places a gating event in the lane immediately left of the action it gates', () => {
+    const { nodeById } = build();
     expect(nodeById.e1.x).toBeLessThan(nodeById.a1.x);
     expect(nodeById.e2.x).toBeLessThan(nodeById.a2.x);
     expect(nodeById.e3.x).toBeLessThan(nodeById.a3.x);
-
-    // a1 and a2 share a tactic but are on the SAME dependency layer (both gated by a first-wave
-    // trigger), so they stack in the same column instead of being forced apart by tactic.
-    expect(nodeById.a1.x).toBe(nodeById.a2.x);
-    expect(nodeById.a1.y).not.toBe(nodeById.a2.y);
+    // Aligned on its action's center, so the event -> action arrow stays horizontal.
+    expect(nodeById.e1.y + nodeById.e1.height / 2).toBe(nodeById.a1.y + nodeById.a1.height / 2);
   });
 
   it('normalizes the layout to the origin (no negative coordinates)', () => {
-    const { nodes, groups, bbox } = build();
+    const { nodes, columns, bbox } = build();
     for (const node of nodes) {
       expect(node.x).toBeGreaterThanOrEqual(0);
       expect(node.y).toBeGreaterThanOrEqual(0);
     }
-    for (const group of groups) {
-      expect(group.x).toBeGreaterThanOrEqual(0);
-      expect(group.y).toBeGreaterThanOrEqual(0);
+    for (const column of columns) {
+      expect(column.x).toBeGreaterThanOrEqual(0);
+      expect(column.y).toBeGreaterThanOrEqual(0);
     }
     expect(bbox.minX).toBe(0);
     expect(bbox.minY).toBe(0);
   });
 });
 
-describe('buildLogicGraphLayout tactic groups', () => {
-  it('emits one padded group hull per tactic, ordered by phase for stable colours', () => {
-    const { groups } = build();
-    expect(groups.map(g => g.tactic)).toEqual(['Discovery', 'Lateral Movement']);
-    expect(groups.map(g => g.order)).toEqual([1, 2]);
-    for (const group of groups) {
-      expect(group.width).toBeGreaterThan(0);
-      expect(group.height).toBeGreaterThan(0);
-      expect(group.headerHeight).toBeGreaterThan(0);
+describe('buildLogicGraphLayout tactic columns', () => {
+  it('emits exactly one band per tactic, ordered by phase for stable colours', () => {
+    const { columns } = build();
+    expect(columns.map(c => c.tactic)).toEqual(['Discovery', 'Lateral Movement']);
+    expect(columns.map(c => c.order)).toEqual([1, 2]);
+    for (const column of columns) {
+      expect(column.width).toBeGreaterThan(0);
+      expect(column.height).toBeGreaterThan(0);
+      expect(column.headerHeight).toBeGreaterThan(0);
     }
   });
 
-  it('pads each hull around its action cards (cards never sit flush on the border)', () => {
-    const { nodeById, groups } = build();
-    const discovery = groups.find(g => g.tactic === 'Discovery')!;
+  it('pads each band around its action cards (cards never sit flush on the border)', () => {
+    const { nodeById, columns } = build();
+    const discovery = columns.find(c => c.tactic === 'Discovery')!;
     for (const id of ['a1', 'a2']) {
       const node = nodeById[id];
-      // Horizontal + bottom padding: the card is strictly inside the hull on every padded side.
       expect(node.x).toBeGreaterThan(discovery.x);
       expect(node.x + node.width).toBeLessThan(discovery.x + discovery.width);
       expect(node.y + node.height).toBeLessThan(discovery.y + discovery.height);
@@ -94,31 +115,121 @@ describe('buildLogicGraphLayout tactic groups', () => {
     }
   });
 
-  it('bounds every action of a tactic even when they span several dependency layers', () => {
-    // a1 (layer 0) and a2 (gated by e2, a later layer) are both Discovery: the hull must span both.
-    const { nodeById, groups } = buildLogicGraphLayout({
+  it('never overlaps anything: band vs band, card vs card, band vs foreign card', () => {
+    // A denser graph than `build()`: several tactics, several actions each, and events shared
+    // between actions of the same tactic (the shape that made the old bounding hulls overlap).
+    const { nodes, columns, nodeById } = buildLogicGraphLayout({
       actionMetas: {
-        a1: action(),
-        e2gate: action(['e2']),
+        scan1: action(),
+        scan2: action(),
+        exec1: action(['smbFound']),
+        exec2: action(['smbFound']),
+        disco1: action(['ldapFound']),
+        creds1: action(['event4']),
+        impair1: action(['event4']),
+        other1: action(),
       },
-      eventMetas: { e2: event() },
+      eventMetas: {
+        smbFound: event(),
+        ldapFound: event(),
+        event4: event(),
+      },
       outputProviders: {},
       tacticForStep: {
-        a1: 'Discovery',
-        e2gate: 'Discovery',
+        scan1: 'Reconnaissance',
+        scan2: 'Reconnaissance',
+        exec1: 'Execution',
+        exec2: 'Execution',
+        disco1: 'Discovery',
+        creds1: 'Credential Access',
+        impair1: 'Defense Impairment',
+        // other1 has no tactic at all -> the "Other" column.
+      },
+      tacticOrder: {
+        'Reconnaissance': 1,
+        'Execution': 2,
+        'Discovery': 3,
+        'Credential Access': 4,
+        'Defense Impairment': 5,
+      },
+    });
+
+    const box = (n: LogicGraphNode | LogicGraphColumn) => ({
+      x: n.x,
+      y: n.y,
+      width: n.width,
+      height: n.height,
+    });
+
+    // 1. No two tactic bands intersect.
+    for (let i = 0; i < columns.length; i += 1) {
+      for (let j = i + 1; j < columns.length; j += 1) {
+        expect(overlaps(box(columns[i]), box(columns[j]))).toBe(false);
+      }
+    }
+
+    // 2. No two cards intersect.
+    for (let i = 0; i < nodes.length; i += 1) {
+      for (let j = i + 1; j < nodes.length; j += 1) {
+        expect(overlaps(box(nodes[i]), box(nodes[j]))).toBe(false);
+      }
+    }
+
+    // 3. A band only ever contains its own tactic's action cards: every other card (foreign tactic,
+    //    and every event, which carries no TTP) stays fully outside it.
+    const tacticOfNode: Record<string, string> = {
+      scan1: 'Reconnaissance',
+      scan2: 'Reconnaissance',
+      exec1: 'Execution',
+      exec2: 'Execution',
+      disco1: 'Discovery',
+      creds1: 'Credential Access',
+      impair1: 'Defense Impairment',
+      other1: '',
+    };
+    for (const column of columns) {
+      for (const node of nodes) {
+        if (node.kind === 'action' && tacticOfNode[node.id] === column.tactic) continue;
+        expect(overlaps(box(node), box(column))).toBe(false);
+      }
+    }
+
+    // 4. One tactic per column: no two tactics share an x.
+    const tacticsByX = new Map<number, Set<string>>();
+    for (const node of nodes) {
+      if (node.kind !== 'action') continue;
+      const set = tacticsByX.get(node.x) ?? new Set<string>();
+      set.add(tacticOfNode[node.id]);
+      tacticsByX.set(node.x, set);
+    }
+    for (const set of tacticsByX.values()) expect(set.size).toBe(1);
+
+    // Sanity: the shared trigger sits left of both actions it gates.
+    expect(nodeById.smbFound.x).toBeLessThan(nodeById.exec1.x);
+    expect(nodeById.smbFound.x).toBeLessThan(nodeById.exec2.x);
+  });
+
+  it('stacks a column\'s cards in causal order (dependency depth first)', () => {
+    // late is gated by a trigger fed by early, so it sits below early in their shared column.
+    const { nodeById } = buildLogicGraphLayout({
+      actionMetas: {
+        late: action(['gate']),
+        early: action(),
+      },
+      eventMetas: { gate: event() },
+      outputProviders: {},
+      tacticForStep: {
+        late: 'Discovery',
+        early: 'Discovery',
       },
       tacticOrder: { Discovery: 1 },
     });
-    const discovery = groups.find(g => g.tactic === 'Discovery')!;
-    for (const id of ['a1', 'e2gate']) {
-      const node = nodeById[id];
-      expect(node.x).toBeGreaterThanOrEqual(discovery.x);
-      expect(node.x + node.width).toBeLessThanOrEqual(discovery.x + discovery.width);
-    }
+    expect(nodeById.late.x).toBe(nodeById.early.x);
+    expect(nodeById.early.y).toBeLessThan(nodeById.late.y);
   });
 
   it('falls a tactic missing from the order map to the end (after the known ones)', () => {
-    const { groups } = buildLogicGraphLayout({
+    const { columns } = buildLogicGraphLayout({
       actionMetas: {
         a1: action(),
         a2: action(),
@@ -133,10 +244,10 @@ describe('buildLogicGraphLayout tactic groups', () => {
       // come first alphabetically.
       tacticOrder: { 'Lateral Movement': 8 },
     });
-    expect(groups.map(g => g.tactic)).toEqual(['Lateral Movement', 'Alpha Unknown']);
+    expect(columns.map(c => c.tactic)).toEqual(['Lateral Movement', 'Alpha Unknown']);
   });
 
-  it('returns an empty layout (no groups) for an empty graph', () => {
+  it('returns an empty layout (no columns) for an empty graph', () => {
     const empty = buildLogicGraphLayout({
       actionMetas: {},
       eventMetas: {},
@@ -145,7 +256,7 @@ describe('buildLogicGraphLayout tactic groups', () => {
       tacticOrder: {},
     });
     expect(empty.nodes).toHaveLength(0);
-    expect(empty.groups).toHaveLength(0);
+    expect(empty.columns).toHaveLength(0);
     // Degenerate fallback bbox is still a real box.
     expect(empty.bbox.height).toBe(ACTION_NODE_HEIGHT);
   });

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts
@@ -102,10 +102,9 @@ describe('buildLogicGraphLayout tactic-column layout', () => {
 });
 
 describe('buildLogicGraphLayout tactic columns', () => {
-  it('emits exactly one band per tactic, ordered by phase for stable colours', () => {
+  it('emits exactly one band per tactic, in kill-chain phase order', () => {
     const { columns } = build();
     expect(columns.map(c => c.tactic)).toEqual(['Discovery', 'Lateral Movement']);
-    expect(columns.map(c => c.order)).toEqual([1, 2]);
     for (const column of columns) {
       expect(column.width).toBeGreaterThan(0);
       expect(column.height).toBeGreaterThan(0);

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
@@ -37,7 +37,7 @@ interface NodePosition {
   y: number;
 }
 
-// Distinct, mid-tone accents for the MITRE-tactic group hulls, cycled by the group's phase order.
+// Distinct, mid-tone accents for the MITRE-tactic column bands, cycled in kill-chain phase order.
 // Mid saturation/lightness reads on both the light and dark "paper" backgrounds once knocked back
 // to a low-alpha fill; the same colour drives the border and header label so a group reads as one.
 const TACTIC_GROUP_COLORS = [
@@ -193,9 +193,8 @@ const LogicGraph = ({
     [actionMetas],
   );
 
-  // Tactic name -> kill-chain phase order, so the layout orders the tactic groups by MITRE phase
-  // (keeping the lowest order when a tactic maps to several phases). Node positions come from
-  // dependency depth, not this order — it only makes the group hulls' colours/order deterministic.
+  // Tactic name -> kill-chain phase order, so the layout orders the tactic columns by MITRE phase
+  // (keeping the lowest order when a tactic maps to several phases).
   const tacticOrder = useMemo(() => {
     const order: Record<string, number> = {};
     for (const phase of Object.values(killChainPhasesMap as Record<string, KillChainPhase>)) {
@@ -495,21 +494,21 @@ const LogicGraph = ({
         onZoomChange={(zoom) => { zoomRef.current = zoom; }}
         onAutoLayout={readOnly ? undefined : handleAutoLayout}
       >
-        {/* MITRE-tactic groups: a rounded, padded hull behind the action cards that share a tactic,
-            with the tactic name as a header. Purely decorative — it groups the cards without ever
-            driving their positions (the causal left-to-right layout owns that). Rendered first so it
-            sits behind the connectors and cards, and never intercepts pointer events. */}
-        {layout.groups.map((group, index) => {
+        {/* MITRE-tactic columns: one padded band behind each tactic's action cards, headed by the
+            tactic name. The layout gives every tactic its own column, so bands are side by side and
+            can never overlap. Rendered first so they sit behind the connectors and cards, and they
+            never intercept pointer events. */}
+        {layout.columns.map((column, index) => {
           const color = tacticGroupColor(index);
           return (
             <div
-              key={`tactic-group-${group.tactic}`}
+              key={`tactic-col-${column.tactic}`}
               style={{
                 position: 'absolute',
-                left: group.x,
-                top: group.y,
-                width: group.width,
-                height: group.height,
+                left: column.x,
+                top: column.y,
+                width: column.width,
+                height: column.height,
                 pointerEvents: 'none',
                 borderRadius: 16,
                 backgroundColor: alpha(color, 0.06),
@@ -522,10 +521,11 @@ const LogicGraph = ({
                   position: 'absolute',
                   top: 0,
                   left: 0,
-                  height: group.headerHeight,
-                  maxWidth: '100%',
+                  height: column.headerHeight,
+                  width: '100%',
                   display: 'flex',
                   alignItems: 'center',
+                  justifyContent: 'center',
                   padding: '0 12px',
                   boxSizing: 'border-box',
                   overflow: 'hidden',
@@ -538,7 +538,7 @@ const LogicGraph = ({
                   color,
                 }}
               >
-                {group.tactic || t('Other')}
+                {column.tactic || t('Other')}
               </div>
             </div>
           );

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
@@ -37,22 +37,6 @@ interface NodePosition {
   y: number;
 }
 
-// Distinct, mid-tone accents for the MITRE-tactic column bands, cycled in kill-chain phase order.
-// Mid saturation/lightness reads on both the light and dark "paper" backgrounds once knocked back
-// to a low-alpha fill; the same colour drives the border and header label so a group reads as one.
-const TACTIC_GROUP_COLORS = [
-  '#5b8def', // blue
-  '#9b6dff', // violet
-  '#e0567a', // rose
-  '#f0a132', // amber
-  '#3fb27f', // green
-  '#48b0c7', // teal
-  '#c9508e', // magenta
-  '#8a8f2f', // olive
-];
-const tacticGroupColor = (index: number) =>
-  TACTIC_GROUP_COLORS[((index % TACTIC_GROUP_COLORS.length) + TACTIC_GROUP_COLORS.length) % TACTIC_GROUP_COLORS.length];
-
 /** Decode HTML entities that occasionally survive in orchestrator-authored titles ("&amp;" -> "&"). */
 const decodeEntities = (value?: string): string =>
   (value ?? '')
@@ -495,54 +479,54 @@ const LogicGraph = ({
         onAutoLayout={readOnly ? undefined : handleAutoLayout}
       >
         {/* MITRE-tactic columns: one padded band behind each tactic's action cards, headed by the
-            tactic name. The layout gives every tactic its own column, so bands are side by side and
-            can never overlap. Rendered first so they sit behind the connectors and cards, and they
-            never intercept pointer events. */}
-        {layout.columns.map((column, index) => {
-          const color = tacticGroupColor(index);
-          return (
+            tactic name. Every band uses the SAME theme blue — a real chain carries far too many
+            tactics for a colour cycle to stay legible, and near-identical hues would read as a
+            meaning they do not carry; the column and its header already identify the tactic. The
+            layout gives every tactic its own column, so bands are side by side and can never overlap.
+            Rendered first so they sit behind the connectors and cards, and they never intercept
+            pointer events. */}
+        {layout.columns.map(column => (
+          <div
+            key={`tactic-col-${column.tactic}`}
+            style={{
+              position: 'absolute',
+              left: column.x,
+              top: column.y,
+              width: column.width,
+              height: column.height,
+              pointerEvents: 'none',
+              borderRadius: 16,
+              backgroundColor: alpha(theme.palette.primary.main, 0.06),
+              border: `1px solid ${alpha(theme.palette.primary.main, 0.28)}`,
+              boxSizing: 'border-box',
+            }}
+          >
             <div
-              key={`tactic-col-${column.tactic}`}
               style={{
                 position: 'absolute',
-                left: column.x,
-                top: column.y,
-                width: column.width,
-                height: column.height,
-                pointerEvents: 'none',
-                borderRadius: 16,
-                backgroundColor: alpha(color, 0.06),
-                border: `1px solid ${alpha(color, 0.28)}`,
+                top: 0,
+                left: 0,
+                height: column.headerHeight,
+                width: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '0 12px',
                 boxSizing: 'border-box',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: '0.09em',
+                textTransform: 'uppercase',
+                color: theme.palette.primary.main,
               }}
             >
-              <div
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  height: column.headerHeight,
-                  width: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  padding: '0 12px',
-                  boxSizing: 'border-box',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  fontSize: 11,
-                  fontWeight: 700,
-                  letterSpacing: '0.09em',
-                  textTransform: 'uppercase',
-                  color,
-                }}
-              >
-                {column.tactic || t('Other')}
-              </div>
+              {column.tactic || t('Other')}
             </div>
-          );
-        })}
+          </div>
+        ))}
         <Connectors
           edges={routedEdges}
           width={contentSize.width}

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
@@ -9,10 +9,13 @@ export const TRIGGER_NODE_HEIGHT = 76;
 
 // -- Tactic-column tokens (px). Actions are laid out in one column per MITRE tactic (ordered by
 // kill-chain phase), and each gating event sits in a lane immediately to the left of the column it
-// feeds. Every tactic owns an exclusive horizontal stride, which is what makes the tactic bands
-// non-overlapping BY CONSTRUCTION (see buildLogicGraphLayout). --
+// feeds. Columns are laid out with a running cursor rather than a fixed stride, so a tactic whose
+// events are absent claims no lane width at all and its band sits right next to its neighbour. Each
+// tactic still owns an exclusive horizontal span, which is what keeps the bands non-overlapping BY
+// CONSTRUCTION (see buildLogicGraphLayout). --
 const EVENT_TO_COL_GAP = 60; // gap between an event lane and the action column it feeds
 const INTER_COLUMN_GAP = 90; // gap between one tactic column and the next column's event lane
+const ADJACENT_BAND_GAP = 40; // gap between two tactic bands with no event lane between them
 const ACTION_ROW_GAP = 40; // vertical gap between stacked actions in a column
 const EVENT_ROW_GAP = 24; // vertical gap when de-overlapping events sharing a lane
 const COLUMN_TOP_MARGIN = 56; // room above the top node, inside the band, for the tactic header
@@ -20,10 +23,6 @@ const BAND_TOP = 8; // top of the tactic band
 const BAND_PADDING_X = 18; // horizontal breathing room between a card and its band border
 const BAND_PADDING_BOTTOM = 20; // padding below the last card inside the band
 const BAND_HEADER_HEIGHT = 26; // room reserved at the top of a band for the tactic label
-// One tactic column spans its event lane + gap + action column; the next starts a stride further.
-const COLUMN_STRIDE = NODE_WIDTH + EVENT_TO_COL_GAP + NODE_WIDTH + INTER_COLUMN_GAP;
-const eventLaneX = (col: number) => col * COLUMN_STRIDE;
-const actionColX = (col: number) => col * COLUMN_STRIDE + NODE_WIDTH + EVENT_TO_COL_GAP;
 
 export type LogicGraphNodeKind = 'action' | 'trigger';
 
@@ -329,9 +328,9 @@ export const buildLogicGraphLayout = ({
   // immediately to the LEFT of its action's column, aligned to the action it gates so the
   // event -> action arrow stays horizontal.
   //
-  // Because every tactic owns an exclusive horizontal stride (event lane + gap + action column +
-  // gap), a tactic band can never intersect another band, nor a card of another tactic. That is the
-  // whole point of laying out by tactic rather than decorating a depth-ordered layout with per-tactic
+  // Because every tactic owns an exclusive horizontal span (event lane + gap + action column + gap),
+  // a tactic band can never intersect another band, nor a card of another tactic. That is the whole
+  // point of laying out by tactic rather than decorating a depth-ordered layout with per-tactic
   // bounding hulls: one tactic's actions would then scatter across several depth columns, so its hull
   // stretched over its neighbours' cards and every stacked hull's header landed on the card above.
   const actionIds = nodeIds.filter(id => kindById[id] === 'action');
@@ -355,6 +354,40 @@ export const buildLogicGraphLayout = ({
   });
   const colOfAction = (id: string) => colByTactic[tacticForStep[id] ?? ''] ?? 0;
 
+  // Which lane does each event belong to? The leftmost tactic among the actions it gates (orphan
+  // events, gating nothing, fall in column 0's lane). Resolved BEFORE the actions are positioned,
+  // because it only needs the column, never the Y — that is what lets an unused lane claim no width
+  // at all instead of reserving an empty card's worth of canvas between two tactics.
+  const laneOfEvent: Record<string, number> = {};
+  for (const [stepId, meta] of Object.entries(actionMetas)) {
+    if (kindById[stepId] !== 'action') continue;
+    const col = colOfAction(stepId);
+    for (const eventId of meta.step_condition_ids) {
+      if (!eventMetas[eventId]) continue;
+      const cur = laneOfEvent[eventId];
+      if (cur === undefined || col < cur) laneOfEvent[eventId] = col;
+    }
+  }
+  const laneCol = (id: string) => laneOfEvent[id] ?? 0;
+  const occupiedLanes = new Set(eventIds.map(laneCol));
+
+  // Walk the columns left to right with a running cursor: a column claims lane width only when its
+  // lane actually holds an event, and the gap to the next column shrinks to ADJACENT_BAND_GAP when
+  // that column has no lane either (nothing has to be routed through the space, so reserving a card's
+  // width there just pushed the bands apart for nothing).
+  const laneX: number[] = [];
+  const actionX: number[] = [];
+  let cursorX = 0;
+  uniqueTactics.forEach((_tactic, col) => {
+    laneX[col] = cursorX;
+    if (occupiedLanes.has(col)) cursorX += NODE_WIDTH + EVENT_TO_COL_GAP;
+    actionX[col] = cursorX;
+    cursorX += NODE_WIDTH
+      + (occupiedLanes.has(col + 1)
+        ? INTER_COLUMN_GAP
+        : ADJACENT_BAND_GAP + 2 * BAND_PADDING_X);
+  });
+
   // Actions per column, stacked in causal order (dependency depth, then input order to stay stable).
   const actionsByCol: Record<number, string[]> = {};
   for (const id of actionIds) (actionsByCol[colOfAction(id)] ??= []).push(id);
@@ -375,7 +408,7 @@ export const buildLogicGraphLayout = ({
         id,
         kind: 'action',
         layer: col,
-        x: actionColX(col),
+        x: actionX[col],
         y,
         width: NODE_WIDTH,
         height: ACTION_NODE_HEIGHT,
@@ -386,44 +419,35 @@ export const buildLogicGraphLayout = ({
     }
   });
 
-  // Resolve, per event, the lane it sits in and the Y to align to: the leftmost tactic among the
-  // actions it gates, aligned to that action's center (topmost when it gates several).
-  const eventPlacement: Record<string, {
-    col: number;
-    anchorY: number;
-  }> = {};
+  // Y to align each event to, now that its actions are placed: the topmost action it gates inside its
+  // own lane's column, so the event -> action arrow stays horizontal.
+  const eventAnchorY: Record<string, number> = {};
   for (const [stepId, meta] of Object.entries(actionMetas)) {
     if (actionCenterY[stepId] === undefined) continue;
     const col = colOfAction(stepId);
     const y = actionCenterY[stepId];
     for (const eventId of meta.step_condition_ids) {
-      if (!eventMetas[eventId]) continue;
-      const cur = eventPlacement[eventId];
-      if (!cur || col < cur.col || (col === cur.col && y < cur.anchorY)) {
-        eventPlacement[eventId] = {
-          col,
-          anchorY: y,
-        };
+      if (!eventMetas[eventId] || laneCol(eventId) !== col) continue;
+      if (eventAnchorY[eventId] === undefined || y < eventAnchorY[eventId]) {
+        eventAnchorY[eventId] = y;
       }
     }
   }
 
-  // Bucket events per lane (orphan events, gating nothing, share column 0's lane), then align each
-  // to its anchor and cascade down only to resolve overlaps ("align, then de-overlap") — a lane
-  // never stacks two cards closer than EVENT_ROW_GAP.
+  // Bucket events per lane, then align each to its anchor and cascade down only to resolve overlaps
+  // ("align, then de-overlap") — a lane never stacks two cards closer than EVENT_ROW_GAP.
   const eventLanes: Record<number, {
     id: string;
     anchorY: number | null;
   }[]> = {};
   for (const id of eventIds) {
-    const col = eventPlacement[id]?.col ?? 0;
-    (eventLanes[col] ??= []).push({
+    (eventLanes[laneCol(id)] ??= []).push({
       id,
-      anchorY: eventPlacement[id]?.anchorY ?? null,
+      anchorY: eventAnchorY[id] ?? null,
     });
   }
-  for (const [laneColStr, items] of Object.entries(eventLanes)) {
-    const laneCol = Number(laneColStr);
+  for (const [colStr, items] of Object.entries(eventLanes)) {
+    const col = Number(colStr);
     items.sort(
       (a, b) => (a.anchorY ?? Number.POSITIVE_INFINITY) - (b.anchorY ?? Number.POSITIVE_INFINITY),
     );
@@ -434,8 +458,8 @@ export const buildLogicGraphLayout = ({
       nodes.push({
         id,
         kind: 'trigger',
-        layer: laneCol,
-        x: eventLaneX(laneCol),
+        layer: col,
+        x: laneX[col],
         y,
         width: NODE_WIDTH,
         height: TRIGGER_NODE_HEIGHT,
@@ -452,7 +476,7 @@ export const buildLogicGraphLayout = ({
     return {
       tactic,
       order: tacticOrder[tactic] ?? 99,
-      x: actionColX(col) - BAND_PADDING_X,
+      x: actionX[col] - BAND_PADDING_X,
       y: BAND_TOP,
       width: NODE_WIDTH + 2 * BAND_PADDING_X,
       height: bottom + BAND_PADDING_BOTTOM - BAND_TOP,

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
@@ -388,11 +388,21 @@ export const buildLogicGraphLayout = ({
         : ADJACENT_BAND_GAP + 2 * BAND_PADDING_X);
   });
 
-  // Actions per column, stacked in causal order (dependency depth, then input order to stay stable).
+  // Actions per column, GATED ONES FIRST, then in causal order (dependency depth, then input order to
+  // stay stable). Gated actions are what a lane's trigger cards align to, and depth order alone put
+  // them last (a gated action's depth is at least 1, an ungated one's is 0): the triggers were then
+  // anchored to the bottom of a tall column, leaving the top of the lane empty over hundreds of px.
+  // Ungated actions have nothing to align with, so they are the ones that belong at the bottom.
+  const isGated = (id: string) =>
+    (actionMetas[id]?.step_condition_ids ?? []).some(condId => eventMetas[condId]);
   const actionsByCol: Record<number, string[]> = {};
   for (const id of actionIds) (actionsByCol[colOfAction(id)] ??= []).push(id);
   for (const ids of Object.values(actionsByCol)) {
-    ids.sort((a, b) => (layer[a] !== layer[b] ? layer[a] - layer[b] : inputOrder[a] - inputOrder[b]));
+    ids.sort((a, b) => {
+      const gatedRank = Number(isGated(b)) - Number(isGated(a));
+      if (gatedRank !== 0) return gatedRank;
+      return layer[a] !== layer[b] ? layer[a] - layer[b] : inputOrder[a] - inputOrder[b];
+    });
   }
 
   // Actions are top-aligned within their column (like a table): every column starts at the same top,

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
@@ -7,19 +7,23 @@ export const NODE_WIDTH = 248;
 export const ACTION_NODE_HEIGHT = 112;
 export const TRIGGER_NODE_HEIGHT = 76;
 
-// Column / row separation. Denser when the chain is large (mirrors XTM One's
-// node-count-driven `dynNodeSep` / `dynRankSep`) so big graphs stay compact.
-const columnGap = (nodeCount: number) => (nodeCount > 14 ? 84 : 120);
-const rowGap = (nodeCount: number) => (nodeCount > 14 ? 18 : 30);
-
-// -- Tactic-group tokens (px). Groups are a PURELY VISUAL overlay drawn behind the nodes: the causal
-// left-to-right layout (see buildLogicGraphLayout) places nodes by dependency depth, and each group
-// is the padded bounding hull of the action nodes that share a MITRE tactic. The padding keeps the
-// cards from sitting flush against the hull border, and the header room reserves space above the
-// topmost card for the tactic label. --
-const GROUP_PADDING_X = 18; // horizontal breathing room between a card and its group border
-const GROUP_PADDING_Y = 16; // vertical breathing room between a card and its group border
-const GROUP_HEADER_HEIGHT = 26; // extra room reserved at the top of a hull for the tactic label
+// -- Tactic-column tokens (px). Actions are laid out in one column per MITRE tactic (ordered by
+// kill-chain phase), and each gating event sits in a lane immediately to the left of the column it
+// feeds. Every tactic owns an exclusive horizontal stride, which is what makes the tactic bands
+// non-overlapping BY CONSTRUCTION (see buildLogicGraphLayout). --
+const EVENT_TO_COL_GAP = 60; // gap between an event lane and the action column it feeds
+const INTER_COLUMN_GAP = 90; // gap between one tactic column and the next column's event lane
+const ACTION_ROW_GAP = 40; // vertical gap between stacked actions in a column
+const EVENT_ROW_GAP = 24; // vertical gap when de-overlapping events sharing a lane
+const COLUMN_TOP_MARGIN = 56; // room above the top node, inside the band, for the tactic header
+const BAND_TOP = 8; // top of the tactic band
+const BAND_PADDING_X = 18; // horizontal breathing room between a card and its band border
+const BAND_PADDING_BOTTOM = 20; // padding below the last card inside the band
+const BAND_HEADER_HEIGHT = 26; // room reserved at the top of a band for the tactic label
+// One tactic column spans its event lane + gap + action column; the next starts a stride further.
+const COLUMN_STRIDE = NODE_WIDTH + EVENT_TO_COL_GAP + NODE_WIDTH + INTER_COLUMN_GAP;
+const eventLaneX = (col: number) => col * COLUMN_STRIDE;
+const actionColX = (col: number) => col * COLUMN_STRIDE + NODE_WIDTH + EVENT_TO_COL_GAP;
 
 export type LogicGraphNodeKind = 'action' | 'trigger';
 
@@ -58,26 +62,27 @@ export interface LogicGraphBBox {
 }
 
 /**
- * One MITRE-tactic group: the padded, rounded hull drawn behind the action nodes that share a
- * tactic, plus its header label. Purely decorative — it never drives node positions (only actions
- * carry a TTP, so events are ignored here). `order` is the tactic's kill-chain phase rank, used by
- * the renderer to pick a stable accent colour.
+ * One MITRE-tactic column: the padded band drawn behind the action cards of that tactic, plus its
+ * header label. Exactly one band per tactic, and bands never overlap — each owns an exclusive
+ * horizontal stride of the canvas. The band covers the ACTION column only: events carry no TTP, so
+ * they sit in the lane to its LEFT, outside any tactic. `order` is the tactic's kill-chain phase
+ * rank, used by the renderer to pick a stable accent colour.
  */
-export interface LogicGraphGroup {
+export interface LogicGraphColumn {
   tactic: string;
   order: number;
   x: number;
   y: number;
   width: number;
   height: number;
-  /** Y reserved for the header label, inside the hull at the top. */
+  /** Height reserved for the header label, inside the band at the top. */
   headerHeight: number;
 }
 
 export interface LogicGraphLayout {
   nodes: LogicGraphNode[];
   edges: LogicGraphEdge[];
-  groups: LogicGraphGroup[];
+  columns: LogicGraphColumn[];
   bbox: LogicGraphBBox;
   nodeById: Record<string, LogicGraphNode>;
 }
@@ -258,13 +263,13 @@ const computeLayers = (nodeIds: string[], acyclicEdges: RawEdge[]): Record<strin
 };
 
 /**
- * Build the auto-laid-out causal graph (nodes + orthogonal connector paths + tactic groups +
- * bounding box) from the parsed action / event metadata. Pure and deterministic so it can be
- * memoized behind a content fingerprint (polling re-renders must not shuffle the layout).
+ * Build the auto-laid-out graph (nodes + orthogonal connector paths + tactic columns + bounding box)
+ * from the parsed action / event metadata. Pure and deterministic so it can be memoized behind a
+ * content fingerprint (polling re-renders must not shuffle the layout).
  *
- * Node positions come purely from dependency depth (longest-path layering), so the chain reads
- * left-to-right as `Action -> Trigger -> Action` waves — the tactic never forces the layout. MITRE
- * tactics are layered back on top as decorative group hulls (see the group computation at the end).
+ * Columns are MITRE tactics, ordered by kill-chain phase: every action sits in its tactic's column
+ * and every gating event in the lane just left of it, so the map reads as one band per tactic with
+ * no overlap possible. Dependency depth only orders the cards inside a column.
  */
 export const buildLogicGraphLayout = ({
   actionMetas,
@@ -314,138 +319,160 @@ export const buildLogicGraphLayout = ({
   }
   const graphEdges = [...prunedInferred, ...nonInferred];
 
-  const preds: Record<string, string[]> = {};
-  for (const edge of graphEdges) (preds[edge.target] ??= []).push(edge.source);
-
+  // Dependency depth. It no longer picks a node's COLUMN (the tactic does, see below) — it only
+  // orders the cards top-down inside a column so a tactic's steps still read in causal order.
   const layer = computeLayers(nodeIds, graphEdges);
 
-  // Bucket nodes per layer, keeping a stable initial order.
-  const layers: Record<number, string[]> = {};
-  for (const id of nodeIds) (layers[layer[id]] ??= []).push(id);
-  const layerKeys = Object.keys(layers).map(Number).sort((a, b) => a - b);
-
-  // Barycenter ordering (single downward pass) to reduce edge crossings: order each layer by the
-  // average row of its predecessors in the previous layer. Same-tactic actions are kept adjacent as
-  // a tie-break so their group hulls stay compact without disturbing the crossing-minimizing order.
-  const orderIndex: Record<string, number> = {};
-  const tacticRank = (id: string) => tacticOrder[tacticForStep[id] ?? ''] ?? 99;
-  layerKeys.forEach((layerKey, layerIdx) => {
-    const ids = layers[layerKey];
-    if (layerIdx === 0) {
-      ids.forEach((id, i) => {
-        orderIndex[id] = i;
-      });
-      return;
-    }
-    const withKey = ids.map((id) => {
-      const parents = (preds[id] ?? []).filter(p => orderIndex[p] !== undefined);
-      const key = parents.length > 0
-        ? parents.reduce((sum, p) => sum + orderIndex[p], 0) / parents.length
-        : Number.MAX_SAFE_INTEGER;
-      return {
-        id,
-        key,
-        tactic: tacticRank(id),
-      };
-    });
-    withKey.sort((a, b) => (a.key !== b.key ? a.key - b.key : a.tactic - b.tactic));
-    layers[layerKey] = withKey.map(w => w.id);
-    layers[layerKey].forEach((id, i) => {
-      orderIndex[id] = i;
-    });
+  // -- Tactic-column positioning ------------------------------------------------------------------
+  // INVARIANT: one MITRE tactic per column, and no overlap anywhere. Actions are bucketed into one
+  // column per tactic (columns ordered by kill-chain phase), and each gating event sits in a lane
+  // immediately to the LEFT of its action's column, aligned to the action it gates so the
+  // event -> action arrow stays horizontal.
+  //
+  // Because every tactic owns an exclusive horizontal stride (event lane + gap + action column +
+  // gap), a tactic band can never intersect another band, nor a card of another tactic. That is the
+  // whole point of laying out by tactic rather than decorating a depth-ordered layout with per-tactic
+  // bounding hulls: one tactic's actions would then scatter across several depth columns, so its hull
+  // stretched over its neighbours' cards and every stacked hull's header landed on the card above.
+  const actionIds = nodeIds.filter(id => kindById[id] === 'action');
+  const eventIds = nodeIds.filter(id => kindById[id] === 'trigger');
+  const inputOrder: Record<string, number> = {};
+  nodeIds.forEach((id, i) => {
+    inputOrder[id] = i;
   });
 
-  const nodeCount = nodeIds.length;
-  const colGap = columnGap(nodeCount);
-  const rGap = rowGap(nodeCount);
-  const heightOf = (id: string) =>
-    (kindById[id] === 'action' ? ACTION_NODE_HEIGHT : TRIGGER_NODE_HEIGHT);
-
-  // Vertically center each column around a shared midline so the chain reads as balanced rather
-  // than top-left heavy.
-  const colHeight: Record<number, number> = {};
-  for (const layerKey of layerKeys) {
-    const ids = layers[layerKey];
-    colHeight[layerKey] = ids.reduce((sum, id) => sum + heightOf(id), 0)
-      + Math.max(0, ids.length - 1) * rGap;
-  }
-  const maxColHeight = Math.max(0, ...Object.values(colHeight));
-
-  const nodes: LogicGraphNode[] = [];
-  for (const layerKey of layerKeys) {
-    const ids = layers[layerKey];
-    let y = (maxColHeight - colHeight[layerKey]) / 2;
-    const x = layerKey * (NODE_WIDTH + colGap);
-    for (const id of ids) {
-      const height = heightOf(id);
-      nodes.push({
-        id,
-        kind: kindById[id],
-        layer: layerKey,
-        x,
-        y,
-        width: NODE_WIDTH,
-        height,
-      });
-      y += height + rGap;
-    }
-  }
-
-  // -- Tactic groups (decorative overlay) ---------------------------------------------------------
-  // For each MITRE tactic present, bound the ACTION nodes that share it (events carry no TTP) and
-  // pad the hull out so cards never sit flush against the border, reserving header room on top for
-  // the tactic label. Groups follow the kill-chain phase order (unknown tactics sort last, then by
-  // name) so their accent colours are stable across renders.
-  const actionsByTactic: Record<string, LogicGraphNode[]> = {};
-  for (const node of nodes) {
-    if (node.kind !== 'action') continue;
-    const tactic = tacticForStep[node.id] ?? '';
-    (actionsByTactic[tactic] ??= []).push(node);
-  }
-  const orderedTactics = Object.keys(actionsByTactic).sort((a, b) => {
+  // The tactic columns present in THIS workflow, ordered by phase (unknown tactics sort last, then
+  // by name for determinism).
+  const uniqueTactics = Array.from(new Set(actionIds.map(id => tacticForStep[id] ?? '')));
+  uniqueTactics.sort((a, b) => {
     const oa = tacticOrder[a] ?? 99;
     const ob = tacticOrder[b] ?? 99;
     return oa !== ob ? oa - ob : a.localeCompare(b);
   });
-  const groups: LogicGraphGroup[] = orderedTactics.map((tactic) => {
-    const members = actionsByTactic[tactic];
-    let gMinX = Infinity;
-    let gMinY = Infinity;
-    let gMaxX = -Infinity;
-    let gMaxY = -Infinity;
-    for (const node of members) {
-      gMinX = Math.min(gMinX, node.x);
-      gMinY = Math.min(gMinY, node.y);
-      gMaxX = Math.max(gMaxX, node.x + node.width);
-      gMaxY = Math.max(gMaxY, node.y + node.height);
+  const colByTactic: Record<string, number> = {};
+  uniqueTactics.forEach((tactic, i) => {
+    colByTactic[tactic] = i;
+  });
+  const colOfAction = (id: string) => colByTactic[tacticForStep[id] ?? ''] ?? 0;
+
+  // Actions per column, stacked in causal order (dependency depth, then input order to stay stable).
+  const actionsByCol: Record<number, string[]> = {};
+  for (const id of actionIds) (actionsByCol[colOfAction(id)] ??= []).push(id);
+  for (const ids of Object.values(actionsByCol)) {
+    ids.sort((a, b) => (layer[a] !== layer[b] ? layer[a] - layer[b] : inputOrder[a] - inputOrder[b]));
+  }
+
+  // Actions are top-aligned within their column (like a table): every column starts at the same top,
+  // just under its header, so headers stay attached to their cards. `colActionBottomY` tracks each
+  // column's lowest ACTION so its band can be sized to fit.
+  const nodes: LogicGraphNode[] = [];
+  const actionCenterY: Record<string, number> = {};
+  const colActionBottomY: Record<number, number> = {};
+  uniqueTactics.forEach((_tactic, col) => {
+    let y = COLUMN_TOP_MARGIN;
+    for (const id of actionsByCol[col] ?? []) {
+      nodes.push({
+        id,
+        kind: 'action',
+        layer: col,
+        x: actionColX(col),
+        y,
+        width: NODE_WIDTH,
+        height: ACTION_NODE_HEIGHT,
+      });
+      actionCenterY[id] = y + ACTION_NODE_HEIGHT / 2;
+      colActionBottomY[col] = y + ACTION_NODE_HEIGHT;
+      y += ACTION_NODE_HEIGHT + ACTION_ROW_GAP;
     }
-    const x = gMinX - GROUP_PADDING_X;
-    const y = gMinY - GROUP_PADDING_Y - GROUP_HEADER_HEIGHT;
+  });
+
+  // Resolve, per event, the lane it sits in and the Y to align to: the leftmost tactic among the
+  // actions it gates, aligned to that action's center (topmost when it gates several).
+  const eventPlacement: Record<string, {
+    col: number;
+    anchorY: number;
+  }> = {};
+  for (const [stepId, meta] of Object.entries(actionMetas)) {
+    if (actionCenterY[stepId] === undefined) continue;
+    const col = colOfAction(stepId);
+    const y = actionCenterY[stepId];
+    for (const eventId of meta.step_condition_ids) {
+      if (!eventMetas[eventId]) continue;
+      const cur = eventPlacement[eventId];
+      if (!cur || col < cur.col || (col === cur.col && y < cur.anchorY)) {
+        eventPlacement[eventId] = {
+          col,
+          anchorY: y,
+        };
+      }
+    }
+  }
+
+  // Bucket events per lane (orphan events, gating nothing, share column 0's lane), then align each
+  // to its anchor and cascade down only to resolve overlaps ("align, then de-overlap") — a lane
+  // never stacks two cards closer than EVENT_ROW_GAP.
+  const eventLanes: Record<number, {
+    id: string;
+    anchorY: number | null;
+  }[]> = {};
+  for (const id of eventIds) {
+    const col = eventPlacement[id]?.col ?? 0;
+    (eventLanes[col] ??= []).push({
+      id,
+      anchorY: eventPlacement[id]?.anchorY ?? null,
+    });
+  }
+  for (const [laneColStr, items] of Object.entries(eventLanes)) {
+    const laneCol = Number(laneColStr);
+    items.sort(
+      (a, b) => (a.anchorY ?? Number.POSITIVE_INFINITY) - (b.anchorY ?? Number.POSITIVE_INFINITY),
+    );
+    let cursor = COLUMN_TOP_MARGIN;
+    for (const { id, anchorY } of items) {
+      const desiredTop = anchorY === null ? cursor : anchorY - TRIGGER_NODE_HEIGHT / 2;
+      const y = Math.max(desiredTop, cursor);
+      nodes.push({
+        id,
+        kind: 'trigger',
+        layer: laneCol,
+        x: eventLaneX(laneCol),
+        y,
+        width: NODE_WIDTH,
+        height: TRIGGER_NODE_HEIGHT,
+      });
+      cursor = y + TRIGGER_NODE_HEIGHT + EVENT_ROW_GAP;
+    }
+  }
+
+  // One band per tactic column, covering the ACTION column only (events have no TTP, so they sit in
+  // the lane to the left, outside any band). Padded so cards never sit flush against the border, and
+  // sized to its own column's actions.
+  const columns: LogicGraphColumn[] = uniqueTactics.map((tactic, col) => {
+    const bottom = colActionBottomY[col] ?? COLUMN_TOP_MARGIN;
     return {
       tactic,
       order: tacticOrder[tactic] ?? 99,
-      x,
-      y,
-      width: gMaxX + GROUP_PADDING_X - x,
-      height: gMaxY + GROUP_PADDING_Y - y,
-      headerHeight: GROUP_HEADER_HEIGHT,
+      x: actionColX(col) - BAND_PADDING_X,
+      y: BAND_TOP,
+      width: NODE_WIDTH + 2 * BAND_PADDING_X,
+      height: bottom + BAND_PADDING_BOTTOM - BAND_TOP,
+      headerHeight: BAND_HEADER_HEIGHT,
     };
   });
 
-  // Normalize the whole layout to the origin: group hulls pad out above and to the left of the
-  // nodes (header room + horizontal padding), so the top-left of the content is a group corner, not
-  // a node. The render container and pan/zoom fit both assume content starts at (0, 0), so shift
-  // every node and group by the negative of the global minimum. Do this BEFORE routing edges so the
-  // connector paths are computed in the final coordinate space.
+  // Normalize the whole layout to the origin: the leftmost/topmost content is a band corner (bands
+  // pad out around their cards), not a node. The render container and pan/zoom fit both assume
+  // content starts at (0, 0), so shift every node and band by the negative of the global minimum. Do
+  // this BEFORE routing edges so the connector paths are computed in the final coordinate space.
   let originX = Infinity;
   let originY = Infinity;
   for (const node of nodes) {
     originX = Math.min(originX, node.x);
     originY = Math.min(originY, node.y);
   }
-  for (const group of groups) {
-    originX = Math.min(originX, group.x);
-    originY = Math.min(originY, group.y);
+  for (const column of columns) {
+    originX = Math.min(originX, column.x);
+    originY = Math.min(originY, column.y);
   }
   const offsetX = Number.isFinite(originX) ? -originX : 0;
   const offsetY = Number.isFinite(originY) ? -originY : 0;
@@ -454,9 +481,9 @@ export const buildLogicGraphLayout = ({
       node.x += offsetX;
       node.y += offsetY;
     }
-    for (const group of groups) {
-      group.x += offsetX;
-      group.y += offsetY;
+    for (const column of columns) {
+      column.x += offsetX;
+      column.y += offsetY;
     }
   }
 
@@ -486,13 +513,13 @@ export const buildLogicGraphLayout = ({
     maxX = Math.max(maxX, node.x + node.width);
     maxY = Math.max(maxY, node.y + node.height);
   }
-  // Fold the group hulls into the bbox so their padded borders and headers (which extend above and
-  // around the nodes) are never framed out on fit.
-  for (const group of groups) {
-    minX = Math.min(minX, group.x);
-    minY = Math.min(minY, group.y);
-    maxX = Math.max(maxX, group.x + group.width);
-    maxY = Math.max(maxY, group.y + group.height);
+  // Fold the tactic bands into the bbox so their padded borders and headers (which extend above and
+  // around the cards) are never framed out on fit.
+  for (const column of columns) {
+    minX = Math.min(minX, column.x);
+    minY = Math.min(minY, column.y);
+    maxX = Math.max(maxX, column.x + column.width);
+    maxY = Math.max(maxY, column.y + column.height);
   }
   if (!Number.isFinite(minX)) {
     minX = 0;
@@ -504,7 +531,7 @@ export const buildLogicGraphLayout = ({
   return {
     nodes,
     edges,
-    groups,
+    columns,
     bbox: {
       minX,
       minY,

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/layout.ts
@@ -63,13 +63,11 @@ export interface LogicGraphBBox {
 /**
  * One MITRE-tactic column: the padded band drawn behind the action cards of that tactic, plus its
  * header label. Exactly one band per tactic, and bands never overlap — each owns an exclusive
- * horizontal stride of the canvas. The band covers the ACTION column only: events carry no TTP, so
- * they sit in the lane to its LEFT, outside any tactic. `order` is the tactic's kill-chain phase
- * rank, used by the renderer to pick a stable accent colour.
+ * horizontal span of the canvas. The band covers the ACTION column only: events carry no TTP, so
+ * they sit in the lane to its LEFT, outside any tactic. Columns come out in kill-chain phase order.
  */
 export interface LogicGraphColumn {
   tactic: string;
-  order: number;
   x: number;
   y: number;
   width: number;
@@ -485,7 +483,6 @@ export const buildLogicGraphLayout = ({
     const bottom = colActionBottomY[col] ?? COLUMN_TOP_MARGIN;
     return {
       tactic,
-      order: tacticOrder[tactic] ?? 99,
       x: actionX[col] - BAND_PADDING_X,
       y: BAND_TOP,
       width: NODE_WIDTH + 2 * BAND_PADDING_X,


### PR DESCRIPTION
### Proposed changes

* Regression from #7226 / #7227: the MITRE tactic bands on the Logic map overlap each other — a band's header lands on the card above it, and one band stretches across the whole canvas swallowing its neighbours' cards.

  Root cause: #7226 turned the tactics into a decorative overlay on a depth-ordered layout. Nodes were placed by dependency depth, then each tactic was drawn as the padded *bounding hull* of the actions sharing it. So a tactic whose actions sat in several depth columns produced a hull spanning all of them (and every card in between), while hulls stacked inside one column reserved 42px of header + padding above a card for a row gap of only 18–30px.

* Lay the graph out by tactic again (restores the `#7218` reading): one column per tactic ordered by kill-chain phase, each gating event in the lane immediately left of the column it feeds, aligned on its action's centre so the event → action arrow stays horizontal.

* Dependency depth no longer picks a node's column — it only orders the cards top-down *inside* a column, so the causal reading #7226 aimed for is kept.

* **The invariant is now structural, not a matter of padding tokens**: every tactic owns an exclusive horizontal stride (event lane + gap + action column + gap), so a band can never intersect another band, nor a card of another tactic.

* `LogicGraph.tsx` renders one band per column (`layout.columns`) instead of the bounding hulls, keeping the per-tactic accent colours introduced by #7226.

### Testing Instructions

1. Open a chained scenario with several tactics on the same causal wave (e.g. *AD Recon to File Exposure via SMB Shares*) → **Logic** tab.
2. Expect exactly one band per tactic, side by side, each headed by its tactic name — no band border or header ever crossing another band or another tactic's card, at any zoom level.
3. Check that a trigger still sits immediately left of the action(s) it gates, vertically aligned with it.
4. `yarn vitest run src/__tests__/admin/components/chaining/logic/logic-graph/layout.test.ts`

### Related issues

* Closes #7240
* Regression introduced by #7226 (#7227)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
