### PR TITLE
fix(front): gate scenario hero AI actions on XTM One availability and EE (#7368)

### DIFF
--- a/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
@@ -45,10 +45,13 @@ import {
 } from '../../../../utils/api-types';
 import { useAppDispatch } from '../../../../utils/hooks';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
 import { isEmptyField, isFeatureEnabled } from '../../../../utils/utils';
+import isXtmOneAvailable from '../../ariane/xtmOneAvailability';
 import AutonomousOutcome from '../../autonomous/AutonomousOutcome';
+import EEChip from '../../common/entreprise_edition/EEChip';
 import MitreCoverageMatrix from '../../common/matrix/MitreCoverageMatrix';
 import ExercisePopover from '../../simulations/simulation/ExercisePopover';
 import SimulationList from '../../simulations/SimulationList';
@@ -93,6 +96,14 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null }
   const isChainingFeatureEnabled = isFeatureEnabled('INJECT_CHAINING');
   const scenarioWorkflowId = (scenario as unknown as Record<string, unknown>).scenario_workflow_id as string | undefined;
   const isScenarioChaining = isChainingFeatureEnabled && !!scenarioWorkflowId;
+  // The Autonomous CTA is an XTM One-driven EE feature (same gate as the header hero and the creation
+  // drawer): hidden unless XTM One is connected, and an EE call-to-action when not Enterprise.
+  const isXtmOneReady = isXtmOneAvailable(settings);
+  const {
+    isValidated: isEnterpriseEdition,
+    openDialog: openEnterpriseEditionDialog,
+    setEEFeatureDetectedInfo,
+  } = useEnterpriseEdition();
 
   const isScopeMissing = isScenarioChaining
     && healthchecks.some((hc: HealthCheck) => hc.type === ('SCOPE_DEFINITION' as HealthCheck['type']) && hc.detail === 'EMPTY');
@@ -374,23 +385,43 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null }
                   </Button>
                 </Box>
               </Tooltip>
