### PR TITLE
fix(attack-path): frame the highlighted path around the selected finding (#7257)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -354,6 +354,8 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   // Cross-focus: clicking a finding item centers its endpoint (focusRequest) and highlights the
   // producing executions in the feed (by their raw ids).
   const [focusRequest, setFocusRequest] = useState<AttackPathFocusRequest | null>(null);
+  // Monotonic, so re-picking the SAME finding re-frames it instead of being swallowed as a no-op.
+  const focusNonce = useRef(0);
   const [highlightedExecutionIds, setHighlightedExecutionIds] = useState<Set<string>>(new Set());
   const feedRowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
@@ -1280,6 +1282,24 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     }
     return fullChain.causalSourceByFinding.get(selectedFindingId) ?? selectedFindingId;
   }, [selectedFindingId, fullChain]);
+
+  // Frame the highlighted path around the finding that was just selected, wherever it was picked
+  // from (graph click, findings drawer, summary list). Keyed off the RESOLVED id so a finding still
+  // inside a collapsed cluster anchors on the cluster node that actually exists on the canvas.
+  //
+  // Until now the camera never moved on a finding click: `focusRequest` was declared and handed to
+  // the canvas but only ever set to null, so `centerOnNode` was dead code. On a large attack path
+  // the selected finding could therefore sit off-screen entirely.
+  useEffect(() => {
+    if (!effectiveSelectedFindingId) {
+      return;
+    }
+    setFocusRequest({
+      nodeId: effectiveSelectedFindingId,
+      nonce: focusNonce.current + 1,
+    });
+    focusNonce.current += 1;
+  }, [effectiveSelectedFindingId]);
 
   const baseFlow = useMemo(
     () => {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathCanvas.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathCanvas.tsx
@@ -343,31 +343,73 @@ const AttackPathCanvas = ({
     }
   }, [animateTo, fitCamera]);
 
-  // Center the camera on one node at a comfortable zoom (click-to-focus / cross-focus).
-  const centerOnNode = useCallback((nodeId: string) => {
+  /**
+   * Frame the highlighted path, anchored on the node that was just selected.
+   *
+   * <p>The zoom tries to contain the whole highlighted path (the nodes still lit, i.e. not dimmed)
+   * but never drops below the readable floor used by the initial fit, and the camera centres on the
+   * anchor rather than on the box centre — so the clicked finding is always the visual subject even
+   * when its chain is too long to fit and overflows.
+   *
+   * <p>Centring alone (the previous {@link centerOnNode}) kept the current zoom, which is what made
+   * a selection unreadable: zoomed out the finding was centred but tiny, zoomed in its connectors
+   * stretched off-screen.
+   */
+  const focusOnPath = useCallback((anchorNodeId: string) => {
     const el = containerRef.current;
-    const r = effectiveRects.get(nodeId);
-    if (!el || !r) {
+    const anchor = effectiveRects.get(anchorNodeId);
+    if (!el || !anchor) {
       return;
     }
-    const zoom = clampZoom(Math.max(0.8, Math.min(1.4, camera.zoom)));
-    const worldCx = r.x + r.width / 2;
-    const worldCy = r.y + r.height / 2;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    nodes.forEach((n) => {
+      if (n.data?.dimmed) {
+        return;
+      }
+      const r = effectiveRects.get(n.id);
+      if (!r) {
+        return;
+      }
+      minX = Math.min(minX, r.x);
+      minY = Math.min(minY, r.y);
+      maxX = Math.max(maxX, r.x + r.width);
+      maxY = Math.max(maxY, r.y + r.height);
+    });
+    // Nothing lit (or no rects yet): fall back to framing the anchor alone.
+    if (minX === Infinity) {
+      minX = anchor.x;
+      minY = anchor.y;
+      maxX = anchor.x + anchor.width;
+      maxY = anchor.y + anchor.height;
+    }
+    const availW = el.clientWidth - FIT_PADDING * 2;
+    const availH = el.clientHeight - FIT_PADDING * 2;
+    if (availW <= 0 || availH <= 0) {
+      return;
+    }
+    const raw = Math.min(availW / Math.max(maxX - minX, 1), availH / Math.max(maxY - minY, 1));
+    const zoom = clampZoom(Math.min(INITIAL_MAX_ZOOM, Math.max(INITIAL_MIN_ZOOM, raw)));
     animateTo({
       zoom,
-      x: el.clientWidth / 2 - worldCx * zoom,
-      y: el.clientHeight / 2 - worldCy * zoom,
+      x: el.clientWidth / 2 - (anchor.x + anchor.width / 2) * zoom,
+      y: el.clientHeight / 2 - (anchor.y + anchor.height / 2) * zoom,
     });
-  }, [effectiveRects, camera.zoom, clampZoom, animateTo]);
+  }, [nodes, effectiveRects, clampZoom, animateTo]);
 
-  // Re-fires on nonce only (repeat focus on the same node re-centers without re-running on every
+  // Re-fires on nonce only (repeat focus on the same node re-frames without re-running on every
   // camera change, hence the ref-carried callback).
-  const centerOnNodeRef = useRef(centerOnNode);
-  centerOnNodeRef.current = centerOnNode;
+  const focusOnPathRef = useRef(focusOnPath);
+  focusOnPathRef.current = focusOnPath;
   useEffect(() => {
     if (focusRequest?.nodeId) {
-      centerOnNodeRef.current(focusRequest.nodeId);
+      // Let the focused layout settle before measuring it.
+      const id = window.setTimeout(() => focusOnPathRef.current(focusRequest.nodeId), 80);
+      return () => window.clearTimeout(id);
     }
+    return undefined;
   }, [focusRequest?.nodeId, focusRequest?.nonce]);
 
   const fitAllRef = useRef(fitAll);


### PR DESCRIPTION
Fixes #7257.

Selecting a finding highlighted it but **never moved the camera**, so on a large attack path the finding could sit off-screen — and when it was visible, the framing was whatever zoom happened to be active, which is where the "enormous connectors" came from.

### Cause

`focusRequest` was declared in `SimulationAttackPath`, passed to the canvas, and only ever set to `null`:

```
356:  const [focusRequest, setFocusRequest] = useState<AttackPathFocusRequest | null>(null);
482:    setFocusRequest(null);
1023:      setFocusRequest(null);
1475:    setFocusRequest(null);
2422:    setFocusRequest(null);
2477:    setFocusRequest(null);
```

So the canvas's `centerOnNode` — reachable only through that request — was dead code, and the comment above the state promised behaviour that never ran.

Simply wiring it up would not have fixed it either: `centerOnNode` preserves the current zoom (`Math.max(0.8, Math.min(1.4, camera.zoom))`), which is exactly what makes a selection unreadable in both directions.

### Change

- **One effect**, keyed on the *resolved* selected finding id, so every entry point is covered — graph click, findings drawer, summary list — and a finding still inside a collapsed cluster anchors on the cluster node that actually exists on the canvas. A monotonic nonce makes re-picking the same finding re-frame it.
- **`focusOnPath(anchor)`** replaces `centerOnNode`: zoom to contain the bounding box of the still-lit (non-dimmed) nodes, floored at `INITIAL_MIN_ZOOM` and capped at `INITIAL_MAX_ZOOM` — the same bounds the initial fit uses — with the camera centred on the **anchor**, not the box centre. A chain too long to fit overflows around the clicked finding instead of shrinking below legibility.

### Verification — and its limit, stated plainly

553 front unit tests pass, ESLint clean, `tsc` unchanged from the `main` baseline.

Measured in the browser, the camera transform does change on selection (`matrix(0.6,0,0,0.6,56,56)` → `matrix(0.6,0,0,0.6,-78.5,212.8)`), **but I could not attribute that move to this change rather than to the pre-existing structural fit**: on the test dataset the computed zoom lands on `0.6`, which is exactly the existing floor, because the container height is the limiting factor. The zoom-clamping behaviour is therefore unproven by measurement here.

It needs a visual check on a **large** attack path — the case the report came from — where the box is wide enough for the zoom to differ from the floor. Reviewers with such a run should confirm that clicking a far-off finding brings it to the centre at a legible zoom.
