### PR TITLE
fix(chaining): credential finding and chokepoint highlighting is not working (#5048)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_TYPE_OVERFLOW_ID, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_CHILD_WALK_PASSES, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_TYPE_OVERFLOW_ID, applyFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, expandPathSet, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -312,6 +312,88 @@ describe('maskFindingValue', () => {
 
   it('returns an empty string for an undefined value', () => {
     expect(maskFindingValue('port', undefined)).toBe('');
+  });
+});
+
+describe('expandPathSet', () => {
+  // A linear chain a -> b -> c -> ... deep enough that any fixed pass cap under its length would
+  // truncate it: the walk must run to a fixpoint, not an arbitrary number of passes. Edges are
+  // listed in REVERSE order so a single pass over the list can only propagate one upstream hop —
+  // the worst case for pass-count-based walks.
+  const chain = (length: number): AttackPathFlowEdge[] =>
+    Array.from({ length }, (_, i) => ({
+      id: `e${i}`,
+      source: `n${i}`,
+      target: `n${i + 1}`,
+    }));
+
+  it('walks upstream to a fixpoint with no arbitrary pass cap', () => {
+    const edges = chain(20);
+    const set = expandPathSet(new Set(['n20']), edges, 'upstream');
+    // Every node of the 20-hop chain is adopted, including the far end.
+    expect(set.size).toBe(21);
+    expect(set.has('n0')).toBe(true);
+  });
+
+  it('walks downstream to a fixpoint symmetrically', () => {
+    // Reverse the edge order too, so downstream also needs one pass per hop.
+    const edges = chain(20).reverse();
+    const set = expandPathSet(new Set(['n0']), edges, 'downstream');
+    expect(set.size).toBe(21);
+    expect(set.has('n20')).toBe(true);
+  });
+
+  it('never adopts a blocked candidate, and does not walk through it', () => {
+    const edges = chain(5);
+    const set = expandPathSet(new Set(['n5']), edges, 'upstream', { blocked: candidate => candidate === 'n2' });
+    // n2 is vetoed, so the walk stops there: n0/n1 are only reachable through it.
+    expect([...set].sort()).toEqual(['n3', 'n4', 'n5']);
+  });
+
+  it('passes the edge to the blocked predicate so edge-level vetoes work', () => {
+    const edges: AttackPathFlowEdge[] = [
+      {
+        id: 'causal',
+        source: 'a',
+        target: 'b',
+        type: 'causal',
+      },
+      {
+        id: 'plain',
+        source: 'c',
+        target: 'b',
+      },
+    ];
+    const set = expandPathSet(new Set(['b']), edges, 'upstream', { blocked: (_candidate, e) => e.type === 'causal' });
+    expect(set.has('c')).toBe(true);
+    expect(set.has('a')).toBe(false);
+  });
+
+  it('honours maxPasses as a cap for deliberately shallow child walks', () => {
+    const edges = chain(10).reverse();
+    const set = expandPathSet(new Set(['n0']), edges, 'downstream', { maxPasses: AP_CHILD_WALK_PASSES });
+    // One upstream-ordered hop per pass: exactly AP_CHILD_WALK_PASSES hops adopted, no more.
+    expect(set.size).toBe(1 + AP_CHILD_WALK_PASSES);
+    expect(set.has(`n${AP_CHILD_WALK_PASSES}`)).toBe(true);
+    expect(set.has(`n${AP_CHILD_WALK_PASSES + 1}`)).toBe(false);
+  });
+
+  it('ignores edges with an empty source or target', () => {
+    const edges: AttackPathFlowEdge[] = [
+      {
+        id: 'dangling',
+        source: '',
+        target: 'seed',
+      },
+      {
+        id: 'ok',
+        source: 'up',
+        target: 'seed',
+      },
+    ];
+    const set = expandPathSet(new Set(['seed']), edges, 'upstream');
+    expect(set.has('')).toBe(false);
+    expect(set.has('up')).toBe(true);
   });
 });
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1030,7 +1030,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       // not just its type cluster (the backend escapes `\`/`|`, so a share value never matches a
       // rebuilt `NODE_FINDING|type|value`, hence matching on typeFindings+value like highlightGraphFinding).
       const canonicalId = (fullDto?.attackPathNodes ?? [])
