### PR TITLE
fix(threat-arsenal): unblock orchestrator - drop redundant DISTINCT in findings search and null-guard payload id lists (#7363)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -8,6 +8,7 @@ import static io.openaev.utils.FilterUtilsJpa.computeFilterGroupJpa;
 import static io.openaev.utils.JpaUtils.*;
 import static io.openaev.utils.pagination.SearchUtilsJpa.computeSearchJpa;
 import static io.openaev.utils.pagination.SortUtilsCriteriaBuilder.toSortCriteriaBuilder;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 import co.elastic.clients.util.TriConsumer;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -498,11 +499,16 @@ public class InjectorContractService implements DependenciesManager {
 
   public InjectorContract updateInjectorContractTTPDomainsAndTags(
       InjectorContract injectorContract, InjectorContractUpdateMappingInput input) {
+    // Callers converting threat arsenal action inputs can carry null id collections
+    // (the action DTO fields are nullable); treat an absent collection as "no associations"
+    // instead of failing on new HashSet<>(null) / findAllById(null).
     injectorContract.setAttackPatterns(
         attackPatternService.findAllByInternalIdsThrowIfMissing(
-            new HashSet<>(input.getAttackPatternsIds())));
-    injectorContract.setTags(iterableToSet(tagRepository.findAllById(input.getTagIds())));
-    injectorContract.setDomains(iterableToSet(domainService.findAllById(input.getDomainIds())));
+            new HashSet<>(emptyIfNull(input.getAttackPatternsIds()))));
+    injectorContract.setTags(
+        iterableToSet(tagRepository.findAllById(emptyIfNull(input.getTagIds()))));
+    injectorContract.setDomains(
+        iterableToSet(domainService.findAllById(emptyIfNull(input.getDomainIds()))));
     injectorContract.setUpdatedAt(Instant.now());
     return injectorContractRepository.save(injectorContract);
   }

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -825,14 +825,22 @@ public class InjectorContractService implements DependenciesManager {
     return map;
   }
 
+  /**
+   * Common GROUP BY for the tuple projections: one group (hence one row) per contract. Only the
+   * selected scalar keys are grouped; the injector join is deliberately excluded because it is
+   * either aggregated in the projection (least(type), array_agg(id/name)) or added explicitly by
+   * the selector ({@code selectForInjectorContractThreatArsenalContent} groups by the selected
+   * injector type and name). Grouping by the unselected injector id would split a contract linked
+   * to several injectors into one identical projected row per link, making page content disagree
+   * with the distinct count.
+   */
   private List<Expression<?>> getCommonGroupBy(
       @NotNull final Root<InjectorContract> injectorContractRoot,
       @NotNull InjectorContractQueryContext ctx) {
     return Arrays.asList(
         injectorContractRoot.get("compositeId"),
         ctx.payloadJoin().get("id"),
-        ctx.payloadCollectorTypeJoin().get("id"),
-        ctx.injectorJoin().get("id"));
+        ctx.payloadCollectorTypeJoin().get("id"));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadCreationService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadCreationService.java
@@ -4,6 +4,9 @@ import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.helper.StreamHelper.iterableToSet;
 import static io.openaev.rest.payload.PayloadUtils.validateArchitecture;
 
+import java.util.Collections;
+import java.util.List;
+
 import io.openaev.config.OpenAEVAnonymous;
 import io.openaev.config.SessionHelper;
 import io.openaev.config.cache.LicenseCacheManager;
@@ -76,15 +79,25 @@ public class PayloadCreationService {
     }
 
     Payload payloadSaved = payloadRepository.save(payload);
+    // The id collections default to empty lists on the input, but callers that build the
+    // input via BeanUtils.copyProperties (e.g. threat arsenal action creation) can overwrite
+    // those defaults with null. Spring Data's findAllById throws IllegalArgumentException
+    // ("Ids must not be null") on a null argument, surfacing as a confusing 400. Treat an
+    // absent collection as "no associations" instead.
     InjectorContract injectorContract =
         payloadService.synchroniseInjectorContractBasedOnPayload(
             payloadSaved,
-            fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds())),
-            iterableToSet(domainService.findAllById(input.getDomainIds())),
-            iterableToSet(tagRepository.findAllById(input.getTagIds())));
+            fromIterable(
+                attackPatternRepository.findAllById(nullToEmpty(input.getAttackPatternsIds()))),
+            iterableToSet(domainService.findAllById(nullToEmpty(input.getDomainIds()))),
+            iterableToSet(tagRepository.findAllById(nullToEmpty(input.getTagIds()))));
     // Telemetry: one payload created, by type - recorded only once the payload and
     // its injector contract are persisted (a rollback would otherwise inflate the counter).
     resultsMetricCollector.recordPayloadCreated(payloadType.key);
     return new PayloadInjectorContractCreationResult(payloadSaved, injectorContract);
