### PR TITLE
fix(phishing): fill editor preview pane and use design-system chips (#7306)

### DIFF
--- a/openaev-front/src/admin/components/components/phishing/PhishingHtmlPreview.tsx
+++ b/openaev-front/src/admin/components/components/phishing/PhishingHtmlPreview.tsx
@@ -75,6 +75,12 @@ const PhishingHtmlPreview = ({ title, iframeTitle, srcDoc, chrome, height = 560 
         display: 'flex',
         flexDirection: 'column',
         height: '100%',
+        // Fill the parent pane: the editor mounts this inside a flex-row column,
+        // so without an explicit width the preview shrinks to its header text
+        // and the width:100% iframe collapses to a narrow strip.
+        width: '100%',
+        minWidth: 0,
+        flex: '1 1 auto',
       }}
       >
         <Box sx={{

--- a/openaev-front/src/admin/components/components/phishing/email_templates/PhishingEmailTemplateEditor.tsx
+++ b/openaev-front/src/admin/components/components/phishing/email_templates/PhishingEmailTemplateEditor.tsx
@@ -67,12 +67,32 @@ const toFormInput = (emailTemplate: PhishingEmailTemplate): PhishingEmailTemplat
   phishing_email_template_add_tracking_pixel: emailTemplate.phishing_email_template_add_tracking_pixel ?? true,
 });
 
-const previewSrcDoc = (html: string) =>
-  '<!doctype html><html><head><meta charset="utf-8">'
-  + '<meta name="viewport" content="width=device-width, initial-scale=1">'
-  + '<style>html,body{margin:0;padding:16px;background:#ffffff;color:#111111;'
-  + 'font-family:Arial,Helvetica,sans-serif;}</style></head>'
-  + `<body>${html}</body></html>`;
+const escapeHtml = (value: string) => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+
+// Preview the rendered HTML body, but fall back to the plain-text alternative
+// (wrapped so line breaks survive) when there is no HTML yet, so a text-only
+// template previews its real content instead of a blank page.
+const previewBody = (html: string, text: string) => {
+  if (html.trim()) {
+    return html;
+  }
+  if (text.trim()) {
+    return `<pre style="white-space:pre-wrap;word-wrap:break-word;font-family:Arial,Helvetica,sans-serif;margin:0">${escapeHtml(text)}</pre>`;
+  }
+  return '';
+};
+
+const previewSrcDoc = (html: string, text: string) => {
+  const body = previewBody(html, text);
+  return '<!doctype html><html><head><meta charset="utf-8">'
+    + '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    + '<style>html,body{margin:0;padding:16px;background:#ffffff;color:#111111;'
+    + 'font-family:Arial,Helvetica,sans-serif;}</style></head>'
+    + `<body>${body}</body></html>`;
+};
 
 const PhishingEmailTemplateEditor: FunctionComponent = () => {
   const { t } = useFormatter();
@@ -319,7 +339,7 @@ const PhishingEmailTemplateEditor: FunctionComponent = () => {
     <PhishingHtmlPreview
       title={t('Preview')}
       iframeTitle={title}
-      srcDoc={previewSrcDoc(watch('phishing_email_template_html_body') ?? '')}
+      srcDoc={previewSrcDoc(watch('phishing_email_template_html_body') ?? '', watch('phishing_email_template_text_body') ?? '')}
       chrome={emailChrome}
       height="100%"
     />

--- a/openaev-front/src/admin/components/components/phishing/landing_pages/PhishingLandingPage.tsx
+++ b/openaev-front/src/admin/components/components/phishing/landing_pages/PhishingLandingPage.tsx
@@ -1,30 +1,15 @@
 import { InfoOutlined } from '@mui/icons-material';
-import { Box, Chip, Tooltip, Typography } from '@mui/material';
+import { Box, Tooltip, Typography } from '@mui/material';
 import { useParams } from 'react-router';
 
 import { type PhishingLandingPagesHelper } from '../../../../../actions/phishing/phishing-helper';
 import { Field, SectionBlock } from '../../../../../components/common/detail/EntityDetailCommon';
 import { useFormatter } from '../../../../../components/i18n';
+import ItemBoolean from '../../../../../components/ItemBoolean';
 import { useHelper } from '../../../../../store';
 import { type PhishingLandingPage as PhishingLandingPageType } from '../../../../../utils/api-types';
 import { emptyFilled } from '../../../../../utils/String';
 import PhishingHtmlPreview from '../PhishingHtmlPreview';
-
-const BooleanChip = ({ enabled, label }: {
-  enabled: boolean;
-  label: string;
-}) => (
-  <Chip
-    label={label}
-    size="small"
-    color={enabled ? 'success' : 'default'}
-    variant={enabled ? 'filled' : 'outlined'}
-    sx={{
-      width: 'fit-content',
-      textTransform: 'none',
-    }}
-  />
-);
 
 const PhishingLandingPage = () => {
   const { landingPageId } = useParams() as { landingPageId: PhishingLandingPageType['phishing_landing_page_id'] };
@@ -74,9 +59,10 @@ const PhishingLandingPage = () => {
             </Typography>
           </Field>
           <Field label={t('Capture submitted data')}>
-            <BooleanChip
-              enabled={landingPage.phishing_landing_page_capture_submitted_data === true}
+            <ItemBoolean
+              status={landingPage.phishing_landing_page_capture_submitted_data === true}
               label={landingPage.phishing_landing_page_capture_submitted_data ? t('Yes') : t('No')}
+              variant="inList"
             />
           </Field>
           <Field label={t('Capture passwords')}>
@@ -86,9 +72,10 @@ const PhishingLandingPage = () => {
               gap: 0.75,
             }}
             >
-              <BooleanChip
-                enabled={landingPage.phishing_landing_page_capture_passwords === true}
+              <ItemBoolean
+                status={landingPage.phishing_landing_page_capture_passwords === true}
                 label={landingPage.phishing_landing_page_capture_passwords ? t('Yes') : t('No')}
+                variant="inList"
               />
               <Tooltip title={t('When enabled, credentials submitted by recipients (username and password) are captured and tracked per target. When disabled, only the submission event is recorded - passwords are never stored.')}>
                 <InfoOutlined sx={{


### PR DESCRIPTION
## Summary

Fixes UI regressions in the full-page phishing editors shipped in #7304.

- Preview pane now fills the right half of both the landing page and lure email
  editors. `PhishingHtmlPreview`'s root sized to its header text width inside the
  flex-row pane, collapsing the `width:100%` iframe to a ~190px strip with a
  large empty area beside it; the root now takes full width, so the intended
  50/50 form + preview split holds.
- Landing page overview boolean chips ("Capture submitted data", "Capture
  passwords") now use the shared `ItemBoolean` component instead of a local solid
  MUI success-green chip, matching the lure email overview and the rest of the
  app.
- The lure email editor preview falls back to the plain-text body (line breaks
  preserved, content escaped) when the HTML body is empty, so a text-only
  template previews its real content instead of a blank page.

## Test plan
- [ ] Landing page editor: preview fills the right half (no narrow strip / empty gap)
- [ ] Lure email editor: preview fills the right half
- [ ] Email editor with only a text body: preview shows that text
- [ ] Landing page overview chips match the ItemBoolean styling used elsewhere
- [ ] yarn check-ts and yarn lint green

Closes #7306
