### PR TITLE
fix(autonomous): decouple scenario deletion from simulation lifecycle (#7295)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
@@ -323,9 +323,9 @@ public class ScenarioApi extends RestBehavior {
       actionPerformed = Action.DELETE,
       resourceType = ResourceType.SCENARIO)
   public void deleteScenario(@PathVariable @NotBlank final String scenarioId) {
-    // Tear down the autonomous run's coordination first (409 if it is still active), then delete the
-    // scenario. Finished simulations are NOT deleted - they detach and remain as history, like any
-    // chained simulation. No-op for manual scenarios.
+    // Tear down the autonomous run's coordination first (409 if it is still active), then delete
+    // the scenario. Finished simulations are NOT deleted - they detach and remain as history, like
+    // any chained simulation. No-op for manual scenarios.
     this.autonomousRunService.deleteForScenario(scenarioId);
     this.scenarioService.deleteScenario(scenarioId);
   }

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
@@ -323,8 +323,9 @@ public class ScenarioApi extends RestBehavior {
       actionPerformed = Action.DELETE,
       resourceType = ResourceType.SCENARIO)
   public void deleteScenario(@PathVariable @NotBlank final String scenarioId) {
-    // An autonomous scenario and its single simulation are one unit: tear the run + simulation down
-    // first (409 if the run is still active), then delete the scenario. No-op for manual scenarios.
+    // Tear down the autonomous run's coordination first (409 if it is still active), then delete the
+    // scenario. Finished simulations are NOT deleted - they detach and remain as history, like any
+    // chained simulation. No-op for manual scenarios.
     this.autonomousRunService.deleteForScenario(scenarioId);
     this.scenarioService.deleteScenario(scenarioId);
   }

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -1298,10 +1298,11 @@ public class AutonomousRunService {
   }
 
   /**
-   * Tears down the autonomous run owning {@code scenarioId} together with its single underlying
-   * simulation (attack-path rows included) and its timeline/directives. An autonomous scenario and
-   * its simulation are one unit, so deleting the scenario must delete the simulation too -
-   * otherwise an orphan run keeps driving a simulation whose scenario is gone.
+   * Tears down the autonomous run owning {@code scenarioId} - its coordination row, timeline and
+   * directives - and halts the orchestration, so deleting the scenario never leaves an orphan run
+   * driving a simulation whose scenario is gone. It does NOT delete a finished LIVE simulation: that
+   * is history, detached by the scenario delete like any other simulation (see {@link
+   * #tearDownRun}). Only a non-executing plan-mode substrate simulation is removed with the run.
    *
    * <p>Deliberately a best-effort no-op for manual scenarios (and when the preview feature is off),
    * so the generic scenario-delete endpoint can call it unconditionally. A still-active run
@@ -1355,20 +1356,29 @@ public class AutonomousRunService {
   }
 
   /**
-   * Tears an autonomous run down together with its underlying simulation, decision timeline, and
-   * steering directives, and halts the XTM One orchestration. Shared by both scenario-delete paths
-   * (single and bulk) so an autonomous run is cleaned up the same way however its scenario is
-   * deleted - never leaving an orphaned run row or a self-resuming durable execution behind.
+   * Tears an autonomous run's COORDINATION down - the run row, its decision timeline and steering
+   * directives - and halts the XTM One orchestration. Shared by both scenario-delete paths (single
+   * and bulk) so a run is cleaned up the same way however its scenario is deleted, never leaving an
+   * orphaned run row or a self-resuming durable execution behind.
+   *
+   * <p>It does NOT delete a real simulation: a finished LIVE simulation is history and is left for
+   * the scenario delete to detach (scenarios_exercises SET_REFERENCE_NULL) like any other
+   * simulation - consistent with "a scenario can carry many simulations", and matching {@link
+   * #supersedePriorRun}. Only a non-executing plan-mode substrate simulation (a throwaway with no
+   * results) is deleted with the run.
    */
   private void tearDownRun(AutonomousRun run) {
     // Halt the XTM One orchestration first: once the run row is gone OpenAEV can no longer be
-    // driven, but a still-live durable execution would keep self-resuming and dispatching injects
-    // against the deleted simulation. Fired after commit (the run id is captured now) so the
-    // upstream cancel resolves the same execution by its stable dedup key. Purge so no orphaned
-    // shared state / work items linger after the scenario and its simulation are gone.
+    // driven, but a still-live durable execution would keep self-resuming and dispatching injects.
+    // Fired after commit (the run id is captured now) so the upstream cancel resolves the same
+    // execution by its stable dedup key. Purge so no orphaned shared state / work items linger.
     String runId = run.getId();
     cancelOrchestratorAfterCommit(runId, "autonomous scenario deleted", true);
-    if (hasText(run.getSimulationId())) {
+    // A plan-mode substrate simulation never executed and holds no results - delete it. A finished
+    // LIVE simulation is real history: keep it (the scenario delete detaches it) so deleting the
+    // scenario never destroys a simulation, which is the legacy 1:1 scenario<->simulation coupling
+    // we no longer want.
+    if (run.isPlanMode() && hasText(run.getSimulationId())) {
       exerciseService.deleteById(run.getSimulationId());
     }
     directiveRepository.deleteByRunId(runId);
@@ -2879,10 +2889,11 @@ public class AutonomousRunService {
   }
 
   /**
-   * Returns the run driving a given scenario, if any. An autonomous run owns exactly one scenario
-   * (and its single simulation), so this is the scenario-side twin of {@link #getBySimulation}: it
-   * lets the scenario detail page render the same AI-driven cockpit and steer the underlying
-   * simulation. 404 when the scenario is not autonomous.
+   * Returns the CURRENT autonomous run of a given scenario, if any. A scenario keeps at most one
+   * live run at a time (a rebuild or relaunch supersedes the prior run row, though its finished
+   * simulation stays as history - see {@link #supersedePriorRun}), so this is the scenario-side twin
+   * of {@link #getBySimulation}: it lets the scenario detail page render the AI-driven cockpit and
+   * steer the current run's simulation. 404 when the scenario has no autonomous run.
    */
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun getByScenario(String scenarioId) {

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -1300,14 +1300,14 @@ public class AutonomousRunService {
   /**
    * Tears down the autonomous run owning {@code scenarioId} - its coordination row, timeline and
    * directives - and halts the orchestration, so deleting the scenario never leaves an orphan run
-   * driving a simulation whose scenario is gone. It does NOT delete a finished LIVE simulation: that
-   * is history, detached by the scenario delete like any other simulation (see {@link
+   * driving a simulation whose scenario is gone. It does NOT delete a finished LIVE simulation:
+   * that is history, detached by the scenario delete like any other simulation (see {@link
    * #tearDownRun}). Only a non-executing plan-mode substrate simulation is removed with the run.
    *
    * <p>Deliberately a best-effort no-op for manual scenarios (and when the preview feature is off),
    * so the generic scenario-delete endpoint can call it unconditionally. A still-active run
-   * (created / running / paused / waiting-input) is refused with 409: the operator must stop it
-   * first, mirroring the UI's disabled Delete entry.
+   * (created / planning / running / paused / waiting-input) is refused with 409: the operator must
+   * stop it first, mirroring the UI's disabled Delete entry.
    */
   @Transactional(rollbackFor = Exception.class)
   public void deleteForScenario(String scenarioId) {
@@ -1322,7 +1322,10 @@ public class AutonomousRunService {
     // treated as terminal so a stale "still running" status can't wrongly block the delete.
     run = reconcileWithSimulation(run);
     AutonomousRunStatus status = run.getStatus();
+    // Same active set as supersedePriorRun (and the frontend's isActive): PLANNING counts - the
+    // orchestrator is still designing the plan, so the delete must be refused mid-design too.
     if (status == AutonomousRunStatus.CREATED
+        || status == AutonomousRunStatus.PLANNING
         || status == AutonomousRunStatus.RUNNING
         || status == AutonomousRunStatus.PAUSED
         || status == AutonomousRunStatus.WAITING_INPUT) {
@@ -2891,9 +2894,9 @@ public class AutonomousRunService {
   /**
    * Returns the CURRENT autonomous run of a given scenario, if any. A scenario keeps at most one
    * live run at a time (a rebuild or relaunch supersedes the prior run row, though its finished
-   * simulation stays as history - see {@link #supersedePriorRun}), so this is the scenario-side twin
-   * of {@link #getBySimulation}: it lets the scenario detail page render the AI-driven cockpit and
-   * steer the current run's simulation. 404 when the scenario has no autonomous run.
+   * simulation stays as history - see {@link #supersedePriorRun}), so this is the scenario-side
+   * twin of {@link #getBySimulation}: it lets the scenario detail page render the AI-driven cockpit
+   * and steer the current run's simulation. 404 when the scenario has no autonomous run.
    */
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun getByScenario(String scenarioId) {

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -41,6 +41,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -754,15 +756,19 @@ class AutonomousRunServiceTest {
     verify(runRepository).delete(run);
   }
 
-  @Test
+  @ParameterizedTest(name = "deleteForScenario refuses (409) a still-active {0} run")
+  @EnumSource(
+      value = AutonomousRunStatus.class,
+      names = {"CREATED", "PLANNING", "RUNNING", "PAUSED", "WAITING_INPUT"})
   @DisplayName("deleteForScenario refuses (409) while the run is still active and touches nothing")
-  void deleteForScenarioRefusesActiveRun() {
+  void deleteForScenarioRefusesActiveRun(AutonomousRunStatus activeStatus) {
     when(previewFeatureService.isAutonomousAttackPathEnabled()).thenReturn(true);
     AutonomousRun run = new AutonomousRun();
     run.setId("run-1");
     run.setScenarioId("scenario-1");
-    run.setPlanMode(false);
-    run.setStatus(AutonomousRunStatus.RUNNING);
+    // PLANNING is the dry-run design phase, so it only ever occurs on a plan-mode run.
+    run.setPlanMode(activeStatus == AutonomousRunStatus.PLANNING);
+    run.setStatus(activeStatus);
     when(runRepository.findByScenarioId("scenario-1")).thenReturn(Optional.of(run));
 
     assertThatThrownBy(() -> service.deleteForScenario("scenario-1"))

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -710,6 +710,71 @@ class AutonomousRunServiceTest {
 
   @Test
   @DisplayName(
+      "deleteForScenario tears down a finished LIVE run's coordination but KEEPS its simulation as"
+          + " history (no legacy scenario<->simulation cascade delete)")
+  void deleteForScenarioKeepsFinishedLiveSimulation() {
+    when(previewFeatureService.isAutonomousAttackPathEnabled()).thenReturn(true);
+    // Deleting a scenario must never destroy a real simulation: a completed LIVE run's simulation
+    // is history and is left for the scenario delete to detach (scenarios_exercises
+    // SET_REFERENCE_NULL), exactly like a manual chained simulation.
+    AutonomousRun run = new AutonomousRun();
+    run.setId("run-1");
+    run.setScenarioId("scenario-1");
+    run.setPlanMode(false);
+    run.setStatus(AutonomousRunStatus.COMPLETED);
+    run.setSimulationId("live-sim");
+    when(runRepository.findByScenarioId("scenario-1")).thenReturn(Optional.of(run));
+
+    service.deleteForScenario("scenario-1");
+
+    verify(exerciseService, never()).deleteById(anyString());
+    verify(directiveRepository).deleteByRunId("run-1");
+    verify(eventService).deleteByRun("run-1");
+    verify(runRepository).delete(run);
+    verify(xtmOneClient).cancelAutonomousRun(eq("run-1"), anyString(), eq(true));
+  }
+
+  @Test
+  @DisplayName(
+      "deleteForScenario deletes only a plan-mode substrate simulation (a throwaway with no"
+          + " results) with the run")
+  void deleteForScenarioDeletesPlanSubstrate() {
+    when(previewFeatureService.isAutonomousAttackPathEnabled()).thenReturn(true);
+    AutonomousRun run = new AutonomousRun();
+    run.setId("run-1");
+    run.setScenarioId("scenario-1");
+    run.setPlanMode(true);
+    run.setStatus(AutonomousRunStatus.PLANNED);
+    run.setSimulationId("plan-sim");
+    when(runRepository.findByScenarioId("scenario-1")).thenReturn(Optional.of(run));
+
+    service.deleteForScenario("scenario-1");
+
+    verify(exerciseService).deleteById("plan-sim");
+    verify(runRepository).delete(run);
+  }
+
+  @Test
+  @DisplayName("deleteForScenario refuses (409) while the run is still active and touches nothing")
+  void deleteForScenarioRefusesActiveRun() {
+    when(previewFeatureService.isAutonomousAttackPathEnabled()).thenReturn(true);
+    AutonomousRun run = new AutonomousRun();
+    run.setId("run-1");
+    run.setScenarioId("scenario-1");
+    run.setPlanMode(false);
+    run.setStatus(AutonomousRunStatus.RUNNING);
+    when(runRepository.findByScenarioId("scenario-1")).thenReturn(Optional.of(run));
+
+    assertThatThrownBy(() -> service.deleteForScenario("scenario-1"))
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT));
+    verify(runRepository, never()).delete(any());
+    verify(exerciseService, never()).deleteById(anyString());
+  }
+
+  @Test
+  @DisplayName(
       "supersedeSettledRunOnManualLaunch never tears down a still-active run (defensive no-op, no"
           + " 409)")
   void supersedeSettledRunOnManualLaunchLeavesActiveRunUntouched() {

--- a/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
+++ b/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
@@ -169,8 +169,10 @@ const useAutonomousRunForSimulation = (simulationId: string | undefined): Autono
   useAutonomousRunDetection(simulationId, fetchAutonomousRunBySimulation);
 
 /**
- * Scenario-side twin: detects the autonomous run owning a scenario so the scenario detail page can
- * render the same AI cockpit and steer its single underlying simulation.
+ * Scenario-side twin: detects the CURRENT autonomous run of a scenario so the scenario detail page
+ * can render the same AI cockpit and steer that run's simulation. A scenario carries at most one
+ * live run at a time (older runs are superseded, their finished simulations kept as history), so
+ * this resolves to the current/last run - never assuming a scenario owns exactly one simulation.
  *
  * <p>Pass the scenario's own {@code scenario_autonomous} flag once the scenario is loaded: when it
  * is {@code false} the scenario is authoritatively manual and the lookup is skipped entirely, so a


### PR DESCRIPTION
## Summary

- Deleting an autonomous scenario no longer cascade-deletes a finished LIVE simulation. `tearDownRun` now removes only a non-executing plan-mode substrate simulation (a throwaway with no results); a finished simulation is kept as history and detached by the scenario delete (`scenarios_exercises` `SET_REFERENCE_NULL`), like any chained simulation.
- A still-active run refuses deletion with 409 and touches nothing. The active-status guard now includes PLANNING (the orchestrator is still designing the plan), aligned with `supersedePriorRun` and the frontend's `isActive`.
- Drops the legacy 1:1 scenario<->simulation framing from Javadoc (`deleteForScenario`, `getByScenario`, `tearDownRun`), the `deleteScenario` endpoint comment, and the frontend `useAutonomousRunForScenario` comment. A scenario can carry many simulations (autonomous and manual) over its lifetime; the current run resolves to the last/running one.

## Test plan

- [x] `AutonomousRunServiceTest`: `deleteForScenarioKeepsFinishedLiveSimulation` (LIVE simulation NOT deleted), `deleteForScenarioDeletesPlanSubstrate` (plan substrate deleted), `deleteForScenarioRefusesActiveRun` parameterized over every active status including PLANNING (409, nothing touched) - 36/36 pass locally.
- [x] `mvn spotless:check` green.
- [ ] Manual: delete an autonomous scenario with a finished simulation -> scenario removed, simulation remains in the simulations list, detached.

Closes #7295