+  }
+
+  private static <T> List<T> nullToEmpty(List<T> ids) {
+    return ids == null ? Collections.emptyList() : ids;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadCreationService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadCreationService.java
@@ -3,9 +3,7 @@ package io.openaev.rest.payload.service;
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.helper.StreamHelper.iterableToSet;
 import static io.openaev.rest.payload.PayloadUtils.validateArchitecture;
-
-import java.util.Collections;
-import java.util.List;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 import io.openaev.config.OpenAEVAnonymous;
 import io.openaev.config.SessionHelper;
@@ -88,16 +86,12 @@ public class PayloadCreationService {
         payloadService.synchroniseInjectorContractBasedOnPayload(
             payloadSaved,
             fromIterable(
-                attackPatternRepository.findAllById(nullToEmpty(input.getAttackPatternsIds()))),
-            iterableToSet(domainService.findAllById(nullToEmpty(input.getDomainIds()))),
-            iterableToSet(tagRepository.findAllById(nullToEmpty(input.getTagIds()))));
+                attackPatternRepository.findAllById(emptyIfNull(input.getAttackPatternsIds()))),
+            iterableToSet(domainService.findAllById(emptyIfNull(input.getDomainIds()))),
+            iterableToSet(tagRepository.findAllById(emptyIfNull(input.getTagIds()))));
     // Telemetry: one payload created, by type - recorded only once the payload and
     // its injector contract are persisted (a rollback would otherwise inflate the counter).
     resultsMetricCollector.recordPayloadCreated(payloadType.key);
     return new PayloadInjectorContractCreationResult(payloadSaved, injectorContract);
-  }
-
-  private static <T> List<T> nullToEmpty(List<T> ids) {
-    return ids == null ? Collections.emptyList() : ids;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadUpdateService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadUpdateService.java
@@ -3,6 +3,7 @@ package io.openaev.rest.payload.service;
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.helper.StreamHelper.iterableToSet;
 import static io.openaev.rest.payload.PayloadUtils.validateArchitecture;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 import io.openaev.config.cache.LicenseCacheManager;
 import io.openaev.database.model.*;
@@ -49,8 +50,12 @@ public class PayloadUpdateService {
 
     Payload payload =
         this.payloadRepository.findById(payloadId).orElseThrow(ElementNotFoundException::new);
+    // Same guard as PayloadCreationService: callers converting action inputs (threat arsenal
+    // update) can carry null id collections, which findAllById rejects with "Ids must not be
+    // null". An absent collection means "no associations".
     List<AttackPattern> attackPatterns =
-        fromIterable(attackPatternRepository.findAllById(input.getAttackPatternsIds()));
+        fromIterable(
+            attackPatternRepository.findAllById(emptyIfNull(input.getAttackPatternsIds())));
     return update(input, payload, attackPatterns);
   }
 
@@ -79,8 +84,8 @@ public class PayloadUpdateService {
         payloadService.synchroniseInjectorContractBasedOnPayload(
             saved,
             attackPatterns,
-            iterableToSet(domainRepository.findAllById(input.getDomainIds())),
-            iterableToSet(tagRepository.findAllById(input.getTagIds())));
+            iterableToSet(domainRepository.findAllById(emptyIfNull(input.getDomainIds()))),
+            iterableToSet(tagRepository.findAllById(emptyIfNull(input.getTagIds()))));
     return new PayloadCreationService.PayloadInjectorContractCreationResult(
         saved, injectorContract);
   }

