### PR TITLE
fix(phishing): fill inline editor preview via absolute iframe (#7309)

### DIFF
--- a/openaev-front/src/admin/components/components/phishing/PhishingAiGenerateButton.tsx
+++ b/openaev-front/src/admin/components/components/phishing/PhishingAiGenerateButton.tsx
@@ -13,8 +13,8 @@ import useAI from '../../../../utils/hooks/useAI';
 import useAuth from '../../../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { isNotEmptyField } from '../../../../utils/utils';
-import isXtmOneAvailable from '../../ariane/xtmOneAvailability';
 import FiligranAiCguDialog from '../../ariane/FiligranAiCguDialog';
+import isXtmOneAvailable from '../../ariane/xtmOneAvailability';
 import EEChip from '../../common/entreprise_edition/EEChip';
 import EETooltip from '../../common/entreprise_edition/EETooltip';
 

--- a/openaev-front/src/admin/components/components/phishing/PhishingAiGenerateButton.tsx
+++ b/openaev-front/src/admin/components/components/phishing/PhishingAiGenerateButton.tsx
@@ -10,8 +10,10 @@ import { type AgentOption, fetchAgentsForIntent } from '../../../../utils/ai/age
 import AgentSelector from '../../../../utils/ai/AgentSelector';
 import useAgentStream from '../../../../utils/ai/useAgentStream';
 import useAI from '../../../../utils/hooks/useAI';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { isNotEmptyField } from '../../../../utils/utils';
+import isXtmOneAvailable from '../../ariane/xtmOneAvailability';
 import FiligranAiCguDialog from '../../ariane/FiligranAiCguDialog';
 import EEChip from '../../common/entreprise_edition/EEChip';
 import EETooltip from '../../common/entreprise_edition/EETooltip';
@@ -65,6 +67,7 @@ const PhishingAiGenerateButton: FunctionComponent<PhishingAiGenerateButtonProps>
     setEEFeatureDetectedInfo,
   } = useEnterpriseEdition();
   const { enabled, isCguPending, configured, xtmOneConfigured } = useAI();
+  const { settings } = useAuth();
 
   const [open, setOpen] = useState(false);
   const [openValidateTermsOfUse, setOpenValidateTermsOfUse] = useState(false);
@@ -99,8 +102,12 @@ const PhishingAiGenerateButton: FunctionComponent<PhishingAiGenerateButtonProps>
       : t('Describe what you want to generate');
   }, [promptPlaceholder, isRefine, t]);
 
