### PR TITLE
feat(front): compact convert-to-manual action, gate on stopped run (#7255)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -484,17 +484,23 @@ const ScenarioHeader = ({
                   the underlying simulation for edit/delete (the in-place path removes the run row
                   every autonomous lock keys off). Gated on the live run so we have the run id. */}
               {isAutonomous && canManage && autonomousRun && (
-                <Tooltip title={t('Convert this AI-driven scenario into a manual chained scenario you can edit by hand (duplicate it, or transform it in place).')}>
-                  <Button
-                    variant="outlined"
-                    color="primary"
-                    size="small"
-                    startIcon={<TransformOutlined />}
-                    onClick={() => setOpenConvert(true)}
-                    data-testid="convert-autonomous-to-manual-button"
-                  >
-                    {t('Convert to manual')}
-                  </Button>
+                <Tooltip
+                  title={isAutonomousActive
+                    ? t('Stop the run before converting it to a manual chained scenario')
+                    : t('Convert this AI-driven scenario into a manual chained scenario you can edit by hand (duplicate it, or transform it in place).')}
+                >
+                  {/* span wrapper so the tooltip still shows while the button is disabled */}
+                  <span>
+                    <IconButton
+                      color="primary"
+                      size="small"
+                      disabled={isAutonomousActive}
+                      onClick={() => setOpenConvert(true)}
+                      data-testid="convert-autonomous-to-manual-button"
+                    >
+                      <TransformOutlined fontSize="small" />
+                    </IconButton>
+                  </span>
                 </Tooltip>
               )}
               {/* Autonomous lifecycle: pause / resume / stop the run and its single simulation,

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "Nicht mehr erzeugen",
   "Stop the autonomous run before deleting its scenario.": "Stoppen Sie den autonomen Lauf, bevor Sie sein Szenario löschen.",
   "Stop the connector before deleting it": "Stoppen Sie den Konnektor, bevor Sie ihn löschen",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "gestoppt",
   "Stopped": "Gestoppt",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "Stop generating",
   "Stop the autonomous run before deleting its scenario.": "Stop the autonomous run before deleting its scenario.",
   "Stop the connector before deleting it": "Stop the connector before deleting it",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "stopped",
   "Stopped": "Stopped",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "Dejar de generar",
   "Stop the autonomous run before deleting its scenario.": "Detén la ejecución autónoma antes de eliminar su escenario.",
   "Stop the connector before deleting it": "Detenga el conector antes de eliminarlo",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "detenido",
   "Stopped": "Detenido",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "Cesser de générer",
   "Stop the autonomous run before deleting its scenario.": "Arrêtez l'exécution autonome avant de supprimer son scénario.",
   "Stop the connector before deleting it": "Arrêtez le connecteur avant de le supprimer",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "stoppé",
   "Stopped": "Arrêtée",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "Smettere di generare",
   "Stop the autonomous run before deleting its scenario.": "Interrompi l'esecuzione autonoma prima di eliminare il suo scenario.",
   "Stop the connector before deleting it": "Arresta il connettore prima di eliminarlo",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "bloccato",
   "Stopped": "Interrotto",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "発電停止",
   "Stop the autonomous run before deleting its scenario.": "シナリオを削除する前に自律実行を停止してください。",
   "Stop the connector before deleting it": "削除する前にコネクターを停止してください",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "阻止",
   "Stopped": "停止",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "생성 중지",
   "Stop the autonomous run before deleting its scenario.": "시나리오를 삭제하기 전에 자율 실행을 중지하세요.",
   "Stop the connector before deleting it": "삭제하기 전에 커넥터를 중지하세요",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "차단됨",
   "Stopped": "중지됨",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "Прекратите генерировать",
   "Stop the autonomous run before deleting its scenario.": "Остановите автономный запуск перед удалением его сценария.",
   "Stop the connector before deleting it": "Остановите коннектор перед удалением",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "остановлено",
   "Stopped": "Остановлено",
   "Storage": "Storage",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3110,6 +3110,7 @@
   "Stop generating": "停止生成",
   "Stop the autonomous run before deleting its scenario.": "在删除其场景之前，请先停止自主运行。",
   "Stop the connector before deleting it": "删除前请先停止连接器",
+  "Stop the run before converting it to a manual chained scenario": "Stop the run before converting it to a manual chained scenario",
   "stopped": "已阻止",
   "Stopped": "已停止",
   "Storage": "Storage",


### PR DESCRIPTION
## Summary

- Turn the autonomous scenario "Convert to manual" hero action into an
  icon-only `IconButton` (Transform icon) with a tooltip, so it matches the
  neighbouring hero icon actions (scheduling, assistant, run controls) instead
  of a bulky outlined text button.
- Gate the action on run state: it is disabled while the run is active
  (CREATED / PLANNING / RUNNING / PAUSED / WAITING_INPUT) and only enabled once
  the run has stopped (PLANNED / COMPLETED / FAILED / CANCELED). Reuses the
  existing `isAutonomousRunActive` single source of truth already used by the
  scenario/simulation delete guards.
- The tooltip is state-aware: it explains the disabled reason ("Stop the run
  before converting it to a manual chained scenario") while active, and the
  full convert description otherwise. The button is wrapped in a `span` so the
  tooltip still shows while disabled.

No API change - frontend only.

## Test plan

- [ ] Autonomous scenario with a RUNNING / PLANNING run: the convert icon is
      visible but disabled, tooltip explains why.
- [ ] Autonomous scenario with a stopped run (COMPLETED / CANCELED / PLANNED):
      the convert icon is enabled and opens the duplicate / in-place dialog.
- [ ] `yarn lint`, `yarn check-ts`, and the i18n checker pass.

Closes #7255