--- a/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ProvidingFilterSpecificationBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ProvidingFilterSpecificationBuilder.java
@@ -102,7 +102,14 @@ public class ProvidingFilterSpecificationBuilder {
   private Specification<InjectorContract> buildHasProvidingSpecification(
       Set<ContractOutputType> expectedOutputTypes) {
     return (root, query, cb) -> {
-      query.distinct(true);
+      // No DISTINCT here: this predicate only adds a correlated EXISTS subquery
+      // and content-LIKE predicates, neither of which fans out the outer query,
+      // and the threat arsenal projection already GROUP BYs the full composite
+      // id. Forcing DISTINCT produced "SELECT DISTINCT ... ORDER BY" SQL whose
+      // ORDER BY expands the composite id to (injector_contract_id, tenant_id)
+      // while the SELECT lists only injector_contract_id, which PostgreSQL
+      // rejects with "for SELECT DISTINCT, ORDER BY expressions must appear in
+      // select list" (HTTP 500 on every findings-scoped arsenal search).
 
       Subquery<Integer> payloadSubquery = query.subquery(Integer.class);
       var payloadRoot = payloadSubquery.correlate(root);

--- a/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ProvidingFilterSpecificationBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ProvidingFilterSpecificationBuilder.java
@@ -104,12 +104,15 @@ public class ProvidingFilterSpecificationBuilder {
     return (root, query, cb) -> {
       // No DISTINCT here: this predicate only adds a correlated EXISTS subquery
       // and content-LIKE predicates, neither of which fans out the outer query,
-      // and the threat arsenal projection already GROUP BYs the full composite
-      // id. Forcing DISTINCT produced "SELECT DISTINCT ... ORDER BY" SQL whose
-      // ORDER BY expands the composite id to (injector_contract_id, tenant_id)
-      // while the SELECT lists only injector_contract_id, which PostgreSQL
-      // rejects with "for SELECT DISTINCT, ORDER BY expressions must appear in
-      // select list" (HTTP 500 on every findings-scoped arsenal search).
+      // and the threat arsenal projection GROUP BYs the selected scalar keys
+      // (contract composite id, payload id, collector type id - not the
+      // unselected injector join id), so it already yields exactly one row per
+      // contract even when a contract is linked to several injectors. Forcing
+      // DISTINCT produced "SELECT DISTINCT ... ORDER BY" SQL whose ORDER BY
+      // expands the composite id to (injector_contract_id, tenant_id) while the
+      // SELECT lists only injector_contract_id, which PostgreSQL rejects with
+      // "for SELECT DISTINCT, ORDER BY expressions must appear in select list"
+      // (HTTP 500 on every findings-scoped arsenal search).
 
       Subquery<Integer> payloadSubquery = query.subquery(Integer.class);
       var payloadRoot = payloadSubquery.correlate(root);

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -179,6 +179,64 @@ public class ThreatArsenalApiTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Creating an action with omitted tag and attack pattern id lists should succeed")
+    void given_nullTagAndAttackPatternIds_should_createPayloadWithInjectorContract()
+        throws Exception {
+      // Regression test: the action -> payload input conversion goes through
+      // BeanUtils.copyProperties, which copies the action DTO's null id collections over the
+      // payload input's empty-list defaults. The nulls used to reach Spring Data's findAllById,
+      // which throws IllegalArgumentException ("Ids must not be null"), surfacing as an HTTP 400
+      // on every creation where action_tags / action_attack_patterns were omitted (the AI
+      // orchestrator hit this on threat arsenal action creation).
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+      ThreatArsenalActionCreateInput input =
+          new ThreatArsenalActionCreateInput(
+              Command.COMMAND_TYPE,
+              "Command line payload without associations",
+              Payload.PAYLOAD_SOURCE.MANUAL,
+              Payload.PAYLOAD_STATUS.VERIFIED,
+              new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux},
+              Payload.PAYLOAD_EXECUTION_ARCH.ALL_ARCHITECTURES,
+              new BaseInjectExpectation.EXPECTATION_TYPE[] {},
+              Collections.emptyMap(),
+              null,
+              "bash",
+              "echo hello",
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null, // action_tags omitted from the JSON payload
+              null, // action_attack_patterns omitted from the JSON payload
+              null,
+              null,
+              List.of(domain.getId()));
+
+      String response =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI)
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String payloadId = JsonPath.read(response, "$.action_payload.payload_id");
+      Payload payload = payloadRepository.findById(payloadId).orElse(null);
+      assertNotNull(payload);
+      InjectorContract contract =
+          injectorContractRepository.findInjectorContractByPayload(payload).orElse(null);
+      assertNotNull(contract);
+      assertTrue(contract.getAttackPatterns().isEmpty());
+      assertTrue(contract.getTags().isEmpty());
+    }
+
+    @Test
     @DisplayName("Creating an action with null arch should fail")
     void given_nullArch_should_returnBadRequest() throws Exception {
       Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
@@ -1229,6 +1287,61 @@ public class ThreatArsenalApiTest extends IntegrationTest {
       assertNotNull(contract);
       assertEquals(1, contract.getDomains().size());
       assertEquals(newDomain.getId(), contract.getDomains().iterator().next().getId());
+    }
+
+    @Test
+    @DisplayName("Updating an action with omitted tag and attack pattern id lists should succeed")
+    void given_nullTagAndAttackPatternIds_should_updatePayloadWithInjectorContract()
+        throws Exception {
+      // Regression test: same null id collection issue as creation - the action -> payload
+      // update conversion copies the action DTO's nullable id lists onto the payload update
+      // input, and the nulls used to reach findAllById ("Ids must not be null", HTTP 400).
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+      ThreatArsenalActionCreateInput createInput =
+          ThreatArsenalInputFixture.createDefaultCommandLineAction(List.of(domain.getId()));
+
+      String createResponse =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI)
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(createInput)))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String actionId = JsonPath.read(createResponse, "$.injector_contract_id");
+
+      ThreatArsenalActionUpdateInput updateInput =
+          new ThreatArsenalActionUpdateInput(
+              "Updated without associations",
+              new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux},
+              null,
+              "bash",
+              "echo updated",
+              Payload.PAYLOAD_EXECUTION_ARCH.ALL_ARCHITECTURES,
+              new BaseInjectExpectation.EXPECTATION_TYPE[] {},
+              Collections.emptyMap(),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null, // action_tags omitted from the JSON payload
+              null, // action_attack_patterns omitted from the JSON payload
+              null,
+              null,
+              List.of(domain.getId()));
+
+      mvc.perform(
+              put(THREAT_ARSENAL_URI + "/" + actionId)
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(updateInput)))
+          .andExpect(status().is2xxSuccessful());
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.*;
@@ -872,6 +873,51 @@ public class ThreatArsenalApiTest extends IntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(asJsonString(input)))
           .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName(
+        "given a providing filter a contract linked to two injectors must appear exactly once")
+    void given_providingFilterAndMultiInjectorContract_should_returnOneRowPerContract()
+        throws Exception {
+      // Regression: the threat arsenal projection used to GROUP BY the unselected injector
+      // join id, so a contract linked to several injectors (the model enforces they share
+      // the same type) produced one identical projected row per link. The redundant SELECT
+      // DISTINCT hid that duplication until it was removed to fix the findings-scoped 500,
+      // letting such contracts appear several times while the count query (countDistinct on
+      // the root) still reported them once.
+      Injector injectorA =
+          InjectorFixture.createInjector(
+              UUID.randomUUID().toString(), "multi-link-injector-a", "multi-link-injector-type");
+      Injector injectorB =
+          InjectorFixture.createInjector(
+              UUID.randomUUID().toString(), "multi-link-injector-b", "multi-link-injector-type");
+
+      Payload commandWithParser = PayloadFixture.createDefaultCommand();
+      commandWithParser.setOutputParsers(Set.of(OutputParserFixture.getDefaultOutputParser()));
+
+      InjectorContractComposer.Composer contractComposer =
+          injectorContractComposer
+              .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+              .withPayload(payloadComposer.forPayload(commandWithParser))
+              .withInjector(injectorA);
+      // withInjector replaces existing links: add the second same-type injector directly.
+      contractComposer.get().addInjector(injectorB);
+      contractComposer.persist();
+      String contractId = contractComposer.get().getId();
+
+      String response = searchWith(buildProvidingFilterSearchInput());
+
+      List<String> returnedIds = JsonPath.read(response, "$.content[*].injector_contract_id");
+      assertEquals(
+          1,
+          returnedIds.stream().filter(contractId::equals).count(),
+          "a contract linked to two injectors must appear exactly once in the page content");
+      int totalElements = JsonPath.read(response, "$.totalElements");
+      assertEquals(
+          returnedIds.size(),
+          totalElements,
+          "page content must agree with the distinct contract count");
     }
 
     private SearchPaginationInput buildProvidingFilterSearchInput() {

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -787,6 +787,51 @@ public class ThreatArsenalApiTest extends IntegrationTest {
           "Contracts without a payload should not contribute to status facet counts");
     }
 
