### PR TITLE
fix(chaining): enforce EE license on chaining creation and import (#4435)

### DIFF
--- a/docs/docs/administration/enterprise.md
+++ b/docs/docs/administration/enterprise.md
@@ -69,6 +69,14 @@ according to the [OpenAEV architecture](../deployment/platform/overview.md#archi
 
 OpenAEV reuses the MDE sensor already deployed on your endpoints and drives it through the Live Response API. On Windows, the implant is launched from a self-deleting SYSTEM scheduled task so it survives the Live Response session teardown. See the [MDE Executor deployment guide](../deployment/ecosystem/executors.md#mde-agent) for the required Azure app permissions and Live Response setup.
 
+### Inject chaining workflows
+
+Inject chaining orchestrates conditional, automated execution of injects within a scenario or simulation workflow. Creating or importing a chaining scenario or simulation requires an active Enterprise Edition license: without one, the platform rejects the operation with a license restriction error.
+
+!!! note
+
+    Inject chaining is currently gated behind the `INJECT_CHAINING` preview feature flag in addition to the Enterprise Edition license.
+
 ## Remediations in CVEs
 
 More detail: [CVEs](taxonomies.md) and [Findings view](../usage/evaluate/findings/findings.md).

--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -16,10 +16,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
+import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.model.Scenario.SEVERITY;
 import io.openaev.database.repository.*;
+import io.openaev.ee.EnterpriseEditionException;
+import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.injectors.challenge.model.ChallengeContent;
 import io.openaev.injectors.channel.model.ChannelContent;
 import io.openaev.rest.domain.DomainService;
@@ -91,6 +94,8 @@ public class V1_DataImporter implements Importer {
   private final io.openaev.service.chaining.WorkflowService workflowService;
   private final io.openaev.service.chaining.StepService chainingStepService;
   private final io.openaev.service.chaining.ConditionService chainingConditionService;
+  private final EnterpriseEditionService enterpriseEditionService;
+  private final LicenseCacheManager licenseCacheManager;
 
   private final InjectorContractContentUtils injectorContractContentUtils;
 
@@ -1844,6 +1849,12 @@ public class V1_DataImporter implements Importer {
     JsonNode workflowNode = importNode.get(workflowKey);
     if (workflowNode == null || workflowNode.isNull() || workflowNode.isEmpty()) {
       return;
+    }
+    // return an exception if the enterprise license is inactive when trying to create a chaining
+    // simulation
+    if (enterpriseEditionService.isEnterpriseLicenseInactive(
+        licenseCacheManager.getEnterpriseEditionInfo())) {
+      throw new EnterpriseEditionException("Enterprise Edition license required");
     }
 
     try {

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/ExerciseApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/ExerciseApi.java
@@ -17,6 +17,7 @@ import io.openaev.api.expectations.ExpectationsDriftService;
 import io.openaev.api.expectations.dto.ExpectationsDriftDismissInput;
 import io.openaev.api.expectations.dto.ExpectationsDriftOutput;
 import io.openaev.api.expectations.dto.ExpectationsRealignOutput;
+import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.context.TenantContext;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
@@ -25,6 +26,8 @@ import io.openaev.database.raw.*;
 import io.openaev.database.repository.*;
 import io.openaev.database.specification.ComcheckSpecification;
 import io.openaev.database.specification.ExerciseLogSpecification;
+import io.openaev.ee.EnterpriseEditionException;
+import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.healthcheck.dto.HealthCheck;
 import io.openaev.rest.asset.endpoint.form.EndpointOutput;
 import io.openaev.rest.asset_group.form.AssetGroupOutput;
@@ -120,6 +123,8 @@ public class ExerciseApi extends RestBehavior {
   private final WorkflowService workflowService;
   private final PreviewFeatureService previewFeatureService;
   private final ExpectationsDriftService expectationsDriftService;
+  private final EnterpriseEditionService enterpriseEditionService;
+  private final LicenseCacheManager licenseCacheManager;
 
   // endregion
 
@@ -504,6 +509,12 @@ public class ExerciseApi extends RestBehavior {
     // workflow to the simulation
     if (previewFeatureService.isFeatureEnabled(PreviewFeature.INJECT_CHAINING)
         && Boolean.TRUE.equals(input.getIsChaining())) {
+      // Chaining is an Enterprise Edition feature: reject the creation of a chaining simulation
+      // when the enterprise license is inactive
+      if (enterpriseEditionService.isEnterpriseLicenseInactive(
+          licenseCacheManager.getEnterpriseEditionInfo())) {
+        throw new EnterpriseEditionException("Enterprise Edition license required");
+      }
       workflowService.creationWorkflow(savedExercise);
     }
 

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
@@ -15,6 +15,7 @@ import io.openaev.api.expectations.ExpectationsDriftService;
 import io.openaev.api.expectations.dto.ExpectationsDriftDismissInput;
 import io.openaev.api.expectations.dto.ExpectationsDriftOutput;
 import io.openaev.api.expectations.dto.ExpectationsRealignOutput;
+import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.context.BulkOperationContext;
 import io.openaev.context.TenantContext;
 import io.openaev.context.TxCtx;
@@ -23,6 +24,8 @@ import io.openaev.database.model.TenantSettingKeys;
 import io.openaev.database.raw.RawPaginationScenario;
 import io.openaev.database.raw.RawPlayer;
 import io.openaev.database.repository.*;
+import io.openaev.ee.EnterpriseEditionException;
+import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.healthcheck.dto.HealthCheck;
 import io.openaev.rest.asset.endpoint.form.EndpointOutput;
 import io.openaev.rest.asset_group.form.AssetGroupOutput;
@@ -92,6 +95,8 @@ public class ScenarioApi extends RestBehavior {
   private final PreviewFeatureService previewFeatureService;
   private final ExpectationsDriftService expectationsDriftService;
   private final AutonomousRunService autonomousRunService;
+  private final EnterpriseEditionService enterpriseEditionService;
+  private final LicenseCacheManager licenseCacheManager;
 
   @PostMapping({SCENARIO_URI, TENANT_SCENARIO_URI})
   @Transactional
@@ -123,6 +128,12 @@ public class ScenarioApi extends RestBehavior {
     // workflow to the scenario
     if (previewFeatureService.isFeatureEnabled(PreviewFeature.INJECT_CHAINING)
         && Boolean.TRUE.equals(input.getIsChaining())) {
+      // Chaining is an Enterprise Edition feature: reject the creation of a chaining scenario
+      // when the enterprise license is inactive
+      if (enterpriseEditionService.isEnterpriseLicenseInactive(
+          licenseCacheManager.getEnterpriseEditionInfo())) {
+        throw new EnterpriseEditionException("Enterprise Edition license required");
+      }
       workflowService.creationWorkflow(savedScenario);
     }
 

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -2,6 +2,8 @@ package io.openaev.importer;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,6 +13,8 @@ import io.openaev.IntegrationTest;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.*;
+import io.openaev.ee.EnterpriseEditionException;
+import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.rest.domain.enums.PresetDomain;
 import io.openaev.utils.constants.Constants;
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +55,7 @@ class V1_DataImporterTest extends IntegrationTest {
   @Autowired private StepRepository stepRepository;
   @Autowired private ConditionRepository conditionRepository;
   @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
+  @MockitoBean private EnterpriseEditionService enterpriseEditionService;
 
   private JsonNode importNode;
 
@@ -74,6 +80,7 @@ class V1_DataImporterTest extends IntegrationTest {
     injectorContractRepository.deleteAll();
     injectorRepository.deleteAll();
     MockitoAnnotations.openMocks(this);
+    when(enterpriseEditionService.isEnterpriseLicenseInactive(any())).thenReturn(false);
     ObjectMapper mapper = new ObjectMapper();
     String jsonContent =
         new String(
@@ -373,6 +380,33 @@ class V1_DataImporterTest extends IntegrationTest {
     assertTrue(
         prerequisites == null || prerequisites.isEmpty(),
         "Prerequisites should be empty when field is explicit null in JSON");
+  }
+
+  @Test
+  @Transactional
+  void given_scenarioWithWorkflow_when_enterpriseLicenseInactive_should_failImport()
+      throws Exception {
+    // -- Arrange --
+    when(enterpriseEditionService.isEnterpriseLicenseInactive(any())).thenReturn(true);
+    JsonNode workflowImport =
+        new ObjectMapper()
+            .readTree(
+                Files.readAllBytes(
+                    Paths.get(
+                        "src/test/resources/importer-v1/import-scenario-with-workflow.json")));
+
+    // -- Act & Assert --
+    assertThrows(
+        EnterpriseEditionException.class,
+        () ->
+            importer.importData(
+                workflowImport,
+                Map.of(),
+                null,
+                null,
+                null,
+                null,
+                Constants.IMPORTED_OBJECT_NAME_SUFFIX));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseApiTest.java
@@ -143,6 +143,27 @@ public class ExerciseApiTest extends IntegrationTest {
     assertEquals(customDashboardSaved.getId(), newExercise.getCustomDashboard().getId());
   }
 
+  @DisplayName("Create chained exercise fails without enterprise edition")
+  @Test
+  @WithMockUser(withCapabilities = {Capability.MANAGE_ASSESSMENT})
+  void given_chainedExerciseCreationWithoutEE_should_fail() throws Exception {
+    // Arrange
+    CreateExerciseInput exerciseInput = new CreateExerciseInput();
+    exerciseInput.setName("My chained exercise");
+    exerciseInput.setIsChaining(true);
+
+    // Act & Assert
+    this.mvc
+        .perform(
+            post(EXERCISE_URI)
+                .content(asJsonString(exerciseInput))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("LICENSE_RESTRICTION"));
+  }
+
   @Nested
   @DisplayName("Retrieving exercise informations")
   class RetrievingExercises {

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioApiTest.java
@@ -214,6 +214,27 @@ public class ScenarioApiTest extends IntegrationTest {
     assertEquals(customDashboardSaved.getId(), newScenario.getCustomDashboard().getId());
   }
 
+  @DisplayName("Create chained scenario fails without enterprise edition")
+  @Test
+  @WithMockUser(withCapabilities = {Capability.MANAGE_ASSESSMENT})
+  void given_chainedScenarioCreationWithoutEE_should_fail() throws Exception {
+    // Arrange
+    ScenarioInput scenarioInput = new ScenarioInput();
+    scenarioInput.setName("My chained scenario");
+    scenarioInput.setIsChaining(true);
+
+    // Act & Assert
+    this.mvc
+        .perform(
+            post(SCENARIO_URI)
+                .content(asJsonString(scenarioInput))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message").value("LICENSE_RESTRICTION"));
+  }
+
   @DisplayName("Retrieve scenarios")
   @Test
   @WithMockUser(withCapabilities = {Capability.ACCESS_ASSESSMENT})


### PR DESCRIPTION
### Proposed changes

- Enforce Enterprise Edition license validation when creating chaining scenarios and simulations: when the INJECT_CHAINING preview feature is enabled and the creation input has `isChaining: true`, the API rejects the request with HTTP 403 (LICENSE_RESTRICTION) if the EE license is inactive. Both creation endpoints are transactional, so the rejected scenario/simulation is fully rolled back.
- Fail V1 scenario/simulation import when the export contains a chaining workflow and the EE license is inactive. The import runs in a single transaction, so no partial data is left behind.
- All three code paths throw `EnterpriseEditionException`, the canonical EE-lock signal used by `AccessControlAspect`, keeping EE gating consistent across the codebase (the dedicated `ChainingApi`/`StepApi`/`WorkflowApi`/`ConditionApi` endpoints are already gated via `@AccessControl(isEnterpriseEdition = true)`).
- Document inject chaining workflows as an Enterprise Edition feature in `docs/docs/administration/enterprise.md`, including a note about the INJECT_CHAINING preview flag.

### Related issue

- Closes #4435

### Testing Instructions

1. Without an active EE license, create a scenario or simulation via the API with `isChaining: true`: the request fails with 403 LICENSE_RESTRICTION.
2. Without an active EE license, import a V1 scenario/simulation export that contains a chaining workflow: the import fails and no partial data is created.

### Test coverage

- `ScenarioApiTest#given_chainedScenarioCreationWithoutEE_should_fail` and `ExerciseApiTest#given_chainedExerciseCreationWithoutEE_should_fail` cover the creation paths (403 + LICENSE_RESTRICTION).
- `V1_DataImporterTest#given_scenarioWithWorkflow_when_enterpriseLicenseInactive_should_failImport` covers the import failure path; the existing workflow import test stubs an active license.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
