### PR TITLE
feat(chaining): display payload self execution (OpenAEV-Platform/filigran-private#259)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_TYPE_OVERFLOW_ID, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_TYPE_OVERFLOW_ID, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -211,22 +211,6 @@ describe('pivotEndpointIds', () => {
       },
     ]).size).toBe(0);
   });
-
-  it('never flags an endpoint whose only source role is a self-loop (endpoint-local action)', () => {
-    // A Whoami-style local action emits source = target = the endpoint; that is not lateral movement.
-    expect(pivotEndpointIds([
-      {
-        type: 'EDGE_EXECUTIONS',
-        edgeSourceId: 'NODE_INJECTOR|nmap',
-        edgeTargetId: 'NODE_ENDPOINT|a',
-      },
-      {
-        type: 'EDGE_EXECUTIONS',
-        edgeSourceId: 'NODE_ENDPOINT|a',
-        edgeTargetId: 'NODE_ENDPOINT|a',
-      },
-    ]).size).toBe(0);
-  });
 });
 
 describe('orderSimulationPickerOptions', () => {
@@ -397,38 +381,6 @@ describe('buildClusteredAttackPathFlow', () => {
     expect(ids).toContain('ep2');
     expect(nodes.find(n => n.id === 'ep1')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
     expect(edges.find(e => e.id === 'cl-ep-all-ep1')?.target).toBe('ep1');
-  });
-
-  it('keeps an endpoint reached only by an endpoint-local action (self-loop) visible, without a self arrow', () => {
-    // Arrange: ep2 is reached ONLY by a Whoami-style local action (execution edge source = target = ep2).
-    const selfLoopDto: AttackPathDTO = {
-      ...clusteredDto,
-      attackPathEdges: [
-        {
-          edgeId: 'x1',
-          edgeSourceId: 'inj',
-          edgeTargetId: 'ep1',
-          type: 'EDGE_EXECUTIONS',
-          count: 5,
-        },
-        {
-          edgeId: 'x-self',
-          edgeSourceId: 'ep2',
-          edgeTargetId: 'ep2',
-          type: 'EDGE_EXECUTIONS',
-          count: 1,
-        },
-      ],
-    };
-    // Act: collapsed (hub) and expanded views.
-    const collapsed = buildClusteredAttackPathFlow(selfLoopDto, new Map(), tt);
-    const expanded = buildClusteredAttackPathFlow(selfLoopDto, new Map([[AP_ALL_ENDPOINTS, 15]]), tt);
-    // Assert: ep2 counts as reached (hub count 2) and renders when expanded, with its findings…
-    expect(collapsed.nodes.find(n => n.id === 'cl-ep-all')?.data.count).toBe(2);
-    expect(expanded.nodes.find(n => n.id === 'ep2')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
-    // …but no arrow loops back onto it: the only edge INTO ep2 comes from the shared hub.
-    expect(expanded.edges.find(e => e.source === 'ep2' && e.target === 'ep2')).toBeUndefined();
-    expect(expanded.edges.filter(e => e.target === 'ep2').map(e => e.source)).toEqual(['cl-ep-all']);
   });
 
   it('still ignores a malformed execution edge that has a target but no source', () => {
@@ -1389,59 +1341,6 @@ describe('buildCausalChainFlow', () => {
     expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE)).toHaveLength(0);
   });
 
-  it('renders an endpoint reached only by an endpoint-local action without an injector node or self arrow', () => {
-    // Arrange: a Whoami-style local action — the execution edge's source IS its target endpoint.
-    const selfLoop: AttackPathDTO = {
-      mode: 'full',
-      attackPathNodes: [
-        {
-          id: 'ep-1',
-          type: 'ASSET',
-          label: 'DC-01',
-          ip: '10.0.0.1',
-        },
-        {
-          id: 'NODE_FINDING|username|bob',
-          type: 'FINDING',
-          typeFindings: 'username',
-          value: 'bob',
-          label: 'bob',
-        },
-      ],
-      attackPathExecutions: [
-        {
-          id: 'x-local',
-          type: 'EXECUTION',
-          ref: 'exec-local',
-          stepTemplateId: 'step-L',
-          contractName: 'Whoami',
-          findingsNodeIds: ['NODE_FINDING|username|bob'],
-          dependsOn: [],
-        },
-      ],
-      attackPathEdges: [
-        {
-          type: 'EDGE_EXECUTIONS',
-          edgeSourceId: 'ep-1',
-          edgeTargetId: 'ep-1',
-          executionIds: ['exec-local'],
-        },
-      ],
-    };
-    // Act
-    const { nodes, edges } = buildCausalChainFlow(selfLoop, tt);
-    const byId = Object.fromEntries(nodes.map(n => [n.id, n]));
-    // Assert: the endpoint and its finding render…
-    expect(byId['chain-ep|0|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
-    expect(byId['NODE_FINDING|username|bob'].type).toBe(AP_FLOW_NODE_TYPE.finding);
-    // …but no injector node is drawn for the local action and no arrow loops onto the endpoint.
-    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector)).toHaveLength(0);
-    expect(edges.find(e => e.source === 'ep-1' || e.target === 'ep-1')).toBeUndefined();
-    // Every emitted edge resolves to placed nodes (nothing dangles on the suppressed injector).
-    const nodeIds = new Set(nodes.map(n => n.id));
-    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
-  });
-
   it('promotes endpoint-local actions to their own action nodes when localActionsAsNodes is set (autonomous action timeline)', () => {
     // Arrange: two endpoint-local actions on the SAME host, chained (LSASS dump depends on the sweep).
     // In a finding-centric BAS chain both collapse into the endpoint and the follow-up adds nothing new;
@@ -1509,78 +1408,6 @@ describe('buildCausalChainFlow', () => {
     // Every emitted edge still resolves to a placed node.
     const nodeIds = new Set(promoted.nodes.map(n => n.id));
     expect(promoted.edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
-  });
-
-  it('emits no causal edge into an endpoint-local step (its injector node is suppressed)', () => {
-    // Arrange: nmap produces port 445 on ep-1; a LOCAL action on ep-1 consumes it (dependsOn step-A).
-    const localConsumer: AttackPathDTO = {
-      mode: 'full',
-      attackPathNodes: [
-        {
-          id: 'inj-nmap',
-          type: 'INJECTOR',
-          label: 'Nmap',
-        },
-        {
-          id: 'ep-1',
-          type: 'ASSET',
-          label: 'DC-01',
-          ip: '10.0.0.1',
-        },
-        {
-          id: 'NODE_FINDING|port|445',
-          type: 'FINDING',
-          typeFindings: 'port',
-          value: '445',
-          label: '445',
-        },
-      ],
-      attackPathExecutions: [
-        {
-          id: 'x1',
-          type: 'EXECUTION',
-          ref: 'exec-1',
-          stepTemplateId: 'step-A',
-          findingsNodeIds: ['NODE_FINDING|port|445'],
-          dependsOn: [],
-        },
-        {
-          id: 'x-local',
-          type: 'EXECUTION',
-          ref: 'exec-local',
-          stepTemplateId: 'step-L',
-          contractName: 'Whoami',
-          consumedFindingKeys: [{
-            keyType: 'port',
-            operator: 'EQ',
-            value: '445',
-            matchedFindingIds: ['NODE_FINDING|port|445'],
-          }],
-          dependsOn: ['step-A'],
-        },
-      ],
-      attackPathEdges: [
-        {
-          type: 'EDGE_EXECUTIONS',
-          edgeSourceId: 'inj-nmap',
-          edgeTargetId: 'ep-1',
-          executionIds: ['exec-1'],
-        },
-        {
-          type: 'EDGE_EXECUTIONS',
-          edgeSourceId: 'ep-1',
-          edgeTargetId: 'ep-1',
-          executionIds: ['exec-local'],
-        },
-      ],
-    };
-    // Act
-    const { nodes, edges } = buildCausalChainFlow(localConsumer, tt);
-    // Assert: no causal edge targets the raw endpoint id (its "injector" node was never placed), and
-    // every edge still resolves to placed nodes.
-    const nodeIds = new Set(nodes.map(n => n.id));
-    expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE && e.target === 'ep-1')).toHaveLength(0);
-    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
   });
 });
 
@@ -1737,74 +1564,6 @@ describe('scopeChainFlowToEndpoint', () => {
     // A single string keeps working (the original signature).
     expect(scopeChainFlowToEndpoint(chainFlow, REF).nodes
       .some(n => n.id === `chain-ep|0|${REF}`)).toBe(true);
-  });
-});
-
-describe('buildFindingPathFlow', () => {
-  const pathDto: AttackPathDTO = {
-    mode: 'collapsed',
-    attackPathNodes: [
-      {
-        id: 'inj-A',
-        type: 'INJECTOR',
-        label: 'NetExec',
-      },
-      {
-        id: 'ep-1',
-        type: 'ASSET',
-        label: 'DC-01',
-        ref: 'dc-01',
-        status: 'RED',
-        findingCounts: { username: 1 },
-      },
-    ],
-    attackPathEdges: [
-      {
-        type: 'EDGE_EXECUTIONS',
-        edgeSourceId: 'inj-A',
-        edgeTargetId: 'ep-1',
-      },
-      {
-        type: 'EDGE_EXECUTIONS',
-        edgeSourceId: 'ep-1',
-        edgeTargetId: 'ep-1',
-      },
-    ],
-  };
-  const finding = {
-    endpointNodeId: 'ep-1',
-    endpointKey: 'dc-01',
-    type: 'username',
-    value: 'bob',
-  };
-
-  it('never lists the endpoint itself as a reaching injector (self-loop filtered)', () => {
-    // Act
-    const { nodes, edges } = buildFindingPathFlow(pathDto, finding, tt);
-    // Assert: only the real injector renders and points at the endpoint; no ep-1 -> ep-1 arrow.
-    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector).map(n => n.id)).toEqual(['inj-A']);
-    expect(edges.find(e => e.source === 'inj-A' && e.target === 'ep-1')).toBeDefined();
-    expect(edges.find(e => e.source === 'ep-1' && e.target === 'ep-1')).toBeUndefined();
-  });
-
-  it('still renders the endpoint and its finding clusters when only a local action reached it', () => {
-    // Arrange: drop the real injector edge — the endpoint is reached by the local action alone.
-    const localOnly: AttackPathDTO = {
-      ...pathDto,
-      attackPathEdges: [
-        {
-          type: 'EDGE_EXECUTIONS',
-          edgeSourceId: 'ep-1',
-          edgeTargetId: 'ep-1',
-        },
-      ],
-    };
-    // Act
-    const { nodes } = buildFindingPathFlow(localOnly, finding, tt);
-    // Assert: no injector, but the endpoint and its per-type cluster still render.
-    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector)).toHaveLength(0);
-    expect(nodes.find(n => n.id === 'ep-1')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
-    expect(nodes.find(n => n.id === 'path-cl-type|username|dc-01')?.type).toBe(AP_FLOW_NODE_TYPE.findingCluster);
   });
 });
 

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_TYPE_OVERFLOW_ID, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
+import { AP_ALL_ENDPOINTS, AP_FLOW_CAUSAL_EDGE_TYPE, AP_FLOW_EDGE_TYPE, AP_FLOW_NODE_TYPE, AP_TYPE_OVERFLOW_ID, applyFindingFilter, type AttackPathFlowNode, buildAttackPathFlow, buildCausalChainFlow, buildCausalEdges, buildClusteredAttackPathFlow, buildFindingPathFlow, buildKillChainMeta, displayIp, FILTER_TO_FINDING_TYPES, findingCategoryNoun, friendlyNodeId, maskFindingValue, orderSimulationPickerOptions, pivotEndpointIds, scopeChainFlowToEndpoint, scopeChainFlowToSeeds } from '../../../../../../admin/components/simulations/simulation/attack_path/attack-path-flow-helpers';
 import type { AttackPathDTO } from '../../../../../../utils/api-types';
 
 // Identity translator with {param} interpolation, mirroring the formatter's key fallback, so the label
