### PR TITLE
fix(audit-log): cap request payload size for multipart endpoints (#7269)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -283,8 +283,9 @@ public class AccessControlAuditLogAspect {
    *
    * <p>Recognizes {@code @RequestBody}, {@code @RequestPart} and {@code @ModelAttribute}. Multipart
    * endpoints (e.g. {@code InjectorApi.registerInjector}) pass their DTO via {@code @RequestPart};
-   * missing them made the payload fall through to the {@code signature} node, which is not
-   * size-capped by {@code ObjectNormalizationUtils} — a heap-exhaustion risk on large payloads.
+   * missing them made the payload fall through to the {@code signature} node, which at the time was
+   * not size-capped by {@code ObjectNormalizationUtils} — a heap-exhaustion risk on large payloads.
+   * {@code LogService} now normalizes the signature node as well, as defense in depth.
    *
    * @return the argument index, or {@code -1} if none matches
    */
@@ -336,7 +337,8 @@ public class AccessControlAuditLogAspect {
       ObjectNode params = objectMapper.createObjectNode();
       if (paramNames != null) {
         for (int i = 0; i < paramNames.length; i++) {
-          // The payload is already captured as inputNode (normalized and size-capped there).
+          // Never re-serialize the payload into the signature; for mutating scopes it is captured
+          // separately as inputNode (normalized and size-capped downstream).
           if (i == payloadIndex) {
             params.put(paramNames[i], "@RequestBody");
           } else {

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -11,8 +11,12 @@ import io.openaev.database.model.EventStatus;
 import io.openaev.database.model.ResourceType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
@@ -25,13 +29,17 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.io.Resource;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -49,7 +57,7 @@ import org.springframework.web.server.ResponseStatusException;
  * {@link AuditLogFailureException} propagates through the transaction interceptor, which rolls back
  * the mutation.
  *
- * <p>Phase 1: delegates to {@link LogService} for console-only output.
+ * <p>Phase 1: delegates to {@link io.openaev.service.LogService} for console-only output.
  */
 @Aspect
 @Component
@@ -152,8 +160,9 @@ public class AccessControlAuditLogAspect {
     try {
       ResourceType resourceType = accessControl.resourceType();
       String resourceId = resolveResourceId(joinPoint, accessControl);
-      JsonNode inputNode = getInputNode(joinPoint, eventScope);
-      JsonNode signatureNode = getMethodSignature(joinPoint, inputNode);
+      int payloadIndex = findRequestPayloadIndex(joinPoint);
+      JsonNode inputNode = getInputNode(joinPoint, payloadIndex, eventScope);
+      JsonNode signatureNode = getMethodSignature(joinPoint, payloadIndex);
 
       // Capture snapshots on the servlet thread before any async handoff.
       Map<String, AuditLogContext.EntitySnapshot> snapshots = captureEntitySnapshots();
@@ -231,20 +240,16 @@ public class AccessControlAuditLogAspect {
   }
 
   // Capture the input DTO for create/update/status_change
-  private JsonNode getInputNode(JoinPoint joinPoint, AuditEventScope eventScope) {
-    JsonNode inputNode = null;
-
-    if (eventScope == AuditEventScope.CREATE
-        || eventScope == AuditEventScope.UPDATE
-        || eventScope == AuditEventScope.STATUS_CHANGE) {
-      Object requestBody = findRequestBody(joinPoint);
-
-      if (requestBody != null) {
-        inputNode = objectMapper.valueToTree(requestBody);
-      }
+  private JsonNode getInputNode(JoinPoint joinPoint, int payloadIndex, AuditEventScope eventScope) {
+    if (payloadIndex < 0
+        || (eventScope != AuditEventScope.CREATE
+            && eventScope != AuditEventScope.UPDATE
+            && eventScope != AuditEventScope.STATUS_CHANGE)) {
+      return null;
     }
 
-    return inputNode;
+    Object requestBody = joinPoint.getArgs()[payloadIndex];
+    return requestBody != null ? objectMapper.valueToTree(requestBody) : null;
   }
 
   private JsonNode getOutputNode(Object output) {
@@ -273,27 +278,53 @@ public class AccessControlAuditLogAspect {
     return errorNode;
   }
 
-  /** Finds the first method argument annotated with {@code @RequestBody}. */
-  private Object findRequestBody(JoinPoint joinPoint) {
+  /**
+   * Finds the index of the argument carrying the request payload.
+   *
+   * <p>Recognizes {@code @RequestBody}, {@code @RequestPart} and {@code @ModelAttribute}. Multipart
+   * endpoints (e.g. {@code InjectorApi.registerInjector}) pass their DTO via {@code @RequestPart};
+   * missing them made the payload fall through to the {@code signature} node, which is not
+   * size-capped by {@code ObjectNormalizationUtils} — a heap-exhaustion risk on large payloads.
+   *
+   * @return the argument index, or {@code -1} if none matches
+   */
+  private int findRequestPayloadIndex(JoinPoint joinPoint) {
     try {
       MethodSignature signature = (MethodSignature) joinPoint.getSignature();
       Annotation[][] paramAnnotations = signature.getMethod().getParameterAnnotations();
       Object[] args = joinPoint.getArgs();
-      for (int i = 0; i < paramAnnotations.length; i++) {
+      for (int i = 0; i < paramAnnotations.length && i < args.length; i++) {
         for (Annotation ann : paramAnnotations[i]) {
-          if (ann instanceof RequestBody) {
-            return args[i];
+          boolean isPayloadAnnotation =
+              ann instanceof RequestBody
+                  || ann instanceof RequestPart
+                  || ann instanceof ModelAttribute;
+          if (isPayloadAnnotation && !isNonSerializableArgument(args[i])) {
+            return i;
           }
         }
       }
     } catch (Exception e) {
-      log.debug("[AUDIT] Failed to find @RequestBody argument: {}", e.getMessage());
+      log.debug("[AUDIT] Failed to find request payload argument: {}", e.getMessage());
     }
-    return null;
+    return -1;
+  }
+
+  /**
+   * Arguments that must never be fed to Jackson: serializing them either materializes the whole
+   * uploaded file in the heap ({@code MultipartFile#getBytes} as base64) or consumes a stream.
+   */
+  private static boolean isNonSerializableArgument(Object value) {
+    Object unwrapped = value instanceof Optional<?> opt ? opt.orElse(null) : value;
+    return unwrapped instanceof MultipartFile
+        || unwrapped instanceof Resource
+        || unwrapped instanceof InputStream
+        || unwrapped instanceof HttpServletRequest
+        || unwrapped instanceof HttpServletResponse;
   }
 
   /** Builds a JsonNode with the method signature and its parameter names mapped to their values. */
-  private JsonNode getMethodSignature(JoinPoint joinPoint, JsonNode inputNode) {
+  private JsonNode getMethodSignature(JoinPoint joinPoint, int payloadIndex) {
     try {
       MethodSignature signature = (MethodSignature) joinPoint.getSignature();
       String[] paramNames = signature.getParameterNames();
@@ -305,19 +336,11 @@ public class AccessControlAuditLogAspect {
       ObjectNode params = objectMapper.createObjectNode();
       if (paramNames != null) {
         for (int i = 0; i < paramNames.length; i++) {
-          Object value = i < args.length ? args[i] : null;
-          // Skip the parameter that was already captured as inputNode
-          if (value != null
-              && inputNode != null
-              && objectMapper.valueToTree(value).equals(inputNode)) {
+          // The payload is already captured as inputNode (normalized and size-capped there).
+          if (i == payloadIndex) {
             params.put(paramNames[i], "@RequestBody");
-            continue;
-          }
-
-          try {
-            params.set(paramNames[i], objectMapper.valueToTree(value));
-          } catch (Exception ex) {
-            params.put(paramNames[i], value != null ? value.toString() : "null");
+          } else {
+            setParameterNode(params, paramNames[i], i < args.length ? args[i] : null);
           }
         }
       }
@@ -327,6 +350,20 @@ public class AccessControlAuditLogAspect {
       log.warn("[AUDIT] Failed to build method signature node: {}", e.getMessage(), e);
     }
     return null;
+  }
+
+  /** Serializes a single method parameter, skipping values Jackson must never walk. */
+  private void setParameterNode(ObjectNode params, String paramName, Object value) {
+    Object unwrapped = value instanceof Optional<?> opt ? opt.orElse(null) : value;
+    if (unwrapped != null && isNonSerializableArgument(unwrapped)) {
+      params.put(paramName, unwrapped.getClass().getSimpleName());
+      return;
+    }
+    try {
+      params.set(paramName, objectMapper.valueToTree(value));
+    } catch (Exception ex) {
+      params.put(paramName, value != null ? value.toString() : "null");
+    }
   }
 
   /** Resolves the resource ID from the annotation's SpEL expression. */

--- a/openaev-api/src/main/java/io/openaev/service/LogService.java
+++ b/openaev-api/src/main/java/io/openaev/service/LogService.java
@@ -160,15 +160,16 @@ public class LogService {
       ctx.put("entity_type", entityTypeName);
 
       if (input != null) {
-        // Redacted input
-        input = objectNormalizationUtils.normalize(input);
+        // Redact before normalizing: the normalization size-cap fallback serializes the tree into
+        // a scalar "preview" that field-name-based redaction cannot scrub afterwards.
         input = ObjectRedactionUtils.redact(input, resourceType);
+        input = objectNormalizationUtils.normalize(input);
         ctx.put("input", toContextValue(input));
       }
 
       if (output != null) {
-        output = objectNormalizationUtils.normalize(output);
         output = ObjectRedactionUtils.redact(output, resourceType);
+        output = objectNormalizationUtils.normalize(output);
         ctx.put("output", toContextValue(output));
       }
 
@@ -179,8 +180,8 @@ public class LogService {
       }
 
       if (signatureNode != null) {
-        signatureNode = objectNormalizationUtils.normalize(signatureNode);
         signatureNode = ObjectRedactionUtils.redact(signatureNode, resourceType);
+        signatureNode = objectNormalizationUtils.normalize(signatureNode);
         doc.getRequestMetadata().setSignature(signatureNode);
       }
 
@@ -289,36 +290,40 @@ public class LogService {
   }
 
   /**
-   * Processes MUTATION-specific contextData entries: normalizes and redacts input/output JsonNodes,
+   * Processes MUTATION-specific contextData entries: redacts and normalizes input/output JsonNodes,
    * and extracts the signature into request metadata.
+   *
+   * <p>Redaction always runs before normalization: when a tree is still oversized after truncation,
+   * the normalization fallback serializes it into a scalar {@code preview} field that field-name
+   * based redaction cannot scrub afterwards. Redacting first guarantees the preview can only ever
+   * contain already-redacted data.
    */
   private void processMutationContext(
       Map<String, Object> ctx, ResourceType resourceType, String eventScope, LogEvent doc) {
-    // Normalize and redact input
+    // Redact and normalize input
     Object inputObj = ctx.get("input");
     if (inputObj instanceof JsonNode inputNode && !inputNode.isNull()) {
-      inputNode = objectNormalizationUtils.normalize(inputNode);
       inputNode = ObjectRedactionUtils.redact(inputNode, resourceType);
+      inputNode = objectNormalizationUtils.normalize(inputNode);
       ctx.put("input", toContextValue(inputNode));
     }
 
-    // Normalize and redact output
+    // Redact and normalize output
     Object outputObj = ctx.get("output");
     if (outputObj instanceof JsonNode outputNode && !outputNode.isNull()) {
-      outputNode = objectNormalizationUtils.normalize(outputNode);
       outputNode = ObjectRedactionUtils.redact(outputNode, resourceType);
+      outputNode = objectNormalizationUtils.normalize(outputNode);
       ctx.put("output", toContextValue(outputNode));
     }
 
-    // Extract signature into request metadata
+    // Extract signature into request metadata. Normalization is what enforces the max event size:
+    // without it a large payload reaching the signature node (e.g. a @RequestPart DTO) is logged
+    // uncapped and can exhaust the heap.
     Object signatureObj = ctx.remove("signature");
     if (signatureObj instanceof JsonNode signatureNode && !signatureNode.isNull()) {
-      // Normalize before redacting: this is what enforces the max event size. Without it a large
-      // payload reaching the signature node (e.g. a @RequestPart DTO) is logged uncapped and can
-      // exhaust the heap.
-      JsonNode normalizedSignature = objectNormalizationUtils.normalize(signatureNode);
-      JsonNode redactedSignature = ObjectRedactionUtils.redact(normalizedSignature, resourceType);
-      doc.getRequestMetadata().setSignature(redactedSignature);
+      JsonNode redactedSignature = ObjectRedactionUtils.redact(signatureNode, resourceType);
+      JsonNode normalizedSignature = objectNormalizationUtils.normalize(redactedSignature);
+      doc.getRequestMetadata().setSignature(normalizedSignature);
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/LogService.java
+++ b/openaev-api/src/main/java/io/openaev/service/LogService.java
@@ -179,6 +179,7 @@ public class LogService {
       }
 
       if (signatureNode != null) {
+        signatureNode = objectNormalizationUtils.normalize(signatureNode);
         signatureNode = ObjectRedactionUtils.redact(signatureNode, resourceType);
         doc.getRequestMetadata().setSignature(signatureNode);
       }
@@ -312,7 +313,11 @@ public class LogService {
     // Extract signature into request metadata
     Object signatureObj = ctx.remove("signature");
     if (signatureObj instanceof JsonNode signatureNode && !signatureNode.isNull()) {
-      JsonNode redactedSignature = ObjectRedactionUtils.redact(signatureNode, resourceType);
+      // Normalize before redacting: this is what enforces the max event size. Without it a large
+      // payload reaching the signature node (e.g. a @RequestPart DTO) is logged uncapped and can
+      // exhaust the heap.
+      JsonNode normalizedSignature = objectNormalizationUtils.normalize(signatureNode);
+      JsonNode redactedSignature = ObjectRedactionUtils.redact(normalizedSignature, resourceType);
       doc.getRequestMetadata().setSignature(redactedSignature);
     }
   }

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AccessControlAuditLogAspectPayloadTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AccessControlAuditLogAspectPayloadTest.java
@@ -39,9 +39,9 @@ import org.springframework.web.multipart.MultipartFile;
  * <p>Covers the Nuclei injector registration OOM: {@code InjectorApi.registerInjector} passes its
  * DTO via {@code @RequestPart} (multipart, because the endpoint also accepts an icon). The aspect
  * used to only recognise {@code @RequestBody}, so the payload fell through to the {@code signature}
- * node — which, unlike {@code input}, is not size-capped by {@code ObjectNormalizationUtils}. The
- * full, uncapped contract payload was then deep-copied several times and queued on the bounded
- * audit executor, exhausting the heap.
+ * node — which, unlike {@code input}, was not size-capped by {@code ObjectNormalizationUtils} at
+ * the time (it now is). The full, uncapped contract payload was then deep-copied several times and
+ * queued on the bounded audit executor, exhausting the heap.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AccessControlAuditLogAspect — request payload resolution")

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AccessControlAuditLogAspectPayloadTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AccessControlAuditLogAspectPayloadTest.java
@@ -1,0 +1,321 @@
+package io.openaev.aop.audit_log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.aop.AccessControl;
+import io.openaev.database.model.Action;
+import io.openaev.database.model.EventStatus;
+import io.openaev.database.model.ResourceType;
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Regression tests for the request-payload resolution of {@link AccessControlAuditLogAspect}.
+ *
+ * <p>Covers the Nuclei injector registration OOM: {@code InjectorApi.registerInjector} passes its
+ * DTO via {@code @RequestPart} (multipart, because the endpoint also accepts an icon). The aspect
+ * used to only recognise {@code @RequestBody}, so the payload fell through to the {@code signature}
+ * node — which, unlike {@code input}, is not size-capped by {@code ObjectNormalizationUtils}. The
+ * full, uncapped contract payload was then deep-copied several times and queued on the bounded
+ * audit executor, exhausting the heap.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AccessControlAuditLogAspect — request payload resolution")
+class AccessControlAuditLogAspectPayloadTest {
+
+  /** Marker written into the signature node in place of the (already captured) payload. */
+  private static final String PAYLOAD_PLACEHOLDER = "@RequestBody";
+
+  private static final String PAYLOAD_NAME = "Nuclei";
+
+  @Mock private AuditLogger auditLogger;
+  @Mock private ProceedingJoinPoint joinPoint;
+  @Mock private MethodSignature methodSignature;
+
+  private AccessControlAuditLogAspect aspect;
+
+  private ArgumentCaptor<JsonNode> inputCaptor;
+  private ArgumentCaptor<JsonNode> signatureCaptor;
+
+  /** Payload DTO standing in for {@code InjectorCreateInput}. */
+  record PayloadInput(String name, String type) {}
+
+  /** Controller-like fixture exposing the annotation shapes the aspect must understand. */
+  @SuppressWarnings("unused")
+  static class SampleApi {
+
+    @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.INJECTOR)
+    void createWithRequestBody(@RequestBody PayloadInput input) {}
+
+    // Mirrors InjectorApi.registerInjector
+    @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.INJECTOR)
+    void createWithRequestPart(
+        @RequestPart("input") PayloadInput input,
+        @RequestPart("icon") Optional<MultipartFile> file) {}
+
+    @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.INJECTOR)
+    void createWithModelAttribute(@ModelAttribute PayloadInput input) {}
+
+    @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.INJECTOR)
+    void createWithFileOnly(@RequestPart("icon") MultipartFile file) {}
+
+    @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.INJECTOR)
+    void createWithServletRequest(@RequestBody PayloadInput input, HttpServletRequest request) {}
+
+    @AccessControl(actionPerformed = Action.DELETE, resourceType = ResourceType.INJECTOR)
+    void deleteWithRequestBody(@RequestBody PayloadInput input) {}
+  }
+
+  @BeforeEach
+  void setup() {
+    aspect = new AccessControlAuditLogAspect(auditLogger, new ObjectMapper());
+
+    inputCaptor = ArgumentCaptor.forClass(JsonNode.class);
+    signatureCaptor = ArgumentCaptor.forClass(JsonNode.class);
+
+    lenient().when(auditLogger.isAuditLoggingEnabled()).thenReturn(true);
+    lenient().when(auditLogger.isAuditLoggingValid(any())).thenReturn(true);
+    lenient()
+        .when(
+            auditLogger.logAccessControlEvent(
+                any(), any(), any(), anyString(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(true));
+  }
+
+  /**
+   * Wires the mocked join point onto the given fixture method and runs the aspect, then captures
+   * the {@code input} and {@code signature} nodes handed to the audit logger.
+   */
+  private void invokeAspect(String methodName, String[] paramNames, Object... args)
+      throws Throwable {
+    Method method =
+        java.util.Arrays.stream(SampleApi.class.getDeclaredMethods())
+            .filter(m -> m.getName().equals(methodName))
+            .findFirst()
+            .orElseThrow();
+
+    when(joinPoint.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    lenient().when(methodSignature.getParameterNames()).thenReturn(paramNames);
+    lenient().when(methodSignature.getDeclaringTypeName()).thenReturn(SampleApi.class.getName());
+    lenient().when(methodSignature.getName()).thenReturn(methodName);
+    when(joinPoint.getArgs()).thenReturn(args);
+    when(joinPoint.proceed()).thenReturn("ok");
+
+    aspect.auditAround(joinPoint);
+
+    verify(auditLogger)
+        .logAccessControlEvent(
+            any(AuditEventScope.class),
+            any(EventStatus.class),
+            any(ResourceType.class),
+            anyString(),
+            inputCaptor.capture(),
+            any(),
+            signatureCaptor.capture(),
+            any());
+  }
+
+  private JsonNode signatureParam(String paramName) {
+    return signatureCaptor.getValue().path("parameters").path(paramName);
+  }
+
+  @Nested
+  @DisplayName("Payload annotation detection")
+  class PayloadAnnotationDetection {
+
+    @Test
+    @DisplayName("@RequestPart payload is captured as input, not duplicated into signature")
+    void given_requestPartPayload_should_captureInputAndPlaceholderInSignature() throws Throwable {
+      // Arrange
+      PayloadInput payload = new PayloadInput(PAYLOAD_NAME, "openaev_nuclei");
+
+      // Act
+      invokeAspect(
+          "createWithRequestPart",
+          new String[] {"input", "file"},
+          payload,
+          Optional.<MultipartFile>empty());
+
+      // Assert — the payload lands in `input` (which IS size-capped downstream)
+      assertThat(inputCaptor.getValue()).isNotNull();
+      assertThat(inputCaptor.getValue().path("name").asText()).isEqualTo(PAYLOAD_NAME);
+
+      // Assert — and is NOT re-serialized into the (uncapped) signature node
+      assertThat(signatureParam("input").asText()).isEqualTo(PAYLOAD_PLACEHOLDER);
+      assertThat(signatureCaptor.getValue().toString()).doesNotContain("openaev_nuclei");
+    }
+
+    @Test
+    @DisplayName("@RequestBody payload is still captured as input (non-regression)")
+    void given_requestBodyPayload_should_captureInputAndPlaceholderInSignature() throws Throwable {
+      // Arrange
+      PayloadInput payload = new PayloadInput(PAYLOAD_NAME, "openaev_nuclei");
+
+      // Act
+      invokeAspect("createWithRequestBody", new String[] {"input"}, payload);
+
+      // Assert
+      assertThat(inputCaptor.getValue().path("name").asText()).isEqualTo(PAYLOAD_NAME);
+      assertThat(signatureParam("input").asText()).isEqualTo(PAYLOAD_PLACEHOLDER);
+    }
+
+    @Test
+    @DisplayName("@ModelAttribute payload is captured as input")
+    void given_modelAttributePayload_should_captureInput() throws Throwable {
+      // Arrange
+      PayloadInput payload = new PayloadInput(PAYLOAD_NAME, "openaev_nuclei");
+
+      // Act
+      invokeAspect("createWithModelAttribute", new String[] {"input"}, payload);
+
+      // Assert
+      assertThat(inputCaptor.getValue().path("name").asText()).isEqualTo(PAYLOAD_NAME);
+      assertThat(signatureParam("input").asText()).isEqualTo(PAYLOAD_PLACEHOLDER);
+    }
+
+    @Test
+    @DisplayName("a @RequestPart file is never selected as the payload")
+    void given_multipartFileOnlyEndpoint_should_notCaptureFileAsInput() throws Throwable {
+      // Arrange
+      MultipartFile icon =
+          new MockMultipartFile("icon", "icon.png", "image/png", new byte[] {1, 2, 3});
+
+      // Act
+      invokeAspect("createWithFileOnly", new String[] {"file"}, icon);
+
+      // Assert
+      assertThat(inputCaptor.getValue()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("Non-serializable arguments")
+  class NonSerializableArguments {
+
+    @Test
+    @DisplayName("a MultipartFile is logged by class name, never as a base64 blob")
+    void given_multipartFileArgument_should_logClassNameOnly() throws Throwable {
+      // Arrange — a payload big enough that base64-serializing it would be visible
+      byte[] content = new byte[4096];
+      java.util.Arrays.fill(content, (byte) 'A');
+      MultipartFile icon = new MockMultipartFile("icon", "icon.png", "image/png", content);
+
+      // Act
+      invokeAspect(
+          "createWithRequestPart",
+          new String[] {"input", "file"},
+          new PayloadInput(PAYLOAD_NAME, "openaev_nuclei"),
+          Optional.of(icon));
+
+      // Assert
+      assertThat(signatureParam("file").asText())
+          .isEqualTo(MockMultipartFile.class.getSimpleName());
+      assertThat(signatureCaptor.getValue().toString()).doesNotContain("AAAA");
+    }
+
+    @Test
+    @DisplayName("an empty Optional does not break signature serialization")
+    void given_emptyOptionalFile_should_serializeSignatureWithoutError() throws Throwable {
+      // Arrange / Act
+      invokeAspect(
+          "createWithRequestPart",
+          new String[] {"input", "file"},
+          new PayloadInput(PAYLOAD_NAME, "openaev_nuclei"),
+          Optional.<MultipartFile>empty());
+
+      // Assert
+      assertThat(signatureCaptor.getValue()).isNotNull();
+      assertThat(signatureCaptor.getValue().path("parameters").has("file")).isTrue();
+    }
+
+    @Test
+    @DisplayName("an HttpServletRequest argument is logged by class name")
+    void given_httpServletRequestArgument_should_logClassNameOnly() throws Throwable {
+      // Arrange
+      HttpServletRequest request = new org.springframework.mock.web.MockHttpServletRequest();
+
+      // Act
+      invokeAspect(
+          "createWithServletRequest",
+          new String[] {"input", "request"},
+          new PayloadInput(PAYLOAD_NAME, "openaev_nuclei"),
+          request);
+
+      // Assert
+      assertThat(signatureParam("request").asText()).isEqualTo("MockHttpServletRequest");
+    }
+  }
+
+  @Nested
+  @DisplayName("Event scope filtering")
+  class EventScopeFiltering {
+
+    @Test
+    @DisplayName("non-mutating scopes do not capture the payload as input")
+    void given_deleteScope_should_notCaptureInput() throws Throwable {
+      // Arrange / Act
+      invokeAspect(
+          "deleteWithRequestBody",
+          new String[] {"input"},
+          new PayloadInput(PAYLOAD_NAME, "openaev_nuclei"));
+
+      // Assert
+      assertThat(inputCaptor.getValue()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("Signature node shape")
+  class SignatureNodeShape {
+
+    @Test
+    @DisplayName("the signature always carries the fully qualified method name")
+    void given_anyAuditedMethod_should_includeMethodName() throws Throwable {
+      // Arrange / Act
+      invokeAspect(
+          "createWithRequestBody",
+          new String[] {"input"},
+          new PayloadInput(PAYLOAD_NAME, "openaev_nuclei"));
+
+      // Assert
+      assertThat(signatureCaptor.getValue().path("method").asText())
+          .isEqualTo(SampleApi.class.getName() + ".createWithRequestBody");
+    }
+
+    @Test
+    @DisplayName("a null parameter name array yields an empty parameters node")
+    void given_missingParameterNames_should_produceEmptyParameters() throws Throwable {
+      // Arrange / Act
+      invokeAspect("createWithRequestBody", null, new PayloadInput(PAYLOAD_NAME, "openaev_nuclei"));
+
+      // Assert
+      assertThat(signatureCaptor.getValue().path("parameters"))
+          .isEqualTo(new ObjectMapper().createObjectNode());
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceSignatureNormalizationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceSignatureNormalizationTest.java
@@ -1,0 +1,246 @@
+package io.openaev.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.aop.audit_log.AuditEvent;
+import io.openaev.aop.audit_log.AuditEventOrigin;
+import io.openaev.aop.audit_log.AuditEventScope;
+import io.openaev.config.AuditLogProperties;
+import io.openaev.config.cache.LicenseCacheManager;
+import io.openaev.database.model.EventStatus;
+import io.openaev.database.model.EventType;
+import io.openaev.database.model.ResourceType;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.engine.EngineService;
+import io.openaev.engine.model.log.LogEvent;
+import io.openaev.utils.SystemLoadGuardUtils;
+import io.openaev.utils.log.dispatcher.AuditLogTransportDispatcherUtils;
+import io.openaev.utils.object.ObjectNormalizationPolicy;
+import io.openaev.utils.object.ObjectNormalizationUtils;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Regression tests for the size capping of the audit {@code signature} node.
+ *
+ * <p>{@code ObjectNormalizationUtils#normalize} is what enforces {@code maxEventSizeBytes}. It used
+ * to be applied only to {@code input} and {@code output}, never to {@code signature}. Combined with
+ * the aspect failing to detect {@code @RequestPart} payloads, a large DTO reaching the signature
+ * node was logged uncapped and exhausted the heap (Nuclei injector registration).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("LogService — audit signature size capping")
+class LogServiceSignatureNormalizationTest {
+
+  private static final int MAX_EVENT_SIZE_BYTES = 512;
+  private static final int MAX_STRING_BYTES = 64;
+  private static final String TRUNCATED_SUFFIX = "...[TRUNCATED]";
+
+  /** Stands in for a Nuclei {@code contract_content} blob. */
+  private static final String HUGE_CONTRACT_CONTENT = "N".repeat(20_000);
+
+  @Mock private AuditLogProperties auditLogProperties;
+  @Mock private AuditLogTransportDispatcherUtils dispatcher;
+  @Mock private EngineService engineService;
+  @Mock private UserService userService;
+  @Mock private EnterpriseEditionService enterpriseEditionService;
+  @Mock private LicenseCacheManager licenseCacheManager;
+  @Mock private SystemLoadGuardUtils systemLoadGuardUtils;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private LogService logService;
+  private ArgumentCaptor<LogEvent> logEventCaptor;
+
+  @BeforeEach
+  void setup() {
+    ObjectNormalizationPolicy policy = new ObjectNormalizationPolicy();
+    ReflectionTestUtils.setField(policy, "maxEventSizeBytes", MAX_EVENT_SIZE_BYTES);
+    ReflectionTestUtils.setField(policy, "maxStringBytes", MAX_STRING_BYTES);
+    ReflectionTestUtils.setField(policy, "truncationPreviewBytes", 128);
+    ReflectionTestUtils.setField(policy, "skipOnHighLoad", true);
+    ReflectionTestUtils.setField(policy, "skipAllNormalization", false);
+    ReflectionTestUtils.setField(policy, "maxProcessCpuLoad", 0.90d);
+    ReflectionTestUtils.setField(policy, "maxHeapUsageRatio", 0.90d);
+
+    // Never take the "system under load" shortcut — we want the full normalization path.
+    lenient().when(systemLoadGuardUtils.isHeapUsageHigh(anyDouble())).thenReturn(false);
+    lenient().when(systemLoadGuardUtils.isProcessCpuLoadHigh(anyDouble())).thenReturn(false);
+
+    ObjectNormalizationUtils normalizationUtils =
+        new ObjectNormalizationUtils(objectMapper, systemLoadGuardUtils, policy);
+
+    logService =
+        new LogService(
+            auditLogProperties,
+            dispatcher,
+            normalizationUtils,
+            engineService,
+            userService,
+            enterpriseEditionService,
+            licenseCacheManager);
+
+    when(auditLogProperties.isEnabled()).thenReturn(true);
+    when(enterpriseEditionService.isLicenseActive(any())).thenReturn(true);
+    when(engineService.getObjectMapper()).thenReturn(objectMapper);
+    when(dispatcher.dispatch(any(LogEvent.class), any())).thenReturn(true);
+
+    logEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
+  }
+
+  /** Builds a signature node shaped like the one produced by the audit aspect. */
+  private JsonNode oversizedSignature() {
+    ObjectNode signature = objectMapper.createObjectNode();
+    signature.put("method", "io.openaev.rest.injector.InjectorApi.registerInjector");
+    ObjectNode params = objectMapper.createObjectNode();
+    params.put("input", HUGE_CONTRACT_CONTENT);
+    signature.set("parameters", params);
+    return signature;
+  }
+
+  private JsonNode dispatchedSignature() {
+    verify(dispatcher).dispatch(logEventCaptor.capture(), any());
+    return logEventCaptor.getValue().getRequestMetadata().getSignature();
+  }
+
+  @Nested
+  @DisplayName("logRequestEvent")
+  class LogRequestEventSignature {
+
+    @Test
+    @DisplayName("an oversized signature is capped instead of being emitted in full")
+    void given_oversizedSignature_should_capEmittedSignature() {
+      // Arrange
+      JsonNode signature = oversizedSignature();
+
+      // Act
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.INJECTOR,
+          UUID.randomUUID().toString(),
+          null,
+          null,
+          signature,
+          null,
+          Level.INFO,
+          UUID.randomUUID().toString());
+
+      // Assert — the full blob never reaches the transport
+      String emitted = dispatchedSignature().toString();
+      assertThat(emitted).doesNotContain(HUGE_CONTRACT_CONTENT);
+      assertThat(emitted.length()).isLessThan(HUGE_CONTRACT_CONTENT.length());
+    }
+
+    @Test
+    @DisplayName("a small signature is left intact")
+    void given_smallSignature_should_keepMethodName() {
+      // Arrange
+      ObjectNode signature = objectMapper.createObjectNode();
+      signature.put("method", "io.openaev.rest.team.TeamApi.updateTeam");
+
+      // Act
+      logService.logRequestEvent(
+          "update",
+          "success",
+          ResourceType.TEAM,
+          UUID.randomUUID().toString(),
+          null,
+          null,
+          signature,
+          null,
+          Level.INFO,
+          UUID.randomUUID().toString());
+
+      // Assert
+      assertThat(dispatchedSignature().path("method").asText())
+          .isEqualTo("io.openaev.rest.team.TeamApi.updateTeam");
+    }
+
+    @Test
+    @DisplayName("sensitive fields in the signature are still redacted after normalization")
+    void given_sensitiveSignatureFields_should_stillRedact() {
+      // Arrange
+      ObjectNode params = objectMapper.createObjectNode();
+      params.put("user_password", "s3cr3t-value");
+      params.put("client_secret", "another-secret");
+      ObjectNode signature = objectMapper.createObjectNode();
+      signature.put("method", "io.openaev.rest.user.UserApi.createUser");
+      signature.set("parameters", params);
+
+      // Act
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.USER,
+          UUID.randomUUID().toString(),
+          null,
+          null,
+          signature,
+          null,
+          Level.INFO,
+          UUID.randomUUID().toString());
+
+      // Assert
+      String emitted = dispatchedSignature().toString();
+      assertThat(emitted).doesNotContain("s3cr3t-value").doesNotContain("another-secret");
+    }
+  }
+
+  @Nested
+  @DisplayName("logGenericEvent — processMutationContext")
+  class LogGenericEventSignature {
+
+    @Test
+    @DisplayName("an oversized signature in the context is capped before emission")
+    void given_oversizedSignatureInContext_should_capEmittedSignature() {
+      // Arrange
+      Map<String, Object> ctx = new LinkedHashMap<>();
+      ctx.put("signature", oversizedSignature());
+
+      AuditEvent event =
+          AuditEvent.builder()
+              .eventType(EventType.MUTATION)
+              .eventScope(AuditEventScope.CREATE)
+              .eventStatus(EventStatus.SUCCESS)
+              .resourceType(ResourceType.INJECTOR)
+              .resourceId(UUID.randomUUID().toString())
+              .contextData(ctx)
+              .origin(AuditEventOrigin.REQUEST)
+              .build();
+
+      // Act
+      logService.logGenericEvent(event, Level.INFO, UUID.randomUUID().toString());
+
+      // Assert
+      String emitted = dispatchedSignature().toString();
+      assertThat(emitted)
+          .doesNotContain(HUGE_CONTRACT_CONTENT)
+          .satisfiesAnyOf(
+              s -> assertThat(s).contains(TRUNCATED_SUFFIX),
+              s -> assertThat(s).contains("\"truncated\":true"));
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceSignatureNormalizationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceSignatureNormalizationTest.java
@@ -120,6 +120,23 @@ class LogServiceSignatureNormalizationTest {
     return signature;
   }
 
+  /**
+   * Builds a signature that stays oversized even after per-string truncation (many small fields),
+   * forcing the {@code buildTruncatedEnvelope} fallback whose {@code preview} embeds serialized
+   * JSON. The sensitive field comes first so it would land inside the preview window.
+   */
+  private JsonNode oversizedSignatureWithLeadingSecret(String secretValue) {
+    ObjectNode params = objectMapper.createObjectNode();
+    params.put("user_password", secretValue);
+    for (int i = 0; i < 60; i++) {
+      params.put("param_" + i, "value-" + i + "-0123456789012345678901234567890123456789");
+    }
+    ObjectNode signature = objectMapper.createObjectNode();
+    signature.put("method", "io.openaev.rest.injector.InjectorApi.registerInjector");
+    signature.set("parameters", params);
+    return signature;
+  }
+
   private JsonNode dispatchedSignature() {
     verify(dispatcher).dispatch(logEventCaptor.capture(), any());
     return logEventCaptor.getValue().getRequestMetadata().getSignature();
@@ -207,6 +224,33 @@ class LogServiceSignatureNormalizationTest {
       String emitted = dispatchedSignature().toString();
       assertThat(emitted).doesNotContain("s3cr3t-value").doesNotContain("another-secret");
     }
+
+    @Test
+    @DisplayName("the truncation-envelope preview never contains unredacted secrets")
+    void given_oversizedSignatureWithSecret_should_notLeakSecretInPreview() {
+      // Arrange
+      String secret = "s3cr3t-preview-leak";
+      JsonNode signature = oversizedSignatureWithLeadingSecret(secret);
+
+      // Act
+      logService.logRequestEvent(
+          "create",
+          "success",
+          ResourceType.INJECTOR,
+          UUID.randomUUID().toString(),
+          null,
+          null,
+          signature,
+          null,
+          Level.INFO,
+          UUID.randomUUID().toString());
+
+      // Assert - the envelope fallback triggered, and the secret is absent even from the preview
+      // (redaction runs before normalization, so the preview only sees redacted data).
+      String emitted = dispatchedSignature().toString();
+      assertThat(emitted).contains("\"truncated\":true");
+      assertThat(emitted).doesNotContain(secret);
+    }
   }
 
   @Nested
@@ -241,6 +285,34 @@ class LogServiceSignatureNormalizationTest {
           .satisfiesAnyOf(
               s -> assertThat(s).contains(TRUNCATED_SUFFIX),
               s -> assertThat(s).contains("\"truncated\":true"));
+    }
+
+    @Test
+    @DisplayName("the truncation-envelope preview never contains unredacted secrets")
+    void given_oversizedSignatureWithSecretInContext_should_notLeakSecretInPreview() {
+      // Arrange
+      String secret = "s3cr3t-preview-leak-generic";
+      Map<String, Object> ctx = new LinkedHashMap<>();
+      ctx.put("signature", oversizedSignatureWithLeadingSecret(secret));
+
+      AuditEvent event =
+          AuditEvent.builder()
+              .eventType(EventType.MUTATION)
+              .eventScope(AuditEventScope.CREATE)
+              .eventStatus(EventStatus.SUCCESS)
+              .resourceType(ResourceType.INJECTOR)
+              .resourceId(UUID.randomUUID().toString())
+              .contextData(ctx)
+              .origin(AuditEventOrigin.REQUEST)
+              .build();
+
+      // Act
+      logService.logGenericEvent(event, Level.INFO, UUID.randomUUID().toString());
+
+      // Assert - redaction runs before normalization on the generic path too
+      String emitted = dispatchedSignature().toString();
+      assertThat(emitted).contains("\"truncated\":true");
+      assertThat(emitted).doesNotContain(secret);
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/LogServiceTest.java
@@ -3,6 +3,7 @@ package io.openaev.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -53,11 +54,23 @@ class LogServiceTest {
     io.openaev.engine.EngineService engineService = mock(io.openaev.engine.EngineService.class);
     lenient().when(engineService.getObjectMapper()).thenReturn(objectMapper);
 
+    // Normalization is exercised in LogServiceSignatureNormalizationTest; here it must behave as a
+    // pass-through so the assertions below target redaction only. Returning Mockito's default
+    // (null) would blank out input/output/signature before they reach the transport.
+    io.openaev.utils.object.ObjectNormalizationUtils objectNormalizationUtils =
+        mock(io.openaev.utils.object.ObjectNormalizationUtils.class);
+    lenient()
+        .when(objectNormalizationUtils.normalize(any(JsonNode.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    lenient()
+        .when(objectNormalizationUtils.normalize(any(JsonNode.class), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
     logService =
         new LogService(
             auditLogProperties,
             auditLogTransportDispatcherUtils,
-            mock(io.openaev.utils.object.ObjectNormalizationUtils.class),
+            objectNormalizationUtils,
             engineService,
             mock(UserService.class),
             enterpriseEditionService,


### PR DESCRIPTION
### Proposed changes

* Recognize `@RequestPart` and `@ModelAttribute` payloads (in addition to `@RequestBody`) in the audit-log aspect, so multipart endpoints such as `InjectorApi.registerInjector` have their DTO captured as the size-capped `input` node instead of falling through to the `signature` node.
* Normalize (size-cap) the audit `signature` node in `LogService` on both the request path and the generic mutation path, as defense in depth against any payload that still reaches it.
* Redact before normalizing in `LogService` (input, output and signature on both paths): the normalization size-cap fallback serializes the tree into a scalar `preview` field that field-name-based redaction cannot scrub afterwards, so redaction must run first to keep secrets out of truncation previews.
* Exclude non-serializable arguments (`MultipartFile`, `Resource`, `InputStream`, servlet request/response, including `Optional`-wrapped ones) from Jackson serialization in the signature, logging them by class name instead.
* Replace the previous `objectMapper.valueToTree(value).equals(inputNode)` payload-deduplication comparison (an O(payload) double serialization) with an index-based check.
* Add regression tests: `AccessControlAuditLogAspectPayloadTest` (payload resolution against the real aspect) and `LogServiceSignatureNormalizationTest` (signature capping and truncation-preview redaction through the real `ObjectNormalizationUtils`).

### Testing Instructions

1. Activate the audit logs with `openaev.audit-logs.transports=CONSOLE`
2. Start the platform and activate the Enterprise Edition
3. Register an injector that generates a huge payload (like Nuclei)
4. Everything should work as usual, without heap exhaustion

### Related issues

* Closes #7269
* Follow-up hardening tracked in #7302 (cap payloads at the AuditLogger queue boundary)