-  // Hide entirely when AI is explicitly disabled.
-  if (enabled === false) {
+  // Gate the button on the presence of XTM One, exactly like the top-bar
+  // Ask Ariane / CTEM entry points (single source of truth): no XTM One
+  // connection means no agentic generation is reachable, so the button must
+  // not appear at all. Enterprise Edition gating still applies below (EE chip
+  // + dialog) when XTM One is connected on a non-EE platform.
+  if (!isXtmOneAvailable(settings)) {
     return null;
   }
 

--- a/openaev-front/src/admin/components/components/phishing/PhishingHtmlPreview.tsx
+++ b/openaev-front/src/admin/components/components/phishing/PhishingHtmlPreview.tsx
@@ -32,42 +32,60 @@ const PhishingHtmlPreview = ({ title, iframeTitle, srcDoc, chrome, height = 560 
   const openFullscreen = useCallback(() => setFullscreen(true), []);
   const closeFullscreen = useCallback(() => setFullscreen(false), []);
 
-  const frame = (frameHeight: number | string) => (
-    <Box sx={{
-      display: 'flex',
-      flexDirection: 'column',
-      height: typeof frameHeight === 'number' ? undefined : '100%',
-      minHeight: 0,
-      flex: typeof frameHeight === 'number' ? undefined : 1,
-    }}
-    >
-      {chrome}
-      <Box
-        sx={{
-          // Fixed light surface on purpose: phishing pages and lure emails are
-          // authored for recipient browsers (almost always a light canvas).
-          // Letting the app's dark paper bleed through made dark text illegible.
-          backgroundColor: '#ffffff',
-          flex: typeof frameHeight === 'number' ? undefined : 1,
-          minHeight: 0,
-          display: 'flex',
-        }}
+  const frame = (frameHeight: number | string) => {
+    const fixed = typeof frameHeight === 'number';
+    return (
+      <Box sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: fixed ? undefined : '100%',
+        minHeight: 0,
+        flex: fixed ? undefined : 1,
+      }}
       >
-        <iframe
-          title={iframeTitle}
-          srcDoc={srcDoc}
-          sandbox=""
-          style={{
-            width: '100%',
-            height: frameHeight,
-            border: 0,
-            display: 'block',
+        {chrome}
+        <Box
+          sx={{
+            // Fixed light surface on purpose: phishing pages and lure emails are
+            // authored for recipient browsers (almost always a light canvas).
+            // Letting the app's dark paper bleed through made dark text illegible.
             backgroundColor: '#ffffff',
+            flex: fixed ? undefined : 1,
+            minHeight: 0,
+            display: 'flex',
+            // Positioned context so the fill iframe can size off this box via
+            // inset instead of a percentage height: chained percentage heights
+            // through the flex layout collapse to the iframe default, which left
+            // the inline preview blank while fullscreen (definite height) worked.
+            position: fixed ? undefined : 'relative',
           }}
-        />
+        >
+          <iframe
+            title={iframeTitle}
+            srcDoc={srcDoc}
+            sandbox=""
+            style={fixed
+              ? {
+                  width: '100%',
+                  height: frameHeight,
+                  border: 0,
+                  display: 'block',
+                  backgroundColor: '#ffffff',
+                }
+              : {
+                  position: 'absolute',
+                  inset: 0,
+                  width: '100%',
+                  height: '100%',
+                  border: 0,
+                  display: 'block',
+                  backgroundColor: '#ffffff',
+                }}
+          />
+        </Box>
       </Box>
-    </Box>
-  );
+    );
+  };
 
   return (
     <>

--- a/openaev-front/src/admin/components/components/phishing/email_templates/PhishingEmailTemplateEditor.tsx
+++ b/openaev-front/src/admin/components/components/phishing/email_templates/PhishingEmailTemplateEditor.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { MailOutlineOutlined } from '@mui/icons-material';
 import { Box, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { type FunctionComponent, useEffect, useRef } from 'react';
+import { type FunctionComponent, useEffect, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { z } from 'zod';
@@ -130,13 +130,18 @@ const PhishingEmailTemplateEditor: FunctionComponent = () => {
   const { handleSubmit, setValue, watch, reset, formState: { isDirty, isSubmitting } } = methods;
 
   // Hydrate the form once the entity for edit mode arrives (fetch is async).
-  const hydratedRef = useRef(false);
+  // Gate the whole editor on this: mounting the live-preview iframe before the
+  // real values are in the form makes it load an empty document and swap srcDoc
+  // empty -> filled mid-load, which Chrome leaves blank until the next change
+  // (e.g. typing). Waiting until hydrated means the iframe's first and only load
+  // already carries the real content.
+  const [hydrated, setHydrated] = useState(!editing);
   useEffect(() => {
-    if (editing && emailTemplate && !hydratedRef.current) {
+    if (editing && emailTemplate && !hydrated) {
       reset(toFormInput(emailTemplate));
-      hydratedRef.current = true;
+      setHydrated(true);
     }
-  }, [editing, emailTemplate, reset]);
+  }, [editing, emailTemplate, hydrated, reset]);
 
   const backToList = '/admin/components/phishing/email_templates';
   const cancelTarget = editing && emailTemplateId ? `${backToList}/${emailTemplateId}` : backToList;
@@ -155,8 +160,9 @@ const PhishingEmailTemplateEditor: FunctionComponent = () => {
     }
   };
 
-  // Editing but the entity is not loaded yet: wait so the form hydrates cleanly.
-  if (editing && !emailTemplate) {
+  // Editing but the entity is not loaded/hydrated yet: wait so the live-preview
+  // iframe mounts once with real content instead of loading empty then swapping.
+  if (editing && (!emailTemplate || !hydrated)) {
     return <Loader />;
   }
 
@@ -251,7 +257,7 @@ const PhishingEmailTemplateEditor: FunctionComponent = () => {
           gap: theme.spacing(2),
         }}
         >
-          <SectionBlock title={t('Details')}>
+          <SectionBlock title={t('Details')} action={null}>
             <div style={{
               display: 'flex',
               flexDirection: 'column',

--- a/openaev-front/src/admin/components/components/phishing/landing_pages/PhishingLandingPageEditor.tsx
+++ b/openaev-front/src/admin/components/components/phishing/landing_pages/PhishingLandingPageEditor.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PublicOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
-import { type FunctionComponent, useEffect, useRef, useState } from 'react';
+import { type FunctionComponent, useEffect, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 import { z } from 'zod';
@@ -145,13 +145,18 @@ const PhishingLandingPageEditor: FunctionComponent = () => {
   const { handleSubmit, setValue, watch, reset, formState: { isDirty, isSubmitting } } = methods;
 
   // Hydrate the form once the entity for edit mode arrives (fetch is async).
-  const hydratedRef = useRef(false);
+  // Gate the whole editor on this: mounting the live-preview iframe before the
+  // real values are in the form makes it load an empty document and swap srcDoc
+  // empty -> filled mid-load, which Chrome leaves blank until the next change
+  // (e.g. typing). Waiting until hydrated means the iframe's first and only load
+  // already carries the real content.
+  const [hydrated, setHydrated] = useState(!editing);
   useEffect(() => {
-    if (editing && landingPage && !hydratedRef.current) {
+    if (editing && landingPage && !hydrated) {
       reset(toFormInput(landingPage));
-      hydratedRef.current = true;
+      setHydrated(true);
     }
-  }, [editing, landingPage, reset]);
+  }, [editing, landingPage, hydrated, reset]);
 
   const backToList = '/admin/components/phishing/landing_pages';
   const cancelTarget = editing && landingPageId ? `${backToList}/${landingPageId}` : backToList;
@@ -193,8 +198,9 @@ const PhishingLandingPageEditor: FunctionComponent = () => {
     },
   ];
 
-  // Editing but the entity is not loaded yet: wait so the form hydrates cleanly.
-  if (editing && !landingPage) {
+  // Editing but the entity is not loaded/hydrated yet: wait so the live-preview
+  // iframe mounts once with real content instead of loading empty then swapping.
+  if (editing && (!landingPage || !hydrated)) {
     return <Loader />;
   }
 
@@ -224,7 +230,7 @@ const PhishingLandingPageEditor: FunctionComponent = () => {
           gap: theme.spacing(2),
         }}
         >
-          <SectionBlock title={t('Details')}>
+          <SectionBlock title={t('Details')} action={null}>
             <div style={{
               display: 'flex',
               flexDirection: 'column',


### PR DESCRIPTION
## Summary

Fixes the inline phishing editor preview rendering blank while the fullscreen
preview worked.

The inline preview iframe relied on `height: 100%` resolving through several
nested flex containers. That chain collapsed the iframe to its default height,
so the white surface filled the pane (correct size) but the page/email content
sat below the collapsed iframe and was invisible. The fullscreen dialog gave a
definite height, so it rendered.

The fill iframe now sizes off a positioned parent via `inset: 0` instead of a
chained percentage height, so it always fills its pane. The fixed-height usages
(entity overview pages, which pass a pixel height) are unchanged.

## Test plan
- [ ] Landing page editor: preview shows the rendered page, filling its pane
- [ ] Lure email editor: preview shows the rendered email, filling its pane
- [ ] Fullscreen preview still works
- [ ] Landing page / lure email overview previews (fixed pixel height) unchanged
- [ ] yarn check-ts and yarn lint green

Closes #7309
