### PR TITLE
fix(autonomous): resume status on directive, idle caption guard, plan-mode time budget (#7290)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -1609,6 +1609,17 @@ public class AutonomousRunService {
         "Operator directive queued",
         content,
         null);
+    // The directive answers whatever the run was parked on. If it was WAITING_INPUT, the operator
+    // has now responded, so leave that state immediately instead of waiting for the next orchestrator
+    // cycle to flip it - otherwise the header keeps reading "Waiting for input" while the run has in
+    // fact resumed (the reported header/cockpit contradiction). A plan run returns to PLANNING (still
+    // authoring logic), a live run to RUNNING; the orchestrator refines this on its next cycle via
+    // update_openaev_run_status. Only WAITING_INPUT is touched, so a directive queued against an
+    // already-active run never perturbs its status.
+    if (run.getStatus() == AutonomousRunStatus.WAITING_INPUT) {
+      run.setStatus(run.isPlanMode() ? AutonomousRunStatus.PLANNING : AutonomousRunStatus.RUNNING);
+      runRepository.save(run);
+    }
     // Re-arm the orchestrator so it picks up the directive now, not only at its next scheduled
     // re-check - crucial when the run is parked in WAITING_INPUT after asking the operator a
     // question. Fired after commit so the orchestrator can never consume before the row is visible.

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -3382,6 +3382,16 @@ public class AutonomousRunService {
       if (run.isPlanMode() || current == AutonomousRunStatus.WAITING_INPUT) {
         return run;
       }
+      // An unconsumed (PENDING) directive is proof-of-life, not a desync: the operator just
+      // steered - addDirective flips WAITING_INPUT to RUNNING right away - and the orchestrator
+      // has not picked the directive up yet, so the simulation legitimately still reads FINISHED
+      // underneath the now-RUNNING run. Completing here would kill the run inside that
+      // answer-to-consume window: the same premature termination the WAITING_INPUT guard above
+      // fixes, just shifted a few seconds later.
+      if (directiveRepository.existsByRunIdAndStatus(
+          run.getId(), AutonomousDirectiveStatus.PENDING)) {
+        return run;
+      }
       target = AutonomousRunStatus.COMPLETED;
     } else {
       // Scheduled / running / paused: the simulation is still live, no desync to fix.

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -1609,13 +1609,14 @@ public class AutonomousRunService {
         "Operator directive queued",
         content,
         null);
-    // The directive answers whatever the run was parked on. If it was WAITING_INPUT, the operator
-    // has now responded, so leave that state immediately instead of waiting for the next orchestrator
-    // cycle to flip it - otherwise the header keeps reading "Waiting for input" while the run has in
-    // fact resumed (the reported header/cockpit contradiction). A plan run returns to PLANNING (still
-    // authoring logic), a live run to RUNNING; the orchestrator refines this on its next cycle via
-    // update_openaev_run_status. Only WAITING_INPUT is touched, so a directive queued against an
-    // already-active run never perturbs its status.
+    // A queued directive answers whatever the run was parked on. If it was
+    // WAITING_INPUT, the operator has now responded, so leave that state right
+    // away instead of waiting for the next orchestrator cycle to flip it -
+    // otherwise the header keeps reading "Waiting for input" while the run has
+    // in fact resumed (the reported header/cockpit contradiction). A plan run
+    // returns to PLANNING (still authoring), a live run to RUNNING; the
+    // orchestrator refines this on its next cycle. Only WAITING_INPUT is
+    // touched, so a directive on an already-active run never perturbs it.
     if (run.getStatus() == AutonomousRunStatus.WAITING_INPUT) {
       run.setStatus(run.isPlanMode() ? AutonomousRunStatus.PLANNING : AutonomousRunStatus.RUNNING);
       runRepository.save(run);

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -767,7 +767,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   if (captionStale && thinkingPhase.active) {
     thinkingPhase = {
       key: 'idle',
-      label: isWaitingInput ? t('Waiting for your input') : t('Paused between moves'),
+      label: isWaitingInput ? t('Waiting for your input') : t('Awaiting the next event'),
       color: theme.palette.text.secondary,
       active: false,
     };

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -34,6 +34,13 @@ import { AUTONOMOUS_PANEL_WIDTH } from './useAutonomousPanelWidth';
 // PLANNED is settled (logic done), so it is intentionally NOT active.
 const ACTIVE_STATUSES: AutonomousRunStatus[] = ['PLANNING', 'RUNNING', 'WAITING_INPUT'];
 const POLL_INTERVAL_MS = 3000;
+// A live ("active") caption keeps pulsing as if the orchestrator were computing right now. If the
+// newest timeline event is older than this, it is NOT: the run is parked between cycles, waiting on
+// a directive re-check, or an upstream cycle stalled. Past this age we settle any active caption
+// into a calm idle one so the cockpit never lies with a frozen "Deciding the next move" for minutes
+// (the reported stuck-cockpit symptom). A fresh event re-animates it. Sized above a normal cycle's
+// event cadence so an ordinary long action does not flip it to idle prematurely.
+const STALE_CAPTION_AFTER_MS = 180000;
 
 // Cap the proposed one-click choices so the callout stays scannable: at most this many radio options
 // are ever shown, and the always-present free-text composer below is the escape hatch for anything
@@ -630,7 +637,14 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // ... the AI is demonstrably working again, so the caption must narrate THAT instead of freezing
   // on "Processing your answer" (the exact "it says processing while it is already executing" bug).
   const newestIsActivity = isActivityType(newestEvent?.autonomous_event_type);
-  const thinkingPhase: ThinkingPhase = (() => {
+  // How long since the newest event? A stale timeline means the orchestrator is not actively
+  // working, whatever the last event type was - used below to stop an active caption pulsing over a
+  // frozen cockpit.
+  const newestEventAgeMs = newestEvent?.autonomous_event_created_at
+    ? Date.now() - new Date(newestEvent.autonomous_event_created_at).getTime()
+    : 0;
+  const captionStale = newestEventAgeMs > STALE_CAPTION_AFTER_MS;
+  let thinkingPhase: ThinkingPhase = (() => {
     if (isWaitingInput && pendingQuestion) {
       // Genuinely idle on the operator: static wait, not a pulsing "still working" animation.
       return {
@@ -745,6 +759,19 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
         };
     }
   })();
+  // Staleness backstop: never keep an active caption pulsing over a timeline that has not moved in
+  // minutes. Settle it into a calm idle caption that tells the truth (still awaiting the operator,
+  // or simply parked between moves). Static captions (open question, end-of-cycle park) already
+  // reflect an idle state, so leave them untouched. A newer event clears captionStale and the live
+  // caption resumes on the next 3s poll.
+  if (captionStale && thinkingPhase.active) {
+    thinkingPhase = {
+      key: 'idle',
+      label: isWaitingInput ? t('Waiting for your input') : t('Paused between moves'),
+      color: theme.palette.text.secondary,
+      active: false,
+    };
+  }
 
   return (
     <Box

--- a/openaev-front/src/admin/components/autonomous/AutonomousRunConfigDrawer.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousRunConfigDrawer.tsx
@@ -25,6 +25,10 @@ interface AutonomousRunConfigDrawerProps {
   /** Default time budget (hours) when nothing pre-fills it: 24h for a live launch, a smaller value
    *  for the AI builder (planning is a quick, untimed design pass). Omit to keep the 24h default. */
   defaultTimeoutHours?: number;
+  /** The drawer hosts the AI builder (a plan-authoring pass), not a live launch. Plan mode is
+   *  untimed server-side, so the time budget always shows the default and is omitted from the
+   *  payload (never persisted as a stale value). Defaults to false (live launch). */
+  planMode?: boolean;
   submitting?: boolean;
   error?: string | null;
   /** Show the "Save for later" action (persist config, start nothing). Defaults to false. */
@@ -53,6 +57,7 @@ const AutonomousRunConfigDrawer = ({
   defaultObjective,
   demoteTemplates,
   defaultTimeoutHours,
+  planMode,
   submitting = false,
   error,
   showSave = false,
@@ -69,6 +74,7 @@ const AutonomousRunConfigDrawer = ({
     initialInput,
     defaultObjective,
     defaultTimeoutHours,
+    isPlanMode: planMode,
   });
 
   // Clear the selection every time the drawer closes so a fresh open starts clean (and a preset

--- a/openaev-front/src/admin/components/autonomous/useAutonomousRunConfig.ts
+++ b/openaev-front/src/admin/components/autonomous/useAutonomousRunConfig.ts
@@ -373,31 +373,39 @@ export const useAutonomousRunConfig = ({
     setAgentsLoaded(false);
   };
 
-  const buildInput = (planMode = false): AutonomousRunCreateInput => ({
-    objective: objective.trim(),
-    objective_template_key: selectedTemplateKey ?? undefined,
-    name: name.trim() || undefined,
-    description: description.trim() || undefined,
-    scope_rules: scopeRules.length > 0 ? scopeRules : undefined,
-    // Authoritative selection: send it as soon as the agents loaded (even empty, i.e. the operator
-    // disabled every agent). Only omit it when the fetch failed, so the backend can fall back to
-    // the tenant defaults rather than silently running with no specialist agents.
-    agent_ids: agentsLoaded ? selectedAgentIds : undefined,
-    agent_modes: agentsLoaded
-      ? {
-          [ORCHESTRATOR_AGENT_ID]: selectedAgentModes[ORCHESTRATOR_AGENT_ID] ?? ORCHESTRATOR_DEFAULT_DISCOVERY_MODE,
-          ...Object.fromEntries(selectedAgentIds.map(id => [id, selectedAgentModes[id] ?? SPECIALIST_DEFAULT_DISCOVERY_MODE])),
-        }
-      : undefined,
-    plan_mode: planMode || undefined,
-    // OpenAEV-enforced run deadline (seconds). Clamp to the advertised 1h-720h range (the HTML
-    // min/max only guard the spinner, not typed input). Omitted entirely in build/plan mode: the
-    // server does not enforce a deadline while planning, and persisting one would carry a stale,
-    // misleading budget back into the next open of the saved config.
-    timeout_seconds: planMode
-      ? undefined
-      : Math.min(720 * 3600, Math.max(3600, Math.round(timeoutHours * 3600))),
-  });
+  const buildInput = (planMode = false): AutonomousRunCreateInput => {
+    // A plan-mode HOST builds a plan payload whatever action was pressed: the AI builder's primary
+    // "Build" action goes through the generic launch callback (buildInput(false)), so keying off
+    // the per-call argument alone would still carry timeout_seconds (which the build flow persists
+    // as the scenario's saved config) and omit plan_mode. A live-launch host (isPlanMode false)
+    // keeps the per-call argument as the sole switch.
+    const effectivePlanMode = isPlanMode || planMode;
+    return {
+      objective: objective.trim(),
+      objective_template_key: selectedTemplateKey ?? undefined,
+      name: name.trim() || undefined,
+      description: description.trim() || undefined,
+      scope_rules: scopeRules.length > 0 ? scopeRules : undefined,
+      // Authoritative selection: send it as soon as the agents loaded (even empty, i.e. the operator
+      // disabled every agent). Only omit it when the fetch failed, so the backend can fall back to
+      // the tenant defaults rather than silently running with no specialist agents.
+      agent_ids: agentsLoaded ? selectedAgentIds : undefined,
+      agent_modes: agentsLoaded
+        ? {
+            [ORCHESTRATOR_AGENT_ID]: selectedAgentModes[ORCHESTRATOR_AGENT_ID] ?? ORCHESTRATOR_DEFAULT_DISCOVERY_MODE,
+            ...Object.fromEntries(selectedAgentIds.map(id => [id, selectedAgentModes[id] ?? SPECIALIST_DEFAULT_DISCOVERY_MODE])),
+          }
+        : undefined,
+      plan_mode: effectivePlanMode || undefined,
+      // OpenAEV-enforced run deadline (seconds). Clamp to the advertised 1h-720h range (the HTML
+      // min/max only guard the spinner, not typed input). Omitted entirely in build/plan mode: the
+      // server does not enforce a deadline while planning, and persisting one would carry a stale,
+      // misleading budget back into the next open of the saved config.
+      timeout_seconds: effectivePlanMode
+        ? undefined
+        : Math.min(720 * 3600, Math.max(3600, Math.round(timeoutHours * 3600))),
+    };
+  };
 
   return {
     templates,

--- a/openaev-front/src/admin/components/autonomous/useAutonomousRunConfig.ts
+++ b/openaev-front/src/admin/components/autonomous/useAutonomousRunConfig.ts
@@ -144,6 +144,14 @@ export interface UseAutonomousRunConfigOptions {
    * (from {@link initialInput}) still wins.
    */
   defaultTimeoutHours?: number;
+  /**
+   * The host is the AI builder (a build / plan-authoring pass), not a live launch. Plan mode is
+   * untimed server-side, so the time budget is meaningless here: we always show {@link
+   * defaultTimeoutHours} (ignoring any timeout a previously-saved build config carried) and omit
+   * `timeout_seconds` from the built payload so a stale value can never be persisted and surfaced
+   * back as a misleading budget on the next open.
+   */
+  isPlanMode?: boolean;
 }
 
 /** Fallback time budget (hours) when a host does not override it: autonomous execution is long-lived. */
@@ -194,6 +202,7 @@ export const useAutonomousRunConfig = ({
   initialInput,
   defaultObjective,
   defaultTimeoutHours = DEFAULT_TIMEOUT_HOURS,
+  isPlanMode = false,
 }: UseAutonomousRunConfigOptions): AutonomousRunConfig => {
   const [templates, setTemplates] = useState<AutonomousObjectiveTemplate[]>([]);
   const [loadingTemplates, setLoadingTemplates] = useState(false);
@@ -284,9 +293,10 @@ export const useAutonomousRunConfig = ({
       setName(initialInput.name ?? '');
       setDescription(initialInput.description ?? '');
       // A saved timeout wins; otherwise fall back to this host's default (24h launch / 1h planning)
-      // rather than leaving whatever a previous open left behind.
+      // rather than leaving whatever a previous open left behind. In plan mode the budget is
+      // server-untimed and meaningless, so always show the default (never a stale saved value).
       setTimeoutHours(
-        initialInput.timeout_seconds && initialInput.timeout_seconds > 0
+        !isPlanMode && initialInput.timeout_seconds && initialInput.timeout_seconds > 0
           ? Math.round(initialInput.timeout_seconds / 3600)
           : defaultTimeoutHours,
       );
@@ -302,7 +312,7 @@ export const useAutonomousRunConfig = ({
         setObjective(defaultObjective);
       }
     }
-  }, [open, initialInput, defaultObjective, defaultTimeoutHours]);
+  }, [open, initialInput, defaultObjective, defaultTimeoutHours, isPlanMode]);
 
   const selectTemplate = (template: AutonomousObjectiveTemplate) => {
     setSelectedTemplateKey(template.autonomous_objective_template_key);
@@ -381,8 +391,12 @@ export const useAutonomousRunConfig = ({
       : undefined,
     plan_mode: planMode || undefined,
     // OpenAEV-enforced run deadline (seconds). Clamp to the advertised 1h-720h range (the HTML
-    // min/max only guard the spinner, not typed input); ignored server-side in build mode.
-    timeout_seconds: Math.min(720 * 3600, Math.max(3600, Math.round(timeoutHours * 3600))),
+    // min/max only guard the spinner, not typed input). Omitted entirely in build/plan mode: the
+    // server does not enforce a deadline while planning, and persisting one would carry a stale,
+    // misleading budget back into the next open of the saved config.
+    timeout_seconds: planMode
+      ? undefined
+      : Math.min(720 * 3600, Math.max(3600, Math.round(timeoutHours * 3600))),
   });
 
   return {

--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -911,6 +911,7 @@ const ScenarioHeader = ({
         // budget to 1h rather than surfacing the misleading 24h execution budget. A live autonomous
         // launch keeps the 24h default (recon + human-in-the-loop steps make it long-lived).
         defaultTimeoutHours={aiDrawerIntent === 'build' ? 1 : undefined}
+        planMode={aiDrawerIntent === 'build'}
         title={aiDrawerTitle}
         infoText={aiDrawerIntent === 'build'
           ? t('Let the AI build this scenario\'s logic for you - set the objective, the specialist agents the orchestrator may consult, and the scope. Save it to build or launch later, or Build now to have the orchestrator author the steps onto the scenario. Nothing runs while building; you launch the scenario afterwards, in normal or autonomous mode.')

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousDirectiveRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousDirectiveRepository.java
@@ -18,6 +18,14 @@ public interface AutonomousDirectiveRepository extends JpaRepository<AutonomousD
 
   List<AutonomousDirective> findByRunIdOrderByCreatedAtAsc(String runId);
 
+  /**
+   * Cheap existence probe: does the run still have a directive in the given status? Used by the
+   * run/simulation reconciliation as a proof-of-life signal - a PENDING directive means the
+   * operator just steered and the orchestrator has not consumed it yet, so the run must not be
+   * settled from a stale simulation status.
+   */
+  boolean existsByRunIdAndStatus(String runId, AutonomousDirectiveStatus status);
+
   /** Bulk-purges a run's steering directives when the run is deleted. */
   @Modifying
   @Query("DELETE FROM AutonomousDirective d WHERE d.runId = :runId")


### PR DESCRIPTION
## Summary

Fixes the OpenAEV-side status/UI correctness for an autonomous "build with AI" run so the cockpit never lies even when a cycle stalls upstream. The cycle-scheduling stall itself is fixed in XTM One (XTM-One-Platform/xtm-one#2780).

Closes #7290.

- `AutonomousRunService.addDirective`: when the run is `WAITING_INPUT`, flip it to `PLANNING` (plan mode) or `RUNNING` (live) as soon as the operator's directive is queued, so the header stops reading "Waiting for input" while the run has in fact resumed. Only `WAITING_INPUT` is touched; a directive queued against an already-active run never perturbs its status. The orchestrator refines the status on its next cycle.
- Reconciliation guard (review follow-up): because the flip above can leave a live run `RUNNING` over a still-empty (`FINISHED`) simulation until the orchestrator consumes the answer, `reconcileWithSimulation` now skips the FINISHED -> COMPLETED sync while the run has a PENDING directive - an unconsumed directive is proof-of-life, not a desync. Without this, the next 3s poll could auto-complete the run right after the operator answered (the same premature termination the existing `WAITING_INPUT` guard prevents).
- `AutonomousReasoningPanel`: add a staleness guard. Once the newest timeline event is older than `STALE_CAPTION_AFTER_MS` (3 min), any active caption ("Deciding the next move", ...) settles into a calm idle caption instead of pulsing forever over a frozen timeline. A fresh event re-animates it. Static captions (open question, end-of-cycle park) are left untouched.
- Time-budget carry-over: `useAutonomousRunConfig` gains an `isPlanMode` flag (plumbed through `AutonomousRunConfigDrawer` from `ScenarioHeader`). In plan/build mode the drawer always shows the build default budget (never a stale saved value), and `buildInput` derives an effective plan mode from the host flag OR its per-call argument (Copilot review follow-up) - so the builder's primary Build action, which goes through the generic launch callback as `buildInput(false)`, also omits `timeout_seconds` (never persisted as a stale budget) and sets `plan_mode: true`. Plan mode is untimed server-side, so this is purely a display/carry-over correctness fix; live-launch payloads are unchanged.

## Test plan

- [x] `yarn eslint` on the changed files
- [x] `yarn check-ts`
- [x] `mvn spotless:apply` + backend compile on the touched modules
- [ ] Manual: build-with-AI, answer the scope question, confirm the header leaves "Waiting for input", the run is not auto-completed while the answer is pending, the cockpit caption settles when idle, and the AI-builder time budget shows 1h.
