### PR TITLE
docs(orm): add ORM write-correctness doctrine and fix contradictory native-delete guidance #7350

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -69,6 +69,7 @@ Then:
 |---|---|
 | `@AccessControl`, `@Filter`, `Capability`, native `@Query`, `Permission` | → **Security Reviewer** |
 | `@OneToMany`, `@ManyToMany`, `FetchType`, `findAll`, new endpoint returning `List<T>` | → **Performance Reviewer** |
+| `nativeQuery = true`, `@Modifying` delete/write, controller returns a JPA `@Entity`, `@IdClass` / composite key | → **ORM Reviewer** |
 | `extends TenantBase`, `tenant_id`, `TenantContext`, `TxCtx`, `active-tables`, `TenantScopedTransaction`, `RequireTenantSelector`, `can_access_tenant`, migration with tenant column | → **Multi-Tenancy Reviewer** |
 | Frontend files (`.tsx`, `.ts`, forms, components) | → **Frontend Reviewer** |
 | No tests, or coverage likely below threshold | → **Test Specialist** |

--- a/.github/agents/orm-reviewer.agent.md
+++ b/.github/agents/orm-reviewer.agent.md
@@ -42,6 +42,7 @@ Additional ORM-specific levels:
 | 🟠 **HIGH** | Controller returns a JPA `@Entity` instead of a DTO / record (align with Backend/Performance) |
 | 🟡 **MEDIUM** | `nativeQuery = true` with no one-line comment justifying both rubric halves (why the ORM cannot express it, why no side effect is lost) |
 | 🟡 **MEDIUM** | A test asserts wall-clock time as a performance gate instead of a query / entity count |
+| 🟡 **MEDIUM** | `instanceof` on a lazy polymorphic association (sees the proxy, not the subclass), or `Hibernate.unproxy()` scattered to resolve a `@Inheritance` subclass instead of an explicit fetch |
 | 🟢 **LOW** | An entity graph is loaded and then dropped to a slice (projection opportunity); align with Performance |
 
 ## Review Procedure
@@ -60,6 +61,9 @@ This agent has no separate skill; run these steps directly.
 4. **Boundary at the API.** Flag controller methods returning a JPA `@Entity`; recommend a DTO / record.
 5. **Test methodology.** Flag ORM/perf tests asserting elapsed / wall-clock time as a gate; recommend
    a Hibernate `Statistics` query / entity count instead.
+6. **Inheritance / proxies.** `grep -rn "Hibernate.unproxy\|instanceof" openaev-api openaev-model`.
+   Flag `instanceof` on a lazy `@Inheritance` association and unproxy proliferation; recommend an
+   explicit `JOIN FETCH` / `@EntityGraph` of the concrete type.
 
 ## What NOT to Flag
 

