### PR TITLE
fix(dashboard): make home resilience gauge row responsive to gauge count (#7342)

### DIFF
--- a/openaev-front/src/admin/components/default_dashboard/DefaultHomeDashboard.tsx
+++ b/openaev-front/src/admin/components/default_dashboard/DefaultHomeDashboard.tsx
@@ -55,13 +55,11 @@ const DefaultHomeDashboard = () => {
   // "Human Response" is situational (manual/article/challenge expectations, e.g.
   // phishing), so - like the command center's human node - the gauge is mounted
   // only when there is data in range, never as a sample-only card. Probe the same
-  // config the gauge queries. Tri-state: null = probe in flight. The grid is NOT
-  // mounted until the probe resolves, because react-grid-layout only reads a
-  // child's data-grid when that child first mounts (existing keys keep their
-  // internal layout): flipping the gauge widths (w=4 -> w=3) under a live grid is
-  // silently ignored, and the late-mounted Human Response gauge then collides
-  // with the stale w=4 row and gets compacted onto a new line.
-  const [humanResponsePresent, setHumanResponsePresent] = useState<boolean | null>(null);
+  // config the gauge queries; default hidden so an empty range never flashes it.
+  // The gauge occupies a RESERVED 4th slot (see defaultHomeWidgets GAUGE_WIDTH):
+  // the three core gauges never move whether or not it is present, so it can arrive
+  // late (after this probe resolves) without reflowing them onto a second row.
+  const [humanResponsePresent, setHumanResponsePresent] = useState(false);
   useEffect(() => {
     let cancelled = false;
     limitWidgetQueries(() => adHocSeries(buildHumanResponseProbeConfig(timeRange)))
@@ -100,7 +98,7 @@ const DefaultHomeDashboard = () => {
   // context value and refetches all ~20 widgets (same rule as DefaultHomeResults).
   // `locale` is the stable signal that t's output actually changed, so a runtime
   // language switch still recomputes the titles (one refetch, but only then).
-  const widgets = useMemo(() => buildDefaultHomeWidgets(timeRange, t, humanResponsePresent === true), [timeRange, locale, humanResponsePresent]);
+  const widgets = useMemo(() => buildDefaultHomeWidgets(timeRange, t, humanResponsePresent), [timeRange, locale, humanResponsePresent]);
 
   const widgetById = useMemo(() => {
     const map = new Map<string, Widget>();
@@ -237,15 +235,13 @@ const DefaultHomeDashboard = () => {
         </Tooltip>
       </div>
       {/*
-        Mounted only once the Human Response probe has resolved, so the gauge row
-        mounts with its final geometry (3 gauges at w=4, or 4 gauges at w=3 on the
-        SAME line). The key remounts the grid if the flag later changes (time range
-        switch): react-grid-layout ignores data-grid updates on existing children,
-        so an in-place flip would strand the new gauge on a second row.
+        Remount the grid when the gauge count changes. react-grid-layout keeps the
+        internal layout of already-mounted children and ignores width changes, so
+        flipping 3 gauges (w=4) <-> 4 gauges (w=3) in place would leave the core
+        gauges at their old width and strand Human Response on a second row. A fresh
+        mount re-reads every gauge's width, so each state fills the row evenly.
       */}
-      {humanResponsePresent !== null && (
-        <CustomDashboardReactLayout key={`default-grid-hr-${humanResponsePresent}`} readOnly />
-      )}
+      <CustomDashboardReactLayout key={`default-grid-hr-${humanResponsePresent}`} readOnly />
     </CustomDashboardContext.Provider>
   );
 };

--- a/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
+++ b/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
@@ -206,8 +206,13 @@ export const buildHumanResponseProbeConfig = (timeRange: DefaultTimeRange): Widg
 /**
  * @param includeHumanResponse whether the "Human Response" gauge is mounted. It is
  *   only shown when human-driven expectations exist in range (see
- *   {@link buildHumanResponseProbeConfig}); when hidden, the three core gauges widen
- *   to fill the 12-column row (w=4) instead of leaving a gap.
+ *   {@link buildHumanResponseProbeConfig}). The gauge row is fully responsive: the
+ *   gauges always divide the 12-column row evenly, so three gauges are w=4 (no gap)
+ *   and four gauges are w=3 (Human Response on the SAME line). The caller MUST
+ *   remount the grid when this flag flips (see DefaultHomeDashboard) - react-grid-
+ *   layout keeps the internal layout of already-mounted children and ignores a
+ *   width change, so an in-place flip would leave the core gauges at their old
+ *   width and strand Human Response on a second row.
  */
 export const buildDefaultHomeWidgets = (
   timeRange: DefaultTimeRange,
@@ -215,10 +220,10 @@ export const buildDefaultHomeWidgets = (
   includeHumanResponse = false,
 ): Widget[] => {
   // -- EXPECTATION RESULTS --
-  // Resilience donuts across the 12-column row. The three core security-control
-  // gauges are always shown; "Human Response" (MANUAL/ARTICLE/CHALLENGE, e.g.
-  // phishing) is appended only when it has data, so an empty range doesn't surface
-  // a sample-only card. With it: four gauges at w=3; without it: three at w=4.
+  // Resilience donuts dividing the 12-column row evenly. The three core
+  // security-control gauges are always shown; "Human Response" (MANUAL/ARTICLE/
+  // CHALLENGE, e.g. phishing) is appended only when it has data. Three gauges fill
+  // the row at w=4; four fill it at w=3. No empty slot in either state.
   const gaugeDefs: {
     id: string;
     title: string;
@@ -247,7 +252,8 @@ export const buildDefaultHomeWidgets = (
       types: HUMAN_RESPONSE_EXPECTATION_TYPES,
     });
   }
-  const gaugeWidth = includeHumanResponse ? 3 : 4;
+  // Evenly divide the 12-column row: 3 gauges -> w=4, 4 gauges -> w=3.
+  const gaugeWidth = 12 / gaugeDefs.length;
   const gaugeWidgets = gaugeDefs.map((gauge, index) => widget(
     gauge.id,
     'resilience-gauge',


### PR DESCRIPTION
## Summary

Makes the default home dashboard (Adversarial exposure overview) resilience
gauge row responsive to the number of gauges shown:

- The gauge width is derived from the count (`12 / gaugeCount`): three gauges ->
  w=4 (fill the row, no gap), four gauges -> w=3 (Human Response on the SAME
  line).
- The grid is remounted (React `key` tied to the Human Response presence flag)
  when the count changes, so react-grid-layout re-reads every gauge's width
  instead of keeping the stale internal layout of the already-mounted core
  gauges. That stale-layout behaviour was why the late-arriving Human Response
  gauge kept getting stranded on a second row.

Fixes #7342.

## Why

"Human Response" (MANUAL / ARTICLE / CHALLENGE expectations, e.g. phishing) is
situational and its presence is resolved by an async probe that returns after
the grid has already mounted. react-grid-layout 2.2.4 reads a child's `data-grid`
only on first mount and ignores later width changes on known children, so an
in-place flip left the three core gauges at w=4 and pushed Human Response to a
new row.

## Test plan

- [ ] Open `/admin` with no human-driven expectations in range: three gauges
      fill the row evenly, no empty slot.
- [ ] Open `/admin` with at least one human-driven expectation (e.g. a phishing
      atomic test) in range: four gauges on one line, evenly sized.
- [ ] Switch the time range so Human Response appears / disappears: the row
      re-fills evenly each time, no wrap.
- [ ] Click the Human Response gauge: the drill-down results page resolves.
