### PR TITLE
fix(workflows): read PR labels live in documentation gap check

### DIFF
--- a/.github/workflows/copilot-docs-review.yml
+++ b/.github/workflows/copilot-docs-review.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           script: |
             const MARKER = '<!-- openaev-docs-gap-check -->';
-            const SKIP_LABEL = 'docs-not-needed';
+            const SKIP_LABELS = ['No need documentation', 'docs-not-needed'];
+            const SKIP_LABEL = SKIP_LABELS[0];
 
             // -- helpers --------------------------------------------------
 
@@ -40,13 +41,24 @@ jobs:
 
             // -- 1. skip label --------------------------------------------
 
-            const prLabels = context.payload.pull_request.labels.map(l => l.name);
-            if (prLabels.includes(SKIP_LABEL)) {
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            const normalize = name => name.trim().toLowerCase();
+            const skipSet = new Set(SKIP_LABELS.map(normalize));
+            const matchedLabel = pr.labels
+              .map(l => l.name)
+              .find(name => skipSet.has(normalize(name)));
+
+            if (matchedLabel) {
               await upsertComment([
                 MARKER,
                 '📖 **Documentation check** — ✅ Skipped',
                 '',
-                `\`${SKIP_LABEL}\` label is present on this PR.`,
+                `\`${matchedLabel}\` label is present on this PR.`,
               ].join('\n'));
               return;
             }
@@ -233,7 +245,7 @@ jobs:
 
             if (blocking.length > 0) {
               lines.push('### Blocking gaps', '');
-              lines.push('Update the docs or add the `docs-not-needed` label to bypass.', '');
+              lines.push(`Update the docs or add the \`${SKIP_LABEL}\` label to bypass.`, '');
               for (const g of blocking) {
                 lines.push(`#### ${g.emoji} ${g.title}`);
                 lines.push(`- **File**: \`${g.file}\``);


### PR DESCRIPTION
## Problem

The documentation gap check could not be bypassed, even with the skip label applied.

Two separate defects:

1. **The label was read from a stale payload.** `context.payload.pull_request.labels` is a frozen snapshot of the event that triggered the run. Adding the label after a failed run left it invisible, and *Re-run failed jobs* replays that same payload — so the natural recovery path silently did nothing.
2. **The expected label does not exist.** The script looked for `docs-not-needed`. This repository only has `No need documentation`. The bypass advertised in the failure comment was therefore impossible to apply.

Seen on #7127: label applied, re-run attempted, check still red.

## Fix

- Fetch the pull request through `pulls.get` so the label list reflects live state. A re-run after labelling now works.
- Match against `No need documentation`, case-insensitively and trimmed. `docs-not-needed` is kept as an accepted alias so nothing that already references it breaks.
- All user-facing messages now derive the advertised label from the same constant, so the comment can no longer name a label the check does not accept.

## Notes

`pulls.get` needs `pull-requests: read`; the job already grants `pull-requests: write`, so permissions are unchanged.