@@ -211,6 +211,23 @@ describe('pivotEndpointIds', () => {
       },
     ]).size).toBe(0);
   });
+
+  it('never flags an endpoint whose only source role is a self-loop (endpoint-local action)', () => {
+    // A Whoami-style local action emits source = target = the endpoint; the self-execution is
+    // displayed in the flows, but it is still not lateral movement, so the endpoint is no pivot.
+    expect(pivotEndpointIds([
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_INJECTOR|nmap',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'NODE_ENDPOINT|a',
+        edgeTargetId: 'NODE_ENDPOINT|a',
+      },
+    ]).size).toBe(0);
+  });
 });
 
 describe('orderSimulationPickerOptions', () => {
@@ -407,6 +424,39 @@ describe('buildClusteredAttackPathFlow', () => {
     const { nodes } = buildClusteredAttackPathFlow(malformedDto, new Map(), tt);
     // Assert: ep2 is NOT counted as reached (pre-existing behavior preserved).
     expect(nodes.find(n => n.id === 'cl-ep-all')?.data.count).toBe(1);
+  });
+
+  it('keeps an endpoint reached only by an endpoint-local action (self-loop) visible', () => {
+    // Arrange: ep2 is reached ONLY by a Whoami-style local action (execution edge source = target = ep2).
+    const selfLoopDto: AttackPathDTO = {
+      ...clusteredDto,
+      attackPathEdges: [
+        {
+          edgeId: 'x1',
+          edgeSourceId: 'inj',
+          edgeTargetId: 'ep1',
+          type: 'EDGE_EXECUTIONS',
+          count: 5,
+        },
+        {
+          edgeId: 'x-self',
+          edgeSourceId: 'ep2',
+          edgeTargetId: 'ep2',
+          type: 'EDGE_EXECUTIONS',
+          count: 1,
+        },
+      ],
+    };
+    // Act: collapsed (hub) and expanded views.
+    const collapsed = buildClusteredAttackPathFlow(selfLoopDto, new Map(), tt);
+    const expanded = buildClusteredAttackPathFlow(selfLoopDto, new Map([[AP_ALL_ENDPOINTS, 15]]), tt);
+    // Assert: the self-execution counts ep2 as reached (hub count 2) and it renders when expanded…
+    expect(collapsed.nodes.find(n => n.id === 'cl-ep-all')?.data.count).toBe(2);
+    expect(expanded.nodes.find(n => n.id === 'ep2')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
+    // …and in this deduped view the only edge INTO ep2 still comes from the shared hub (self-executions
+    // add no separate arrow here because only INJECTOR dto nodes are drawn on the left band).
+    expect(expanded.edges.find(e => e.source === 'ep2' && e.target === 'ep2')).toBeUndefined();
+    expect(expanded.edges.filter(e => e.target === 'ep2').map(e => e.source)).toEqual(['cl-ep-all']);
   });
 
   // Six finding types on the reached endpoints > cap of 4: the two smallest collapse behind one
@@ -1394,11 +1444,18 @@ describe('buildCausalChainFlow', () => {
         },
       ],
     };
-    // Act: without the flag both local actions are hidden (finding-centric); with it they become nodes.
-    const suppressed = buildCausalChainFlow(localChain, tt);
+    // Act: without the flag both local actions aggregate into ONE self-execution node keyed by the
+    // endpoint; with the flag each authored step becomes its own action node.
+    const aggregated = buildCausalChainFlow(localChain, tt);
     const promoted = buildCausalChainFlow(localChain, tt, new Set(), new Map(), new Set(), true);
-    // Assert: default keeps the tested BAS behaviour — no action nodes for local commands.
-    expect(suppressed.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector)).toHaveLength(0);
+    // Assert: the default displays the self-execution as a single action card anchored on the endpoint
+    // (labelled from the first execution's contract), pointing at the endpoint node.
+    const aggregatedActions = aggregated.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector);
+    expect(aggregatedActions.map(n => n.id)).toEqual(['ep-1']);
+    expect(aggregatedActions[0].data.label).toBe('Credential Sweep');
+    expect(aggregated.edges.find(e => e.source === 'ep-1' && e.target === 'chain-ep|0|ep-1')).toBeDefined();
+    const aggregatedIds = new Set(aggregated.nodes.map(n => n.id));
+    expect(aggregated.edges.every(e => aggregatedIds.has(e.source) && aggregatedIds.has(e.target))).toBe(true);
     // With the flag: one action node per authored local step, labelled from its contract, and no self
     // arrow (the action sits to the left of the endpoint and points at it).
     const actionNodes = promoted.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector);
