### PR TITLE
fix: phishing expectation reconciliation, attack-path action nodes/icons and expectation display-merge leak (#7322)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -26,6 +26,7 @@ import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.InjectorContractId;
 import io.openaev.database.model.PhishingEmailTemplate;
 import io.openaev.database.model.PhishingLandingPage;
+import io.openaev.database.model.SecurityPlatform;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.PhishingEmailTemplateRepository;
@@ -52,6 +53,7 @@ import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -419,15 +421,38 @@ public class PhishingLandingPageService {
   }
 
   /**
-   * Available expectations for a phishing action: the three human-response steps of a phishing test
-   * - the recipient opening the lure email, following the link (landing page loaded) and submitting
-   * data. Each is a predefined MANUAL expectation, so every phishing inject measures all three by
-   * default. Their polarity is inverted (see {@link PhishingTrackingService}): a step is GREEN
-   * ("resisted") while the recipient has not performed it and flips RED ("fell for it") the moment
-   * they do, so a recipient who never interacts keeps the green verdict through expiration.
+   * Available expectations for a phishing action. Two complementary families, all predefined so
+   * every phishing inject measures them by default:
+   *
+   * <ul>
+   *   <li><b>Human response</b> - the three steps of a phishing test: the recipient opening the
+   *       lure email, following the link (landing page loaded) and submitting data. Each is a MANUAL
+   *       expectation with inverted polarity (see {@link PhishingTrackingService}): GREEN
+   *       ("resisted") while the recipient has not performed the step, flipping RED ("fell for it")
+   *       the moment they do, so a recipient who never interacts keeps the green verdict through
+   *       expiration.
+   *   <li><b>Security control</b> - PREVENTION and DETECTION, exactly like most technical injector
+   *       contracts: a phishing simulation is only complete if the platform can also score whether
+   *       the lure was blocked (prevention) or detected (detection). Both are focused on {@link
+   *       SecurityPlatform.SECURITY_PLATFORM_TYPE#EMAIL_SECURITY} platforms - the control that
+   *       actually inspects inbound mail - instead of asking every connected collector for a
+   *       verdict.
+   * </ul>
    */
   private List<Expectation> buildPhishingExpectations() {
+    Expectation prevention = this.expectationBuilderService.buildPreventionExpectation();
+    prevention.setPredefined(true);
+    prevention.setExpectedSecurityPlatformTypes(
+        new ArrayList<>(List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.EMAIL_SECURITY)));
+
+    Expectation detection = this.expectationBuilderService.buildDetectionExpectation();
+    detection.setPredefined(true);
+    detection.setExpectedSecurityPlatformTypes(
+        new ArrayList<>(List.of(SecurityPlatform.SECURITY_PLATFORM_TYPE.EMAIL_SECURITY)));
+
     return List.of(
+        detection,
+        prevention,
         buildPhishingStep(
             PhishingTrackingService.STEP_OPENED,
             "Red once the recipient opens the lure email (tracking pixel loaded); green while the"

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -426,8 +426,8 @@ public class PhishingLandingPageService {
    *
    * <ul>
    *   <li><b>Human response</b> - the three steps of a phishing test: the recipient opening the
-   *       lure email, following the link (landing page loaded) and submitting data. Each is a MANUAL
-   *       expectation with inverted polarity (see {@link PhishingTrackingService}): GREEN
+   *       lure email, following the link (landing page loaded) and submitting data. Each is a
+   *       MANUAL expectation with inverted polarity (see {@link PhishingTrackingService}): GREEN
    *       ("resisted") while the recipient has not performed the step, flipping RED ("fell for it")
    *       the moment they do, so a recipient who never interacts keeps the green verdict through
    *       expiration.

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
@@ -411,13 +411,31 @@ public class PhishingTrackingService {
     // the team recomputation then reads, so it sees the fresh player scores without re-querying.
     List<BaseInjectExpectation> injectExpectations =
         injectExpectationRepository.findAllByInjectId(inject.getId());
-    injectExpectations.stream()
-        .filter(expectation -> isPlayerRowForUser(expectation, user.getId()))
-        .filter(expectation -> matchesSteps(expectation, stepNames))
-        .forEach(expectation -> markCompromised(expectation, message));
+    List<BaseInjectExpectation> playerSteps =
+        injectExpectations.stream()
+            .filter(expectation -> isPlayerRowForUser(expectation, user.getId()))
+            .filter(expectation -> matchesSteps(expectation, stepNames))
+            .toList();
+    playerSteps.forEach(expectation -> markCompromised(expectation, message));
+    // Only the recipient's own team(s) can have changed: recomputing every team of the inject
+    // would rewrite unrelated team rows (result text / updatedAt churn) on each click.
+    Set<String> affectedTeamIds =
+        playerSteps.stream()
+            .map(expectation -> ((TableTopInjectExpectation) expectation).getTeam())
+            .filter(Objects::nonNull)
+            .map(team -> team.getId())
+            .collect(Collectors.toSet());
+    if (affectedTeamIds.isEmpty()) {
+      return;
+    }
     injectExpectations.stream()
         .filter(PhishingTrackingService::isTeamRow)
         .filter(expectation -> matchesSteps(expectation, stepNames))
+        .filter(
+            expectation ->
+                expectation instanceof TableTopInjectExpectation teamRow
+                    && teamRow.getTeam() != null
+                    && affectedTeamIds.contains(teamRow.getTeam().getId()))
         .forEach(teamRow -> recomputeTeamStepFromPlayers(teamRow, injectExpectations));
   }
 

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
@@ -91,6 +91,12 @@ public class PhishingTrackingService {
   /** Result message stamped on a team step whose recomputed verdict is RED ("fell for it"). */
   private static final String TEAM_COMPROMISED_MESSAGE = "A team member fell for the phishing";
 
+  /**
+   * Result message for a team step that stays GREEN under the "at least one" rule even though some
+   * member fell: "no interaction" would be factually wrong there.
+   */
+  private static final String TEAM_RESISTED_MESSAGE = "At least one team member resisted";
+
   // Form-field names accepted as the username / password of a submitted credential. Kept broad so a
   // cloned real-world login form (e.g. Microsoft's "loginfmt", not "username") is still captured.
   private static final List<String> USERNAME_KEYS =
@@ -482,10 +488,13 @@ public class PhishingTrackingService {
       return;
     }
     boolean resisted = score >= team.getExpectedScore();
-    team.setResults(
-        List.of(
-            buildForTeamManualValidation(
-                resisted ? NO_INTERACTION_MESSAGE : TEAM_COMPROMISED_MESSAGE, score)));
+    boolean anyCompromised =
+        players.stream().anyMatch(p -> p.getScore() != null && p.getScore() <= COMPROMISED_SCORE);
+    String message =
+        resisted
+            ? (anyCompromised ? TEAM_RESISTED_MESSAGE : NO_INTERACTION_MESSAGE)
+            : TEAM_COMPROMISED_MESSAGE;
+    team.setResults(List.of(buildForTeamManualValidation(message, score)));
     team.setScore(score);
     team.setUpdatedAt(now());
     injectExpectationRepository.save(team);

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
@@ -12,13 +12,13 @@ import io.openaev.database.model.InjectExpectationResult;
 import io.openaev.database.model.PhishingLandingPage;
 import io.openaev.database.model.PhishingResult;
 import io.openaev.database.model.TableTopInjectExpectation;
-import io.openaev.database.model.Team;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.PhishingResultRepository;
 import io.openaev.database.repository.TeamRepository;
 import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.finding.FindingService;
+import io.openaev.service.InjectExpectationUtils;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.security.SecureRandom;
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -86,6 +87,9 @@ public class PhishingTrackingService {
 
   /** Result message stamped on a step the recipient never triggered (GREEN). */
   private static final String NO_INTERACTION_MESSAGE = "No phishing interaction detected";
+
+  /** Result message stamped on a team step whose recomputed verdict is RED ("fell for it"). */
+  private static final String TEAM_COMPROMISED_MESSAGE = "A team member fell for the phishing";
 
   // Form-field names accepted as the username / password of a submitted credential. Kept broad so a
   // cloned real-world login form (e.g. Microsoft's "loginfmt", not "username") is still captured.
@@ -383,9 +387,18 @@ public class PhishingTrackingService {
   }
 
   /**
-   * Flips the named phishing steps to RED (compromised) for the recipient and their team. The
-   * team-level row is flipped too: a team has fallen for the phishing as soon as any one of its
-   * members does. Idempotent per step - an already-compromised step keeps its earliest signal.
+   * Flips the named phishing steps to RED (compromised) for the recipient, then re-derives the
+   * team-level rows of those steps from their player rows.
+   *
+   * <p>The team row is NEVER written directly here: a team's verdict must follow the expectation's
+   * validation rule ({@code expectationGroup}) exactly like every other human expectation. With the
+   * default "all players must validate" rule the team turns RED as soon as one member falls for the
+   * phishing; with "at least one player" it stays GREEN until every member does. Writing the team
+   * row directly (as before) both ignored that rule and left the team stuck GREEN whenever the
+   * recipient's team could not be resolved back on the tracking row - hence a compromised person
+   * next to a green team. Deriving it from the same player rows the rest of the platform uses keeps
+   * person and team consistent by construction. Idempotent per player step - an already-compromised
+   * step keeps its earliest signal.
    */
   private void compromiseSteps(
       final PhishingResult result, final Set<String> stepNames, final String message) {
@@ -394,30 +407,77 @@ public class PhishingTrackingService {
     if (user == null || inject == null) {
       return;
     }
-    injectExpectationRepository.findAllByInjectAndPlayer(inject.getId(), user.getId()).stream()
+    // findAllByInjectId returns managed entities: the player flips below mutate the very instances
+    // the team recomputation then reads, so it sees the fresh player scores without re-querying.
+    List<BaseInjectExpectation> injectExpectations =
+        injectExpectationRepository.findAllByInjectId(inject.getId());
+    injectExpectations.stream()
+        .filter(expectation -> isPlayerRowForUser(expectation, user.getId()))
         .filter(expectation -> matchesSteps(expectation, stepNames))
-        .forEach(expectation -> markCompromised(expectation, message, false));
-    Team team = result.getTeam();
-    if (team != null) {
-      injectExpectationRepository.findAllByInjectAndTeam(inject.getId(), team.getId()).stream()
-          .filter(expectation -> matchesSteps(expectation, stepNames))
-          .forEach(expectation -> markCompromised(expectation, message, true));
-    }
+        .forEach(expectation -> markCompromised(expectation, message));
+    injectExpectations.stream()
+        .filter(PhishingTrackingService::isTeamRow)
+        .filter(expectation -> matchesSteps(expectation, stepNames))
+        .forEach(teamRow -> recomputeTeamStepFromPlayers(teamRow, injectExpectations));
   }
 
-  private void markCompromised(
-      final BaseInjectExpectation expectation, final String message, final boolean team) {
+  private void markCompromised(final BaseInjectExpectation expectation, final String message) {
     if (expectation.getScore() != null && expectation.getScore() <= COMPROMISED_SCORE) {
       return;
     }
-    InjectExpectationResult result =
-        team
-            ? buildForTeamManualValidation(message, COMPROMISED_SCORE)
-            : buildForPlayerManualValidation(message, COMPROMISED_SCORE);
-    expectation.setResults(List.of(result));
+    expectation.setResults(List.of(buildForPlayerManualValidation(message, COMPROMISED_SCORE)));
     expectation.setScore(COMPROMISED_SCORE);
     expectation.setUpdatedAt(now());
     injectExpectationRepository.save(expectation);
+  }
+
+  /**
+   * Recomputes one team-level phishing step from its player rows, honoring the expectation's
+   * validation rule (all-vs-any) and the inverted phishing polarity, via the same {@link
+   * InjectExpectationUtils#computeChildrenScore} aggregation used for every human expectation. A
+   * team with no player rows, or whose players are all still pending, is left untouched (it keeps
+   * its pre-scored GREEN "resisted" verdict).
+   */
+  private void recomputeTeamStepFromPlayers(
+      final BaseInjectExpectation teamRow, final List<BaseInjectExpectation> injectExpectations) {
+    if (!(teamRow instanceof TableTopInjectExpectation team) || team.getTeam() == null) {
+      return;
+    }
+    String teamId = team.getTeam().getId();
+    List<BaseInjectExpectation> players =
+        injectExpectations.stream()
+            .filter(
+                expectation ->
+                    expectation instanceof TableTopInjectExpectation player
+                        && player.getUser() != null
+                        && player.getTeam() != null
+                        && teamId.equals(player.getTeam().getId())
+                        && Objects.equals(player.getName(), team.getName()))
+            .toList();
+    if (players.isEmpty()) {
+      return;
+    }
+    Double score =
+        InjectExpectationUtils.computeChildrenScore(
+            team.isExpectationGroup(), team.getExpectedScore(), players);
+    if (score == null) {
+      return;
+    }
+    boolean resisted = score >= team.getExpectedScore();
+    team.setResults(
+        List.of(
+            buildForTeamManualValidation(
+                resisted ? NO_INTERACTION_MESSAGE : TEAM_COMPROMISED_MESSAGE, score)));
+    team.setScore(score);
+    team.setUpdatedAt(now());
+    injectExpectationRepository.save(team);
+  }
+
+  private static boolean isPlayerRowForUser(
+      final BaseInjectExpectation expectation, final String userId) {
+    return expectation instanceof TableTopInjectExpectation tableTop
+        && tableTop.getUser() != null
+        && userId.equals(tableTop.getUser().getId());
   }
 
   private static boolean matchesSteps(

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1688,8 +1688,18 @@ public class InjectExpectationService {
   /**
    * Merges expectation results by expectation type, keeping one expectation per type.
    *
-   * <p>Results from collector sources are not copied to the merged expectation. The score is set to
-   * the maximum score among all results.
+   * <p>Display-only: when several expectations share a type (e.g. the three phishing steps, all
+   * MANUAL), the merge is built on a DETACHED clone of the first expectation. The inputs are
+   * managed entities on an open session, so mutating them here would flush the merged results and
+   * score back to the database on commit - every read of a results page would then re-append the
+   * sibling rows' results into the elected row (unbounded JSONB growth, requests eventually
+   * exceeding the connection-leak threshold and exhausting the pool) and overwrite its persisted
+   * score.
+   *
+   * <p>Results from collector sources are not copied to the merged clone. The merged score is the
+   * worst (minimum) score among the answered same-type expectations: a target validates a type only
+   * if every expectation of that type validated it, so e.g. one compromised phishing step keeps the
+   * merged human-response verdict red even when the other steps were resisted.
    *
    * @param expectations the list of expectations to merge
    * @return a list with one expectation per type containing merged results
@@ -1698,37 +1708,40 @@ public class InjectExpectationService {
       List<? extends BaseInjectExpectation> expectations) {
     List<String> notCopiedSourceTypes = List.of(COLLECTOR);
 
-    HashMap<BaseInjectExpectation.EXPECTATION_TYPE, BaseInjectExpectation> electedExpectations =
-        new HashMap<>();
+    Map<BaseInjectExpectation.EXPECTATION_TYPE, List<BaseInjectExpectation>> byType =
+        new LinkedHashMap<>();
     for (BaseInjectExpectation expectation : expectations) {
-      if (!electedExpectations.containsKey(expectation.getType())) {
-        electedExpectations.put(expectation.getType(), expectation);
+      byType.computeIfAbsent(expectation.getType(), k -> new ArrayList<>()).add(expectation);
+    }
+
+    List<BaseInjectExpectation> merged = new ArrayList<>(byType.size());
+    for (List<BaseInjectExpectation> sameType : byType.values()) {
+      BaseInjectExpectation elected = sameType.get(0);
+      if (sameType.size() == 1) {
+        merged.add(elected);
         continue;
       }
-
-      for (InjectExpectationResult expectationResult : expectation.getResults()) {
-        if (!notCopiedSourceTypes.contains(expectationResult.getSourceType())
-            && expectationResult.getResult() != null
-            && expectationResult.getScore() != null) {
-          electedExpectations
-              .get(expectation.getType())
-              .setResults(
-                  Stream.concat(
-                          electedExpectations.get(expectation.getType()).getResults().stream(),
-                          Stream.of(expectationResult))
-                      .toList());
-          electedExpectations
-              .get(expectation.getType())
-              .setScore(
-                  electedExpectations.get(expectation.getType()).getResults().stream()
-                      .map(InjectExpectationResult::getScore)
-                      .filter(Objects::nonNull)
-                      .max(Double::compareTo)
-                      .orElse(null));
+      BaseInjectExpectation clone = elected.clone();
+      List<InjectExpectationResult> combinedResults = new ArrayList<>(elected.getResults());
+      for (BaseInjectExpectation other : sameType.subList(1, sameType.size())) {
+        for (InjectExpectationResult expectationResult : other.getResults()) {
+          if (!notCopiedSourceTypes.contains(expectationResult.getSourceType())
+              && expectationResult.getResult() != null
+              && expectationResult.getScore() != null) {
+            combinedResults.add(expectationResult);
+          }
         }
       }
+      clone.setResults(combinedResults);
+      clone.setScore(
+          sameType.stream()
+              .map(BaseInjectExpectation::getScore)
+              .filter(Objects::nonNull)
+              .min(Double::compareTo)
+              .orElse(null));
+      merged.add(clone);
     }
-    return electedExpectations.values().stream().toList();
+    return merged;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationService.java
@@ -1696,10 +1696,12 @@ public class InjectExpectationService {
    * exceeding the connection-leak threshold and exhausting the pool) and overwrite its persisted
    * score.
    *
-   * <p>Results from collector sources are not copied to the merged clone. The merged score is the
-   * worst (minimum) score among the answered same-type expectations: a target validates a type only
-   * if every expectation of that type validated it, so e.g. one compromised phishing step keeps the
-   * merged human-response verdict red even when the other steps were resisted.
+   * <p>Collector-source results of the SIBLING expectations are not copied onto the merged clone;
+   * the elected expectation's own results (collector ones included) are kept as-is. The merged
+   * score is the worst (minimum) score among the answered same-type expectations: a target
+   * validates a type only if every expectation of that type validated it, so e.g. one compromised
+   * phishing step keeps the merged human-response verdict red even when the other steps were
+   * resisted.
    *
    * @param expectations the list of expectations to merge
    * @return a list with one expectation per type containing merged results

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -648,8 +648,7 @@ public class AttackPathGraphService {
     applyContractNames(page, feedByExecutionId);
     applyExecutionStatuses(page, feedByExecutionId);
     applyPayloadIconMetadata(page, feedByExecutionId);
-    applyFeedAttackPatterns(
-        page, feedByExecutionId, loadPatternsByContract(feedContractIds(page)));
+    applyFeedAttackPatterns(page, feedByExecutionId, loadPatternsByContract(feedContractIds(page)));
     return new AttackPathEndpointRelationsDTO(
         new ArrayList<>(feedByExecutionId.values()),
         new ArrayList<>(edges.values()),

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -26,6 +26,7 @@ import io.openaev.database.repository.ConditionRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectStatusRepository;
 import io.openaev.database.repository.InjectorContractRepository;
+import io.openaev.database.repository.PayloadRepository;
 import io.openaev.database.repository.StepConditionRow;
 import io.openaev.database.repository.StepRepository;
 import io.openaev.database.repository.attackpath.AttackPathExecutionRemediationRepository;
@@ -152,6 +153,7 @@ public class AttackPathGraphService {
   private final AssetRepository assetRepository;
   private final InjectStatusRepository injectStatusRepository;
   private final InjectRepository injectRepository;
+  private final PayloadRepository payloadRepository;
 
   /**
    * Above this many executions a simulation is served collapsed by default. Tied to the front
@@ -645,6 +647,7 @@ public class AttackPathGraphService {
     }
     applyContractNames(page, feedByExecutionId);
     applyExecutionStatuses(page, feedByExecutionId);
+    applyPayloadIconMetadata(page, feedByExecutionId);
     return new AttackPathEndpointRelationsDTO(
         new ArrayList<>(feedByExecutionId.values()),
         new ArrayList<>(edges.values()),
@@ -697,6 +700,8 @@ public class AttackPathGraphService {
     applyEventDependencies(executions, findings, feedByExecutionId);
     Map<String, String> contractNames = applyContractNames(executions, feedByExecutionId);
     applyExecutionStatuses(executions, feedByExecutionId);
+    applyPayloadIconMetadata(executions, feedByExecutionId);
+    applyFeedAttackPatterns(executions, feedByExecutionId);
     applyInjectorNodeLabels(nodes, contractsByInjectorNode, contractNames);
 
     // Endpoint (ASSET) nodes, with attributes and colour from the executions targeting them.
@@ -859,19 +864,11 @@ public class AttackPathGraphService {
       Map<String, AttackPathNodeDTO> nodes, Map<String, Set<String>> contractsByInjectorNode) {
     Set<String> externalIds = new HashSet<>();
     contractsByInjectorNode.values().forEach(externalIds::addAll);
-    if (externalIds.isEmpty()) {
+    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract =
+        loadPatternsByContract(externalIds);
+    if (patternsByContract.isEmpty()) {
       return;
     }
-    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract = new HashMap<>();
-    injectorContractRepository
-        .findInjectorAttackPatternsByExternalIdIn(externalIds)
-        .forEach(
-            row ->
-                patternsByContract
-                    .computeIfAbsent(row.contractExternalId(), k -> new ArrayList<>())
-                    .add(
-                        new AttackPathAttackPatternDTO(
-                            row.patternExternalId(), row.patternName())));
     contractsByInjectorNode.forEach(
         (nodeId, contractIds) -> {
           Map<String, AttackPathAttackPatternDTO> deduped = new LinkedHashMap<>();
@@ -884,6 +881,29 @@ public class AttackPathGraphService {
             nodes.get(nodeId).setAttackPatterns(new ArrayList<>(deduped.values()));
           }
         });
+  }
+
+  /**
+   * The {@code contract external id -> ATT&CK techniques} map for a set of contracts, in one
+   * batched read. Shared by the injector-node and feed-node technique resolutions so each graph
+   * pass pays for at most one such query per consumer. Empty input means no query at all.
+   */
+  private Map<String, List<AttackPathAttackPatternDTO>> loadPatternsByContract(
+      Set<String> externalIds) {
+    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract = new HashMap<>();
+    if (externalIds.isEmpty()) {
+      return patternsByContract;
+    }
+    injectorContractRepository
+        .findInjectorAttackPatternsByExternalIdIn(externalIds)
+        .forEach(
+            row ->
+                patternsByContract
+                    .computeIfAbsent(row.contractExternalId(), k -> new ArrayList<>())
+                    .add(
+                        new AttackPathAttackPatternDTO(
+                            row.patternExternalId(), row.patternName())));
+    return patternsByContract;
   }
 
   /**
@@ -1423,6 +1443,76 @@ public class AttackPathGraphService {
   }
 
   /**
+   * Resolves each feed node's payload icon metadata (payload type + collector type name) from its
+   * frozen payload id, in ONE batched read for the whole feed. An agent-executed action's
+   * injectorType is always the implant, so without this the map can only draw the generic agent
+   * icon; the collector type name (e.g. openaev_netexec) is what the catalog icon is keyed by. Rows
+   * with no payload (network executions) or a deleted payload simply keep null fields.
+   */
+  private void applyPayloadIconMetadata(
+      List<AttackPathExecutionRow> executions, Map<String, AttackPathNodeDTO> feedByExecutionId) {
+    Set<String> payloadIds =
+        executions.stream()
+            .map(AttackPathExecutionRow::payloadId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    if (payloadIds.isEmpty()) {
+      return;
+    }
+    Map<String, String> typeByPayload = new HashMap<>();
+    Map<String, String> collectorTypeByPayload = new HashMap<>();
+    for (Object[] row : payloadRepository.findIconMetadataByIds(payloadIds)) {
+      if (row[0] instanceof String payloadId) {
+        if (row[1] instanceof String payloadType) {
+          typeByPayload.put(payloadId, payloadType);
+        }
+        if (row[2] instanceof String collectorType) {
+          collectorTypeByPayload.put(payloadId, collectorType);
+        }
+      }
+    }
+    for (AttackPathExecutionRow e : executions) {
+      AttackPathNodeDTO node = feedByExecutionId.get(e.id());
+      if (node == null || e.payloadId() == null) {
+        continue;
+      }
+      node.setPayloadType(typeByPayload.get(e.payloadId()));
+      node.setPayloadCollectorType(collectorTypeByPayload.get(e.payloadId()));
+    }
+  }
+
+  /**
+   * Sets each feed node's ATT&CK techniques from its own frozen contract, in ONE batched read. An
+   * endpoint-local action promoted to its own map node has no injector node to read techniques
+   * from (its source is the endpoint itself), so the feed entry must carry them for the ACTION
+   * card to render the same technique chips as a real injector node.
+   */
+  private void applyFeedAttackPatterns(
+      List<AttackPathExecutionRow> executions, Map<String, AttackPathNodeDTO> feedByExecutionId) {
+    Set<String> externalIds =
+        executions.stream()
+            .map(AttackPathExecutionRow::contractExternalId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract =
+        loadPatternsByContract(externalIds);
+    if (patternsByContract.isEmpty()) {
+      return;
+    }
+    for (AttackPathExecutionRow e : executions) {
+      AttackPathNodeDTO node =
+          e.contractExternalId() == null ? null : feedByExecutionId.get(e.id());
+      if (node == null) {
+        continue;
+      }
+      List<AttackPathAttackPatternDTO> patterns = patternsByContract.get(e.contractExternalId());
+      if (patterns != null && !patterns.isEmpty()) {
+        node.setAttackPatterns(new ArrayList<>(patterns));
+      }
+    }
+  }
+
+  /**
    * Labels each per-contract injector node with its contract's name, so two nodes of the same
    * injector are distinguishable on the map. Reuses the names already resolved for the feed nodes,
    * so no extra query; a node whose contract name did not resolve keeps its injector-name label.
@@ -1535,6 +1625,9 @@ public class AttackPathGraphService {
     node.setAgentName(e.agentName());
     node.setPrivilege(e.agentPrivilege());
     node.setStepTemplateId(e.stepTemplateId());
+    // The injector type frozen on the row (the implant for an agent-executed payload), so a feed
+    // entry promoted to its own ACTION node on the map can at least fall back to the injector icon.
+    node.setInjectorType(e.injectorType());
     return node;
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -648,7 +648,8 @@ public class AttackPathGraphService {
     applyContractNames(page, feedByExecutionId);
     applyExecutionStatuses(page, feedByExecutionId);
     applyPayloadIconMetadata(page, feedByExecutionId);
-    applyFeedAttackPatterns(page, feedByExecutionId);
+    applyFeedAttackPatterns(
+        page, feedByExecutionId, loadPatternsByContract(feedContractIds(page)));
     return new AttackPathEndpointRelationsDTO(
         new ArrayList<>(feedByExecutionId.values()),
         new ArrayList<>(edges.values()),
@@ -702,7 +703,12 @@ public class AttackPathGraphService {
     Map<String, String> contractNames = applyContractNames(executions, feedByExecutionId);
     applyExecutionStatuses(executions, feedByExecutionId);
     applyPayloadIconMetadata(executions, feedByExecutionId);
-    applyFeedAttackPatterns(executions, feedByExecutionId);
+    // ONE batched technique read serves both the feed nodes (here) and the injector nodes
+    // (resolveInjectorAttackPatterns below): the feed's contract set is a superset of the
+    // injector-node one, so the full pass keeps its constant query count.
+    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract =
+        loadPatternsByContract(feedContractIds(executions));
+    applyFeedAttackPatterns(executions, feedByExecutionId, patternsByContract);
     applyInjectorNodeLabels(nodes, contractsByInjectorNode, contractNames);
 
     // Endpoint (ASSET) nodes, with attributes and colour from the executions targeting them.
@@ -805,7 +811,7 @@ public class AttackPathGraphService {
           }
         });
 
-    resolveInjectorAttackPatterns(nodes, contractsByInjectorNode);
+    resolveInjectorAttackPatterns(nodes, contractsByInjectorNode, patternsByContract);
     applyEndpointCriticality(nodes);
 
     AttackPathCounters counters =
@@ -852,21 +858,20 @@ public class AttackPathGraphService {
       }
     }
     applyInjectorNodeLabels(nodes, contractsByInjectorNode, resolveContractNames(externalIds));
-    resolveInjectorAttackPatterns(nodes, contractsByInjectorNode);
+    resolveInjectorAttackPatterns(
+        nodes, contractsByInjectorNode, loadPatternsByContract(externalIds));
   }
 
   /**
-   * Sets each injector node's ATT&CK techniques from its contracts, in ONE batched query for the
-   * whole graph. A node's techniques are the union across every contract that injector ran, deduped
-   * by technique id, since one injector can run several contracts in a simulation. No injector
-   * contract in scope means no query at all, so a graph without injectors stays at its two reads.
+   * Sets each injector node's ATT&CK techniques from its contracts, out of the caller-supplied
+   * {@code patternsByContract} batch. A node's techniques are the union across every contract that
+   * injector ran, deduped by technique id, since one injector can run several contracts in a
+   * simulation. An empty batch means no injector contract resolved a technique, so nothing to set.
    */
   private void resolveInjectorAttackPatterns(
-      Map<String, AttackPathNodeDTO> nodes, Map<String, Set<String>> contractsByInjectorNode) {
-    Set<String> externalIds = new HashSet<>();
-    contractsByInjectorNode.values().forEach(externalIds::addAll);
-    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract =
-        loadPatternsByContract(externalIds);
+      Map<String, AttackPathNodeDTO> nodes,
+      Map<String, Set<String>> contractsByInjectorNode,
+      Map<String, List<AttackPathAttackPatternDTO>> patternsByContract) {
     if (patternsByContract.isEmpty()) {
       return;
     }
@@ -1482,21 +1487,25 @@ public class AttackPathGraphService {
     }
   }
 
+  /** The distinct contract external ids of a set of execution rows (the feed's technique keys). */
+  private static Set<String> feedContractIds(List<AttackPathExecutionRow> executions) {
+    return executions.stream()
+        .map(AttackPathExecutionRow::contractExternalId)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
   /**
-   * Sets each feed node's ATT&CK techniques from its own frozen contract, in ONE batched read. An
-   * endpoint-local action promoted to its own map node has no injector node to read techniques from
-   * (its source is the endpoint itself), so the feed entry must carry them for the ACTION card to
-   * render the same technique chips as a real injector node.
+   * Sets each feed node's ATT&CK techniques from its own frozen contract, out of the
+   * caller-supplied {@code patternsByContract} batch. An endpoint-local action promoted to its own
+   * map node has no injector node to read techniques from (its source is the endpoint itself), so
+   * the feed entry must carry them for the ACTION card to render the same technique chips as a real
+   * injector node.
    */
   private void applyFeedAttackPatterns(
-      List<AttackPathExecutionRow> executions, Map<String, AttackPathNodeDTO> feedByExecutionId) {
-    Set<String> externalIds =
-        executions.stream()
-            .map(AttackPathExecutionRow::contractExternalId)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
-    Map<String, List<AttackPathAttackPatternDTO>> patternsByContract =
-        loadPatternsByContract(externalIds);
+      List<AttackPathExecutionRow> executions,
+      Map<String, AttackPathNodeDTO> feedByExecutionId,
+      Map<String, List<AttackPathAttackPatternDTO>> patternsByContract) {
     if (patternsByContract.isEmpty()) {
       return;
     }

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -1483,9 +1483,9 @@ public class AttackPathGraphService {
 
   /**
    * Sets each feed node's ATT&CK techniques from its own frozen contract, in ONE batched read. An
-   * endpoint-local action promoted to its own map node has no injector node to read techniques
-   * from (its source is the endpoint itself), so the feed entry must carry them for the ACTION
-   * card to render the same technique chips as a real injector node.
+   * endpoint-local action promoted to its own map node has no injector node to read techniques from
+   * (its source is the endpoint itself), so the feed entry must carry them for the ACTION card to
+   * render the same technique chips as a real injector node.
    */
   private void applyFeedAttackPatterns(
       List<AttackPathExecutionRow> executions, Map<String, AttackPathNodeDTO> feedByExecutionId) {

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/AttackPathGraphService.java
@@ -648,6 +648,7 @@ public class AttackPathGraphService {
     applyContractNames(page, feedByExecutionId);
     applyExecutionStatuses(page, feedByExecutionId);
     applyPayloadIconMetadata(page, feedByExecutionId);
+    applyFeedAttackPatterns(page, feedByExecutionId);
     return new AttackPathEndpointRelationsDTO(
         new ArrayList<>(feedByExecutionId.values()),
         new ArrayList<>(edges.values()),

--- a/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
+++ b/openaev-api/src/main/java/io/openaev/service/attackpath/dto/AttackPathNodeDTO.java
@@ -71,6 +71,13 @@ public class AttackPathNodeDTO {
   // front address this execution's live inject without first fetching its detail row.
   private String injectId;
   private String payloadId;
+  // EXECUTION: the payload's discriminator type (Command, Executable, ...) and, when the payload
+  // was shipped by a collector, that collector type's name (e.g. openaev_netexec,
+  // openaev_atomic_red_team). They drive the action's real catalog icon on the map: without them an
+  // agent-executed action can only fall back to the generic agent icon, since its injectorType is
+  // always the implant. Null for a network execution (no payload) or an unresolvable payload.
+  private String payloadType;
+  private String payloadCollectorType;
   // EXECUTION: whether the inject actually RAN (EXECUTED / ERROR / PENDING…), as opposed to whether
   // it was caught, which is what `status` above carries. Shipped with the graph so a list of
   // executions renders it on first paint; the front previously needed two sequential fetches per

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
@@ -20,6 +20,7 @@ import io.openaev.database.model.Inject;
 import io.openaev.database.model.ManualInjectExpectation;
 import io.openaev.database.model.PhishingLandingPage;
 import io.openaev.database.model.PhishingResult;
+import io.openaev.database.model.Team;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.PhishingResultRepository;
@@ -67,16 +68,46 @@ class PhishingTrackingServiceTest {
   }
 
   /**
-   * A player-scoped MANUAL step expectation, pre-scored GREEN (resisted) like the executor does.
+   * A player-scoped MANUAL step expectation for the tracked recipient ({@code user-1}), pre-scored
+   * GREEN (resisted) like the executor does. Bound to {@code team-1} so team-level derivation can
+   * find it.
    */
   private ManualInjectExpectation resistedStep(final String name) {
-    ManualInjectExpectation expectation = new ManualInjectExpectation();
+    return playerStep(name, "user-1", "team-1", 100.0, false);
+  }
+
+  /** A player-scoped MANUAL step row bound to a user + team, with an explicit score and rule. */
+  private ManualInjectExpectation playerStep(
+      final String name,
+      final String userId,
+      final String teamId,
+      final double score,
+      final boolean expectationGroup) {
+    ManualInjectExpectation expectation = teamStep(name, teamId, score, expectationGroup);
     // A distinct id keeps equals()/hashCode() well-defined when several rows are matched in the
     // same verify() (an id-less expectation dereferences a null id during Mockito's comparison).
-    expectation.setId(name);
+    expectation.setId(name + ":" + userId);
+    User user = new User();
+    user.setId(userId);
+    expectation.setUser(user);
+    return expectation;
+  }
+
+  /** A team-level MANUAL step row (no user) bound to a team, with an explicit score and rule. */
+  private ManualInjectExpectation teamStep(
+      final String name,
+      final String teamId,
+      final double score,
+      final boolean expectationGroup) {
+    ManualInjectExpectation expectation = new ManualInjectExpectation();
+    expectation.setId(name + ":team:" + teamId);
     expectation.setName(name);
     expectation.setExpectedScore(100.0);
-    expectation.setScore(100.0);
+    expectation.setScore(score);
+    expectation.setExpectationGroup(expectationGroup);
+    Team team = new Team();
+    team.setId(teamId);
+    expectation.setTeam(team);
     return expectation;
   }
 
@@ -120,7 +151,7 @@ class PhishingTrackingServiceTest {
         .thenAnswer(i -> i.getArgument(0));
     ManualInjectExpectation opened = resistedStep(PhishingTrackingService.STEP_OPENED);
     ManualInjectExpectation clicked = resistedStep(PhishingTrackingService.STEP_CLICKED);
-    when(injectExpectationRepository.findAllByInjectAndPlayer("inject-1", "user-1"))
+    when(injectExpectationRepository.findAllByInjectId("inject-1"))
         .thenReturn(List.of(opened, clicked));
 
     // -- ACT --
@@ -147,7 +178,7 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
     ManualInjectExpectation unrelated = resistedStep("Some operator check");
-    when(injectExpectationRepository.findAllByInjectAndPlayer("inject-1", "user-1"))
+    when(injectExpectationRepository.findAllByInjectId("inject-1"))
         .thenReturn(List.of(unrelated));
 
     // -- ACT --
@@ -160,6 +191,69 @@ class PhishingTrackingServiceTest {
 
   @Test
   @DisplayName(
+      "markClicked should turn the team RED when the rule is 'all must validate' and one member"
+          + " falls")
+  void markClicked_should_failTeamUnderAllValidateRule() {
+    // -- ARRANGE -- one team, one player (the recipient); "all must validate" (expectationGroup
+    // false), both rows start GREEN (resisted).
+    PhishingResult result = resultWith(false, false);
+    when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
+    when(phishingResultRepository.save(any(PhishingResult.class)))
+        .thenAnswer(i -> i.getArgument(0));
+    ManualInjectExpectation playerClicked =
+        playerStep(PhishingTrackingService.STEP_CLICKED, "user-1", "team-1", 100.0, false);
+    ManualInjectExpectation teamClicked =
+        teamStep(PhishingTrackingService.STEP_CLICKED, "team-1", 100.0, false);
+    when(injectExpectationRepository.findAllByInjectId("inject-1"))
+        .thenReturn(List.of(playerClicked, teamClicked));
+
+    // -- ACT --
+    phishingTrackingService.markClicked("token-1", "1.2.3.4", "curl/8");
+
+    // -- ASSERT -- person RED and team RED (a compromised member fails the "all must validate"
+    // team), never a red person next to a green team.
+    assertEquals(0.0, playerClicked.getScore(), "the recipient who clicked must be RED");
+    assertEquals(
+        0.0,
+        teamClicked.getScore(),
+        "under 'all must validate' one fallen member turns the whole team RED");
+    verify(injectExpectationRepository).save(teamClicked);
+  }
+
+  @Test
+  @DisplayName(
+      "markClicked should keep the team GREEN under 'at least one' rule while another member"
+          + " resisted")
+  void markClicked_should_keepTeamGreenUnderAnyValidateRule() {
+    // -- ARRANGE -- one team, two players; "at least one" rule (expectationGroup true). Only the
+    // recipient (user-1) clicks; user-2 keeps resisting.
+    PhishingResult result = resultWith(false, false);
+    when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
+    when(phishingResultRepository.save(any(PhishingResult.class)))
+        .thenAnswer(i -> i.getArgument(0));
+    ManualInjectExpectation recipient =
+        playerStep(PhishingTrackingService.STEP_CLICKED, "user-1", "team-1", 100.0, true);
+    ManualInjectExpectation teammate =
+        playerStep(PhishingTrackingService.STEP_CLICKED, "user-2", "team-1", 100.0, true);
+    ManualInjectExpectation teamClicked =
+        teamStep(PhishingTrackingService.STEP_CLICKED, "team-1", 100.0, true);
+    when(injectExpectationRepository.findAllByInjectId("inject-1"))
+        .thenReturn(List.of(recipient, teammate, teamClicked));
+
+    // -- ACT --
+    phishingTrackingService.markClicked("token-1", "1.2.3.4", "curl/8");
+
+    // -- ASSERT -- recipient RED, teammate untouched, team still GREEN (at least one resisted).
+    assertEquals(0.0, recipient.getScore(), "the recipient who clicked must be RED");
+    assertEquals(100.0, teammate.getScore(), "a member who did not click is untouched");
+    assertEquals(
+        100.0,
+        teamClicked.getScore(),
+        "under 'at least one' the team stays GREEN while any member resisted");
+  }
+
+  @Test
+  @DisplayName(
       "markSubmitted should capture credentials as a Credentials finding when capture is on")
   void markSubmitted_should_createCredentialsFinding() {
     // -- ARRANGE --
@@ -167,8 +261,7 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
-    when(injectExpectationRepository.findAllByInjectAndPlayer(anyString(), anyString()))
-        .thenReturn(List.of());
+    when(injectExpectationRepository.findAllByInjectId(anyString())).thenReturn(List.of());
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
@@ -192,8 +285,7 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
-    when(injectExpectationRepository.findAllByInjectAndPlayer(anyString(), anyString()))
-        .thenReturn(List.of());
+    when(injectExpectationRepository.findAllByInjectId(anyString())).thenReturn(List.of());
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
@@ -211,8 +303,7 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
-    when(injectExpectationRepository.findAllByInjectAndPlayer(anyString(), anyString()))
-        .thenReturn(List.of());
+    when(injectExpectationRepository.findAllByInjectId(anyString())).thenReturn(List.of());
 
     // -- ACT --
     phishingTrackingService.markSubmitted(
@@ -233,8 +324,7 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
-    when(injectExpectationRepository.findAllByInjectAndPlayer(anyString(), anyString()))
-        .thenReturn(List.of());
+    when(injectExpectationRepository.findAllByInjectId(anyString())).thenReturn(List.of());
 
     // -- ACT --
     Map<String, String> fields = Map.of("username", "victim@corp.test", "password", "hunter2");

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
@@ -95,10 +95,7 @@ class PhishingTrackingServiceTest {
 
   /** A team-level MANUAL step row (no user) bound to a team, with an explicit score and rule. */
   private ManualInjectExpectation teamStep(
-      final String name,
-      final String teamId,
-      final double score,
-      final boolean expectationGroup) {
+      final String name, final String teamId, final double score, final boolean expectationGroup) {
     ManualInjectExpectation expectation = new ManualInjectExpectation();
     expectation.setId(name + ":team:" + teamId);
     expectation.setName(name);
@@ -178,8 +175,7 @@ class PhishingTrackingServiceTest {
     when(phishingResultRepository.save(any(PhishingResult.class)))
         .thenAnswer(i -> i.getArgument(0));
     ManualInjectExpectation unrelated = resistedStep("Some operator check");
-    when(injectExpectationRepository.findAllByInjectId("inject-1"))
-        .thenReturn(List.of(unrelated));
+    when(injectExpectationRepository.findAllByInjectId("inject-1")).thenReturn(List.of(unrelated));
 
     // -- ACT --
     phishingTrackingService.markClicked("token-1", "1.2.3.4", "curl/8");

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingTrackingServiceTest.java
@@ -249,6 +249,36 @@ class PhishingTrackingServiceTest {
   }
 
   @Test
+  @DisplayName("markClicked should not rewrite the team rows of teams the recipient is not in")
+  void markClicked_should_leaveUnrelatedTeamRowsUntouched() {
+    // -- ARRANGE -- the recipient (user-1) is in team-1; team-2 has its own member and team row.
+    PhishingResult result = resultWith(false, false);
+    when(phishingResultRepository.findByToken("token-1")).thenReturn(Optional.of(result));
+    when(phishingResultRepository.save(any(PhishingResult.class)))
+        .thenAnswer(i -> i.getArgument(0));
+    ManualInjectExpectation recipient =
+        playerStep(PhishingTrackingService.STEP_CLICKED, "user-1", "team-1", 100.0, false);
+    ManualInjectExpectation teamClicked =
+        teamStep(PhishingTrackingService.STEP_CLICKED, "team-1", 100.0, false);
+    ManualInjectExpectation otherMember =
+        playerStep(PhishingTrackingService.STEP_CLICKED, "user-2", "team-2", 100.0, false);
+    ManualInjectExpectation otherTeamClicked =
+        teamStep(PhishingTrackingService.STEP_CLICKED, "team-2", 100.0, false);
+    when(injectExpectationRepository.findAllByInjectId("inject-1"))
+        .thenReturn(List.of(recipient, teamClicked, otherMember, otherTeamClicked));
+
+    // -- ACT --
+    phishingTrackingService.markClicked("token-1", "1.2.3.4", "curl/8");
+
+    // -- ASSERT -- only the recipient's team is recomputed; team-2's rows see no write at all.
+    assertEquals(0.0, teamClicked.getScore(), "the recipient's team must be recomputed");
+    assertEquals(100.0, otherMember.getScore(), "another team's member is untouched");
+    assertEquals(100.0, otherTeamClicked.getScore(), "another team's row keeps its score");
+    verify(injectExpectationRepository, never()).save(otherMember);
+    verify(injectExpectationRepository, never()).save(otherTeamClicked);
+  }
+
+  @Test
   @DisplayName(
       "markSubmitted should capture credentials as a Credentials finding when capture is on")
   void markSubmitted_should_createCredentialsFinding() {

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -1187,6 +1187,78 @@ class InjectExpectationServiceTest {
   }
 
   @Nested
+  @DisplayName("findMergedExpectationsByInjectAndTargetAndTargetType same-type display merge")
+  class SameTypeDisplayMergeTests {
+
+    private ManualInjectExpectation manualStep(String id, String name, Double score) {
+      ManualInjectExpectation expectation = new ManualInjectExpectation();
+      expectation.setId(id);
+      expectation.setName(name);
+      expectation.setScore(score);
+      expectation.setExpectedScore(100.0);
+      expectation.setResults(
+          new ArrayList<>(
+              List.of(
+                  InjectExpectationResult.builder()
+                      .sourceId("phishing-injector")
+                      .sourceType("injector")
+                      .sourceName("Phishing")
+                      .result(score != null && score == 0.0 ? "Compromised" : "No interaction")
+                      .score(score)
+                      .build())));
+      return expectation;
+    }
+
+    @Test
+    @DisplayName("Merging same-type expectations never mutates the managed entities")
+    void sameTypeMergeIsDisplayOnly() {
+      // Regression: the three phishing steps are all MANUAL, so the display merge fires. It used
+      // to append the sibling rows' results into the FIRST managed entity and overwrite its score
+      // with the max - Hibernate then flushed that on commit, so every poll of the results page
+      // grew the row's results JSON (until requests exceeded the Hikari leak threshold and
+      // exhausted the pool) and flipped a compromised step back to green in the database.
+      ManualInjectExpectation opened = manualStep("exp-opened", "Email opened", 0.0);
+      ManualInjectExpectation clicked = manualStep("exp-clicked", "Phishing link clicked", 100.0);
+      ManualInjectExpectation submitted =
+          manualStep("exp-submitted", "Credentials submitted", 100.0);
+      when(injectExpectationRepository.findAllByInjectAndTeam("inject-id", "team-id"))
+          .thenReturn(List.of(opened, clicked, submitted));
+
+      List<? extends BaseInjectExpectation> merged =
+          injectExpectationService.findMergedExpectationsByInjectAndTargetAndTargetType(
+              "inject-id", "team-id", "TEAMS");
+
+      assertEquals(1, merged.size());
+      BaseInjectExpectation electedClone = merged.get(0);
+      assertNotSame(opened, electedClone);
+      assertEquals(3, electedClone.getResults().size());
+      // Worst-step verdict: one compromised step keeps the merged human response red.
+      assertEquals(0.0, electedClone.getScore());
+      // The managed entities are untouched: nothing to flush back to the database.
+      assertEquals(1, opened.getResults().size());
+      assertEquals(0.0, opened.getScore());
+      assertEquals(1, clicked.getResults().size());
+      assertEquals(100.0, clicked.getScore());
+      assertEquals(1, submitted.getResults().size());
+      assertEquals(100.0, submitted.getScore());
+    }
+
+    @Test
+    @DisplayName("A single expectation per type is returned as-is")
+    void singleExpectationPerTypeIsReturnedAsIs() {
+      ManualInjectExpectation single = manualStep("exp-single", "Manual validation", null);
+      when(injectExpectationRepository.findAllByInjectAndTeam("inject-id", "team-id"))
+          .thenReturn(List.of(single));
+
+      List<? extends BaseInjectExpectation> merged =
+          injectExpectationService.findMergedExpectationsByInjectAndTargetAndTargetType(
+              "inject-id", "team-id", "TEAMS");
+
+      assertEquals(List.of(single), merged);
+    }
+  }
+
+  @Nested
   @DisplayName("findMergedExpectationsByInjectAndTargetAndTargetType for asset groups")
   class AssetGroupSecurityPlatformEnrichmentTests {
 

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.test.ts
@@ -1473,10 +1473,11 @@ describe('buildCausalChainFlow', () => {
     expect(edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE)).toHaveLength(0);
   });
 
-  it('promotes endpoint-local actions to their own action nodes when localActionsAsNodes is set (autonomous action timeline)', () => {
+  it('gives each agent-executed action on the same host its own action node (never groups distinct actions)', () => {
     // Arrange: two endpoint-local actions on the SAME host, chained (LSASS dump depends on the sweep).
-    // In a finding-centric BAS chain both collapse into the endpoint and the follow-up adds nothing new;
-    // an autonomous run must instead show BOTH as their own action nodes so the timeline never freezes.
+    // They used to collapse into ONE self-execution node keyed by the endpoint - the bug where a single
+    // card ("Credential Sweep") silently grouped an unrelated follow-up under its name and icon. Every
+    // agent-executed action must now be its OWN action node so the map never misleads.
     const localChain: AttackPathDTO = {
       mode: 'full',
       attackPathNodes: [
@@ -1526,20 +1527,10 @@ describe('buildCausalChainFlow', () => {
         },
       ],
     };
-    // Act: without the flag both local actions aggregate into ONE self-execution node keyed by the
-    // endpoint; with the flag each authored step becomes its own action node.
-    const aggregated = buildCausalChainFlow(localChain, tt);
-    const promoted = buildCausalChainFlow(localChain, tt, new Set(), new Map(), new Set(), true);
-    // Assert: the default displays the self-execution as a single action card anchored on the endpoint
-    // (labelled from the first execution's contract), pointing at the endpoint node.
-    const aggregatedActions = aggregated.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector);
-    expect(aggregatedActions.map(n => n.id)).toEqual(['ep-1']);
-    expect(aggregatedActions[0].data.label).toBe('Credential Sweep');
-    expect(aggregated.edges.find(e => e.source === 'ep-1' && e.target === 'chain-ep|0|ep-1')).toBeDefined();
-    const aggregatedIds = new Set(aggregated.nodes.map(n => n.id));
-    expect(aggregated.edges.every(e => aggregatedIds.has(e.source) && aggregatedIds.has(e.target))).toBe(true);
-    // With the flag: one action node per authored local step, labelled from its contract, and no self
-    // arrow (the action sits to the left of the endpoint and points at it).
+    // Act
+    const promoted = buildCausalChainFlow(localChain, tt);
+    // Assert: one action node per authored local step, labelled from its own contract, and no self
+    // arrow (each action sits to the left of the endpoint and points at it) - the two are never merged.
     const actionNodes = promoted.nodes.filter(n => n.type === AP_FLOW_NODE_TYPE.injector);
     expect(actionNodes.map(n => n.id).sort()).toEqual(['chain-local|step-lsass', 'chain-local|step-sweep']);
     expect(actionNodes.map(n => n.data.label).sort()).toEqual(['Credential Sweep', 'LSASS Dump']);
@@ -1547,6 +1538,66 @@ describe('buildCausalChainFlow', () => {
     // Every emitted edge still resolves to a placed node.
     const nodeIds = new Set(promoted.nodes.map(n => n.id));
     expect(promoted.edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
+  });
+
+  it('carries each promoted action node its payload collector logo metadata (real icon, not the generic agent bolt)', () => {
+    // Arrange: two DISTINCT agent payloads on one host - the exact GPP/Mimikatz shape from the report.
+    const iconChain: AttackPathDTO = {
+      mode: 'full',
+      attackPathNodes: [
+        {
+          id: 'ep-1',
+          type: 'ASSET',
+          label: 'WIN-1',
+          ip: '10.0.0.1',
+        },
+      ],
+      attackPathExecutions: [
+        {
+          id: 'x-gpp',
+          type: 'EXECUTION',
+          ref: 'exec-gpp',
+          stepTemplateId: 'step-gpp',
+          payloadName: 'GPP Passwords (Get-GPPPassword)',
+          injectorType: 'openaev_agent',
+          payloadType: 'Command',
+          payloadCollectorType: 'openaev_atomic_red_team',
+          dependsOn: [],
+        },
+        {
+          id: 'x-mimikatz',
+          type: 'EXECUTION',
+          ref: 'exec-mimikatz',
+          stepTemplateId: 'step-mimikatz',
+          payloadName: 'In-Memory Mimikatz - LSASS Credential Dump',
+          injectorType: 'openaev_agent',
+          payloadType: 'Executable',
+          payloadCollectorType: 'openaev_openaev',
+          dependsOn: [],
+        },
+      ],
+      attackPathEdges: [
+        {
+          type: 'EDGE_EXECUTIONS',
+          edgeSourceId: 'ep-1',
+          edgeTargetId: 'ep-1',
+          executionIds: ['exec-gpp', 'exec-mimikatz'],
+        },
+      ],
+    };
+    // Act
+    const { nodes } = buildCausalChainFlow(iconChain, tt);
+    const byId = Object.fromEntries(nodes.map(n => [n.id, n]));
+    // Assert: two separate action nodes, each labelled from its own payload and carrying the payload
+    // collector type the ActionCard resolves the real logo from (never merged, never generic).
+    const gpp = byId['chain-local|step-gpp'];
+    const mimikatz = byId['chain-local|step-mimikatz'];
+    expect(gpp?.data.label).toBe('GPP Passwords (Get-GPPPassword)');
+    expect(gpp?.data.isPayload).toBe(true);
+    expect(gpp?.data.payloadCollectorType).toBe('openaev_atomic_red_team');
+    expect(mimikatz?.data.label).toBe('In-Memory Mimikatz - LSASS Credential Dump');
+    expect(mimikatz?.data.isPayload).toBe(true);
+    expect(mimikatz?.data.payloadCollectorType).toBe('openaev_openaev');
   });
 
   it('renders an endpoint-local action as a self-execution node pointing at its endpoint', () => {
@@ -1594,11 +1645,11 @@ describe('buildCausalChainFlow', () => {
     // Assert: the endpoint and its finding render…
     expect(byId['chain-ep|0|ep-1'].type).toBe(AP_FLOW_NODE_TYPE.asset);
     expect(byId['NODE_FINDING|username|bob'].type).toBe(AP_FLOW_NODE_TYPE.finding);
-    // …and the self-execution is displayed: one action node (the endpoint acting on itself), labelled
-    // from the contract name, with a labelled edge onto the endpoint node.
-    expect(byId['ep-1'].type).toBe(AP_FLOW_NODE_TYPE.injector);
-    expect(byId['ep-1'].data.label).toBe('Whoami');
-    const selfEdge = edges.find(e => e.source === 'ep-1' && e.target === 'chain-ep|0|ep-1');
+    // …and the local action is its OWN action node (keyed by its authored step, not the endpoint),
+    // labelled from the contract name, with a labelled edge onto the endpoint node.
+    expect(byId['chain-local|step-L'].type).toBe(AP_FLOW_NODE_TYPE.injector);
+    expect(byId['chain-local|step-L'].data.label).toBe('Whoami');
+    const selfEdge = edges.find(e => e.source === 'chain-local|step-L' && e.target === 'chain-ep|0|ep-1');
     expect(selfEdge?.data?.label).toBe('Whoami');
     // Every emitted edge resolves to placed nodes.
     const nodeIds = new Set(nodes.map(n => n.id));
@@ -1670,13 +1721,13 @@ describe('buildCausalChainFlow', () => {
     };
     // Act
     const { nodes, edges } = buildCausalChainFlow(localConsumer, tt);
-    // Assert: the local step sits one depth after its producer (its own endpoint copy at depth 1) and
-    // the produced finding's causal edge now targets the self-execution node instead of being dropped.
+    // Assert: the local action is its own node (keyed by its authored step) sitting one depth after its
+    // producer, and the produced finding's causal edge targets that action node instead of being dropped.
     const causal = edges.filter(e => e.type === AP_FLOW_CAUSAL_EDGE_TYPE);
     expect(causal).toHaveLength(1);
     expect(causal[0].source).toBe('NODE_FINDING|port|445');
-    expect(causal[0].target).toBe('ep-1');
-    // Every edge still resolves to placed nodes (the self-execution node IS placed).
+    expect(causal[0].target).toBe('chain-local|step-L');
+    // Every edge still resolves to placed nodes (the action node IS placed).
     const nodeIds = new Set(nodes.map(n => n.id));
     expect(edges.every(e => nodeIds.has(e.source) && nodeIds.has(e.target))).toBe(true);
   });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -219,14 +219,6 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   // so live updating stops there; an unknown status (synthetic seed simulations) is treated as live.
   const selectedRunStatus = metaById.get(simulationId)?.exercise_status;
   const runTerminal = selectedRunStatus === 'FINISHED' || selectedRunStatus === 'CANCELED';
-  // Render the causal chain as an ACTION TIMELINE (endpoint-local actions - recon, dumps, local
-  // escalation on a host the agent already owns - render as their own action nodes instead of being
-  // folded into the endpoint they ran on) for autonomous runs, whose engagement is almost entirely
-  // local steps on a single compromised host; without this the graph looks frozen after the first
-  // finding even though every step executed. Derived from the selected simulation's DURABLE
-  // exercise_autonomous marker (not the live run row) so a finished autonomous run keeps action-centric
-  // rendering in both the simulation and scenario contexts. Off for manual BAS runs (finding-centric).
-  const actionCentric = metaById.get(simulationId)?.exercise_autonomous ?? false;
   // The causal overlay needs the per-execution kill-chain fields, which only the full graph carries, so
   // it is seeded only under the size ceiling (mirrors the backend collapse-threshold) — a large run never
   // downloads a full payload. The gate uses the initial summary-row count; a run that grows past the
@@ -1286,9 +1278,9 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
   );
   const fullChain = useMemo(
     () => (chainMode && fullDto
-      ? buildCausalChainFlow(fullDto, t, expandedFindingClusters, endpointClusterBatch, pinnedFindingTypes, actionCentric)
+      ? buildCausalChainFlow(fullDto, t, expandedFindingClusters, endpointClusterBatch, pinnedFindingTypes)
       : null),
-    [chainMode, fullDto, t, expandedFindingClusters, endpointClusterBatch, pinnedFindingTypes, actionCentric],
+    [chainMode, fullDto, t, expandedFindingClusters, endpointClusterBatch, pinnedFindingTypes],
   );
 
   // A finding picked from a drawer/summary list (rather than clicked directly on an already-rendered

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/attack-path-flow-helpers.ts
@@ -75,6 +75,15 @@ export interface AttackPathFlowNodeData {
   // For an injector node: the real injector type/slug from the backend (AttackPathNodeDTO.injectorType),
   // used to resolve the catalog icon without guessing from the label. Absent on synthetic seed injectors.
   injectorType?: string;
+  // For an ACTION node standing for an agent-executed payload: the payload's discriminator type
+  // (Command, Executable, ...) and, when it was shipped by a collector, that collector type's name
+  // (e.g. openaev_netexec, openaev_atomic_red_team). The ActionCard resolves the real catalog icon
+  // from these (mirroring the logic tab) instead of the generic agent bolt. Absent on injector nodes.
+  payloadType?: string;
+  payloadCollectorType?: string;
+  // True when this action node represents a payload (agent-executed action), so the icon resolver
+  // treats payloadCollectorType/payloadType as a payload icon rather than an injector slug.
+  isPayload?: boolean;
   // For an injector node: the ATT&CK techniques the backend resolved from its contract
   // (AttackPathNodeDTO.attackPatterns), surfaced on the node so the analyst sees them without a click.
   attackPatterns?: AttackPathAttackPatternDTO[];
@@ -1620,9 +1629,9 @@ const CHAIN_ENDPOINTS_MAX_PER_DEPTH = 4; // a depth column with more distinct en
 // the overflow into a single "+N" endpoint cluster (click to expand), so a step reaching dozens of hosts
 // stays a few blocks tall instead of one node per host in a long unreadable vertical stack.
 
-// Synthetic step-id prefix for an endpoint-local (self-loop) action promoted to its own ACTION node
-// (localActionsAsNodes). Keyed by the authored step so re-runs coalesce and never collides with a real
-// endpoint node id (NODE_ENDPOINT|<uuid>) or injector node id.
+// Synthetic step-id prefix for an agent-executed action promoted to its own ACTION node (every
+// agent/endpoint-sourced execution is split out this way). Keyed by the authored step so re-runs
+// coalesce and never collides with a real endpoint node id (NODE_ENDPOINT|<uuid>) or injector node id.
 const LOCAL_ACTION_ID_PREFIX = 'chain-local|';
 
 interface ChainStep {
@@ -1639,10 +1648,13 @@ interface ChainStep {
   statusByEndpoint: Map<string, Array<string | undefined>>;
   consumed: CausalConsumedKey[];
   deps: Set<string>;
-  // For an endpoint-local action promoted to its own node (localActionsAsNodes): the execution metadata
-  // needed to draw a proper ACTION card (catalog icon + ATT&CK techniques) when the full graph carries
+  // For an agent/endpoint-sourced action promoted to its own node: the execution metadata needed to
+  // draw a proper ACTION card (catalog icon + ATT&CK techniques + label) when the full graph carries
   // no injector node for it. Captured from the representative execution; unused for real injector steps.
   actionInjectorType?: string;
+  actionPayloadType?: string;
+  actionPayloadCollectorType?: string;
+  actionPayloadName?: string;
   actionAttackPatterns?: AttackPathAttackPatternDTO[];
 }
 
@@ -1659,11 +1671,6 @@ export const buildCausalChainFlow = (
   // a finding whose type happens to fall past the cap (ties are broken by name, so "share" can lose to
   // "cve") leaves it with no node to focus at all, and the view silently falls back to another path.
   pinnedTypes: ReadonlySet<string> = new Set(),
-  // Render each endpoint-local (self-loop) execution as its OWN ACTION node instead of aggregating
-  // them into one self-execution step per endpoint. Off by default; ON for an AUTONOMOUS run, whose
-  // story is the ACTION TIMELINE on a mostly single, already-compromised host, so a chain of local
-  // steps stays visible step by step even when it produces no new distinct finding.
-  localActionsAsNodes = false,
 ): {
   nodes: AttackPathFlowNode[];
   edges: AttackPathFlowEdge[];
@@ -1727,22 +1734,20 @@ export const buildCausalChainFlow = (
       }
     }
   }
-  // Endpoint-local actions (recon, credential dumps, local privilege ops) run ON the host the agent is
-  // already on, so the backend records them as a self-loop (execution edge source == target == that
-  // endpoint). By default all of an endpoint's local executions aggregate into ONE step keyed by the
-  // endpoint itself, rendered as a single self-execution ACTION card pointing at the endpoint. But an
-  // AUTONOMOUS engagement is an ACTION TIMELINE on a mostly single, already-compromised host: a run of
-  // several local steps would then collapse into that one card even though every step executed.
-  // When localActionsAsNodes is set, re-key each self-loop to its OWN authored step so each local action
-  // becomes its own ACTION node anchored on the endpoint (drawn to the left, exactly like an injector).
-  // Keyed by stepTemplateId so re-runs of the same step coalesce and dependsOn between local steps
-  // still resolves to a real causal depth.
-  if (localActionsAsNodes) {
-    for (const [ref, ex] of execByRef) {
-      const src = injByExec.get(ref);
-      if (src && src === epByExec.get(ref)) {
-        injByExec.set(ref, `${LOCAL_ACTION_ID_PREFIX}${ex.stepTemplateId ?? ref}`);
-      }
+  // Every agent-executed action (a payload the implant ran: recon, credential dump, GPP scan, an
+  // in-memory Mimikatz, a remote SMB brute force, ...) is re-keyed to its OWN authored step so each
+  // distinct action becomes its own ACTION node. Without this, ALL of an agent's executions collapse
+  // into a single node keyed by their source endpoint — the bug where one card reads "GPP Passwords"
+  // yet silently groups Mimikatz and a PowerShell history search under that one misleading name and a
+  // generic icon. A real injector source (a network inject like Nmap/NetExec launched by the platform,
+  // present in injectorById) keeps its per-contract injector node; only agent/endpoint sources (a
+  // self-loop local action OR an agent->remote pivot, never an injector node) are split out. Keyed by
+  // stepTemplateId so re-runs of the same step coalesce and dependsOn between steps still resolves to a
+  // real causal depth; falling back to the execution ref keeps distinct un-templated actions distinct.
+  for (const [ref, ex] of execByRef) {
+    const src = injByExec.get(ref);
+    if (src && !injectorById.has(src)) {
+      injByExec.set(ref, `${LOCAL_ACTION_ID_PREFIX}${ex.stepTemplateId ?? ref}`);
     }
   }
   // Resolve a dependsOn (a prerequisite step template id) to the injector that ran it.
@@ -1792,10 +1797,21 @@ export const buildCausalChainFlow = (
       }
       s.statusByEndpoint.set(ep, (s.statusByEndpoint.get(ep) ?? []).concat(ex.status));
     }
-    // Capture the action's own icon/technique metadata, used only when this step renders as a synthetic
-    // node (endpoint-local action) that has no injector node of its own to read from.
+    // Capture the action's own icon/technique/label metadata, used only when this step renders as a
+    // synthetic node (an agent-executed action) that has no injector node of its own to read from.
+    // The payload collector type is what resolves the real catalog logo (e.g. netexec, atomic-red-team);
+    // the injector type is only the implant fallback and the payload type the last resort.
     if (ex.injectorType && !s.actionInjectorType) {
       s.actionInjectorType = ex.injectorType;
+    }
+    if (ex.payloadCollectorType && !s.actionPayloadCollectorType) {
+      s.actionPayloadCollectorType = ex.payloadCollectorType;
+    }
+    if (ex.payloadType && !s.actionPayloadType) {
+      s.actionPayloadType = ex.payloadType;
+    }
+    if (ex.payloadName && !s.actionPayloadName) {
+      s.actionPayloadName = ex.payloadName;
     }
     if ((ex.attackPatterns?.length ?? 0) > 0 && !s.actionAttackPatterns) {
       s.actionAttackPatterns = ex.attackPatterns;
@@ -1956,11 +1972,11 @@ export const buildCausalChainFlow = (
     let cursorY = PADDING;
     const injectorPlaced = new Set<string>();
     for (const epId of visibleAssetIds) {
-      // An endpoint-local action keeps the endpoint itself as its "injector" (injId === epId): it is
-      // laid out like any other producing step — an ACTION card (labelled from its contract name, the
-      // injector-node lookup below misses on the asset id) pointing at the endpoint node — so a
-      // self-execution is displayed instead of silently dropped. localActionsAsNodes additionally
-      // re-keys each authored local step to its own chain-local|<step> node.
+      // Each agent-executed action is its own chain-local|<step> node (re-keyed above), laid out like
+      // any other producing step — an ACTION card (labelled from its contract/payload name, since the
+      // injector-node lookup below misses on the synthetic id) pointing at the endpoint it acted on.
+      // A rare un-templated self-execution still keeps the endpoint id as its injector and renders the
+      // same way, so it is displayed rather than silently dropped.
       const injectors = assetInjectors.get(epId) as string[];
       const findingIds = assetFindings.get(epId) as string[];
       // Group the endpoint's findings by type; a type with more than the cap collapses into ONE "+N"
@@ -2052,11 +2068,11 @@ export const buildCausalChainFlow = (
             ? blockCenter
             : blockTop + (i + 0.5) * (h / injectors.length);
           const injDto = injectorById.get(injId);
-          // The full graph may omit injector nodes (e.g. an endpoint-local action promoted to a node);
-          // label the action from its contract name rather than the raw step id, so the node never reads
-          // "NODE_*|<uuid>", and carry its captured icon/technique metadata so it renders a real ACTION
-          // card instead of the generic fallback icon.
-          const injActionLabel = [...s.contractByEndpoint.values()][0];
+          // The full graph may omit injector nodes (e.g. an agent-executed action promoted to a node);
+          // label the action from its contract name (else the payload name) rather than the raw step id,
+          // so the node never reads "NODE_*|<uuid>", and carry its captured icon/technique metadata so it
+          // renders a real ACTION card with the payload's catalog logo instead of the generic fallback.
+          const injActionLabel = [...s.contractByEndpoint.values()][0] || s.actionPayloadName;
           nodes.push({
             id: injId,
             type: AP_FLOW_NODE_TYPE.injector,
@@ -2069,6 +2085,9 @@ export const buildCausalChainFlow = (
               : {
                   label: injActionLabel || friendlyNodeId(injId),
                   injectorType: s.actionInjectorType,
+                  payloadType: s.actionPayloadType,
+                  payloadCollectorType: s.actionPayloadCollectorType,
+                  isPayload: !!(s.actionPayloadType || s.actionPayloadCollectorType),
                   attackPatterns: s.actionAttackPatterns,
                 },
           });
@@ -2249,7 +2268,7 @@ export const buildCausalChainFlow = (
             ? blockCenter
             : blockTop + (i + 0.5) * (hCluster / clusterInjectors.length);
           const injDto = injectorById.get(injId);
-          const injActionLabel = [...s.contractByEndpoint.values()][0];
+          const injActionLabel = [...s.contractByEndpoint.values()][0] || s.actionPayloadName;
           nodes.push({
             id: injId,
             type: AP_FLOW_NODE_TYPE.injector,
@@ -2262,6 +2281,9 @@ export const buildCausalChainFlow = (
               : {
                   label: injActionLabel || friendlyNodeId(injId),
                   injectorType: s.actionInjectorType,
+                  payloadType: s.actionPayloadType,
+                  payloadCollectorType: s.actionPayloadCollectorType,
+                  isPayload: !!(s.actionPayloadType || s.actionPayloadCollectorType),
                   attackPatterns: s.actionAttackPatterns,
                 },
           });

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/cards/ActionCard.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/cards/ActionCard.tsx
@@ -7,6 +7,7 @@ import { useFormatter } from '../../../../../../../components/i18n';
 import { buildTenantApiPath } from '../../../../../../../utils/url-helper';
 import LogicNodeTooltip, { type TooltipRow } from '../../../../../chaining/logic/chaining_flow/NodeTooltip';
 import graphTooltipSlotProps from '../../../../../chaining/logic/logic-graph/graphTooltipSlotProps';
+import InjectIcon from '../../../../../common/injects/InjectIcon';
 import { type AttackPathFlowNodeData } from '../../attack-path-flow-helpers';
 import ImageWithFallback from '../../ImageWithFallback';
 import { buildCardSx, CAPTION_SX, EYEBROW_SX, TITLE_SX } from './card-styles';
@@ -31,11 +32,59 @@ const ActionCard = ({ data, selected = false }: Props) => {
   const theme = useTheme();
   const { t } = useFormatter();
 
-  // Resolve the catalog image slug exactly like the previous node did (aliases cover renamed tools).
+  // An agent-executed action stands for a PAYLOAD, not an injector: its injectorType is always the
+  // implant (openaev_agent), so the only faithful logo is the payload's collector logo (e.g.
+  // openaev_netexec, openaev_atomic_red_team) - exactly what the logic tab shows. Resolve that first;
+  // a payload with no backing collector (a hand-authored Command/Executable) falls back to the
+  // payload-type glyph. Only a real injector node (network inject) keeps the injector-slug logo.
+  const isPayloadAction = !!data.isPayload;
+  const collectorType = (data.payloadCollectorType ?? '').toLowerCase();
+  const hasCollectorLogo = collectorType.startsWith('openaev_');
+
+  // Resolve the injector catalog image slug exactly like the previous node did (aliases cover
+  // renamed tools); only used for a real injector node, never for an agent-executed payload.
   const raw = (data.label ?? '').toLowerCase();
   const aliases: Record<string, string> = { crackmapexec: 'netexec' };
   const base = (data.injectorType ?? '').toLowerCase() || aliases[raw] || raw;
   const injectorSlug = base.startsWith('openaev_') ? base : `openaev_${base}`;
+  const showInjectorLogo = !isPayloadAction && !!base;
+
+  const boltFallback = (
+    <BoltOutlined sx={{
+      fontSize: 20,
+      color: theme.palette.grey[700],
+    }}
+    />
+  );
+
+  // Icon precedence: collector logo (agent payload shipped by a collector) -> payload-type glyph
+  // (hand-authored Command/Executable) -> injector-slug logo (network inject) -> generic bolt.
+  let iconContent = boltFallback;
+  if (hasCollectorLogo) {
+    iconContent = (
+      <ImageWithFallback
+        src={buildTenantApiPath(`/api/collectors/${collectorType}/image`)}
+        alt={data.label ?? ''}
+        width={34}
+        height={34}
+        style={{ objectFit: 'cover' }}
+        fallback={boltFallback}
+      />
+    );
+  } else if (isPayloadAction) {
+    iconContent = <InjectIcon type={data.payloadType} isPayload size="small" />;
+  } else if (showInjectorLogo) {
+    iconContent = (
+      <ImageWithFallback
+        src={buildTenantApiPath(`/api/injectors/${injectorSlug}/image`)}
+        alt={data.label ?? ''}
+        width={34}
+        height={34}
+        style={{ objectFit: 'cover' }}
+        fallback={boltFallback}
+      />
+    );
+  }
 
   const techniques = data.attackPatterns ?? [];
   const techLabels = techniques
@@ -43,10 +92,13 @@ const ActionCard = ({ data, selected = false }: Props) => {
     .filter(Boolean);
 
   const tooltipRows: TooltipRow[] = [];
-  if (data.injectorType) {
+  const typeForTooltip = isPayloadAction
+    ? (data.payloadCollectorType || data.payloadType)
+    : data.injectorType;
+  if (typeForTooltip) {
     tooltipRows.push({
       label: t('Type'),
-      value: prettifyType(data.injectorType),
+      value: prettifyType(typeForTooltip),
     });
   }
   const tooltip = (
@@ -87,30 +139,7 @@ const ActionCard = ({ data, selected = false }: Props) => {
           },
         }}
         >
-          {base
-            ? (
-                <ImageWithFallback
-                  src={buildTenantApiPath(`/api/injectors/${injectorSlug}/image`)}
-                  alt={data.label ?? ''}
-                  width={34}
-                  height={34}
-                  style={{ objectFit: 'cover' }}
-                  fallback={(
-                    <BoltOutlined sx={{
-                      fontSize: 20,
-                      color: theme.palette.grey[700],
-                    }}
-                    />
-                  )}
-                />
-              )
-            : (
-                <BoltOutlined sx={{
-                  fontSize: 20,
-                  color: theme.palette.grey[700],
-                }}
-                />
-              )}
+          {iconContent}
         </Box>
         <Box sx={{
           flex: 1,

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1122,8 +1122,10 @@ export interface AttackPathNodeDTO {
   ip?: string;
   isFinding?: boolean;
   label?: string;
+  payloadCollectorType?: string;
   payloadId?: string;
   payloadName?: string;
+  payloadType?: string;
   platform?: string;
   privilege?: string;
   ref?: string;

--- a/openaev-model/src/main/java/io/openaev/database/repository/PayloadRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/PayloadRepository.java
@@ -28,7 +28,8 @@ public interface PayloadRepository
    * backing collector. Lets the attack-path graph resolve each agent-executed action's real catalog
    * icon (the collector logo, e.g. netexec / atomic-red-team) instead of the generic agent icon.
    */
-  @Query("SELECT p.id, p.type, ct.name FROM Payload p LEFT JOIN p.collectorType ct WHERE p.id IN :ids")
+  @Query(
+      "SELECT p.id, p.type, ct.name FROM Payload p LEFT JOIN p.collectorType ct WHERE p.id IN :ids")
   List<Object[]> findIconMetadataByIds(@Param("ids") Set<String> ids);
 
   @Query(

--- a/openaev-model/src/main/java/io/openaev/database/repository/PayloadRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/PayloadRepository.java
@@ -6,6 +6,7 @@ import io.openaev.database.model.Payload;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,6 +21,15 @@ public interface PayloadRepository
   Optional<Payload> findById(@NotNull String id);
 
   Optional<Payload> findByExternalId(@NotNull String externalId);
+
+  /**
+   * Icon metadata for a batch of payloads in one read: {@code [id, payloadType,
+   * collectorTypeName]}, the collector type name being null for a hand-authored payload with no
+   * backing collector. Lets the attack-path graph resolve each agent-executed action's real catalog
+   * icon (the collector logo, e.g. netexec / atomic-red-team) instead of the generic agent icon.
+   */
+  @Query("SELECT p.id, p.type, ct.name FROM Payload p LEFT JOIN p.collectorType ct WHERE p.id IN :ids")
+  List<Object[]> findIconMetadataByIds(@Param("ids") Set<String> ids);
 
   @Query(
       value =


### PR DESCRIPTION
## Summary

Enhancement-wave follow-ups found while running phishing atomic testing and
chained simulations. Four independent, atomic fixes:

- **fix(attack-path)**: give each agent-executed action its own map node
  (keyed by its step template) so distinct actions never collapse under one
  misleading name, and resolve the real icon from the payload's collector
  type / payload type (collector logo -> payload glyph -> injector logo ->
  bolt). Backend now freezes payload type + collector type name and
  per-execution ATT&CK techniques onto the execution feed nodes; adds
  `payloadType` / `payloadCollectorType` to `AttackPathNodeDTO` and the
  generated api-types.
- **fix(expectations)**: merge same-type expectation results onto a detached
  clone instead of mutating the managed JPA entity on the read path (stops
  score corruption, JSONB growth and HikariCP connection leaks that made
  phishing team results load slowly or never), using the worst-step score for
  the type verdict.
- **fix(phishing)**: mark only player rows compromised and re-derive each
  team step from its players via `computeChildrenScore`, so the team verdict
  follows the expectation group rule and can no longer drift back to green
  while a player is red.
- **fix(phishing)**: restore the predefined PREVENTION and DETECTION
  expectations (focused on EMAIL_SECURITY platforms) alongside the three
  human-response steps, so a phishing action again measures both the human
  response and the email security control.

## Test plan

- [ ] `openaev-front`: `yarn check-ts`, `yarn lint`, attack-path flow-helpers
      vitest (77 tests) - all green locally.
- [ ] Backend unit tests: `InjectExpectationServiceTest`,
      `PhishingTrackingServiceTest` (new team-rule cases) via CI.
- [ ] Attack path: each agent action is its own node with its real tool logo;
      no generic grouping.
- [ ] Phishing atomic testing on a team: link-clicked stays red for the
      player and the team follows the group rule; results load fast with no
      connection-leak warnings.
- [ ] New phishing inject / atomic testing shows Detection + Prevention plus
      the three manual steps.

Closes #7322
