### PR TITLE
fix(endpoints): make endpoint list count consistent for multi-agent endpoints (#3208)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/rest/EndpointApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/EndpointApiTest.java
@@ -437,6 +437,76 @@ class EndpointApiTest extends IntegrationTest {
   }
 
   @Nested
+  @DisplayName("Search endpoints counting")
+  @WithMockUser(isAdmin = true)
+  class SearchEndpointCounting {
+
+    @Test
+    @DisplayName("An endpoint with several primary agents should count once in totals (#3208)")
+    void given_endpointWithSeveralPrimaryAgents_should_countOnceInSearchTotals() throws Exception {
+      // -- PREPARE --
+      // Endpoint with TWO primary agents (no parent, no inject): the previous join + groupBy
+      // specification made Spring Data's count query sum the per-group counts (counting agent
+      // rows instead of endpoints), so this endpoint used to count twice in totalElements.
+      Endpoint multiAgent = EndpointFixture.createEndpoint("count-3208-multi-agent");
+      multiAgent.setAgents(
+          new ArrayList<>(
+              List.of(
+                  createAgent(multiAgent, "count-3208-agent-1"),
+                  createAgent(multiAgent, "count-3208-agent-2"))));
+      multiAgent = endpointRepository.save(multiAgent);
+
+      Endpoint singleAgent = EndpointFixture.createEndpoint("count-3208-single-agent");
+      singleAgent.setAgents(
+          new ArrayList<>(List.of(createAgent(singleAgent, "count-3208-agent-3"))));
+      singleAgent = endpointRepository.save(singleAgent);
+
+      Endpoint agentless =
+          endpointRepository.save(EndpointFixture.createEndpoint("count-3208-agentless"));
+
+      // A full first page (size 2 < 3 matching endpoints) forces Spring Data to execute the
+      // count query instead of short-circuiting with the content size.
+      SearchPaginationInput searchInput =
+          PaginationFixture.getDefault().textSearch("count-3208").size(2).build();
+
+      // -- EXECUTE --
+      String response =
+          mvc.perform(
+                  post(ENDPOINT_URI + "/search")
+                      .content(asJsonString(searchInput))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -- ASSERT --
+      // totalElements must count distinct endpoints (3), not joined agent rows (4)
+      assertEquals(Integer.valueOf(3), JsonPath.read(response, "$.totalElements"));
+      assertEquals(Integer.valueOf(2), JsonPath.read(response, "$.totalPages"));
+
+      // The last page must contain the one remaining endpoint, keeping pagination consistent
+      SearchPaginationInput lastPageInput =
+          PaginationFixture.getDefault().textSearch("count-3208").size(2).page(1).build();
+      String lastPageResponse =
+          mvc.perform(
+                  post(ENDPOINT_URI + "/search")
+                      .content(asJsonString(lastPageInput))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      assertEquals(Integer.valueOf(1), JsonPath.read(lastPageResponse, "$.numberOfElements"));
+      assertEquals(Integer.valueOf(3), JsonPath.read(lastPageResponse, "$.totalElements"));
+    }
+  }
+
+  @Nested
   @DisplayName("Retrieve targets")
   @WithMockUser(isAdmin = true)
   class TargetEndpoint {

--- a/openaev-model/src/main/java/io/openaev/database/specification/EndpointSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/EndpointSpecification.java
@@ -1,15 +1,21 @@
 package io.openaev.database.specification;
 
 import io.openaev.database.model.Agent;
+import io.openaev.database.model.Asset;
 import io.openaev.database.model.AssetGroup;
 import io.openaev.database.model.Endpoint;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.data.jpa.domain.Specification;
 
+// These specifications rely on correlated EXISTS subqueries instead of join + groupBy on purpose:
+// with a groupBy, Spring Data's derived count query sums the per-group counts (it counts joined
+// agent rows, not endpoints), which inflates pagination totals for endpoints with several primary
+// agents (see https://github.com/spring-projects/spring-data-jpa/issues/2361 and #3208).
 public class EndpointSpecification {
 
   private EndpointSpecification() {}
@@ -18,30 +24,43 @@ public class EndpointSpecification {
     return findAgentlessEndpoints().or(findEndpointsForInjection());
   }
 
+  /** Endpoints having at least one primary agent (agent without parent nor inject). */
   public static Specification<Endpoint> findEndpointsForInjection() {
     return (root, query, criteriaBuilder) -> {
-      Join<Endpoint, Agent> agentsJoin = root.join("agents", JoinType.LEFT);
-      query.groupBy(root.get("id"));
-      return criteriaBuilder.and(
-          criteriaBuilder.isNull(agentsJoin.get("parent")),
-          criteriaBuilder.isNull(agentsJoin.get("inject")));
+      Subquery<String> agentSubquery = query.subquery(String.class);
+      Root<Agent> agent = agentSubquery.from(Agent.class);
+      agentSubquery
+          .select(agent.get("id"))
+          .where(
+              criteriaBuilder.equal(agent.get("asset"), root),
+              criteriaBuilder.isNull(agent.get("parent")),
+              criteriaBuilder.isNull(agent.get("inject")));
+      return criteriaBuilder.exists(agentSubquery);
     };
   }
 
+  /** Endpoints without any agent. */
   public static Specification<Endpoint> findAgentlessEndpoints() {
     return (root, query, criteriaBuilder) -> {
-      query.groupBy(root.get("id"));
-      return criteriaBuilder.and(criteriaBuilder.isEmpty(root.get("agents")));
+      Subquery<String> agentSubquery = query.subquery(String.class);
+      Root<Agent> agent = agentSubquery.from(Agent.class);
+      agentSubquery.select(agent.get("id")).where(criteriaBuilder.equal(agent.get("asset"), root));
+      return criteriaBuilder.not(criteriaBuilder.exists(agentSubquery));
     };
   }
 
   public static Specification<Endpoint> findEndpointsForAssetGroup(
       @NotNull final String assetGroupId) {
     return (root, query, criteriaBuilder) -> {
-      Join<Endpoint, AssetGroup> assetGroupJoin = root.join("assetGroups", JoinType.LEFT);
-      query.groupBy(root.get("id"));
-      query.distinct(true);
-      return criteriaBuilder.and(criteriaBuilder.equal(assetGroupJoin.get("id"), assetGroupId));
+      Subquery<String> assetGroupSubquery = query.subquery(String.class);
+      Root<AssetGroup> assetGroup = assetGroupSubquery.from(AssetGroup.class);
+      Join<AssetGroup, Asset> assets = assetGroup.join("assets");
+      assetGroupSubquery
+          .select(assetGroup.get("id"))
+          .where(
+              criteriaBuilder.equal(assetGroup.get("id"), assetGroupId),
+              criteriaBuilder.equal(assets.get("id"), root.get("id")));
+      return criteriaBuilder.exists(assetGroupSubquery);
     };
   }
 


### PR DESCRIPTION
## Summary

- Rewrites `EndpointSpecification.findEndpointsForInjection()`, `findAgentlessEndpoints()` and `findEndpointsForAssetGroup()` to use correlated `EXISTS` / `NOT EXISTS` subqueries instead of `join` + `groupBy`.
- With the previous `groupBy`-based specifications, Spring Data's derived count query summed the per-group counts (effectively counting joined agent rows instead of endpoints), so any endpoint with 2+ primary agents inflated `totalElements` in the Endpoints list (known Spring Data limitation, spring-data-jpa#2361). The count query is now a plain count over endpoints.
- The rewrite is semantics-preserving: all callers (`EndpointService.searchEndpoints` / `searchManagedEndpoints`, `AssetGroupService`, `EndpointApi.endpoints`) only use these specs as filters and never read agent columns from the join. Entity mappings backing the correlated subqueries were verified (`Agent.asset` is the owning side of `Endpoint.agents`, and `AssetGroup.assets` is the owning side of `Asset.assetGroups`).
- The branch has been rebased onto the latest `main`: it is now a single signed commit on top of `main`, and the earlier compensating fix for the `RoleService` -> `TenantRoleService` rename conflict was dropped because `main` now carries its own fix (#7351).

## Test plan

- Added `EndpointApiTest > Search endpoints counting`: creates an endpoint with two primary agents, one with a single agent and one agentless endpoint, then searches with page size 2 (a full first page forces Spring Data to execute the count query instead of short-circuiting). Asserts `totalElements == 3` and that the last page contains the one remaining endpoint.
- Verified the test fails on the previous specification (`expected: <3> but was: <4>`) and passes with the fix (run locally against the Docker test services).
- `mvn spotless:apply` and `mvn -pl openaev-model,openaev-api -am test-compile -Pdev` pass.

Closes #3208