@@ -1408,6 +1465,209 @@ describe('buildCausalChainFlow', () => {
     // Every emitted edge still resolves to a placed node.
     const nodeIds = new Set(promoted.nodes.map(n => n.id));
     expect(promoted.edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+
+  it('renders an endpoint-local action as a self-execution node pointing at its endpoint', () => {
+    // Arrange: a Whoami-style local action — the execution edge's source IS its target endpoint.
+    const selfLoop: AttackPathDTO = {
+      mode: 'full',
+      attackPathNodes: [
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'DC-01',
+          ip: '10.0.0.1',
+        },
+        {
+          id: 'NODE_FINDING|username|bob',
+          type: 'FINDING',
+          typeFindings: 'username',
+          value: 'bob',
+          label: 'bob',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'x-local',
+          type: 'EXECUTION',
+          ref: 'exec-local',
+          stepTemplateId: 'step-L',
+          contractName: 'Whoami',
+          findingsNodeIds: ['NODE_FINDING|username|bob'],
+          dependsOn: [],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-local'],
+        },
+      ],
+    };
+    // Act
+    const { nodes, edges } = buildCausalChainFlow(selfLoop, tt);
+    const byId = Object.fromEntries(nodes.map(n => [n.id, n]));
+    // Assert: the endpoint and its finding render…
+    expect(byId['chain-ep|0|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
+    expect(byId['NODE_FINDING|username|bob'].type).toBe(AP_FLOW_NODE_TYPE.finding);
+    // …and the self-execution is displayed: one action node (the endpoint acting on itself), labelled
+    // from the contract name, with a labelled edge onto the endpoint node.
+    expect(byId['ep-1'].type).toBe(AP_FLOW_NODE_TYPE.injector);
+    expect(byId['ep-1'].data.label).toBe('Whoami');
+    const selfEdge = edges.find(e => e.source === 'ep-1' && e.target === 'chain-ep|0|ep-1');
+    expect(selfEdge?.data?.label).toBe('Whoami');
+    // Every emitted edge resolves to placed nodes.
+    const nodeIds = new Set(nodes.map(n => n.id));
+    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+
+  it('draws the causal edge into an endpoint-local step that consumes an upstream finding', () => {
+    // Arrange: nmap produces port 445 on ep-1; a LOCAL action on ep-1 consumes it (dependsOn step-A).
+    const localConsumer: AttackPathDTO = {
+      mode: 'full',
+      attackPathNodes: [
+        {
+          id: 'inj-nmap',
+          type: 'INJECTOR',
+          label: 'Nmap',
+        },
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'DC-01',
+          ip: '10.0.0.1',
+        },
+        {
+          id: 'NODE_FINDING|port|445',
+          type: 'FINDING',
+          typeFindings: 'port',
+          value: '445',
+          label: '445',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'x1',
+          type: 'EXECUTION',
+          ref: 'exec-1',
+          stepTemplateId: 'step-A',
+          findingsNodeIds: ['NODE_FINDING|port|445'],
+          dependsOn: [],
+        },
+        {
+          id: 'x-local',
+          type: 'EXECUTION',
+          ref: 'exec-local',
+          stepTemplateId: 'step-L',
+          contractName: 'Whoami',
+          consumedFindingKeys: [{
+            keyType: 'port',
+            operator: 'EQ',
+            value: '445',
+            matchedFindingIds: ['NODE_FINDING|port|445'],
+          }],
+          dependsOn: ['step-A'],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-nmap',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-1'],
+        },
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-local'],
+        },
+      ],
+    };
+    // Act
+    const { nodes, edges } = buildCausalChainFlow(localConsumer, tt);
+    // Assert: the local step sits one depth after its producer (its own endpoint copy at depth 1) and
+    // the produced finding's causal edge now targets the self-execution node instead of being dropped.
+    const causal = edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE);
+    expect(causal).toHaveLength(1);
+    expect(causal[0].source).toBe('NODE_FINDING|port|445');
+    expect(causal[0].target).toBe('ep-1');
+    // Every edge still resolves to placed nodes (the self-execution node IS placed).
+    const nodeIds = new Set(nodes.map(n => n.id));
+    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+
+  it('emits no causal edge for a malformed step whose execution edge has a source but no target', () => {
+    // Arrange: exec-broken's edge carries a source but no target, so its step aggregates no endpoint
+    // and is never placed as a node; its dependsOn must not produce an edge to a missing node either.
+    const malformed: AttackPathDTO = {
+      mode: 'full',
+      attackPathNodes: [
+        {
+          id: 'inj-nmap',
+          type: 'INJECTOR',
+          label: 'Nmap',
+        },
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'DC-01',
+          ip: '10.0.0.1',
+        },
+        {
+          id: 'NODE_FINDING|port|445',
+          type: 'FINDING',
+          typeFindings: 'port',
+          value: '445',
+          label: '445',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'x1',
+          type: 'EXECUTION',
+          ref: 'exec-1',
+          stepTemplateId: 'step-A',
+          findingsNodeIds: ['NODE_FINDING|port|445'],
+          dependsOn: [],
+        },
+        {
+          id: 'x-broken',
+          type: 'EXECUTION',
+          ref: 'exec-broken',
+          stepTemplateId: 'step-B',
+          consumedFindingKeys: [{
+            keyType: 'port',
+            operator: 'EQ',
+            value: '445',
+            matchedFindingIds: ['NODE_FINDING|port|445'],
+          }],
+          dependsOn: ['step-A'],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-nmap',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-1'],
+        },
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'inj-broken',
+          executionIds: ['exec-broken'],
+        },
+      ],
+    };
+    // Act
+    const { nodes, edges } = buildCausalChainFlow(malformed, tt);
+    // Assert: no dangling edge — every emitted edge resolves to a placed node, and nothing targets the
+    // unplaced broken step.
+    const nodeIds = new Set(nodes.map(n => n.id));
+    expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+    expect(edges.find(e => e.target === 'inj-broken')).toBeUndefined();
   });
 });
 