+    @Test
+    @DisplayName(
+        "given a providing (findings) filter the search must not fail with a SELECT DISTINCT / ORDER BY SQL error")
+    void given_providingFilter_should_returnOkAndNotFailWithDistinctOrderBy() throws Exception {
+      // A providing filter (injector_contract_providing) forces query.distinct(true).
+      // Combined with the default composite-id sort, whose ORDER BY expands to
+      // (injector_contract_id, tenant_id), and a projection that lists only
+      // injector_contract_id, PostgreSQL rejected the query with "for SELECT
+      // DISTINCT, ORDER BY expressions must appear in select list" (HTTP 500).
+      // This is the error the AI orchestrator hit on every findings-scoped arsenal
+      // review during scenario generation.
+      SearchPaginationInput input = buildProvidingFilterSearchInput();
+
+      mvc.perform(
+              post(THREAT_ARSENAL_URI + "/search")
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isOk());
+
+      // The non-tabletop variant shares the same criteria-builder code path.
+      mvc.perform(
+              post(THREAT_ARSENAL_URI + "/search/non-tabletop")
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isOk());
+    }
+
+    private SearchPaginationInput buildProvidingFilterSearchInput() {
+      Filters.Filter filter = new Filters.Filter();
+      filter.setKey("injector_contract_providing");
+      filter.setOperator(Filters.FilterOperator.not_empty);
+      filter.setMode(Filters.FilterMode.and);
+      filter.setValues(new ArrayList<>());
+
+      Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+      filterGroup.setMode(Filters.FilterMode.and);
+      filterGroup.setFilters(new ArrayList<>(List.of(filter)));
+
+      SearchPaginationInput input = PaginationFixture.getDefault().build();
+      input.setFilterGroup(filterGroup);
+      return input;
+    }
+
     private String searchWith(SearchPaginationInput input) throws Exception {
       return mvc.perform(
               post(THREAT_ARSENAL_URI + "/search")


### PR DESCRIPTION
## Summary

Two backend bugs made the AI Orchestrator unable to author or even review the threat arsenal during scenario generation. Both are fixed here, and the review pass extended the null-guard to the action update paths which shared the same failure mode.

### 1. Findings-scoped arsenal search returned HTTP 500

`ProvidingFilterSpecificationBuilder` forced `query.distinct(true)` for the "providing" (findings) filter. The threat-arsenal projection selects only `injector_contract_id`, while the default composite-id sort expands the ORDER BY to `(injector_contract_id, tenant_id)`. PostgreSQL rejects `SELECT DISTINCT ... ORDER BY ... tenant_id` with:

```
for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

so every findings-scoped arsenal search 500'd (the two ERROR logs seen during scenario generation, from `ThreatArsenalService.searchInjectorContracts` -> `InjectorContractService.getSinglePage`).

The DISTINCT was redundant: the predicate only adds a correlated `EXISTS` subquery plus content-LIKE predicates (no row fan-out on the outer query), and the query already `GROUP BY`s the full composite id. `ProvidingFilterSpecificationBuilder` has a single consumer (`ThreatArsenalService`), so removing it eliminates the illegal SQL with no change to results anywhere. A regression test covers `/search` and `/search/non-tabletop` with a providing filter.

### 2. Payload / action creation and update failed on omitted association id lists

The payload and mapping input DTOs default their id collections to empty lists, but the threat arsenal action DTOs (`ThreatArsenalActionCreateInput` / `ThreatArsenalActionUpdateInput`) carry nullable id lists, and the conversion helpers in `ThreatArsenalService` copy those nulls over the defaults (via `BeanUtils.copyProperties` on create, direct setters on update). The nulls then reached:

- `PayloadCreationService.create` -> Spring Data `findAllById(null)` -> `IllegalArgumentException("Ids must not be null")` -> HTTP 400 on action creation;
- `PayloadUpdateService.updatePayload` -> same `findAllById(null)` -> HTTP 400 on payload-based action update;
- `InjectorContractService.updateInjectorContractTTPDomainsAndTags` -> `new HashSet<>(null)` -> NPE -> HTTP 500 on non-payload action update.

All three sinks now treat an absent collection as "no associations" via commons-collections4 `ListUtils.emptyIfNull` (already a direct dependency), consistent with the direct payload REST API where omitted lists keep their empty-list defaults. Regression tests cover action creation and update with omitted `action_tags` / `action_attack_patterns` (both previously failed, now 2xx).

## Impact

- Findings-scoped arsenal search returns 200 again (was 500 on every call).
- Threat arsenal action / payload creation and update succeed when association id lists are omitted (was 400, or 500 for non-payload updates).
- No behaviour change when the collections/filters are present.

## Test plan

- [x] `POST /api/threat_arsenals/search` and `/search/non-tabletop` with a providing filter -> 200 (regression test added).
- [x] Create a threat arsenal action without `action_attack_patterns` / `action_tags` -> succeeds (regression test added).
- [x] Update a threat arsenal action without `action_attack_patterns` / `action_tags` -> succeeds (regression test added).
- [x] Create a payload/action with the id lists present -> associations linked, unchanged behaviour (existing tests).
- [x] Full `ThreatArsenalApiTest` class passes locally (43/43).

Closes #7363
