### PR TITLE
feat(challenges): validate regex flags when creating or editing a challenge (#227)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/challenge/ChallengeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/challenge/ChallengeApi.java
@@ -70,7 +70,9 @@ public class ChallengeApi extends RestBehavior {
       resourceType = ResourceType.CHALLENGE)
   @Transactional(rollbackFor = Exception.class)
   public Challenge updateChallenge(
-      @PathVariable String challengeId, @Valid @RequestBody ChallengeInput input) {
+      @PathVariable String challengeId, @Valid @RequestBody ChallengeInput input)
+      throws InputValidationException {
+    challengeService.validateFlags(input.flags());
     Challenge challenge =
         challengeRepository.findById(challengeId).orElseThrow(ElementNotFoundException::new);
     challenge.setTags(iterableToSet(tagRepository.findAllById(input.tagIds())));
@@ -99,7 +101,9 @@ public class ChallengeApi extends RestBehavior {
   @PostMapping({CHALLENGE_URI, TENANT_CHALLENGE_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.CHALLENGE)
   @Transactional(rollbackFor = Exception.class)
-  public Challenge createChallenge(@Valid @RequestBody ChallengeInput input) {
+  public Challenge createChallenge(@Valid @RequestBody ChallengeInput input)
+      throws InputValidationException {
+    challengeService.validateFlags(input.flags());
     Challenge challenge = new Challenge();
     challenge.setUpdateAttributes(input);
     challenge.setTags(iterableToSet(tagRepository.findAllById(input.tagIds())));

--- a/openaev-api/src/main/java/io/openaev/service/ChallengeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/ChallengeService.java
@@ -16,10 +16,12 @@ import io.openaev.database.repository.InjectExpectationRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.injectors.challenge.model.ChallengeContent;
 import io.openaev.rest.challenge.form.ChallengeTryInput;
+import io.openaev.rest.challenge.form.FlagInput;
 import io.openaev.rest.challenge.response.ChallengeInformation;
 import io.openaev.rest.challenge.response.ChallengeResult;
 import io.openaev.rest.challenge.response.SimulationChallengesReader;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.rest.exception.InputValidationException;
 import io.openaev.rest.exercise.form.ExpectationUpdateInput;
 import io.openaev.service.challenge.ChallengeAttemptService;
 import jakarta.annotation.Resource;
@@ -27,11 +29,14 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChallengeService {
@@ -83,6 +88,25 @@ public class ChallengeService {
 
   public Iterable<Challenge> getInjectsChallenges(@NotNull final List<Inject> injects) {
     return resolveChallenges(injects).toList();
+  }
+
+  /**
+   * Validate that every REGEXP flag holds a compilable regular expression.
+   *
+   * @param flags the flag inputs submitted at challenge creation or update
+   * @throws InputValidationException when a REGEXP flag value is not a valid pattern
+   */
+  public void validateFlags(List<FlagInput> flags) throws InputValidationException {
+    for (FlagInput flag : flags) {
+      if (ChallengeFlag.FLAG_TYPE.REGEXP.name().equals(flag.getType())) {
+        try {
+          Pattern.compile(flag.getValue());
+        } catch (PatternSyntaxException e) {
+          throw new InputValidationException(
+              "challenge_flags", "Invalid regular expression: " + flag.getValue());
+        }
+      }
+    }
   }
 
   public ChallengeResult tryChallenge(String challengeId, ChallengeTryInput input) {
@@ -265,7 +289,13 @@ public class ChallengeService {
         return value.equals(flag.getValue());
       }
       case REGEXP -> {
-        return Pattern.compile(flag.getValue()).matcher(value).matches();
+        try {
+          return Pattern.compile(flag.getValue()).matcher(value).matches();
+        } catch (PatternSyntaxException e) {
+          // Defensive: a bad pattern stored before validation existed must not break answering
+          log.warn("Ignoring invalid REGEXP challenge flag pattern: {}", flag.getValue());
+          return false;
+        }
       }
       default -> {
         return false;

--- a/openaev-api/src/main/java/io/openaev/service/ChallengeService.java
+++ b/openaev-api/src/main/java/io/openaev/service/ChallengeService.java
@@ -41,6 +41,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChallengeService {
 
+  public static final String INVALID_REGEXP_MESSAGE = "Invalid regular expression";
+
   private final ExerciseRepository exerciseRepository;
   private final ChallengeRepository challengeRepository;
   private final InjectRepository injectRepository;
@@ -99,11 +101,16 @@ public class ChallengeService {
   public void validateFlags(List<FlagInput> flags) throws InputValidationException {
     for (FlagInput flag : flags) {
       if (ChallengeFlag.FLAG_TYPE.REGEXP.name().equals(flag.getType())) {
+        // Bean Validation does not cascade into the flag list elements, so the value may be null
+        String pattern = flag.getValue();
+        if (pattern == null) {
+          continue;
+        }
         try {
-          Pattern.compile(flag.getValue());
+          Pattern.compile(pattern);
         } catch (PatternSyntaxException e) {
-          throw new InputValidationException(
-              "challenge_flags", "Invalid regular expression: " + flag.getValue());
+          // Stable message (no raw pattern): the frontend translates it and the 400 stays small
+          throw new InputValidationException("challenge_flags", INVALID_REGEXP_MESSAGE);
         }
       }
     }
@@ -289,11 +296,18 @@ public class ChallengeService {
         return value.equals(flag.getValue());
       }
       case REGEXP -> {
+        // Defensive: bad stored data (pre-validation or imported) must not break answering
+        if (flag.getValue() == null) {
+          log.warn("Ignoring REGEXP challenge flag with null pattern (flag {})", flag.getId());
+          return false;
+        }
         try {
           return Pattern.compile(flag.getValue()).matcher(value).matches();
         } catch (PatternSyntaxException e) {
-          // Defensive: a bad pattern stored before validation existed must not break answering
-          log.warn("Ignoring invalid REGEXP challenge flag pattern: {}", flag.getValue());
+          log.warn(
+              "Ignoring invalid REGEXP challenge flag pattern (flag {}): {}",
+              flag.getId(),
+              flag.getValue());
           return false;
         }
       }

--- a/openaev-api/src/test/java/io/openaev/service/ChallengeServiceFlagValidationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ChallengeServiceFlagValidationTest.java
@@ -1,0 +1,106 @@
+package io.openaev.service;
+
+import static io.openaev.database.model.ChallengeFlag.FLAG_TYPE.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.Challenge;
+import io.openaev.database.model.ChallengeFlag;
+import io.openaev.database.repository.ChallengeRepository;
+import io.openaev.database.repository.ExerciseRepository;
+import io.openaev.database.repository.InjectExpectationRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.rest.challenge.form.ChallengeTryInput;
+import io.openaev.rest.challenge.form.FlagInput;
+import io.openaev.rest.challenge.response.ChallengeResult;
+import io.openaev.rest.exception.InputValidationException;
+import io.openaev.service.challenge.ChallengeAttemptService;
+import io.openaev.utils.fixtures.ChallengeFixture;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ChallengeServiceFlagValidationTest {
+
+  @Mock private ExerciseRepository exerciseRepository;
+  @Mock private ChallengeRepository challengeRepository;
+  @Mock private InjectRepository injectRepository;
+  @Mock private InjectExpectationService injectExpectationService;
+  @Mock private InjectExpectationRepository injectExpectationRepository;
+  @Mock private ChallengeAttemptService challengeAttemptService;
+
+  private ChallengeService challengeService;
+
+  @BeforeEach
+  void setUp() {
+    this.challengeService =
+        new ChallengeService(
+            exerciseRepository,
+            challengeRepository,
+            injectRepository,
+            injectExpectationService,
+            injectExpectationRepository,
+            challengeAttemptService);
+  }
+
+  private FlagInput buildFlagInput(String type, String value) {
+    FlagInput flagInput = new FlagInput();
+    flagInput.setType(type);
+    flagInput.setValue(value);
+    return flagInput;
+  }
+
+  @Test
+  @DisplayName("Should accept a REGEXP flag with a valid pattern")
+  void shouldAcceptValidRegexpFlag() {
+    List<FlagInput> flags = List.of(buildFlagInput(REGEXP.name(), ".*\\btest\\b.*"));
+
+    assertDoesNotThrow(() -> challengeService.validateFlags(flags));
+  }
+
+  @Test
+  @DisplayName("Should reject a REGEXP flag with an invalid pattern")
+  void shouldRejectInvalidRegexpFlag() {
+    List<FlagInput> flags = List.of(buildFlagInput(REGEXP.name(), "[unclosed"));
+
+    InputValidationException exception =
+        assertThrows(InputValidationException.class, () -> challengeService.validateFlags(flags));
+    assertEquals("challenge_flags", exception.getField());
+    assertTrue(exception.getMessage().contains("Invalid regular expression"));
+  }
+
+  @Test
+  @DisplayName("Should not check regex syntax for VALUE flags")
+  void shouldIgnoreValueFlags() {
+    // An invalid pattern is fine on a VALUE flag: it is matched literally
+    List<FlagInput> flags = List.of(buildFlagInput(VALUE.name(), "[unclosed"));
+
+    assertDoesNotThrow(() -> challengeService.validateFlags(flags));
+  }
+
+  @Test
+  @DisplayName("Should treat an invalid stored REGEXP pattern as non-matching")
+  void shouldReturnFalseForInvalidStoredPattern() {
+    Challenge challenge = ChallengeFixture.createDefaultChallenge();
+    ChallengeFlag flag = ChallengeFixture.createDefaultChallengeFlag();
+    flag.setType(REGEXP);
+    flag.setValue("[unclosed");
+    challenge.setFlags(new ArrayList<>(List.of(flag)));
+
+    ChallengeTryInput input = new ChallengeTryInput();
+    input.setValue("any answer");
+
+    when(challengeRepository.findById("test")).thenReturn(Optional.of(challenge));
+
+    ChallengeResult result = assertDoesNotThrow(() -> challengeService.tryChallenge("test", input));
+    assertNotNull(result);
+    assertFalse(result.isResult());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/ChallengeServiceFlagValidationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ChallengeServiceFlagValidationTest.java
@@ -73,7 +73,17 @@ public class ChallengeServiceFlagValidationTest {
     InputValidationException exception =
         assertThrows(InputValidationException.class, () -> challengeService.validateFlags(flags));
     assertEquals("challenge_flags", exception.getField());
-    assertTrue(exception.getMessage().contains("Invalid regular expression"));
+    // Exact stable message: the frontend translates it via the i18n key
+    assertEquals("Invalid regular expression", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("Should skip a REGEXP flag with a null value instead of throwing")
+  void shouldSkipNullRegexpFlagValue() {
+    // Bean Validation does not cascade into the flag list elements, so null values can reach us
+    List<FlagInput> flags = List.of(buildFlagInput(REGEXP.name(), null));
+
+    assertDoesNotThrow(() -> challengeService.validateFlags(flags));
   }
 
   @Test
@@ -92,6 +102,25 @@ public class ChallengeServiceFlagValidationTest {
     ChallengeFlag flag = ChallengeFixture.createDefaultChallengeFlag();
     flag.setType(REGEXP);
     flag.setValue("[unclosed");
+    challenge.setFlags(new ArrayList<>(List.of(flag)));
+
+    ChallengeTryInput input = new ChallengeTryInput();
+    input.setValue("any answer");
+
+    when(challengeRepository.findById("test")).thenReturn(Optional.of(challenge));
+
+    ChallengeResult result = assertDoesNotThrow(() -> challengeService.tryChallenge("test", input));
+    assertNotNull(result);
+    assertFalse(result.isResult());
+  }
+
+  @Test
+  @DisplayName("Should treat a null stored REGEXP pattern as non-matching")
+  void shouldReturnFalseForNullStoredPattern() {
+    Challenge challenge = ChallengeFixture.createDefaultChallenge();
+    ChallengeFlag flag = ChallengeFixture.createDefaultChallengeFlag();
+    flag.setType(REGEXP);
+    flag.setValue(null);
     challenge.setFlags(new ArrayList<>(List.of(flag)));
 
     ChallengeTryInput input = new ChallengeTryInput();

--- a/openaev-front/src/admin/components/components/challenges/ChallengeForm.jsx
+++ b/openaev-front/src/admin/components/components/challenges/ChallengeForm.jsx
@@ -125,8 +125,20 @@ const ChallengeForm = (props) => {
     });
     return errors;
   };
-  const required = value => (value ? undefined : t('This field is required.'));
   const requiredArray = value => (value && value.length > 0 ? undefined : t('This field is required.'));
+  const flagValueValidator = index => (value, allValues) => {
+    if (!value) {
+      return t('This field is required.');
+    }
+    if (allValues?.challenge_flags?.[index]?.flag_type === 'REGEXP') {
+      try {
+        RegExp(value);
+      } catch {
+        return t('Invalid regular expression');
+      }
+    }
+    return undefined;
+  };
   const { documentsMap } = useHelper(helper => ({ documentsMap: helper.getDocumentsMap() }));
 
   useDataLoader(() => {
@@ -375,7 +387,7 @@ const ChallengeForm = (props) => {
                       </OldSelectField>
                       <OldTextField
                         name={`${name}.flag_value`}
-                        validate={required}
+                        validate={flagValueValidator(index)}
                         fullWidth={true}
                         label={t('Value')}
                         style={{ marginRight: 20 }}

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "Ungültige IP-Adressen",
   "Invalid MAC address": "Ungültige MAC-Adresse",
   "Invalid MAC addresses": "Ungültige MAC-Adressen",
+  "Invalid regular expression": "Ungültiger regulärer Ausdruck",
   "Invalid URL": "Ungültige URL",
   "Invalid user or password": "Ungültiger Benutzer oder ungültiges Passwort",
   "INVALID_USAGE": "Ungültige Verwendung",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "Invalid IP addresses",
   "Invalid MAC address": "Invalid MAC address",
   "Invalid MAC addresses": "Invalid MAC addresses",
+  "Invalid regular expression": "Invalid regular expression",
   "Invalid URL": "Invalid URL",
   "Invalid user or password": "Invalid user or password",
   "INVALID_USAGE": "Invalid usage",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "Direcciones IP no válidas",
   "Invalid MAC address": "Dirección MAC no válida",
   "Invalid MAC addresses": "Direcciones MAC no válidas",
+  "Invalid regular expression": "Expresión regular no válida",
   "Invalid URL": "URL no válida",
   "Invalid user or password": "Usuario o contraseña no válidos",
   "INVALID_USAGE": "Uso no válido",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "Adresses IP invalides",
   "Invalid MAC address": "Mac adresse non valide",
   "Invalid MAC addresses": "Adresses MAC invalides",
+  "Invalid regular expression": "Expression régulière non valide",
   "Invalid URL": "URL non valide",
   "Invalid user or password": "Nom d'utilisateur ou mot de passe incorrect",
   "INVALID_USAGE": "Utilisation invalide",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "Indirizzi IP non validi",
   "Invalid MAC address": "Indirizzo MAC non valido",
   "Invalid MAC addresses": "Indirizzi MAC non validi",
+  "Invalid regular expression": "Espressione regolare non valida",
   "Invalid URL": "URL non valido",
   "Invalid user or password": "Utente o password non validi",
   "INVALID_USAGE": "Utilizzo non valido",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "無効なIPアドレス",
   "Invalid MAC address": "無効なMACアドレス",
   "Invalid MAC addresses": "無効なMACアドレス",
+  "Invalid regular expression": "無効な正規表現",
   "Invalid URL": "無効なURL",
   "Invalid user or password": "無効なユーザーまたはパスワード",
   "INVALID_USAGE": "無効な使用方法",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "잘못된 IP 주소",
   "Invalid MAC address": "잘못된 MAC 주소",
   "Invalid MAC addresses": "잘못된 MAC 주소",
+  "Invalid regular expression": "잘못된 정규 표현식",
   "Invalid URL": "잘못된 URL",
   "Invalid user or password": "잘못된 사용자 또는 비밀번호",
   "INVALID_USAGE": "잘못된 사용법",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "Недействительные IP-адреса",
   "Invalid MAC address": "Неверный MAC-адрес",
   "Invalid MAC addresses": "Неверные MAC-адреса",
+  "Invalid regular expression": "Неверное регулярное выражение",
   "Invalid URL": "Неверный URL",
   "Invalid user or password": "Неверный пользователь или пароль",
   "INVALID_USAGE": "Неверное использование",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -1887,6 +1887,7 @@
   "Invalid IP addresses": "无效IP地址",
   "Invalid MAC address": "Mac地址不正确",
   "Invalid MAC addresses": "无效MAC地址",
+  "Invalid regular expression": "无效的正则表达式",
   "Invalid URL": "无效 URL",
   "Invalid user or password": "用户名或密码错误",
   "INVALID_USAGE": "无效使用",


### PR DESCRIPTION
## Summary

- Frontend: the challenge form now validates that a flag value compiles as a regular expression when the flag type is REGEXP, surfacing an inline "Invalid regular expression" error (translation key added to all 9 lang files).
- Backend: `ChallengeService.validateFlags()` rejects invalid REGEXP flag values at challenge create and update with a proper 400 validation error (`InputValidationException` on field `challenge_flags`) instead of letting `Pattern.compile` explode later. The error message is the stable string "Invalid regular expression" (no raw pattern echoed), so the frontend can translate it via the existing i18n key and the 400 body stays small.
- Backend: `validateFlags()` also guards null flag values - Bean Validation does not cascade into the flag list elements, so a null `flag_value` previously reached `Pattern.compile(null)` and produced a 500.
- Backend: `checkFlag()` is now defensive - an invalid or null stored REGEXP pattern (pre-existing bad data or legacy imports) is logged with the flag id and treated as non-matching instead of throwing a 500 at player answer time.

Notes and trade-offs:

- JS `RegExp` and Java `Pattern` syntax differ slightly; the frontend check is a UX convenience while the backend check is authoritative. Rare Java-only constructs (e.g. possessive quantifiers) are rejected client-side; backend 400s still surface through the standard error toast and form error mapping.
- `V1_DataImporter` intentionally keeps creating challenge flags without this validation so legacy export bundles keep importing; the defensive `checkFlag()` path covers such data at answer time.

## Test plan

- [x] Plain unit tests (no Docker) in `ChallengeServiceFlagValidationTest`: valid REGEXP flag accepted, invalid REGEXP flag rejected with field `challenge_flags` and the exact stable message, null REGEXP flag value skipped, invalid pattern on a VALUE flag ignored, and `tryChallenge` with an invalid or null stored pattern returns false instead of throwing - all passing via `mvn -pl openaev-api -am test`.
- [x] `mvn spotless:apply` clean.
- [x] `yarn check-ts` and eslint on changed frontend files clean; all lang JSON files parse.
- [ ] Manual: create/edit a challenge with an invalid REGEXP flag and verify the inline form error and the API 400.

Closes #227
