### PR TITLE
fix(threat-arsenal): attack-path execution fallback and phishing Credentials output (#7337)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.api.custom_domain.CustomDomainService;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.AttackPattern;
+import io.openaev.database.model.ContractOutputType;
 import io.openaev.database.model.CustomDomain;
 import io.openaev.database.model.CustomDomain.CustomDomainStatus;
 import io.openaev.database.model.Endpoint;
@@ -41,6 +42,7 @@ import io.openaev.injector_contract.ContractConfig;
 import io.openaev.injector_contract.ContractDef;
 import io.openaev.injector_contract.fields.ContractElement;
 import io.openaev.injector_contract.fields.ContractSelect;
+import io.openaev.injector_contract.outputs.InjectorContractContentOutputElement;
 import io.openaev.injectors.phishing.PhishingContract;
 import io.openaev.injectors.phishing.form.PhishingLandingPageBulkProcessingInput;
 import io.openaev.model.inject.form.Expectation;
@@ -470,7 +472,32 @@ public class PhishingLandingPageService {
     // static built-in contract; the entity-level attackPatterns are resolved from these ids in
     // synchroniseInjectorContract (and the kill chain phases are derived from them).
     PHISHING_ATTACK_PATTERN_EXTERNAL_IDS.forEach(contract::addAttackPattern);
+
+    // A capture-enabled landing page turns submitted data into a Credentials finding
+    // (PhishingTrackingService.captureCredentials). Phishing is a native, payload-less injector, so
+    // this contract "outputs" declaration is the only place that finding type is machine-readable:
+    // it feeds InjectorContract.getProviding() (Threat Arsenal "Outputs" section, findings-based
+    // chaining, the injector_contract_providing filter). A page that does not capture declares no
+    // output, matching what is actually produced.
+    if (landingPage.isCaptureSubmittedData()) {
+      contract.addOutput(buildCredentialsOutput());
+    }
     return contract;
+  }
+
+  /**
+   * The single {@code Credentials} finding a credential-capture phishing page produces, shaped like
+   * a payload output element ({@code isFindingCompatible}) so the Threat Arsenal drawer renders it
+   * exactly like a scanner's parsed output.
+   */
+  private InjectorContractContentOutputElement buildCredentialsOutput() {
+    InjectorContractContentOutputElement credentials = new InjectorContractContentOutputElement();
+    credentials.setType(ContractOutputType.Credentials);
+    credentials.setField(PhishingTrackingService.CREDENTIALS_FIELD);
+    credentials.setLabels(new String[] {"Credentials"});
+    credentials.setMultiple(false);
+    credentials.setFindingCompatible(true);
+    return credentials;
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.AttackPattern;
+import io.openaev.database.model.ContractOutputType;
 import io.openaev.database.model.Document;
 import io.openaev.database.model.Injector;
 import io.openaev.database.model.InjectorContract;
@@ -29,7 +31,9 @@ import io.openaev.database.repository.PhishingEmailTemplateRepository;
 import io.openaev.database.repository.PhishingLandingPageRepository;
 import io.openaev.expectation.ExpectationBuilderService;
 import io.openaev.helper.SupportedLanguage;
+import io.openaev.injector_contract.Contract;
 import io.openaev.injector_contract.ContractConfig;
+import io.openaev.injector_contract.outputs.InjectorContractContentOutputElement;
 import io.openaev.injectors.phishing.PhishingContract;
 import io.openaev.injectors.phishing.form.PhishingLandingPageBulkProcessingInput;
 import io.openaev.model.inject.form.Expectation;
@@ -45,6 +49,7 @@ import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -145,6 +150,93 @@ class PhishingLandingPageServiceTest {
     verify(attackPatternRepository)
         .findAllByExternalIdInIgnoreCaseAndTenantId(eq(List.of("T1566.002", "T1598.003")), any());
     assertEquals(List.of(spearphishingLink, phishingForInfo), result.getAttackPatterns());
+  }
+
+  @Test
+  @DisplayName(
+      "synchroniseInjectorContract declares a Credentials output when the page captures data")
+  void synchronise_should_declareCredentialsOutputWhenCapturing() throws Exception {
+    // -- ARRANGE --
+    // A capture-enabled page turns submitted data into a Credentials finding, so the synthesized
+    // contract must declare that output - otherwise getProviding() (and the Threat Arsenal drawer)
+    // report the action as producing nothing.
+    PhishingLandingPage landingPage = new PhishingLandingPage();
+    landingPage.setId("lp-1");
+    landingPage.setName("Login page");
+    landingPage.setCaptureSubmittedData(true);
+    arrangeSynchroniseStubs();
+
+    ArgumentCaptor<Object> contractCaptor = ArgumentCaptor.forClass(Object.class);
+
+    // -- ACT --
+    phishingLandingPageService.synchroniseInjectorContract(landingPage);
+
+    // -- ASSERT --
+    verify(mapper).writeValueAsString(contractCaptor.capture());
+    Contract serialized = (Contract) contractCaptor.getValue();
+    List<ContractOutputType> declared =
+        serialized.getOutputs().stream()
+            .map(InjectorContractContentOutputElement::getType)
+            .toList();
+    assertEquals(List.of(ContractOutputType.Credentials), declared);
+    assertTrue(serialized.getOutputs().getFirst().isFindingCompatible());
+  }
+
+  @Test
+  @DisplayName("synchroniseInjectorContract declares no output when the page does not capture data")
+  void synchronise_should_declareNoOutputWhenNotCapturing() throws Exception {
+    // -- ARRANGE --
+    PhishingLandingPage landingPage = new PhishingLandingPage();
+    landingPage.setId("lp-1");
+    landingPage.setName("Awareness only");
+    landingPage.setCaptureSubmittedData(false);
+    arrangeSynchroniseStubs();
+
+    ArgumentCaptor<Object> contractCaptor = ArgumentCaptor.forClass(Object.class);
+
+    // -- ACT --
+    phishingLandingPageService.synchroniseInjectorContract(landingPage);
+
+    // -- ASSERT --
+    verify(mapper).writeValueAsString(contractCaptor.capture());
+    Contract serialized = (Contract) contractCaptor.getValue();
+    assertTrue(serialized.getOutputs().isEmpty());
+  }
+
+  /**
+   * Common stubs for a successful {@link
+   * PhishingLandingPageService#synchroniseInjectorContract(PhishingLandingPage)} run: the phishing
+   * injector is registered, no contract exists yet, and the config / lookups / (mocked) mapper all
+   * resolve so the synthesized contract is built and captured.
+   */
+  private void arrangeSynchroniseStubs() throws Exception {
+    Injector injector = new Injector();
+    injector.setId("phishing-injector");
+    when(injectorRepository.findByTypeAndTenantId(eq(PhishingContract.TYPE), any()))
+        .thenReturn(Optional.of(injector));
+    when(injectorContractRepository.findById(any(InjectorContractId.class)))
+        .thenReturn(Optional.empty());
+    when(phishingContract.getConfig())
+        .thenReturn(
+            new ContractConfig(
+                PhishingContract.TYPE,
+                Map.of(SupportedLanguage.en, "Phishing"),
+                "#000000",
+                "#ffffff",
+                null));
+    when(emailTemplateRepository.findAll()).thenReturn(List.of());
+    when(expectationBuilderService.buildPreventionExpectation()).thenReturn(new Expectation());
+    when(expectationBuilderService.buildDetectionExpectation()).thenReturn(new Expectation());
+    when(expectationBuilderService.buildManualExpectation()).thenReturn(new Expectation());
+    when(domainService.upsertDomainEntities(any(), any())).thenReturn(Set.of());
+    when(organizationService.findOrCreateByName(any())).thenReturn(new Organization());
+    when(attackPatternRepository.findAllByExternalIdInIgnoreCaseAndTenantId(any(), any()))
+        .thenReturn(List.of());
+    when(mapper.writeValueAsString(any())).thenReturn("{}");
+    when(mapper.readValue(anyString(), eq(ObjectNode.class)))
+        .thenReturn(JsonNodeFactory.instance.objectNode());
+    when(injectorContractRepository.save(any(InjectorContract.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @Test

--- a/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
+++ b/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
@@ -5,6 +5,7 @@ import io.openaev.database.model.Domain;
 import io.openaev.database.model.Endpoint.PLATFORM_TYPE;
 import io.openaev.helper.SupportedLanguage;
 import io.openaev.injector_contract.fields.ContractElement;
+import io.openaev.injector_contract.outputs.InjectorContractContentOutputElement;
 import io.openaev.injector_contract.variables.VariableHelper;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -101,6 +102,19 @@ public class Contract {
   @Setter
   @JsonProperty("domains")
   private Set<Domain> domains;
+
+  /**
+   * Output/finding types this contract's execution produces. For a native, payload-less injector
+   * (e.g. phishing credential capture) this array is the ONLY machine-readable declaration of what
+   * findings the action can generate: {@link
+   * io.openaev.database.model.InjectorContract#getProviding()} reads it from the serialized content
+   * when the contract has no payload, so the Threat Arsenal "Outputs" section and findings-based
+   * chaining can surface it. Payload-backed contracts derive their outputs from the payload's
+   * output parsers instead and leave this empty.
+   */
+  @Setter
+  @JsonProperty("outputs")
+  private List<InjectorContractContentOutputElement> outputs = new ArrayList<>();
 
   private Contract(
       @NotNull final ContractConfig config,
@@ -229,6 +243,19 @@ public class Contract {
   public void addAttackPattern(String externalId) {
     if (externalId != null && !externalId.isBlank()) {
       attackPatternsExternalIds.add(externalId);
+    }
+  }
+
+  /**
+   * Declares an output/finding type this contract's execution produces. Only needed for native,
+   * payload-less injectors that generate findings through their own side effects rather than a
+   * payload's output parsers (e.g. phishing credential capture); see {@link #outputs}.
+   *
+   * @param output the output element to declare (ignored when null)
+   */
+  public void addOutput(InjectorContractContentOutputElement output) {
+    if (output != null) {
+      outputs.add(output);
     }
   }
 }

--- a/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.test.tsx
@@ -150,6 +150,93 @@ describe('ExecutionRowStatusBadge', () => {
     expect(mocks.fetchExecutionDetail).not.toHaveBeenCalled();
   });
 
+  // A payload action whose per-agent resolution yields nothing used to render a blank Execution
+  // cell even though the action clearly ran (issue 7337): the graph-shipped inject-level status now
+  // fills that hole, and only that hole - the per-agent chip still wins when traces resolve (covered
+  // by the per-target test above).
+  it('falls back to the inject-level chip when the per-agent result resolves empty', async () => {
+    mocks.searchTargets.mockResolvedValue({
+      data: {
+        content: [{
+          target_id: 'target-7',
+          target_type: 'ASSETS',
+          target_name: 'CORP-HOST',
+        }],
+      },
+    });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({ data: null });
+
+    renderWithTheme(
+      <ExecutionRowStatusBadge
+        simulationId="sim-1"
+        executionRef="exec-ref-7"
+        endpointName="CORP-HOST"
+        injectId="inject-7"
+        payloadId="payload-7"
+        executionStatus="EXECUTED"
+      />,
+    );
+
+    expect(await screen.findByText('EXECUTED')).toBeDefined();
+    expect(mocks.fetchInjectExecutionResult).toHaveBeenCalledWith('inject-7', 'target-7', 'ASSETS');
+  });
+
+  it('falls back to the inject-level chip when the per-agent result fetch fails', async () => {
+    mocks.searchTargets.mockResolvedValue({
+      data: {
+        content: [{
+          target_id: 'target-8',
+          target_type: 'ASSETS',
+          target_name: 'CORP-HOST',
+        }],
+      },
+    });
+    mocks.fetchInjectExecutionResult.mockRejectedValue(new Error('boom'));
+
+    renderWithTheme(
+      <ExecutionRowStatusBadge
+        simulationId="sim-1"
+        executionRef="exec-ref-8"
+        endpointName="CORP-HOST"
+        injectId="inject-8"
+        payloadId="payload-8"
+        executionStatus="EXECUTED"
+      />,
+    );
+
+    expect(await screen.findByText('EXECUTED')).toBeDefined();
+  });
+
+  // A seeded/demo snapshot ships no live inject status: the historical empty render is kept rather
+  // than inventing a status.
+  it('keeps the empty render when the per-agent result is empty and there is no fallback status', async () => {
+    mocks.searchTargets.mockResolvedValue({
+      data: {
+        content: [{
+          target_id: 'target-9',
+          target_type: 'ASSETS',
+          target_name: 'CORP-HOST',
+        }],
+      },
+    });
+    mocks.fetchInjectExecutionResult.mockResolvedValue({ data: null });
+
+    const { container } = renderWithTheme(
+      <ExecutionRowStatusBadge
+        simulationId="sim-1"
+        executionRef="exec-ref-9"
+        endpointName="CORP-HOST"
+        injectId="inject-9"
+        payloadId="payload-9"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.fetchInjectExecutionResult).toHaveBeenCalled();
+    });
+    expect(container.textContent).toBe('');
+  });
+
   it('refines a non-terminal graph status instead of trusting it, straight from its injectId', async () => {
     mocks.getInjectStatusWithGlobalExecutionTraces.mockResolvedValue({
       data: {

--- a/openaev-front/src/actions/inject_status/useFetchInjectExecutionResult.tsx
+++ b/openaev-front/src/actions/inject_status/useFetchInjectExecutionResult.tsx
@@ -6,15 +6,21 @@ import { fetchInjectExecutionResult } from './inject-status-action';
 // `target` may be null while the caller is still resolving which target to show
 // (e.g. the attack-path panel resolves it from a search): the fetch simply waits
 // until a target with an id and type is provided.
+//
+// `undefined` means the fetch has not settled yet; a settled fetch with no result (empty payload or
+// a failed request) lands on `null`, so a consumer can tell "still in flight" from "resolved empty"
+// (the attack-path execution-status badge keys its fallback rendering on that distinction).
 const useFetchInjectExecutionResult = (injectId: string, target: InjectTarget | null) => {
-  const [injectExecutionResult, setInjectExecutionResult] = useState<InjectResultPayloadExecutionOutput>();
+  const [injectExecutionResult, setInjectExecutionResult] = useState<InjectResultPayloadExecutionOutput | null>();
   const [loading, setLoading] = useState(false);
   const fetch = async () => {
     if (!injectId || !target?.target_id || !target.target_type) return;
     setLoading(true);
     try {
       const result = await fetchInjectExecutionResult(injectId, target.target_id, target.target_type);
-      setInjectExecutionResult(result.data || undefined);
+      setInjectExecutionResult(result.data ?? null);
+    } catch {
+      setInjectExecutionResult(null);
     } finally {
       setLoading(false);
     }

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -15,23 +15,42 @@ import useResolvedAssetTarget from './useResolvedAssetTarget';
 // verdicts shown elsewhere answer "was it caught?", never "did it run at all?" — a technical failure
 // (timeout, access denied…) and a clean run that simply went undetected previously looked identical.
 // Resolves the same target + traces the live terminal view does (a second, independent fetch — this
-// badge and that view render independently of one another), and renders nothing once resolved without
-// any real traces (a seeded/demo snapshot has no live target to match).
-export const PayloadExecutionStatusBadge = ({ injectId, endpointName }: {
+// badge and that view render independently of one another).
+//
+// When that per-agent resolution comes back with no EXECUTION-action trace for the endpoint the panel
+// picked, it falls back to the graph-shipped inject-level status rather than rendering nothing: an
+// action whose traces do not link back to the resolved asset (or that recorded no EXECUTION-action
+// trace) otherwise showed a blank Execution cell even though it clearly ran. Absent that fallback
+// status too (a seeded/demo snapshot with no live inject), it keeps the historical empty render.
+export const PayloadExecutionStatusBadge = ({ injectId, endpointName, fallbackStatus }: {
   injectId: string;
   endpointName?: string;
+  fallbackStatus?: string;
 }) => {
-  const { target } = useResolvedAssetTarget(injectId, endpointName);
-  const { injectExecutionResult } = useFetchInjectExecutionResult(injectId, target);
+  const { t } = useFormatter();
+  const { target, loading: targetLoading } = useResolvedAssetTarget(injectId, endpointName);
+  const { injectExecutionResult, loading: resultLoading } = useFetchInjectExecutionResult(injectId, target);
   const allTraces = useMemo(
     () => Object.values(injectExecutionResult?.execution_traces ?? {}).flat(),
     [injectExecutionResult],
   );
   const agentStatus = useAgentStatus(allTraces);
-  if (allTraces.length === 0) {
+  if (allTraces.length > 0) {
+    return <TraceStatusChip status={agentStatus.statusName} />;
+  }
+  // Still settling: a resolved target whose result has not come back yet would flash the fallback for
+  // a frame before the real per-agent chip. Wait until the target and its result have both settled.
+  const resolving = targetLoading || resultLoading || (!!target && injectExecutionResult === undefined);
+  if (resolving || !fallbackStatus) {
     return null;
   }
-  return <TraceStatusChip status={agentStatus.statusName} />;
+  return (
+    <ExecutionRanChip
+      status={fallbackStatus}
+      label={t(getInjectStatusLabel(fallbackStatus))}
+      tooltip={t(getInjectStatusTooltip(fallbackStatus))}
+    />
+  );
 };
 
 // Inject-level execution status for a network injector (NetExec, Nmap…) (issue 244): its own traces have
@@ -130,6 +149,12 @@ export const ExecutionRowStatusBadge = ({ simulationId, executionRef, endpointNa
     return null;
   }
   return detail.payloadId
-    ? <PayloadExecutionStatusBadge injectId={detail.injectId} endpointName={endpointName} />
+    ? (
+        <PayloadExecutionStatusBadge
+          injectId={detail.injectId}
+          endpointName={endpointName}
+          fallbackStatus={executionStatus}
+        />
+      )
     : <InjectorExecutionStatusBadge injectId={detail.injectId} />;
 };

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/ExecutionStatusBadge.tsx
@@ -39,8 +39,12 @@ export const PayloadExecutionStatusBadge = ({ injectId, endpointName, fallbackSt
     return <TraceStatusChip status={agentStatus.statusName} />;
   }
   // Still settling: a resolved target whose result has not come back yet would flash the fallback for
-  // a frame before the real per-agent chip. Wait until the target and its result have both settled.
-  const resolving = targetLoading || resultLoading || (!!target && injectExecutionResult === undefined);
+  // a frame before the real per-agent chip. Wait until the target and its result have both settled:
+  // `undefined` is "fetch not applied yet" (the hook settles an empty or failed fetch to `null`), and
+  // the fetch only ever fires for a target carrying an id and a type - the same precondition guards
+  // the wait, so a target the hook will never fetch cannot suppress the fallback forever.
+  const awaitingResult = !!target?.target_id && !!target.target_type && injectExecutionResult === undefined;
+  const resolving = targetLoading || resultLoading || awaitingResult;
   if (resolving || !fallbackStatus) {
     return null;
   }


### PR DESCRIPTION
## Summary

This PR bundles two attack-path / Threat Arsenal display fixes.

### 1. Attack-path execution status fallback (front-end)

- In the attack-path action (injector) panel, a payload-backed action whose per-agent execution traces do not resolve for the endpoint the panel picked showed an empty Execution status cell for every row, even though the action clearly ran (the Result verdict and the other payload actions on the same endpoints rendered fine). Reported for "GPP Passwords (Get-GPPPassword)".
- `PayloadExecutionStatusBadge` now falls back to the graph-shipped inject-level `executionStatus` chip when the independent per-agent resolution returns no execution trace, instead of rendering nothing.
- No behavior change when per-agent traces resolve: the more granular per-agent chip still wins. When there is no fallback status either (a seeded/demo snapshot with no live inject), the historical empty render is kept. A brief "still resolving" guard avoids flashing the fallback before the per-agent chip settles.
- Review hardening: `useFetchInjectExecutionResult` now settles an empty or failed fetch to `null` instead of leaving the state `undefined` forever (which would have suppressed the fallback exactly in the cases the fix targets, and also left a fetch failure as an unhandled promise rejection), and the "still resolving" guard only waits for targets the hook will actually fetch (`target_id` + `target_type` present).

See #7337 for the full root-cause analysis and a prod SQL query to confirm the underlying trace-linkage shape.

### 2. Phishing action declares its Credentials output (backend)

- The Threat Arsenal "Outputs" section showed "no output / no finding" for phishing actions, even though a capture-enabled landing page produces a Credentials finding.
- Root cause: phishing is a native, payload-less injector, and its synthesized contract never declared an `outputs` array, so `InjectorContract.getProviding()` (which reads the content `outputs` for a payload-less contract) returned empty.
- Fix: the framework `Contract` now carries an `outputs` list, and `PhishingLandingPageService` declares a `Credentials` output element (`isFindingCompatible`) when the landing page captures submitted data. A non-capturing page declares nothing, matching what `PhishingTrackingService.captureCredentials` actually produces.
- This also feeds findings-based chaining and the `injector_contract_providing` filter, and removes a latent NPE in `getContractOutputs` (which assumed the `outputs` key always exists).
- Existing phishing contracts self-heal via `resyncAllContracts` at startup, so no migration is required.

## Test plan

- [x] Front-end unit tests: `yarn vitest run src/__tests__/admin/components/simulations/simulation/attack_path`, `yarn lint`, `yarn check-ts`.
- [x] Backend unit tests: `PhishingLandingPageServiceTest` (capture -> Credentials output declared; no capture -> no output).
- [x] Attack-path action panel: a payload action with resolvable per-agent traces still shows the per-agent status chip, unchanged.
- [x] A payload action whose traces do not resolve per-agent now shows the inject-level status chip (e.g. Executed) instead of a blank cell.
- [x] Threat Arsenal drawer for a capture-enabled phishing action now shows a "Credentials" output in the Outputs section.
- [x] Threat Arsenal drawer for a non-capturing phishing action still shows no output.

Closes #7337
