### PR TITLE
fix(injects): show deprecated payload indicator in inject lists and atomic testing (#3839)

### DIFF
--- a/openaev-front/src/admin/components/atomic_testings/InjectResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/InjectResultList.tsx
@@ -31,6 +31,7 @@ import InjectImportJsonDialog from '../common/injects/InjectImportJsonDialog';
 import InjectorContract from '../common/injects/InjectorContract';
 import InjectStatus from '../common/injects/status/InjectStatus';
 import ToolBar from '../common/ToolBar';
+import PayloadDeprecatedChip from '../payloads/PayloadDeprecatedChip';
 import AtomicTestingPopover from './atomic_testing/AtomicTestingPopover';
 import AtomicTestingResult from './atomic_testing/AtomicTestingResult';
 
@@ -139,7 +140,24 @@ const InjectResultList: FunctionComponent<Props> = ({
       label: 'Name',
       isSortable: true,
       value: (injectResultOutput: InjectResultOutput) => {
-        return <>{injectResultOutput.inject_title}</>;
+        return (
+          <span style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            maxWidth: '100%',
+          }}
+          >
+            <span style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+            >
+              {injectResultOutput.inject_title}
+            </span>
+            <PayloadDeprecatedChip status={injectResultOutput.inject_injector_contract?.injector_contract_payload?.payload_status} />
+          </span>
+        );
       },
     },
     {

--- a/openaev-front/src/admin/components/atomic_testings/InjectResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/InjectResultList.tsx
@@ -142,15 +142,19 @@ const InjectResultList: FunctionComponent<Props> = ({
       value: (injectResultOutput: InjectResultOutput) => {
         return (
           <span style={{
-            display: 'inline-flex',
+            display: 'flex',
             alignItems: 'center',
             gap: 8,
             maxWidth: '100%',
           }}
           >
+            {/* minWidth: 0 lets the flex item shrink below its content width so the
+                ellipsis can kick in instead of pushing the chip out of the cell */}
             <span style={{
               overflow: 'hidden',
               textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
             }}
             >
               {injectResultOutput.inject_title}

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/InjectHero.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/InjectHero.tsx
@@ -12,6 +12,7 @@ import handle from '../../../../utils/period/Period';
 import { truncate } from '../../../../utils/String';
 import InjectIcon from '../../common/injects/InjectIcon';
 import InjectStatus from '../../common/injects/status/InjectStatus';
+import PayloadDeprecatedChip from '../../payloads/PayloadDeprecatedChip';
 import InjectScoreTiles from './InjectScoreTiles';
 
 // Inject-level statuses whose concrete failure reason is worth surfacing on the
@@ -142,6 +143,7 @@ const InjectHero: FunctionComponent<Props> = ({ injectResultOverview, actions })
       chips={(
         <>
           <InjectStatus status={statusName as InjectStatusType['status_name']} errorMessage={errorMessage} />
+          <PayloadDeprecatedChip status={payload?.payload_status} />
           {isScheduled && (
             <Tooltip title={scheduleLabel ?? ''}>
               <Chip

--- a/openaev-front/src/admin/components/common/injects/Injects.tsx
+++ b/openaev-front/src/admin/components/common/injects/Injects.tsx
@@ -138,15 +138,19 @@ const Injects: FunctionComponent<Props> = ({
       isSortable: true,
       value: (inject: InjectOutputType, _: InjectorContractConverted['convertedContent']) => (
         <span style={{
-          display: 'inline-flex',
+          display: 'flex',
           alignItems: 'center',
           gap: 8,
           maxWidth: '100%',
         }}
         >
+          {/* minWidth: 0 lets the flex item shrink below its content width so the
+              ellipsis can kick in instead of pushing the chip out of the cell */}
           <span style={{
             overflow: 'hidden',
             textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
           }}
           >
             {inject.inject_title}

--- a/openaev-front/src/admin/components/common/injects/Injects.tsx
+++ b/openaev-front/src/admin/components/common/injects/Injects.tsx
@@ -36,6 +36,7 @@ import { MESSAGING$ } from '../../../../utils/Environment';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 import { splitDuration } from '../../../../utils/Time';
 import { download, isNotEmptyField } from '../../../../utils/utils';
+import PayloadDeprecatedChip from '../../payloads/PayloadDeprecatedChip';
 import { InjectContext, InjectTestContext, PermissionsContext, ViewModeContext } from '../Context';
 import ToolBar from '../ToolBar';
 import InjectIcon from './InjectIcon';
@@ -135,7 +136,24 @@ const Injects: FunctionComponent<Props> = ({
       field: 'inject_title',
       label: 'Title',
       isSortable: true,
-      value: (inject: InjectOutputType, _: InjectorContractConverted['convertedContent']) => <>{inject.inject_title}</>,
+      value: (inject: InjectOutputType, _: InjectorContractConverted['convertedContent']) => (
+        <span style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          maxWidth: '100%',
+        }}
+        >
+          <span style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          >
+            {inject.inject_title}
+          </span>
+          <PayloadDeprecatedChip status={inject.inject_injector_contract?.injector_contract_payload?.payload_status} />
+        </span>
+      ),
     },
     {
       field: 'inject_contract_domains',

--- a/openaev-front/src/admin/components/payloads/PayloadDeprecatedChip.tsx
+++ b/openaev-front/src/admin/components/payloads/PayloadDeprecatedChip.tsx
@@ -1,0 +1,39 @@
+import { Chip, Tooltip } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+
+import { useFormatter } from '../../../components/i18n';
+import { type PayloadSimple } from '../../../utils/api-types';
+
+interface Props { status?: PayloadSimple['payload_status'] }
+
+/**
+ * Compact inline "Deprecated" chip shown next to injects whose contract payload
+ * is deprecated (issue #3839). Renders nothing for any other status so callers
+ * can pass the payload status unconditionally.
+ */
+const PayloadDeprecatedChip = ({ status }: Props) => {
+  const { t } = useFormatter();
+  const theme = useTheme();
+
+  if (status !== 'DEPRECATED') {
+    return null;
+  }
+  return (
+    <Tooltip title={t('Deprecated: Functionality not guaranteed')}>
+      <Chip
+        size="small"
+        variant="outlined"
+        label={t('Deprecated')}
+        sx={{
+          borderRadius: 1,
+          height: 20,
+          fontSize: 11,
+          color: theme.palette.text.disabled,
+          borderColor: alpha(theme.palette.text.disabled, 0.4),
+        }}
+      />
+    </Tooltip>
+  );
+};
+
+export default PayloadDeprecatedChip;

--- a/openaev-front/src/admin/components/payloads/PayloadDeprecatedChip.tsx
+++ b/openaev-front/src/admin/components/payloads/PayloadDeprecatedChip.tsx
@@ -30,6 +30,8 @@ const PayloadDeprecatedChip = ({ status }: Props) => {
           fontSize: 11,
           color: theme.palette.text.disabled,
           borderColor: alpha(theme.palette.text.disabled, 0.4),
+          // Never let the chip shrink when rendered next to a truncating title
+          flexShrink: 0,
         }}
       />
     </Tooltip>


### PR DESCRIPTION
## Summary

- Adds a new compact `PayloadDeprecatedChip` component (outlined MUI Chip with the existing "Deprecated" label and "Deprecated: Functionality not guaranteed" tooltip, reusing the Threat Arsenal translation keys and its disabled-grey status color) that renders only when the contract payload has `payload_status === 'DEPRECATED'`.
- Shows the chip inline next to the inject title in the scenario/simulation injects list (`Injects.tsx`) and in the atomic testings list (`InjectResultList.tsx`).
- Shows the chip in the atomic testing / inject detail hero (`InjectHero.tsx`) next to the execution status chip.
- Review fix: the title span next to the chip now truncates reliably (`whiteSpace: nowrap` + `minWidth: 0` on the flex item, `flexShrink: 0` on the chip) so long inject titles ellipsize instead of pushing the chip out of the cell.

Frontend-only change; the payload status was already present in the list DTOs (`InjectorContractSimple.injector_contract_payload.payload_status` and the full contract on `InjectOutput`).

## Test plan

- `yarn check-ts` - passes
- `npx eslint` on the 4 changed files - passes
- Suggested visual check: mark a payload as deprecated (Threat Arsenal), then verify a "Deprecated" chip with tooltip appears (1) on the inject row in a scenario/simulation injects list, (2) on the atomic testing row in the atomic testings list, (3) in the atomic testing header next to the status chip. Injects whose payload is VERIFIED/UNVERIFIED or that have no payload are unchanged. Long inject titles ellipsize and keep the chip visible.

Closes #3839
