### PR TITLE
fix(phishing): surface findings and score three inverted awareness steps (#7313)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
@@ -131,9 +131,9 @@ public class PhishingExecutor extends Injector {
             .toList();
     injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
 
-    // Phishing expectations are inverted: pre-score every step to GREEN ("resisted") now, before any
-    // lure is sent. The matching open/click/submit transition flips a step to RED ("fell for it")
-    // later. A recipient who never interacts keeps the green verdict, because the expiration
+    // Phishing expectations are inverted: pre-score every step to GREEN ("resisted") now, before
+    // any lure is sent. The matching open/click/submit transition flips a step to RED ("fell for
+    // it") later. A recipient who never interacts keeps the green verdict, because the expiration
     // collector only touches rows whose score is still null.
     phishingTrackingService.initializeExpectationsAsResisted(inject.getId());
 

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/PhishingExecutor.java
@@ -131,6 +131,12 @@ public class PhishingExecutor extends Injector {
             .toList();
     injectExpectationService.buildAndSaveInjectExpectations(injection, expectations);
 
+    // Phishing expectations are inverted: pre-score every step to GREEN ("resisted") now, before any
+    // lure is sent. The matching open/click/submit transition flips a step to RED ("fell for it")
+    // later. A recipient who never interacts keeps the green verdict, because the expiration
+    // collector only touches rows whose score is still null.
+    phishingTrackingService.initializeExpectationsAsResisted(inject.getId());
+
     // The execution context carries each recipient's team NAME (see InjectHelper), but
     // phishing_result_team is an FK to teams.team_id. Map the name back to the real id from the
     // inject's target teams; otherwise createResult inserts the name ("CEO") as the team id and

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/api/HostedPublicApi.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/api/HostedPublicApi.java
@@ -12,6 +12,7 @@ import io.openaev.rest.helper.RestBehavior;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -98,11 +99,7 @@ public class HostedPublicApi extends RestBehavior {
     }
     Optional<PhishingResult> result =
         phishingTrackingService.markSubmitted(
-            token,
-            resolveUsername(input),
-            resolvePassword(input),
-            clientIp(request),
-            request.getHeader("User-Agent"));
+            token, submittedFields(input), clientIp(request), request.getHeader("User-Agent"));
     String redirectUrl =
         result
             .map(PhishingResult::getLandingPage)
@@ -138,34 +135,23 @@ public class HostedPublicApi extends RestBehavior {
         .body(TRACKING_PIXEL);
   }
 
-  private String resolveUsername(PhishingSubmitInput input) {
+  /**
+   * Flattens the submitted payload into a single field map: the free-form {@code data} map plus the
+   * explicit {@code username} / {@code password} fields (when present). The tracking service resolves
+   * the credential out of this map and keeps every field as the completeness record.
+   */
+  private Map<String, String> submittedFields(PhishingSubmitInput input) {
+    Map<String, String> fields = new LinkedHashMap<>();
+    if (input.getData() != null) {
+      fields.putAll(input.getData());
+    }
     if (input.getUsername() != null && !input.getUsername().isBlank()) {
-      return input.getUsername();
+      fields.putIfAbsent("username", input.getUsername());
     }
-    if (input.getData() != null) {
-      for (String key : new String[] {"username", "email", "user", "login"}) {
-        String value = input.getData().get(key);
-        if (value != null && !value.isBlank()) {
-          return value;
-        }
-      }
-    }
-    return null;
-  }
-
-  private String resolvePassword(PhishingSubmitInput input) {
     if (input.getPassword() != null && !input.getPassword().isBlank()) {
-      return input.getPassword();
+      fields.putIfAbsent("password", input.getPassword());
     }
-    if (input.getData() != null) {
-      for (String key : new String[] {"password", "passwd", "pass"}) {
-        String value = input.getData().get(key);
-        if (value != null && !value.isBlank()) {
-          return value;
-        }
-      }
-    }
-    return null;
+    return fields;
   }
 
   /** Best-effort client IP, honoring a single X-Forwarded-For hop. */

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/api/HostedPublicApi.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/api/HostedPublicApi.java
@@ -137,13 +137,22 @@ public class HostedPublicApi extends RestBehavior {
 
   /**
    * Flattens the submitted payload into a single field map: the free-form {@code data} map plus the
-   * explicit {@code username} / {@code password} fields (when present). The tracking service resolves
-   * the credential out of this map and keeps every field as the completeness record.
+   * explicit {@code username} / {@code password} fields (when present). The tracking service
+   * resolves the credential out of this map and keeps every field as the completeness record. Blank
+   * {@code data} values are dropped so an empty {@code data.username} / {@code data.password} never
+   * blocks the non-blank dedicated fields from being captured.
    */
   private Map<String, String> submittedFields(PhishingSubmitInput input) {
     Map<String, String> fields = new LinkedHashMap<>();
     if (input.getData() != null) {
-      fields.putAll(input.getData());
+      input
+          .getData()
+          .forEach(
+              (key, value) -> {
+                if (value != null && !value.isBlank()) {
+                  fields.put(key, value);
+                }
+              });
     }
     if (input.getUsername() != null && !input.getUsername().isBlank()) {
       fields.putIfAbsent("username", input.getUsername());

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/api/PhishingPublicApi.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/api/PhishingPublicApi.java
@@ -11,6 +11,7 @@ import io.openaev.rest.helper.RestBehavior;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -97,11 +98,7 @@ public class PhishingPublicApi extends RestBehavior {
     TenantContext.setCurrentTenant(tenantId);
     Optional<PhishingResult> result =
         phishingTrackingService.markSubmitted(
-            token,
-            resolveUsername(input),
-            resolvePassword(input),
-            clientIp(request),
-            request.getHeader("User-Agent"));
+            token, submittedFields(input), clientIp(request), request.getHeader("User-Agent"));
     String redirectUrl =
         result
             .map(PhishingResult::getLandingPage)
@@ -110,34 +107,23 @@ public class PhishingPublicApi extends RestBehavior {
     return java.util.Collections.singletonMap("redirect_url", redirectUrl);
   }
 
-  private String resolveUsername(PhishingSubmitInput input) {
+  /**
+   * Flattens the submitted payload into a single field map: the free-form {@code data} map plus the
+   * explicit {@code username} / {@code password} fields (when present). The tracking service resolves
+   * the credential out of this map and keeps every field as the completeness record.
+   */
+  private Map<String, String> submittedFields(PhishingSubmitInput input) {
+    Map<String, String> fields = new LinkedHashMap<>();
+    if (input.getData() != null) {
+      fields.putAll(input.getData());
+    }
     if (input.getUsername() != null && !input.getUsername().isBlank()) {
-      return input.getUsername();
+      fields.putIfAbsent("username", input.getUsername());
     }
-    if (input.getData() != null) {
-      for (String key : new String[] {"username", "email", "user", "login"}) {
-        String value = input.getData().get(key);
-        if (value != null && !value.isBlank()) {
-          return value;
-        }
-      }
-    }
-    return null;
-  }
-
-  private String resolvePassword(PhishingSubmitInput input) {
     if (input.getPassword() != null && !input.getPassword().isBlank()) {
-      return input.getPassword();
+      fields.putIfAbsent("password", input.getPassword());
     }
-    if (input.getData() != null) {
-      for (String key : new String[] {"password", "passwd", "pass"}) {
-        String value = input.getData().get(key);
-        if (value != null && !value.isBlank()) {
-          return value;
-        }
-      }
-    }
-    return null;
+    return fields;
   }
 
   /** Best-effort client IP, honoring a single X-Forwarded-For hop. */

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/api/PhishingPublicApi.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/api/PhishingPublicApi.java
@@ -109,13 +109,22 @@ public class PhishingPublicApi extends RestBehavior {
 
   /**
    * Flattens the submitted payload into a single field map: the free-form {@code data} map plus the
-   * explicit {@code username} / {@code password} fields (when present). The tracking service resolves
-   * the credential out of this map and keeps every field as the completeness record.
+   * explicit {@code username} / {@code password} fields (when present). The tracking service
+   * resolves the credential out of this map and keeps every field as the completeness record. Blank
+   * {@code data} values are dropped so an empty {@code data.username} / {@code data.password} never
+   * blocks the non-blank dedicated fields from being captured.
    */
   private Map<String, String> submittedFields(PhishingSubmitInput input) {
     Map<String, String> fields = new LinkedHashMap<>();
     if (input.getData() != null) {
-      fields.putAll(input.getData());
+      input
+          .getData()
+          .forEach(
+              (key, value) -> {
+                if (value != null && !value.isBlank()) {
+                  fields.put(key, value);
+                }
+              });
     }
     if (input.getUsername() != null && !input.getUsername().isBlank()) {
       fields.putIfAbsent("username", input.getUsername());

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -26,7 +26,6 @@ import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.InjectorContractId;
 import io.openaev.database.model.PhishingEmailTemplate;
 import io.openaev.database.model.PhishingLandingPage;
-import io.openaev.database.model.SecurityPlatform;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.PhishingEmailTemplateRepository;
@@ -53,7 +52,6 @@ import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -421,25 +419,35 @@ public class PhishingLandingPageService {
   }
 
   /**
-   * Available expectations for a phishing action. Like most technical injector contracts, phishing
-   * carries PREVENTION and DETECTION on top of the always-available MANUAL expectation: a phishing
-   * simulation is only meaningful if the platform can score whether the lure was blocked
-   * (prevention) or detected (detection). Both are predefined so every phishing inject measures
-   * them by default, and both are focused on {@link
-   * SecurityPlatform.SECURITY_PLATFORM_TYPE#EMAIL_SECURITY} platforms - the security control that
-   * actually inspects inbound mail - instead of asking every connected collector for a verdict.
+   * Available expectations for a phishing action: the three human-response steps of a phishing test
+   * - the recipient opening the lure email, following the link (landing page loaded) and submitting
+   * data. Each is a predefined MANUAL expectation, so every phishing inject measures all three by
+   * default. Their polarity is inverted (see {@link PhishingTrackingService}): a step is GREEN
+   * ("resisted") while the recipient has not performed it and flips RED ("fell for it") the moment
+   * they do, so a recipient who never interacts keeps the green verdict through expiration.
    */
   private List<Expectation> buildPhishingExpectations() {
-    Expectation prevention = this.expectationBuilderService.buildPreventionExpectation();
-    prevention.setPredefined(true);
-    prevention.setExpectedSecurityPlatformTypes(
-        new ArrayList<>(List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.EMAIL_SECURITY)));
+    return List.of(
+        buildPhishingStep(
+            PhishingTrackingService.STEP_OPENED,
+            "Red once the recipient opens the lure email (tracking pixel loaded); green while the"
+                + " email is never opened."),
+        buildPhishingStep(
+            PhishingTrackingService.STEP_CLICKED,
+            "Red once the recipient opens the phishing landing page; green while the link is never"
+                + " followed."),
+        buildPhishingStep(
+            PhishingTrackingService.STEP_SUBMITTED,
+            "Red once the recipient submits data on the phishing page; green while nothing is ever"
+                + " submitted."));
+  }
 
-    Expectation detection = this.expectationBuilderService.buildDetectionExpectation();
-    detection.setPredefined(true);
-    detection.setExpectedSecurityPlatformTypes(
-        new ArrayList<>(List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.EMAIL_SECURITY)));
-
-    return List.of(detection, prevention, this.expectationBuilderService.buildManualExpectation());
+  private Expectation buildPhishingStep(final String name, final String description) {
+    Expectation expectation = this.expectationBuilderService.buildManualExpectation();
+    expectation.setName(name);
+    expectation.setDescription(description);
+    expectation.setPredefined(true);
+    expectation.setMultiSelectable(false);
+    return expectation;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
@@ -48,14 +48,16 @@ import org.springframework.transaction.annotation.Transactional;
  * the recipient RESISTED a step (opening the lure, following the link, submitting data). Resisting
  * is the desired outcome, so each of the three step expectations is pre-scored to its full expected
  * score at send time - GREEN / "resisted" - by {@link #initializeExpectationsAsResisted(String)}.
- * The matching transition then flips the step to a zero score - RED / "fell for it" - the moment the
- * recipient performs it. Because a pre-scored row is no longer {@code score IS NULL}, the generic
- * expiration collector never touches these rows: a recipient who never interacts simply keeps the
- * green "resisted" verdict for good, which is exactly the intended "expired means success" semantics
- * without a bespoke expiration branch.
+ * The matching transition then flips the step to a zero score - RED / "fell for it" - the moment
+ * the recipient performs it. Because a pre-scored row is no longer {@code score IS NULL}, the
+ * generic expiration collector never touches these rows: a recipient who never interacts simply
+ * keeps the green "resisted" verdict for good, which is exactly the intended "expired means
+ * success" semantics without a bespoke expiration branch.
  *
  * <p>All methods are tenant-scoped: the executor runs inside the inject execution job (tenant
- * filter set), and the public endpoints set the tenant from the token before calling in.
+ * filter set), and the public endpoints set the tenant before calling in - {@code HostedPublicApi}
+ * resolves it from the token, while the legacy {@code PhishingPublicApi} routes take it from the
+ * {@code tenantId} path segment.
  */
 @Slf4j
 @Service
@@ -68,8 +70,8 @@ public class PhishingTrackingService {
 
   /**
    * Names of the three phishing-awareness expectation steps. Shared with {@code
-   * PhishingLandingPageService} (which advertises them in the injector contract) so the contract and
-   * the runtime scoring can never drift on which row represents which step.
+   * PhishingLandingPageService} (which advertises them in the injector contract) so the contract
+   * and the runtime scoring can never drift on which row represents which step.
    */
   public static final String STEP_OPENED = "Email opened";
 
@@ -89,8 +91,18 @@ public class PhishingTrackingService {
   // cloned real-world login form (e.g. Microsoft's "loginfmt", not "username") is still captured.
   private static final List<String> USERNAME_KEYS =
       List.of(
-          "username", "email", "user", "login", "loginfmt", "user_name", "userid", "user_id",
-          "identifier", "emailaddress", "e-mail", "account");
+          "username",
+          "email",
+          "user",
+          "login",
+          "loginfmt",
+          "user_name",
+          "userid",
+          "user_id",
+          "identifier",
+          "emailaddress",
+          "e-mail",
+          "account");
   private static final List<String> PASSWORD_KEYS =
       List.of("password", "passwd", "pass", "pwd", "passwordinput", "userpassword");
 
@@ -189,7 +201,9 @@ public class PhishingTrackingService {
     return phishingResultRepository.findTenantIdByToken(token);
   }
 
-  /** Marks the email as opened (first open wins) and flips the "email opened" step to compromised. */
+  /**
+   * Marks the email as opened (first open wins) and flips the "email opened" step to compromised.
+   */
   public Optional<PhishingResult> markOpened(
       @NotBlank final String token, final String ip, final String userAgent) {
     return phishingResultRepository
@@ -232,7 +246,8 @@ public class PhishingTrackingService {
 
   /**
    * Records submitted data, captures it as a {@code Credentials} finding (when the landing page is
-   * configured to capture) and flips all three steps to compromised (a submit implies open + click).
+   * configured to capture) and flips all three steps to compromised (a submit implies open +
+   * click).
    *
    * @param fields the raw submitted form fields (field name to value), used both to build the
    *     credential value and as the completeness record
@@ -317,8 +332,8 @@ public class PhishingTrackingService {
 
   /**
    * Builds the credential value stored on the {@code Credentials} finding. Prefers a recognized
-   * username (plus password when capture is enabled). When no field name is recognized - a custom or
-   * cloned login form with atypical field names - it falls back to capturing every non-empty
+   * username (plus password when capture is enabled). When no field name is recognized - a custom
+   * or cloned login form with atypical field names - it falls back to capturing every non-empty
    * submitted field so a genuine submission is never silently dropped. Returns {@code null} when
    * there is nothing to capture.
    */

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
@@ -1,6 +1,7 @@
 package io.openaev.injectors.phishing.service;
 
 import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.buildForPlayerManualValidation;
+import static io.openaev.utils.inject_expectation_result.ExpectationResultBuilder.buildForTeamManualValidation;
 import static java.time.Instant.now;
 
 import io.openaev.database.model.BaseInjectExpectation;
@@ -10,6 +11,8 @@ import io.openaev.database.model.Inject;
 import io.openaev.database.model.InjectExpectationResult;
 import io.openaev.database.model.PhishingLandingPage;
 import io.openaev.database.model.PhishingResult;
+import io.openaev.database.model.TableTopInjectExpectation;
+import io.openaev.database.model.Team;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.PhishingResultRepository;
@@ -21,8 +24,13 @@ import jakarta.validation.constraints.NotNull;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,13 +41,21 @@ import org.springframework.transaction.annotation.Transactional;
  * Encapsulates the per-recipient tracking lifecycle of the internal phishing injector: creation of
  * the opaque tracking token when the lure email is sent, and the open/click/submit transitions
  * driven by the public tracking endpoints. Also owns the two side effects those transitions carry -
- * auto-fulfilling the recipient's MANUAL inject expectation (mirroring the article auto-fulfill
- * pattern in {@code ChannelService.validateArticles}) and turning submitted data into a {@code
+ * scoring the recipient's phishing-awareness expectations and turning submitted data into a {@code
  * Credentials} {@link Finding}.
  *
+ * <p><b>Expectation polarity is inverted for phishing.</b> A phishing expectation measures whether
+ * the recipient RESISTED a step (opening the lure, following the link, submitting data). Resisting
+ * is the desired outcome, so each of the three step expectations is pre-scored to its full expected
+ * score at send time - GREEN / "resisted" - by {@link #initializeExpectationsAsResisted(String)}.
+ * The matching transition then flips the step to a zero score - RED / "fell for it" - the moment the
+ * recipient performs it. Because a pre-scored row is no longer {@code score IS NULL}, the generic
+ * expiration collector never touches these rows: a recipient who never interacts simply keeps the
+ * green "resisted" verdict for good, which is exactly the intended "expired means success" semantics
+ * without a bespoke expiration branch.
+ *
  * <p>All methods are tenant-scoped: the executor runs inside the inject execution job (tenant
- * filter set), and the public endpoints set the tenant from the {@code tenantId} path segment
- * before calling in.
+ * filter set), and the public endpoints set the tenant from the token before calling in.
  */
 @Slf4j
 @Service
@@ -49,6 +65,34 @@ public class PhishingTrackingService {
 
   /** Finding field used for captured credentials (dedup key together with type + value). */
   public static final String CREDENTIALS_FIELD = "phishing_credentials";
+
+  /**
+   * Names of the three phishing-awareness expectation steps. Shared with {@code
+   * PhishingLandingPageService} (which advertises them in the injector contract) so the contract and
+   * the runtime scoring can never drift on which row represents which step.
+   */
+  public static final String STEP_OPENED = "Email opened";
+
+  public static final String STEP_CLICKED = "Phishing link clicked";
+  public static final String STEP_SUBMITTED = "Credentials submitted";
+
+  private static final Set<String> PHISHING_STEP_NAMES =
+      Set.of(STEP_OPENED, STEP_CLICKED, STEP_SUBMITTED);
+
+  /** Score of a step the recipient fell for (RED). Full expected score is the GREEN "resisted". */
+  private static final double COMPROMISED_SCORE = 0.0;
+
+  /** Result message stamped on a step the recipient never triggered (GREEN). */
+  private static final String NO_INTERACTION_MESSAGE = "No phishing interaction detected";
+
+  // Form-field names accepted as the username / password of a submitted credential. Kept broad so a
+  // cloned real-world login form (e.g. Microsoft's "loginfmt", not "username") is still captured.
+  private static final List<String> USERNAME_KEYS =
+      List.of(
+          "username", "email", "user", "login", "loginfmt", "user_name", "userid", "user_id",
+          "identifier", "emailaddress", "e-mail", "account");
+  private static final List<String> PASSWORD_KEYS =
+      List.of("password", "passwd", "pass", "pwd", "passwordinput", "userpassword");
 
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
@@ -105,6 +149,33 @@ public class PhishingTrackingService {
     return phishingResultRepository.save(result);
   }
 
+  /**
+   * Pre-scores every phishing-awareness expectation of the inject to its full expected score
+   * (GREEN, "resisted"). Called once by the executor right after the expectations are built, before
+   * any lure email is sent, so a recipient starts out having resisted every step. A step is only
+   * flipped to RED later, when the recipient actually performs it. Idempotent: a step that already
+   * carries a result (pre-scored or flipped) is left untouched.
+   */
+  public void initializeExpectationsAsResisted(@NotBlank final String injectId) {
+    injectExpectationRepository.findAllByInjectId(injectId).stream()
+        .filter(PhishingTrackingService::isPhishingStep)
+        .filter(expectation -> hasNoResults(expectation.getResults()))
+        .forEach(
+            expectation -> {
+              boolean team = isTeamRow(expectation);
+              InjectExpectationResult result =
+                  team
+                      ? buildForTeamManualValidation(
+                          NO_INTERACTION_MESSAGE, expectation.getExpectedScore())
+                      : buildForPlayerManualValidation(
+                          NO_INTERACTION_MESSAGE, expectation.getExpectedScore());
+              expectation.setResults(List.of(result));
+              expectation.setScore(expectation.getExpectedScore());
+              expectation.setUpdatedAt(now());
+              injectExpectationRepository.save(expectation);
+            });
+  }
+
   public Optional<PhishingResult> resolveByToken(@NotBlank final String token) {
     return phishingResultRepository.findByToken(token);
   }
@@ -118,7 +189,7 @@ public class PhishingTrackingService {
     return phishingResultRepository.findTenantIdByToken(token);
   }
 
-  /** Marks the email as opened (first open wins) and records request metadata. */
+  /** Marks the email as opened (first open wins) and flips the "email opened" step to compromised. */
   public Optional<PhishingResult> markOpened(
       @NotBlank final String token, final String ip, final String userAgent) {
     return phishingResultRepository
@@ -129,13 +200,15 @@ public class PhishingTrackingService {
                 result.setOpenedAt(now());
               }
               applyRequestMetadata(result, ip, userAgent);
-              return phishingResultRepository.save(result);
+              PhishingResult saved = phishingResultRepository.save(result);
+              compromiseSteps(saved, Set.of(STEP_OPENED), "Opened the phishing email");
+              return saved;
             });
   }
 
   /**
-   * Marks the tracking link as clicked and auto-fulfills the recipient's MANUAL expectation
-   * (clicking the lure is the "fell for phishing" signal). An open is implied by a click.
+   * Marks the tracking link as clicked and flips the "email opened" and "link clicked" steps to
+   * compromised (loading the landing page implies the email was opened).
    */
   public Optional<PhishingResult> markClicked(
       @NotBlank final String token, final String ip, final String userAgent) {
@@ -151,19 +224,22 @@ public class PhishingTrackingService {
               }
               applyRequestMetadata(result, ip, userAgent);
               PhishingResult saved = phishingResultRepository.save(result);
-              fulfillManualExpectation(saved, "Clicked the phishing link");
+              compromiseSteps(
+                  saved, Set.of(STEP_OPENED, STEP_CLICKED), "Opened the phishing landing page");
               return saved;
             });
   }
 
   /**
    * Records submitted data, captures it as a {@code Credentials} finding (when the landing page is
-   * configured to capture) and fulfills the recipient's MANUAL expectation.
+   * configured to capture) and flips all three steps to compromised (a submit implies open + click).
+   *
+   * @param fields the raw submitted form fields (field name to value), used both to build the
+   *     credential value and as the completeness record
    */
   public Optional<PhishingResult> markSubmitted(
       @NotBlank final String token,
-      final String username,
-      final String password,
+      final Map<String, String> fields,
       final String ip,
       final String userAgent) {
     return phishingResultRepository
@@ -186,12 +262,13 @@ public class PhishingTrackingService {
               }
               applyRequestMetadata(result, ip, userAgent);
               if (firstSubmit) {
-                captureCredentials(result, username, password);
+                captureCredentials(result, fields);
               }
               PhishingResult saved = phishingResultRepository.save(result);
-              if (firstSubmit) {
-                fulfillManualExpectation(saved, "Submitted data on the phishing page");
-              }
+              compromiseSteps(
+                  saved,
+                  Set.of(STEP_OPENED, STEP_CLICKED, STEP_SUBMITTED),
+                  "Submitted data on the phishing page");
               return saved;
             });
   }
@@ -206,22 +283,18 @@ public class PhishingTrackingService {
     }
   }
 
-  private void captureCredentials(
-      final PhishingResult result, final String username, final String password) {
+  private void captureCredentials(final PhishingResult result, final Map<String, String> fields) {
     PhishingLandingPage landingPage = result.getLandingPage();
     if (landingPage == null || !landingPage.isCaptureSubmittedData()) {
       return;
     }
-    if (username == null || username.isBlank()) {
-      return;
-    }
     Inject inject = result.getInject();
-    if (inject == null) {
+    if (inject == null || fields == null || fields.isEmpty()) {
       return;
     }
-    String value = username;
-    if (landingPage.isCapturePasswords() && password != null && !password.isBlank()) {
-      value = username + " / " + password;
+    String value = buildCredentialValue(fields, landingPage.isCapturePasswords());
+    if (value == null || value.isBlank()) {
+      return;
     }
     Finding finding = new Finding();
     finding.setType(ContractOutputType.Credentials);
@@ -243,29 +316,108 @@ public class PhishingTrackingService {
   }
 
   /**
-   * Sets the MANUAL expectation of this recipient to its expected score (idempotent: only the first
-   * signal fills it). Mirrors {@code ChannelService.validateArticles} auto-fulfillment.
+   * Builds the credential value stored on the {@code Credentials} finding. Prefers a recognized
+   * username (plus password when capture is enabled). When no field name is recognized - a custom or
+   * cloned login form with atypical field names - it falls back to capturing every non-empty
+   * submitted field so a genuine submission is never silently dropped. Returns {@code null} when
+   * there is nothing to capture.
    */
-  private void fulfillManualExpectation(final PhishingResult result, final String message) {
+  static String buildCredentialValue(
+      final Map<String, String> fields, final boolean capturePasswords) {
+    Map<String, String> lowerKeyed = lowerKeyed(fields);
+    String username = firstNonBlank(lowerKeyed, USERNAME_KEYS);
+    String password = firstNonBlank(lowerKeyed, PASSWORD_KEYS);
+    if (username != null) {
+      return capturePasswords && password != null && !password.isBlank()
+          ? username + " / " + password
+          : username;
+    }
+    String joined =
+        fields.entrySet().stream()
+            .filter(entry -> entry.getValue() != null && !entry.getValue().isBlank())
+            .filter(entry -> capturePasswords || !isPasswordKey(entry.getKey()))
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining("; "));
+    return joined.isBlank() ? null : joined;
+  }
+
+  private static Map<String, String> lowerKeyed(final Map<String, String> fields) {
+    Map<String, String> lowerKeyed = new LinkedHashMap<>();
+    fields.forEach(
+        (key, value) -> {
+          if (key != null) {
+            lowerKeyed.putIfAbsent(key.toLowerCase(Locale.ROOT), value);
+          }
+        });
+    return lowerKeyed;
+  }
+
+  private static String firstNonBlank(
+      final Map<String, String> lowerKeyed, final List<String> keys) {
+    for (String key : keys) {
+      String value = lowerKeyed.get(key);
+      if (value != null && !value.isBlank()) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private static boolean isPasswordKey(final String key) {
+    return key != null && PASSWORD_KEYS.contains(key.toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Flips the named phishing steps to RED (compromised) for the recipient and their team. The
+   * team-level row is flipped too: a team has fallen for the phishing as soon as any one of its
+   * members does. Idempotent per step - an already-compromised step keeps its earliest signal.
+   */
+  private void compromiseSteps(
+      final PhishingResult result, final Set<String> stepNames, final String message) {
     User user = result.getUser();
     Inject inject = result.getInject();
     if (user == null || inject == null) {
       return;
     }
-    List<BaseInjectExpectation> expectations =
-        injectExpectationRepository.findAllByInjectAndPlayer(inject.getId(), user.getId());
-    expectations.stream()
-        .filter(
-            expectation -> expectation.getType() == BaseInjectExpectation.EXPECTATION_TYPE.MANUAL)
-        .filter(expectation -> hasNoResults(expectation.getResults()))
-        .forEach(
-            expectation -> {
-              expectation.setResults(
-                  List.of(buildForPlayerManualValidation(message, expectation.getExpectedScore())));
-              expectation.setScore(expectation.getExpectedScore());
-              expectation.setUpdatedAt(now());
-              injectExpectationRepository.save(expectation);
-            });
+    injectExpectationRepository.findAllByInjectAndPlayer(inject.getId(), user.getId()).stream()
+        .filter(expectation -> matchesSteps(expectation, stepNames))
+        .forEach(expectation -> markCompromised(expectation, message, false));
+    Team team = result.getTeam();
+    if (team != null) {
+      injectExpectationRepository.findAllByInjectAndTeam(inject.getId(), team.getId()).stream()
+          .filter(expectation -> matchesSteps(expectation, stepNames))
+          .forEach(expectation -> markCompromised(expectation, message, true));
+    }
+  }
+
+  private void markCompromised(
+      final BaseInjectExpectation expectation, final String message, final boolean team) {
+    if (expectation.getScore() != null && expectation.getScore() <= COMPROMISED_SCORE) {
+      return;
+    }
+    InjectExpectationResult result =
+        team
+            ? buildForTeamManualValidation(message, COMPROMISED_SCORE)
+            : buildForPlayerManualValidation(message, COMPROMISED_SCORE);
+    expectation.setResults(List.of(result));
+    expectation.setScore(COMPROMISED_SCORE);
+    expectation.setUpdatedAt(now());
+    injectExpectationRepository.save(expectation);
+  }
+
+  private static boolean matchesSteps(
+      final BaseInjectExpectation expectation, final Set<String> stepNames) {
+    return expectation.getType() == BaseInjectExpectation.EXPECTATION_TYPE.MANUAL
+        && expectation.getName() != null
+        && stepNames.contains(expectation.getName());
+  }
+
+  private static boolean isPhishingStep(final BaseInjectExpectation expectation) {
+    return matchesSteps(expectation, PHISHING_STEP_NAMES);
+  }
+
+  private static boolean isTeamRow(final BaseInjectExpectation expectation) {
+    return expectation instanceof TableTopInjectExpectation tableTop && tableTop.getUser() == null;
   }
 
   private boolean hasNoResults(final List<InjectExpectationResult> results) {

--- a/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/ExpectationUtils.java
@@ -224,9 +224,20 @@ public class ExpectationUtils {
       Map<String, Endpoint> valueTargetedAssetsMap,
       Inject inject) {
     String injectId = inject != null ? inject.getId() : null;
+    // A prevention verdict for an inject that does NOT run through an OAEV agent (network
+    // scanners such as Nmap, Netexec, HTTP...) belongs to the targeted asset itself, never to
+    // the agents that merely happen to run on that endpoint. Building one per-agent row per
+    // scoped endpoint is what let a single host + time-window security-platform alert be fanned
+    // out across every endpoint of a chained execution (including endpoints with no EDR at all).
+    // So for a non-agent inject we keep only the agentless, asset-level expectation - exactly
+    // what atomic testing and normal simulations produce.
+    boolean runsThroughAgents = inject == null || injectRunsThroughAgents(inject);
+    List<Agent> effectiveAgents = runsThroughAgents ? executedAgents : List.of();
+    boolean agentless =
+        !runsThroughAgents || isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject);
     return getExpectations(
         assetToExecute,
-        executedAgents,
+        effectiveAgents,
         (AssetGroup assetGroup) -> {
           PreventionExpectation preventionExpectation =
               preventionExpectationForAsset(
@@ -264,7 +275,7 @@ public class ExpectationUtils {
               expectation.getExpectedSecurityPlatformTypes());
           return preventionExpectation;
         },
-        isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject));
+        agentless);
   }
 
   /**
@@ -286,9 +297,20 @@ public class ExpectationUtils {
       Map<String, Endpoint> valueTargetedAssetsMap,
       Inject inject) {
     String injectId = inject != null ? inject.getId() : null;
+    // A detection verdict for an inject that does NOT run through an OAEV agent (network
+    // scanners such as Nmap, Netexec, HTTP...) belongs to the targeted asset itself, never to
+    // the agents that merely happen to run on that endpoint. Building one per-agent row per
+    // scoped endpoint is what let a single host + time-window security-platform alert be fanned
+    // out across every endpoint of a chained execution (including endpoints with no EDR at all).
+    // So for a non-agent inject we keep only the agentless, asset-level expectation - exactly
+    // what atomic testing and normal simulations produce.
+    boolean runsThroughAgents = inject == null || injectRunsThroughAgents(inject);
+    List<Agent> effectiveAgents = runsThroughAgents ? executedAgents : List.of();
+    boolean agentless =
+        !runsThroughAgents || isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject);
     return getExpectations(
         assetToExecute,
-        executedAgents,
+        effectiveAgents,
         (AssetGroup assetGroup) -> {
           DetectionExpectation detectionExpectation =
               detectionExpectationForAsset(
@@ -326,7 +348,7 @@ public class ExpectationUtils {
               expectation.getExpectedSecurityPlatformTypes());
           return detectionExpectation;
         },
-        isAgentlessAssetExpectationNecessary(assetToExecute.asset(), inject));
+        agentless);
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
@@ -3,6 +3,7 @@ package io.openaev.injectors.phishing.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -13,10 +14,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.openaev.database.model.BaseInjectExpectation;
 import io.openaev.database.model.ContractOutputType;
 import io.openaev.database.model.Finding;
 import io.openaev.database.model.Inject;
+import io.openaev.database.model.ManualInjectExpectation;
 import io.openaev.database.model.PhishingLandingPage;
 import io.openaev.database.model.PhishingResult;
 import io.openaev.database.model.User;
@@ -26,6 +27,7 @@ import io.openaev.database.repository.TeamRepository;
 import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.finding.FindingService;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,6 +66,15 @@ class PhishingTrackingServiceTest {
     return result;
   }
 
+  /** A player-scoped MANUAL step expectation, pre-scored GREEN (resisted) like the executor does. */
+  private ManualInjectExpectation resistedStep(final String name) {
+    ManualInjectExpectation expectation = new ManualInjectExpectation();
+    expectation.setName(name);
+    expectation.setExpectedScore(100.0);
+    expectation.setScore(100.0);
+    return expectation;
+  }
+
   @Test
   @DisplayName("generateToken should produce unguessable, URL-safe, unique tokens")
   void generateToken_should_produceUrlSafeUniqueTokens() {
@@ -76,19 +87,35 @@ class PhishingTrackingServiceTest {
 
   @Test
   @DisplayName(
-      "markClicked should set clickedAt (implying open) and auto-fulfill the MANUAL expectation")
-  void markClicked_should_fulfillManualExpectation() {
+      "initializeExpectationsAsResisted should pre-score every phishing step to its expected score")
+  void initializeExpectationsAsResisted_should_preScoreStepsGreen() {
+    // -- ARRANGE --
+    ManualInjectExpectation opened = new ManualInjectExpectation();
+    opened.setName(PhishingTrackingService.STEP_OPENED);
+    opened.setUser(new User());
+    opened.setExpectedScore(100.0);
+    when(injectExpectationRepository.findAllByInjectId("inject-1")).thenReturn(List.of(opened));
+
+    // -- ACT --
+    phishingTrackingService.initializeExpectationsAsResisted("inject-1");
+
+    // -- ASSERT --
+    assertEquals(100.0, opened.getScore(), "a never-interacted step must stay GREEN (resisted)");
+    assertNotNull(opened.getResults());
+    verify(injectExpectationRepository).save(opened);
+  }
+
+  @Test
+  @DisplayName("markClicked should flip the opened and clicked steps to compromised (RED)")
+  void markClicked_should_compromiseOpenedAndClickedSteps() {
     // -- ARRANGE --
     PhishingResult result = resultWith(true, true);
     when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
-    BaseInjectExpectation expectation = org.mockito.Mockito.mock(BaseInjectExpectation.class);
-    when(expectation.getType()).thenReturn(BaseInjectExpectation.EXPECTATION_TYPE.MANUAL);
-    when(expectation.getResults()).thenReturn(List.of());
-    when(expectation.getExpectedScore()).thenReturn(100.0);
+    ManualInjectExpectation clicked = resistedStep(PhishingTrackingService.STEP_CLICKED);
     when(injectExpectationRepository.findAllByInjectAndPlayer("inject-1", "user-1"))
-        .thenReturn(List.of(expectation));
+        .thenReturn(List.of(clicked));
 
     // -- ACT --
     Optional<PhishingResult> updated =
@@ -98,8 +125,28 @@ class PhishingTrackingServiceTest {
     assertTrue(updated.isPresent());
     assertNotNull(updated.get().getClickedAt());
     assertNotNull(updated.get().getOpenedAt());
-    verify(expectation).setScore(100.0);
-    verify(injectExpectationRepository).save(expectation);
+    assertEquals(0.0, clicked.getScore(), "a followed link must flip the step to RED");
+    verify(injectExpectationRepository).save(clicked);
+  }
+
+  @Test
+  @DisplayName("markClicked should leave unrelated (non-step) manual expectations untouched")
+  void markClicked_should_ignoreNonStepExpectations() {
+    // -- ARRANGE --
+    PhishingResult result = resultWith(true, true);
+    when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
+    when(phishingResultRepository.save(any(PhishingResult.class)))
+        .thenAnswer(i -> i.getArgument(0));
+    ManualInjectExpectation unrelated = resistedStep("Some operator check");
+    when(injectExpectationRepository.findAllByInjectAndPlayer("inject-1", "user-1"))
+        .thenReturn(List.of(unrelated));
+
+    // -- ACT --
+    phishingTrackingService.markClicked("token-1", "1.2.3.4", "curl/8");
+
+    // -- ASSERT --
+    assertEquals(100.0, unrelated.getScore(), "a non-step expectation must not be flipped");
+    verify(injectExpectationRepository, never()).save(unrelated);
   }
 
   @Test
@@ -116,7 +163,10 @@ class PhishingTrackingServiceTest {
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
-        "token-1", "victim@corp.test", "hunter2", "1.2.3.4", "ua");
+        "token-1",
+        Map.of("username", "victim@corp.test", "password", "hunter2"),
+        "1.2.3.4",
+        "ua");
 
     // -- ASSERT --
     ArgumentCaptor<List<Finding>> captor = ArgumentCaptor.forClass(List.class);
@@ -141,7 +191,7 @@ class PhishingTrackingServiceTest {
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
-        "token-1", "victim@corp.test", "hunter2", "1.2.3.4", "ua");
+        "token-1", Map.of("username", "victim@corp.test", "password", "hunter2"), "1.2.3.4", "ua");
 
     // -- ASSERT --
     verify(findingService, never()).createFindings(anyList(), anyString());
@@ -160,7 +210,7 @@ class PhishingTrackingServiceTest {
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
-        "token-1", "victim@corp.test", "hunter2", "1.2.3.4", "ua");
+        "token-1", Map.of("username", "victim@corp.test", "password", "hunter2"), "1.2.3.4", "ua");
 
     // -- ASSERT --
     ArgumentCaptor<List<Finding>> captor = ArgumentCaptor.forClass(List.class);
@@ -181,10 +231,9 @@ class PhishingTrackingServiceTest {
         .thenReturn(List.of());
 
     // -- ACT --
-    phishingTrackingService.markSubmitted(
-        "token-1", "victim@corp.test", "hunter2", "1.2.3.4", "ua");
-    phishingTrackingService.markSubmitted(
-        "token-1", "victim@corp.test", "hunter2", "1.2.3.4", "ua");
+    Map<String, String> fields = Map.of("username", "victim@corp.test", "password", "hunter2");
+    phishingTrackingService.markSubmitted("token-1", fields, "1.2.3.4", "ua");
+    phishingTrackingService.markSubmitted("token-1", fields, "1.2.3.4", "ua");
 
     // -- ASSERT --
     verify(findingService, org.mockito.Mockito.times(1)).createFindings(anyList(), anyString());
@@ -197,5 +246,29 @@ class PhishingTrackingServiceTest {
     Optional<PhishingResult> updated = phishingTrackingService.markOpened("nope", "1.2.3.4", "ua");
     assertTrue(updated.isEmpty());
     verifyNoInteractions(findingService);
+  }
+
+  @Test
+  @DisplayName(
+      "buildCredentialValue should recognize an atypical login field name (cloned real form)")
+  void buildCredentialValue_should_recognizeAtypicalLoginField() {
+    String value =
+        PhishingTrackingService.buildCredentialValue(
+            Map.of("loginfmt", "victim@corp.test", "passwd", "hunter2"), true);
+    assertEquals("victim@corp.test / hunter2", value);
+  }
+
+  @Test
+  @DisplayName("buildCredentialValue should fall back to every submitted field when none is known")
+  void buildCredentialValue_should_fallBackToAllFields() {
+    String value =
+        PhishingTrackingService.buildCredentialValue(Map.of("employee_ref", "A-42"), true);
+    assertEquals("employee_ref=A-42", value);
+  }
+
+  @Test
+  @DisplayName("buildCredentialValue should return null when there is nothing to capture")
+  void buildCredentialValue_should_returnNullWhenEmpty() {
+    assertNull(PhishingTrackingService.buildCredentialValue(Map.of(), true));
   }
 }

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
@@ -66,9 +66,14 @@ class PhishingTrackingServiceTest {
     return result;
   }
 
-  /** A player-scoped MANUAL step expectation, pre-scored GREEN (resisted) like the executor does. */
+  /**
+   * A player-scoped MANUAL step expectation, pre-scored GREEN (resisted) like the executor does.
+   */
   private ManualInjectExpectation resistedStep(final String name) {
     ManualInjectExpectation expectation = new ManualInjectExpectation();
+    // A distinct id keeps equals()/hashCode() well-defined when several rows are matched in the
+    // same verify() (an id-less expectation dereferences a null id during Mockito's comparison).
+    expectation.setId(name);
     expectation.setName(name);
     expectation.setExpectedScore(100.0);
     expectation.setScore(100.0);
@@ -113,9 +118,10 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
+    ManualInjectExpectation opened = resistedStep(PhishingTrackingService.STEP_OPENED);
     ManualInjectExpectation clicked = resistedStep(PhishingTrackingService.STEP_CLICKED);
     when(injectExpectationRepository.findAllByInjectAndPlayer("inject-1", "user-1"))
-        .thenReturn(List.of(clicked));
+        .thenReturn(List.of(opened, clicked));
 
     // -- ACT --
     Optional<PhishingResult> updated =
@@ -125,8 +131,11 @@ class PhishingTrackingServiceTest {
     assertTrue(updated.isPresent());
     assertNotNull(updated.get().getClickedAt());
     assertNotNull(updated.get().getOpenedAt());
-    assertEquals(0.0, clicked.getScore(), "a followed link must flip the step to RED");
+    assertEquals(0.0, clicked.getScore(), "a followed link must flip the clicked step to RED");
+    assertEquals(
+        0.0, opened.getScore(), "a followed link implies an open, so the opened step flips too");
     verify(injectExpectationRepository).save(clicked);
+    verify(injectExpectationRepository).save(opened);
   }
 
   @Test
@@ -163,10 +172,7 @@ class PhishingTrackingServiceTest {
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
-        "token-1",
-        Map.of("username", "victim@corp.test", "password", "hunter2"),
-        "1.2.3.4",
-        "ua");
+        "token-1", Map.of("username", "victim@corp.test", "password", "hunter2"), "1.2.3.4", "ua");
 
     // -- ASSERT --
     ArgumentCaptor<List<Finding>> captor = ArgumentCaptor.forClass(List.class);

--- a/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
@@ -35,6 +35,9 @@ class ExpectationUtilsTest extends IntegrationTest {
     // -- PREPARE --
     Endpoint endpoint = EndpointFixture.createEndpoint();
     InjectorContract injectorContract = InjectorContractFixture.createDefaultInjectorContract();
+    // An OAEV implant runs through the agent, so its contract needs an executor: this is what makes
+    // getPreventionExpectationsByAsset / getDetectionExpectationsByAsset build the per-agent rows.
+    injectorContract.setNeedsExecutor(true);
     Inject inject = InjectFixture.createTechnicalInject(injectorContract, "Inject", endpoint);
     inject.setId("injectId");
 
@@ -169,6 +172,10 @@ class ExpectationUtilsTest extends IntegrationTest {
     endpoint.setSeenIp(fakeSeenIPV6);
 
     InjectorContract injectorContract = InjectorContractFixture.createDefaultInjectorContract();
+    // An OAEV implant runs through the agent, so its contract needs an executor: this is what makes
+    // getPreventionExpectationsByAsset build the per-agent row carrying the signatures asserted
+    // here.
+    injectorContract.setNeedsExecutor(true);
     Inject inject = InjectFixture.createTechnicalInject(injectorContract, "Inject", endpoint);
     inject.setId("injectId");
 

--- a/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/Expectation/ExpectationUtilsTest.java
@@ -4,6 +4,7 @@ import static io.openaev.utils.ExpectationSignatureUtils.*;
 import static io.openaev.utils.ExpectationUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.openaev.IntegrationTest;
@@ -319,5 +320,55 @@ class ExpectationUtilsTest extends IntegrationTest {
     Inject inject = injectWithInjector(InjectorFixture.createDefaultPayloadInjector());
 
     assertFalse(isAgentlessAssetExpectationNecessary(null, inject));
+  }
+
+  @Test
+  @DisplayName(
+      "Network (non-agent) inject on an endpoint carrying an agent builds ONLY an asset-level"
+          + " detection/prevention expectation, never a per-agent one")
+  void
+      given_nonAgentInjectOnEndpointWithAgent_should_buildOnlyAssetLevelDetectionPreventionExpectation() {
+    // Regression for the chained-execution fan-out: a network scanner (Nmap, Netexec...) never
+    // runs on the OAEV agent, yet chaining pins it onto agent-bearing endpoints. Building a
+    // per-agent detection/prevention row per scoped endpoint let a single host + time-window
+    // security-platform alert be attributed to every endpoint (even endpoints with no EDR). The
+    // verdict must stay at the asset level - exactly what atomic testing and normal simulations do.
+    Endpoint endpoint = EndpointFixture.createEndpoint();
+    Agent agent = AgentFixture.createAgent(endpoint, "ext");
+    agent.setId("agentId");
+    endpoint.setAgents(List.of(agent));
+
+    // A non-payload injector => injectRunsThroughAgents(inject) == false.
+    Inject inject =
+        injectWithInjector(InjectorFixture.createInjector("injectorId", "manual", "manual"));
+    inject.setId("injectId");
+
+    AssetToExecute assetToExecute = new AssetToExecute(endpoint, true, List.of());
+
+    // Even though the buggy call site would pass the endpoint's active agents as "executed
+    // agents", the fix must ignore them for a non-agent inject.
+    List<PreventionExpectation> preventionExpectations =
+        getPreventionExpectationsByAsset(
+            OAEV_IMPLANT,
+            assetToExecute,
+            List.of(agent),
+            ExpectationFixture.createExpectation(),
+            new HashMap<>(),
+            inject);
+
+    List<DetectionExpectation> detectionExpectations =
+        getDetectionExpectationsByAsset(
+            OAEV_IMPLANT,
+            assetToExecute,
+            List.of(agent),
+            ExpectationFixture.createExpectation(),
+            new HashMap<>(),
+            inject);
+
+    assertEquals(1, preventionExpectations.size());
+    assertNull(preventionExpectations.getFirst().getAgent());
+
+    assertEquals(1, detectionExpectations.size());
+    assertNull(detectionExpectations.getFirst().getAgent());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/injects/technical_inject/OpenAEVImplantExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/injects/technical_inject/OpenAEVImplantExecutorTest.java
@@ -69,6 +69,15 @@ public class OpenAEVImplantExecutorTest extends IntegrationTest {
     collectorComposer.reset();
   }
 
+  // An OAEV implant runs through the agent, so its contract needs an executor: this is what makes
+  // ExpectationUtils build the per-agent detection/prevention rows this test asserts on.
+  private static InjectorContract oaevImplantContract() {
+    InjectorContract contract =
+        InjectorContractFixture.createDefaultInjectorContractWithExternalId("external-id");
+    contract.setNeedsExecutor(true);
+    return contract;
+  }
+
   private Inject createTechnicalInjectHelper(List<Expectation> expectationList) {
     Inject inject = InjectFixture.getDefaultInject();
     OpenAEVImplantInjectContent content = new OpenAEVImplantInjectContent();
@@ -97,9 +106,7 @@ public class OpenAEVImplantExecutorTest extends IntegrationTest {
                             agentComposer.forAgent(AgentFixture.createDefaultAgentService()))))
         .withInjectorContract(
             injectorContractComposer
-                .forInjectorContract(
-                    InjectorContractFixture.createDefaultInjectorContractWithExternalId(
-                        "external-id"))
+                .forInjectorContract(oaevImplantContract())
                 .withInjector(injectorFixture.getWellKnownOaevImplantInjector()))
         .persist()
         .get();

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphActionCard.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphActionCard.tsx
@@ -202,9 +202,23 @@ const GraphActionCard = ({
             'lineHeight': 0,
             'color': 'transparent',
             'backgroundColor': theme.palette.action.hover,
-            '& img': {
-              maxWidth: '100%',
-              maxHeight: '100%',
+            // The glyph arrives wrapped in CustomTooltip's inline <span> (which carries its own
+            // inline line-height) and with a fixed 20px inline size; both leave it floating
+            // off-center in the square. Flatten the wrapper into a centering flex layer and force
+            // the glyph to fill the padded square so every logo is centered horizontally and
+            // vertically, whatever its intrinsic shape.
+            'padding': '3px',
+            '& > span': {
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '100%',
+              height: '100%',
+            },
+            '& img, & svg': {
+              display: 'block',
+              width: '100% !important',
+              height: '100% !important',
               objectFit: 'contain',
             },
           }}

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/EndpointDetailPanel.tsx
@@ -19,6 +19,21 @@ interface FindingGroup {
 const PAGE_SIZE_OPTIONS = [5, 10, 25, 50];
 const DEFAULT_PAGE_SIZE = 10;
 
+// Executions render as an aligned three-column table (Action | Execution | Result). A network inject
+// carries no agent metadata, so without a fixed grid the rows were ragged and the two status chips
+// landed at a different x on every row; the fixed template plus right-aligned status cells turn them
+// into a proper column with a header that says what each chip means.
+const EXECUTION_GRID_COLUMNS = 'minmax(0, 1fr) 132px 116px';
+
+const executionHeaderCellSx = {
+  fontFamily: '"Geologica", sans-serif',
+  fontWeight: 600,
+  fontSize: 10,
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase',
+  color: 'text.secondary',
+} as const;
+
 // A compact "N / page" selector rendered in the Findings section header: values are all loaded, so
 // this only windows the display of a group that would otherwise render an unbounded list of values.
 const PageSizeSelect = ({ value, onChange }: {
@@ -244,132 +259,162 @@ const EndpointDetailPanel = ({
         )}
 
         <InjectFormSection title={`${t('Executions')} (${executions.length})`}>
-          <Box sx={{
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-          >
-            {executions.map((e) => {
-              const status = execStatusLabel(e.status);
-              const highlighted = !!e.ref && highlightedExecutionIds.has(e.ref);
-              return (
-                <Box
-                  key={e.id}
-                  ref={(el: HTMLDivElement | null) => {
-                    if (e.id) {
-                      registerRow(e.id, el);
-                    }
-                  }}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => e.ref && onSelectExecution(e.ref)}
-                  onKeyDown={(ev) => {
-                    if (e.ref && (ev.key === 'Enter' || ev.key === ' ')) {
-                      ev.preventDefault();
-                      onSelectExecution(e.ref);
-                    }
-                  }}
-                  sx={{
-                    'display': 'flex',
-                    'alignItems': 'center',
-                    'gap': 1,
-                    'py': 0.75,
-                    'px': 0.5,
-                    'borderRadius': 1,
-                    'borderBottom': `1px solid ${theme.palette.divider}`,
-                    'backgroundColor': highlighted ? 'action.selected' : undefined,
-                    // A left accent so the finding's producing execution stands out in the feed.
-                    'borderLeft': highlighted ? `2px solid ${theme.palette.primary.main}` : '2px solid transparent',
-                    'cursor': 'pointer',
-                    'transition': theme.transitions.create(['background-color', 'border-color']),
-                    '&:hover': { backgroundColor: 'action.hover' },
-                    '&:focus-visible': {
-                      outline: `2px solid ${theme.palette.primary.main}`,
-                      outlineOffset: -2,
-                    },
-                  }}
+          {executions.length === 0
+            ? <Alert severity="info">{t('No execution reached this target')}</Alert>
+            : (
+                <Box sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
                 >
+                  {/* Column headers, aligned with the row grid below so the two status columns read as a
+                      table and the reader knows what each chip means. */}
                   <Box sx={{
-                    minWidth: 0,
-                    flex: 1,
+                    display: 'grid',
+                    gridTemplateColumns: EXECUTION_GRID_COLUMNS,
+                    alignItems: 'center',
+                    gap: 1,
+                    px: 0.5,
+                    pb: 0.75,
+                    borderBottom: `1px solid ${theme.palette.divider}`,
                   }}
                   >
-                    <Typography variant="body2" noWrap>{e.payloadName || e.label}</Typography>
-                    <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
-                      {[e.agentName, e.privilege].filter(Boolean).join(' · ')}
+                    <Typography sx={executionHeaderCellSx}>{t('Action')}</Typography>
+                    <Typography sx={{
+                      ...executionHeaderCellSx,
+                      textAlign: 'right',
+                    }}
+                    >
+                      {t('Execution')}
+                    </Typography>
+                    <Typography sx={{
+                      ...executionHeaderCellSx,
+                      textAlign: 'right',
+                    }}
+                    >
+                      {t('Result')}
                     </Typography>
                   </Box>
-                  {/* Whether this execution actually ran at all (issue 244), at a glance in the list —
-                      the verdict pill beside it only answers whether it was caught. Both sit in
-                      fixed-width slots: their labels vary in length ("Executed"/"Timeout",
-                      "DETECTED"/"UNDETECTED"), so intrinsic widths made every row's pair land on a
-                      different x and the column read as ragged. */}
-                  <Box sx={{
-                    flexShrink: 0,
-                    width: 92,
-                    display: 'flex',
-                    justifyContent: 'flex-end',
-                  }}
-                  >
-                    <ExecutionRowStatusBadge
-                      simulationId={simulationId}
-                      executionRef={e.ref}
-                      endpointName={e.hostname}
-                      injectId={e.injectId}
-                      payloadId={e.payloadId}
-                      executionStatus={e.executionStatus}
-                    />
-                  </Box>
-                  <Box sx={{
-                    flexShrink: 0,
-                    width: 104,
-                    display: 'flex',
-                    justifyContent: 'flex-end',
-                  }}
-                  >
-                    <AttackPathVerdictPill label={status} status={e.status} />
-                  </Box>
+                  {executions.map((e) => {
+                    const status = execStatusLabel(e.status);
+                    const highlighted = !!e.ref && highlightedExecutionIds.has(e.ref);
+                    const subtitle = [e.agentName, e.privilege].filter(Boolean).join(' · ');
+                    return (
+                      <Box
+                        key={e.id}
+                        ref={(el: HTMLDivElement | null) => {
+                          if (e.id) {
+                            registerRow(e.id, el);
+                          }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => e.ref && onSelectExecution(e.ref)}
+                        onKeyDown={(ev) => {
+                          if (e.ref && (ev.key === 'Enter' || ev.key === ' ')) {
+                            ev.preventDefault();
+                            onSelectExecution(e.ref);
+                          }
+                        }}
+                        sx={{
+                          'display': 'grid',
+                          'gridTemplateColumns': EXECUTION_GRID_COLUMNS,
+                          'alignItems': 'center',
+                          'gap': 1,
+                          'minHeight': 44,
+                          'py': 0.5,
+                          'px': 0.5,
+                          'borderBottom': `1px solid ${theme.palette.divider}`,
+                          'backgroundColor': highlighted ? 'action.selected' : undefined,
+                          // A left accent so the finding's producing execution stands out in the feed.
+                          'borderLeft': highlighted ? `2px solid ${theme.palette.primary.main}` : '2px solid transparent',
+                          'cursor': 'pointer',
+                          'transition': theme.transitions.create(['background-color', 'border-color']),
+                          '&:hover': { backgroundColor: 'action.hover' },
+                          '&:focus-visible': {
+                            outline: `2px solid ${theme.palette.primary.main}`,
+                            outlineOffset: -2,
+                          },
+                        }}
+                      >
+                        <Box sx={{ minWidth: 0 }}>
+                          <Typography variant="body2" noWrap title={e.payloadName || e.label}>
+                            {e.payloadName || e.label}
+                          </Typography>
+                          {subtitle && (
+                            <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+                              {subtitle}
+                            </Typography>
+                          )}
+                        </Box>
+                        {/* Whether this execution actually ran at all (issue 244) - the verdict pill in the
+                            last column only answers whether it was caught. Both status cells are right-aligned
+                            in their fixed grid column so agent-based and network-based rows line up. */}
+                        <Box sx={{
+                          display: 'flex',
+                          justifyContent: 'flex-end',
+                          minWidth: 0,
+                        }}
+                        >
+                          <ExecutionRowStatusBadge
+                            simulationId={simulationId}
+                            executionRef={e.ref}
+                            endpointName={e.hostname}
+                            injectId={e.injectId}
+                            payloadId={e.payloadId}
+                            executionStatus={e.executionStatus}
+                          />
+                        </Box>
+                        <Box sx={{
+                          display: 'flex',
+                          justifyContent: 'flex-end',
+                          minWidth: 0,
+                        }}
+                        >
+                          <AttackPathVerdictPill label={status} status={e.status} />
+                        </Box>
+                      </Box>
+                    );
+                  })}
+                  {/* The list holds one page, so reaching the rest must be an action rather than a dead
+                      caption: same slot, a text button that fetches the next page (See More precedent).
+                      Where the caller cannot fetch more (the injector panel reads a bounded set in one go),
+                      say what is not shown rather than truncate silently. */}
+                  {(totalExecutions ?? 0) > executions.length && (
+                    onShowMore
+                      ? (
+                          <Button
+                            size="small"
+                            variant="text"
+                            disabled={loadingMore}
+                            onClick={() => onShowMore()}
+                            sx={{
+                              mt: 1,
+                              alignSelf: 'flex-start',
+                              textTransform: 'none',
+                            }}
+                          >
+                            {`${t('Show more')} (${(totalExecutions ?? 0) - executions.length})`}
+                          </Button>
+                        )
+                      : (
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              display: 'block',
+                              pt: 1,
+                            }}
+                          >
+                            {t('Showing the first {count} of {total}', {
+                              count: executions.length,
+                              total: totalExecutions,
+                            })}
+                          </Typography>
+                        )
+                  )}
                 </Box>
-              );
-            })}
-            {/* The list holds one page, so reaching the rest must be an action rather than a dead caption:
-                same slot, a text button that fetches the next page (See More precedent). Where the caller
-                cannot fetch more (the injector panel reads a bounded set in one go), say what is not shown
-                rather than truncate silently. */}
-            {(totalExecutions ?? 0) > executions.length && (
-              onShowMore
-                ? (
-                    <Button
-                      size="small"
-                      variant="text"
-                      disabled={loadingMore}
-                      onClick={() => onShowMore()}
-                      sx={{
-                        mt: 1,
-                        alignSelf: 'flex-start',
-                        textTransform: 'none',
-                      }}
-                    >
-                      {`${t('Show more')} (${(totalExecutions ?? 0) - executions.length})`}
-                    </Button>
-                  )
-                : (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{
-                        display: 'block',
-                        pt: 1,
-                      }}
-                    >
-                      {t('Showing the first {count} of {total}', {
-                        count: executions.length,
-                        total: totalExecutions,
-                      })}
-                    </Typography>
-                  )
-            )}
-          </Box>
+              )}
         </InjectFormSection>
       </Box>
     </Paper>

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionRanChip.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionRanChip.tsx
@@ -1,0 +1,49 @@
+import { alpha, Chip, Tooltip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { type FunctionComponent } from 'react';
+
+import { getStatusIconComponent } from '../../../../../utils/statusIcons';
+import { getStatusColor } from '../../../../../utils/statusUtils';
+
+interface Props {
+  /** Backend status key (agent trace status OR inject-level status). */
+  status?: string;
+  /** Translated, display-ready label (status is never conveyed by colour alone). */
+  label: string;
+  /** Optional explanatory tooltip, already translated. */
+  tooltip?: string;
+}
+
+// Compact, alpha-tinted "did it run" chip for network/inject-level executions. It is styled to be
+// pixel-identical to the agent-based TraceStatusChip beside it (same height, tint language, uppercase
+// label + status icon) so the Executions column reads as one aligned table. It replaces the old 150px
+// solid-fill ItemStatus, whose fixed width, float and different tint made the status column ragged and
+// off design-system in the attack-path asset overview.
+const ExecutionRanChip: FunctionComponent<Props> = ({ status, label, tooltip }) => {
+  const theme = useTheme();
+  const color = getStatusColor(theme, status);
+  const StatusIcon = getStatusIconComponent(status);
+
+  const chip = (
+    <Chip
+      size="medium"
+      label={label}
+      icon={<StatusIcon sx={{ fontSize: theme.typography.caption.fontSize }} />}
+      sx={{
+        'maxWidth': '100%',
+        'backgroundColor': alpha(color, 0.08),
+        'color': color,
+        'fontSize': theme.typography.caption.fontSize,
+        'fontWeight': theme.typography.fontWeightBold,
+        'textTransform': 'uppercase',
+        'borderRadius': Number(theme.shape.borderRadius) / 2,
+        'height': theme.spacing(3),
+        '& .MuiChip-icon': { color: 'inherit' },
+      }}
+    />
+  );
+
+  return tooltip ? <Tooltip title={tooltip}>{chip}</Tooltip> : chip;
+};
+
+export default ExecutionRanChip;

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -3,10 +3,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { fetchExecutionDetail } from '../../../../../actions/attack-path/attack-path-actions';
 import useFetchInjectExecutionResult from '../../../../../actions/inject_status/useFetchInjectExecutionResult';
 import { getInjectStatusWithGlobalExecutionTraces } from '../../../../../actions/injects/inject-action';
-import type { InjectStatus as InjectStatusType, InjectStatusOutput } from '../../../../../utils/api-types';
-import InjectStatus from '../../../common/injects/status/InjectStatus';
+import { useFormatter } from '../../../../../components/i18n';
+import type { InjectStatusOutput } from '../../../../../utils/api-types';
+import { getInjectStatusLabel, getInjectStatusTooltip } from '../../../../../utils/statusLabels';
 import TraceStatusChip from '../../../common/injects/status/traces/TraceStatusChip';
 import useAgentStatus from '../../../common/injects/status/traces/useAgentStatus';
+import ExecutionRanChip from './ExecutionRanChip';
 import useResolvedAssetTarget from './useResolvedAssetTarget';
 
 // Per-target execution status for a payload-backed execution (issue 244): the prevention/detection
@@ -37,6 +39,7 @@ export const PayloadExecutionStatusBadge = ({ injectId, endpointName }: {
 // list with no status chip of its own. Fetched independently and rendered wherever this execution's
 // status needs to be visible at a glance.
 export const InjectorExecutionStatusBadge = ({ injectId }: { injectId: string }) => {
+  const { t } = useFormatter();
   const [statusName, setStatusName] = useState<string | null>(null);
   useEffect(() => {
     let active = true;
@@ -50,7 +53,13 @@ export const InjectorExecutionStatusBadge = ({ injectId }: { injectId: string })
   if (!statusName) {
     return null;
   }
-  return <InjectStatus status={statusName as InjectStatusType['status_name']} />;
+  return (
+    <ExecutionRanChip
+      status={statusName}
+      label={t(getInjectStatusLabel(statusName))}
+      tooltip={t(getInjectStatusTooltip(statusName))}
+    />
+  );
 };
 
 // An inject-level status the backend cannot still change under us: anything else (a run in flight, or
@@ -76,6 +85,7 @@ export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointNa
   payloadId?: string;
   executionStatus?: string;
 }) => {
+  const { t } = useFormatter();
   const settledFromGraph = !!injectId
     && !payloadId
     && !!executionStatus
@@ -102,7 +112,13 @@ export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointNa
     };
   }, [simulationId, executionRef, injectId]);
   if (settledFromGraph) {
-    return <InjectStatus status={executionStatus as InjectStatusType['status_name']} />;
+    return (
+      <ExecutionRanChip
+        status={executionStatus}
+        label={t(getInjectStatusLabel(executionStatus))}
+        tooltip={t(getInjectStatusTooltip(executionStatus))}
+      />
+    );
   }
   const detail = injectId
     ? {

--- a/openaev-front/src/utils/injector_contract/InjectorContractUtils.ts
+++ b/openaev-front/src/utils/injector_contract/InjectorContractUtils.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 
 import { type AttackPattern, type InjectorContractFullOutput } from '../api-types';
 
-export const externalContractTypesWithFindings = ['openaev_nmap', 'openaev_nuclei', 'openaev_aws', 'openaev_netexec'];
+export const externalContractTypesWithFindings = ['openaev_nmap', 'openaev_nuclei', 'openaev_aws', 'openaev_netexec', 'openaev_phishing'];
 
 const computeAttackPatterns = (attackPatternIds: InjectorContractFullOutput['injector_contract_attack_patterns'], attackPatternsMap: Record<string, AttackPattern>) => {
   const attackPatternParents = (attackPatternIds ?? []).flatMap((attackPattern) => {

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "Kein benutzerdefiniertes Dashboard ausgewählt.",
   "No CWEs listed.": "Keine CWEs aufgelistet.",
+  "No execution reached this target": "Keine Ausfuhrung hat dieses Ziel erreicht",
   "No data available": "Keine Daten verfügbar",
   "No data capture": "Keine Datenerfassung",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "Zu diesem Zeitpunkt wurden für diesen Bereich keine Daten gesammelt. Führen Sie ein Szenario aus, um Ihre Position in diesem Bereich zu analysieren.",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -2339,6 +2339,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "No custom dashboard selected.",
   "No CWEs listed.": "No CWEs listed.",
+  "No execution reached this target": "No execution reached this target",
   "No data available": "No data available",
   "No data capture": "No data capture",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "No se ha seleccionado ningún dashboard personalizado.",
   "No CWEs listed.": "No hay CWEs en la lista.",
+  "No execution reached this target": "Ninguna ejecucion alcanzo este objetivo",
   "No data available": "No hay datos disponibles",
   "No data capture": "Sin captura de datos",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "Por el momento no se han recopilado datos sobre este dominio. Inicie un escenario para comenzar a analizar su posición en este dominio.",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "Aucun tableau de bord personnalisé n'a été sélectionné.",
   "No CWEs listed.": "Aucun CWE n'a été répertorié.",
+  "No execution reached this target": "Aucune execution n'a atteint cette cible",
   "No data available": "Aucune donnée disponible (répété)",
   "No data capture": "Pas de capture de données",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "Aucune donnée n'a été collectée sur ce domaine pour le moment. Lancez un scénario pour commencer à analyser votre position sur ce domaine.",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "Non è stato selezionato alcun cruscotto personalizzato.",
   "No CWEs listed.": "Nessun CWE elencato.",
+  "No execution reached this target": "Nessuna esecuzione ha raggiunto questo bersaglio",
   "No data available": "Nessun dato disponibile",
   "No data capture": "Nessuna acquisizione dati",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "Al momento non sono stati raccolti dati su questo dominio. Eseguite uno scenario per iniziare ad analizzare la vostra posizione su questo dominio.",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "カスタムダッシュボードが選択されていない",
   "No CWEs listed.": "CWE が表示されていない",
+  "No execution reached this target": "この対象に到達した実行はありません",
   "No data available": "データがない",
   "No data capture": "データ取得なし",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "現在、このドメインに関するデータは収集されていない。シナリオを実行し、このドメインのポジション分析を開始する。",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "사용자 지정 대시보드가 선택되지 않았습니다.",
   "No CWEs listed.": "나열된 CWE가 없습니다.",
+  "No execution reached this target": "이 대상에 도달한 실행이 없습니다",
   "No data available": "사용 가능한 데이터가 없습니다",
   "No data capture": "데이터 수집 없음",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "현재 이 도메인에서 수집된 데이터가 없습니다. 시나리오를 실행하여 이 도메인에 대한 위치 분석을 시작하세요.",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "Не выбрана пользовательская приборная панель.",
   "No CWEs listed.": "В списке нет CWE.",
+  "No execution reached this target": "Ни одно выполнение не достигло этой цели",
   "No data available": "Нет данных",
   "No data capture": "Без сбора данных",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "На данный момент данные по этому домену не собраны. Запустите сценарий, чтобы начать анализировать свое положение в этом домене.",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -2342,6 +2342,7 @@
   "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.": "No custom agents are available yet. The built-in payload creator is always available; create more agents in XTM One to consult them here.",
   "No custom dashboard selected.": "未选择自定义仪表板。",
   "No CWEs listed.": "没有列出 CWE。",
+  "No execution reached this target": "没有执行到达此目标",
   "No data available": "无可用数据",
   "No data capture": "不捕获数据",
   "No data collected on this domain at this time. Run a scenario to start analyzing your position on this domain.": "暫時未有收集呢個範疇嘅數據。  開始一個場景,開始分析你喺呢個範疇嘅位置。",

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -79,7 +79,16 @@ public class ElasticService implements EngineService {
     String target = ofNullable(parameters.getOrDefault(value, value)).orElse("");
     PropertySchema propertyField = commonSearchService.getIndexingSchema().get(field);
     if (propertyField == null) {
-      throw new AnalyticsEngineException("Unknown field: " + field);
+      // A base field such as base_representative is a searchable analyzed-text string (see
+      // BASE_FIELDS / queryFromSearch) but carries no @Queryable annotation, so it is absent from
+      // the indexing schema. Treat its value as a string instead of failing, so filtering on it
+      // (e.g. the asset expectation list search box) works. Any other unknown field stays a hard
+      // error.
+      if (!BASE_FIELDS.contains(field)) {
+        throw new AnalyticsEngineException("Unknown field: " + field);
+      }
+      builder.stringValue(target);
+      return builder.build();
     }
     if (propertyField.getType().isAssignableFrom(String.class)
         || (propertyField.getType().isAssignableFrom(Set.class)
@@ -155,7 +164,7 @@ public class ElasticService implements EngineService {
                 .map(
                     v -> {
                       FieldValue val = toVal(field, v, parameters);
-                      if (propertyField.isKeyword()) {
+                      if (propertyField != null && propertyField.isKeyword()) {
                         // Champ keyword : wildcard
                         return WildcardQuery.of(
                                 w ->
@@ -182,7 +191,7 @@ public class ElasticService implements EngineService {
                 .map(
                     v -> {
                       FieldValue val = toVal(field, v, parameters);
-                      if (propertyField.isKeyword()) {
+                      if (propertyField != null && propertyField.isKeyword()) {
                         return WildcardQuery.of(
                                 w -> w.field(elasticField).value("*" + val.stringValue() + "*"))
                             ._toQuery();
@@ -1225,6 +1234,16 @@ public class ElasticService implements EngineService {
 
   private String toElasticField(@NotBlank final String field) {
     PropertySchema propertyField = commonSearchService.getIndexingSchema().get(field);
+    if (propertyField == null) {
+      // base_representative & co.: searchable analyzed-text base fields absent from the @Queryable
+      // indexing schema. They have no ".keyword" subfield, so target the raw text field instead of
+      // throwing a NullPointerException that 500s the whole search request. Other unknown fields
+      // stay a hard error.
+      if (!BASE_FIELDS.contains(field)) {
+        throw new AnalyticsEngineException("Unknown field: " + field);
+      }
+      return field;
+    }
     return propertyField.isKeyword() ? (field + ".keyword") : field;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
+++ b/openaev-model/src/main/java/io/openaev/service/OpenSearchService.java
@@ -100,7 +100,16 @@ public class OpenSearchService implements EngineService {
     String target = ofNullable(parameters.getOrDefault(value, value)).orElse("");
     PropertySchema propertyField = commonSearchService.getIndexingSchema().get(field);
     if (propertyField == null) {
-      throw new AnalyticsEngineException("Unknown field: " + field);
+      // A base field such as base_representative is a searchable analyzed-text string (see
+      // BASE_FIELDS / queryFromSearch) but carries no @Queryable annotation, so it is absent from
+      // the indexing schema. Treat its value as a string instead of failing, so filtering on it
+      // (e.g. the asset expectation list search box) works. Any other unknown field stays a hard
+      // error.
+      if (!BASE_FIELDS.contains(field)) {
+        throw new AnalyticsEngineException("Unknown field: " + field);
+      }
+      builder.stringValue(target);
+      return builder.build();
     }
     if (propertyField.getType().isAssignableFrom(String.class)
         || (propertyField.getType().isAssignableFrom(Set.class)
@@ -185,7 +194,7 @@ public class OpenSearchService implements EngineService {
                 .map(
                     v -> {
                       FieldValue val = toVal(field, v, parameters);
-                      if (propertyField.isKeyword()) {
+                      if (propertyField != null && propertyField.isKeyword()) {
                         // Champ keyword : wildcard
                         return WildcardQuery.of(
                                 w ->
@@ -212,7 +221,7 @@ public class OpenSearchService implements EngineService {
                 .map(
                     v -> {
                       FieldValue val = toVal(field, v, parameters);
-                      if (propertyField.isKeyword()) {
+                      if (propertyField != null && propertyField.isKeyword()) {
                         return WildcardQuery.of(
                                 w -> w.field(elasticField).value("*" + val.stringValue() + "*"))
                             .toQuery();
@@ -1299,6 +1308,16 @@ public class OpenSearchService implements EngineService {
    */
   private String toElasticField(@NotBlank final String field) {
     PropertySchema propertyField = commonSearchService.getIndexingSchema().get(field);
+    if (propertyField == null) {
+      // base_representative & co.: searchable analyzed-text base fields absent from the @Queryable
+      // indexing schema. They have no ".keyword" subfield, so target the raw text field instead of
+      // throwing a NullPointerException that 500s the whole search request. Other unknown fields
+      // stay a hard error.
+      if (!BASE_FIELDS.contains(field)) {
+        throw new AnalyticsEngineException("Unknown field: " + field);
+      }
+      return field;
+    }
     return propertyField.isKeyword() ? (field + ".keyword") : field;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #7313. After a phishing atomic test (open the lure, follow the link, submit the form) the platform recorded nothing an operator could see - no Findings tab, no captured credentials, no expectation results - even though the tracking POST succeeded. This PR makes the phishing outcome observable and scores it, and folds in a few closely related attack-path scoring / search / UI fixes surfaced while validating the phishing flow end to end.

## What was wrong

- **Findings tab hidden.** The atomic-testing Findings tab is gated on an injector allow-list that did not include `openaev_phishing`.
- **Credential capture too narrow.** The submit endpoints recognized only a few field names, so a cloned real-world login form (e.g. Microsoft's `loginfmt`) produced no `Credentials` finding at all.
- **No meaningful expectations.** The contract advertised DETECTION/PREVENTION plus a single generic MANUAL expectation that was never predefined, so a phishing inject produced no scored expectations and no representation of the human-response outcome.

## Changes (phishing)

- Add `openaev_phishing` to `externalContractTypesWithFindings` so the Findings tab shows for phishing atomic tests.
- Broaden credential capture (larger username/password key lists) and fall back to capturing every non-empty submitted field so a genuine submission is never silently dropped. Both public submit endpoints (`HostedPublicApi`, `PhishingPublicApi`) now flatten the payload into a single field map and hand it to `PhishingTrackingService`, which owns resolution - the duplicated `resolveUsername` / `resolvePassword` helpers are gone. Blank `data` values are dropped before merging the dedicated `username` / `password` fields, so a blank `data.username` / `data.password` can never block a non-blank dedicated field.
- Replace the phishing expectations with three predefined MANUAL steps: "Email opened", "Phishing link clicked", "Credentials submitted" (names shared as constants between the contract builder and the runtime scoring).
- Invert expectation polarity for phishing. The executor pre-scores every step GREEN ("resisted") at send time via `initializeExpectationsAsResisted`; `markOpened` / `markClicked` / `markSubmitted` flip the matching steps RED ("fell for it"). A recipient who never interacts keeps the green verdict, because the generic expiration collector only touches rows whose score is still null - so no bespoke expiration branch is needed.

## Also included (attack-path / search / UI)

- **Network detect/prevent scoring.** For an inject that does not run through an OAEV agent (Nmap, Netexec, HTTP...), the detection/prevention verdict now stays at the asset level instead of fanning one per-agent row out across every endpoint of a chained execution - so a single host + time-window security-platform alert is no longer attributed to endpoints with no EDR. Adds a regression test in `ExpectationUtilsTest`.
- **Expectation search NullPointerException.** Filtering the asset-overview expectation list by keyword sent a `contains` filter on `base_representative`, a searchable analyzed-text base field absent from the `@Queryable` indexing schema; `ElasticService` / `OpenSearchService` now treat base fields as analyzed text instead of dereferencing a null `PropertySchema` and 500-ing the ad-hoc query.
- **Executions list UI.** Rebuilt the asset-overview Executions list as an aligned three-column grid (Action / Execution / Result) with headers and a compact alpha-tinted `ExecutionRanChip` that is pixel-consistent with the agent chip beside it, and an empty-state message.
- **Chaining logic tab.** Center the action-card logo in its square.

## Expectation semantics (phishing)

| Step | Initial (never interacts) | After the recipient performs it |
|------|---------------------------|---------------------------------|
| Email opened | GREEN (resisted) | RED |
| Phishing link clicked | GREEN (resisted) | RED (also flips "opened") |
| Credentials submitted | GREEN (resisted) | RED (also flips "opened" + "clicked") |

The team-level row is flipped as soon as any one member falls for a step.

## Review follow-up

- Dropped blank submitted values before merging the dedicated username/password fields on both public submit endpoints (Copilot: `putIfAbsent` could let a blank `data` value block a real credential).
- Clarified the `PhishingTrackingService` tenant Javadoc (`HostedPublicApi` resolves the tenant from the token; the legacy `PhishingPublicApi` routes take it from the `tenantId` path segment).
- Strengthened the `markClicked` test to stub and assert that both the opened and clicked steps flip to RED.
- Marked the OAEV implant test contracts as needs-executor so `ExpectationUtils` rebuilds the per-agent detection/prevention rows (kept `ExpectationUtilsTest` and `OpenAEVImplantExecutorTest` green after the non-agent scoring gate).
- Added the "No execution reached this target" i18n key to all supported languages.

## Test plan

- [ ] Run a phishing atomic test targeting one team / one player.
- [ ] Open the lure email -> "Email opened" turns RED; other steps stay GREEN.
- [ ] Follow the link -> "Phishing link clicked" turns RED.
- [ ] Submit the login form -> "Credentials submitted" turns RED and a `Credentials` finding appears in the Findings tab (respecting capture-submitted-data / capture-passwords).
- [ ] Submit a form whose fields use atypical names (e.g. `loginfmt`) -> a finding is still created.
- [ ] Let a recipient never interact -> all three steps remain GREEN after expiration.
- [ ] `PhishingTrackingServiceTest`, `ExpectationUtilsTest` and `OpenAEVImplantExecutorTest` pass.
