### PR TITLE
fix(attack-path): ship each execution's run status with the graph, and clamp a long finding value (#7275)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -335,6 +335,15 @@ public class AttackPathGraphService {
         e.getPreventionStatus(),
         e.getDetectionStatus(),
         e.getVulnerabilityStatus(),
+        // Same resolution as the graph feed's (see applyExecutionStatuses), for the single row
+        // here.
+        injectId == null
+            ? null
+            : injectStatusRepository
+                .findByInjectId(injectId)
+                .map(InjectStatus::getName)
+                .map(Enum::name)
+                .orElse(null),
         e.getExecutedAt() == null ? null : e.getExecutedAt().toString(),
         findings,
         securityPlatformResolver.resolve(e.getId(), e.getTenant().getId()),
@@ -635,6 +644,7 @@ public class AttackPathGraphService {
       feedByExecutionId.put(e.id(), executionFeedNode(e));
     }
     applyContractNames(page, feedByExecutionId);
+    applyExecutionStatuses(page, feedByExecutionId);
     return new AttackPathEndpointRelationsDTO(
         new ArrayList<>(feedByExecutionId.values()),
         new ArrayList<>(edges.values()),
@@ -686,6 +696,7 @@ public class AttackPathGraphService {
     applyKillChain(executions, feedByExecutionId);
     applyEventDependencies(executions, findings, feedByExecutionId);
     Map<String, String> contractNames = applyContractNames(executions, feedByExecutionId);
+    applyExecutionStatuses(executions, feedByExecutionId);
     applyInjectorNodeLabels(nodes, contractsByInjectorNode, contractNames);
 
     // Endpoint (ASSET) nodes, with attributes and colour from the executions targeting them.
@@ -1356,6 +1367,59 @@ public class AttackPathGraphService {
       }
     }
     return nameByExternalId;
+  }
+
+  /**
+   * Fills each feed node's inject reference and execution status ("did it actually run"), resolved
+   * the same way the Result drawer's detail read resolves its {@code injectId}: from the durable
+   * step the frozen row is keyed by, since the row itself only stores a step id.
+   *
+   * <p>Two queries for the whole set, not two per row: the client used to fetch the detail row of
+   * every visible execution just to learn its injectId, then that inject's status, so a list of ten
+   * executions cost twenty sequential round-trips and rendered no status for a second or two.
+   *
+   * <p>A row with no resolvable inject, or an inject with no status row yet (a run in flight),
+   * simply keeps a null status — the front renders nothing rather than guessing.
+   */
+  private void applyExecutionStatuses(
+      List<AttackPathExecutionRow> executions, Map<String, AttackPathNodeDTO> feedByExecutionId) {
+    Set<String> stepIds =
+        executions.stream()
+            .map(AttackPathExecutionRow::stepId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    if (stepIds.isEmpty()) {
+      return;
+    }
+    Map<String, String> injectIdByStepId = new HashMap<>();
+    for (Object[] row : stepRepository.findInjectIdsByStepIds(stepIds)) {
+      if (row[0] instanceof String stepId && row[1] instanceof String injectId) {
+        injectIdByStepId.put(stepId, injectId);
+      }
+    }
+    Map<String, String> statusByInjectId = new HashMap<>();
+    if (!injectIdByStepId.isEmpty()) {
+      for (Object[] row :
+          injectStatusRepository.findStatusNamesByInjectIds(
+              new HashSet<>(injectIdByStepId.values()))) {
+        if (row[0] instanceof String injectId && row[1] != null) {
+          statusByInjectId.put(injectId, row[1].toString());
+        }
+      }
+    }
+    for (AttackPathExecutionRow e : executions) {
+      AttackPathNodeDTO node = feedByExecutionId.get(e.id());
+      if (node == null) {
+        continue;
+      }
+      node.setPayloadId(e.payloadId());
+      String injectId = e.stepId() == null ? null : injectIdByStepId.get(e.stepId());
+      if (injectId == null) {
+        continue;
+      }
+      node.setInjectId(injectId);
+      node.setExecutionStatus(statusByInjectId.get(injectId));
+    }
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathExecutionDetailDTO.java
@@ -27,6 +27,10 @@ public record AttackPathExecutionDetailDTO(
     String preventionStatus,
     String detectionStatus,
     String vulnerabilityStatus,
+    // Whether the inject actually RAN (EXECUTED / ERROR / PENDING…), as opposed to whether it was
+    // caught, which the three statuses above carry. Resolved from the inject this row's step points
+    // at, so the drawer renders it on open instead of fetching the inject's status itself.
+    String executionStatus,
     String executedAt,
     List<AttackPathExecutionFindingItemDTO> findings,
     // the security platforms that acted (prevention/detection), resolved live from the inject's

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
@@ -65,6 +65,18 @@ public class AttackPathNodeDTO {
   private String agentName;
   private String privilege;
   private String stepTemplateId;
+  // EXECUTION: the run's inject and, when it has one, the payload it ran — resolved from the
+  // durable
+  // step the frozen row is keyed by, exactly as the Result drawer's detail read does. They let the
+  // front address this execution's live inject without first fetching its detail row.
+  private String injectId;
+  private String payloadId;
+  // EXECUTION: whether the inject actually RAN (EXECUTED / ERROR / PENDING…), as opposed to whether
+  // it was caught, which is what `status` above carries. Shipped with the graph so a list of
+  // executions renders it on first paint; the front previously needed two sequential fetches per
+  // visible row (detail for the injectId, then the inject's status) and so showed nothing for a
+  // second or two. Null when the row has no resolvable inject or its inject has no status yet.
+  private String executionStatus;
   // Kill-chain, resolved per step template (keyed by stepTemplateId): the step templates this one
   // depends on, and the finding keys it consumes. Full mode only; the front correlates by
   // stepTemplateId to draw the causal edges.

--- a/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
@@ -227,4 +227,49 @@ class StepRepositoryTest extends IntegrationTest {
     Assertions.assertEquals(1, stepIdsForInject2.size(), "Should return exactly 1 step ID");
     Assertions.assertTrue(stepIdsForInject2.contains(step2.getId()), "Should contain step2");
   }
+
+  @Test
+  void whenFindInjectIdsByStepIds_thenReturnsOnePairPerResolvedStep() {
+    // GIVEN: two steps carrying an inject_id, one carrying none
+    Step withInject1 =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data("{\"inject_id\": \"inject-batch-1\"}")
+            .build();
+    Step withInject2 =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data("{\"inject_id\": \"inject-batch-2\"}")
+            .build();
+    Step withoutInject =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data("{\"something_else\": \"no inject here\"}")
+            .build();
+
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+        .withStep(stepComposer.forStep(withInject1))
+        .withStep(stepComposer.forStep(withInject2))
+        .withStep(stepComposer.forStep(withoutInject))
+        .persist();
+
+    // WHEN: resolving all three in one query
+    List<Object[]> pairs =
+        stepRepository.findInjectIdsByStepIds(
+            List.of(withInject1.getId(), withInject2.getId(), withoutInject.getId()));
+
+    // THEN: the step with no inject_id is filtered out, not returned as a null pair
+    Assertions.assertEquals(2, pairs.size(), "Only the steps carrying an inject_id come back");
+    Set<String> resolved =
+        pairs.stream()
+            .map(row -> row[0] + "=" + row[1])
+            .collect(java.util.stream.Collectors.toSet());
+    Assertions.assertTrue(resolved.contains(withInject1.getId() + "=inject-batch-1"));
+    Assertions.assertTrue(resolved.contains(withInject2.getId() + "=inject-batch-2"));
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/database/repository/InjectStatusRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/repository/InjectStatusRepositoryTest.java
@@ -97,4 +97,38 @@ class InjectStatusRepositoryTest extends IntegrationTest {
         .extracting(ExecutionTrace::getMessage)
         .containsExactly("early", "middle", "late");
   }
+
+  @Test
+  @DisplayName("findStatusNamesByInjectIds returns one pair per inject that has a status")
+  void given_injectsWithAndWithoutStatus_should_returnOnlyTheOnesWithAStatus() {
+    // Arrange: one executed inject, one pending, one with no status row at all.
+    Inject executed =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withInjectStatus(
+                injectStatusComposer.forInjectStatus(InjectStatusFixture.createSuccessStatus()))
+            .persist()
+            .get();
+    Inject pending =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withInjectStatus(
+                injectStatusComposer.forInjectStatus(
+                    InjectStatusFixture.createPendingInjectStatus()))
+            .persist()
+            .get();
+    Inject statusless = injectComposer.forInject(InjectFixture.getDefaultInject()).persist().get();
+    entityManager.flush();
+    entityManager.clear();
+
+    // Act
+    List<Object[]> pairs =
+        injectStatusRepository.findStatusNamesByInjectIds(
+            List.of(executed.getId(), pending.getId(), statusless.getId()));
+
+    // Assert: the statusless inject is absent rather than present with a null status.
+    assertThat(pairs)
+        .extracting(row -> row[0] + "=" + row[1])
+        .containsExactlyInAnyOrder(executed.getId() + "=EXECUTED", pending.getId() + "=PENDING");
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/attackpath/AttackPathGraphServiceTest.java
@@ -5,7 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.AssetCriticality;
 import io.openaev.database.model.Endpoint;
+import io.openaev.database.model.Inject;
 import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.Step;
+import io.openaev.database.model.StepActionClass;
+import io.openaev.database.model.StepStatus;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.attackpath.AttackPathExecution;
 import io.openaev.database.model.attackpath.AttackPathExecutionFinding;
@@ -20,9 +24,18 @@ import io.openaev.service.attackpath.dto.AttackPathEndpointRelationsDTO;
 import io.openaev.service.attackpath.dto.AttackPathExpandDTO;
 import io.openaev.service.attackpath.dto.AttackPathNodeDTO;
 import io.openaev.utils.fixtures.EndpointFixture;
+import io.openaev.utils.fixtures.ExerciseFixture;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.InjectStatusFixture;
 import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.WorkflowFixture;
 import io.openaev.utils.fixtures.composers.AttackPatternComposer;
+import io.openaev.utils.fixtures.composers.ExerciseComposer;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectStatusComposer;
 import io.openaev.utils.fixtures.composers.InjectorContractComposer;
+import io.openaev.utils.fixtures.composers.StepComposer;
+import io.openaev.utils.fixtures.composers.WorkflowComposer;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
 import java.time.Instant;
@@ -53,6 +66,11 @@ class AttackPathGraphServiceTest extends IntegrationTest {
   @Autowired private AssetRepository assetRepository;
   @Autowired private InjectorContractComposer injectorContractComposer;
   @Autowired private AttackPatternComposer attackPatternComposer;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectStatusComposer injectStatusComposer;
+  @Autowired private WorkflowComposer workflowComposer;
+  @Autowired private StepComposer stepComposer;
+  @Autowired private ExerciseComposer simulationComposer;
 
   private Tenant tenant;
   private String exec1Id;
@@ -169,6 +187,64 @@ class AttackPathGraphServiceTest extends IntegrationTest {
     assertThat(feedNode.getRef())
         .as("the feed node carries the raw execution id for the drawer cross-focus")
         .isEqualTo(exec1Id);
+  }
+
+  @Test
+  @DisplayName(
+      "An execution feed node carries its inject and its execution status, resolved from the step")
+  void fills_execution_status_from_the_step() {
+    // A run's inject id lives in the durable step's data (the frozen row only keys the step), and
+    // its
+    // "did it run" status on the inject itself - exactly what the Result drawer's detail read
+    // resolves.
+    Inject inject =
+        injectComposer
+            .forInject(InjectFixture.getDefaultInject())
+            .withInjectStatus(
+                injectStatusComposer.forInjectStatus(InjectStatusFixture.createSuccessStatus()))
+            .persist()
+            .get();
+    Step step =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data("{\"inject_id\": \"" + inject.getId() + "\"}")
+            .build();
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+        .withStep(stepComposer.forStep(step))
+        .persist();
+    String execId =
+        injectorExecution(
+            "NMAP", "status-01", "CORP-STATUS-01", "Not Prevented", "Not Detected", "Nmap", at(9));
+    AttackPathExecution row = executionRepository.findById(execId).orElseThrow();
+    row.setStepId(step.getId());
+    executionRepository.save(row);
+    entityManager.flush();
+    entityManager.clear();
+
+    AttackPathDTO dto = service.buildGraph(SIM);
+
+    String feedNodeId = AttackPathIds.executionNode(execId, "status-01", null);
+    AttackPathNodeDTO feedNode =
+        dto.attackPathExecutions().stream()
+            .filter(n -> feedNodeId.equals(n.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(feedNode.getInjectId()).isEqualTo(inject.getId());
+    assertThat(feedNode.getExecutionStatus())
+        .as("shipped with the graph, so a list of executions renders it without a round-trip")
+        .isEqualTo("EXECUTED");
+    // A row with no step resolves to nothing rather than guessing.
+    String noStepNodeId = AttackPathIds.executionNode(exec1Id, "dc-01", null);
+    AttackPathNodeDTO noStepNode =
+        dto.attackPathExecutions().stream()
+            .filter(n -> noStepNodeId.equals(n.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertThat(noStepNode.getInjectId()).isNull();
+    assertThat(noStepNode.getExecutionStatus()).isNull();
   }
 
   @Test

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.test.tsx
@@ -1,0 +1,104 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import EndpointDetailPanel from '../../../../../../admin/components/simulations/simulation/attack_path/EndpointDetailPanel';
+
+// The run-status badge fetches on its own; stub it so these tests are about the findings list only.
+vi.mock('../../../../../../admin/components/simulations/simulation/attack_path/ExecutionStatusBadge', () => ({ ExecutionRowStatusBadge: () => <span data-testid="exec-status" /> }));
+
+vi.mock('../../../../../../components/i18n', () => ({
+  useFormatter: () => ({
+    t: (s: string, values?: Record<string, string | number>) =>
+      (values ? Object.entries(values).reduce((acc, [k, v]) => acc.replace(`{${k}}`, String(v)), s) : s),
+  }),
+}));
+
+const value = (prefix: string, i: number) => `${prefix}-${i}`;
+
+const renderPanel = (props: Partial<Parameters<typeof EndpointDetailPanel>[0]> = {}) => render(
+  <ThemeProvider theme={createTheme()}>
+    <EndpointDetailPanel
+      simulationId="sim-1"
+      endpointLabel="CORP-HOST"
+      findingsLoading={false}
+      findingGroups={[]}
+      executions={[]}
+      highlightedExecutionIds={new Set()}
+      registerRow={vi.fn()}
+      onSelectExecution={vi.fn()}
+      execStatusLabel={(status?: string) => status ?? '-'}
+      onClose={vi.fn()}
+      {...props}
+    />
+  </ThemeProvider>,
+);
+
+describe('EndpointDetailPanel findings pagination', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('gives a paginated group its own pager, on the group header row', () => {
+    // 13 files (two pages of 10) and 2 ports (one page): only the file group is paginated, and its
+    // pager belongs to that group's header — under the last value it sat between two groups and read
+    // as paging the whole section.
+    renderPanel({
+      findingGroups: [
+        {
+          type: 'file',
+          values: Array.from({ length: 13 }, (_, i) => value('file', i)),
+        },
+        {
+          type: 'port',
+          values: ['445', '3389'],
+        },
+      ],
+    });
+
+    const pagers = screen.getAllByRole('navigation');
+    expect(pagers).toHaveLength(1);
+    expect(pagers[0].getAttribute('aria-label')).toBe('Findings pagination for file');
+
+    // The pager sits inside the same row as the group's "FILE (13)" label, not after its values.
+    const header = screen.getByText('file (13)');
+    expect(header.parentElement?.contains(pagers[0])).toBe(true);
+  });
+
+  it('pages that group alone, leaving the others untouched', () => {
+    renderPanel({
+      findingGroups: [
+        {
+          type: 'file',
+          values: Array.from({ length: 13 }, (_, i) => value('file', i)),
+        },
+        {
+          type: 'port',
+          values: ['445', '3389'],
+        },
+      ],
+    });
+
+    expect(screen.getByText('file-0')).toBeDefined();
+    expect(screen.queryByText('file-12')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Go to page 2'));
+
+    expect(screen.getByText('file-12')).toBeDefined();
+    expect(screen.queryByText('file-0')).toBeNull();
+    // The other group never paged.
+    expect(screen.getByText('445')).toBeDefined();
+    expect(screen.getByText('3389')).toBeDefined();
+  });
+
+  it('shows no pager when every group fits on one page', () => {
+    renderPanel({
+      findingGroups: [{
+        type: 'port',
+        values: ['445', '3389'],
+      }],
+    });
+    expect(screen.queryByRole('navigation')).toBeNull();
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
@@ -111,13 +111,7 @@ describe('ExecutionRowStatusBadge', () => {
     expect(mocks.getInjectStatusWithGlobalExecutionTraces).not.toHaveBeenCalled();
   });
 
-  it('still resolves per target when the row is payload-backed, whatever the inject-level status', async () => {
-    mocks.fetchExecutionDetail.mockResolvedValue({
-      data: {
-        injectId: 'inject-4',
-        payloadId: 'payload-4',
-      },
-    });
+  it('still resolves per target when the row is payload-backed, without refetching the detail', async () => {
     mocks.searchTargets.mockResolvedValue({
       data: {
         content: [{
@@ -150,12 +144,13 @@ describe('ExecutionRowStatusBadge', () => {
       />,
     );
 
-    // The inject ran, but THIS agent timed out: the per-target status wins.
+    // The inject ran, but THIS agent timed out: the per-target status wins — resolved straight from
+    // the graph-provided injectId/payloadId, with no detail round-trip.
     expect(await screen.findByText('Timeout')).toBeDefined();
+    expect(mocks.fetchExecutionDetail).not.toHaveBeenCalled();
   });
 
-  it('refines a non-terminal graph status instead of trusting it', async () => {
-    mocks.fetchExecutionDetail.mockResolvedValue({ data: { injectId: 'inject-5' } });
+  it('refines a non-terminal graph status instead of trusting it, straight from its injectId', async () => {
     mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({
       data: {
         status_id: 'status-5',
@@ -173,7 +168,34 @@ describe('ExecutionRowStatusBadge', () => {
     );
 
     expect(await screen.findByText('EXECUTED')).toBeDefined();
-    expect(mocks.fetchExecutionDetail).toHaveBeenCalledWith('sim-1', 'exec-ref-5');
+    // The graph already named the inject: refining its status needs no detail fetch.
+    expect(mocks.fetchExecutionDetail).not.toHaveBeenCalled();
+    expect(mocks.getInjectStatusWithGlobalExecutionTraces).toHaveBeenCalledWith('inject-5');
+  });
+
+  it('drops a fetched status when the execution ref goes away instead of keeping it stale', async () => {
+    mocks.fetchExecutionDetail.mockResolvedValue({ data: { injectId: 'inject-6' } });
+    mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({
+      data: {
+        status_id: 'status-6',
+        status_name: 'EXECUTED',
+      },
+    });
+
+    const { rerender, container } = renderWithTheme(
+      <ExecutionRowStatusBadge simulationId="sim-1" executionRef="exec-ref-6" />,
+    );
+    expect(await screen.findByText('EXECUTED')).toBeDefined();
+
+    rerender(
+      <ThemeProvider theme={createTheme()}>
+        <ExecutionRowStatusBadge simulationId="sim-1" />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toBe('');
+    });
   });
 
   it('renders nothing and fires no resolution without an execution ref', async () => {

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
@@ -92,6 +92,90 @@ describe('ExecutionRowStatusBadge', () => {
     expect(mocks.searchTargets).not.toHaveBeenCalled();
   });
 
+  // The graph row now carries injectId/payloadId/executionStatus (AttackPathGraphService resolves them
+  // from the durable step), so the common case renders with no round-trip at all.
+  it('renders the graph-provided status immediately, with no fetch, for a settled injector row', async () => {
+    renderWithTheme(
+      <ExecutionRowStatusBadge
+        simulationId="sim-1"
+        executionRef="exec-ref-3"
+        injectId="inject-3"
+        executionStatus="EXECUTED"
+      />,
+    );
+
+    expect(screen.getByText('EXECUTED')).toBeDefined();
+    await waitFor(() => {
+      expect(mocks.fetchExecutionDetail).not.toHaveBeenCalled();
+    });
+    expect(mocks.getInjectStatusWithGlobalExecutionTraces).not.toHaveBeenCalled();
+  });
+
+  it('still resolves per target when the row is payload-backed, whatever the inject-level status', async () => {
+    mocks.fetchExecutionDetail.mockResolvedValue({
+      data: {
+        injectId: 'inject-4',
+        payloadId: 'payload-4',
+      },
+    });
+    mocks.searchTargets.mockResolvedValue({
+      data: {
+        content: [{
+          target_id: 'target-4',
+          target_type: 'ASSETS',
+          target_name: 'CORP-HOST',
+        }],
+      },
+    });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({
+      data: {
+        execution_traces: {
+          'target-4': [{
+            execution_action: 'COMPLETE',
+            execution_status: 'TIMEOUT',
+            execution_time: '2026-01-01T00:00:00Z',
+          }],
+        },
+      },
+    });
+
+    renderWithTheme(
+      <ExecutionRowStatusBadge
+        simulationId="sim-1"
+        executionRef="exec-ref-4"
+        endpointName="CORP-HOST"
+        injectId="inject-4"
+        payloadId="payload-4"
+        executionStatus="EXECUTED"
+      />,
+    );
+
+    // The inject ran, but THIS agent timed out: the per-target status wins.
+    expect(await screen.findByText('Timeout')).toBeDefined();
+  });
+
+  it('refines a non-terminal graph status instead of trusting it', async () => {
+    mocks.fetchExecutionDetail.mockResolvedValue({ data: { injectId: 'inject-5' } });
+    mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({
+      data: {
+        status_id: 'status-5',
+        status_name: 'EXECUTED',
+      },
+    });
+
+    renderWithTheme(
+      <ExecutionRowStatusBadge
+        simulationId="sim-1"
+        executionRef="exec-ref-5"
+        injectId="inject-5"
+        executionStatus="PENDING"
+      />,
+    );
+
+    expect(await screen.findByText('EXECUTED')).toBeDefined();
+    expect(mocks.fetchExecutionDetail).toHaveBeenCalledWith('sim-1', 'exec-ref-5');
+  });
+
   it('renders nothing and fires no resolution without an execution ref', async () => {
     const { container } = renderWithTheme(<ExecutionRowStatusBadge simulationId="sim-1" />);
 

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/FindingDetailPanel.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/FindingDetailPanel.test.tsx
@@ -1,0 +1,119 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import FindingDetailPanel, { type ProducingAction } from '../../../../../../admin/components/simulations/simulation/attack_path/FindingDetailPanel';
+
+// The execution-status badge does its own fetching (execution detail, then inject status): stub it and
+// assert the panel wires each producing action to it, rather than re-testing the badge here.
+vi.mock('../../../../../../admin/components/simulations/simulation/attack_path/ExecutionStatusBadge', () => ({
+  ExecutionRowStatusBadge: ({ simulationId, executionRef, endpointName }: {
+    simulationId: string;
+    executionRef?: string;
+    endpointName?: string;
+  }) => (
+    <span data-testid="exec-status" data-sim={simulationId} data-ref={executionRef} data-endpoint={endpointName} />
+  ),
+}));
+
+vi.mock('../../../../../../components/i18n', () => ({ useFormatter: () => ({ t: (s: string) => s }) }));
+
+const action = (ref: string): ProducingAction => ({
+  ref,
+  contract: `contract-${ref}`,
+  statusColor: '#ff0000',
+  statusLabel: 'Undetected',
+  subtitle: 'agent · admin',
+});
+
+const renderPanel = (props: Partial<Parameters<typeof FindingDetailPanel>[0]> = {}): ReactElement => {
+  const element = (
+    <ThemeProvider theme={createTheme()}>
+      <FindingDetailPanel
+        value="445"
+        type="port"
+        simulationId="sim-1"
+        endpointLabel="CORP-HOST"
+        endpointName="CORP-HOST"
+        actions={[action('exec-1')]}
+        activeRef={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        {...props}
+      />
+    </ThemeProvider>
+  );
+  render(element);
+  return element;
+};
+
+// An Nmap XML report as an output-only value: long enough to bury the rest of the panel.
+const LONG_VALUE = `<?xml version="1.0" encoding="UTF-8"?><nmaprun scanner="nmap" args="nmap -Pn -sT">${'<port protocol="tcp" portid="445"/>'.repeat(20)}</nmaprun>`;
+
+describe('FindingDetailPanel value clamping', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('offers no toggle for a short value', () => {
+    renderPanel();
+    expect(screen.getByText('445')).toBeDefined();
+    expect(screen.queryByText('Show more')).toBeNull();
+    expect(screen.queryByText('Show less')).toBeNull();
+  });
+
+  it('clamps a long value behind a Show more / Show less toggle', () => {
+    renderPanel({ value: LONG_VALUE });
+
+    const more = screen.getByText('Show more');
+    expect(more).toBeDefined();
+
+    fireEvent.click(more);
+    expect(screen.getByText('Show less')).toBeDefined();
+    expect(screen.queryByText('Show more')).toBeNull();
+
+    fireEvent.click(screen.getByText('Show less'));
+    expect(screen.getByText('Show more')).toBeDefined();
+  });
+
+  it('keeps the toggle when the value sits under the verdict badges', () => {
+    renderPanel({
+      value: LONG_VALUE,
+      expectations: {
+        prevention: 'failed',
+        detection: 'failed',
+        vulnerability: 'success',
+      },
+    });
+    expect(screen.getByText('Show more')).toBeDefined();
+  });
+});
+
+describe('FindingDetailPanel producing actions', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows the run status of every producing action, alongside its verdict', () => {
+    renderPanel({ actions: [action('exec-1'), action('exec-2')] });
+
+    const badges = screen.getAllByTestId('exec-status');
+    expect(badges).toHaveLength(2);
+    expect(badges.map(b => b.getAttribute('data-ref'))).toEqual(['exec-1', 'exec-2']);
+    for (const badge of badges) {
+      expect(badge.getAttribute('data-sim')).toBe('sim-1');
+      expect(badge.getAttribute('data-endpoint')).toBe('CORP-HOST');
+    }
+    // The detection verdict stays: it answers a different question than "did it run".
+    expect(screen.getAllByText('Undetected')).toHaveLength(2);
+  });
+
+  it('renders no run status when there is no producing action', () => {
+    renderPanel({ actions: [] });
+    expect(screen.queryByTestId('exec-status')).toBeNull();
+    expect(screen.getByText('No producing action found for this finding')).toBeDefined();
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/FindingDetailPanel.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/FindingDetailPanel.test.tsx
@@ -78,6 +78,34 @@ describe('FindingDetailPanel value clamping', () => {
     expect(screen.getByText('Show more')).toBeDefined();
   });
 
+  it('re-collapses when a different value is shown while the panel stays mounted', () => {
+    // The panel is not remounted between two findings: without a reset the second long value would
+    // open already expanded because the first one's toggle left the state on.
+    const panel = (value: string) => (
+      <ThemeProvider theme={createTheme()}>
+        <FindingDetailPanel
+          value={value}
+          type="port"
+          simulationId="sim-1"
+          endpointLabel="CORP-HOST"
+          endpointName="CORP-HOST"
+          actions={[action('exec-1')]}
+          activeRef={null}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </ThemeProvider>
+    );
+    const { rerender } = render(panel(LONG_VALUE));
+    fireEvent.click(screen.getByText('Show more'));
+    expect(screen.getByText('Show less')).toBeDefined();
+
+    rerender(panel(`${LONG_VALUE} -- another run's output`));
+
+    expect(screen.getByText('Show more')).toBeDefined();
+    expect(screen.queryByText('Show less')).toBeNull();
+  });
+
   it('keeps the toggle when the value sits under the verdict badges', () => {
     renderPanel({
       value: LONG_VALUE,

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx
@@ -11,8 +11,13 @@ import { AbilityContext } from '../../../../../../utils/permissions/permissionsC
 type FlowProps = {
   focusRequest?: { nodeId: string };
   fitRequest?: number;
+  anchorRequest?: {
+    nodeId: string;
+    nonce: number;
+  } | null;
   onEndpointClick?: (nodeId: string, ref?: string, label?: string) => void;
   onInjectorSelect?: (injectorId: string, label?: string) => void;
+  onFindingClusterClick?: (clusterId: string, typeFindings: string | undefined, injectorId: string | undefined, endpointRef: string | undefined, kind: 'header' | 'overflow' | 'typeOverflow') => void;
 };
 
 // Capture the props AttackPathCanvas receives (mocked so the canvas is not instantiated), and stub
@@ -244,6 +249,41 @@ describe('SimulationAttackPath findings drawer + cross-focus', () => {
     // the width the focus just revealed. The graph stays rendered, the detail is one node click away.
     expect(await screen.findByTestId('attack-path-flow')).toBeTruthy();
     expect(screen.queryByText(/Executions/)).toBeNull();
+  });
+
+  it('holds the view on an expanded finding cluster instead of re-fitting the whole graph', async () => {
+    setup();
+    await screen.findByTestId('attack-path-flow');
+    // Both initial reads (the collapsed seed, then the causal overlay merged in) bump the fit nonce as
+    // part of the initial framing; settle them before measuring what the click alone does.
+    await waitFor(() => {
+      expect(mocks.fetchAttackPathGraph).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const fitBefore = mocks.flowProps.current?.fitRequest ?? 0;
+
+    // Expanding reveals nodes and so grows the world. Without an anchor the canvas reads that growth
+    // as the graph changing shape and re-frames everything, dumping the user back at its entrance.
+    act(() => {
+      mocks.flowProps.current?.onFindingClusterClick?.('cl-type|file|host-x', 'file', undefined, 'host-x', 'header');
+    });
+
+    await waitFor(() => {
+      expect(mocks.flowProps.current?.anchorRequest?.nodeId).toBe('cl-type|file|host-x');
+    });
+    // Anchoring is not fitting: the whole-graph fit must NOT have been requested.
+    expect(mocks.flowProps.current?.fitRequest ?? 0).toBe(fitBefore);
+
+    // Collapsing the same cluster removes nodes, where re-fitting IS the readable behaviour.
+    act(() => {
+      mocks.flowProps.current?.onFindingClusterClick?.('cl-type|file|host-x', 'file', undefined, 'host-x', 'header');
+    });
+    await waitFor(() => {
+      expect(mocks.flowProps.current?.fitRequest ?? 0).toBeGreaterThan(fitBefore);
+    });
   });
 
   it('opens the result & terminal panel for a clicked execution and focuses its endpoint on the map', async () => {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -208,6 +208,23 @@ const EndpointDetailPanel = ({
                     >
                       {`${g.type} (${g.values.length})`}
                     </Typography>
+                    {/* The pager belongs to THIS group only (each finding type pages on its own), so it
+                        sits on the group's own header row. Under the last value it landed between two
+                        groups, equidistant from both, and read as paging the whole section. */}
+                    {pageCount > 1 && (
+                      <Pagination
+                        size="small"
+                        count={pageCount}
+                        page={page}
+                        siblingCount={0}
+                        aria-label={t('Findings pagination for {type}', { type: g.type })}
+                        onChange={(_, value) => setGroupPages(prev => ({
+                          ...prev,
+                          [g.type]: value,
+                        }))}
+                        sx={{ ml: 'auto' }}
+                      />
+                    )}
                   </Box>
                   {pageValues.map((v, i) => (
                     <Typography
@@ -220,21 +237,6 @@ const EndpointDetailPanel = ({
                       {v}
                     </Typography>
                   ))}
-                  {pageCount > 1 && (
-                    <Pagination
-                      size="small"
-                      count={pageCount}
-                      page={page}
-                      onChange={(_, value) => setGroupPages(prev => ({
-                        ...prev,
-                        [g.type]: value,
-                      }))}
-                      sx={{
-                        mt: 0.5,
-                        pl: 2.25,
-                      }}
-                    />
-                  )}
                 </Box>
               );
             })}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -313,6 +313,9 @@ const EndpointDetailPanel = ({
                       simulationId={simulationId}
                       executionRef={e.ref}
                       endpointName={e.hostname}
+                      injectId={e.injectId}
+                      payloadId={e.payloadId}
+                      executionStatus={e.executionStatus}
                     />
                   </Box>
                   <Box sx={{

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -62,11 +62,12 @@ const TERMINAL_INJECT_STATUSES = new Set(['EXECUTED', 'PARTIAL', 'ERROR']);
 // injector's status renders on FIRST PAINT — it used to cost two sequential fetches per visible row
 // (detail for the injectId, then the inject's status) and showed nothing for a second or two.
 //
-// Two cases still fetch:
+// Two cases still resolve live, but from the graph-provided injectId, with no detail fetch:
 //   - a payload-backed execution, because "did it run" is per AGENT there, read from that target's
 //     traces; the inject-level status cannot answer it for one agent among several;
 //   - a row with no status, or a non-terminal one (a live run): the graph's value would go stale until
 //     the next delta touching that row, so it is refined here rather than trusted.
+// The detail fetch only remains for a row the graph could not resolve (no injectId shipped).
 export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointName, injectId, payloadId, executionStatus }: {
   simulationId: string;
   executionRef?: string;
@@ -79,32 +80,36 @@ export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointNa
     && !payloadId
     && !!executionStatus
     && TERMINAL_INJECT_STATUSES.has(executionStatus.toUpperCase());
-  const [detail, setDetail] = useState<{
+  // Fetched fallback for a row the graph shipped no injectId for. Derived per render from the props
+  // otherwise, so a prop update (a delta filling the ids in) is picked up without a remount.
+  const [fetchedDetail, setFetchedDetail] = useState<{
     injectId?: string;
     payloadId?: string;
-  } | null>(injectId
-    ? {
-        injectId,
-        payloadId,
-      }
-    : null);
+  } | null>(null);
   useEffect(() => {
     let active = true;
-    if (!executionRef || settledFromGraph) {
+    if (!executionRef || injectId) {
+      setFetchedDetail(null);
       return () => {
         active = false;
       };
     }
     fetchExecutionDetail(simulationId, executionRef)
-      .then(r => active && setDetail(r.data))
-      .catch(() => active && setDetail(null));
+      .then(r => active && setFetchedDetail(r.data))
+      .catch(() => active && setFetchedDetail(null));
     return () => {
       active = false;
     };
-  }, [simulationId, executionRef, settledFromGraph]);
+  }, [simulationId, executionRef, injectId]);
   if (settledFromGraph) {
     return <InjectStatus status={executionStatus as InjectStatusType['status_name']} />;
   }
+  const detail = injectId
+    ? {
+        injectId,
+        payloadId,
+      }
+    : fetchedDetail;
   if (!detail?.injectId) {
     return null;
   }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -53,23 +53,44 @@ export const InjectorExecutionStatusBadge = ({ injectId }: { injectId: string })
   return <InjectStatus status={statusName as InjectStatusType['status_name']} />;
 };
 
-// One execution row (endpoint/injector panel list) rarely has its injectId/payloadId already loaded —
-// those live on the execution DETAIL DTO, not the lightweight graph row — so this resolves them first
-// (a small extra fetch per visible row) before delegating to the same two badges the Result tab uses,
-// so every place an execution shows up agrees on the same "did it actually run" status.
-export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointName }: {
+// An inject-level status the backend cannot still change under us: anything else (a run in flight, or
+// a status the graph snapshot froze before it settled) is refined by this component's own fetch.
+const TERMINAL_INJECT_STATUSES = new Set(['EXECUTED', 'PARTIAL', 'ERROR']);
+
+// One execution row (endpoint/injector panel list). The graph row now ships this execution's inject,
+// payload and inject-level status (see AttackPathGraphService#applyExecutionStatuses), so a network
+// injector's status renders on FIRST PAINT — it used to cost two sequential fetches per visible row
+// (detail for the injectId, then the inject's status) and showed nothing for a second or two.
+//
+// Two cases still fetch:
+//   - a payload-backed execution, because "did it run" is per AGENT there, read from that target's
+//     traces; the inject-level status cannot answer it for one agent among several;
+//   - a row with no status, or a non-terminal one (a live run): the graph's value would go stale until
+//     the next delta touching that row, so it is refined here rather than trusted.
+export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointName, injectId, payloadId, executionStatus }: {
   simulationId: string;
   executionRef?: string;
   endpointName?: string;
+  injectId?: string;
+  payloadId?: string;
+  executionStatus?: string;
 }) => {
+  const settledFromGraph = !!injectId
+    && !payloadId
+    && !!executionStatus
+    && TERMINAL_INJECT_STATUSES.has(executionStatus.toUpperCase());
   const [detail, setDetail] = useState<{
     injectId?: string;
     payloadId?: string;
-  } | null>(null);
+  } | null>(injectId
+    ? {
+        injectId,
+        payloadId,
+      }
+    : null);
   useEffect(() => {
     let active = true;
-    if (!executionRef) {
-      setDetail(null);
+    if (!executionRef || settledFromGraph) {
       return () => {
         active = false;
       };
@@ -80,7 +101,10 @@ export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointNa
     return () => {
       active = false;
     };
-  }, [simulationId, executionRef]);
+  }, [simulationId, executionRef, settledFromGraph]);
+  if (settledFromGraph) {
+    return <InjectStatus status={executionStatus as InjectStatusType['status_name']} />;
+  }
   if (!detail?.injectId) {
     return null;
   }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
@@ -75,6 +75,13 @@ const FindingDetailPanel = ({
   const { t } = useFormatter();
   const isOutputOnly = isFinding === false;
   const [valueExpanded, setValueExpanded] = useState(false);
+  // The panel stays mounted while the user hops from one finding to the next: re-collapse whenever a
+  // DIFFERENT value comes in, so a long value never opens pre-expanded by the previous one's toggle.
+  const [lastValue, setLastValue] = useState(value);
+  if (value !== lastValue) {
+    setLastValue(value);
+    setValueExpanded(false);
+  }
   const isValueLong = value.length > VALUE_CLAMP_CHARS;
 
   // Colour a verdict per its expectation type: a successful prevention is green, a successful

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/FindingDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { Close, InfoOutlined } from '@mui/icons-material';
-import { Alert, Box, Button, Chip, IconButton, Paper, Tooltip, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, IconButton, Link, Paper, Tooltip, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
+import { useState } from 'react';
 
 import FindingIcon from '../../../../../components/FindingIcon';
 import { useFormatter } from '../../../../../components/i18n';
@@ -8,6 +9,7 @@ import LogicNodeTooltip from '../../../chaining/logic/chaining_flow/NodeTooltip'
 import graphTooltipSlotProps from '../../../chaining/logic/logic-graph/graphTooltipSlotProps';
 import expectationIconByType from '../../../common/ExpectationIconByType';
 import InjectFormSection from '../../../common/injects/form/InjectFormSection';
+import { ExecutionRowStatusBadge } from './ExecutionStatusBadge';
 
 export interface ProducingAction {
   ref: string;
@@ -15,6 +17,12 @@ export interface ProducingAction {
   statusColor: string;
   statusLabel: string;
   subtitle: string;
+  // Straight off the graph row, so the run-status badge renders on first paint (see
+  // ExecutionRowStatusBadge). Absent on a row the graph could not resolve — it then falls back to
+  // fetching, as it always did.
+  injectId?: string;
+  payloadId?: string;
+  executionStatus?: string;
 }
 
 export type ExpectationVerdict = 'success' | 'failed' | 'unknown';
@@ -29,8 +37,11 @@ interface Props {
   // Masked, display-ready finding value (secrets already hidden by the caller).
   value: string;
   type: string;
+  simulationId: string;
   endpointLabel: string;
   endpointSub?: string;
+  // Endpoint hostname, used to resolve this execution's own target when reading its run status.
+  endpointName?: string;
   // Prevention / detection / vulnerability verdicts for this finding (backend-provided).
   expectations?: FindingExpectations;
   actions: ProducingAction[];
@@ -44,15 +55,27 @@ interface Props {
 
 const EXPECTATION_ORDER: (keyof FindingExpectations)[] = ['prevention', 'detection', 'vulnerability'];
 
+// An output-only value can be a whole command output (an Nmap XML report is several KB), which pushed
+// everything else in the panel — the type chip, the endpoint, the producing actions — kilometres below
+// the fold. Clamp the value to a few lines and let it be expanded on demand. Short values (the common
+// case: a port, a share, a hash) stay untouched and get no toggle.
+const VALUE_CLAMP_LINES = 3;
+const VALUE_CLAMP_CHARS = 180;
+
 // Right-side panel describing one finding picked in the attack-path graph: its prevention/detection/
 // vulnerability verdicts, what it is, on which endpoint it was found, and which action(s) produced it.
 // Selecting a producing action opens the Result & Terminal panel next to it, so the finding, its path
 // (highlighted on the map) and the raw execution result can all be inspected at once. All values are
 // rendered as inert text (secrets are masked upstream); nothing here is injected as HTML.
-const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectations, actions, activeRef, isFinding = true, onSelect, onClose }: Props) => {
+const FindingDetailPanel = ({
+  value, type, simulationId, endpointLabel, endpointSub, endpointName,
+  expectations, actions, activeRef, isFinding = true, onSelect, onClose,
+}: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
   const isOutputOnly = isFinding === false;
+  const [valueExpanded, setValueExpanded] = useState(false);
+  const isValueLong = value.length > VALUE_CLAMP_CHARS;
 
   // Colour a verdict per its expectation type: a successful prevention is green, a successful
   // detection is orange, a failed verdict is red, and an unknown one is muted.
@@ -83,6 +106,43 @@ const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectati
     return t('Result: not evaluated - no matching control result was reported for this finding.');
   };
   const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+  // The value, clamped unless expanded. Rendered in the header row when there is no verdict badge row
+  // to hold it, and just under those badges otherwise — one definition for both.
+  const valueBlock = (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography
+        variant="h5"
+        sx={{
+          wordBreak: 'break-all',
+          margin: 0,
+          ...(isValueLong && !valueExpanded
+            ? {
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: VALUE_CLAMP_LINES,
+                overflow: 'hidden',
+              }
+            : {}),
+        }}
+        title={value}
+      >
+        {value}
+      </Typography>
+      {isValueLong && (
+        <Link
+          component="button"
+          type="button"
+          variant="caption"
+          underline="hover"
+          onClick={() => setValueExpanded(expanded => !expanded)}
+          sx={{ mt: 0.25 }}
+        >
+          {valueExpanded ? t('Show less') : t('Show more')}
+        </Link>
+      )}
+    </Box>
+  );
 
   return (
     <Paper
@@ -167,36 +227,13 @@ const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectati
                     })}
                   </Box>
                 )
-              : (
-                  <Typography
-                    variant="h5"
-                    sx={{
-                      wordBreak: 'break-all',
-                      margin: 0,
-                    }}
-                    title={value}
-                  >
-                    {value}
-                  </Typography>
-                )}
+              : valueBlock}
           </Box>
           <IconButton size="small" aria-label={t('Close')} onClick={onClose} sx={{ flexShrink: 0 }}>
             <Close fontSize="small" />
           </IconButton>
         </Box>
-        {expectations && (
-          <Typography
-            variant="h5"
-            sx={{
-              wordBreak: 'break-all',
-              margin: 0,
-              mt: 1,
-            }}
-            title={value}
-          >
-            {value}
-          </Typography>
-        )}
+        {expectations && <Box sx={{ mt: 1 }}>{valueBlock}</Box>}
         <Chip
           size="small"
           variant="outlined"
@@ -303,13 +340,35 @@ const FindingDetailPanel = ({ value, type, endpointLabel, endpointSub, expectati
                     {a.subtitle}
                   </Typography>
                 </Box>
+                {/* Whether this action actually RAN (issue 244) — the verdict pill next to it only says
+                    whether it was caught, so a timeout and a clean-but-undetected run read the same.
+                    Same badge and same fixed-width slot as the endpoint panel's execution list, so both
+                    lists line up and agree. It resolves from its own fetches and renders nothing until
+                    then, hence the pill beside it appearing first. */}
+                <Box sx={{
+                  flexShrink: 0,
+                  width: 92,
+                  display: 'flex',
+                  justifyContent: 'flex-end',
+                }}
+                >
+                  <ExecutionRowStatusBadge
+                    simulationId={simulationId}
+                    executionRef={a.ref}
+                    endpointName={endpointName}
+                    injectId={a.injectId}
+                    payloadId={a.payloadId}
+                    executionStatus={a.executionStatus}
+                  />
+                </Box>
                 {/* Verdict pill in the shared StatusPill visual language, from the caller-resolved colour. */}
                 <Box
                   component="span"
                   sx={{
                     display: 'inline-flex',
                     alignItems: 'center',
-                    paddingInline: 1,
+                    justifyContent: 'center',
+                    width: 104,
                     paddingBlock: 0.25,
                     borderRadius: 1,
                     backgroundColor: alpha(a.statusColor, 0.08),

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2158,6 +2158,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         statusColor: attackPathStatusColor(theme, e.status),
         statusLabel: t(statusLabelKey(e.status)),
         subtitle: [e.agentName, e.privilege].filter(Boolean).join(' · '),
+        injectId: e.injectId,
+        payloadId: e.payloadId,
+        executionStatus: e.executionStatus,
       }));
   }, [findingDetail, highlightedExecutionIds, executions, fullDto?.attackPathExecutions, theme, t]);
 
@@ -2870,8 +2873,10 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
                 <FindingDetailPanel
                   value={maskFindingValue(findingDetail.type, findingDetail.value)}
                   type={findingDetail.type}
+                  simulationId={simulationId}
                   endpointLabel={findingEndpoint?.hostname || findingEndpoint?.label || findingEndpoint?.ref || pathFinding?.endpointKey || t('Endpoint')}
                   endpointSub={[findingEndpoint?.ip, findingEndpoint?.platform].filter(Boolean).join(' · ')}
+                  endpointName={findingEndpoint?.hostname}
                   expectations={findingExpectations}
                   isFinding={findingDetailIsFinding}
                   actions={producingActions}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -22,7 +22,7 @@ import { AP_GLOBAL_STYLES, AP_PANEL_DEFAULT_WIDTH, AP_PANEL_MAX_WIDTH, AP_PANEL_
 import AttackPathHeader, { type FindingCard, type SearchOption } from './AttackPathHeader';
 import AttackPathLegend from './AttackPathLegend';
 import AttackPathTableView, { type AttackPathEndpointRow } from './AttackPathTableView';
-import AttackPathCanvas, { type AttackPathFocusRequest, type AttackPathPursuitRequest } from './canvas/AttackPathCanvas';
+import AttackPathCanvas, { type AttackPathAnchorRequest, type AttackPathFocusRequest, type AttackPathPursuitRequest } from './canvas/AttackPathCanvas';
 import CategoryFindingsPanel from './CategoryFindingsPanel';
 import EndpointDetailPanel from './EndpointDetailPanel';
 import ExecutionResultTerminalPanel from './ExecutionResultTerminalPanel';
@@ -363,6 +363,15 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   // endpoint -> finding path that produced the finding picked in the drawer. fitNonce bumps to frame it.
   const [pathFinding, setPathFinding] = useState<PathFinding | null>(null);
   const [fitNonce, setFitNonce] = useState(0);
+  // Expanding a cluster holds the view on the clicked node: the canvas's growth-driven fit would
+  // otherwise re-frame the whole graph and throw the user back to its entrance.
+  const [anchorRequest, setAnchorRequest] = useState<AttackPathAnchorRequest | null>(null);
+  const anchorOnNode = useCallback((nodeId: string) => {
+    setAnchorRequest(prev => ({
+      nodeId,
+      nonce: (prev?.nonce ?? 0) + 1,
+    }));
+  }, []);
   // Bumped whenever a side panel/drawer opens so the graph legend folds away (reopenable by the user).
   const [legendCollapseNonce, setLegendCollapseNonce] = useState(0);
 
@@ -743,15 +752,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     });
     if (collapsing) {
       setFitNonce(n => n + 1);
+    } else {
+      // Expanding: hold the view on the injector whose endpoints just appeared.
+      anchorOnNode(injectorId);
     }
-  }, [endpointBatch]);
+  }, [endpointBatch, anchorOnNode]);
 
   // Causal-chain view: reveal another ENDPOINT_BATCH_SIZE of a depth's hidden endpoints per click — never
   // the whole overflow at once, so drilling into a heavy step doesn't dump the user back into a wall of
   // nodes. Keeps the current view (no refit): the newly revealed hosts appear near where the user clicked.
   const onEndpointClusterClick = useCallback((clusterId: string) => {
     setEndpointClusterBatch(prev => new Map(prev).set(clusterId, (prev.get(clusterId) ?? 0) + ENDPOINT_BATCH_SIZE));
-  }, []);
+    anchorOnNode(clusterId);
+  }, [anchorOnNode]);
 
   // injector id -> refs of the endpoints it reached (asset ref or id), for the bounded finding fetch.
   const injectorEndpointRefs = useMemo(() => {
@@ -843,6 +856,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     (clusterId: string, typeFindings: string | undefined, injectorId: string | undefined, endpointRef: string | undefined, kind: 'header' | 'overflow' | 'typeOverflow') => {
       if (kind === 'overflow') {
         setFindingBatch(prev => new Map(prev).set(clusterId, (prev.get(clusterId) ?? 0) + FINDING_BATCH_SIZE));
+        anchorOnNode(clusterId);
         return;
       }
       // "+N other types": purely a layout toggle (reveal/hide the type clusters the column capped
@@ -874,6 +888,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       }
       setExpandedFindingClusters(prev => new Set(prev).add(clusterId));
       setFindingBatch(prev => new Map(prev).set(clusterId, FINDING_BATCH_SIZE));
+      // Hold the view on the cluster that was clicked: the revealed findings grow the world, which the
+      // canvas would otherwise read as the graph changing shape and re-fit from the entrance.
+      anchorOnNode(clusterId);
       setSelectedFindingId(clusterId);
       setFindingDetail(null);
       // In the focused view, scope the highlight to the action(s) that PRODUCED this finding type — so
@@ -929,7 +946,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         }
       }
     },
-    [expandedFindingClusters, findingsByCluster, fetchClusterFindings, simulationId, pathFinding, fullDto],
+    [expandedFindingClusters, findingsByCluster, fetchClusterFindings, simulationId, pathFinding, fullDto, anchorOnNode],
   );
 
   // Auto-expand the focused finding's own type cluster (fetching its individual findings if not
@@ -2824,6 +2841,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
                 onBackgroundClick={onCanvasBackgroundClick}
                 focusRequest={focusRequest}
                 fitRequest={fitNonce}
+                anchorRequest={anchorRequest}
                 pursuitRequest={pathFinding ? null : pursuitRequest}
                 pursuitActive={pursuitActive && !pathFinding}
                 showMiniMap={!pathFinding && nodes.length > 40}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathCanvas.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathCanvas.tsx
@@ -36,6 +36,12 @@ export interface AttackPathPursuitRequest {
   nonce: number;
 }
 
+/** Keep the view on one node across a layout change the user caused (expanding a cluster). */
+export interface AttackPathAnchorRequest {
+  nodeId: string;
+  nonce: number;
+}
+
 interface AttackPathCanvasProps {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
@@ -61,6 +67,14 @@ interface AttackPathCanvasProps {
    * pursuit and by explicit fit/focus requests, so a live run stays framed on the action.
    */
   pursuitActive?: boolean;
+  /**
+   * Expanding a cluster: hold the view on the node that was clicked instead of re-fitting the whole
+   * graph. The growth-driven fit below cannot tell a user expansion from the graph changing shape on
+   * its own, and re-framing everything threw the user back to the graph's entrance. Pans at the
+   * CURRENT zoom, because the surrounding layout reflows around the newly revealed nodes, so holding
+   * the camera still would not hold the clicked node still.
+   */
+  anchorRequest?: AttackPathAnchorRequest | null;
   showMiniMap?: boolean;
   /** Overlay rendered in the bottom-right stack, under the minimap (the graph legend). */
   legend?: ReactNode;
@@ -113,6 +127,7 @@ const AttackPathCanvas = ({
   fitRequest,
   pursuitRequest,
   pursuitActive = false,
+  anchorRequest,
   showMiniMap = true,
   legend,
 }: AttackPathCanvasProps) => {
@@ -253,6 +268,9 @@ const AttackPathCanvas = ({
   const pursuitActiveRef = useRef(pursuitActive);
   pursuitActiveRef.current = pursuitActive;
   const fittedSig = useRef<string>('');
+  // Set while an anchored expansion is in flight: the world change it causes is adopted WITHOUT a
+  // re-fit, and the camera is then panned onto the anchor instead (see the anchorRequest effect).
+  const holdForAnchorRef = useRef(false);
   const worldSig = `${Math.round(worldWidth)}x${Math.round(worldHeight)}`;
   useLayoutEffect(() => {
     const el = containerRef.current;
@@ -269,7 +287,7 @@ const AttackPathCanvas = ({
       if (w > 0 && h > 0 && fittedSig.current !== worldSig) {
         const firstFit = fittedSig.current === '';
         fittedSig.current = worldSig;
-        if (firstFit || !pursuitActiveRef.current) {
+        if (firstFit || (!pursuitActiveRef.current && !holdForAnchorRef.current)) {
           setCamera(fitCamera(w, h));
         }
       }
@@ -286,6 +304,8 @@ const AttackPathCanvas = ({
   const markManual = useCallback(() => {
     lastManualAt.current = performance.now();
   }, []);
+  const markManualRef = useRef(markManual);
+  markManualRef.current = markManual;
 
   // Ctrl/Cmd + wheel zoom around the cursor (native listener so we can preventDefault).
   useEffect(() => {
@@ -423,13 +443,11 @@ const AttackPathCanvas = ({
     return undefined;
   }, [fitRequest]);
 
-  // Live pursuit: pan to center the bounding box of the delta's new nodes, keeping the CURRENT zoom
-  // (that is the whole point — the run stops "unzooming" and the camera chases the action instead).
-  // Backs off while a manual interaction is fresh, so a user inspecting the graph — or holding the
-  // full overview after a fit — is not fought over the camera.
-  const pursueNodes = useCallback((nodeIds: readonly string[]) => {
+  // Pan to center a set of nodes, keeping the CURRENT zoom. Unconditional: the caller decides whether
+  // the camera may move (live pursuit backs off, a user expansion does not).
+  const centerOnNodes = useCallback((nodeIds: readonly string[]) => {
     const el = containerRef.current;
-    if (!el || performance.now() - lastManualAt.current < PURSUIT_MANUAL_PAUSE_MS) {
+    if (!el) {
       return;
     }
     let minX = Infinity;
@@ -446,7 +464,7 @@ const AttackPathCanvas = ({
       maxX = Math.max(maxX, r.x + r.width);
       maxY = Math.max(maxY, r.y + r.height);
     });
-    // None of the delta's nodes exist in this view (e.g. clustered away): leave the camera alone.
+    // None of the nodes exist in this view (e.g. clustered away): leave the camera alone.
     if (minX === Infinity) {
       return;
     }
@@ -457,8 +475,21 @@ const AttackPathCanvas = ({
       y: el.clientHeight / 2 - ((minY + maxY) / 2) * zoom,
     });
   }, [effectiveRects, camera.zoom, animateTo]);
+
+  // Live pursuit: chase the nodes the latest delta introduced (that is the whole point — the run stops
+  // "unzooming" and the camera follows the action instead). Backs off while a manual interaction is
+  // fresh, so a user inspecting the graph — or holding the full overview after a fit — is not fought
+  // over the camera.
+  const pursueNodes = useCallback((nodeIds: readonly string[]) => {
+    if (performance.now() - lastManualAt.current < PURSUIT_MANUAL_PAUSE_MS) {
+      return;
+    }
+    centerOnNodes(nodeIds);
+  }, [centerOnNodes]);
   const pursueNodesRef = useRef(pursueNodes);
   pursueNodesRef.current = pursueNodes;
+  const centerOnNodesRef = useRef(centerOnNodes);
+  centerOnNodesRef.current = centerOnNodes;
   useEffect(() => {
     if (pursuitRequest && pursuitRequest.nodeIds.length > 0) {
       // Let the delta's new cards lay out before chasing them.
@@ -469,6 +500,27 @@ const AttackPathCanvas = ({
     return undefined;
     // Keyed on the nonce alone: nodeIds travel with it, and the ref keeps pursueNodes fresh.
   }, [pursuitRequest?.nonce]);
+  // Anchored expansion: raise the hold BEFORE the expanded nodes land (this effect runs on the same
+  // commit as the click, the bigger world arrives on the next one), then re-center the anchor at the
+  // current zoom once the layout has settled, and drop the hold. Uses centerOnNodes, not pursueNodes:
+  // the user just asked for this, so it is not subject to pursuit's manual-interaction back-off. It
+  // counts as a manual move itself, so a live delta does not immediately yank the camera off it.
+  useEffect(() => {
+    if (!anchorRequest?.nodeId) {
+      return undefined;
+    }
+    holdForAnchorRef.current = true;
+    const nodeId = anchorRequest.nodeId;
+    const id = window.setTimeout(() => {
+      centerOnNodesRef.current([nodeId]);
+      markManualRef.current();
+      holdForAnchorRef.current = false;
+    }, 80);
+    return () => {
+      window.clearTimeout(id);
+      holdForAnchorRef.current = false;
+    };
+  }, [anchorRequest?.nodeId, anchorRequest?.nonce]);
 
   // Drag-to-pan on the empty canvas: a move past the threshold pans; a click without movement
   // clears the selection (background click). Cards stop propagation of their own pointerdown.

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1041,6 +1041,7 @@ export interface AttackPathExecutionDetailDTO {
   detectionStatus?: string;
   endpointKey?: string;
   executedAt?: string;
+  executionStatus?: string;
   findings?: AttackPathExecutionFindingItemDTO[];
   injectId?: string;
   injectorCommandLine?: string;
@@ -1101,6 +1102,7 @@ export interface AttackPathNodeDTO {
   dependsOn?: string[];
   entityKind?: string;
   executedAt?: string;
+  executionStatus?: string;
   executionsTraces?: any[];
   expectations?: any[];
   findingCounts?: Record<string, number>;
@@ -1108,10 +1110,12 @@ export interface AttackPathNodeDTO {
   findingsTypeNodeId?: string;
   hostname?: string;
   id?: string;
+  injectId?: string;
   injectorType?: string;
   ip?: string;
   isFinding?: boolean;
   label?: string;
+  payloadId?: string;
   payloadName?: string;
   platform?: string;
   privilege?: string;

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "Erkenntnisse nach Typ",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "Findings-Seitennavigation für {type}",
   "Finished": "Beendet",
   "Fire a single technique": "Einzelne Technik auslösen",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "Alle Assets anzeigen",
   "Show covered TTP only": "Nur abgedeckte TTP anzeigen",
   "Show in findings": "In Befunden anzeigen",
+  "Show less": "Weniger anzeigen",
   "Show more": "Mehr anzeigen",
   "Show timeline": "Zeitleiste anzeigen",
   "Show Timeline": "Zeitleiste anzeigen",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "Show all assets",
   "Show covered TTP only": "Show covered TTP only",
   "Show in findings": "Show in findings",
+  "Show less": "Show less",
   "Show more": "Show more",
   "Show timeline": "Show timeline",
   "Show Timeline": "Show Timeline",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "Findings by type",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "Findings pagination for {type}",
   "Finished": "Finished",
   "Fire a single technique": "Fire a single technique",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "Hallazgos por tipo",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "Paginación de findings para {type}",
   "Finished": "Terminado",
   "Fire a single technique": "Dispare una técnica única",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "Mostrar todos los activos",
   "Show covered TTP only": "Mostrar sólo Patrones de ataques cubiertos",
   "Show in findings": "Mostrar en resultados",
+  "Show less": "Mostrar menos",
   "Show more": "Mostrar más",
   "Show timeline": "Mostrar línea de tiempo",
   "Show Timeline": "Mostrar línea de tiempo",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Les findings ne sont pas disponibles pour ce sujet de rapport.",
   "Findings by type": "Résultats par type",
   "Findings collected over the period, by type and most recent.": "Findings collectés sur la période, par type et plus récents.",
+  "Findings pagination for {type}": "Pagination des findings pour {type}",
   "Finished": "Terminé",
   "Fire a single technique": "Déclenchez une technique unique",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "Afficher tous les actifs",
   "Show covered TTP only": "Afficher uniquement les TTP couverts",
   "Show in findings": "Afficher dans les résultats",
+  "Show less": "Afficher moins",
   "Show more": "Afficher plus",
   "Show timeline": "Afficher la chronologie",
   "Show Timeline": "Afficher la chronologie",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "Rilevamenti per tipo",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "Paginazione dei findings per {type}",
   "Finished": "Finito",
   "Fire a single technique": "Lancia una singola tecnica",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "Mostra tutti gli asset",
   "Show covered TTP only": "Mostra solo il TTP coperto",
   "Show in findings": "Mostra nei risultati",
+  "Show less": "Mostra meno",
   "Show more": "Mostra di più",
   "Show timeline": "Mostra linea temporale",
   "Show Timeline": "Mostra linea temporale",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "種類別の検出結果",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "{type} の finding のページ送り",
   "Finished": "終了",
   "Fire a single technique": "単一のテクニックを実行",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "すべてのアセットを表示する",
   "Show covered TTP only": "カバーされたTTPのみを表示する",
   "Show in findings": "所見で表示",
+  "Show less": "表示を減らす",
   "Show more": "もっと見る",
   "Show timeline": "タイムラインを表示する",
   "Show Timeline": "タイムラインの表示",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "모든 자산 표시",
   "Show covered TTP only": "커버된 TTP만 표시",
   "Show in findings": "결과에 표시",
+  "Show less": "간략히 보기",
   "Show more": "더 보기",
   "Show timeline": "타임라인 표시",
   "Show Timeline": "타임라인 표시",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "유형별 발견 항목",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "{type} 발견 항목 페이지 이동",
   "Finished": "완성된",
   "Fire a single technique": "단일 기법 실행",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "Находки по типу",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "Постраничная навигация по findings для {type}",
   "Finished": "Готовые",
   "Fire a single technique": "Выполните одну технику",
   "Firewall": "Firewall",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "Показать все активы",
   "Show covered TTP only": "Показать только покрытые ТТП",
   "Show in findings": "Показать в выводах",
+  "Show less": "Показать меньше",
   "Show more": "Показать больше",
   "Show timeline": "Показать временную шкалу",
   "Show Timeline": "Показать временную шкалу",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3003,6 +3003,7 @@
   "Show all assets": "显示所有资产",
   "Show covered TTP only": "只显示覆盖的 TTP",
   "Show in findings": "在调查结果中显示",
+  "Show less": "收起",
   "Show more": "显示更多",
   "Show timeline": "显示时间线",
   "Show Timeline": "显示时间线",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -1470,6 +1470,7 @@
   "Findings are not available for this report subject.": "Findings are not available for this report subject.",
   "Findings by type": "按类型划分的发现",
   "Findings collected over the period, by type and most recent.": "Findings collected over the period, by type and most recent.",
+  "Findings pagination for {type}": "{type} 的发现分页",
   "Finished": "已完成",
   "Fire a single technique": "发起单一技术",
   "Firewall": "Firewall",

--- a/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathExecutionRow.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/attackpath/projection/AttackPathExecutionRow.java
@@ -36,4 +36,10 @@ public record AttackPathExecutionRow(
     // still renders its hostname/ip/platform instead of a bare id.
     String sourceHostname,
     String sourceIp,
-    String sourcePlatform) {}
+    String sourcePlatform,
+    // The durable step this row is keyed by, and the payload it ran (null for a network injector).
+    // The graph read resolves the run's inject and its execution status from the step, exactly as
+    // the Result drawer's detail read does, so a row's "did it actually run" status ships with the
+    // graph instead of costing two client round-trips per visible row.
+    String stepId,
+    String payloadId) {}

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectStatusRepository.java
@@ -3,6 +3,7 @@ package io.openaev.database.repository;
 import io.openaev.database.model.InjectStatus;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -34,6 +35,20 @@ public interface InjectStatusRepository
               + " ORDER BY t.execution_time ASC, t.execution_trace_id ASC",
       nativeQuery = true)
   Optional<InjectStatus> findInjectStatusWithGlobalExecutionTraces(String injectId);
+
+  /**
+   * The execution status name of many injects at once, as {@code (injectId, statusName)} pairs. The
+   * attack-path graph read ships every execution's "did it actually run" status, so resolving it
+   * per row would be one query per visible execution. Injects with no status row yet simply do not
+   * appear.
+   *
+   * @param injectIds the injects whose status name is wanted
+   * @return one row per inject that has a status: {@code [injectId, statusName]}
+   */
+  @Query(
+      "SELECT istatus.inject.id, istatus.name FROM InjectStatus istatus"
+          + " WHERE istatus.inject.id IN :injectIds AND istatus.name IS NOT NULL")
+  List<Object[]> findStatusNamesByInjectIds(@Param("injectIds") Collection<String> injectIds);
 
   @Modifying(clearAutomatically = true)
   @Query("delete from InjectStatus i where i.id in :ids")

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -2,6 +2,7 @@ package io.openaev.database.repository;
 
 import io.openaev.database.model.Step;
 import io.openaev.database.model.StepStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -165,6 +166,26 @@ public interface StepRepository extends JpaRepository<Step, String> {
       """,
       nativeQuery = true)
   Optional<String> findInjectIdByStepId(@Param("stepId") String stepId);
+
+  /**
+   * The same resolution as {@link #findInjectIdByStepId(String)} for many steps at once, as {@code
+   * (stepId, injectId)} pairs. The attack-path graph read resolves the inject of every execution it
+   * returns, so doing it row by row would be one query per visible execution. Steps whose data
+   * carries no {@code inject_id} are filtered out rather than returned as null pairs.
+   *
+   * @param stepIds the steps whose data may carry an inject_id
+   * @return one row per resolved step: {@code [stepId, injectId]}
+   */
+  @Query(
+      value =
+          """
+      SELECT step_id, jsonb_path_query_first(step_data, '$.**.inject_id') #>> '{}' AS inject_id
+      FROM steps
+      WHERE step_id IN (:stepIds)
+        AND jsonb_path_query_first(step_data, '$.**.inject_id') #>> '{}' IS NOT NULL
+      """,
+      nativeQuery = true)
+  List<Object[]> findInjectIdsByStepIds(@Param("stepIds") Collection<String> stepIds);
 
   /**
    * Returns the step IDs associated with any of the given inject IDs in a single query.

--- a/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/attackpath/AttackPathExecutionRepository.java
@@ -90,7 +90,8 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform, "
+          + "e.stepId, e.payloadId) "
           + "FROM AttackPathExecution e WHERE e.simulationId = :simulationId")
   List<AttackPathExecutionRow> findGraphRows(@Param("simulationId") String simulationId);
 
@@ -104,7 +105,8 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform, "
+          + "e.stepId, e.payloadId) "
           + "FROM AttackPathExecution e "
           + "WHERE e.simulationId = :simulationId AND e.rowVersion > :since")
   List<AttackPathExecutionRow> findGraphRowsSince(
@@ -191,7 +193,8 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform, "
+          + "e.stepId, e.payloadId) "
           + "FROM AttackPathExecution e "
           + "WHERE e.simulationId = :simulationId AND e.id IN :ids")
   List<AttackPathExecutionRow> findGraphRowsByIds(
@@ -206,7 +209,8 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform, "
+          + "e.stepId, e.payloadId) "
           + "FROM AttackPathExecution e "
           + "WHERE e.simulationId = :simulationId AND e.targetKey = :targetKey")
   List<AttackPathExecutionRow> findByTarget(
@@ -227,7 +231,8 @@ public interface AttackPathExecutionRepository extends CrudRepository<AttackPath
           + "e.id, e.sourceKind, e.sourceAssetId, e.agentId, e.agentName, e.agentPrivilege, "
           + "e.sourceInjector, e.targetKind, e.targetAssetId, e.targetRawValue, e.targetKey, "
           + "e.targetHostname, e.targetIp, e.targetPlatform, e.payloadName, e.executedAt, "
-          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform) "
+          + "e.preventionStatus, e.detectionStatus, e.vulnerabilityStatus, e.stepTemplateId, e.contractExternalId, e.injectorType, e.sourceHostname, e.sourceIp, e.sourcePlatform, "
+          + "e.stepId, e.payloadId) "
           + "FROM AttackPathExecution e "
           + "WHERE e.simulationId = :simulationId AND e.targetKey = :targetKey "
           + "ORDER BY e.executedAt, e.id")


### PR DESCRIPTION
### Proposed changes

Five problems on the **Attack path** page: three in the drawer a finding (or an output-only value) opens, and two reported on the page itself.

* **A long value floods the panel.** An output-only value is often a whole command output (an Nmap XML report is several KB) and was rendered in full, pushing the type chip, the endpoint and the producing actions far below the fold. It is now clamped to three lines behind a `Show more` / `Show less` toggle, and the clamp re-collapses whenever a DIFFERENT value is shown while the panel stays mounted, so a second long value never opens pre-expanded. A short value (a port, a share, a hash) is untouched and gets no toggle.

* **The finding drawer never showed a run status.** Its *Discovered by* rows only carried the prevention/detection verdict, so a timeout and a clean-but-undetected run read identically. It now mounts the same badge `EndpointDetailPanel`'s execution list uses, in the same fixed-width slot so the two lists line up, **next to** the verdict rather than instead of it - they answer different questions.

* **That badge lagged the verdict by seconds**, structurally: the verdict is already in the graph DTO, in memory, while the run status was nowhere in it. `ExecutionRowStatusBadge` had to resolve it with **two sequential fetches per visible row** - the detail row for the `injectId` (it lives on the detail DTO, not on the lightweight graph row), then the inject's status - rendering nothing until both landed. Ten visible executions cost twenty round-trips. It is now resolved server-side, the way the detail read already resolves its `injectId`: from the durable step the frozen row is keyed by. The graph projection carries `stepId`/`payloadId`, and one enrichment pass (`AttackPathGraphService#applyExecutionStatuses`) fills each execution node's `injectId`, `payloadId` and `executionStatus` in **two queries for the whole set** - new batch reads on `StepRepository` and `InjectStatusRepository` - on both read paths: the graph (hence the deltas, since it is the same code) and an endpoint's relations. `AttackPathExecutionDetailDTO` carries the status too, so the Result tab stops fetching it as well. On the front, the graph-provided ids are derived from the props on every render: a payload-backed row goes straight to its per-target resolution and a non-terminal status is refined directly from its `injectId`, with **no detail fetch at all** - that fetch only remains for a row the graph could not resolve, and it is dropped (not left stale) when the execution ref goes away.

* **The Findings pager floated between two groups.** Each finding type pages on its own, but the pager sat under its group's last value, equidistant from that group and the next one, so it read as paging the whole section. It now sits on the group's own header row, right-aligned.

* **Expanding a cluster threw the camera back to the graph's entrance.** The canvas re-fits whenever the world's size signature changes and could not tell a user expansion from the graph changing shape on its own. Expansions (a finding cluster, an injector's endpoints, an endpoint overflow) now raise an anchor request: the canvas adopts the bigger world without re-fitting, then pans onto the clicked node at the current zoom once the layout has settled. The pan counts as a manual move, so a live delta does not immediately yank the camera off what was just opened. Collapsing still re-fits - nodes disappear there, and re-framing keeps the result readable.

### Two cases deliberately still resolve client-side

* a **payload-backed** execution: "did it run" is per AGENT there, read from that target's traces. An inject-level `EXECUTED` would hide this agent's `Timeout`.
* a **missing or non-terminal** status (a live run): an inject status change does not bump the execution row's `rowVersion`, so a `PENDING` shipped by the graph would stay stale until the next delta touching that row. It is refined client-side rather than trusted - straight from the graph-provided `injectId`, with no detail fetch.

### Testing Instructions

1. Open a chained scenario -> **Attack path** -> click an endpoint, then a finding or an output-only value.
2. The value is clamped with a `Show more` toggle when long; expanding shows it whole, `Show less` collapses it again; picking another finding re-collapses it.
3. Every row under *Discovered by* shows its run status (`EXECUTED`...) **on first paint**, alongside its `UNDETECTED`/`DETECTED` verdict, aligned with the endpoint panel's list.
4. In the endpoint panel, a paginated finding group's pager sits on its own header row; expanding a cluster on the map holds the view on it instead of re-fitting the whole graph.
5. Backend: `mvn -pl openaev-api -am test -Dtest="AttackPathGraphServiceTest,StepRepositoryTest,InjectStatusRepositoryTest"`
6. Front: `yarn vitest run src/__tests__/admin/components/simulations/simulation/attack_path/`
7. `api-types.d.ts` was regenerated against a backend running this branch (byte-identical to the committed file). Note that `swagger-typescript-api` cannot fetch from port `10080` - it is in the Fetch spec's blocked-ports list - so fetch `/api-docs` to a file first.

### Verified

* Live API on this branch, two real simulations: 15/15 and 12/12 executions come back with both `injectId` and `executionStatus` (`EXECUTED`), `payloadId: null` - the no-fetch path.
* Backend: 37 tests green (`AttackPathGraphServiceTest` 30 including a new one asserting a node carries its inject and status and that a step-less row resolves to null; `StepRepositoryTest` 5; `InjectStatusRepositoryTest` 2), Spotless clean.
* Front: attack_path vitest suites 132 tests green across 8 files (including `ExecutionStatusBadge.test.tsx` asserting the settled, payload-backed and non-terminal paths fire no detail fetch and that a vanished ref drops the fetched status; `FindingDetailPanel.test.tsx` covering the clamp toggle and its per-finding reset; new `EndpointDetailPanel.test.tsx` for the per-group pager; a `SimulationAttackPath.test.tsx` case asserting an expansion anchors instead of re-fitting), ESLint clean, `tsc` clean.

### Related issues

* Closes #7275
* Builds on the run-status badge from issue 244

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