--- a/.github/agents/orm-reviewer.agent.md
+++ b/.github/agents/orm-reviewer.agent.md
@@ -1,0 +1,105 @@
+---
+name: "ORM Reviewer"
+description: "Reviews ORM doctrine: write correctness (listener chain), native-query justification, composite-key coverage, and query-count test methodology."
+tools: [ "codebase", "terminal" ]
+---
+
+# ORM Reviewer
+
+## Mission
+
+You review OpenAEV code for conformance to the ORM doctrine that the other reviewers do not own.
+Your focus is correctness of writes and the discipline around native queries, not raw performance.
+A fast query that leaves a ghost in the search index, drops an audit entry, or skips a stream event
+is a correctness bug, not an optimization.
+
+## Context Loading
+
+Always load:
+1. **Read `AGENTS.md`** — architecture overview, Shared Severity Rubric, Shared Exceptions
+2. **Read `.github/instructions/orm.instructions.md`** — the ORM doctrine you enforce
+3. **Read `.github/copilot-instructions.md`** — conventions and multi-tenancy model
+
+Load conditionally based on the diff:
+- **`nativeQuery = true` / `@Modifying` / raw JDBC** → also read `.github/instructions/multi-tenancy.instructions.md` for the tenant-predicate rule
+- **`FetchType`, `@OneToMany`, `@ManyToMany`, `findAll`** → this is Performance turf; delegate (see Boundaries)
+
+## Model Policy
+
+Use **Sonnet** for standard ORM reviews. Escalate to **Opus 4.6** for write-correctness (listener
+chain) and composite-key reasoning, where false negatives are correctness bugs.
+
+## Severity Rubric
+
+Use the **Shared Severity Rubric** from `AGENTS.md` as the base.
+
+Additional ORM-specific levels:
+
+| Severity | ORM-specific criteria |
+|---|---|
+| 🔴 **CRITICAL** | Native or bulk write (`nativeQuery`, `@Modifying @Query`, raw JDBC) on an `@Indexable` / `@AuditDiffTracked` / streamed entity with no compensating update: the index, audit, or stream silently goes stale |
+| 🔴 **CRITICAL** | `@Id` / `@IdClass` does not cover the real composite primary key (missing `tenant_id`): cross-tenant identity bug |
+| 🟠 **HIGH** | Controller returns a JPA `@Entity` instead of a DTO / record (align with Backend/Performance) |
+| 🟡 **MEDIUM** | `nativeQuery = true` with no one-line comment justifying both rubric halves (why the ORM cannot express it, why no side effect is lost) |
+| 🟡 **MEDIUM** | A test asserts wall-clock time as a performance gate instead of a query / entity count |
+| 🟢 **LOW** | An entity graph is loaded and then dropped to a slice (projection opportunity); align with Performance |
+
+## Review Procedure
+
+This agent has no separate skill; run these steps directly.
+
+1. **Native queries.** `grep -rn "nativeQuery = true" openaev-model openaev-api`. For each hit apply
+   the two-question rubric from `orm.instructions.md`: can the ORM express it (else unjustified), and
+   is a session side effect lost (else a write-correctness bug). KEEP a justified query that carries
+   the one-line comment; flag a missing comment as MEDIUM.
+2. **Write correctness.** For every native / bulk / `@Modifying` write, check the target entity for
+   `@Indexable` and `@AuditDiffTracked`, and whether `ModelBaseListener` streams it (`isListened()`).
+   If any holds and nothing compensates, flag CRITICAL.
+3. **Composite keys.** For entities whose real primary key includes `tenant_id`, verify the
+   `@Id` / `@IdClass` covers every key column.
+4. **Boundary at the API.** Flag controller methods returning a JPA `@Entity`; recommend a DTO / record.
+5. **Test methodology.** Flag ORM/perf tests asserting elapsed / wall-clock time as a gate; recommend
+   a Hibernate `Statistics` query / entity count instead.
+
+## What NOT to Flag
+
+In addition to **Shared Exceptions** in `AGENTS.md`:
+
+- A justified native query (atomic `INSERT ... ON CONFLICT`, `array_agg`, CTE, window function,
+  set-based maintenance) on non-indexed / non-audited / non-streamed data, with the rubric comment.
+  Example: `InjectExpectationTraceRepository.insertIfNotExists`.
+- A pure N+1 or fetch-strategy issue with no correctness angle → Performance Reviewer owns it.
+- A native query missing `WHERE tenant_id` → Multi-Tenancy Reviewer owns it.
+- `FetchType.EAGER` forced by `@JoinColumnsOrFormulas` / `@JoinFormula` (Hibernate cannot make it
+  lazy): flag the projection fix on the hot path, not a mapping flip.
+- A `*Benchmark` class or a documented scale-guard that intentionally measures wall-clock time.
+
+## Output Format
+
+```
+🧭 ORM Review Summary
+Native queries triaged: [count]
+Findings: 🔴 [n] Critical | 🟠 [n] High | 🟡 [n] Medium | 🟢 [n] Low
+
+## Findings
+
+### [Severity emoji] [Category] — [Short description]
+- **File**: `path/to/file.java:line`
+- **Rule**: [Which rule from orm.instructions.md]
+- **Impact**: [Stale index/audit/stream, cross-tenant identity, etc.]
+- **Fix**: [Concrete change]
+
+## ORM Verdict
+[CONFORMANT ✅ | CONDITIONAL ⚠️ | NON-CONFORMANT 🔴]
+[One sentence justification]
+```
+
+## Boundaries
+
+- Never modify production code — only flag issues via conventional comments.
+- Focus on ORM doctrine and write correctness. Delegate raw N+1, pagination, indexing, and memory to
+  **Performance Reviewer**; delegate the `WHERE tenant_id` predicate on native queries to
+  **Multi-Tenancy Reviewer**; delegate schema/migration shape to **Migration Reviewer**.
+- Where a finding is both (a native write that is also a tenant-filter gap), state the ORM angle and
+  name the owning reviewer rather than restating their rule.
+- If you find a 🔴 CRITICAL issue, recommend blocking the PR explicitly.

