### PR TITLE
fix(rbac): lenient scope filtering on role capability update (#7321)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260811100000000__Purge_out_of_scope_role_capabilities.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260811100000000__Purge_out_of_scope_role_capabilities.java
@@ -1,0 +1,53 @@
+package io.openaev.migration;
+
+import io.openaev.database.model.Capability;
+import java.sql.PreparedStatement;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Purges {@code roles_capabilities} rows a role must not hold: a tenant role (non-null {@code
+ * tenant_id}) keeps only tenant-scoped capabilities, a platform role only platform-scoped ones
+ */
+@Component
+public class V6_20260811100000000__Purge_out_of_scope_role_capabilities extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    // Tenant roles keep only tenant-scoped capabilities, platform roles only platform-scoped ones.
+    deleteAllExcept(context, "IS NOT NULL", allowed(Capability.allTenantScoped()));
+    deleteAllExcept(context, "IS NULL", allowed(Capability.allPlatformScoped()));
+  }
+
+  /** Both helpers exclude BYPASS, which is legitimate in either scope - add it back. */
+  private static Set<Capability> allowed(Set<Capability> scoped) {
+    Set<Capability> allowed = EnumSet.of(Capability.BYPASS);
+    allowed.addAll(scoped);
+    return allowed;
+  }
+
+  private void deleteAllExcept(Context context, String tenantIdCondition, Set<Capability> allowed)
+      throws Exception {
+    // Never empty (BYPASS is always in): an empty whitelist would wipe every row of the scope.
+    String placeholders = allowed.stream().map(c -> "?").collect(Collectors.joining(","));
+    String sql =
+        "DELETE FROM roles_capabilities rc USING roles r"
+            + " WHERE rc.role_id = r.role_id"
+            + " AND r.tenant_id "
+            + tenantIdCondition
+            + " AND rc.capability NOT IN ("
+            + placeholders
+            + ");";
+    try (PreparedStatement statement = context.getConnection().prepareStatement(sql)) {
+      int index = 1;
+      for (Capability capability : allowed) {
+        statement.setString(index++, capability.name());
+      }
+      statement.execute();
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/TenantRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/TenantRoleService.java
@@ -116,10 +116,12 @@ public class TenantRoleService {
       @NotBlank final String roleName,
       @NotBlank final String roleDescription,
       @NotNull final Set<Capability> capabilities) {
-    assertCanAssignCapabilities(userService.currentUser(), capabilities, CapabilityScope.TENANT);
+    Set<Capability> scopedCapabilities = Capability.filterForTenantRole(capabilities);
+    assertCanAssignCapabilities(
+        userService.currentUser(), scopedCapabilities, CapabilityScope.TENANT);
     ReservedKeyValidator.validateRoleId(roleId);
     return updateRoleInternal(
-        roleId, roleName, roleDescription, capabilities, TenantContext.getCurrentTenant());
+        roleId, roleName, roleDescription, scopedCapabilities, TenantContext.getCurrentTenant());
   }
 
   /** Internal method for system-managed roles. Bypasses reserved name validation. */
@@ -129,7 +131,7 @@ public class TenantRoleService {
       @NotBlank final String roleDescription,
       @NotNull final Set<Capability> capabilities,
       String tenantId) {
-    Capability.validateForTenantRole(capabilities);
+    Set<Capability> scopedCapabilities = Capability.filterForTenantRole(capabilities);
     Optional<Role> roleOpt = findByIdAndTenant(roleId, tenantId);
     if (roleOpt.isEmpty()) {
       throw new ElementNotFoundException("Role not found with id: " + roleId);
@@ -137,7 +139,7 @@ public class TenantRoleService {
     Role role = roleOpt.get();
     role.setName(roleName);
     role.setDescription(roleDescription);
-    role.setCapabilities(capabilities);
+    role.setCapabilities(scopedCapabilities);
     return roleRepository.save(role);
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
@@ -105,12 +105,13 @@ public class PlatformRoleService {
       @NotBlank final String name,
       final String description,
       @NotNull final Set<Capability> capabilities) {
-    assertCanAssignCapabilities(userService.currentUser(), capabilities, CapabilityScope.PLATFORM);
-    Capability.validateForPlatformRole(capabilities);
+    Set<Capability> scopedCapabilities = Capability.filterForPlatformRole(capabilities);
+    assertCanAssignCapabilities(
+        userService.currentUser(), scopedCapabilities, CapabilityScope.PLATFORM);
     Role role = findById(roleId);
     role.setName(name);
     role.setDescription(description);
-    role.setCapabilities(capabilities);
+    role.setCapabilities(scopedCapabilities);
     return roleRepository.save(role);
   }
 

--- a/openaev-api/src/test/java/io/openaev/rest/role/PlatformRoleApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/role/PlatformRoleApiTest.java
@@ -340,6 +340,50 @@ public class PlatformRoleApiTest extends IntegrationTest {
     }
 
     @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES})
+    @DisplayName(
+        "Given a platform role polluted with a tenant-only capability, update should drop it"
+            + " instead of rejecting the payload")
+    void given_pollutedPlatformRole_should_dropOutOfScopeCapabilityOnUpdate() throws Exception {
+      // -------- Arrange --------
+      Role role =
+          platformRoleComposer
+              .forPlatformRole(
+                  PlatformRoleFixture.getPlatformRole(
+                      "Polluted",
+                      Set.of(
+                          Capability.ACCESS_PLATFORM_USERS_GROUPS_AND_ROLES,
+                          Capability.ACCESS_ASSETS)))
+              .persist()
+              .get();
+
+      PlatformRoleInput input =
+          new PlatformRoleInput(
+              "Healed",
+              "healed",
+              Set.of(Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES, Capability.ACCESS_ASSETS));
+
+      // -------- Act --------
+      mvc.perform(
+              put(PLATFORM_ROLES_URI + "/" + role.getId())
+                  .content(asJsonString(input))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().isOk());
+
+      // -------- Assert --------
+      entityManager.flush();
+      entityManager.clear();
+      Role reloaded = roleRepository.findById(role.getId()).orElseThrow();
+      assertFalse(
+          reloaded.getCapabilities().contains(Capability.ACCESS_ASSETS),
+          "the tenant-only capability should have been dropped");
+      assertTrue(
+          reloaded.getCapabilities().contains(Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES));
+    }
+
+    @Test
     @WithMockUser(withCapabilities = {Capability.ACCESS_PLATFORM_USERS_GROUPS_AND_ROLES})
     @DisplayName("Given ACCESS_PLATFORM_USERS_GROUPS_AND_ROLES only, should be forbidden to update")
     void given_accessPlatform_should_forbidUpdate() throws Exception {

--- a/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
@@ -340,6 +340,50 @@ public class TenantRoleApiTest extends IntegrationTest {
     }
 
     @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_SETTINGS})
+    @DisplayName(
+        "Given a tenant role polluted with a platform-only capability, update should drop it"
+            + " instead of rejecting the payload")
+    void given_pollutedTenantRole_should_dropOutOfScopeCapabilityOnUpdate() throws Exception {
+      // -------- Arrange --------
+      Role role =
+          tenantRoleComposer
+              .forRole(
+                  TenantRoleFixture.getRole(
+                      "Polluted",
+                      Set.of(Capability.ACCESS_ASSETS, Capability.ACCESS_PLATFORM_SETTINGS)))
+              .persist()
+              .get();
+
+      RoleInput input =
+          RoleInput.builder()
+              .name("Healed")
+              .capabilities(
+                  Set.of(Capability.MANAGE_TENANT_SETTINGS, Capability.ACCESS_PLATFORM_SETTINGS))
+              .build();
+
+      // -------- Act --------
+      String response =
+          mvc.perform(
+                  put(tenantUri("/api/tenants/{tenantId}/roles/") + role.getId())
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -------- Assert --------
+      List<String> caps = JsonPath.read(response, "$.role_capabilities");
+      assertFalse(
+          caps.contains(Capability.ACCESS_PLATFORM_SETTINGS.name()),
+          "the platform-only capability should have been dropped");
+      assertTrue(caps.contains(Capability.MANAGE_TENANT_SETTINGS.name()));
+    }
+
+    @Test
     @WithMockUser(withCapabilities = {Capability.ACCESS_TENANT_SETTINGS})
     @DisplayName("Given ACCESS_TENANT_SETTINGS only, should be forbidden to update")
     void given_accessTenantSettings_should_forbidUpdate() throws Exception {

--- a/openaev-model/src/main/java/io/openaev/database/model/Capability.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Capability.java
@@ -10,7 +10,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public enum Capability {
 
   // Superuser
@@ -537,28 +539,52 @@ public enum Capability {
     return result;
   }
 
-  public static void validateForPlatformRole(Set<Capability> capabilities) {
-    validateScope(capabilities, CapabilityScope.PLATFORM);
-  }
+  // -- GET --
 
-  public static void validateForTenantRole(Set<Capability> capabilities) {
-    validateScope(capabilities, CapabilityScope.TENANT);
-  }
-
-  /** Returns all capabilities that include the PLATFORM scope (excluding BYPASS itself). */
+  /**
+   * Returns every capability whose scopes include PLATFORM, {@code BYPASS} excluded - being valid in
+   * both scopes, it belongs to no single one. Hidden and deprecated capabilities are included, so
+   * the result describes the scope, not what a UI should offer.
+   */
   public static Set<Capability> allPlatformScoped() {
     return Arrays.stream(values())
         .filter(c -> c != BYPASS && c.scopes.contains(CapabilityScope.PLATFORM))
         .collect(Collectors.toUnmodifiableSet());
   }
 
-  /** Returns all capabilities that include the TENANT scope (excluding BYPASS itself). */
+  /**
+   * Returns every capability whose scopes include TENANT, {@code BYPASS} excluded - being valid in
+   * both scopes, it belongs to no single one. Hidden and deprecated capabilities are included, so
+   * the result describes the scope, not what a UI should offer.
+   */
   public static Set<Capability> allTenantScoped() {
     return Arrays.stream(values())
         .filter(c -> c != BYPASS && c.scopes.contains(CapabilityScope.TENANT))
         .collect(Collectors.toUnmodifiableSet());
   }
 
+  // -- VALIDATE --
+
+  /**
+   * Throws {@link IllegalArgumentException} naming every capability that is not valid in the PLATFORM
+   * scope, and returns silently when they all are. Nothing is modified or logged.
+   */
+  public static void validateForPlatformRole(Set<Capability> capabilities) {
+    validateScope(capabilities, CapabilityScope.PLATFORM);
+  }
+
+  /**
+   * Throws {@link IllegalArgumentException} naming every capability that is not valid in the TENANT
+   * scope, and returns silently when they all are. Nothing is modified or logged.
+   */
+  public static void validateForTenantRole(Set<Capability> capabilities) {
+    validateScope(capabilities, CapabilityScope.TENANT);
+  }
+
+  /**
+   * Fail-closed scope check: collects every capability missing {@code requiredScope} and throws them
+   * all in a single message, so a caller sees the complete set of offenders rather than the first one.
+   */
   private static void validateScope(Set<Capability> capabilities, CapabilityScope requiredScope) {
     Set<Capability> invalid =
         capabilities.stream()
@@ -568,5 +594,48 @@ public enum Capability {
       throw new IllegalArgumentException(
           "Capabilities " + invalid + " are not allowed for scope " + requiredScope);
     }
+  }
+
+  // -- FILTER --
+
+  /**
+   * Returns a new set holding only the capabilities that include the PLATFORM scope; the others are
+   * dropped and reported in a single warning. The given set is left untouched and nothing is
+   * thrown, however many capabilities are dropped - an all-out-of-scope input yields an empty set.
+   */
+  public static Set<Capability> filterForPlatformRole(Set<Capability> capabilities) {
+    return filterScope(capabilities, CapabilityScope.PLATFORM);
+  }
+
+  /**
+   * Returns a new set holding only the capabilities that include the TENANT scope; the others are
+   * dropped and reported in a single warning. The given set is left untouched and nothing is
+   * thrown, however many capabilities are dropped - an all-out-of-scope input yields an empty set.
+   */
+  public static Set<Capability> filterForTenantRole(Set<Capability> capabilities) {
+    return filterScope(capabilities, CapabilityScope.TENANT);
+  }
+
+  /**
+   * Fail-open counterpart of {@link #validateScope}: splits the capabilities on {@code requiredScope},
+   * returns the valid ones in a new mutable set and warns once about those dropped. Never throws, so
+   * the caller must treat the returned set - possibly empty - as the authoritative one.
+   */
+  private static Set<Capability> filterScope(
+      Set<Capability> capabilities, CapabilityScope requiredScope) {
+    Set<Capability> valid = new HashSet<>();
+    Set<Capability> dropped = new HashSet<>();
+    for (Capability capability : capabilities) {
+      if (capability.scopes.contains(requiredScope)) {
+        valid.add(capability);
+      } else {
+        dropped.add(capability);
+      }
+    }
+    if (!dropped.isEmpty()) {
+      log.warn(
+          "Dropping out-of-scope capabilities {} not allowed for scope {}", dropped, requiredScope);
+    }
+    return valid;
   }
 }

--- a/openaev-model/src/main/java/io/openaev/database/model/Capability.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Capability.java
@@ -542,9 +542,9 @@ public enum Capability {
   // -- GET --
 
   /**
-   * Returns every capability whose scopes include PLATFORM, {@code BYPASS} excluded - being valid in
-   * both scopes, it belongs to no single one. Hidden and deprecated capabilities are included, so
-   * the result describes the scope, not what a UI should offer.
+   * Returns every capability whose scopes include PLATFORM, {@code BYPASS} excluded - being valid
+   * in both scopes, it belongs to no single one. Hidden and deprecated capabilities are included,
+   * so the result describes the scope, not what a UI should offer.
    */
   public static Set<Capability> allPlatformScoped() {
     return Arrays.stream(values())
@@ -566,8 +566,8 @@ public enum Capability {
   // -- VALIDATE --
 
   /**
-   * Throws {@link IllegalArgumentException} naming every capability that is not valid in the PLATFORM
-   * scope, and returns silently when they all are. Nothing is modified or logged.
+   * Throws {@link IllegalArgumentException} naming every capability that is not valid in the
+   * PLATFORM scope, and returns silently when they all are. Nothing is modified or logged.
    */
   public static void validateForPlatformRole(Set<Capability> capabilities) {
     validateScope(capabilities, CapabilityScope.PLATFORM);
@@ -582,8 +582,9 @@ public enum Capability {
   }
 
   /**
-   * Fail-closed scope check: collects every capability missing {@code requiredScope} and throws them
-   * all in a single message, so a caller sees the complete set of offenders rather than the first one.
+   * Fail-closed scope check: collects every capability missing {@code requiredScope} and throws
+   * them all in a single message, so a caller sees the complete set of offenders rather than the
+   * first one.
    */
   private static void validateScope(Set<Capability> capabilities, CapabilityScope requiredScope) {
     Set<Capability> invalid =
@@ -617,9 +618,10 @@ public enum Capability {
   }
 
   /**
-   * Fail-open counterpart of {@link #validateScope}: splits the capabilities on {@code requiredScope},
-   * returns the valid ones in a new mutable set and warns once about those dropped. Never throws, so
-   * the caller must treat the returned set - possibly empty - as the authoritative one.
+   * Fail-open counterpart of {@link #validateScope}: splits the capabilities on {@code
+   * requiredScope}, returns the valid ones in a new mutable set and warns once about those dropped.
+   * Never throws, so the caller must treat the returned set - possibly empty - as the authoritative
+   * one.
    */
   private static Set<Capability> filterScope(
       Set<Capability> capabilities, CapabilityScope requiredScope) {


### PR DESCRIPTION
## Problem

Closes #7321.

Updating a **tenant** role (e.g. unchecking "Manage Assessment") fails with `IllegalArgumentException` whenever that role already holds a **platform-only** capability, and vice-versa for platform roles. This is legacy data left over from the dual-scope split (`V5_04__Merge_roles_and_groups_dual_scope`): roles/groups became nullable-tenant without a migration cleaning up capabilities that no longer matched their role's scope.

`Capability.validateForTenantRole()` / `validateForPlatformRole()` reject the **whole payload** as soon as **one** capability is out of scope — so a polluted role can never be updated again, including by the very update that would remove the offending capability. This explains why "Manage Assessment" breaks and "Delete assets" doesn't: it's not the capability being toggled, it's whatever stale capability the role already carries.