### PR TITLE
fix(threatarsenal): slim the pagination toolbar so the create button stays accessible (#7340)

### DIFF
--- a/openaev-front/src/admin/components/threat_arsenal/ThreatArsenal.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/ThreatArsenal.tsx
@@ -6,7 +6,6 @@ import {
 import {
   Box,
   Checkbox,
-  FormControlLabel,
   IconButton,
   List,
   ListItem,
@@ -16,7 +15,6 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
-  Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useContext, useState } from 'react';
@@ -246,6 +244,16 @@ const ThreatArsenal = () => {
     // swallowed here to avoid an unhandled rejection on this detached call.
     bulkDeleteThreatArsenalActions(input).catch(() => {});
   };
+
+  // Former visible caption of the select-all control, now carried by its
+  // tooltip and accessible name (the toolbar shows the bare checkbox only).
+  // String() narrows the formatter's `string | ReactNode[]` return type for
+  // the aria-label: with a numeric placeholder the result is always a string.
+  const selectAllLabel = (() => {
+    if (numberOfSelectedElements === 0) return t('Select all');
+    if (numberOfSelectedElements === 1) return t('1 action selected');
+    return String(t('{count} actions selected', { count: numberOfSelectedElements }));
+  })();
 
   const hasActiveFilters = !!(
     (searchPaginationInput.filterGroup?.filters?.length ?? 0) > 0
@@ -538,28 +546,19 @@ const ThreatArsenal = () => {
                     display: 'flex',
                     alignItems: 'center',
                     gap: 0.5,
-                    marginRight: 2,
+                    marginRight: 1,
+                    flexShrink: 0,
                   }}
                   >
-                    <FormControlLabel
-                      label={(
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            color: 'text.secondary',
-                            fontWeight: 500,
-                            fontSize: 12.5,
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {(() => {
-                            if (numberOfSelectedElements === 0) return t('Select all');
-                            if (numberOfSelectedElements === 1) return t('1 action selected');
-                            return t('{count} actions selected', { count: numberOfSelectedElements });
-                          })()}
-                        </Typography>
-                      )}
-                      control={(
+                    {/* Checkbox only, no text label (#7340): the toolbar must fit
+                        on one row at ~1512px, so the former "Select all" /
+                        "N selected" caption moves into the tooltip and the
+                        accessible name. The selection count stays visible in the
+                        floating selection bar once something is selected. This
+                        single control drives select-all for BOTH the grid and
+                        the list view (the toolbar is shared by the two). */}
+                    <Tooltip title={selectAllLabel}>
+                      <span>
                         <Checkbox
                           size="small"
                           checked={selectAll}
@@ -569,14 +568,10 @@ const ThreatArsenal = () => {
                           }
                           onChange={handleToggleSelectAll}
                           disabled={threatArsenalActions.length === 0}
+                          inputProps={{ 'aria-label': selectAllLabel }}
                         />
-                      )}
-                      sx={{
-                        'marginLeft': -0.5,
-                        'marginRight': 1,
-                        '& .MuiFormControlLabel-label': { marginLeft: 0.5 },
-                      }}
-                    />
+                      </span>
+                    </Tooltip>
                     {canDeleteThreatArsenal && (
                       <Tooltip title={t('Select orphaned actions (no injector, no payload) to purge them at once')}>
                         <IconButton

--- a/openaev-front/src/admin/components/threat_arsenal/ThreatArsenalSortSelect.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/ThreatArsenalSortSelect.tsx
@@ -40,10 +40,15 @@ const ThreatArsenalSortSelect: FunctionComponent<Props> = ({ sortHelpers }) => {
       display: 'flex',
       alignItems: 'center',
       gap: 0.5,
-      marginLeft: 1.25,
+      marginLeft: 1,
+      // The sort control is small and must stay whole: the wider search /
+      // filter inputs are the ones that compress in a tight toolbar (#7340).
+      flexShrink: 0,
     }}
     >
-      <FormControl size="small" sx={{ minWidth: 140 }}>
+      {/* 110px fits the widest option ("Updated") and the "Sort by" label
+          while keeping the single-row toolbar compact at ~1512px (#7340). */}
+      <FormControl size="small" sx={{ minWidth: 110 }}>
         <InputLabel id="threat-arsenal-sort-by-label">{t('Sort by')}</InputLabel>
         <Select
           labelId="threat-arsenal-sort-by-label"

--- a/openaev-front/src/components/common/queryable/filter/FilterAutocomplete.tsx
+++ b/openaev-front/src/components/common/queryable/filter/FilterAutocomplete.tsx
@@ -13,6 +13,11 @@ const useStyles = makeStyles()(() => ({
   container: {
     display: 'flex',
     gap: 10,
+    // In a width-constrained toolbar the autocomplete is allowed to shrink
+    // (see minWidth on the input below) instead of pushing the actions on the
+    // right out of view (#7340).
+    minWidth: 0,
+    flexShrink: 1,
   },
 }));
 
@@ -58,7 +63,13 @@ const FilterAutocomplete: FunctionComponent<Props> = ({
     <div className={classes.container}>
       <MuiAutocomplete
         options={options}
-        sx={{ width: domains ? '95%' : 200 }}
+        sx={{
+          // 200px when space allows, shrinkable down to 120px in a tight
+          // toolbar (the label truncates but the control stays usable).
+          width: domains ? '95%' : 200,
+          minWidth: domains ? undefined : 120,
+          flexShrink: 1,
+        }}
         value={null}
         onChange={(_, selectOptionValue) => {
           if (selectOptionValue) {

--- a/openaev-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
+++ b/openaev-front/src/components/common/queryable/pagination/PaginationComponentV2.tsx
@@ -24,6 +24,10 @@ const useStyles = makeStyles<{ topPagination?: boolean }>()((theme, props) => ({
   topbar: {
     display: 'flex',
     alignItems: 'center',
+    // The primary actions (pagination + create button) must never be the part
+    // that gives way when the toolbar runs out of width (#7340): the filter
+    // row on the left is the one that compresses.
+    flexShrink: 0,
   },
   topPagination: { display: 'block' },
   parameters: {
@@ -232,6 +236,11 @@ const PaginationComponentV2 = <T extends object>({
         <div style={{
           display: 'flex',
           alignItems: 'center',
+          // Single-row toolbar contract (#7340): when width runs out this
+          // filter section is the one that compresses (its items may shrink),
+          // never the actions on the right, and nothing wraps to a second row.
+          minWidth: 0,
+          flexShrink: 1,
         }}
         >
           {leftSlot}


### PR DESCRIPTION
## Summary

- Root cause: on the Threat Arsenal page the create button lives in the `topBarButtons` slot of the `PaginationComponentV2` toolbar, a single non-wrapping flex row that also holds the select-all control, text search, filter autocomplete and (in grid view) the sort select, with the content column further narrowed by the facet sidebar. At ~1512px the row overflows and the button is pushed out of view.
- Fix: keep the create button exactly where it is and slim the toolbar so everything fits on ONE row at ~1512px and keeps degrading gracefully below that - no wrapping, no extra vertical space, the screen stays as packed as before.
- What was slimmed on Threat Arsenal: the "Select all" / "N selected" text label is removed and the control becomes a bare checkbox whose former caption moves into a tooltip and the checkbox aria-label (existing i18n keys reused, no new strings); the selection count remains visible in the floating selection bar once something is selected. This single control drives select-all for both the grid and the list view. The orphan-purge control was already icon-only with a tooltip. The grid-view "Sort by" select shrinks from 140px to 110px (fits its widest option) and is marked flex-shrink 0 so it stays whole.
- Shared primitive hardening (`PaginationComponentV2` + `FilterAutocomplete`), chosen deliberately because it is generic and strictly improves overflow behavior for every consumer: the actions group (pagination + top bar buttons) gets `flex-shrink: 0` so it can never be the part that gives way, the filter row gets `min-width: 0` / `flex-shrink: 1` so it is the section that compresses, and the filter autocomplete may shrink from 200px down to a 120px floor (label truncates, control stays usable). None of these change anything while the row fits; they only decide who yields when it does not. Sanity-checked other consumers (Scenarios, Endpoints, Simulations): they pass buttons through `topBarButtons` and rely on none of the previous overflow behavior.

## Test plan

- `yarn check-ts` passes.
- `yarn eslint` on the four changed files passes (no issues).
- Manual check: open Threat Arsenal, resize the browser to ~1512x712; the toolbar stays on a single row with the create button visible and clickable at the right. Narrow further: the filter autocomplete compresses first, the actions never move or shrink, and no second toolbar row ever appears. Hover the select-all checkbox to see the "Select all" / "N selected" tooltip; screen readers get the same text via aria-label. Verify the button is absent for a user without the Threat Arsenal MANAGE capability.

Closes #7340
