### PR TITLE
fix(notification): reject internal address forms missed by the webhook target guard

### DIFF
--- a/openaev-api/src/main/java/io/openaev/notification/engine/WebhookTargetValidator.java
+++ b/openaev-api/src/main/java/io/openaev/notification/engine/WebhookTargetValidator.java
@@ -1,5 +1,7 @@
 package io.openaev.notification.engine;
 
+import com.google.common.net.InetAddresses;
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
@@ -14,8 +16,9 @@ import org.springframework.stereotype.Component;
  * with a small allow-list of HTTP verbs. Applied both when a notifier is saved and again at
  * dispatch time (the configuration is raw JSON and could bypass the API-time check).
  *
- * <p>On-premise deployments that legitimately post to internal endpoints can opt out of the
- * private-address restriction with {@code openaev.notification.webhook-allow-internal-targets}.
+ * <p>On-premise deployments that legitimately post to internal endpoints can opt out with {@code
+ * openaev.notification.webhook-allow-internal-targets}. That switch disables target checking
+ * entirely, not only the RFC1918 ranges.
  */
 @Component
 public class WebhookTargetValidator {
@@ -79,8 +82,12 @@ public class WebhookTargetValidator {
     }
   }
 
-  // Loopback, link-local (incl. 169.254.169.254 cloud metadata), RFC1918 site-local, wildcard,
-  // multicast and IPv6 unique-local (fc00::/7) ranges are considered internal.
+  /**
+   * Whether an address is internal. Loopback, link-local, RFC1918 site-local, wildcard, multicast
+   * and IPv6 unique-local (fc00::/7) come from the JDK, extended with the special-purpose IPv4
+   * ranges of {@link #isReservedIpv4}. When an IPv6 address carries an IPv4 address inside it, the
+   * embedded address decides.
+   */
   private static boolean isInternal(InetAddress address) {
     if (address.isLoopbackAddress()
         || address.isLinkLocalAddress()
@@ -89,10 +96,66 @@ public class WebhookTargetValidator {
         || address.isMulticastAddress()) {
       return true;
     }
-    if (address instanceof Inet6Address) {
-      byte firstByte = address.getAddress()[0];
-      return (firstByte & 0xFE) == 0xFC;
+    if (address instanceof Inet6Address ipv6) {
+      if ((ipv6.getAddress()[0] & 0xFE) == 0xFC) {
+        return true;
+      }
+      Inet4Address embedded = embeddedIpv4(ipv6);
+      return embedded != null && isInternal(embedded);
     }
-    return false;
+    // Any other address family is a four-byte IPv4 address.
+    return isReservedIpv4(address.getAddress());
+  }
+
+  /**
+   * IANA special-purpose IPv4 ranges the JDK does not classify: {@code 0.0.0.0/8} (this network),
+   * {@code 100.64.0.0/10} (RFC 6598 shared address space), {@code 192.0.0.0/24} (RFC 6890 protocol
+   * assignments), {@code 198.18.0.0/15} (RFC 2544 benchmarking) and {@code 240.0.0.0/4} (reserved).
+   * None of them is a valid public webhook destination.
+   */
+  private static boolean isReservedIpv4(byte[] bytes) {
+    int first = bytes[0] & 0xFF;
+    int second = bytes[1] & 0xFF;
+    return first == 0
+        || (first == 100 && second >= 64 && second <= 127)
+        || (first == 192 && second == 0 && (bytes[2] & 0xFF) == 0)
+        || (first == 198 && (second == 18 || second == 19))
+        || first >= 240;
+  }
+
+  /**
+   * Returns the IPv4 address carried by an IPv6 address, or null when it carries none.
+   *
+   * <p>Recognises the IPv4-compatible and 6to4 forms, the Teredo client address, ISATAP, and NAT64
+   * inside {@code 64:ff9b::/32} when the IPv4 sits in the last four bytes, which is the layout RFC
+   * 6052 defines for a /96 prefix and the one DNS64 resolvers produce in practice.
+   */
+  private static Inet4Address embeddedIpv4(Inet6Address address) {
+    if (InetAddresses.hasEmbeddedIPv4ClientAddress(address)) {
+      return InetAddresses.getEmbeddedIPv4ClientAddress(address);
+    }
+    if (InetAddresses.isIsatapAddress(address)) {
+      return InetAddresses.getIsatapIPv4Address(address);
+    }
+    return nat64Ipv4(address.getAddress());
+  }
+
+  private static Inet4Address nat64Ipv4(byte[] bytes) {
+    boolean nat64Range =
+        bytes[0] == 0x00 && bytes[1] == 0x64 && bytes[2] == (byte) 0xFF && bytes[3] == (byte) 0x9B;
+    if (!nat64Range) {
+      return null;
+    }
+    for (int i = 6; i < 12; i++) {
+      if (bytes[i] != 0x00) {
+        return null;
+      }
+    }
+    int embedded =
+        (bytes[12] & 0xFF) << 24
+            | (bytes[13] & 0xFF) << 16
+            | (bytes[14] & 0xFF) << 8
+            | (bytes[15] & 0xFF);
+    return InetAddresses.fromInteger(embedded);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/notification/engine/WebhookTargetValidator.java
+++ b/openaev-api/src/main/java/io/openaev/notification/engine/WebhookTargetValidator.java
@@ -127,8 +127,9 @@ public class WebhookTargetValidator {
    * Returns the IPv4 address carried by an IPv6 address, or null when it carries none.
    *
    * <p>Recognises the IPv4-compatible and 6to4 forms, the Teredo client address, ISATAP, and NAT64
-   * inside {@code 64:ff9b::/32} when the IPv4 sits in the last four bytes, which is the layout RFC
-   * 6052 defines for a /96 prefix and the one DNS64 resolvers produce in practice.
+   * addresses of the form {@code 64:ff9b:X::a.b.c.d}, that is a prefix inside {@code 64:ff9b::/32}
+   * followed by zeroes and the IPv4 in the last four bytes. That is the layout RFC 6052 defines for
+   * a /96 prefix and the one DNS64 resolvers produce.
    */
   private static Inet4Address embeddedIpv4(Inet6Address address) {
     if (InetAddresses.hasEmbeddedIPv4ClientAddress(address)) {

--- a/openaev-api/src/test/java/io/openaev/notification/engine/WebhookTargetValidatorTest.java
+++ b/openaev-api/src/test/java/io/openaev/notification/engine/WebhookTargetValidatorTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Webhook target validation (SSRF guard)")
 class WebhookTargetValidatorTest {
@@ -50,10 +52,129 @@ class WebhookTargetValidatorTest {
         IllegalArgumentException.class, () -> validator.validateUrl("http://172.16.0.1/hook"));
   }
 
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "http://[::1]/hook",
+        "http://[fc00::1]/hook",
+        "http://[fd12:3456::1]/hook",
+        "http://[fe80::1]/hook",
+        "http://[::]/hook",
+      })
+  void rejects_ipv6_internal_ranges(String url) {
+    assertThrows(IllegalArgumentException.class, () -> validator.validateUrl(url));
+  }
+
+  // Each address below writes an internal IPv4 address in an IPv6 form.
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        // NAT64, well-known prefix 64:ff9b::/96
+        "http://[64:ff9b::7f00:1]/hook",
+        "http://[64:ff9b::a9fe:a9fe]/hook",
+        "http://[64:ff9b::ac10:fe01]/hook",
+        "http://[64:ff9b::c0a8:101]/hook",
+        // NAT64, local prefix 64:ff9b:1::/48
+        "http://[64:ff9b:1::7f00:1]/hook",
+        "http://[64:ff9b:1::a9fe:a9fe]/hook",
+        // 6to4, 2002::/16
+        "http://[2002:7f00:0001::]/hook",
+        "http://[2002:c0a8:0101::]/hook",
+        "http://[2002:a9fe:a9fe::]/hook",
+        // Teredo, 2001:0::/32, embedded address is bitwise inverted
+        "http://[2001:0:0:0:0:0:80ff:fffe]/hook",
+        "http://[2001:0:0:0:0:0:5601:5601]/hook",
+        // IPv4-compatible, deprecated but still parsed
+        "http://[::7f00:1]/hook",
+        "http://[::a9fe:a9fe]/hook",
+        "http://[::c0a8:101]/hook",
+        // ISATAP, IPv4 in the interface identifier
+        "http://[2001:db8::5efe:7f00:1]/hook",
+        "http://[2001:db8::200:5efe:a9fe:a9fe]/hook",
+      })
+  void rejects_ipv6_addresses_wrapping_an_internal_ipv4(String url) {
+    assertThrows(IllegalArgumentException.class, () -> validator.validateUrl(url));
+  }
+
+  // IANA special-purpose ranges the JDK reports as ordinary addresses.
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "http://100.64.0.1/hook",
+        "http://100.127.255.254/hook",
+        "http://0.0.0.5/hook",
+        "http://192.0.0.1/hook",
+        "http://198.18.0.1/hook",
+        "http://198.19.255.254/hook",
+        "http://240.0.0.1/hook",
+        "http://255.255.255.255/hook",
+      })
+  void rejects_reserved_ipv4_ranges(String url) {
+    assertThrows(IllegalArgumentException.class, () -> validator.validateUrl(url));
+  }
+
+  // The reserved ranges above must stay rejected once wrapped in an IPv6 carrier.
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "http://[64:ff9b::6440:1]/hook",
+        "http://[2002:6440:0001::]/hook",
+        "http://[::6440:1]/hook",
+        "http://[64:ff9b::c000:1]/hook",
+      })
+  void rejects_ipv6_wrapping_a_reserved_ipv4(String url) {
+    assertThrows(IllegalArgumentException.class, () -> validator.validateUrl(url));
+  }
+
+  // Any prefix inside 64:ff9b::/32, not only the two IANA-assigned ones.
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "http://[64:ff9b:2::7f00:1]/hook",
+        "http://[64:ff9b:ffff::a9fe:a9fe]/hook",
+      })
+  void rejects_nat64_range_beyond_the_assigned_prefixes(String url) {
+    assertThrows(IllegalArgumentException.class, () -> validator.validateUrl(url));
+  }
+
+  // The JDK returns an Inet4Address for these. Pinned so a change to the IPv6 handling
+  // cannot regress them.
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "http://[::ffff:127.0.0.1]/hook",
+        "http://[::ffff:7f00:1]/hook",
+        "http://[::ffff:a9fe:a9fe]/hook",
+        "http://2130706433/hook",
+      })
+  void rejects_ipv4_mapped_and_decimal_forms(String url) {
+    assertThrows(IllegalArgumentException.class, () -> validator.validateUrl(url));
+  }
+
+  // Public targets must stay reachable, including when they are written in a transition form.
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+      strings = {
+        "http://[64:ff9b::808:808]/hook",
+        "http://[2002:0808:0808::]/hook",
+        "http://[64:ff9b:1::808:808]/hook",
+        "http://[2606:4700::1111]/hook",
+        "http://8.8.8.8/hook",
+      })
+  void allows_public_targets(String url) {
+    assertDoesNotThrow(() -> validator.validateUrl(url));
+  }
+
   @Test
   void allows_internal_targets_when_configured() {
     assertDoesNotThrow(() -> permissiveValidator.validateUrl("http://127.0.0.1/hook"));
     assertDoesNotThrow(() -> permissiveValidator.validateUrl("http://10.0.0.5/hook"));
+  }
+
+  @Test
+  void allows_wrapped_internal_targets_when_configured() {
+    assertDoesNotThrow(() -> permissiveValidator.validateUrl("http://[64:ff9b::7f00:1]/hook"));
+    assertDoesNotThrow(() -> permissiveValidator.validateUrl("http://[::a9fe:a9fe]/hook"));
   }
 
   @Test


### PR DESCRIPTION
The webhook target guard relied on the address classification the JDK provides. Two categories of internal target fell outside it and were accepted: IPv4 addresses in IANA special-purpose ranges that the JDK does not report as private, and IPv6 addresses that carry an IPv4 address inside them.

Both are now resolved to the address they designate and checked against the existing rules. Public targets are unaffected, including when written in an IPv6 form that carries an IPv4 address.

Guava is already a dependency and provides the address decoding.

Tests: the suite had no IPv6 case. It now covers both categories, the ranges that must stay rejected, and public targets that must stay reachable.