### PR TITLE
fix(phishing): resolve recipient team name to id for phishing_results (#7311)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
@@ -133,8 +133,8 @@ public class PhishingExecutor extends Injector {
 
     // The execution context carries each recipient's team NAME (see InjectHelper), but
     // phishing_result_team is an FK to teams.team_id. Map the name back to the real id from the
-    // inject's target teams; otherwise createResult would insert the name ("CEO") as the team id and
-    // fail the phishing_results_team_fk constraint. Duplicate names keep the first (any is correct).
+    // inject's target teams; otherwise createResult inserts the name ("CEO") as the team id and
+    // fails the phishing_results_team_fk constraint. Duplicate names keep the first (any is right).
     Map<String, String> teamIdByName =
         injection.getTeams().stream()
             .collect(Collectors.toMap(Team::getName, Team::getId, (first, ignored) -> first));

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
@@ -13,6 +13,7 @@ import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.PhishingEmailTemplate;
 import io.openaev.database.model.PhishingLandingPage;
 import io.openaev.database.model.PhishingResult;
+import io.openaev.database.model.Team;
 import io.openaev.database.repository.PhishingEmailTemplateRepository;
 import io.openaev.database.repository.PhishingLandingPageRepository;
 import io.openaev.execution.ExecutableInject;
@@ -30,6 +31,8 @@ import io.openaev.model.ExecutionProcess;
 import io.openaev.service.InjectExpectationService;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
@@ -128,13 +131,22 @@ public class PhishingExecutor extends Injector {
             .toList();
     injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
 
+    // The execution context carries each recipient's team NAME (see InjectHelper), but
+    // phishing_result_team is an FK to teams.team_id. Map the name back to the real id from the
+    // inject's target teams; otherwise createResult would insert the name ("CEO") as the team id and
+    // fail the phishing_results_team_fk constraint. Duplicate names keep the first (any is correct).
+    Map<String, String> teamIdByName =
+        injection.getTeams().stream()
+            .collect(Collectors.toMap(Team::getName, Team::getId, (first, ignored) -> first));
+
     for (ExecutionContext userContext : users) {
       try {
         ProtectUser targetUser = userContext.getUser();
-        String teamId =
+        String teamName =
             userContext.getTeams() != null && !userContext.getTeams().isEmpty()
                 ? userContext.getTeams().getFirst()
                 : null;
+        String teamId = teamName != null ? teamIdByName.get(teamName) : null;
         PhishingResult result =
             phishingTrackingService.createResult(inject, landingPage, targetUser.getId(), teamId);
         // Victim-facing landing URL: e.g. https://security.acme.com/auth/<token> - benign path, no

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/PhishingExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/PhishingExecutorTest.java
@@ -1,0 +1,117 @@
+package io.openaev.injectors.phishing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import io.openaev.config.OpenAEVConfig;
+import io.openaev.database.model.Execution;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Injection;
+import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.PhishingEmailTemplate;
+import io.openaev.database.model.PhishingLandingPage;
+import io.openaev.database.model.PhishingResult;
+import io.openaev.database.model.Team;
+import io.openaev.database.model.User;
+import io.openaev.database.repository.PhishingEmailTemplateRepository;
+import io.openaev.database.repository.PhishingLandingPageRepository;
+import io.openaev.execution.ExecutableInject;
+import io.openaev.execution.ExecutionContext;
+import io.openaev.executors.InjectorContext;
+import io.openaev.injectors.email.service.EmailService;
+import io.openaev.injectors.phishing.model.PhishingContent;
+import io.openaev.injectors.phishing.service.PhishingTrackingService;
+import io.openaev.service.InjectExpectationService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayName("Phishing executor tests")
+class PhishingExecutorTest {
+
+  @Test
+  @DisplayName("createResult receives the resolved team id, not the team name (phishing_results_team_fk)")
+  void process_should_resolveTeamNameToTeamId() throws Exception {
+    // Collaborators
+    InjectorContext context = mock(InjectorContext.class);
+    EmailService emailService = mock(EmailService.class);
+    InjectExpectationService injectExpectationService = mock(InjectExpectationService.class);
+    PhishingTrackingService phishingTrackingService = mock(PhishingTrackingService.class);
+    PhishingLandingPageRepository landingPageRepository = mock(PhishingLandingPageRepository.class);
+    PhishingEmailTemplateRepository emailTemplateRepository =
+        mock(PhishingEmailTemplateRepository.class);
+
+    OpenAEVConfig config = mock(OpenAEVConfig.class);
+    when(context.getOpenAEVConfig()).thenReturn(config);
+    when(config.getBaseUrl()).thenReturn("https://app.test");
+    when(config.getDefaultReplyTo()).thenReturn("noreply@app.test");
+    when(config.getDefaultMailer()).thenReturn("mailer@app.test");
+    when(config.getDefaultMailerName()).thenReturn("Mailer");
+
+    PhishingExecutor executor =
+        new PhishingExecutor(
+            context,
+            emailService,
+            injectExpectationService,
+            phishingTrackingService,
+            landingPageRepository,
+            emailTemplateRepository);
+
+    // The target team: the execution context carries its NAME, the FK needs its ID.
+    Team team = new Team();
+    team.setId("team-ceo-id");
+    team.setName("CEO");
+
+    User user = new User();
+    user.setId("user-1");
+    user.setEmail("ceo@corp.test");
+    ExecutionContext userContext = new ExecutionContext(user, List.of("CEO"));
+
+    InjectorContract contract = new InjectorContract();
+    contract.setId("lp-1");
+    Inject inject = new Inject();
+    inject.setId("inject-1");
+    inject.setInjectorContract(contract);
+
+    PhishingLandingPage landingPage = new PhishingLandingPage();
+    when(landingPageRepository.findById("lp-1")).thenReturn(Optional.of(landingPage));
+
+    PhishingEmailTemplate emailTemplate = new PhishingEmailTemplate();
+    emailTemplate.setSubject("Subject");
+    when(emailTemplateRepository.findById("template-1")).thenReturn(Optional.of(emailTemplate));
+
+    PhishingContent content = new PhishingContent();
+    content.setEmailTemplate("template-1");
+
+    ExecutableInject injection = mock(ExecutableInject.class);
+    Injection injectionEntity = mock(Injection.class);
+    when(injection.getInjection()).thenReturn(injectionEntity);
+    when(injectionEntity.getInject()).thenReturn(inject);
+    when(injectionEntity.getExercise()).thenReturn(null);
+    when(injection.getUsers()).thenReturn(List.of(userContext));
+    when(injection.getTeams()).thenReturn(List.of(team));
+    when(injectExpectationService.contentConvert(injection, PhishingContent.class))
+        .thenReturn(content);
+
+    PhishingResult result = new PhishingResult();
+    result.setToken("token-1");
+    when(phishingTrackingService.createResult(any(), any(), any(), any())).thenReturn(result);
+
+    Execution execution = mock(Execution.class);
+
+    executor.process(execution, injection);
+
+    ArgumentCaptor<String> teamCaptor = ArgumentCaptor.forClass(String.class);
+    verify(phishingTrackingService)
+        .createResult(eq(inject), eq(landingPage), eq("user-1"), teamCaptor.capture());
+    // The bug wrote the team NAME ("CEO") into phishing_result_team (an FK to teams.team_id),
+    // failing phishing_results_team_fk. The fix resolves it to the real team id.
+    assertEquals("team-ceo-id", teamCaptor.getValue());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/PhishingExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/PhishingExecutorTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.database.model.Execution;

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/PhishingExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/PhishingExecutorTest.java
@@ -36,7 +36,8 @@ import org.mockito.ArgumentCaptor;
 class PhishingExecutorTest {
 
   @Test
-  @DisplayName("createResult receives the resolved team id, not the team name (phishing_results_team_fk)")
+  @DisplayName(
+      "createResult receives the resolved team id, not the team name (phishing_results_team_fk)")
   void process_should_resolveTeamNameToTeamId() throws Exception {
     // Collaborators
     InjectorContext context = mock(InjectorContext.class);


### PR DESCRIPTION
## Summary

Fixes a production foreign key violation that made phishing atomic tests /
simulations fail at send time whenever they target a team.

`PhishingExecutor` built the per-recipient tracking row from the execution
context's team value:

```java
String teamId = userContext.getTeams().getFirst();
phishingTrackingService.createResult(inject, landingPage, userId, teamId);
```

But `ExecutionContext.getTeams()` carries team NAMES, not ids - `InjectHelper`
populates it with `team.getName()` for both the atomic-testing and simulation
paths. `createResult` stores that value in `phishing_result_team`, a foreign key
to `teams.team_id`, so the insert failed:

```
ERROR: insert or update on table "phishing_results"
  violates foreign key constraint "phishing_results_team_fk"
  Detail: Key (phishing_result_team)=(CEO) is not present in table "teams".
```

Because the write runs in its own `REQUIRES_NEW` transaction, it rolled back and
no tracking row was ever persisted (opens / clicks / submits untrackable).

## Changes

- `PhishingExecutor` now builds a team-name -> team-id map from the inject's
  target teams (`injection.getTeams()`, the exact source of the context names,
  covering the all-teams case) and resolves the recipient's team name to the real
  id before calling `createResult`. An unknown name resolves to `null` (no team),
  never to an invalid FK value.
- Adds `PhishingExecutorTest` asserting `createResult` receives the resolved team
  id, not the name.

## Test plan

- [ ] `PhishingExecutorTest` passes.
- [ ] Manual: run a phishing atomic test targeting a team with >= 1 player; a
      `phishing_results` row is created and no FK violation is logged.

Closes #7311
