### PR TITLE
fix(chaining): scenario import not working when multiple injector types for a same tenant exist (#5048)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -2778,7 +2778,7 @@ public class V1_DataImporter implements Importer {
 
     // (b) Injector of the referenced type must exist on the target instance.
     String injectorType = extractInjectorType(injectContractNode);
-    if (hasText(injectorType) && injectorService.injectorByType(injectorType).isEmpty()) {
+    if (hasText(injectorType) && !injectorService.injectorTypeExists(injectorType)) {
       return Optional.of(
           new SkippedWorkflowStep(SkippedWorkflowStepType.INJECTOR, injectTitle, injectorType));
     }

--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -2745,7 +2745,8 @@ public class V1_DataImporter implements Importer {
    *
    * <ul>
    *   <li>(b) its injector type ({@code injector_contract_injector_type}) is present but no
-   *       injector of that type exists on the target ({@link InjectorService#injectorByType}); or
+   *       injector of that type exists on the target ({@link
+   *       InjectorService#injectorTypeExists(String)}); or
    *   <li>(a) its injector contract is neither already present on the target for the current tenant
    *       ({@code existsByContractIdAndTenant} / previously resolved) nor resolvable read-only from
    *       the payload external id ({@link #resolveInjectorContractReadOnly}).

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -328,9 +328,9 @@ public class PhishingLandingPageService {
   public InjectorContract synchroniseInjectorContract(
       @NotNull final PhishingLandingPage landingPage) {
     String tenantId = resolveTenantId(landingPage);
-    Injector injector =
-        injectorRepository.findByTypeAndTenantId(PhishingContract.TYPE, tenantId).orElse(null);
-    if (injector == null) {
+    List<Injector> injectors =
+        injectorRepository.findByPhishingContractTypeByTenantId(PhishingContract.TYPE, tenantId);
+    if (injectors.isEmpty()) {
       log.warn("Phishing injector not registered for tenant {}, skipping contract sync", tenantId);
       return null;
     }
@@ -345,7 +345,7 @@ public class PhishingLandingPageService {
                   return created;
                 });
 
-    Contract contract = buildContract(landingPage, injector, tenantId);
+    Contract contract = buildContract(landingPage);
 
     // Prefix so Threat Arsenal search / category browsing makes the phishing origin obvious.
     Map<String, String> labels =
@@ -355,7 +355,7 @@ public class PhishingLandingPageService {
             "fr",
             "Hameconnage : " + landingPage.getName());
     injectorContract.setLabels(labels);
-    injectorContract.addInjector(injector);
+    injectors.forEach(injectorContract::addInjector);
 
     // The Threat Arsenal and the atomic-testing picker read these entity columns, NOT the
     // serialized
@@ -421,8 +421,7 @@ public class PhishingLandingPageService {
         : TenantContext.getCurrentTenant();
   }
 
-  private Contract buildContract(
-      final PhishingLandingPage landingPage, final Injector injector, final String tenantId) {
+  private Contract buildContract(final PhishingLandingPage landingPage) {
     ContractConfig contractConfig = phishingContract.getConfig();
 
     // Email template chooser populated from the tenant's reusable templates.

--- a/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/security_platforms/SecurityPlatformApi.java
@@ -160,9 +160,11 @@ public class SecurityPlatformApi {
       return;
     }
     injectorRepository
-        .findByTypeAndTenantId(externalReference, securityPlatform.getTenant().getId())
+        .findBySecurityPlatformExternalReferenceByTenantId(
+            externalReference, securityPlatform.getTenant().getId())
+        .stream()
         .filter(injector -> injector.getSecurityPlatform() == null)
-        .ifPresent(
+        .forEach(
             injector -> {
               injector.setSecurityPlatform(securityPlatform);
               injectorRepository.save(injector);

--- a/openaev-api/src/main/java/io/openaev/service/InjectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectorService.java
@@ -214,28 +214,11 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
 
   /**
    * Checks whether at least one injector of the given type exists for the current tenant. Multiple
-   * injector instances of the same type are supported since V4_77 (Connector Manager); use this
-   * instead of injectorByType() when only existence matters and no NonUniqueResultException risk is
-   * acceptable.
+   * injector instances of the same type are supported since V4_77 (Connector Manager).
    */
   public boolean injectorTypeExists(@NotBlank final String injectorType) {
     return injectorRepository.existsByTypeAndTenantId(
         injectorType, TenantContext.getCurrentTenant());
-  }
-
-  /**
-   * Find injector by its type.
-   *
-   * @param injectorType injector type to search for
-   * @return an Optional containing the injector if found, empty otherwise
-   * @deprecated Since V4_77 (Connector Manager), an injector type is no longer guaranteed unique
-   *     per tenant - multiple instances of the same connector type may coexist. This method throws
-   *     NonUniqueResultException if more than one result exists. Prefer {@link
-   *     InjectorService#injectorTypeExists(String)} (backed by existsByTypeAndTenantId) when only
-   *     existence matters.
-   */
-  public Optional<Injector> injectorByType(@NotBlank final String injectorType) {
-    return injectorRepository.findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant());
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/InjectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectorService.java
@@ -213,10 +213,26 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
   }
 
   /**
-   * Find injector by its type
+   * Checks whether at least one injector of the given type exists for the current tenant. Multiple
+   * injector instances of the same type are supported since V4_77 (Connector Manager); use this
+   * instead of injectorByType() when only existence matters and no NonUniqueResultException risk is
+   * acceptable.
+   */
+  public boolean injectorTypeExists(@NotBlank final String injectorType) {
+    return injectorRepository.existsByTypeAndTenantId(
+        injectorType, TenantContext.getCurrentTenant());
+  }
+
+  /**
+   * Find injector by its type.
    *
    * @param injectorType injector type to search for
    * @return an Optional containing the injector if found, empty otherwise
+   * @deprecated Since V4_77 (Connector Manager), an injector type is no longer guaranteed unique
+   *     per tenant - multiple instances of the same connector type may coexist. This method throws
+   *     NonUniqueResultException if more than one result exists. Prefer {@link
+   *     InjectorService#injectorTypeExists(String)} (backed by existsByTypeAndTenantId) when only
+   *     existence matters.
    */
   public Optional<Injector> injectorByType(@NotBlank final String injectorType) {
     return injectorRepository.findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant());

--- a/openaev-api/src/test/java/io/openaev/executors/ExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/ExecutorTest.java
@@ -1,7 +1,6 @@
 package io.openaev.executors;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -132,8 +131,6 @@ class ExecutorTest {
       // -------- Assert --------
       verify(injectorRepository)
           .findFirstByContractsCompositeIdIdAndTenantId(CONTRACT_ID, TENANT_ID);
-      // The stale, filter-guarded fallback must not be used anymore
-      verify(injectorRepository, never()).findByTypeAndTenantId(any(), any());
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -22,6 +22,7 @@ import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationF
 import io.openaev.rest.domain.DomainService;
 import io.openaev.rest.domain.enums.PresetDomain;
 import io.openaev.utils.constants.Constants;
+import io.openaev.utils.fixtures.InjectorFixture;
 import io.openaev.utils.fixtures.PayloadFixture;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
@@ -2204,6 +2205,57 @@ class V1_DataImporterTest extends IntegrationTest {
     assertTrue(
         result.missingActions().isEmpty(),
         "recreating the embedded payload must not report a missing action");
+  }
+
+  @Test
+  @Transactional
+  @WithMockUser
+  void
+      given_twoInjectorsWithSameTypeForTenant_when_importingWorkflowStep_shouldRemainResolvableWithoutNonUniqueFailure()
+          throws Exception {
+    // -- Arrange --
+    openaevInjectorIntegrationFactory.registerConnectorForTenant(TenantContext.getCurrentTenant());
+    ObjectNode importData = (ObjectNode) readMissingContractWithPayloadFixture();
+    String injectorType =
+        importData
+            .get("scenario_workflow")
+            .get("workflow_steps")
+            .get(0)
+            .get("step_data")
+            .get("inject_injector_contract")
+            .get("injector_contract_injector_type")
+            .asText();
+    assertFalse(injectorType.isBlank(), "fixture must carry an injector type");
+
+    Injector duplicateInjector =
+        InjectorFixture.createInjector(
+            UUID.randomUUID().toString(), "duplicate importer injector", injectorType);
+    injectorRepository.save(duplicateInjector);
+    entityManager.flush();
+    entityManager.clear();
+
+    // -- Act --
+    ImportResult result =
+        assertDoesNotThrow(
+            () ->
+                this.importer.importData(
+                    importData,
+                    Map.of(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    Constants.IMPORTED_OBJECT_NAME_SUFFIX));
+
+    // -- Assert --
+    Workflow workflow = findImportedWorkflow("wf step missing contract payload");
+    assertEquals(
+        1,
+        stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId(workflow.getId()).size(),
+        "the chaining step must stay resolvable when multiple injectors share the same type");
+    assertTrue(
+        result.missingActions().isEmpty(),
+        "no missing action must be reported when at least one injector of the type exists");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -210,10 +210,9 @@ class V1_DataImporterTest extends IntegrationTest {
             .findById("93d27459-68d0-43b1-ad65-eacc3cfa5cf7")
             .orElseThrow();
     assertTrue(importedContract.getInjectors().isEmpty());
-    assertTrue(
-        this.injectorRepository
-            .findByTypeAndTenantId(NMAP_DUMMY_INJECTOR_TYPE, TenantContext.getCurrentTenant())
-            .isEmpty());
+    assertFalse(
+        this.injectorRepository.existsByTypeAndTenantId(
+            NMAP_DUMMY_INJECTOR_TYPE, TenantContext.getCurrentTenant()));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
@@ -83,8 +83,8 @@ class PhishingLandingPageServiceTest {
     PhishingLandingPage landingPage = new PhishingLandingPage();
     landingPage.setId("lp-1");
     landingPage.setName("Login page");
-    when(injectorRepository.findByTypeAndTenantId(eq(PhishingContract.TYPE), any()))
-        .thenReturn(Optional.empty());
+    when(injectorRepository.findByPhishingContractTypeByTenantId(eq(PhishingContract.TYPE), any()))
+        .thenReturn(List.of());
 
     // -- ACT --
     InjectorContract contract = phishingLandingPageService.synchroniseInjectorContract(landingPage);
@@ -105,8 +105,8 @@ class PhishingLandingPageServiceTest {
 
     Injector injector = new Injector();
     injector.setId("phishing-injector");
-    when(injectorRepository.findByTypeAndTenantId(eq(PhishingContract.TYPE), any()))
-        .thenReturn(Optional.of(injector));
+    when(injectorRepository.findByPhishingContractTypeByTenantId(eq(PhishingContract.TYPE), any()))
+        .thenReturn(List.of(injector));
     when(injectorContractRepository.findById(any(InjectorContractId.class)))
         .thenReturn(Optional.empty());
 
@@ -212,8 +212,8 @@ class PhishingLandingPageServiceTest {
   private void arrangeSynchroniseStubs() throws Exception {
     Injector injector = new Injector();
     injector.setId("phishing-injector");
-    when(injectorRepository.findByTypeAndTenantId(eq(PhishingContract.TYPE), any()))
-        .thenReturn(Optional.of(injector));
+    when(injectorRepository.findByPhishingContractTypeByTenantId(eq(PhishingContract.TYPE), any()))
+        .thenReturn(List.of(injector));
     when(injectorContractRepository.findById(any(InjectorContractId.class)))
         .thenReturn(Optional.empty());
     when(phishingContract.getConfig())
@@ -317,8 +317,8 @@ class PhishingLandingPageServiceTest {
     when(landingPageRepository.findById("lp-1")).thenReturn(Optional.of(landingPage));
     when(documentService.document("doc-dark")).thenReturn(darkLogo);
     when(landingPageRepository.save(any(PhishingLandingPage.class))).thenReturn(landingPage);
-    when(injectorRepository.findByTypeAndTenantId(eq(PhishingContract.TYPE), any()))
-        .thenReturn(Optional.empty());
+    when(injectorRepository.findByPhishingContractTypeByTenantId(eq(PhishingContract.TYPE), any()))
+        .thenReturn(List.of());
 
     // -- ACT --
     PhishingLandingPage updated = phishingLandingPageService.updateLogos("lp-1", "doc-dark", null);
@@ -363,8 +363,8 @@ class PhishingLandingPageServiceTest {
     // -- ARRANGE --
     when(landingPageRepository.save(any(PhishingLandingPage.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
-    when(injectorRepository.findByTypeAndTenantId(eq(PhishingContract.TYPE), any()))
-        .thenReturn(Optional.empty());
+    when(injectorRepository.findByPhishingContractTypeByTenantId(eq(PhishingContract.TYPE), any()))
+        .thenReturn(List.of());
 
     for (String url :
         new String[] {"/dashboard", "https://example.com/next", "http://example.com"}) {

--- a/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
@@ -4,8 +4,6 @@ import static io.openaev.rest.asset.security_platforms.SecurityPlatformApi.SECUR
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -29,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -94,8 +91,9 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("existsByTypeAndTenantId stays safe with duplicate injector types per tenant")
-  void existsByTypeSupportsNonUniqueTypes() {
+  @DisplayName(
+      "findBySecurityPlatformExternalReferenceByTenantId supports duplicates and returns all matches")
+  void findBySecurityPlatformExternalReferenceSupportsNonUniqueTypes() {
     String duplicateType = "duplicate-type-" + UUID.randomUUID();
     injectorRepository.save(
         InjectorFixture.createInjector(UUID.randomUUID().toString(), "dup-1", duplicateType));
@@ -104,14 +102,12 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
     entityManager.flush();
     entityManager.clear();
 
-    assertTrue(
-        injectorRepository.existsByTypeAndTenantId(
-            duplicateType, TenantContext.getCurrentTenant()));
-    assertThrows(
-        IncorrectResultSizeDataAccessException.class,
-        () ->
-            injectorRepository.findByTypeAndTenantId(
-                duplicateType, TenantContext.getCurrentTenant()));
+    assertEquals(
+        2,
+        injectorRepository
+            .findBySecurityPlatformExternalReferenceByTenantId(
+                duplicateType, TenantContext.getCurrentTenant())
+            .size());
   }
 
   @Test
@@ -150,7 +146,10 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
 
     Injector linked =
         injectorRepository
-            .findByTypeAndTenantId(INJECTOR_TYPE, TenantContext.getCurrentTenant())
+            .findBySecurityPlatformExternalReferenceByTenantId(
+                INJECTOR_TYPE, TenantContext.getCurrentTenant())
+            .stream()
+            .findFirst()
             .orElseThrow();
     injectorRepository.delete(linked);
     entityManager.flush();
@@ -207,7 +206,10 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
     // The caller's injector links to the caller-tenant platform, not the foreign one.
     Injector reloaded =
         injectorRepository
-            .findByTypeAndTenantId(INJECTOR_TYPE, TenantContext.getCurrentTenant())
+            .findBySecurityPlatformExternalReferenceByTenantId(
+                INJECTOR_TYPE, TenantContext.getCurrentTenant())
+            .stream()
+            .findFirst()
             .orElseThrow();
     assertEquals(platformId, reloaded.getSecurityPlatform().getId());
   }

--- a/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/asset/security_platforms/SecurityPlatformInjectorLifecycleTest.java
@@ -4,6 +4,8 @@ import static io.openaev.rest.asset.security_platforms.SecurityPlatformApi.SECUR
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -88,6 +91,27 @@ class SecurityPlatformInjectorLifecycleTest extends IntegrationTest {
     entityManager.flush();
     entityManager.clear();
     return JsonPath.read(response, "$.asset_id");
+  }
+
+  @Test
+  @DisplayName("existsByTypeAndTenantId stays safe with duplicate injector types per tenant")
+  void existsByTypeSupportsNonUniqueTypes() {
+    String duplicateType = "duplicate-type-" + UUID.randomUUID();
+    injectorRepository.save(
+        InjectorFixture.createInjector(UUID.randomUUID().toString(), "dup-1", duplicateType));
+    injectorRepository.save(
+        InjectorFixture.createInjector(UUID.randomUUID().toString(), "dup-2", duplicateType));
+    entityManager.flush();
+    entityManager.clear();
+
+    assertTrue(
+        injectorRepository.existsByTypeAndTenantId(
+            duplicateType, TenantContext.getCurrentTenant()));
+    assertThrows(
+        IncorrectResultSizeDataAccessException.class,
+        () ->
+            injectorRepository.findByTypeAndTenantId(
+                duplicateType, TenantContext.getCurrentTenant()));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/tenants/TenantServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/tenants/TenantServiceTest.java
@@ -162,8 +162,10 @@ class TenantServiceTest extends IntegrationTest {
     session.enableFilter("tenantFilter").setParameter("tenantId", created.getId());
 
     Injector emailInjector =
-        injectorRepository
-            .findByTypeAndTenantId(EmailContract.TYPE, created.getId())
+        injectorRepository.findAll().stream()
+            .filter(i -> EmailContract.TYPE.equals(i.getType()))
+            .filter(i -> created.getId().equals(i.getTenantId()))
+            .findFirst()
             .orElseThrow(
                 () -> new AssertionError("the email injector was not provisioned for the tenant"));
     assertThat(emailInjector.getContracts())
@@ -178,8 +180,10 @@ class TenantServiceTest extends IntegrationTest {
     session = entityManager.unwrap(Session.class);
     session.enableFilter("tenantFilter").setParameter("tenantId", DEFAULT_TENANT_UUID);
     Injector defaultEmailInjector =
-        injectorRepository
-            .findByTypeAndTenantId(EmailContract.TYPE, DEFAULT_TENANT_UUID)
+        injectorRepository.findAll().stream()
+            .filter(i -> EmailContract.TYPE.equals(i.getType()))
+            .filter(i -> DEFAULT_TENANT_UUID.equals(i.getTenantId()))
+            .findFirst()
             .orElseThrow(() -> new AssertionError("the default tenant lost its email injector"));
     assertThat(defaultEmailInjector.getContracts())
         .as("the default tenant's link must be untouched by the new-tenant copy")

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/InjectorFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/InjectorFixture.java
@@ -76,8 +76,10 @@ public class InjectorFixture {
       throw new RuntimeException("Failed to initialize injector: " + injectorType, e);
     }
 
-    return injectorRepository
-        .findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant())
+    return injectorRepository.findAll().stream()
+        .filter(i -> injectorType.equals(i.getType()))
+        .filter(i -> TenantContext.getCurrentTenant().equals(i.getTenantId()))
+        .findFirst()
         .orElseThrow(
             () ->
                 new IllegalStateException(
@@ -87,8 +89,10 @@ public class InjectorFixture {
   private Injector getWellKnownInjector(
       String injectorType, BuiltinIntegrationFactory factory, boolean isPayload) {
     Injector injector =
-        injectorRepository
-            .findByTypeAndTenantId(injectorType, TenantContext.getCurrentTenant())
+        injectorRepository.findAll().stream()
+            .filter(i -> injectorType.equals(i.getType()))
+            .filter(i -> TenantContext.getCurrentTenant().equals(i.getTenantId()))
+            .findFirst()
             .orElseGet(() -> initializeBuiltInInjector(factory, injectorType));
     // ensure the injector is marked for payloads
     // some tests not running in a transaction may flip this

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorRepository.java
@@ -18,6 +18,15 @@ public interface InjectorRepository
 
   Optional<Injector> findByIdAndTenantId(@NotNull String id, @NotNull String tenantId);
 
+  boolean existsByTypeAndTenantId(@NotNull String type, @NotNull String tenantId);
+
+  /**
+   * @deprecated Since V4_77 (Connector Manager), an injector type is no longer guaranteed unique
+   *     per tenant - multiple instances of the same connector type may coexist. This method throws
+   *     NonUniqueResultException if more than one result exists. Prefer {@code
+   *     InjectorService#injectorTypeExists(String)} (backed by existsByTypeAndTenantId) when only
+   *     existence matters.
+   */
   @NotNull
   Optional<Injector> findByTypeAndTenantId(@NotNull String type, @NotNull String tenantId);
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorRepository.java
@@ -20,15 +20,21 @@ public interface InjectorRepository
 
   boolean existsByTypeAndTenantId(@NotNull String type, @NotNull String tenantId);
 
-  /**
-   * @deprecated Since V4_77 (Connector Manager), an injector type is no longer guaranteed unique
-   *     per tenant - multiple instances of the same connector type may coexist. This method throws
-   *     NonUniqueResultException if more than one result exists. Prefer {@code
-   *     InjectorService#injectorTypeExists(String)} (backed by existsByTypeAndTenantId) when only
-   *     existence matters.
-   */
-  @NotNull
-  Optional<Injector> findByTypeAndTenantId(@NotNull String type, @NotNull String tenantId);
+  @Query(
+      "SELECT i FROM Injector i "
+          + "WHERE i.type = :externalReference AND i.tenantId = :tenantId "
+          + "ORDER BY i.id")
+  List<Injector> findBySecurityPlatformExternalReferenceByTenantId(
+      @Param("externalReference") @NotNull String externalReference,
+      @Param("tenantId") @NotNull String tenantId);
+
+  @Query(
+      "SELECT i FROM Injector i "
+          + "WHERE i.type = :contractType AND i.tenantId = :tenantId "
+          + "ORDER BY i.id")
+  List<Injector> findByPhishingContractTypeByTenantId(
+      @Param("contractType") @NotNull String contractType,
+      @Param("tenantId") @NotNull String tenantId);
 
   @Query(
       "SELECT l.injector FROM InjectorInjectorContract l "


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removed legacy findbyTypeAndTenantId function from InjectorRepository (unicity of type doesn't exist anymore)
* Created new functions to replace it

### Testing Instructions

1. Deploy multiple instance of an injector on your testing instance (example: 2 netexec)
2. Create a simulation with an inject using one of these injector and export it
3. Import it again, it should work

### Related issues

* Closes https://github.com/OpenAEV-Platform/filigran-private/issues/305

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
