### PR TITLE
fix(chaining): allow an action to be gated by several events (#7266)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -575,17 +575,17 @@ public class StepService {
           "New step (TEMPLATE): At least 1 condition must be a root (no parent)");
     }
 
-    // Allow one event/filter root plus any number of mapper roots.
-    // This happens when a step has one linked event root and one or more action mappings.
-    if (rootConditions.size() > 1) {
-      long nonMapperRootCount =
-          rootConditions.stream().filter(c -> c.getType() != ConditionType.MAPPER).count();
-      if (nonMapperRootCount > 1) {
-        throw new IllegalArgumentException(
-            "New step (TEMPLATE): Only 1 condition can be first parent");
-      }
-    }
-
+    // Any number of event/filter roots is accepted, plus any number of mapper roots.
+    //
+    // The logic map lets an action be gated by SEVERAL events - `step_condition_ids` is a list, the
+    // graph appends to it, and linkExistingConditionsToStep links every id as a root - and the
+    // engine
+    // already ANDs across gating trees (evaluateFilterConditions returns false on the first
+    // unsatisfied tree). The loop below already copies every root and its subtree. This guard was
+    // the
+    // only thing rejecting more than one event root, so a scenario built that way in the UI became
+    // permanently unlaunchable, failing at copy time with "Only 1 condition can be first parent".
+    //
     // Full set of the source workflow's non-MAPPER conditions, to resolve children by parent id
     // independent of conditions_steps linkage (Event-API links only the root to the step).
     List<Condition> allSourceConditions =

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1299,6 +1299,77 @@ class StepServiceTest {
   class CopyStepConditionTemplateFields {
 
     @Test
+    void given_stepGatedByTwoEvents_should_copyBothTreesInsteadOfThrowing() {
+      // Arrange — an action gated by TWO events, which the logic map lets you build
+      // (step_condition_ids is a list) and the engine already ANDs across.
+      Workflow sourceWorkflow = new Workflow();
+      sourceWorkflow.setId("source-workflow-id");
+
+      Step sourceStep = new Step();
+      sourceStep.setId("source-step-id");
+      sourceStep.setWorkflow(sourceWorkflow);
+
+      Workflow targetWorkflow = new Workflow();
+      targetWorkflow.setId("target-workflow-id");
+
+      Step targetStep = new Step();
+      targetStep.setId("target-step-id");
+      targetStep.setWorkflow(targetWorkflow);
+
+      Condition firstEvent = Condition.builder().type(ConditionType.AND).name("SMB_FOUND").build();
+      firstEvent.setId("event-1");
+      Condition firstLeaf =
+          Condition.builder()
+              .type(ConditionType.EQ)
+              .key("port")
+              .keyTypes(List.of(PrimitiveType.Port))
+              .value("445")
+              .conditionParent(firstEvent)
+              .build();
+      firstLeaf.setId("leaf-1");
+
+      Condition secondEvent =
+          Condition.builder().type(ConditionType.AND).name("SHARE_FOUND").build();
+      secondEvent.setId("event-2");
+      Condition secondLeaf =
+          Condition.builder()
+              .type(ConditionType.IS_NOT_NULL)
+              .key("share")
+              .keyTypes(List.of(PrimitiveType.ShareName))
+              .conditionParent(secondEvent)
+              .build();
+      secondLeaf.setId("leaf-2");
+
+      List<Condition> all = List.of(firstEvent, firstLeaf, secondEvent, secondLeaf);
+      when(conditionService.findAllConditionsByStepId("source-step-id")).thenReturn(all);
+      when(conditionService.findAllNonMapperConditionsByWorkflowId("source-workflow-id"))
+          .thenReturn(all);
+
+      List<Condition> savedConditions = new ArrayList<>();
+      when(conditionService.saveCondition(any(Condition.class)))
+          .thenAnswer(
+              invocation -> {
+                Condition c = invocation.getArgument(0);
+                c.setId(UUID.randomUUID().toString());
+                savedConditions.add(c);
+                return c;
+              });
+
+      // Act — used to throw "Only 1 condition can be first parent", making a scenario built that
+      // way in the UI permanently unlaunchable.
+      stepService.copyStepConditionTemplate(sourceStep, targetStep, new HashMap<>());
+
+      // Assert — both trees copied, roots and leaves alike
+      assertEquals(4, savedConditions.size());
+      assertEquals(
+          List.of("SMB_FOUND", "SHARE_FOUND"),
+          savedConditions.stream()
+              .filter(c -> c.getConditionParent() == null)
+              .map(Condition::getName)
+              .toList());
+    }
+
+    @Test
     void given_conditionWithAllFields_should_copyAllConfigFieldsToNewCondition() {
       // Arrange
       Workflow sourceWorkflow = new Workflow();


### PR DESCRIPTION
Fixes #7266.

Launching a scenario failed with a toast and nothing ran:

```
New step (TEMPLATE): Only 1 condition can be first parent
```

The scenario was valid as far as the UI is concerned: one action was gated by **two events**, rendered on the card as `2 trigger(s)`.

### Why allowing it is the coherent fix

Everything in the stack except one guard already supports several gating events:

- **Linking is unbounded.** `step_condition_ids` is a list, the graph appends to it (`[...action.step_condition_ids, triggerId]`), and `linkExistingConditionsToStep` links every id as a root with no cardinality check.
- **The engine already ANDs across trees.** `ConditionService.evaluateFilterConditions` iterates the conditions and returns `false` on the first unsatisfied tree — so "all events must be satisfied" is the existing, implemented semantics.
- **The copy already handles N roots.** The loop in `copyStepConditionTemplate` iterates `rootConditions` and copies each subtree.

Only the cardinality guard immediately above that loop rejected more than one non-MAPPER root, so a state the UI happily builds made the scenario permanently unlaunchable.

### Change

Drop that guard. Deliberately left in place:

- the **"at least one root"** check in the same method;
- `findRootConditionInput` — an **Event API** tree is one event, so exactly one root is right;
- the single-non-MAPPER-root rule for a tree authored **inline** with a step (`ConditionService.createConditionTree`), which is not how the UI links existing events, and which two existing tests pin.

### Verification

Unit test added, run **with and without** the change:

| | result |
|---|---|
| without | `IllegalArgument New step (TEMPLATE): Only 1 condition can be first parent` — the reported error, exactly |
| with | passes; both trees copied (4 conditions), roots `SMB_FOUND` and `SHARE_FOUND` |

`253 tests, 0 failures` across `StepServiceTest`, `StepServiceIntegrationTest`, `ConditionServiceTest`, `StepServiceScenarioIntegrationTest`, `WorkflowServiceTest`. Spotless applied.

### Worth a reviewer's eye

The AND-across-events semantics is **inherited, not chosen here** — it is what `evaluateFilterConditions` already does. If the product intent for two events on one action is OR, this PR makes that wrong behaviour reachable instead of blocked, and the combination logic needs its own change. Flagging it explicitly rather than assuming.
