### PR TITLE
fix(attack-path): trace the highlighted path on the connectors, not just the cards (#7253)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathConnectors.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathConnectors.tsx
@@ -37,11 +37,19 @@ const AttackPathConnectors = ({ geometries, width, height }: Props) => {
         const data = edge.data;
         const isCausal = edge.type === AP_FLOW_CAUSAL_EDGE_TYPE;
         const dimmed = data?.dimmed ?? false;
-        const color = isCausal
+        // An edge on the highlighted path is drawn in the primary colour, like the border of the
+        // cards it joins, so the path reads as a continuous route rather than as a set of lit boxes.
+        // Only its verdict colour used to be honoured, so selecting an endpoint or a finding lit the
+        // cards blue and left the connectors between them in their status colour - the chain was
+        // never actually traced.
+        const onPath = !!edge.selected;
+        const restColor = isCausal
           ? attackPathCausalColor(theme)
           : attackPathStatusColor(theme, data?.status);
+        const color = onPath ? theme.palette.primary.main : restColor;
         const dashed = isCausal && data?.causalKind !== 'finding';
-        const opacity = dimmed ? 0.08 : 0.85;
+        const restOpacity = onPath ? 1 : 0.85;
+        const opacity = dimmed ? 0.08 : restOpacity;
         const count = data?.count ?? 1;
         const label = data?.label ?? (count > 1 ? `+${count}` : undefined);
         const showLabel = !dimmed && !!label;
@@ -51,7 +59,7 @@ const AttackPathConnectors = ({ geometries, width, height }: Props) => {
               d={path}
               fill="none"
               stroke={color}
-              strokeWidth={1.5}
+              strokeWidth={onPath ? 2.5 : 1.5}
               strokeDasharray={dashed ? '6 4' : undefined}
               style={{
                 opacity,


### PR DESCRIPTION
Fixes #7253.

Selecting an endpoint, a finding or a chokepoint lit the **cards** in blue but left the **connectors between them** in their verdict colour — so the path was never traced. Only a set of boxes lit up, and the route had to be inferred.

### Cause

`AttackPathConnectors` never read the edge's `selected` flag:

```js
const color = isCausal
  ? attackPathCausalColor(theme)
  : attackPathStatusColor(theme, data?.status);
```

Colour came only from the edge kind and its verdict; selection changed nothing but the opacity of *off-path* edges. The highlight memo already sets `selected: pathSet.has(e.source) && pathSet.has(e.target)` and `AttackPathFlowEdge` already exposes `selected?: boolean` — the renderer was the only missing piece. The cards, meanwhile, do honour it (`buildCardSx` paints `primary.main` on the border), which is exactly why the two disagreed.

### Change

A path edge is drawn in `theme.palette.primary.main` at `strokeWidth 2.5` (instead of `1.5`) and full opacity, matching the border of the cards it joins. Off-path edges are untouched.

### Verification

Measured in the browser on a simulation with 68 findings, clicking the `PORTSCAN` summary tile — reading the actual `stroke` / `stroke-width` attributes of the rendered connectors:

| | connectors | colours | width |
|---|---|---|---|
| full graph | 55 | 47 red, 3 primary, 5 grey | 1.5 |
| focused, **before** | 10 | 10 **red** (`#F14337`) | 1.5 |
| focused, **after** | 10 | 10 **primary** (`#0fbcff`) | 2.5 |

The path now reads continuously from the producing actions through the endpoint to the finding. 553 front unit tests pass, ESLint clean, `tsc` unchanged from the `main` baseline.

### One trade-off worth settling in review

In the focused view every visible edge is on the path, so all of them turn primary and the **verdict colour disappears from the edges there** (it stays on the endpoint/finding cards, in the side panel, and in each edge's tooltip — but the green/orange/red legend is momentarily unrepresented on the lines).

If reviewers prefer to keep both signals, the alternative is a **primary halo**: a wider semi-transparent primary stroke underneath, keeping the verdict-coloured core on top. Happy to switch — this version was chosen because it matches the request ("highlight the path in blue") and the existing card styling.
