### PR TITLE
test(rbac): fix phishing roles migration test after RoleService rename (#7351)

### DIFF
--- a/openaev-api/src/test/java/io/openaev/processor/core/V20260811_Add_phishing_reporting_capabilities_to_default_rolesTest.java
+++ b/openaev-api/src/test/java/io/openaev/processor/core/V20260811_Add_phishing_reporting_capabilities_to_default_rolesTest.java
@@ -6,7 +6,8 @@ import io.openaev.IntegrationTest;
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.Role;
 import io.openaev.database.repository.RoleRepository;
-import io.openaev.service.RoleService;
+import io.openaev.service.TenantRoleService;
+import io.openaev.utils.mockUser.WithMockUser;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +25,14 @@ import org.springframework.transaction.annotation.Transactional;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("Add phishing/reporting capabilities to default roles migration tests")
 @Transactional
+// Roles are created through TenantRoleService#createRole, which now enforces that the current
+// user holds the capabilities it hands out: run as admin to short-circuit that check.
+@WithMockUser(isAdmin = true)
 public class V20260811_Add_phishing_reporting_capabilities_to_default_rolesTest
     extends IntegrationTest {
 
   @Autowired private V20260811_Add_phishing_reporting_capabilities_to_default_roles migration;
-  @Autowired private RoleService roleService;
+  @Autowired private TenantRoleService roleService;
   @Autowired private RoleRepository roleRepository;
 
   /** The Observer capability set the buggy preset generated (roots only — no parents to add). */


### PR DESCRIPTION
## Summary

- `main` no longer compiles: commit ca27cd015 (PR #7198) renamed `io.openaev.service.RoleService` to `TenantRoleService` while `V20260811_Add_phishing_reporting_capabilities_to_default_rolesTest` (added by PR #7332) still imported the old class, so `pipeline / Backend Compile` fails on main and on every open PR (PR builds compile the merge with main).
- This PR renames the import and the autowired field to `TenantRoleService`.
- `TenantRoleService#createRole` now also runs `PrivilegeEscalationValidator.assertCanAssignCapabilities` against the current user, so the test class additionally gets `@WithMockUser(isAdmin = true)` to short-circuit that check the same way production admins do.

## Test plan

- `pipeline / Backend Compile` goes green on this PR (it currently fails on main with `cannot find symbol: class RoleService`).
- `pipeline / API Tests` covering `V20260811_Add_phishing_reporting_capabilities_to_default_rolesTest` validate the runtime path with the admin mock user.

Closes #7351
