### PR TITLE
fix(scenario): route manual chained launch to the simulation attack path (#7286)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -391,7 +391,8 @@ const ScenarioHeader = ({
   // control surface (single reasoning panel + lifecycle controls) and stays synced with the live
   // simulation through the Execution / Attack path tabs - so we push the run up to reveal the
   // cockpit and stay here rather than jumping to the simulation (whose cockpit is a read-only
-  // mirror). Landing on Attack path lets the operator watch it build live.
+  // mirror). Landing on the scenario overview puts the operator in front of the AI cockpit -
+  // timeline, gaps and findings - while the Attack path tab stays one click away.
   const handleAiLaunch = async (input: AutonomousRunCreateInput) => {
     setAiSubmitting(true);
     setAiError(null);
@@ -403,9 +404,7 @@ const ScenarioHeader = ({
       dispatch(fetchScenario(scenarioId));
       setAiDrawerOpen(false);
       MESSAGING$.notifySuccess(t('Autonomous run launched; the orchestrator is now driving the simulation'));
-      if (isAttackPathEnabled) {
-        navigate(`/admin/scenarios/${scenarioId}/attack-path`);
-      }
+      navigate(`/admin/scenarios/${scenarioId}`);
     } catch {
       setAiError(t('Failed to launch the autonomous run'));
     } finally {

--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -873,12 +873,12 @@ const ScenarioHeader = ({
               // lookup now 404s), so forget the latched run: the overview reverts to the manual view
               // instead of keeping the stale AI plan outcome + status chip until a full page reload.
               onAutonomousRunCleared?.();
-              // Launching from the scenario keeps the operator on the scenario: a chained scenario
-              // lands on its own Attack path tab (which mirrors the running simulation live), so the
-              // context stays the scenario rather than jumping into the new simulation. A time-based
-              // scenario has no attack-path tab, so it still lands on the simulation overview.
+              // A manual launch jumps into the simulation that was just created: a chained scenario
+              // lands on the simulation's Attack path tab (the live execution view), a time-based
+              // scenario on the simulation overview. Only the AUTONOMOUS launch stays on the
+              // scenario (its attack-path tab hosts the AI cockpit) - see handleAiLaunch.
               if (isScenarioChaining && isAttackPathEnabled) {
-                navigate(`/admin/scenarios/${scenarioId}/attack-path`);
+                navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}/attack-path`);
               } else {
                 navigate(`${SIMULATION_BASE_URL}/${exercise.exercise_id}`);
               }

--- a/openaev-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/ExerciseHeader.tsx
@@ -249,7 +249,7 @@ const ExerciseHeader = ({ onLoading, isLoading, autonomousRun = null }: {
   isLoading: boolean;
   // Present when this simulation is an autonomous (AI-driven) run. The simulation view is then
   // observe-only: all manual scope / scheduling / configuration controls AND the run lifecycle
-  // controls are hidden. Full control (pause / resume / stop / restart / steer) lives on the parent
+  // controls are hidden. Full control (pause / resume / stop / steer) lives on the parent
   // scenario, reached via the "Parent scenario" button; here operators only follow the run live.
   autonomousRun?: AutonomousRun | null;
 }) => {
@@ -542,7 +542,8 @@ const ExerciseHeader = ({ onLoading, isLoading, autonomousRun = null }: {
               {/* Unified parent-scenario pivot: whenever a simulation was run from a scenario (manual
                   or autonomous), the top-right hero action is an outlined button carrying the scenario
                   name. For autonomous runs the parent scenario is also where the full control surface
-                  (pause / resume / stop / restart / steer) lives. */}
+                  (pause / resume / stop / steer) lives; once stopped, relaunch happens from the
+                  scenario's Normal / Autonomous launch buttons - there is no restart. */}
               {parentScenarioId && (
                 <Tooltip title={parentScenario?.scenario_name ?? t('Parent scenario')}>
                   <span style={{ display: 'inline-flex' }}>


### PR DESCRIPTION
## Summary

- A normal (manual) launch of a chained scenario now navigates to the new simulation's Attack path tab (the live execution view), restoring the pre-#7263 "jump into the simulation" behavior. Time-based scenarios keep landing on the simulation overview.
- An autonomous launch now lands on the scenario overview, which hosts the AI cockpit (timeline, gaps, findings and the reasoning panel); the scenario's Attack path tab stays one click away.
- Cleaned up two stale comments in ExerciseHeader.tsx that still described a "restart" control for autonomous runs: the control surface is Pause / Resume / Stop only, and once a run settles the scenario hero returns to the Launch (normal or autonomous) actions.

Verified while preparing this change (no code change needed):

- In autonomous mode, Stop (cancelAutonomousRun -> AutonomousRunService.cancel) settles the run to CANCELED and transitions the underlying simulation to CANCELED best-effort, so an already-terminal simulation never blocks the stop.
- No Restart button is exposed anywhere in the UI for autonomous runs; the simulation view hides all lifecycle buttons when the simulation is autonomous.

## Test plan

- [ ] From a chained scenario, launch in normal mode: the browser navigates to /admin/simulations/{id}/attack-path of the new simulation.
- [ ] From a time-based scenario, launch in normal mode: the browser navigates to the simulation overview.
- [ ] From a chained scenario, launch in autonomous mode: the browser lands on the scenario overview (/admin/scenarios/{id}) showing the AI cockpit.
- [ ] While an autonomous run is active, the hero shows Pause / Stop only; after Stop, the underlying simulation is CANCELED and the hero shows the Normal / Autonomous launch buttons again.

Closes #7286