--- a/.github/agents/performance-reviewer.agent.md
+++ b/.github/agents/performance-reviewer.agent.md
@@ -78,6 +78,7 @@ Estimated query impact: [e.g. "+15 queries per request on /api/scenarios/search"
 
 - Never modify production code directly — only suggest changes via conventional comments
 - Focus on performance — leave security to the Security Reviewer and style to linters
+- When recommending a native or bulk delete/write for performance, verify the entity is not `@Indexable` / `@AuditDiffTracked` / streamed; if it is, defer to the **ORM Reviewer** (the write skips the listener chain, so the index, audit, and stream go stale). See `orm.instructions.md`
 - Escalate to a human reviewer if a fix requires significant architectural changes
 - Prefer DB-level fixes (indexes, queries, fetch strategies) over application-level workarounds
 - When quantifying impact, state assumptions (e.g. "assuming default page size of 20")

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,6 +106,7 @@ Conventions are defined in dedicated instruction files that activate automatical
 | Tests (integration/unit/fixtures)    | [testing.instructions.md](.github/instructions/testing.instructions.md)                   |
 | Security (RBAC/@AccessControl)       | [security.instructions.md](.github/instructions/security.instructions.md)                 |
 | Performance (N+1/pagination/fetch)   | [performance.instructions.md](.github/instructions/performance.instructions.md)           |
+| ORM (write correctness/native/tests) | [orm.instructions.md](.github/instructions/orm.instructions.md)                           |
 | Code Review                          | [code-review.instructions.md](.github/instructions/code-review.instructions.md)           |
 
 ### Available Agents
@@ -115,6 +116,7 @@ Conventions are defined in dedicated instruction files that activate automatical
 | `code-reviewer`          | General-purpose reviewer: architecture, conventions, readability, delegation |
 | `security-reviewer`      | Reviews code for RBAC, tenant isolation, data exposure, auth bypasses    |
 | `performance-reviewer`   | Reviews code for N+1, fetch strategy, pagination, indexing, memory      |
+| `orm-reviewer`           | Reviews ORM doctrine: write correctness (listener chain), native-query justification, composite keys, test methodology |
 | `multi-tenancy-reviewer` | Reviews code for tenant isolation, cross-tenant leaks, filter bypasses |
 | `frontend-reviewer`      | Reviews frontend for component patterns, forms, permissions, MUI, i18n   |
 | `test-specialist`        | Creates and maintains tests following project patterns                   |

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -77,7 +77,7 @@ public Page<{Entity}Output> search(...) { return service.search(input).map({Enti
 - Prefer unidirectional relationships
 - `@Transactional` does NOT work on self-calls (Spring proxy bypass)
 - Background tasks: explicit `@Transactional` (no OSIV outside controllers)
-- `deleteById()` does a SELECT first — use native `@Query @Modifying` for perf-critical deletes
+- `deleteById()` does a SELECT first — use native `@Query @Modifying` for perf-critical deletes, but only when the entity is not `@Indexable`, `@AuditDiffTracked`, or streamed: a native or bulk delete skips the listener chain, so the search index, audit log, and activity stream are not updated (see `orm.instructions.md`)
 - **Never mutate a managed entity in a read path — `readOnly = true` does NOT make it safe**:
   with OSIV the Hibernate session outlives the controller's read-only transaction, and any later
   read-write transaction on the same thread (e.g. the spring-session JDBC save at response commit)

--- a/.github/instructions/orm.instructions.md
+++ b/.github/instructions/orm.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: "openaev-model/src/main/java/**/*.java,openaev-api/src/main/java/**/*.java,openaev-api/src/test/java/**/*Test.java"
-description: "ORM doctrine not covered elsewhere: write correctness (listener chain), native-query justification, and query-count test methodology"
+description: "ORM doctrine not covered elsewhere: write correctness (listener chain), native-query justification, composite keys, inheritance proxies, and query-count test methodology"
 ---
 
 # ORM Doctrine
@@ -39,6 +39,26 @@ Every `nativeQuery = true` must carry a one-line comment stating both halves of 
 
 If the first half fails, the query is unjustified: express it through the ORM (JPQL, Criteria, or a
 projection). If the second half fails, it is a write-correctness bug (see above), not a style issue.
+
+## Composite keys
+
+When an entity's real primary key is composite (for example `(id, tenant_id)`), its `@Id` /
+`@IdClass` / `@EmbeddedId` must cover every key column. A single-column `@Id` on a composite-key
+table is a correctness bug: an update or lookup keyed on the partial id can match another tenant's
+rows (it surfaces as `TooManyRowsAffectedException` on writes), so the mapping's identity is not
+tenant-safe.
+
+## Inheritance and proxies
+
+A lazy association to a `@Inheritance(SINGLE_TABLE)` base type (for example `Asset`, `Payload`)
+loads as a base-type proxy, so `instanceof Subclass` is false and subclass state is hidden until the
+proxy is initialized. `Hibernate.unproxy(...)` unwraps it, but frequent unproxy calls signal a
+polymorphic association being worked around, not a fix.
+
+- Do not branch on `instanceof` against a lazy polymorphic association; it sees the proxy, not the
+  concrete class.
+- Where a path needs the concrete subclass, fetch it explicitly (`JOIN FETCH` / `@EntityGraph`)
+  instead of scattering `Hibernate.unproxy(...)`.
 
 ## Test methodology
 

--- a/.github/instructions/orm.instructions.md
+++ b/.github/instructions/orm.instructions.md
@@ -1,0 +1,59 @@
+---
+applyTo: "openaev-model/src/main/java/**/*.java,openaev-api/src/main/java/**/*.java,openaev-api/src/test/java/**/*Test.java"
+description: "ORM doctrine not covered elsewhere: write correctness (listener chain), native-query justification, and query-count test methodology"
+---
+
+# ORM Doctrine
+
+This file carries only the ORM rules that the other instruction files do not own. It does not
+restate them. For N+1, fetch strategy, pagination, indexing, projections, and returning DTOs
+instead of entities at the boundary, see `performance.instructions.md` and `backend.instructions.md`.
+For the `WHERE tenant_id` requirement on native queries, see `multi-tenancy.instructions.md`.
+
+## Write correctness (the listener chain)
+
+A native or bulk write (`nativeQuery = true`, `@Modifying @Query`, raw JDBC) skips the Hibernate
+session, so `ModelBaseListener` does not run. The search index, the audit log, and the activity
+stream are therefore NOT updated by that write.
+
+- Use a native or bulk write only when the target entity is not `@Indexable`, not
+  `@AuditDiffTracked`, and not streamed, and no in-session copy of the affected rows is read
+  afterward.
+- If the entity carries any of those, keep the session-based write, or update the side effect
+  explicitly (for example a companion index/audit update). A fast delete that leaves a ghost in
+  search is a correctness bug, not an optimization.
+- This applies to deletes too: prefer database `ON DELETE CASCADE` plus a session delete of the
+  root over a native cascade delete when children are indexed, audited, or streamed.
+
+Detecting the signal: `@Indexable` and `@AuditDiffTracked` are annotations you can grep on the
+entity. "Streamed" is behavioral, not an annotation: an entity is streamed when `ModelBaseListener`
+publishes a `BaseEvent` for it (gated by `isListened()`). When you cannot tell, treat the entity as
+streamed and keep the session write.
+
+## Justify every native query
+
+Every `nativeQuery = true` must carry a one-line comment stating both halves of the rubric:
+1. why the ORM cannot express it cleanly (atomic upsert `ON CONFLICT`, `array_agg`, a CTE or
+   window function, a set-based operation, or deliberate cross-tenant maintenance), and
+2. why no session side effect is lost (the touched rows are not indexed, audited, or streamed).
+
+If the first half fails, the query is unjustified: express it through the ORM (JPQL, Criteria, or a
+projection). If the second half fails, it is a write-correctness bug (see above), not a style issue.
+
+## Test methodology
+
+Assert what an ORM change actually controls: the number of entities or SQL statements, read from
+Hibernate `Statistics` (`getPrepareStatementCount`, entity load counts). Never assert wall-clock
+time as a performance gate; it is machine-dependent and flaky in CI. Timing belongs in a narrative,
+the query count belongs in the assertion.
+
+- Exception: a class named `*Benchmark`, or a documented scale-guard that intentionally bounds
+  wall-clock time, is allowed to measure time. This rule targets ORM unit/integration tests that
+  use elapsed time as a stand-in for a query-count assertion.
+
+## Source and maintenance
+
+Distilled from the cross-team ORM guide maintained by the XTM / backend guild (an external
+reference, not a skill in this repository), guide baseline `4829b8d7d`. Re-distill when the guide's
+doctrine changes; keep this file to the nucleus above and let the other instruction files own
+everything they already cover.

--- a/.github/instructions/orm.instructions.md
+++ b/.github/instructions/orm.instructions.md
@@ -51,9 +51,7 @@ the query count belongs in the assertion.
   wall-clock time, is allowed to measure time. This rule targets ORM unit/integration tests that
   use elapsed time as a stand-in for a query-count assertion.
 
-## Source and maintenance
+## Maintenance
 
-Distilled from the cross-team ORM guide maintained by the XTM / backend guild (an external
-reference, not a skill in this repository), guide baseline `4829b8d7d`. Re-distill when the guide's
-doctrine changes; keep this file to the nucleus above and let the other instruction files own
-everything they already cover.
+This file is a hand-maintained digest of the cross-team ORM guide. Re-sync it when the guide's
+doctrine changes. Owner: XTM / backend guild.

--- a/.github/instructions/performance.instructions.md
+++ b/.github/instructions/performance.instructions.md
@@ -55,7 +55,7 @@ Repositories that are used with `ReferenceResolver` must expose a `countByIdIn(S
 
 - Prefer repository methods or `@Query` JPQL over `CrudRepository.findAll()` when filtering
 - Use `existsById()` instead of `findById().isPresent()` for existence checks
-- Use `@Modifying @Query` for bulk updates/deletes — avoid loading entities just to delete them
+- Use `@Modifying @Query` for bulk updates/deletes to avoid loading entities just to delete them, but only when the entity is not `@Indexable`, `@AuditDiffTracked`, or streamed: a native or bulk write skips the listener chain, so the index, audit, and stream are not updated (see `orm.instructions.md`). Otherwise keep the session delete or update them explicitly
 - Use projections (DTO queries) for read-heavy endpoints that don't need the full entity
 - Add database indexes on columns used in WHERE, ORDER BY, and JOIN conditions
 - Verify with `EXPLAIN` on realistic data volumes (>= 100k rows) that new indexes are actually

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Do NOT look for conventions here — they live in dedicated instruction files, a
 | **Database** (migrations, schema, indexes)                        | [database.instructions.md](.github/instructions/database.instructions.md) | `**/db/migration/**`, `**/model/**` |
 | **Security** (auth, RBAC, tenant isolation)                       | [security.instructions.md](.github/instructions/security.instructions.md) | All Java & TypeScript files |
 | **Performance** (queries, caching, patterns)                      | [performance.instructions.md](.github/instructions/performance.instructions.md) | All Java files |
+| **ORM** (write correctness, native-query justification, test methodology) | [orm.instructions.md](.github/instructions/orm.instructions.md) | `openaev-api/**`, `openaev-model/**`, `*Test.java` |
 | **Multi-Tenancy** (isolation, filters, context)                   | [multi-tenancy.instructions.md](.github/instructions/multi-tenancy.instructions.md) | Entities, repositories, migrations |
 | **Testing** (unit, integration, coverage)                         | [testing.instructions.md](.github/instructions/testing.instructions.md) | `**/*Test.java`, `**/*.test.tsx` |
 | **Code Review** (review checklist)                                | [code-review.instructions.md](.github/instructions/code-review.instructions.md) | All files |
@@ -71,6 +72,7 @@ Do NOT look for conventions here — they live in dedicated instruction files, a
 | [Migration Reviewer](.github/agents/migration-reviewer.agent.md) | Audit Flyway migration safety, idempotency, tenant isolation, rollout risk | `AGENTS.md` → `copilot-instructions.md` → `migration.instructions.md` | `review-migration` skill |
 | [Multi-Tenancy Reviewer](.github/agents/multi-tenancy-reviewer.agent.md) | Audit tenant isolation, cross-tenant leaks, filter bypasses, migration safety | `AGENTS.md` → `copilot-instructions.md` → `multi-tenancy.instructions.md` | `review-multi-tenancy` skill |
 | [Performance Reviewer](.github/agents/performance-reviewer.agent.md) | Audit N+1, lazy loading, query efficiency, pagination | `AGENTS.md` → `copilot-instructions.md` → `performance.instructions.md` | `review-performance` skill |
+| [ORM Reviewer](.github/agents/orm-reviewer.agent.md) | Audit ORM doctrine: write correctness (listener chain), native-query justification, composite keys, test methodology | `AGENTS.md` → `copilot-instructions.md` → `orm.instructions.md` | n/a |
 | [Security Reviewer](.github/agents/security-reviewer.agent.md) | Audit auth, RBAC, data exposure, secrets | `AGENTS.md` → `copilot-instructions.md` → `security.instructions.md` | `review-security` skill |
 | [Test Specialist](.github/agents/test-specialist.agent.md) | Write/improve tests, check coverage | `AGENTS.md` → `copilot-instructions.md` → `testing.instructions.md` | `add-test` skill |
 | [Chaining Engine Reviewer](.github/agents/chaining-engine-reviewer.agent.md) | Audit chaining engine: steps, conditions, queues, state, scope, timeout | `AGENTS.md` → `chaining-engine.instructions.md` | `review-chaining-engine` skill |
@@ -143,6 +145,7 @@ The mapping is:
 | `database.instructions.md` | `migration-reviewer.agent.md` |
 | `security.instructions.md` | `security-reviewer.agent.md` |
 | `performance.instructions.md` | `performance-reviewer.agent.md` |
+| `orm.instructions.md` | `orm-reviewer.agent.md` |
 | `multi-tenancy.instructions.md` | `multi-tenancy-reviewer.agent.md` |
 | `migration.instructions.md` | `migration-reviewer.agent.md` |
 | `testing.instructions.md` | `test-specialist.agent.md` |


### PR DESCRIPTION
Closes #7350

## What

Adds a small `orm.instructions.md` carrying the ORM doctrine that the existing Performance,
Backend and Multi-Tenancy instructions do not own, and fixes a contradiction those files
currently contain.

## Why

Two auto-applied instruction files (`backend.instructions.md`, `performance.instructions.md`)
recommend native/bulk deletes for performance. That is unsafe for `@Indexable` /
`@AuditDiffTracked` / streamed entities: a native or bulk write skips the `ModelBaseListener`
chain, so the search index, audit log and activity stream are not updated. This PR adds the
listener-safe caveat to both lines and centralizes the doctrine.

## Scope (deliberately small)

- New `orm.instructions.md`: write correctness (listener chain), native-query justification
  rubric, and query-count (not wall-clock) test methodology. Cross-references the existing files
  for N+1 / fetch / pagination / DTO-at-boundary / projection instead of restating them.
- Caveat added to the two contradicting delete rules.
- Registered in the two conventions tables (`AGENTS.md`, `copilot-instructions.md`).

Distilled from the cross-team ORM guide (`treat-orm-legacy`), owner: XTM / backend guild.