### PR TITLE
fix(injectors): remove user variables from multi-recipients email contract cheat sheet (#3878)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/email/EmailContract.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/EmailContract.java
@@ -20,6 +20,7 @@ import io.openaev.expectation.ExpectationBuilderService;
 import io.openaev.injector_contract.*;
 import io.openaev.injector_contract.fields.ContractElement;
 import io.openaev.injector_contract.fields.ContractExpectations;
+import io.openaev.injector_contract.variables.VariableHelper;
 import io.openaev.rest.domain.enums.PresetDomain;
 import java.io.InputStream;
 import java.util.List;
@@ -103,6 +104,9 @@ public class EmailContract extends Contractor {
             false,
             Set.of(PresetDomain.getEmailInfiltration(), PresetDomain.getTabletop()));
     globalEmail.addVariable(documentUriVariable);
+    // A single mail is sent to all recipients at once, so per-user variables cannot be resolved
+    // and must not be advertised in the available variables cheat sheet.
+    globalEmail.removeVariable(VariableHelper.USER);
     return List.of(standardEmail, globalEmail);
   }
 

--- a/openaev-api/src/main/java/io/openaev/injectors/email/EmailContract.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/email/EmailContract.java
@@ -105,8 +105,11 @@ public class EmailContract extends Contractor {
             Set.of(PresetDomain.getEmailInfiltration(), PresetDomain.getTabletop()));
     globalEmail.addVariable(documentUriVariable);
     // A single mail is sent to all recipients at once, so per-user variables cannot be resolved
-    // and must not be advertised in the available variables cheat sheet.
-    globalEmail.removeVariable(VariableHelper.USER);
+    // and must not be advertised in the available variables cheat sheet. The filtering is done
+    // here (openaev-framework is deprecated and must not grow new API like removeVariable).
+    globalEmail
+        .getVariables()
+        .removeIf(contractVariable -> VariableHelper.USER.equals(contractVariable.getKey()));
     return List.of(standardEmail, globalEmail);
   }
 

--- a/openaev-api/src/test/java/io/openaev/injectors/email/EmailContractVariablesTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/email/EmailContractVariablesTest.java
@@ -1,0 +1,54 @@
+package io.openaev.injectors.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.expectation.ExpectationBuilderService;
+import io.openaev.expectation.ExpectationPropertiesConfig;
+import io.openaev.injector_contract.Contract;
+import io.openaev.injector_contract.ContractVariable;
+import io.openaev.injector_contract.variables.VariableHelper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Email contract available variables")
+class EmailContractVariablesTest {
+
+  private final EmailContract emailContract =
+      new EmailContract(new ExpectationBuilderService(new ExpectationPropertiesConfig()));
+
+  @Test
+  void given_singleEmailContract_should_exposeUserVariable() {
+    Contract standardEmail = findContract(EmailContract.EMAIL_DEFAULT);
+
+    assertThat(standardEmail.getVariables())
+        .extracting(ContractVariable::getKey)
+        .contains(VariableHelper.USER);
+  }
+
+  @Test
+  void given_multiRecipientsEmailContract_should_notExposeUserVariable() {
+    Contract globalEmail = findContract(EmailContract.EMAIL_GLOBAL);
+
+    assertThat(globalEmail.getVariables())
+        .extracting(ContractVariable::getKey)
+        .doesNotContain(VariableHelper.USER);
+  }
+
+  @Test
+  void given_multiRecipientsEmailContract_should_keepOtherDefaultVariables() {
+    Contract globalEmail = findContract(EmailContract.EMAIL_GLOBAL);
+
+    assertThat(globalEmail.getVariables())
+        .extracting(ContractVariable::getKey)
+        .contains(VariableHelper.EXERCISE, VariableHelper.TEAMS, VariableHelper.PLAYER_URI);
+  }
+
+  private Contract findContract(String contractId) {
+    List<Contract> contracts = emailContract.contracts();
+    return contracts.stream()
+        .filter(contract -> contractId.equals(contract.getId()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Missing email contract " + contractId));
+  }
+}

--- a/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
+++ b/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
@@ -236,6 +236,22 @@ public class Contract {
   }
 
   /**
+   * Removes a variable (and its children) from this contract by its key.
+   *
+   * <p>Default variables are added to every contract by the constructor; this method allows a
+   * specific contract to opt out of a variable that does not apply to it (e.g. the {@code user}
+   * variable on the multi-recipients email contract, where a single mail is sent to many recipients
+   * so per-user placeholders cannot be resolved).
+   *
+   * @param key the key of the variable to remove (e.g., "user")
+   */
+  public void removeVariable(String key) {
+    if (key != null && !key.isBlank()) {
+      variables.removeIf(variable -> key.equals(variable.getKey()));
+    }
+  }
+
+  /**
    * Associates a MITRE ATT&CK pattern with this contract by its external ID.
    *
    * @param externalId the external ID of the attack pattern (e.g., "T1566.001")

--- a/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
+++ b/openaev-framework/src/main/java/io/openaev/injector_contract/Contract.java
@@ -236,22 +236,6 @@ public class Contract {
   }
 
   /**
-   * Removes a variable (and its children) from this contract by its key.
-   *
-   * <p>Default variables are added to every contract by the constructor; this method allows a
-   * specific contract to opt out of a variable that does not apply to it (e.g. the {@code user}
-   * variable on the multi-recipients email contract, where a single mail is sent to many recipients
-   * so per-user placeholders cannot be resolved).
-   *
-   * @param key the key of the variable to remove (e.g., "user")
-   */
-  public void removeVariable(String key) {
-    if (key != null && !key.isBlank()) {
-      variables.removeIf(variable -> key.equals(variable.getKey()));
-    }
-  }
-
-  /**
    * Associates a MITRE ATT&CK pattern with this contract by its external ID.
    *
    * @param externalId the external ID of the attack pattern (e.g., "T1566.001")


### PR DESCRIPTION
## Summary

- The `Contract` constructor unconditionally adds the `user` variable group (user.id / email / firstname / lastname / lang) to every injector contract, so the "multi-recipients" email contract (`EMAIL_GLOBAL`) advertised $user placeholders in the available variables cheat sheet even though a single mail is sent to all recipients at once and per-user variables cannot be resolved there.
- The `user` variable group is now stripped from the `globalEmail` contract in `EmailContract.contracts()` (`openaev-api`) by filtering the list returned by the existing `Contract.getVariables()` accessor. The deprecated `openaev-framework` module is not touched (no new `removeVariable` API), per the repository convention that forbids adding new code there. The single-recipient contract (`EMAIL_DEFAULT`) is unchanged.
- The frontend cheat sheet (`AvailableVariablesDialog.tsx`) renders whatever the contract exposes, and contracts are re-synced at startup, so no frontend change is needed. Verified the multi-recipients contract has no default subject/body content referencing ${user...}.

## Test plan

- [x] New unit test `EmailContractVariablesTest` (no Docker needed): the multi-recipients contract does not expose the `user` variable, the single-mail contract still does, and the other default variables (exercise, teams, player_uri) remain on the multi-recipients contract. 3/3 pass locally.
- [x] `mvn spotless:apply` clean.
- [x] `mvn -pl openaev-api -am test-compile -DskipTests -Pdev` succeeds.

Closes #3878