-        .find(n => n.type === 'FINDING' && (n.typeFindings ?? '') === (item.type ?? '') && (n.value ?? n.label) === (item.value ?? ''))?.id;
+        .find(n => n.type === 'FINDING' && (n.typeFindings ?? '') === (item.type ?? '') && findingValuesMatch(item.type ?? '', n.value ?? n.label ?? '', item.value ?? ''))?.id;
       if (!chainMode) {
         // Non-chain path-focus view: the finding's own node only exists once its type cluster is
         // expanded (see the auto-expand effect below), so leave selectedFindingId null here — the
@@ -1762,32 +1762,69 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     // Focused finding-path view: keep the focused scope, and let clicks on findings/clusters
     // highlight the exact sub-path (injector -> endpoint -> selection).
     if (pathFinding) {
-      // Endpoint focus (no specific finding, e.g. a chokepoint click) with nothing sub-selected: only
-      // the focused endpoint is "selected" (blue); its injectors, edges and finding clusters keep their
-      // verdict colour (green/orange/red) so blue means "what I picked", not "the whole subgraph".
+      // Endpoint focus (no specific finding, e.g. a chokepoint click) with nothing sub-selected: mirror
+      // the finding/injector highlight below — walk the endpoint's FULL incoming path (every injector
+      // and finding cluster that reached it) and light it blue, dimming everything off that path. Same
+      // visual language as picking a finding: blue means "the path to what I picked".
       if (!pathFinding.type && !selectedInjectorId && !selectedFindingId) {
         // The endpoint's own node id in the scoped chain graph is `chain-ep|depth|<raw id>`, not the
         // raw id itself (that's the non-chain buildFindingPathFlow layout's scheme) — match either.
         const isFocusedEndpoint = (nodeId: string) => nodeId === pathFinding.endpointNodeId
           || (nodeId.startsWith('chain-ep|') && nodeId.endsWith(`|${pathFinding.endpointNodeId}`));
+        // A DIFFERENT endpoint's own instance in the scoped chain graph (any `chain-ep|...` node that
+        // isn't this one). The causal chain dedupes identical actions/finding VALUES across hosts into
+        // ONE shared node (e.g. two hosts both exposing port 445 collapse to a single "port|445" node,
+        // and a step run against several hosts is one shared injector node) — walking through those
+        // shared hops is correct (they genuinely are on this endpoint's path too), but must never carry
+        // the walk INTO another endpoint's own node, or every host sharing any recon result/action with
+        // this one lights up as if it were on the path (nothing left to dim, an all-blue graph).
+        const isOtherEndpoint = (nodeId: string) => nodeId.startsWith('chain-ep|') && !isFocusedEndpoint(nodeId);
+        const focusedNodeIds = baseFlow.nodes.filter(n => isFocusedEndpoint(n.id)).map(n => n.id);
+        const pathSet = new Set<string>(focusedNodeIds);
+        // Walk UPSTREAM from the endpoint: every injector/finding/endpoint that eventually leads into
+        // it (mirrors the selectedInjectorId/selectedFindingId upstream walks a few branches below).
+        for (let pass = 0; pass < 8; pass += 1) {
+          for (const e of baseFlow.edges) {
+            if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source) && !isOtherEndpoint(e.source)) {
+              pathSet.add(e.source);
+            }
+          }
+        }
+        // Walk DOWNSTREAM too, scoped from the endpoint itself: its own finding clusters hang off it as
+        // children, so without this pass they'd render dimmed even though they belong to this chokepoint.
+        const down = new Set<string>(focusedNodeIds);
+        for (let pass = 0; pass < 3; pass += 1) {
+          for (const e of baseFlow.edges) {
+            if (e.source && e.target && down.has(e.source) && !down.has(e.target) && !isOtherEndpoint(e.target)) {
+              down.add(e.target);
+              pathSet.add(e.target);
+            }
+          }
+        }
         return {
-          nodes: baseFlow.nodes.map(n => ({
-            ...n,
-            selected: isFocusedEndpoint(n.id),
-            data: {
-              ...(n.data ?? {}),
-              dimmed: false,
-            },
-          })),
-          edges: baseFlow.edges.map(e => ({
-            ...e,
-            selected: false,
-            data: {
-              ...(e.data ?? {}),
-              count: e.data?.count ?? 1,
-              dimmed: false,
-            },
-          })),
+          nodes: baseFlow.nodes.map((n) => {
+            const selected = pathSet.has(n.id);
+            return {
+              ...n,
+              selected,
+              data: {
+                ...(n.data ?? {}),
+                dimmed: !selected,
+              },
+            };
+          }),
+          edges: baseFlow.edges.map((e) => {
+            const selected = pathSet.has(e.source) && pathSet.has(e.target);
+            return {
+              ...e,
+              selected,
+              data: {
+                ...(e.data ?? {}),
+                count: e.data?.count ?? 1,
+                dimmed: !selected,
+              },
+            };
+          }),
         };
       }
       const injectorIds = new Set(
@@ -1798,6 +1835,13 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
           .filter(n => n.type === AP_FLOW_NODE_TYPE.asset || n.type === AP_FLOW_NODE_TYPE.endpointCluster)
           .map(n => n.id),
       );