-              <Tooltip title={t('Launch in autonomous mode - configure the objective, agents and scope, then let the orchestrator drive and adapt from live findings')}>
-                <Box component="span" sx={{ display: 'inline-flex' }}>
-                  <Button
-                    startIcon={<AutoAwesome />}
-                    variant="contained"
-                    onClick={() => navigate(`/admin/scenarios/${scenarioId}?openAiLaunch=true`)}
+              {/* Autonomous is an XTM One-driven EE feature: hidden when XTM One is unavailable (only
+                  the Normal CTA remains), and an EE call-to-action when the platform is not
+                  Enterprise (EE chip + EE dialog instead of routing to the launch drawer). */}
+              {isXtmOneReady && (
+                <Tooltip title={t('Launch in autonomous mode - configure the objective, agents and scope, then let the orchestrator drive and adapt from live findings')}>
+                  <Box
+                    component="span"
                     sx={{
-                      'whiteSpace': 'nowrap',
-                      'backgroundColor': theme.palette.ai.main,
-                      'color': theme.palette.ai.contrastText,
-                      '&:hover': { backgroundColor: theme.palette.ai.dark },
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 0.5,
                     }}
                   >
-                    {t('Autonomous')}
-                  </Button>
-                </Box>
-              </Tooltip>
+                    <Button
+                      startIcon={<AutoAwesome />}
+                      variant="contained"
+                      onClick={() => {
+                        if (!isEnterpriseEdition) {
+                          setEEFeatureDetectedInfo(t('Autonomous attack path'));
+                          openEnterpriseEditionDialog();
+                          return;
+                        }
+                        navigate(`/admin/scenarios/${scenarioId}?openAiLaunch=true`);
+                      }}
+                      sx={{
+                        'whiteSpace': 'nowrap',
+                        'backgroundColor': theme.palette.ai.main,
+                        'color': theme.palette.ai.contrastText,
+                        '&:hover': { backgroundColor: theme.palette.ai.dark },
+                      }}
+                    >
+                      {t('Autonomous')}
+                    </Button>
+                    {!isEnterpriseEdition && <EEChip />}
+                  </Box>
+                </Tooltip>
+              )}
             </Box>
           )}
           {canLaunch && !isScenarioChaining && (

--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -257,13 +257,15 @@ const ScenarioHeader = ({
   // Deep link from the overview "no run yet" banner (Autonomous button): open the launch config
   // drawer so the operator configures the objective / agents / scope, then launches the live run.
   // The header owns the drawer (single control surface), so the banner just routes here. Strip the
-  // param after so a refresh / back does not reopen it.
+  // param after so a refresh / back does not reopen it. Gated on canLaunch (not canManage) to match
+  // the two surfaces that produce this link - the overview Autonomous CTA and the hero Autonomous
+  // button - both launch-permission surfaces; the builder deep link above stays manage-gated.
   useEffect(() => {
-    if (openAiLaunchQueryParam === 'true' && canManage && isAutonomousModeEnabled && !isRunActive && isXtmOneReady && isEnterpriseEdition) {
+    if (openAiLaunchQueryParam === 'true' && canLaunch && isAutonomousModeEnabled && !isRunActive && isXtmOneReady && isEnterpriseEdition) {
       void openAiDrawer('launch');
       navigate(location.pathname, { replace: true });
     }
-  }, [openAiLaunchQueryParam, canManage, isAutonomousModeEnabled, isRunActive, isXtmOneReady, isEnterpriseEdition, scenarioId]);
+  }, [openAiLaunchQueryParam, canLaunch, isAutonomousModeEnabled, isRunActive, isXtmOneReady, isEnterpriseEdition, scenarioId]);
 
   const { workflowConfiguration } = useHelper((helper: WorkflowConfigurationHelper) => ({
     workflowConfiguration: scenarioWorkflowId

--- a/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/ScenarioHeader.tsx
@@ -64,17 +64,21 @@ import {
 } from '../../../../utils/api-types';
 import { MESSAGING$, useQueryParameter } from '../../../../utils/Environment';
 import { useAppDispatch } from '../../../../utils/hooks';
+import useAuth from '../../../../utils/hooks/useAuth';
 import useDataLoader from '../../../../utils/hooks/useDataLoader';
+import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { type Cron } from '../../../../utils/period/Cron';
 import handle from '../../../../utils/period/Period';
 import useScenarioPermissions from '../../../../utils/permissions/useScenarioPermissions';
 import { truncate } from '../../../../utils/String';
 import { isFeatureEnabled } from '../../../../utils/utils';
+import isXtmOneAvailable from '../../ariane/xtmOneAvailability';
 import AutonomousRunConfigDrawer from '../../autonomous/AutonomousRunConfigDrawer';
 import AutonomousRunControls from '../../autonomous/AutonomousRunControls';
 import AutonomousRunStatusChip from '../../autonomous/AutonomousRunStatusChip';
 import { isAutonomousRunActive, isAutonomousRunSettled } from '../../autonomous/autonomousStatus';
 import { DEFAULT_TIMEOUT_HOURS } from '../../autonomous/useAutonomousRunConfig';
+import EEChip from '../../common/entreprise_edition/EEChip';
 import HealthcheckIndicator from '../../common/healthchecks/HealthcheckIndicator';
 import ExpectationsDriftIndicator from '../../common/injects/expectations/ExpectationsDriftIndicator';
 import { countDistinctInjectTargets } from '../../common/injects/utils';
@@ -116,6 +120,12 @@ const ScenarioHeader = ({
   const { scenarioId } = useParams() as { scenarioId: Scenario['scenario_id'] };
   const [openScenarioAssistantQueryParam, openAiBuilderQueryParam, openAiLaunchQueryParam] = useQueryParameter(['openScenarioAssistant', 'openAiBuilder', 'openAiLaunch']);
   const { canLaunch, canManage, canDelete } = useScenarioPermissions(scenarioId);
+  const { settings } = useAuth();
+  const {
+    isValidated: isEnterpriseEdition,
+    openDialog: openEnterpriseEditionDialog,
+    setEEFeatureDetectedInfo,
+  } = useEnterpriseEdition();
 
   const [openConfiguration, setOpenConfiguration] = useState(false);
   const [openScheduling, setOpenScheduling] = useState(false);
@@ -156,6 +166,19 @@ const ScenarioHeader = ({
       : saved);
     setAiDrawerIntent(intent);
     setAiDrawerOpen(true);
+  };
+
+  // EE-aware entry point for both AI actions (Autonomous launch + AI builder): on a non-Enterprise
+  // platform they degrade to the standard EE call-to-action (the same dialog + feature label the
+  // creation drawer raises) instead of opening the config drawer. XTM One availability is enforced
+  // at render (the buttons are not shown without it), so this only arbitrates the EE gate.
+  const openAiDrawerOrEE = (intent: 'build' | 'launch') => {
+    if (!isEnterpriseEdition) {
+      setEEFeatureDetectedInfo(t('Autonomous attack path'));
+      openEnterpriseEditionDialog();
+      return;
+    }
+    void openAiDrawer(intent);
   };
 
   // Preserve the deep link that used to open the assistant drawer: it now
@@ -205,6 +228,12 @@ const ScenarioHeader = ({
   // orchestrator, gated by the same chaining feature. Time-based scenarios only ever launch a normal
   // simulation.
   const isAutonomousModeEnabled = isScenarioChaining;
+  // The Autonomous launch + AI builder are XTM One-driven Enterprise features, so they are gated
+  // exactly like the top-bar AI shortcuts (hidden unless XTM One is connected, via the shared
+  // isXtmOneAvailable predicate) AND like the scenario creation drawer (a standard EE call-to-action
+  // when the platform is not Enterprise). Previously they were gated only on chaining, so they showed
+  // even with no XTM One available and led nowhere.
+  const isXtmOneReady = isXtmOneAvailable(settings);
   // A run is "active" while the orchestrator is planning or driving: the hero then shows lifecycle
   // controls (pause / resume / stop) instead of the launch actions, and the page hosts the cockpit.
   // A settled run (PLANNED / completed) leaves the launch actions available again so the operator can
@@ -219,22 +248,22 @@ const ScenarioHeader = ({
   // once, then strip the query param so a refresh / back does not reopen it. Only for a chained
   // scenario the operator can manage and while no run already owns it.
   useEffect(() => {
-    if (openAiBuilderQueryParam === 'true' && canManage && isAutonomousModeEnabled && !isRunActive) {
+    if (openAiBuilderQueryParam === 'true' && canManage && isAutonomousModeEnabled && !isRunActive && isXtmOneReady && isEnterpriseEdition) {
       void openAiDrawer('build');
       navigate(location.pathname, { replace: true });
     }
-  }, [openAiBuilderQueryParam, canManage, isAutonomousModeEnabled, isRunActive, scenarioId]);
+  }, [openAiBuilderQueryParam, canManage, isAutonomousModeEnabled, isRunActive, isXtmOneReady, isEnterpriseEdition, scenarioId]);
 
   // Deep link from the overview "no run yet" banner (Autonomous button): open the launch config
   // drawer so the operator configures the objective / agents / scope, then launches the live run.
   // The header owns the drawer (single control surface), so the banner just routes here. Strip the
   // param after so a refresh / back does not reopen it.
   useEffect(() => {
-    if (openAiLaunchQueryParam === 'true' && canManage && isAutonomousModeEnabled && !isRunActive) {
+    if (openAiLaunchQueryParam === 'true' && canManage && isAutonomousModeEnabled && !isRunActive && isXtmOneReady && isEnterpriseEdition) {
       void openAiDrawer('launch');
       navigate(location.pathname, { replace: true });
     }
-  }, [openAiLaunchQueryParam, canManage, isAutonomousModeEnabled, isRunActive, scenarioId]);
+  }, [openAiLaunchQueryParam, canManage, isAutonomousModeEnabled, isRunActive, isXtmOneReady, isEnterpriseEdition, scenarioId]);
 
   const { workflowConfiguration } = useHelper((helper: WorkflowConfigurationHelper) => ({
     workflowConfiguration: scenarioWorkflowId
@@ -537,28 +566,41 @@ const ScenarioHeader = ({
             </Button>
           </Box>
         </Tooltip>
-        <Tooltip title={isRunSettled
-          ? t('Relaunch in autonomous mode - configure the objective, agents and scope, then let the orchestrator drive and adapt from live findings')
-          : t('Launch in autonomous mode - configure the objective, agents and scope, then let the orchestrator drive and adapt from live findings')}
-        >
-          <Box component="span" sx={{ display: 'inline-flex' }}>
-            <Button
-              startIcon={<AutoAwesome />}
-              variant="contained"
-              size="small"
-              onClick={() => openAiDrawer('launch')}
-              data-testid="scenario-launch-autonomous-button"
+        {/* Autonomous is an XTM One-driven EE feature: hidden entirely when XTM One is unavailable
+            (only Normal remains), and shown as an EE call-to-action when the platform is not
+            Enterprise (the EE chip + the dialog raised by openAiDrawerOrEE). */}
+        {isXtmOneReady && (
+          <Tooltip title={isRunSettled
+            ? t('Relaunch in autonomous mode - configure the objective, agents and scope, then let the orchestrator drive and adapt from live findings')
+            : t('Launch in autonomous mode - configure the objective, agents and scope, then let the orchestrator drive and adapt from live findings')}
+          >
+            <Box
+              component="span"
               sx={{
-                'whiteSpace': 'nowrap',
-                'backgroundColor': theme.palette.ai.main,
-                'color': theme.palette.ai.contrastText,
-                '&:hover': { backgroundColor: theme.palette.ai.dark },
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
               }}
             >
-              {t('Autonomous')}
-            </Button>
-          </Box>
-        </Tooltip>
+              <Button
+                startIcon={<AutoAwesome />}
+                variant="contained"
+                size="small"
+                onClick={() => openAiDrawerOrEE('launch')}
+                data-testid="scenario-launch-autonomous-button"
+                sx={{
+                  'whiteSpace': 'nowrap',
+                  'backgroundColor': theme.palette.ai.main,
+                  'color': theme.palette.ai.contrastText,
+                  '&:hover': { backgroundColor: theme.palette.ai.dark },
+                }}
+              >
+                {t('Autonomous')}
+              </Button>
+              {!isEnterpriseEdition && <EEChip />}
+            </Box>
+          </Tooltip>
+        )}
       </>
     );
   } else {
@@ -737,15 +779,25 @@ const ScenarioHeader = ({
                   Saves it for later or Builds it now (the orchestrator authors the attack path onto
                   this scenario, nothing executed). Hidden while a run is active (its lifecycle
                   controls own the hero then). */}
-              {canManage && isAutonomousModeEnabled && !isRunActive && (
+              {/* AI builder: an XTM One-driven EE feature, gated like the Autonomous button - hidden
+                  unless XTM One is available, and an EE call-to-action (EE chip + EE dialog via
+                  openAiDrawerOrEE) when the platform is not Enterprise. */}
+              {canManage && isAutonomousModeEnabled && !isRunActive && isXtmOneReady && (
                 <Tooltip title={isRunSettled
                   ? t('Rebuild with AI - re-author this scenario\'s logic (this wipes the current logic map and starts fresh)')
                   : t('AI builder - let the orchestrator author this scenario\'s logic; save it for later or build it now (nothing runs while building)')}
                 >
-                  <Box component="span" sx={{ display: 'inline-flex' }}>
+                  <Box
+                    component="span"
+                    sx={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                    }}
+                  >
                     <IconButton
                       size="small"
-                      onClick={() => openAiDrawer('build')}
+                      onClick={() => openAiDrawerOrEE('build')}
                       aria-label={isRunSettled ? t('Rebuild with AI') : t('AI builder')}
                       data-testid="scenario-plan-with-ai-button"
                       sx={{
@@ -758,6 +810,7 @@ const ScenarioHeader = ({
                     >
                       <AutoFixHigh fontSize="small" />
                     </IconButton>
+                    {!isEnterpriseEdition && <EEChip />}
                   </Box>
                 </Tooltip>
               )}


### PR DESCRIPTION
## Summary

- Gates the two AI actions of the chained scenario hero (`ScenarioHeader`) - the **Autonomous** launch button and the **AI builder** ("plan with AI") icon button - on BOTH XTM One availability and the Enterprise Edition license, matching the top bar AI shortcuts and the scenario creation drawer:
  - XTM One unavailable (shared `isXtmOneAvailable` predicate: agentic AI not disabled + `platform_xtm_one_configured` + valid `platform_xtm_one_url`) -> the buttons are not rendered at all; only the Normal launch remains.
  - XTM One available but platform not EE -> the buttons become the standard EE call to action: an EE chip is shown next to them and clicking opens the Enterprise Edition dialog (feature "Autonomous attack path", exactly like the creation drawer's "Generate with AI" toggle) instead of the AI config drawer.
  - XTM One available and EE validated -> unchanged behavior (open the AI config drawer).
- Applies the same gate to the overview sample-preview **Autonomous** CTA (`Scenario.tsx`), which routes to the header's launch drawer via `?openAiLaunch=true`.
- Hardens the `?openAiBuilder=true` / `?openAiLaunch=true` deep-link effects with the same XTM One + EE guards, so a stale query parameter can no longer open the AI drawer on a non-eligible platform.
- Review follow-up: the `?openAiLaunch=true` deep-link effect now gates on `canLaunch` (not `canManage`), matching the two surfaces that produce the link (the overview Autonomous CTA and the hero Autonomous button, both rendered for launch-permission users); the `?openAiBuilder=true` deep link stays manage-gated like the AI builder icon.

Fixes #7368

## Test plan

- [x] `yarn lint` (eslint) clean
- [x] `yarn check-ts` clean
- [ ] Manual: with `platform_xtm_one_configured = false`, the hero shows only the Normal launch (no Autonomous, no AI builder icon)
- [ ] Manual: with XTM One configured on a CE platform, both buttons show an EE chip and clicking opens the EE dialog ("Autonomous attack path")
- [ ] Manual: with XTM One configured on an EE platform, both buttons open the AI config drawer as before
- [ ] Manual: a launch-only (no manage) user clicking the overview Autonomous CTA lands on the scenario with the launch drawer open