@@ -1564,6 +1824,77 @@ describe('scopeChainFlowToEndpoint', () => {
     // A single string keeps working (the original signature).
     expect(scopeChainFlowToEndpoint(chainFlow, REF).nodes
       .some(n => n.id === `chain-ep|0|${REF}`)).toBe(true);
+  });
+});
+
+describe('buildFindingPathFlow', () => {
+  const pathDto: AttackPathDTO = {
+    mode: 'collapsed',
+    attackPathNodes: [
+      {
+        id: 'inj-A',
+        type: 'INJECTOR',
+        label: 'NetExec',
+      },
+      {
+        id: 'ep-1',
+        type: 'ASSET',
+        label: 'DC-01',
+        ref: 'dc-01',
+        status: 'RED',
+        findingCounts: { username: 1 },
+      },
+    ],
+    attackPathEdges: [
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'inj-A',
+        edgeTargetId: 'ep-1',
+      },
+      {
+        type: 'EDGE_EXECUTIONS',
+        edgeSourceId: 'ep-1',
+        edgeTargetId: 'ep-1',
+      },
+    ],
+  };
+  const finding = {
+    endpointNodeId: 'ep-1',
+    endpointKey: 'dc-01',
+    type: 'username',
+    value: 'bob',
+  };
+
+  it('renders the reaching injector without duplicating the endpoint as its own injector card', () => {
+    // The self-execution registers the endpoint among the sources that reached it, but this focused
+    // view only draws INJECTOR dto nodes on the left, so the endpoint is never duplicated as a card
+    // whose id would collide with its own asset node.
+    const { nodes, edges } = buildFindingPathFlow(pathDto, finding, tt);
+    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector).map(n => n.id)).toEqual(['inj-A']);
+    expect(edges.find(e => e.source === 'inj-A' && e.target === 'ep-1')).toBeDefined();
+    expect(edges.find(e => e.source === 'ep-1' && e.target === 'ep-1')).toBeUndefined();
+    // No duplicate node ids (the endpoint appears exactly once).
+    expect(nodes.filter(n => n.id === 'ep-1')).toHaveLength(1);
+  });
+
+  it('still renders the endpoint and its finding clusters when only a local action reached it', () => {
+    // Arrange: drop the real injector edge — the endpoint is reached by the local action alone.
+    const localOnly: AttackPathDTO = {
+      ...pathDto,
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+        },
+      ],
+    };
+    // Act
+    const { nodes } = buildFindingPathFlow(localOnly, finding, tt);
+    // Assert: no injector card, but the endpoint and its per-type cluster still render.
+    expect(nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector)).toHaveLength(0);
+    expect(nodes.find(n => n.id === 'ep-1')?.type).toBe(AP_FLOW_NODE_TYPE.asset);
+    expect(nodes.find(n => n.id === 'path-cl-type|username|dc-01')?.type).toBe(AP_FLOW_NODE_TYPE.findingCluster);
   });
 });
 

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1986,19 +1986,13 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
         baseFlow.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector).map(n => n.id),
       );
       const producingInjectors = new Set<string>();
