### PR TITLE
fix(attack-path): same-username credentials could show the wrong producing action when highlighted (#7278)

### DIFF
--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -1162,16 +1162,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
     const applyExec = (ids: string[]) => setHighlightedExecutionIds(new Set(ids));
     const matchIn = (items: AttackPathFindingItemDTO[]) =>
       items.find(it => it.endpointKey === endpointKey && (it.type ?? '') === type && findingValuesMatch(type, it.value ?? '', value));
-    const loaded = matchIn(findingsPage?.items ?? []);
-    if (loaded) {
-      applyExec(loaded.executionIds ?? []);
-      return;
-    }
-    // Authoritative for EVERY finding type: the full graph's execution→findings links. This covers types
-    // the drawer categories don't (port, hash…), which otherwise resolved to no producer — leaving every
-    // injector on the endpoint highlighted instead of just the one that produced the finding. Resolve the
-    // finding's CANONICAL node id from the graph (the backend escapes `\`/`|`, so a share value never
-    // matches a rebuilt `NODE_FINDING|type|value`) and match executions on that.
+    // Authoritative for EVERY finding type: the full graph's execution→findings links, resolved by the
+    // finding's own CANONICAL node id (exact match on the RAW value, unlike the drawer's category page
+    // whose credential values are masked server-side). Tried FIRST — a credentials category match is
+    // ambiguous whenever two findings share a username but differ only by password/hash, since
+    // findingValuesMatch() compares just the username for that type (the drawer can't compare masked
+    // secrets): picking the category-page match first would silently attribute the wrong producing
+    // action to whichever entry happens to sort first in the page. The canonical lookup below never has
+    // this ambiguity because it compares the full, unmasked value.
     const canonicalId = (fullDto?.attackPathNodes ?? [])
       .find(n => n.type === 'FINDING' && (n.typeFindings ?? '') === type && (n.value ?? n.label) === value)?.id;
     const fromFull = canonicalId
@@ -1182,6 +1180,14 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       : [];
     if (fromFull.length > 0) {
       applyExec(fromFull);
+      return;
+    }
+    // Fallback for finding types the full graph didn't resolve (or wasn't loaded yet): the drawer's
+    // already-loaded category page. Ambiguous for same-username credentials, but only reached when the
+    // exact resolution above found nothing.
+    const loaded = matchIn(findingsPage?.items ?? []);
+    if (loaded) {
+      applyExec(loaded.executionIds ?? []);
       return;
     }
     const category = CATEGORY_OF_TYPE[type];
@@ -1277,8 +1283,20 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId }: SimulationAtt
       setHighlightedExecutionIds(new Set(producerRefs));
       return true;
     }
-    // Scope the feed (and the producing-action list) to THIS finding's producing executions, resolved
-    // from its category page exactly like a drawer pick.
+    // Producing executions, resolved by this finding's OWN node id (exact, unambiguous — unlike the
+    // drawer category page below, whose credential values are masked server-side, so two findings
+    // sharing a username but differing only by password/hash would otherwise be indistinguishable).
+    const fromFull = (fullDto?.attackPathExecutions ?? [])
+      .filter(e => (e.findingsNodeIds ?? []).includes(nodeId))
+      .map(e => e.ref)
+      .filter((r): r is string => !!r);
+    if (fromFull.length > 0) {
+      setHighlightedExecutionIds(new Set(fromFull));
+      return true;
+    }
+    // Fallback for finding types/graphs the exact lookup above didn't resolve: the drawer's category
+    // page, exactly like a drawer pick. Ambiguous for same-username credentials, but only reached when
+    // the exact resolution above found nothing.
     const category = CATEGORY_OF_TYPE[type];
     if (!category) {
       setHighlightedExecutionIds(new Set());


### PR DESCRIPTION
## Follow-up to #7278

## Problem

Follow-up finding while validating #7278 (chokepoint/credential highlighting): when a **credential finding** is clicked in the Attack Path graph, the node/path highlighting itself is correct (keyed by the finding's own unique node id), but the **"producing execution" resolution** (which drives the Result/Terminal + execution-feed scoping) could point at the wrong finding.

## Root cause

`highlightGraphFinding` / `openFindingFromGraph` tried the drawer's category-page match (`findingValuesMatch()`) first. For the `credentials` type, that helper compares **only the username**, because the drawer's finding value is masked server-side (`"user:••••"`) — the secret can never be compared client-side.

So two credential findings sharing the same username but differing only by password/hash resolve identically in the drawer (`"user : ••••••"` both), and the category-page `.find()` silently returns whichever one sorts first — attributing the wrong producing action to the finding actually clicked.

## Fix

Resolve the producing executions from the **full graph's exact, unmasked execution→finding links**, matched by the finding's own node id (or canonical id) FIRST. Fall back to the ambiguous category-page match only when that exact lookup finds nothing (e.g. the full graph isn't loaded yet). This mirrors the exact-match approach already used for chain-mode finding clicks.

## Testing

- `yarn tsc --noEmit -p .` — 0 errors
- `yarn vitest run src/__tests__/admin/components/simulations/simulation/attack_path/SimulationAttackPath.test.tsx` — 4/4 passed

## Note for reviewers

This does not change any node/path highlighting behavior (already correct per #7278) — it only fixes which execution gets attributed as the "producing action" for a clicked credential finding when two credentials share a username.