+      // Same guard as the chokepoint branch above: never let the walk carry INTO another endpoint's own
+      // node in the chain view — the causal chain dedupes identical actions/finding values shared by
+      // several hosts into ONE node, so an unrestricted walk from a finding/action on one host bleeds
+      // into every OTHER host that happens to share that same recon result or step (all-blue graph).
+      const isFocusedChainEndpoint = (nodeId: string) => nodeId === pathFinding.endpointNodeId
+        || (nodeId.startsWith('chain-ep|') && nodeId.endsWith(`|${pathFinding.endpointNodeId}`));
+      const isOtherChainEndpoint = (nodeId: string) => chainMode && nodeId.startsWith('chain-ep|') && !isFocusedChainEndpoint(nodeId);
       const pathSet = new Set<string>();
       // Tracks the finding-focus "active" node (its own leaf if selected, else its type cluster) across
       // both branches below, so the downstream pass after them can re-key off it instead of
@@ -1813,7 +1857,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         pathSet.add(selectedInjectorId);
         for (let pass = 0; pass < 8; pass += 1) {
           for (const e of baseFlow.edges) {
-            if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
+            if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source) && !isOtherChainEndpoint(e.source)) {
               pathSet.add(e.source);
             }
           }
@@ -1821,7 +1865,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         const down = new Set<string>([selectedInjectorId]);
         for (let pass = 0; pass < 8; pass += 1) {
           for (const e of baseFlow.edges) {
-            if (e.source && e.target && down.has(e.source) && !down.has(e.target)) {
+            if (e.source && e.target && down.has(e.source) && !down.has(e.target) && !isOtherChainEndpoint(e.target)) {
               down.add(e.target);
               pathSet.add(e.target);
             }
@@ -1864,6 +1908,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         for (let pass = 0; pass < 8; pass += 1) {
           for (const e of baseFlow.edges) {
             if (e.target && e.source && pathSet.has(e.target) && !pathSet.has(e.source)) {
+              if (isOtherChainEndpoint(e.source)) {
+                continue;
+              }
               if (restrictInjectors && injectorIds.has(e.source) && !producingInjectorIds.has(e.source)) {
                 continue;
               }
@@ -1889,7 +1936,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         const down = new Set<string>([activeId]);
         for (let pass = 0; pass < 3; pass += 1) {
           for (const e of baseFlow.edges) {
-            if (e.source && e.target && down.has(e.source) && !down.has(e.target)) {
+            if (e.source && e.target && down.has(e.source) && !down.has(e.target) && !isOtherChainEndpoint(e.target)) {
               down.add(e.target);
               pathSet.add(e.target);
             }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1417,16 +1417,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     const applyExec = (ids: string[]) => setHighlightedExecutionIds(new Set(ids));
     const matchIn = (items: AttackPathFindingItemDTO[]) =>
       items.find(it => it.endpointKey === endpointKey && (it.type ?? '') === type && findingValuesMatch(type, it.value ?? '', value));
-    const loaded = matchIn(findingsPage?.items ?? []);
-    if (loaded) {
-      applyExec(loaded.executionIds ?? []);
-      return;
-    }
-    // Authoritative for EVERY finding type: the full graph's execution→findings links. This covers types
-    // the drawer categories don't (port, hash…), which otherwise resolved to no producer — leaving every
-    // injector on the endpoint highlighted instead of just the one that produced the finding. Resolve the
-    // finding's CANONICAL node id from the graph (the backend escapes `\`/`|`, so a share value never
-    // matches a rebuilt `NODE_FINDING|type|value`) and match executions on that.
+    // Authoritative for EVERY finding type: the full graph's execution→findings links, resolved by the
+    // finding's own CANONICAL node id (exact match on the RAW value, unlike the drawer's category page
+    // whose credential values are masked server-side). Tried FIRST — a credentials category match is
+    // ambiguous whenever two findings share a username but differ only by password/hash, since
+    // findingValuesMatch() compares just the username for that type (the drawer can't compare masked
+    // secrets): picking the category-page match first would silently attribute the wrong producing
+    // action to whichever entry happens to sort first in the page. The canonical lookup below never has
+    // this ambiguity because it compares the full, unmasked value.
     const canonicalId = (fullDto?.attackPathNodes ?? [])
       .find(n => n.type === 'FINDING' && (n.typeFindings ?? '') === type && (n.value ?? n.label) === value)?.id;
     const fromFull = canonicalId
@@ -1437,6 +1435,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       : [];
     if (fromFull.length > 0) {
       applyExec(fromFull);
+      return;
+    }
+    // Fallback for finding types the full graph didn't resolve (or wasn't loaded yet): the drawer's
+    // already-loaded category page. Ambiguous for same-username credentials, but only reached when the
+    // exact resolution above found nothing.
+    const loaded = matchIn(findingsPage?.items ?? []);
+    if (loaded) {
+      applyExec(loaded.executionIds ?? []);
       return;
     }
     const category = CATEGORY_OF_TYPE[type];
@@ -1543,8 +1549,20 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       setHighlightedExecutionIds(new Set(producerRefs));
       return true;
     }
-    // Scope the feed (and the producing-action list) to THIS finding's producing executions, resolved
-    // from its category page exactly like a drawer pick.
+    // Producing executions, resolved by this finding's OWN node id (exact, unambiguous — unlike the
+    // drawer category page below, whose credential values are masked server-side, so two findings
+    // sharing a username but differing only by password/hash would otherwise be indistinguishable).
+    const fromFull = (fullDto?.attackPathExecutions ?? [])
+      .filter(e => (e.findingsNodeIds ?? []).includes(nodeId))
+      .map(e => e.ref)
+      .filter((r): r is string => !!r);
+    if (fromFull.length > 0) {
+      setHighlightedExecutionIds(new Set(fromFull));
+      return true;
+    }
+    // Fallback for finding types/graphs the exact lookup above didn't resolve: the drawer's category
+    // page, exactly like a drawer pick. Ambiguous for same-username credentials, but only reached when
+    // the exact resolution above found nothing.
     const category = CATEGORY_OF_TYPE[type];
     if (!category) {
       setHighlightedExecutionIds(new Set());

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -17,7 +17,7 @@ import type { AttackPathEdges, AttackPathExecutionDetailDTO, AttackPathFindingIt
 import { MESSAGING$ } from '../../../../../utils/Environment';
 import useRemainingViewportHeight from '../../../../../utils/hooks/useRemainingViewportHeight';
 import attackPathStatusColor from './attack-path-colors';
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from './attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_CHILD_WALK_PASSES, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_SHARED_EP_CLUSTER_ID, applyFindingFilter, type AttackPathFindingFilter, type AttackPathFlowEdge, type AttackPathFlowNode, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, ENDPOINT_BATCH_SIZE, expandPathSet, FILTER_TO_FINDING_TYPES, FINDING_BATCH_SIZE, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, type PathFinding, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from './attack-path-flow-helpers';
 import { AP_GLOBAL_STYLES, AP_PANEL_DEFAULT_WIDTH, AP_PANEL_MAX_WIDTH, AP_PANEL_MIN_WIDTH, AP_VIEW_HEIGHT, AP_VISUALLY_HIDDEN } from './attack-path-styles';
 import AttackPathHeader, { type FindingCard, type SearchOption } from './AttackPathHeader';
 import AttackPathLegend from './AttackPathLegend';
@@ -155,9 +155,14 @@ const CATEGORY_OF_TYPE: Record<string, string> = {
   file: 'files',
 };
 
-// Match a drawer finding value to a graph finding value. Credentials are masked server-side in the
-// drawer ("user:••••") but raw in the graph ("user:pass"), so compare only the username before the
-// separator; other types compare exactly.
+// Match a drawer finding value to a graph finding value. Credentials are the ONLY category whose
+// values the backend masks in the drawer DTOs (AttackPathGraphService masks the secret half but
+// keeps the username: "user:pass" -> "user:••••"; the graph node keeps the raw value), so compare
+// only the username before the separator for that type; every other type compares exactly.
+// Other secret types (password_policy, sid) are masked in the FRONT for display only
+// (maskFindingValue), are not drawer categories (CATEGORY_OF_TYPE has no entry, so no drawer item
+// of those types ever reaches this matcher), and carry no plaintext half to compare anyway — they
+// resolve by their exact graph node id instead of by value.
 const findingValuesMatch = (type: string, a: string, b: string): boolean => {
   if (a === b) {
     return true;
@@ -1780,45 +1785,35 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
     // Focused finding-path view: keep the focused scope, and let clicks on findings/clusters
     // highlight the exact sub-path (injector -> endpoint -> selection).
     if (pathFinding) {
+      // The endpoint's own node id in the scoped chain graph is `chain-ep|depth|<raw id>`, not the
+      // raw id itself (that's the non-chain buildFindingPathFlow layout's scheme) — match either.
+      const isFocusedChainEndpoint = (nodeId: string) => nodeId === pathFinding.endpointNodeId
+        || (nodeId.startsWith('chain-ep|') && nodeId.endsWith(`|${pathFinding.endpointNodeId}`));
+      // A DIFFERENT endpoint's own instance in the scoped chain graph (any `chain-ep|...` node that
+      // isn't this one — such ids only exist in the chain layouts, so this is a no-op elsewhere).
+      // The causal chain dedupes identical actions/finding VALUES across hosts into ONE shared node
+      // (e.g. two hosts both exposing port 445 collapse to a single "port|445" node, and a step run
+      // against several hosts is one shared injector node) — walking through those shared hops is
+      // correct (they genuinely are on this endpoint's path too), but must never carry the walk INTO
+      // another endpoint's own node, or every host sharing any recon result/action with this one
+      // lights up as if it were on the path (nothing left to dim, an all-blue graph).
+      const isOtherChainEndpoint = (nodeId: string) => nodeId.startsWith('chain-ep|') && !isFocusedChainEndpoint(nodeId);
       // Endpoint focus (no specific finding, e.g. a chokepoint click) with nothing sub-selected: mirror
       // the finding/injector highlight below — walk the endpoint's FULL incoming path (every injector
       // and finding cluster that reached it) and light it blue, dimming everything off that path. Same
       // visual language as picking a finding: blue means "the path to what I picked".
       if (!pathFinding.type && !selectedInjectorId && !selectedFindingId) {
-        // The endpoint's own node id in the scoped chain graph is `chain-ep|depth|<raw id>`, not the
-        // raw id itself (that's the non-chain buildFindingPathFlow layout's scheme) — match either.
-        const isFocusedEndpoint = (nodeId: string) => nodeId === pathFinding.endpointNodeId
-          || (nodeId.startsWith('chain-ep|') && nodeId.endsWith(`|${pathFinding.endpointNodeId}`));
-        // A DIFFERENT endpoint's own instance in the scoped chain graph (any `chain-ep|...` node that
-        // isn't this one). The causal chain dedupes identical actions/finding VALUES across hosts into
-        // ONE shared node (e.g. two hosts both exposing port 445 collapse to a single "port|445" node,
-        // and a step run against several hosts is one shared injector node) — walking through those
-        // shared hops is correct (they genuinely are on this endpoint's path too), but must never carry
-        // the walk INTO another endpoint's own node, or every host sharing any recon result/action with
-        // this one lights up as if it were on the path (nothing left to dim, an all-blue graph).
-        const isOtherEndpoint = (nodeId: string) => nodeId.startsWith('chain-ep|') && !isFocusedEndpoint(nodeId);
-        const focusedNodeIds = baseFlow.nodes.filter(n => isFocusedEndpoint(n.id)).map(n => n.id);
-        const pathSet = new Set<string>(focusedNodeIds);
+        const focusedNodeIds = baseFlow.nodes.filter(n => isFocusedChainEndpoint(n.id)).map(n => n.id);
         // Walk UPSTREAM from the endpoint: every injector/finding/endpoint that eventually leads into
         // it (mirrors the selectedInjectorId/selectedFindingId upstream walks a few branches below).
-        for (let pass = 0; pass < 8; pass += 1) {
-          for (const e of baseFlow.edges) {
-            if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source) && !isOtherEndpoint(e.source)) {
-              pathSet.add(e.source);
-            }
-          }
-        }
+        const pathSet = expandPathSet(new Set<string>(focusedNodeIds), baseFlow.edges, 'upstream', { blocked: isOtherChainEndpoint });
         // Walk DOWNSTREAM too, scoped from the endpoint itself: its own finding clusters hang off it as
         // children, so without this pass they'd render dimmed even though they belong to this chokepoint.
-        const down = new Set<string>(focusedNodeIds);
-        for (let pass = 0; pass < 3; pass += 1) {
-          for (const e of baseFlow.edges) {
-            if (e.source && e.target && down.has(e.source) && !down.has(e.target) && !isOtherEndpoint(e.target)) {
-              down.add(e.target);
-              pathSet.add(e.target);
-            }
-          }
-        }
+        const down = expandPathSet(new Set<string>(focusedNodeIds), baseFlow.edges, 'downstream', {
+          blocked: isOtherChainEndpoint,
+          maxPasses: AP_CHILD_WALK_PASSES,
+        });
+        down.forEach(id => pathSet.add(id));
         return {
           nodes: baseFlow.nodes.map((n) => {
             const selected = pathSet.has(n.id);
@@ -1853,13 +1848,6 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
           .filter(n => n.type === AP_FLOW_NODE_TYPE.asset || n.type === AP_FLOW_NODE_TYPE.endpointCluster)
           .map(n => n.id),
       );
-      // Same guard as the chokepoint branch above: never let the walk carry INTO another endpoint's own
-      // node in the chain view — the causal chain dedupes identical actions/finding values shared by
-      // several hosts into ONE node, so an unrestricted walk from a finding/action on one host bleeds
-      // into every OTHER host that happens to share that same recon result or step (all-blue graph).
-      const isFocusedChainEndpoint = (nodeId: string) => nodeId === pathFinding.endpointNodeId
-        || (nodeId.startsWith('chain-ep|') && nodeId.endsWith(`|${pathFinding.endpointNodeId}`));
-      const isOtherChainEndpoint = (nodeId: string) => chainMode && nodeId.startsWith('chain-ep|') && !isFocusedChainEndpoint(nodeId);
       const pathSet = new Set<string>();
       // Tracks the finding-focus "active" node (its own leaf if selected, else its type cluster) across
       // both branches below, so the downstream pass after them can re-key off it instead of
@@ -1873,22 +1861,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         // only (the old behaviour) left a late-stage action like "Send individual mails" lighting just
         // its recipient — everything that led there went dark, which read as "nothing highlighted".
         pathSet.add(selectedInjectorId);
-        for (let pass = 0; pass < 8; pass += 1) {
-          for (const e of baseFlow.edges) {
-            if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source) && !isOtherChainEndpoint(e.source)) {
-              pathSet.add(e.source);
-            }
-          }
-        }
-        const down = new Set<string>([selectedInjectorId]);
-        for (let pass = 0; pass < 8; pass += 1) {
-          for (const e of baseFlow.edges) {
-            if (e.source && e.target && down.has(e.source) && !down.has(e.target) && !isOtherChainEndpoint(e.target)) {
-              down.add(e.target);
-              pathSet.add(e.target);
-            }
-          }
-        }
+        expandPathSet(pathSet, baseFlow.edges, 'upstream', { blocked: isOtherChainEndpoint });
+        const down = expandPathSet(new Set<string>([selectedInjectorId]), baseFlow.edges, 'downstream', { blocked: isOtherChainEndpoint });
+        down.forEach(id => pathSet.add(id));
       } else {
         // The focused finding is highlighted inside its own type cluster (no extracted node), so the
         // default active node is that type's cluster. A leaf finding clicked in place overrides it.
@@ -1923,26 +1898,11 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
             : [],
         );
         pathSet.add(activeId);
-        for (let pass = 0; pass < 8; pass += 1) {
-          for (const e of baseFlow.edges) {
-            if (e.target && e.source && pathSet.has(e.target) && !pathSet.has(e.source)) {
-              if (isOtherChainEndpoint(e.source)) {
-                continue;
-              }
-              if (restrictInjectors && injectorIds.has(e.source) && !producingInjectorIds.has(e.source)) {
-                continue;
-              }
-              if (
-                injectorIds.has(e.source)
-                && focusEndpointIds.has(e.target)
-                && !producingInjectorIds.has(e.source)
-              ) {
-                continue;
-              }
-              pathSet.add(e.source);
-            }
-          }
-        }
+        expandPathSet(pathSet, baseFlow.edges, 'upstream', {
+          blocked: (candidate, e) => isOtherChainEndpoint(candidate)
+            || (restrictInjectors && injectorIds.has(candidate) && !producingInjectorIds.has(candidate))
+            || (injectorIds.has(candidate) && focusEndpointIds.has(e.target) && !producingInjectorIds.has(candidate)),
+        });
       }
       // A selected finding CLUSTER sits upstream of its expanded children (cluster → finding). The up-walk
       // above never reaches them, so they'd render dimmed once expanded. Add a scoped DOWNSTREAM pass from
@@ -1951,15 +1911,11 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       // previously only an explicitly clicked leaf/cluster id (selectedFindingId truthy) did, so the last
       // hop (type cluster -> the specific finding) stayed dimmed on the initial/default focus.
       if (activeId && pathSet.has(activeId)) {
-        const down = new Set<string>([activeId]);
-        for (let pass = 0; pass < 3; pass += 1) {
-          for (const e of baseFlow.edges) {
-            if (e.source && e.target && down.has(e.source) && !down.has(e.target) && !isOtherChainEndpoint(e.target)) {
-              down.add(e.target);
-              pathSet.add(e.target);
-            }
-          }
-        }
+        const down = expandPathSet(new Set<string>([activeId]), baseFlow.edges, 'downstream', {
+          blocked: isOtherChainEndpoint,
+          maxPasses: AP_CHILD_WALK_PASSES,
+        });
+        down.forEach(id => pathSet.add(id));
       }
       return {
         nodes: baseFlow.nodes.map((n) => {
@@ -1995,13 +1951,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       // through BOTH production and causal ("Triggered …") edges (target in set → add source), so the path
       // from the first action to the one clicked — findings, endpoints and the actions between — is shown.
       pathSet.add(selectedInjectorId);
-      for (let pass = 0; pass < 8; pass += 1) {
-        for (const e of baseFlow.edges) {
-          if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
-            pathSet.add(e.source);
-          }
-        }
-      }
+      expandPathSet(pathSet, baseFlow.edges, 'upstream');
     } else if (selectedInjectorId) {
       // Clustered view: an injector's downstream highlight shows its REACH — the endpoints it targeted — not
       // the findings. In the clustered view findings hang off the SHARED endpoint hub and aggregate every
@@ -2016,13 +1966,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
           .map(n => n.id),
       );
       pathSet.add(selectedInjectorId);
-      for (let pass = 0; pass < 6; pass += 1) {
-        for (const e of baseFlow.edges) {
-          if (e.source && e.target && pathSet.has(e.source) && !pathSet.has(e.target) && !findingNodeIds.has(e.target)) {
-            pathSet.add(e.target);
-          }
-        }
-      }
+      expandPathSet(pathSet, baseFlow.edges, 'downstream', { blocked: candidate => findingNodeIds.has(candidate) });
     } else if (effectiveSelectedFindingId && chainMode) {
       // Chain view: mirror the selectedInjectorId&&chainMode branch above — a finding several hops
       // into the causal chain (e.g. a captured file dropped by a late-stage action) previously only
@@ -2033,13 +1977,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       // selectedFindingId): a finding picked from a drawer/summary list may be hidden inside a still-
       // collapsed type cluster, which has no node of its own to seed on.
       pathSet.add(effectiveSelectedFindingId);
-      for (let pass = 0; pass < 8; pass += 1) {
-        for (const e of baseFlow.edges) {
-          if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
-            pathSet.add(e.source);
-          }
-        }
-      }
+      expandPathSet(pathSet, baseFlow.edges, 'upstream');
     } else if (selectedFindingId) {
       // Walk UP a finding's PRODUCTION path only: endpoint(s) it was found on, then the injector(s) that
       // actually produced it. Two guards keep it scoped on a shared/hub endpoint (clustered view): never
@@ -2065,32 +2003,17 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       }
       const restrictInjectors = hasProducingExecution;
       pathSet.add(selectedFindingId);
-      for (let pass = 0; pass < 6; pass += 1) {
-        for (const e of baseFlow.edges) {
-          if (e.type === AP_FLOW_CAUSAL_EDGE_TYPE) {
-            continue;
-          }
-          if (e.target && e.source && pathSet.has(e.target) && !pathSet.has(e.source)) {
-            if (restrictInjectors && injectorNodeIds.has(e.source) && !producingInjectors.has(e.source)) {
-              continue;
-            }
-            pathSet.add(e.source);
-          }
-        }
-      }
+      expandPathSet(pathSet, baseFlow.edges, 'upstream', {
+        blocked: (candidate, e) => e.type === AP_FLOW_CAUSAL_EDGE_TYPE
+          || (restrictInjectors && injectorNodeIds.has(candidate) && !producingInjectors.has(candidate)),
+      });
     } else if (selectedNodeId && chainMode) {
       // Chain view: same unrestricted backward walk as the injector/finding branches above — an
       // endpoint click previously fell through to the clustered branch below, which compares
       // against `dto`'s (collapsed-view) node ids and never matches the chain graph's own
       // (`chain-ep|depth|id`-style) ids, so it found nothing to light past the endpoint itself.
       pathSet.add(selectedNodeId);
-      for (let pass = 0; pass < 8; pass += 1) {
-        for (const e of baseFlow.edges) {
-          if (e.source && e.target && pathSet.has(e.target) && !pathSet.has(e.source)) {
-            pathSet.add(e.source);
-          }
-        }
-      }
+      expandPathSet(pathSet, baseFlow.edges, 'upstream');
     } else if (selectedNodeId) {
       // Clustered endpoint click: injectors converge on the shared hub, so walking the rendered edges up
       // would light EVERY injector. Instead resolve the injectors that actually target this endpoint from

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1226,6 +1226,53 @@ export const FILTER_TO_FINDING_TYPES: Record<Exclude<AttackPathFindingFilter, 'e
   cves: ['cve'],
 };
 
+// Pass cap for the deliberately SHALLOW downstream walks (a selection's own expanded children:
+// endpoint -> its finding clusters -> their expanded findings). Those walks must stay scoped to the
+// selection's immediate subtree, not sweep in the whole downstream cone the way the full-path walks
+// do — expandPathSet with no cap would keep going through shared nodes into unrelated branches.
+export const AP_CHILD_WALK_PASSES = 3;
+
+/**
+ * Expand `set` in place along `edges` until a full pass adds nothing (a fixpoint): 'upstream'
+ * adopts each edge's source once its target is in the set (everything that eventually leads INTO
+ * the seed), 'downstream' the reverse. The set only grows and is bounded by the graph's node ids,
+ * so the fixpoint always terminates — no arbitrary pass cap needed for full-path walks. `blocked`
+ * vetoes adopting a candidate node for a given edge (e.g. "never walk into another endpoint's own
+ * chain node", or "skip causal edges"). `maxPasses` bounds the expansion for the deliberately
+ * shallow child walks (see {@link AP_CHILD_WALK_PASSES}); note a single pass over the edge list can
+ * propagate several hops when the edge order permits, so it is a cap, not an exact depth.
+ */
+export const expandPathSet = (
+  set: Set<string>,
+  edges: readonly AttackPathFlowEdge[],
+  direction: 'upstream' | 'downstream',
+  options?: {
+    blocked?: (candidate: string, edge: AttackPathFlowEdge) => boolean;
+    maxPasses?: number;
+  },
+): Set<string> => {
+  const blocked = options?.blocked;
+  const maxPasses = options?.maxPasses ?? Number.POSITIVE_INFINITY;
+  for (let pass = 0; pass < maxPasses; pass += 1) {
+    let changed = false;
+    for (const e of edges) {
+      if (!e.source || !e.target) {
+        continue;
+      }
+      const from = direction === 'upstream' ? e.target : e.source;
+      const candidate = direction === 'upstream' ? e.source : e.target;
+      if (set.has(from) && !set.has(candidate) && !blocked?.(candidate, e)) {
+        set.add(candidate);
+        changed = true;
+      }
+    }
+    if (!changed) {
+      break;
+    }
+  }
+  return set;
+};
+
 const DIMMED_OPACITY = 0.18;
 
 /**


### PR DESCRIPTION
## Fixes

Fixes OpenAEV-Platform/filigran-private#265

Related to #5048 (attack path view epic - not closed by this PR)

## Problem

When selecting a Chokepoint or a Discovered Credential finding in the Attack Path graph, the highlighted path did not match the selection - only the endpoint node itself got marked, with no path/links highlighted in blue and nothing dimmed, unlike every other finding type.

## Root causes

1. **Chokepoint click had no path highlighting at all.** It only set `selected: true` on the endpoint node - no upstream/downstream path walk, no dimming of unrelated nodes/edges (finding clicks already did this).
2. **Credential findings couldn't resolve their canonical graph node.** The drawer's finding value is masked server-side (`"user:****"`), but the graph's raw finding node value is unmasked (`"user:pass"`). The lookup used strict equality instead of the existing `findingValuesMatch()` helper (already used correctly in `highlightGraphFinding`/`openFindingFromGraph`), so the match silently failed and the credential's path never highlighted.
3. **Fixing both surfaced a further, chain-mode-specific bug**: the causal graph dedupes identical actions/finding values shared by multiple hosts into a single node (e.g. two hosts both exposing port 445, or the same step run against several hosts). An unrestricted path walk through those shared nodes bled into every other endpoint sharing the same recon result or action - highlighting the whole graph instead of just the selected path.

## Fix

- Added the same upstream/downstream path-set computation + dimming used for finding highlights to the chokepoint (endpoint-only) focus branch.
- Replaced the strict-equality canonical node lookup for drawer-clicked credential findings with `findingValuesMatch()`.
- Added a guard so the path walk (both for chokepoint and finding highlights) never marks another endpoint's own chain node as selected, while still allowing genuinely shared upstream nodes (injector/finding) to light up.
- **Producing-execution attribution for same-username credentials** (second commit): two credentials findings sharing a username but differing only by password/hash resolved to whichever category-page entry sorted first, so the wrong finding's producing action could be shown. Producing executions are now resolved from the full graph's exact execution->finding links (matched by the finding's own node id) FIRST, with the ambiguous category-page match kept only as a fallback.

## Review follow-up

- The upstream/downstream path walks (both the ones added here and the pre-existing ones they mirror) iterated a magic number of passes (8/6/3) over the edge list. They now go through a shared `expandPathSet()` helper that expands to a fixpoint (terminates because the set only grows, bounded by the graph's node ids), with walk-specific guards expressed as a `blocked()` predicate. The two deliberately shallow child walks keep an explicit cap via the named `AP_CHILD_WALK_PASSES` constant. Unit tests added for the helper.
- Documented on `findingValuesMatch()` why only credentials get the username-half comparison: the backend masks ONLY the credentials category in drawer DTO values; `password_policy`/`sid` are display-masked in the front, are not drawer categories, and resolve by exact node id instead.

## Testing

- `yarn check-ts` - 0 errors
- `yarn eslint` on the three touched files - clean
- `yarn vitest run src/__tests__/admin/components/simulations/simulation/attack_path/` - 6 files, 124/124 passed (includes 6 new `expandPathSet` tests, among them a 20-hop chain a fixed 8-pass cap would have truncated)
- Verified against live API data from a real chaining scenario (2-endpoint causal chain with shared injectors/findings) to confirm the endpoint-leak fix scopes correctly
- Manually verified in a locally rebuilt/redeployed instance: chokepoint clicks and credential-finding clicks now highlight only the correct path and dim everything else

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
