### PR TITLE
fix(front): responsive autonomous-attack agent list and live heartbeat handling (#7370)

### DIFF
--- a/openaev-front/src/admin/components/autonomous/AutonomousAgentsSelector.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousAgentsSelector.tsx
@@ -319,13 +319,28 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
   }
 
   const renderRow = (row: RowData) => {
-    const cells: { field: string; node: ReactNode }[] = [
-      { field: 'agent_name', node: nameNode(row.name) },
-      { field: 'agent_description', node: descriptionNode(row.description) },
-      { field: 'agent_built_in', node: row.chip },
+    const cells: {
+      field: string;
+      node: ReactNode;
+    }[] = [
+      {
+        field: 'agent_name',
+        node: nameNode(row.name),
+      },
+      {
+        field: 'agent_description',
+        node: descriptionNode(row.description),
+      },
+      {
+        field: 'agent_built_in',
+        node: row.chip,
+      },
     ];
     if (showModes) {
-      cells.push({ field: 'agent_mode', node: row.modeNode });
+      cells.push({
+        field: 'agent_mode',
+        node: row.modeNode,
+      });
     }
     const content = isSmall
       ? (
@@ -363,7 +378,9 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
         <ListItemIcon sx={isSmall ? { marginTop: 0.5 } : undefined}>
           <SmartToyOutlined fontSize="small" sx={{ color: row.iconColor }} />
         </ListItemIcon>
-        <ListItemText primary={content} />
+        {/* disableTypography: the content is a Stack/div tree with its own Typography elements, so
+            the default span wrapper would produce invalid HTML (block elements inside a span). */}
+        <ListItemText disableTypography primary={content} />
       </ListItem>
     );
   };
@@ -433,6 +450,7 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
                     <Skeleton variant="circular" width={20} height={20} />
                   </ListItemIcon>
                   <ListItemText
+                    disableTypography
                     primary={isSmall
                       ? <Skeleton variant="text" width="70%" />
                       : (
@@ -485,6 +503,16 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
 
               {sorted.map((agent) => {
                 const enabled = enabledIds.includes(agent.id);
+                let modeNode: ReactNode = null;
+                if (showModes) {
+                  modeNode = enabled
+                    ? renderModeSelect(agent.id)
+                    : (
+                        <Typography variant="caption" color="text.disabled">
+                          -
+                        </Typography>
+                      );
+                }
                 return renderRow({
                   key: agent.id,
                   name: agentName(agent),
@@ -501,15 +529,7 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
                         />
                       )
                     : null,
-                  modeNode: !showModes
-                    ? null
-                    : enabled
-                        ? renderModeSelect(agent.id)
-                        : (
-                            <Typography variant="caption" color="text.disabled">
-                              -
-                            </Typography>
-                          ),
+                  modeNode,
                   trailing: (
                     <Switch
                       edge="end"

--- a/openaev-front/src/admin/components/autonomous/AutonomousAgentsSelector.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousAgentsSelector.tsx
@@ -318,11 +318,13 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
     trailing: ReactNode;
   }
 
+  interface RowCell {
+    field: string;
+    node: ReactNode;
+  }
+
   const renderRow = (row: RowData) => {
-    const cells: {
-      field: string;
-      node: ReactNode;
-    }[] = [
+    const cells: RowCell[] = [
       {
         field: 'agent_name',
         node: nameNode(row.name),
@@ -349,7 +351,9 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
               {nameNode(row.name)}
               {row.chip}
             </Stack>
-            {descriptionNode(row.description)}
+            {/* No placeholder dash on the stacked card - a dangling "-" line is just noise there
+                (the "-" only exists to keep the wide table's description column visually filled). */}
+            {row.description ? descriptionNode(row.description) : null}
             {showModes && row.modeNode ? <div>{row.modeNode}</div> : null}
           </Stack>
         )

--- a/openaev-front/src/admin/components/autonomous/AutonomousAgentsSelector.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousAgentsSelector.tsx
@@ -13,9 +13,10 @@ import {
   Switch,
   Tooltip,
   Typography,
+  useMediaQuery,
 } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
-import { type CSSProperties, type FunctionComponent, useMemo, useState } from 'react';
+import { type CSSProperties, type FunctionComponent, type ReactNode, useMemo, useState } from 'react';
 
 import { type AdditionalAgent, AUTONOMOUS_DISCOVERY_MODES, type AutonomousDiscoveryMode, ORCHESTRATOR_DEFAULT_DISCOVERY_MODE, SPECIALIST_DEFAULT_DISCOVERY_MODE } from '../../../actions/autonomous/autonomous-types';
 import colorStyles from '../../../components/Color';
@@ -99,6 +100,11 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
   const [keyword, setKeyword] = useState('');
   const [sortBy, setSortBy] = useState('agent_name');
   const [sortAsc, setSortAsc] = useState(true);
+
+  // The fixed-width, single-line column layout below needs real horizontal room (four columns plus a
+  // Select and the settings side-menu). Below `md` it collapses to a stacked card per agent where the
+  // name/description wrap and the toggle stays reachable, instead of truncating everything to nothing.
+  const isSmall = useMediaQuery(theme.breakpoints.down('md'));
 
   const showModes = !!onModeChange;
 
@@ -216,43 +222,24 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
         agent_built_in: { width: '20%' },
       };
 
+  // Column definitions drive ONLY the wide-screen sortable header row and column widths; the row body
+  // (both layouts) is rendered by renderRow so there is a single source of truth for cell content.
   const headers: Header[] = useMemo(() => {
     const base: Header[] = [
       {
         field: 'agent_name',
         label: 'Name',
         isSortable: true,
-        value: (agent: AdditionalAgent) => (
-          <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
-            {agentName(agent)}
-          </Typography>
-        ),
       },
       {
         field: 'agent_description',
         label: 'Description',
         isSortable: false,
-        value: (agent: AdditionalAgent) => (
-          <Typography variant="caption" color="text.secondary" noWrap title={agent.description ?? undefined}>
-            {agent.description ?? '-'}
-          </Typography>
-        ),
       },
       {
         field: 'agent_built_in',
         label: 'Built-in',
         isSortable: true,
-        value: (agent: AdditionalAgent) => (agent.slug === builtinSlug
-          ? (
-              <Chip
-                style={{
-                  ...chipInList,
-                  ...colorStyles.grey,
-                }}
-                label={t('Built-in')}
-              />
-            )
-          : undefined),
       },
     ];
     if (showModes) {
@@ -260,21 +247,10 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
         field: 'agent_mode',
         label: 'Discovery mode',
         isSortable: true,
-        value: (agent: AdditionalAgent) => {
-          const enabled = enabledIds.includes(agent.id);
-          if (!enabled) {
-            return (
-              <Typography variant="caption" color="text.disabled">
-                -
-              </Typography>
-            );
-          }
-          return renderModeSelect(agent.id);
-        },
       });
     }
     return base;
-  }, [showModes, enabledIds, modes, disabled, builtinSlug, theme]);
+  }, [showModes]);
 
   const filtered = useMemo(() => {
     const needle = keyword.trim().toLowerCase();
@@ -312,6 +288,85 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
       return sortAsc ? cmp : -cmp;
     });
   }, [filtered, sortBy, sortAsc, modes, builtinSlug]);
+
+  const nameNode = (name: string) => (
+    <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap={!isSmall}>
+      {name}
+    </Typography>
+  );
+  const descriptionNode = (description?: string | null) => (
+    <Typography
+      variant="caption"
+      color="text.secondary"
+      noWrap={!isSmall}
+      title={!isSmall ? (description ?? undefined) : undefined}
+      sx={isSmall ? { whiteSpace: 'normal' } : undefined}
+    >
+      {description ?? '-'}
+    </Typography>
+  );
+
+  // One row model shared by the orchestrator, every agent and both layouts, so the wide table and the
+  // small-screen stack can never drift and the toggle is always rendered as the ListItem's action.
+  interface RowData {
+    key: string;
+    name: string;
+    description?: string | null;
+    iconColor: string;
+    chip: ReactNode;
+    modeNode: ReactNode;
+    trailing: ReactNode;
+  }
+
+  const renderRow = (row: RowData) => {
+    const cells: { field: string; node: ReactNode }[] = [
+      { field: 'agent_name', node: nameNode(row.name) },
+      { field: 'agent_description', node: descriptionNode(row.description) },
+      { field: 'agent_built_in', node: row.chip },
+    ];
+    if (showModes) {
+      cells.push({ field: 'agent_mode', node: row.modeNode });
+    }
+    const content = isSmall
+      ? (
+          <Stack spacing={0.5} sx={{ minWidth: 0 }}>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ minWidth: 0 }}>
+              {nameNode(row.name)}
+              {row.chip}
+            </Stack>
+            {descriptionNode(row.description)}
+            {showModes && row.modeNode ? <div>{row.modeNode}</div> : null}
+          </Stack>
+        )
+      : (
+          <div style={bodyItemsStyles.bodyItems}>
+            {cells.map(cell => (
+              <div
+                key={cell.field}
+                style={{
+                  ...bodyItemsStyles.bodyItem,
+                  ...inlineStyles[cell.field],
+                }}
+              >
+                {cell.node}
+              </div>
+            ))}
+          </div>
+        );
+    return (
+      <ListItem
+        key={row.key}
+        divider
+        alignItems={isSmall ? 'flex-start' : 'center'}
+        secondaryAction={row.trailing}
+      >
+        <ListItemIcon sx={isSmall ? { marginTop: 0.5 } : undefined}>
+          <SmartToyOutlined fontSize="small" sx={{ color: row.iconColor }} />
+        </ListItemIcon>
+        <ListItemText primary={content} />
+      </ListItem>
+    );
+  };
 
   // Shared header row so the loading skeleton and the loaded list line up column-for-column.
   const headerRow = (
@@ -367,7 +422,7 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
       {loading
         ? (
             <List>
-              {headerRow}
+              {!isSmall && headerRow}
               {['s1', 's2', 's3'].map(key => (
                 <ListItem
                   key={key}
@@ -378,21 +433,23 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
                     <Skeleton variant="circular" width={20} height={20} />
                   </ListItemIcon>
                   <ListItemText
-                    primary={(
-                      <div style={bodyItemsStyles.bodyItems}>
-                        {headers.map(header => (
-                          <div
-                            key={header.field}
-                            style={{
-                              ...bodyItemsStyles.bodyItem,
-                              ...inlineStyles[header.field],
-                            }}
-                          >
-                            <Skeleton variant="text" width="80%" />
+                    primary={isSmall
+                      ? <Skeleton variant="text" width="70%" />
+                      : (
+                          <div style={bodyItemsStyles.bodyItems}>
+                            {headers.map(header => (
+                              <div
+                                key={header.field}
+                                style={{
+                                  ...bodyItemsStyles.bodyItem,
+                                  ...inlineStyles[header.field],
+                                }}
+                              >
+                                <Skeleton variant="text" width="80%" />
+                              </div>
+                            ))}
                           </div>
-                        ))}
-                      </div>
-                    )}
+                        )}
                   />
                 </ListItem>
               ))}
@@ -400,113 +457,70 @@ const AutonomousAgentsSelector: FunctionComponent<Props> = ({
           )
         : (
             <List>
-              {headerRow}
+              {!isSmall && headerRow}
 
-              {orchestrator && (
-                <ListItem
-                  divider
-                  secondaryAction={(
-                    <Tooltip title={t('The orchestrator is always active - it plans and drives the attack and cannot be disabled.')}>
-                      <span>
-                        <Switch edge="end" size="small" checked disabled inputProps={{ 'aria-label': orchestrator.name }} />
-                      </span>
-                    </Tooltip>
-                  )}
-                >
-                  <ListItemIcon>
-                    <SmartToyOutlined fontSize="small" sx={{ color: theme.palette.ai.main }} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={(
-                      <div style={bodyItemsStyles.bodyItems}>
-                        <div style={{
-                          ...bodyItemsStyles.bodyItem,
-                          ...inlineStyles.agent_name,
-                        }}
-                        >
-                          <Typography variant="body2" sx={{ fontWeight: 500 }} noWrap>
-                            {orchestrator.name}
-                          </Typography>
-                        </div>
-                        <div style={{
-                          ...bodyItemsStyles.bodyItem,
-                          ...inlineStyles.agent_description,
-                        }}
-                        >
-                          <Typography variant="caption" color="text.secondary" noWrap title={orchestrator.description}>
-                            {orchestrator.description ?? '-'}
-                          </Typography>
-                        </div>
-                        <div style={{
-                          ...bodyItemsStyles.bodyItem,
-                          ...inlineStyles.agent_built_in,
-                        }}
-                        >
-                          <Chip
-                            style={{
-                              ...chipInList,
-                              ...colorStyles.purple,
-                            }}
-                            label={t('Orchestrator')}
-                          />
-                        </div>
-                        {showModes && (
-                          <div style={{
-                            ...bodyItemsStyles.bodyItem,
-                            ...inlineStyles.agent_mode,
-                          }}
-                          >
-                            {renderModeSelect(orchestrator.id)}
-                          </div>
-                        )}
-                      </div>
-                    )}
+              {orchestrator && renderRow({
+                key: orchestrator.id,
+                name: orchestrator.name,
+                description: orchestrator.description,
+                iconColor: theme.palette.ai.main,
+                chip: (
+                  <Chip
+                    style={{
+                      ...chipInList,
+                      ...colorStyles.purple,
+                    }}
+                    label={t('Orchestrator')}
                   />
-                </ListItem>
-              )}
+                ),
+                modeNode: showModes ? renderModeSelect(orchestrator.id) : null,
+                trailing: (
+                  <Tooltip title={t('The orchestrator is always active - it plans and drives the attack and cannot be disabled.')}>
+                    <span>
+                      <Switch edge="end" size="small" checked disabled inputProps={{ 'aria-label': orchestrator.name }} />
+                    </span>
+                  </Tooltip>
+                ),
+              })}
 
               {sorted.map((agent) => {
                 const enabled = enabledIds.includes(agent.id);
-                return (
-                  <ListItem
-                    key={agent.id}
-                    divider
-                    secondaryAction={(
-                      <Switch
-                        edge="end"
-                        size="small"
-                        checked={enabled}
-                        disabled={disabled}
-                        onChange={event => onToggle(agent.id, event.target.checked)}
-                        inputProps={{ 'aria-label': agentName(agent) }}
-                      />
-                    )}
-                  >
-                    <ListItemIcon>
-                      <SmartToyOutlined
-                        fontSize="small"
-                        sx={{ color: enabled ? theme.palette.ai.main : theme.palette.text.disabled }}
-                      />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={(
-                        <div style={bodyItemsStyles.bodyItems}>
-                          {headers.map(header => (
-                            <div
-                              key={header.field}
-                              style={{
-                                ...bodyItemsStyles.bodyItem,
-                                ...inlineStyles[header.field],
-                              }}
-                            >
-                              {header.value?.(agent)}
-                            </div>
-                          ))}
-                        </div>
-                      )}
+                return renderRow({
+                  key: agent.id,
+                  name: agentName(agent),
+                  description: agent.description,
+                  iconColor: enabled ? theme.palette.ai.main : theme.palette.text.disabled,
+                  chip: agent.slug === builtinSlug
+                    ? (
+                        <Chip
+                          style={{
+                            ...chipInList,
+                            ...colorStyles.grey,
+                          }}
+                          label={t('Built-in')}
+                        />
+                      )
+                    : null,
+                  modeNode: !showModes
+                    ? null
+                    : enabled
+                        ? renderModeSelect(agent.id)
+                        : (
+                            <Typography variant="caption" color="text.disabled">
+                              -
+                            </Typography>
+                          ),
+                  trailing: (
+                    <Switch
+                      edge="end"
+                      size="small"
+                      checked={enabled}
+                      disabled={disabled}
+                      onChange={event => onToggle(agent.id, event.target.checked)}
+                      inputProps={{ 'aria-label': agentName(agent) }}
                     />
-                  </ListItem>
-                );
+                  ),
+                });
               })}
 
               {sorted.length === 0 && keyword.trim() && (

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -53,6 +53,23 @@ const MAX_QUESTION_CHOICES = 3;
 const ACTIVITY_EVENT_TYPES = ['DECISION', 'TOOL_ACTION', 'PROOF', 'GAP', 'HANDOVER', 'AGENT_DELEGATION', 'NARRATION'] as const;
 const isActivityType = (type: string | undefined): boolean => (ACTIVITY_EVENT_TYPES as readonly string[]).includes(type ?? '');
 
+// A heartbeat is a lightweight STATUS event the XTM One orchestrator emits every ~45s WHILE a
+// decision cycle is actively running (flagged {"heartbeat": true} in its data). It exists only to
+// keep this cockpit's "working" indicator honest and to nudge the graph poll during a long silent
+// burst - it is NOT an operator-facing decision. So it is filtered OUT of the visible timeline, yet
+// still counts for freshness: its timestamp resets the staleness backstop so the caption keeps
+// animating over the last real activity instead of collapsing to "Awaiting the next event".
+const isHeartbeatEvent = (event: AutonomousEvent | undefined): boolean => {
+  if (!event || event.autonomous_event_type !== 'STATUS' || !event.autonomous_event_data) {
+    return false;
+  }
+  try {
+    return (JSON.parse(event.autonomous_event_data) as { heartbeat?: boolean }).heartbeat === true;
+  } catch {
+    return false;
+  }
+};
+
 interface QuestionChoice {
   id: string;
   label: string;
@@ -481,10 +498,16 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     return () => clearInterval(interval);
   }, [isActive, refreshRun, pollTimeline]);
 
-  // Keep the stream pinned to the latest decision as it grows.
+  // Keep the stream pinned to the latest decision as it grows - but only when the operator is
+  // already at (or near) the bottom, so a background heartbeat tick or a new event never yanks them
+  // away from an older decision they scrolled up to read.
   useEffect(() => {
     const node = scrollRef.current;
-    if (node) {
+    if (!node) {
+      return;
+    }
+    const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight;
+    if (distanceFromBottom < 80) {
       node.scrollTop = node.scrollHeight;
     }
   }, [events.length]);
@@ -580,6 +603,11 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     e => isActivityType(e.autonomous_event_type),
   )?.autonomous_event_type;
 
+  // The operator-facing decision feed excludes heartbeats (they are freshness pings, not decisions),
+  // so a long silent burst does not fill the timeline with "Working" rows. Freshness/caption logic
+  // above still keys off the raw `events` (including heartbeats) so the cockpit stays animated.
+  const visibleEvents = events.filter(e => !isHeartbeatEvent(e));
+
   // The latest agent-delegation event drives the "delegating to / waiting for <agent>" caption. A
   // 'start' phase with no following 'result' reads as waiting (static), mirroring the parked model.
   const lastDelegation = [...events].reverse().find(
@@ -629,8 +657,14 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
       return false;
     }
   })();
-  // Parked only when the newest STATUS is a genuine end-of-cycle wait (NOT an engagement marker).
-  const parkedOnStatus = newestEvent?.autonomous_event_type === 'STATUS' && !engagedOnStatus;
+  // A heartbeat STATUS means the orchestrator is actively grinding a long cycle - the opposite of a
+  // park. It must NOT read as the calm "Awaiting the next event"; instead we fall through to the
+  // switch below so the caption keeps animating over the last real activity.
+  const heartbeatOnStatus = isHeartbeatEvent(newestEvent);
+  // Parked only when the newest STATUS is a genuine end-of-cycle wait (NOT an engagement marker and
+  // NOT a still-working heartbeat).
+  const parkedOnStatus = newestEvent?.autonomous_event_type === 'STATUS'
+    && !engagedOnStatus && !heartbeatOnStatus;
   // Has the orchestrator RESUMED since the operator answered? The backend run status stays
   // WAITING_INPUT until a later 3s poll flips it, so it lies about "still waiting" for a while. The
   // truthful signal is a fresh activity event: once the newest event is a DECISION / TOOL_ACTION /
@@ -854,7 +888,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
           padding: theme.spacing(1, 2),
         }}
       >
-        {events.length === 0 && !isActive
+        {visibleEvents.length === 0 && !isActive
           ? (
               <Stack sx={{
                 alignItems: 'center',
@@ -880,7 +914,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                 paddingBlock: 1,
               }}
               >
-                {events.map((event) => {
+                {visibleEvents.map((event) => {
                   const color = eventAccent(event, theme);
                   const eventTitle = sanitizeEventText(event.autonomous_event_title);
                   const eventContent = sanitizeEventText(event.autonomous_event_content);

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -63,6 +63,11 @@ const isHeartbeatEvent = (event: AutonomousEvent | undefined): boolean => {
   if (!event || event.autonomous_event_type !== 'STATUS' || !event.autonomous_event_data) {
     return false;
   }
+  // Cheap substring pre-check before the JSON.parse: this runs for every event on every render of
+  // the feed, and most STATUS payloads never mention "heartbeat" at all.
+  if (!event.autonomous_event_data.includes('"heartbeat"')) {
+    return false;
+  }
   try {
     return (JSON.parse(event.autonomous_event_data) as { heartbeat?: boolean }).heartbeat === true;
   } catch {

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -7,7 +7,7 @@ import {
 import { Box, Chip, CircularProgress, FormControlLabel, IconButton, Radio, RadioGroup, Stack, TextField, Typography } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import { alpha, useTheme } from '@mui/material/styles';
-import { type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { type FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   addAutonomousDirective,
@@ -41,6 +41,10 @@ const POLL_INTERVAL_MS = 3000;
 // (the reported stuck-cockpit symptom). A fresh event re-animates it. Sized above a normal cycle's
 // event cadence so an ordinary long action does not flip it to idle prematurely.
 const STALE_CAPTION_AFTER_MS = 180000;
+
+// The stream auto-follows the newest event only while the operator is within this distance (px) of
+// the bottom - anything further means they deliberately scrolled up to read an older decision.
+const STICK_TO_BOTTOM_THRESHOLD_PX = 80;
 
 // Cap the proposed one-click choices so the callout stays scannable: at most this many radio options
 // are ever shown, and the always-present free-text composer below is the escape hatch for anything
@@ -385,6 +389,12 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   const [answeredQuestionId, setAnsweredQuestionId] = useState<string | null>(null);
   const cursorRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Whether the operator is at (or near) the bottom of the stream, sampled in the onScroll handler
+  // - i.e. BEFORE new content grows the list. Measuring inside the pin effect below would run
+  // after render, when a tall new decision has already pushed the bottom away by more than the
+  // threshold, silently breaking the auto-follow exactly when the operator was reading live.
+  // Starts true so a fresh stream pins to the newest event.
+  const stickToBottomRef = useRef(true);
   // Identity of the run/simulation the stream is currently populated for. The reset-and-reload
   // effect below keys off this so it fires ONLY on a genuine run or simulation switch (navigation /
   // restart) - never spuriously on a re-render, which would blank the live stream to empty (and drop
@@ -485,6 +495,9 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     }
     streamKeyRef.current = nextKey;
     cursorRef.current = 0;
+    // A fresh stream should follow its newest event even if the operator had scrolled up in the
+    // previous run's timeline.
+    stickToBottomRef.current = true;
     setEvents([]);
     pollTimelineRef.current();
   }, [runId, simulationId]);
@@ -503,19 +516,24 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     return () => clearInterval(interval);
   }, [isActive, refreshRun, pollTimeline]);
 
-  // Keep the stream pinned to the latest decision as it grows - but only when the operator is
-  // already at (or near) the bottom, so a background heartbeat tick or a new event never yanks them
-  // away from an older decision they scrolled up to read.
+  // The operator-facing decision feed excludes heartbeats (they are freshness pings, not
+  // decisions), so a long silent burst does not fill the timeline with "Working" rows. The
+  // freshness/caption logic below still keys off the raw `events` (including heartbeats) so the
+  // cockpit stays animated. Memoised: the predicate JSON-parses STATUS payloads, so it should run
+  // once per new batch of events, not on every incidental re-render.
+  const visibleEvents = useMemo(() => events.filter(e => !isHeartbeatEvent(e)), [events]);
+
+  // Keep the stream pinned to the latest decision as it grows - but only while the operator was
+  // already at (or near) the bottom before the new content rendered (see stickToBottomRef), so a
+  // new event never yanks them away from an older decision they scrolled up to read. Keyed on the
+  // VISIBLE feed length: filtered-out heartbeats do not change the rendered stream, so they should
+  // not re-trigger the pin at all.
   useEffect(() => {
     const node = scrollRef.current;
-    if (!node) {
-      return;
-    }
-    const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight;
-    if (distanceFromBottom < 80) {
+    if (node && stickToBottomRef.current) {
       node.scrollTop = node.scrollHeight;
     }
-  }, [events.length]);
+  }, [visibleEvents.length]);
 
   const isWaitingInput = status === 'WAITING_INPUT';
   const latestQuestion = isWaitingInput
@@ -607,11 +625,6 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   const lastActivityType = [...events].reverse().find(
     e => isActivityType(e.autonomous_event_type),
   )?.autonomous_event_type;
-
-  // The operator-facing decision feed excludes heartbeats (they are freshness pings, not decisions),
-  // so a long silent burst does not fill the timeline with "Working" rows. Freshness/caption logic
-  // above still keys off the raw `events` (including heartbeats) so the cockpit stays animated.
-  const visibleEvents = events.filter(e => !isHeartbeatEvent(e));
 
   // The latest agent-delegation event drives the "delegating to / waiting for <agent>" caption. A
   // 'start' phase with no following 'result' reads as waiting (static), mirroring the parked model.
@@ -887,6 +900,10 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
       {/* Reasoning stream. */}
       <Box
         ref={scrollRef}
+        onScroll={(event) => {
+          const node = event.currentTarget;
+          stickToBottomRef.current = node.scrollHeight - node.scrollTop - node.clientHeight < STICK_TO_BOTTOM_THRESHOLD_PX;
+        }}
         sx={{
           flex: 1,
           overflowY: 'auto',


### PR DESCRIPTION
Fixes the OpenAEV frontend half of the autonomous attack-path sweep. Pairs with the XTM One backend PR (heartbeat emission + payload authoring correctness) for issue XTM-One-Platform/xtm-one#2839; both ship together. Closes #7370.

## Summary

- Keep the autonomous cockpit "working" while XTM One grinds a long decision cycle, by consuming the new heartbeat STATUS events without polluting the decision feed or hijacking the operator's scroll.
- Make the autonomous-attack agent list fully responsive so enable/disable works on small screens instead of truncating everything off-screen.

## Changes

### Heartbeat-aware cockpit (`AutonomousReasoningPanel.tsx`)

- New `isHeartbeatEvent()` recognizes the STATUS events flagged `data.heartbeat = true`, with a cheap substring pre-check before `JSON.parse` so non-heartbeat STATUS payloads never pay for a parse.
- The "parked / Awaiting the next event" state now excludes heartbeats, so an actively grinding run keeps its animated "working" caption.
- The visible decision feed filters heartbeats out (they are freshness pings, not decisions) and is memoized so the filter runs once per event batch; freshness/caption logic still keys off the raw event stream including heartbeats.
- Auto-scroll only pins to the latest event when the operator is already near the bottom. The stickiness is sampled in `onScroll` (before new content renders), so a tall new decision cannot break auto-follow for an operator reading live, and a background heartbeat never yanks them off an older decision they scrolled up to read.

### Responsive agent list (`AutonomousAgentsSelector.tsx`)

- Below the `md` breakpoint the list switches from the fixed-width, single-line multi-column table to a stacked card per agent: name + chip on the first line, the description wrapping underneath (hidden when empty instead of a dangling dash), the discovery-mode selector on its own line.
- The enable/disable Switch stays the ListItem action in both layouts, so it is always visible and reachable (no longer hidden behind truncated columns).
- Name/description wrap on small screens (single-line only on wide); the sortable header row is hidden on small screens where there are no columns.
- Refactored the orchestrator row and agent rows through one `renderRow` helper (single row model) so the wide table and the small-screen stack cannot drift; the now-dead per-column render functions were trimmed from the column defs (which now drive only the header labels and column widths). Loading skeletons are responsive too.
- Row content is rendered with `disableTypography` on `ListItemText` so the block-level card layout is not nested inside the default inline span wrapper (invalid HTML).
- The same shared component powers the run-launch drawer, which benefits from the same responsive behaviour.

## Review

- Both Copilot review comments are addressed: the heartbeat predicate has a pre-parse guard + memoized call site, and the ListItemText wrappers use `disableTypography`.
- An independent review pass added the scroll-stickiness hardening (sampled before render) and the small-screen empty-description cleanup.

## Test plan

- Settings > Customization > Autonomous attack at a narrow viewport: rows stack, description wraps, and each specialist can be toggled on/off; the orchestrator shows its locked-on switch and tooltip.
- Wide viewport: the sortable multi-column table is unchanged.
- Run a long autonomous cycle: the cockpit stays "working" (no "Awaiting the next event") while heartbeats arrive, heartbeats never appear as decision rows, and scrolling up to an older decision is not interrupted.
- `yarn lint` and `yarn check-ts` clean.
