### PR TITLE
fix(front): keep the scenario overview while AI planning is active (#7386)

### DIFF
--- a/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
@@ -274,10 +274,9 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
     .catch(() => {}), [runId]);
 
   useEffect(() => {
-    if (usesSharedTimeline) {
-      return undefined;
+    if (!usesSharedTimeline) {
+      reload();
     }
-    reload();
   }, [reload, usesSharedTimeline]);
 
   const isActive = ACTIVE_STATUSES.includes(status);

--- a/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
@@ -216,8 +216,11 @@ const OutcomeCard: FunctionComponent<{
 interface AutonomousOutcomeProps {
   run: AutonomousRun;
   // Live cockpit polls the timeline while the run is active; the durable read on a settled scenario
-  // fetches once and never polls. Defaults to live.
+  // fetches once and never polls. Defaults to live. Ignored when `sharedEvents` is provided.
   live?: boolean;
+  // When the parent already owns a live timeline (the reasoning panel), reuse it instead of
+  // starting a second full-from-cursor-0 poll of the same endpoint.
+  sharedEvents?: AutonomousEvent[];
 }
 
 /**
@@ -231,7 +234,7 @@ interface AutonomousOutcomeProps {
  * the proofs column, the "Proofs" hero stat and the sample PROOF timeline node are all dropped, and
  * the gaps column takes the full width.
  */
-const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, live = true }) => {
+const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, live = true, sharedEvents }) => {
   const theme = useTheme();
   const { t, nsdt, vnsdt } = useFormatter();
   const accent = theme.palette.ai?.main ?? theme.palette.primary.main;
@@ -244,7 +247,7 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
   const status = run.autonomous_run_status;
   const simulationId = run.autonomous_run_simulation_id;
 
-  const [events, setEvents] = useState<AutonomousEvent[]>([]);
+  const [events, setEvents] = useState<AutonomousEvent[]>(sharedEvents ?? []);
   // The gap / proof card the operator drilled into, with the tags already
   // extracted so the dialog does not re-parse them.
   const [selectedOutcome, setSelectedOutcome] = useState<{
@@ -259,24 +262,34 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
   const timelineScrollRef = useRef<HTMLDivElement | null>(null);
   const timelinePinnedRef = useRef(true);
 
+  const usesSharedTimeline = sharedEvents !== undefined;
+  useEffect(() => {
+    if (sharedEvents !== undefined) {
+      setEvents(sharedEvents);
+    }
+  }, [sharedEvents]);
+
   const reload = useCallback(() => fetchAutonomousTimeline(runId, 0)
     .then(res => setEvents(res.data ?? []))
     .catch(() => {}), [runId]);
 
   useEffect(() => {
+    if (usesSharedTimeline) {
+      return undefined;
+    }
     reload();
-  }, [reload]);
+  }, [reload, usesSharedTimeline]);
 
   const isActive = ACTIVE_STATUSES.includes(status);
   useEffect(() => {
-    if (!live || !isActive) {
+    if (usesSharedTimeline || !live || !isActive) {
       return undefined;
     }
     const interval = setInterval(() => {
       reload();
     }, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [live, isActive, reload]);
+  }, [live, isActive, reload, usesSharedTimeline]);
 
   // Keep timelinePinnedRef in sync with how close the operator is to the right
   // edge, so we only tail-follow when they are already watching the latest.

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -326,6 +326,9 @@ interface AutonomousReasoningPanelProps {
   run: AutonomousRun;
   /** Lift status transitions up so the hero + tab set stay in sync without a second poll loop. */
   onRunUpdate?: (run: AutonomousRun) => void;
+  /** Share the incrementally polled timeline with a sibling (the overview outcome layer) so that
+   *  layer does not start a second full-from-cursor-0 poll of the same endpoint. */
+  onTimelineEvents?: (events: AutonomousEvent[]) => void;
   /** Live panel width (px), owned by the parent via {@link useAutonomousPanelWidth} so the content
    *  padding follows the drag. */
   width?: number;
@@ -348,6 +351,7 @@ interface AutonomousReasoningPanelProps {
 const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps> = ({
   run: initialRun,
   onRunUpdate,
+  onTimelineEvents,
   width = AUTONOMOUS_PANEL_WIDTH,
   onWidthChange,
   readOnly = false,
@@ -364,6 +368,9 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
 
   const [run, setRun] = useState<AutonomousRun>(initialRun);
   const [events, setEvents] = useState<AutonomousEvent[]>([]);
+  useEffect(() => {
+    onTimelineEvents?.(events);
+  }, [events, onTimelineEvents]);
   const [directive, setDirective] = useState('');
   // Which proposed one-click choice the operator picked (null = none; they can still type freely in
   // the always-visible composer, which takes precedence over a selected choice).

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -85,7 +85,11 @@ const IndexScenarioComponent: FunctionComponent<{
     if (cockpitStreamKeyRef.current === nextKey) {
       return;
     }
-    if (cockpitStreamKeyRef.current !== null && !simulationId) {
+    const previousRunId = cockpitStreamKeyRef.current?.split('::')[0];
+    // Ignore a transient missing simulation id on the SAME run only. A new run
+    // (including plan-mode with no simulation yet) must still reset the timeline
+    // so the previous run's outcome does not flash on the overview.
+    if (cockpitStreamKeyRef.current !== null && previousRunId === runId && !simulationId) {
       return;
     }
     cockpitStreamKeyRef.current = nextKey;

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -1,8 +1,8 @@
 import { Alert, AlertTitle, Box, Tab, Tabs } from '@mui/material';
-import { type FunctionComponent, lazy, Suspense, useMemo, useState } from 'react';
+import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 
-import { type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
+import { type AutonomousEvent, type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
 import { searchInjectTests } from '../../../../actions/inject_test/scenario-inject-test-actions';
 import { fetchScenario } from '../../../../actions/scenarios/scenario-actions';
 import { type ScenariosHelper } from '../../../../actions/scenarios/scenario-helper';
@@ -68,6 +68,10 @@ const IndexScenarioComponent: FunctionComponent<{
   // is ACTIVE. A settled run unlocks Scope/Logic again; the overview itself always stays the
   // normal scenario page with the AI outcome layered on top (see overviewElement).
   const hasCockpit = isAutonomousRunActive(autonomousRun);
+  const [cockpitTimeline, setCockpitTimeline] = useState<AutonomousEvent[]>([]);
+  useEffect(() => {
+    setCockpitTimeline([]);
+  }, [autonomousRun?.autonomous_run_id, autonomousRun?.autonomous_run_simulation_id]);
   // Resizable reasoning-panel width, shared with the content padding so the scenario content never
   // renders underneath the panel (mirrors the simulation cockpit).
   const [panelWidth, setPanelWidth] = useAutonomousPanelWidth();
@@ -222,6 +226,7 @@ const IndexScenarioComponent: FunctionComponent<{
     autonomousRun,
     setOpenInstantiateSimulationAndStart,
     onAutonomousRunCleared,
+    timelineEvents: hasCockpit ? cockpitTimeline : undefined,
   });
 
   return (
@@ -308,6 +313,7 @@ const IndexScenarioComponent: FunctionComponent<{
             <AutonomousReasoningPanel
               run={autonomousRun}
               onRunUpdate={onAutonomousRunUpdate}
+              onTimelineEvents={setCockpitTimeline}
               width={panelWidth}
               onWidthChange={setPanelWidth}
             />

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -1,5 +1,5 @@
 import { Alert, AlertTitle, Box, Tab, Tabs } from '@mui/material';
-import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 
 import { type AutonomousEvent, type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
@@ -69,7 +69,26 @@ const IndexScenarioComponent: FunctionComponent<{
   // normal scenario page with the AI outcome layered on top (see overviewElement).
   const hasCockpit = isAutonomousRunActive(autonomousRun);
   const [cockpitTimeline, setCockpitTimeline] = useState<AutonomousEvent[]>([]);
+  // Same identity-change rule as AutonomousReasoningPanel: clear only on a real run /
+  // simulation switch. A transient payload that momentarily lost its simulation id must
+  // not blank the overview layer (it would receive sharedEvents=[] and would not poll).
+  const cockpitStreamKeyRef = useRef<string | null>(null);
   useEffect(() => {
+    const runId = autonomousRun?.autonomous_run_id;
+    const simulationId = autonomousRun?.autonomous_run_simulation_id;
+    if (!runId) {
+      cockpitStreamKeyRef.current = null;
+      setCockpitTimeline([]);
+      return;
+    }
+    const nextKey = `${runId}::${simulationId ?? ''}`;
+    if (cockpitStreamKeyRef.current === nextKey) {
+      return;
+    }
+    if (cockpitStreamKeyRef.current !== null && !simulationId) {
+      return;
+    }
+    cockpitStreamKeyRef.current = nextKey;
     setCockpitTimeline([]);
   }, [autonomousRun?.autonomous_run_id, autonomousRun?.autonomous_run_simulation_id]);
   // Resizable reasoning-panel width, shared with the content padding so the scenario content never

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -64,10 +64,9 @@ const IndexScenarioComponent: FunctionComponent<{
     && isChainingFeatureEnabled
     && !!scenario.scenario_workflow_id;
   const isChained = isChainingFeatureEnabled && !!scenario.scenario_workflow_id;
-  // The AI cockpit is live only while a run is ACTIVE (the orchestrator is planning or driving). A
-  // settled run (PLANNED / completed) leaves the scenario a normal editable chained scenario again,
-  // so scope/logic unlock and the overview reverts to the manual one - the operator then reviews the
-  // authored steps and launches (or relaunches) from the hero.
+  // The AI cockpit (right-hand reasoning panel + read-only Scope/Logic) is live only while a run
+  // is ACTIVE. A settled run unlocks Scope/Logic again; the overview itself always stays the
+  // normal scenario page with the AI outcome layered on top (see overviewElement).
   const hasCockpit = isAutonomousRunActive(autonomousRun);
   // Resizable reasoning-panel width, shared with the content padding so the scenario content never
   // renders underneath the panel (mirrors the simulation cockpit).

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -21,9 +21,8 @@ import useDataLoader from '../../../../utils/hooks/useDataLoader';
 import { INHERITED_CONTEXT } from '../../../../utils/permissions/types';
 import useScenarioPermissions from '../../../../utils/permissions/useScenarioPermissions';
 import { isFeatureEnabled } from '../../../../utils/utils';
-import AutonomousOverview from '../../autonomous/AutonomousOverview';
 import AutonomousReasoningPanel from '../../autonomous/AutonomousReasoningPanel';
-import { isAutonomousRunActive, isAutonomousRunSettled } from '../../autonomous/autonomousStatus';
+import { isAutonomousRunActive } from '../../autonomous/autonomousStatus';
 import useAutonomousPanelWidth from '../../autonomous/useAutonomousPanelWidth';
 import { useAutonomousRunForScenario } from '../../autonomous/useAutonomousRunForSimulation';
 import { DocumentContext, type DocumentContextType, InjectContext, PermissionsContext, type PermissionsContextType } from '../../common/Context';
@@ -213,22 +212,18 @@ const IndexScenarioComponent: FunctionComponent<{
     );
   };
 
-  // Overview swaps to the AI cockpit overview while a run is live; otherwise the manual scenario
-  // overview. Scope and Logic go read-only while the orchestrator owns them (planning or driving) so
-  // an operator edit can never race the AI, and unlock again once the run settles.
-  //
-  // Once the run has SETTLED the cockpit is torn down (scope/logic editable again, no steer panel),
-  // but the manual overview keeps a durable, read-only AI outcome (mission, decision timeline, gaps
-  // and - for a live run - proofs): the settled run is threaded into the manual overview so the
-  // "we lost the timeline / gaps once the scenario is done" gap is closed.
-  const settledRun = isAutonomousRunSettled(autonomousRun) ? autonomousRun : null;
-  const overviewElement = hasCockpit && autonomousRun
-    ? <AutonomousOverview run={autonomousRun} />
-    : errorWrapper(ScenarioComponent)({
-        autonomousRun: settledRun,
-        setOpenInstantiateSimulationAndStart,
-        onAutonomousRunCleared,
-      });
+  // The AI planning / run layer is ADDITIVE, never a replacement: the scenario keeps its FULL normal
+  // overview (posture, information, posture trend, kill chain) and the AI outcome (mission, decision
+  // timeline, capability gaps and - for a live run - proofs) renders as a layer ON TOP of it, for an
+  // active OR a settled run. Passing the current run here (not just a settled one) is what stops
+  // "building with AI" from wiping the normal overview - it is the same scenario with a planning
+  // layer, not a different page. The live reasoning stream still lives in the right-hand cockpit
+  // panel, and Scope / Logic still go read-only while the orchestrator owns them (see hasCockpit).
+  const overviewElement = errorWrapper(ScenarioComponent)({
+    autonomousRun,
+    setOpenInstantiateSimulationAndStart,
+    onAutonomousRunCleared,
+  });
 
   return (
     <PermissionsContext.Provider value={permissionsContext}>

--- a/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
@@ -54,6 +54,7 @@ import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
 import { isEmptyField, isFeatureEnabled } from '../../../../utils/utils';
 import isXtmOneAvailable from '../../ariane/xtmOneAvailability';
 import AutonomousOutcome from '../../autonomous/AutonomousOutcome';
+import { isAutonomousRunActive } from '../../autonomous/autonomousStatus';
 import EEChip from '../../common/entreprise_edition/EEChip';
 import MitreCoverageMatrix from '../../common/matrix/MitreCoverageMatrix';
 import ExercisePopover from '../../simulations/simulation/ExercisePopover';
@@ -64,10 +65,12 @@ import ScenarioDistributionByExercise from './ScenarioDistributionByExercise';
 
 const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, onAutonomousRunCleared }: {
   setOpenInstantiateSimulationAndStart: Dispatch<SetStateAction<boolean>>;
-  // The settled autonomous run owning this scenario, if any. When present, the overview keeps a
-  // durable, read-only AI outcome (mission, decision timeline, gaps, proofs) even though the live
-  // cockpit and steer panel are gone. Null for a never-run or purely-manual chained scenario, or
-  // while a run is still active (the live cockpit owns the overview then).
+  // The autonomous run owning this scenario, if any - ACTIVE (the orchestrator is planning / driving)
+  // or SETTLED (planned / done). The AI outcome (mission, decision timeline, capability gaps, proofs)
+  // renders as a layer ON TOP of the full normal overview, never replacing it: building with AI is
+  // the same scenario with a planning layer. While active it polls live and the right-hand reasoning
+  // panel owns the streaming detail; while settled it is a durable read. Null for a never-run or
+  // purely-manual chained scenario.
   autonomousRun?: AutonomousRun | null;
   // Forget the run locally so the AI outcome panel disappears immediately after the operator clears
   // it server-side (the by-scenario lookup now 404s), without waiting for a page reload.
@@ -245,6 +248,11 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
   const canLaunch = ability.can(ACTIONS.LAUNCH, SUBJECTS.RESOURCE, scenario.scenario_id);
   const canManageScenario = ability.can(ACTIONS.MANAGE, SUBJECTS.RESOURCE, scenario.scenario_id)
     || ability.can(ACTIONS.MANAGE, SUBJECTS.ASSESSMENT);
+  // While a run is still active (planning or driving) the AI outcome polls live and the right-hand
+  // reasoning panel owns the streaming detail; the in-overview run controls (clear outcome, launch
+  // CTAs) are hidden because an active run is steered from the header / panel and the scenario
+  // cannot be relaunched while one owns it. A settled run is a durable, editable-again read.
+  const isRunActive = isAutonomousRunActive(autonomousRun);
   // "Clear AI outcome": drop the settled run (its decision timeline + capability gaps) server-side
   // and revert the overview to the normal manual view. The authored attack path (logic map) and the
   // run simulation are kept - it is the convert-to-manual IN_PLACE flip, which unlocks the scenario
@@ -356,8 +364,9 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
               )}
               {/* Clear the AI outcome and return to the normal overview: drops the run + decision
                   timeline + capability gaps, keeps the authored logic (and run simulation). Only for
-                  operators who can manage the scenario. */}
-              {canManageScenario && (
+                  operators who can manage the scenario, and only once the run has settled - an active
+                  run is stopped from the header / reasoning panel, not cleared from here. */}
+              {canManageScenario && !isRunActive && (
                 <Tooltip title={autonomousRun.autonomous_run_plan_mode
                   ? t('Clear the AI plan outcome and return to the normal overview')
                   : t('Clear the autonomous run outcome and return to the normal overview')}
@@ -373,7 +382,7 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
               )}
             </Box>
           </Box>
-          <AutonomousOutcome run={autonomousRun} live={false} />
+          <AutonomousOutcome run={autonomousRun} live={isRunActive} />
           <DialogConfirmation
             open={clearOutcomeOpen}
             handleClose={() => setClearOutcomeOpen(false)}
@@ -422,7 +431,7 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
               (Normal) or an orchestrator-driven live run (Autonomous). The Autonomous button
               opens the hero's launch config drawer (objective / agents / scope) via the query
               param. A time-based scenario only ever launches a normal simulation. */}
-          {canLaunch && isScenarioChaining && (
+          {canLaunch && !isRunActive && isScenarioChaining && (
             <Box sx={{
               display: 'flex',
               gap: 1,
@@ -481,7 +490,7 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
               )}
             </Box>
           )}
-          {canLaunch && !isScenarioChaining && (
+          {canLaunch && !isRunActive && !isScenarioChaining && (
             <Button
               startIcon={<PlayArrowOutlined />}
               variant="contained"

--- a/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
@@ -314,11 +314,10 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
       paddingBottom: theme.spacing(5),
     }}
     >
-      {/* Durable AI outcome: once an autonomous run has settled the live cockpit is gone, but the
-          scenario keeps a read-only read of what the orchestrator produced (mission, decision
-          timeline, capability gaps and - for a live run - proof of exploitation), so the timeline
-          and gaps are never lost when the scenario is "done". A live run owns the overview via the
-          cockpit instead, so this only ever renders for a settled run. */}
+      {/* Additive AI outcome: while a run is active OR settled, the scenario keeps its full
+          normal overview and layers the mission / decision timeline / capability gaps (and, for
+          a live run, proofs) on top. The right-hand cockpit still owns the streaming reasoning
+          while the run is active; this block is the in-overview layer, not a replacement page. */}
       {autonomousRun && (
         <Box sx={{
           display: 'flex',

--- a/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Scenario.tsx
@@ -7,7 +7,7 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router';
 
 import { type AgentHelper } from '../../../../actions/agents/agent-helper';
 import { convertAutonomousRunToManual } from '../../../../actions/autonomous/autonomous-actions';
-import { type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
+import { type AutonomousEvent, type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
 import type { CollectorHelper } from '../../../../actions/collectors/collector-helper';
 import { fetchExerciseExpectationResult, fetchExerciseInjectExpectationResults } from '../../../../actions/exercises/exercise-action';
 import { type ExercisesHelper } from '../../../../actions/exercises/exercise-helper';
@@ -63,18 +63,21 @@ import { CONTEXTUAL_POSTURE_WIDGET_ID, contextualResultsUrl } from '../../worksp
 import SamplePreview from '../../workspaces/custom_dashboards/widgets/viz/sample/SamplePreview';
 import ScenarioDistributionByExercise from './ScenarioDistributionByExercise';
 
-const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, onAutonomousRunCleared }: {
+const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, onAutonomousRunCleared, timelineEvents }: {
   setOpenInstantiateSimulationAndStart: Dispatch<SetStateAction<boolean>>;
   // The autonomous run owning this scenario, if any - ACTIVE (the orchestrator is planning / driving)
   // or SETTLED (planned / done). The AI outcome (mission, decision timeline, capability gaps, proofs)
   // renders as a layer ON TOP of the full normal overview, never replacing it: building with AI is
-  // the same scenario with a planning layer. While active it polls live and the right-hand reasoning
-  // panel owns the streaming detail; while settled it is a durable read. Null for a never-run or
-  // purely-manual chained scenario.
+  // the same scenario with a planning layer. While active the overview reuses the cockpit's
+  // incremental timeline (no second poll); while settled it is a durable one-shot read. Null for a
+  // never-run or purely-manual chained scenario.
   autonomousRun?: AutonomousRun | null;
   // Forget the run locally so the AI outcome panel disappears immediately after the operator clears
   // it server-side (the by-scenario lookup now 404s), without waiting for a page reload.
   onAutonomousRunCleared?: () => void;
+  // Live timeline already polled by the right-hand cockpit. When provided, the outcome layer
+  // consumes it instead of fetching / polling fetchAutonomousTimeline itself.
+  timelineEvents?: AutonomousEvent[];
 }) => {
   const theme = useTheme();
   const { t } = useFormatter();
@@ -381,7 +384,7 @@ const Scenario = ({ setOpenInstantiateSimulationAndStart, autonomousRun = null, 
               )}
             </Box>
           </Box>
-          <AutonomousOutcome run={autonomousRun} live={isRunActive} />
+          <AutonomousOutcome run={autonomousRun} live={isRunActive} sharedEvents={timelineEvents} />
           <DialogConfirmation
             open={clearOutcomeOpen}
             handleClose={() => setClearOutcomeOpen(false)}


### PR DESCRIPTION
## Summary

Building a scenario with AI no longer replaces the normal overview. The AI plan outcome (mission, decision timeline, capability gaps) renders as a layer on top of the full scenario overview, including while planning is still running.

Closes #7386.

## Changes

- `Index.tsx`: always render `ScenarioComponent` and pass the current `autonomousRun` (active or settled). Drop the `AutonomousOverview` swap on the scenario overview tab. Scope / Logic still go read-only while the orchestrator owns them; the live reasoning stream still lives in the right-hand cockpit panel.
- `Scenario.tsx`: the AI outcome polls live while the run is active (`live={isAutonomousRunActive(...)}`). Hide "Clear AI outcome" and the in-overview launch CTAs while a run is active (an active run is steered from the header / reasoning panel, and the scenario cannot be relaunched while one owns it).

## Test plan

- [ ] Start building a scenario with AI: the overview keeps posture, Information, posture trend and kill-chain results, with the AI mission / decision timeline / capability gaps layered on top.
- [ ] While planning is running, "Clear AI outcome" and the Normal / Autonomous launch buttons are hidden.
- [ ] When the plan is ready, the same layered overview remains; Clear AI outcome is available again.
- [x] ESLint on the two touched files is clean
