### PR TITLE
fix(attack-path): removed password_policy masking from the attack path view (#5048)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -295,13 +295,13 @@ describe('maskFindingValue', () => {
     expect(maskFindingValue('credentials', 'nosecrethere')).toBe('••••••••');
     expect(maskFindingValue('credentials', ':secretonly')).toBe('••••••••');
     expect(maskFindingValue('sid', 'S-1-5-21')).toBe('••••••••');
-    expect(maskFindingValue('password_policy', 'complex')).toBe('••••••••');
   });
 
   it('shows non-secret finding values as-is', () => {
     expect(maskFindingValue('cve', 'CVE-2023-1')).toBe('CVE-2023-1');
     expect(maskFindingValue('port', '443')).toBe('443');
     expect(maskFindingValue('username', 'bob')).toBe('bob');
+    expect(maskFindingValue('password_policy', 'complex')).toBe('complex');
   });
 
   it('displays a file as its basename, keeping the full path out of the label', () => {

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -1180,14 +1180,14 @@ export const buildFindingPathFlow = (
 // resolved through FILTER_TO_FINDING_TYPES, defaulting to the type itself so new types work with no code.
 export type AttackPathFindingFilter = 'endpoints' | string;
 
-// Finding types whose value is a captured secret; masked by default in the UI (spec §14). Revealing
-// them is an explicit, permission-gated action handled by the Result/Terminal increment.
-export const SENSITIVE_FINDING_TYPES = new Set(['credentials', 'password_policy', 'sid']);
+// Finding types whose value is a captured secret; masked by default in the UI (spec §14). Only
+// credentials and sid are masked here; revealing remains a permission-gated action.
+export const SENSITIVE_FINDING_TYPES = new Set(['credentials', 'sid']);
 
 // Mask a finding value for display (rendered as text by the callers — never as HTML). Credentials
-// keep the username visible but mask the secret ("user:pass" -> "user : ••••••"); other secret types
-// (sid, password_policy) are fully masked; a `file` value is the full location but displays as its
-// basename (the full path stays available in the detail panel); everything else is shown as-is.
+// keep the username visible but mask the secret ("user:pass" -> "user : ••••••"); sid is fully
+// masked; a `file` value is the full location but displays as its basename (the full path stays
+// available in the detail panel); everything else is shown as-is.
 export const maskFindingValue = (typeFindings?: string, value?: string): string => {
   if (!value) {
     return '';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Align the viewing of password policies from the attack path view to match the one in the finding screens
* Password policies are now therefore unmasked

### Testing Instructions

1. Create a simulation with an inject generating a password output
2. Launch the simulation then check the attack path view, the password policy shouldn't be masked when it appears.

### Related issues

* Relates to https://github.com/OpenAEV-Platform/filigran-private/issues/266

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