-      let hasProducingExecution = false;
       for (const e of fullDto?.attackPathEdges ?? []) {
         if (e.type === 'EDGE_EXECUTIONS' && e.edgeSourceId
           && (e.executionIds ?? []).some(id => highlightedExecutionIds.has(id))) {
-          hasProducingExecution = true;
-          // A self-loop (endpoint-local action) has no injector node to light: it still activates the
-          // restriction (the producer is known — it is the endpoint itself), but adds no injector.
-          if (e.edgeSourceId !== e.edgeTargetId) {
-            producingInjectors.add(e.edgeSourceId);
-          }
+          producingInjectors.add(e.edgeSourceId);
         }
       }
-      const restrictInjectors = hasProducingExecution;
+      const restrictInjectors = producingInjectors.size > 0;
       pathSet.add(selectedFindingId);
       for (let pass = 0; pass < 6; pass += 1) {
         for (const e of baseFlow.edges) {
@@ -2033,8 +2027,7 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
       pathSet.add(selectedNodeId);
       pathSet.add(AP_SHARED_EP_CLUSTER_ID);
       for (const e of dto?.attackPathEdges ?? []) {
-        if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === selectedNodeId && e.edgeSourceId
-          && e.edgeSourceId !== e.edgeTargetId) {
+        if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === selectedNodeId && e.edgeSourceId) {
           pathSet.add(e.edgeSourceId);
         }
       }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -627,8 +627,8 @@ export const buildClusteredAttackPathFlow = (
     if (srcKind === 'TEAM' || srcKind === 'PERSON' || srcKind === 'ASSET_GROUP') {
       continue;
     }
-    // The endpoint is a reached node even for endpoint-local actions.
-
+    // An endpoint-local action (source === target) registers the endpoint as its own injector and
+    // marks it reached, like any other producing execution (self-executions are displayed, not hidden).
     const injs = injectorsByEndpoint.get(tgt) ?? [];
     if (!injs.includes(src)) {
       injs.push(src);
@@ -1612,10 +1612,10 @@ export const buildCausalChainFlow = (
   // a finding whose type happens to fall past the cap (ties are broken by name, so "share" can lose to
   // "cve") leaves it with no node to focus at all, and the view silently falls back to another path.
   pinnedTypes: ReadonlySet<string> = new Set(),
-  // Render endpoint-local (self-loop) executions as their own ACTION nodes instead of collapsing them
-  // into the endpoint. Off by default (the finding-centric BAS chain hides the self-arrow); ON for an
-  // AUTONOMOUS run, whose story is the ACTION TIMELINE on a mostly single, already-compromised host, so
-  // a chain of local steps stays visible even when it produces no new distinct finding.
+  // Render each endpoint-local (self-loop) execution as its OWN ACTION node instead of aggregating
+  // them into one self-execution step per endpoint. Off by default; ON for an AUTONOMOUS run, whose
+  // story is the ACTION TIMELINE on a mostly single, already-compromised host, so a chain of local
+  // steps stays visible step by step even when it produces no new distinct finding.
   localActionsAsNodes = false,
 ): {
   nodes: AttackPathFlowNode[];
@@ -1682,14 +1682,14 @@ export const buildCausalChainFlow = (
   }
   // Endpoint-local actions (recon, credential dumps, local privilege ops) run ON the host the agent is
   // already on, so the backend records them as a self-loop (execution edge source == target == that
-  // endpoint). The finding-centric BAS chain deliberately hides that self-arrow and represents the
-  // action purely by the findings it produced (see the self-loop tests). But an AUTONOMOUS engagement is
-  // an ACTION TIMELINE on a mostly single, already-compromised host: a run of local steps that yields no
-  // NEW distinct finding would then leave the graph visually frozen even though every step executed.
+  // endpoint). By default all of an endpoint's local executions aggregate into ONE step keyed by the
+  // endpoint itself, rendered as a single self-execution ACTION card pointing at the endpoint. But an
+  // AUTONOMOUS engagement is an ACTION TIMELINE on a mostly single, already-compromised host: a run of
+  // several local steps would then collapse into that one card even though every step executed.
   // When localActionsAsNodes is set, re-key each self-loop to its OWN authored step so each local action
-  // becomes its own ACTION node anchored on the endpoint (drawn to the left, exactly like an injector)
-  // instead of collapsing into the endpoint node. Keyed by stepTemplateId so re-runs of the same step
-  // coalesce and dependsOn between local steps still resolves to a real causal depth.
+  // becomes its own ACTION node anchored on the endpoint (drawn to the left, exactly like an injector).
+  // Keyed by stepTemplateId so re-runs of the same step coalesce and dependsOn between local steps
+  // still resolves to a real causal depth.
   if (localActionsAsNodes) {
     for (const [ref, ex] of execByRef) {
       const src = injByExec.get(ref);
@@ -1909,10 +1909,11 @@ export const buildCausalChainFlow = (
     let cursorY = PADDING;
     const injectorPlaced = new Set<string>();
     for (const epId of visibleAssetIds) {
-      // Endpoint-local action whose "injector" is this very endpoint (self-loop). Unless it was promoted
-      // to its own ACTION node (localActionsAsNodes re-keys it to chain-local|<step>, so injId !== epId),
-      // drop it BEFORE the layout so no injector node, no self arrow, and no empty injector slot is
-      // reserved for it — the endpoint node and its findings still render.
+      // An endpoint-local action keeps the endpoint itself as its "injector" (injId === epId): it is
+      // laid out like any other producing step — an ACTION card (labelled from its contract name, the
+      // injector-node lookup below misses on the asset id) pointing at the endpoint node — so a
+      // self-execution is displayed instead of silently dropped. localActionsAsNodes additionally
+      // re-keys each authored local step to its own chain-local|<step> node.
       const injectors = assetInjectors.get(epId) as string[];
       const findingIds = assetFindings.get(epId) as string[];
       // Group the endpoint's findings by type; a type with more than the cap collapses into ONE "+N"
@@ -2261,6 +2262,13 @@ export const buildCausalChainFlow = (
   const drawnCausalEdges = new Set<string>();
   const labelledCausal = new Set<string>();
   for (const [injId, s] of steps) {
+    // A malformed execution ref (e.g. an edge carrying a source but no target) yields a step that was
+    // never placed as a node — skip it, or the emitted edge would point React Flow at a node id that
+    // does not exist. Endpoint-local steps (self-executions) ARE placed like any other producing step,
+    // so they pass this guard and get their causal edges.
+    if (!nodeById.has(injId)) {
+      continue;
+    }
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
@@ -2316,8 +2324,8 @@ export const buildCausalChainFlow = (
     }
     if (!matched) {
       for (const dep of s.deps) {
-        // The depended step's node may itself be an unplaced endpoint-local step — same guard.
-        if (steps.has(dep)) {
+        // The depended step's node may itself be unplaced (malformed ref) — same guard as above.
+        if (steps.has(dep) && nodeById.has(dep)) {
           edges.push({
             id: `${AP_FLOW_CAUSAL_EDGE_TYPE}-depend-${dep}-${injId}`,
             source: dep,

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -628,18 +628,15 @@ export const buildClusteredAttackPathFlow = (
       continue;
     }
     // The endpoint is a reached node even for endpoint-local actions.
-    if (!reachedOrder.includes(tgt)) {
-      reachedOrder.push(tgt);
-    }
-    // Endpoint-local action (source === target): not reached "by" an injector — no self arrow.
-    if (src === tgt) {
-      continue;
-    }
+
     const injs = injectorsByEndpoint.get(tgt) ?? [];
     if (!injs.includes(src)) {
       injs.push(src);
     }
     injectorsByEndpoint.set(tgt, injs);
+    if (!reachedOrder.includes(tgt)) {
+      reachedOrder.push(tgt);
+    }
   }
 
   // Reveal the most-exposed endpoints first (most findings = highest chokepoint score), so expanding
@@ -970,8 +967,7 @@ export const buildFindingPathFlow = (
   const injectorIds = new Set<string>();
   const statusesByInjector = new Map<string, Array<string | undefined>>();
   for (const e of dto.attackPathEdges ?? []) {
-    if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === endpointId && e.edgeSourceId
-      && e.edgeSourceId !== e.edgeTargetId) {
+    if (e.type === 'EDGE_EXECUTIONS' && e.edgeTargetId === endpointId && e.edgeSourceId) {
       injectorIds.add(e.edgeSourceId);
       const statuses = (e.executionIds ?? []).map(ref => execByRef.get(ref)?.status);
       statusesByInjector.set(
@@ -1917,7 +1913,7 @@ export const buildCausalChainFlow = (
       // to its own ACTION node (localActionsAsNodes re-keys it to chain-local|<step>, so injId !== epId),
       // drop it BEFORE the layout so no injector node, no self arrow, and no empty injector slot is
       // reserved for it — the endpoint node and its findings still render.
-      const injectors = (assetInjectors.get(epId) as string[]).filter(injId => injId !== epId);
+      const injectors = assetInjectors.get(epId) as string[];
       const findingIds = assetFindings.get(epId) as string[];
       // Group the endpoint's findings by type; a type with more than the cap collapses into ONE "+N"
       // cluster row (unless the user expanded it), so a heavy endpoint stays a handful of rows tall.
@@ -2265,11 +2261,6 @@ export const buildCausalChainFlow = (
   const drawnCausalEdges = new Set<string>();
   const labelledCausal = new Set<string>();
   for (const [injId, s] of steps) {
-    // An endpoint-local step (self-loop) has no injector node in the graph, so there is nothing to
-    // anchor a causal edge on — emitting one would target a node React Flow cannot resolve.
-    if (!nodeById.has(injId)) {
-      continue;
-    }
     let matched = false;
     const injY = nodeById.get(injId)?.position.y ?? 0;
     for (const key of s.consumed) {
@@ -2326,7 +2317,7 @@ export const buildCausalChainFlow = (
     if (!matched) {
       for (const dep of s.deps) {
         // The depended step's node may itself be an unplaced endpoint-local step — same guard.
-        if (steps.has(dep) && nodeById.has(dep)) {
+        if (steps.has(dep)) {
           edges.push({
             id: `${AP_FLOW_CAUSAL_EDGE_TYPE}-depend-${dep}-${injId}`,
             source: dep,


### PR DESCRIPTION
## Description

Endpoint-local actions - executions where the source and target of an EDGE_EXECUTIONS edge are the same endpoint (e.g. a Whoami-style local recon action) - were previously treated as "self-loops" and explicitly suppressed across the attack path / causal chain rendering pipeline: no injector node was created for the endpoint acting on itself, no self-referencing arrow was drawn, the endpoint was excluded from its own injector list, and causal edges targeting or depending on such an unplaced "injector" node were silently dropped.

This PR removes that suppression so a self-execution is displayed like any other producing execution:

- In the causal chain flow, the endpoint acting on itself is laid out as an ACTION card (labelled from its contract name) pointing at the endpoint node, and causal edges are drawn to and from it instead of being skipped.
- In the clustered flow, an endpoint reached only by a local action registers the endpoint as its own injector and still counts as reached.
- In the finding path highlighting, a self-execution counts as a producing execution for the injector-restriction logic.

Review follow-up hardening (0214e86):

- Restored the nodeById guards in the causal edge emission, now scoped to genuinely unplaced steps (malformed execution refs carrying a source but no target), so no emitted edge ever targets a node React Flow cannot resolve; self-execution steps are placed nodes and pass the guard.
- Updated the stale comments that still described the removed suppression (layout block, localActionsAsNodes parameter, self-loop re-keying block, clustered flow).
- Rebuilt the test coverage instead of only deleting the old suppression tests: new tests assert the self-execution node and its labelled edge, the causal edge into an endpoint-local consumer, the malformed-step guard, the clustered-view visibility of a self-loop-only endpoint, the buildFindingPathFlow view (the endpoint is never duplicated as its own injector card), and pivotEndpointIds (a self-loop is still not a pivot).

Rebased on latest main. Verified locally: yarn vitest run (554/554 passed), eslint and check-ts clean.

Tracked by OpenAEV-Platform/filigran-private#259; part of the attack path view epic #5048.
