### PR TITLE
feat: unblock execution when input are not mandatories (#4824)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -10,6 +10,7 @@ import static org.springframework.util.StringUtils.hasText;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
 import io.openaev.injectors.openaev.model.OpenAEVImplantInjectContent;
@@ -23,13 +24,16 @@ import jakarta.annotation.Resource;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -111,9 +115,22 @@ public class ExecutableInjectService {
       List<PayloadArgument> defaultPayloadArguments,
       List<ObjectNode> injectorContractContentFields,
       ObjectNode injectContent,
-      boolean enforceMandatory,
-      boolean pruneMissingOptionalFlags) {
+      ResolutionMode mode) {
 
+    List<PayloadArgument> payloadArguments =
+        defaultPayloadArguments != null ? defaultPayloadArguments : List.of();
+    List<ObjectNode> contractFields =
+        injectorContractContentFields != null ? injectorContractContentFields : List.of();
+    ObjectNode safeInjectContent =
+        injectContent != null ? injectContent : JsonNodeFactory.instance.objectNode();
+
+    Map<String, PayloadArgument> payloadArgumentByKey =
+        payloadArguments.stream()
+            .filter(arg -> arg.getKey() != null)
+            .collect(
+                Collectors.toMap(
+                    PayloadArgument::getKey, Function.identity(), (first, second) -> first));
+    Map<String, FieldPolicy> policiesByKey = buildFieldPolicies(contractFields);
     Set<String> argumentKeys = getArgumentsFromCommandLines(command);
     Set<String> missingOptionalKeys = new HashSet<>();
 
@@ -122,24 +139,26 @@ public class ExecutableInjectService {
         continue;
       }
 
-      PayloadArgument defaultPayloadArgument =
-          defaultPayloadArguments.stream()
-              .filter(a -> a.getKey().equals(argumentKey))
-              .findFirst()
-              .orElse(null);
+      PayloadArgument defaultPayloadArgument = payloadArgumentByKey.get(argumentKey);
+      FieldPolicy policy =
+          policiesByKey.getOrDefault(
+              argumentKey,
+              new FieldPolicy(
+                  false,
+                  defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : ""));
       ResolvedArgument resolvedArgument =
           resolveArgumentValue(
-              argumentKey, defaultPayloadArgument, injectorContractContentFields, injectContent);
+              argumentKey, defaultPayloadArgument, policy, contractFields, safeInjectContent);
 
       if (resolvedArgument.missing()) {
-        if (enforceMandatory && resolvedArgument.mandatory()) {
+        if (mode.enforceMandatory() && resolvedArgument.policy().mandatory()) {
           log.error(
               "[Inject execution] Missing mandatory input '{}' -> step run can not be created/executed",
               argumentKey);
           throw new IllegalStateException(
               "Missing mandatory input '%s' for inject execution".formatted(argumentKey));
         }
-        if (pruneMissingOptionalFlags && !resolvedArgument.mandatory()) {
+        if (mode.pruneMissingOptionalFlags() && !resolvedArgument.policy().mandatory()) {
           missingOptionalKeys.add(argumentKey);
         }
       }
@@ -147,7 +166,7 @@ public class ExecutableInjectService {
     }
 
     String commandToRender = command;
-    if (pruneMissingOptionalFlags && !missingOptionalKeys.isEmpty()) {
+    if (mode.pruneMissingOptionalFlags() && !missingOptionalKeys.isEmpty()) {
       commandToRender = pruneOptionalFlagSegments(command, missingOptionalKeys);
     }
     return binder.render(commandToRender);
@@ -174,20 +193,18 @@ public class ExecutableInjectService {
         defaultPayloadArguments,
         injectorContractContentFields,
         injectContent,
-        false,
-        true);
+        ResolutionMode.DISPLAY_PERMISSIVE);
   }
 
   /** Resolves the effective value of a single argument, before any shell escaping. */
   private ResolvedArgument resolveArgumentValue(
       String argumentKey,
       PayloadArgument defaultPayloadArgument,
+      FieldPolicy policy,
       List<ObjectNode> injectorContractContentFields,
       ObjectNode injectContent) {
     PrimitiveType type = defaultPayloadArgument != null ? defaultPayloadArgument.getType() : null;
-    boolean mandatory = isMandatoryField(argumentKey, injectorContractContentFields);
-    String defaultValue =
-        resolveDefaultValue(argumentKey, defaultPayloadArgument, injectorContractContentFields);
+    String defaultValue = resolveDefaultValue(defaultPayloadArgument, policy);
     String value = "";
     boolean missing = true;
 
@@ -218,7 +235,7 @@ public class ExecutableInjectService {
         log.error("Payload argument target unexisting document", e);
       }
     }
-    return new ResolvedArgument(value, missing, mandatory);
+    return new ResolvedArgument(value, missing, policy);
   }
 
   public static String replaceCmdVariables(String cmd) {
@@ -260,15 +277,12 @@ public class ExecutableInjectService {
     return formattedCommand.toString();
   }
 
-  private String processAndEncodeCommand(
+  String renderCommandForExecution(
       String command,
       String executor,
       List<PayloadArgument> defaultPayloadArguments,
       ObjectNode injectContent,
-      List<ObjectNode> injectorContractContentFields,
-      String obfuscator) {
-    OpenAEVObfuscationMap obfuscationMap = new OpenAEVObfuscationMap(executor);
-
+      List<ObjectNode> injectorContractContentFields) {
     String computedCommand = command;
     // cmd-specific rewrites are applied to the TEMPLATE only: running them after substitution would
     // let an argument value smuggle a %VAR% / newline through them.
@@ -284,8 +298,26 @@ public class ExecutableInjectService {
             defaultPayloadArguments,
             injectorContractContentFields,
             injectContent,
-            true,
-            true);
+            ResolutionMode.EXECUTION_STRICT);
+
+    return computedCommand;
+  }
+
+  private String processAndEncodeCommand(
+      String command,
+      String executor,
+      List<PayloadArgument> defaultPayloadArguments,
+      ObjectNode injectContent,
+      List<ObjectNode> injectorContractContentFields,
+      String obfuscator) {
+    OpenAEVObfuscationMap obfuscationMap = new OpenAEVObfuscationMap(executor);
+    String computedCommand =
+        renderCommandForExecution(
+            command,
+            executor,
+            defaultPayloadArguments,
+            injectContent,
+            injectorContractContentFields);
 
     computedCommand = obfuscationMap.executeObfuscation(obfuscator, computedCommand, executor);
 
@@ -466,45 +498,17 @@ public class ExecutableInjectService {
             dnsResolution.getArguments(),
             null,
             inject.getContent(),
-            false,
-            false));
+            ResolutionMode.DNS_LITERAL));
     return dnsResolution;
   }
 
-  private ObjectNode findFieldByKey(
-      String argumentKey, List<ObjectNode> injectorContractContentFields) {
-    if (injectorContractContentFields == null || injectorContractContentFields.isEmpty()) {
-      return null;
-    }
-    return injectorContractContentFields.stream()
-        .filter(field -> field.has(CONTRACT_ELEMENT_CONTENT_KEY))
-        .filter(field -> argumentKey.equals(field.get(CONTRACT_ELEMENT_CONTENT_KEY).asText()))
-        .findFirst()
-        .orElse(null);
-  }
-
-  private boolean isMandatoryField(
-      String argumentKey, List<ObjectNode> injectorContractContentFields) {
-    ObjectNode field = findFieldByKey(argumentKey, injectorContractContentFields);
-    if (field == null || !field.has(CONTRACT_ELEMENT_CONTENT_MANDATORY)) {
-      return false;
-    }
-    return field.get(CONTRACT_ELEMENT_CONTENT_MANDATORY).asBoolean(false);
-  }
-
-  private String resolveDefaultValue(
-      String argumentKey,
-      PayloadArgument defaultPayloadArgument,
-      List<ObjectNode> injectorContractContentFields) {
+  private String resolveDefaultValue(PayloadArgument defaultPayloadArgument, FieldPolicy policy) {
     if (defaultPayloadArgument != null && hasText(defaultPayloadArgument.getDefaultValue())) {
       return defaultPayloadArgument.getDefaultValue();
     }
-
-    ObjectNode field = findFieldByKey(argumentKey, injectorContractContentFields);
-    if (field == null || !field.has(DEFAULT_VALUE_FIELD)) {
-      return defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : "";
-    }
-    return field.get(DEFAULT_VALUE_FIELD).asText("");
+    return policy.defaultValue() != null
+        ? policy.defaultValue()
+        : defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : "";
   }
 
   private String pruneOptionalFlagSegments(String command, Set<String> missingOptionalKeys) {
@@ -515,10 +519,53 @@ public class ExecutableInjectService {
       pruned = pruned.replaceAll("\\s+-[A-Za-z0-9]\\s+(?:\"|')?" + placeholder + "(?:\"|')?", "");
       pruned = pruned.replaceAll("\\s+--[\\w-]+=((?:\"|')?)" + placeholder + "\\1", "");
       pruned = pruned.replaceAll("\\s+-[A-Za-z0-9]=((?:\"|')?)" + placeholder + "\\1", "");
-      pruned = pruned.replaceAll("(?:\"|')?" + placeholder + "(?:\"|')?", "");
     }
     return pruned.replaceAll("\\s{2,}", " ").trim();
   }
 
-  private record ResolvedArgument(String value, boolean missing, boolean mandatory) {}
+  private Map<String, FieldPolicy> buildFieldPolicies(
+      List<ObjectNode> injectorContractContentFields) {
+    if (injectorContractContentFields == null || injectorContractContentFields.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return injectorContractContentFields.stream()
+        .filter(field -> field.has(CONTRACT_ELEMENT_CONTENT_KEY))
+        .collect(
+            Collectors.toMap(
+                field -> field.get(CONTRACT_ELEMENT_CONTENT_KEY).asText(),
+                field ->
+                    new FieldPolicy(
+                        field.has(CONTRACT_ELEMENT_CONTENT_MANDATORY)
+                            && field.get(CONTRACT_ELEMENT_CONTENT_MANDATORY).asBoolean(false),
+                        field.has(DEFAULT_VALUE_FIELD)
+                            ? field.get(DEFAULT_VALUE_FIELD).asText("")
+                            : ""),
+                (first, second) -> first));
+  }
+
+  private record FieldPolicy(boolean mandatory, String defaultValue) {}
+
+  private record ResolvedArgument(String value, boolean missing, FieldPolicy policy) {}
+
+  private enum ResolutionMode {
+    EXECUTION_STRICT(true, true),
+    DISPLAY_PERMISSIVE(false, true),
+    DNS_LITERAL(false, false);
+
+    private final boolean enforceMandatory;
+    private final boolean pruneMissingOptionalFlags;
+
+    ResolutionMode(boolean enforceMandatory, boolean pruneMissingOptionalFlags) {
+      this.enforceMandatory = enforceMandatory;
+      this.pruneMissingOptionalFlags = pruneMissingOptionalFlags;
+    }
+
+    boolean enforceMandatory() {
+      return enforceMandatory;
+    }
+
+    boolean pruneMissingOptionalFlags() {
+      return pruneMissingOptionalFlags;
+    }
+  }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -1,6 +1,9 @@
 package io.openaev.rest.inject.service;
 
+import static io.openaev.database.model.InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY;
 import static io.openaev.database.model.InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY_TARGETED_ASSET_SEPARATOR;
+import static io.openaev.database.model.InjectorContract.CONTRACT_ELEMENT_CONTENT_MANDATORY;
+import static io.openaev.database.model.InjectorContract.DEFAULT_VALUE_FIELD;
 import static io.openaev.executors.Executor.CMD;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.hasText;
@@ -20,6 +23,7 @@ import jakarta.annotation.Resource;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -106,9 +110,12 @@ public class ExecutableInjectService {
       CommandArgumentBinder binder,
       List<PayloadArgument> defaultPayloadArguments,
       List<ObjectNode> injectorContractContentFields,
-      ObjectNode injectContent) {
+      ObjectNode injectContent,
+      boolean enforceMandatory,
+      boolean pruneMissingOptionalFlags) {
 
     Set<String> argumentKeys = getArgumentsFromCommandLines(command);
+    Set<String> missingOptionalKeys = new HashSet<>();
 
     for (String argumentKey : argumentKeys) {
       if (RESERVED_PLACEHOLDERS.contains(argumentKey)) {
@@ -120,12 +127,30 @@ public class ExecutableInjectService {
               .filter(a -> a.getKey().equals(argumentKey))
               .findFirst()
               .orElse(null);
-      binder.bind(
-          argumentKey,
+      ResolvedArgument resolvedArgument =
           resolveArgumentValue(
-              argumentKey, defaultPayloadArgument, injectorContractContentFields, injectContent));
+              argumentKey, defaultPayloadArgument, injectorContractContentFields, injectContent);
+
+      if (resolvedArgument.missing()) {
+        if (enforceMandatory && resolvedArgument.mandatory()) {
+          log.error(
+              "[Inject execution] Missing mandatory input '{}' -> step run can not be created/executed",
+              argumentKey);
+          throw new IllegalStateException(
+              "Missing mandatory input '%s' for inject execution".formatted(argumentKey));
+        }
+        if (pruneMissingOptionalFlags && !resolvedArgument.mandatory()) {
+          missingOptionalKeys.add(argumentKey);
+        }
+      }
+      binder.bind(argumentKey, resolvedArgument.value());
     }
-    return binder.render(command);
+
+    String commandToRender = command;
+    if (pruneMissingOptionalFlags && !missingOptionalKeys.isEmpty()) {
+      commandToRender = pruneOptionalFlagSegments(command, missingOptionalKeys);
+    }
+    return binder.render(commandToRender);
   }
 
   /**
@@ -134,9 +159,9 @@ public class ExecutableInjectService {
    * raw template.
    *
    * <p>This performs a plain, verbatim substitution and the result <b>must never be executed</b>:
-   * only {@link #replaceArgumentsByValue(String, CommandArgumentBinder, List, List, ObjectNode)}
-   * with a shell-aware binder is safe for dispatch. The two paths intentionally share the same
-   * value-resolution rule ({@link #resolveArgumentValue}) so display and execution stay in sync.
+   * only {@link #replaceArgumentsByValue} with a shell-aware binder is safe for dispatch. The two
+   * paths intentionally share the same value-resolution rule ({@link #resolveArgumentValue}) so
+   * display and execution stay in sync.
    */
   public String resolveArgumentsForDisplay(
       String command,
@@ -148,41 +173,52 @@ public class ExecutableInjectService {
         CommandArgumentBinder.literal(),
         defaultPayloadArguments,
         injectorContractContentFields,
-        injectContent);
+        injectContent,
+        false,
+        true);
   }
 
   /** Resolves the effective value of a single argument, before any shell escaping. */
-  private String resolveArgumentValue(
+  private ResolvedArgument resolveArgumentValue(
       String argumentKey,
       PayloadArgument defaultPayloadArgument,
       List<ObjectNode> injectorContractContentFields,
       ObjectNode injectContent) {
     PrimitiveType type = defaultPayloadArgument != null ? defaultPayloadArgument.getType() : null;
+    boolean mandatory = isMandatoryField(argumentKey, injectorContractContentFields);
+    String defaultValue =
+        resolveDefaultValue(argumentKey, defaultPayloadArgument, injectorContractContentFields);
+    String value = "";
+    boolean missing = true;
 
     // If the argument is a targeted asset, we need to fetch the asset details
     if (PrimitiveType.TargetedAsset == type) {
-      return getTargetedAssetArgumentValue(
-          argumentKey, injectContent, defaultPayloadArgument, injectorContractContentFields);
+      value =
+          getTargetedAssetArgumentValue(
+              argumentKey, injectContent, defaultPayloadArgument, injectorContractContentFields);
+      missing = !hasText(value);
+    } else if (injectContent.get(argumentKey) != null
+        && !injectContent.get(argumentKey).asText().isEmpty()) {
+      value = injectContent.get(argumentKey).asText();
+      missing = false;
+    } else if (hasText(defaultValue)) {
+      value = defaultValue;
+      missing = false;
     }
-
-    String value =
-        getArgumentValueOrDefault(
-            argumentKey,
-            injectContent,
-            defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : "");
 
     // If arg is a doc, specific handling
     // We need to resolve the doc name and add special prefix #{location} that will be resolved
     // by the implant
-    if (PrimitiveType.Document == type && !value.isEmpty()) {
+    if (PrimitiveType.Document == type && hasText(value)) {
       try {
         Document doc = documentService.document(value);
-        return "#{location}/" + doc.getName();
+        value = "#{location}/" + doc.getName();
+        missing = false;
       } catch (ElementNotFoundException e) {
         log.error("Payload argument target unexisting document", e);
       }
     }
-    return value;
+    return new ResolvedArgument(value, missing, mandatory);
   }
 
   public static String replaceCmdVariables(String cmd) {
@@ -247,7 +283,9 @@ public class ExecutableInjectService {
             CommandArgumentBinder.forExecutor(executor),
             defaultPayloadArguments,
             injectorContractContentFields,
-            injectContent);
+            injectContent,
+            true,
+            true);
 
     computedCommand = obfuscationMap.executeObfuscation(obfuscator, computedCommand, executor);
 
@@ -427,7 +465,60 @@ public class ExecutableInjectService {
             CommandArgumentBinder.literal(),
             dnsResolution.getArguments(),
             null,
-            inject.getContent()));
+            inject.getContent(),
+            false,
+            false));
     return dnsResolution;
   }
+
+  private ObjectNode findFieldByKey(
+      String argumentKey, List<ObjectNode> injectorContractContentFields) {
+    if (injectorContractContentFields == null || injectorContractContentFields.isEmpty()) {
+      return null;
+    }
+    return injectorContractContentFields.stream()
+        .filter(field -> field.has(CONTRACT_ELEMENT_CONTENT_KEY))
+        .filter(field -> argumentKey.equals(field.get(CONTRACT_ELEMENT_CONTENT_KEY).asText()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private boolean isMandatoryField(
+      String argumentKey, List<ObjectNode> injectorContractContentFields) {
+    ObjectNode field = findFieldByKey(argumentKey, injectorContractContentFields);
+    if (field == null || !field.has(CONTRACT_ELEMENT_CONTENT_MANDATORY)) {
+      return false;
+    }
+    return field.get(CONTRACT_ELEMENT_CONTENT_MANDATORY).asBoolean(false);
+  }
+
+  private String resolveDefaultValue(
+      String argumentKey,
+      PayloadArgument defaultPayloadArgument,
+      List<ObjectNode> injectorContractContentFields) {
+    if (defaultPayloadArgument != null && hasText(defaultPayloadArgument.getDefaultValue())) {
+      return defaultPayloadArgument.getDefaultValue();
+    }
+
+    ObjectNode field = findFieldByKey(argumentKey, injectorContractContentFields);
+    if (field == null || !field.has(DEFAULT_VALUE_FIELD)) {
+      return defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : "";
+    }
+    return field.get(DEFAULT_VALUE_FIELD).asText("");
+  }
+
+  private String pruneOptionalFlagSegments(String command, Set<String> missingOptionalKeys) {
+    String pruned = command;
+    for (String key : missingOptionalKeys) {
+      String placeholder = "#\\{" + Pattern.quote(key) + "\\}";
+      pruned = pruned.replaceAll("\\s+--[\\w-]+\\s+(?:\"|')?" + placeholder + "(?:\"|')?", "");
+      pruned = pruned.replaceAll("\\s+-[A-Za-z0-9]\\s+(?:\"|')?" + placeholder + "(?:\"|')?", "");
+      pruned = pruned.replaceAll("\\s+--[\\w-]+=((?:\"|')?)" + placeholder + "\\1", "");
+      pruned = pruned.replaceAll("\\s+-[A-Za-z0-9]=((?:\"|')?)" + placeholder + "\\1", "");
+      pruned = pruned.replaceAll("(?:\"|')?" + placeholder + "(?:\"|')?", "");
+    }
+    return pruned.replaceAll("\\s{2,}", " ").trim();
+  }
+
+  private record ResolvedArgument(String value, boolean missing, boolean mandatory) {}
 }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -9,7 +9,7 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
 import io.openaev.injectors.openaev.model.OpenAEVImplantInjectContent;
@@ -19,6 +19,7 @@ import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.payload.service.PayloadService;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.utils.command.CommandArgumentBinder;
+import jakarta.annotation.Resource;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -44,6 +45,8 @@ public class ExecutableInjectService {
   private final InjectStatusService injectStatusService;
   private final InjectExpectationService injectExpectationService;
   private final PayloadService payloadService;
+
+  @Resource protected ObjectMapper mapper;
 
   private static final Set<String> RESERVED_PLACEHOLDERS = Set.of("location", "payload_location");
   private static final Pattern argumentsRegex = Pattern.compile("#\\{([^#{}]+)}");
@@ -109,14 +112,13 @@ public class ExecutableInjectService {
       ObjectNode injectContent,
       boolean enforceMandatory) {
 
+    Set<String> argumentKeys = getArgumentsFromCommandLines(command);
     List<PayloadArgument> payloadArguments =
         defaultPayloadArguments != null ? defaultPayloadArguments : List.of();
     List<ObjectNode> contractFields =
         injectorContractContentFields != null ? injectorContractContentFields : List.of();
     ObjectNode safeInjectContent =
-        injectContent != null ? injectContent : JsonNodeFactory.instance.objectNode();
-
-    Set<String> argumentKeys = getArgumentsFromCommandLines(command);
+        injectContent != null ? injectContent : mapper.createObjectNode();
 
     for (String argumentKey : argumentKeys) {
       if (RESERVED_PLACEHOLDERS.contains(argumentKey)) {
@@ -136,14 +138,12 @@ public class ExecutableInjectService {
               contractFields,
               safeInjectContent);
 
-      if (resolvedArgument.missing()) {
-        if (enforceMandatory && resolvedArgument.mandatory()) {
-          log.error(
-              "[Inject execution] Missing mandatory input '{}' -> step run can not be created/executed",
-              argumentKey);
-          throw new IllegalStateException(
-              "Missing mandatory input '%s' for inject execution".formatted(argumentKey));
-        }
+      if (resolvedArgument.missing() && enforceMandatory && resolvedArgument.mandatory()) {
+        log.error(
+            "[Inject execution] Missing mandatory input '{}' -> step run can not be created/executed",
+            argumentKey);
+        throw new IllegalStateException(
+            "Missing mandatory input '%s' for inject execution".formatted(argumentKey));
       }
       binder.bind(argumentKey, resolvedArgument.value());
     }
@@ -204,7 +204,7 @@ public class ExecutableInjectService {
     // If arg is a doc, specific handling
     // We need to resolve the doc name and add special prefix #{location} that will be resolved
     // by the implant
-    if (PrimitiveType.Document == type && hasText(value)) {
+    if (PrimitiveType.Document == type && !value.isEmpty()) {
       try {
         Document doc = documentService.document(value);
         value = "#{location}/" + doc.getName();
@@ -263,6 +263,7 @@ public class ExecutableInjectService {
       List<ObjectNode> injectorContractContentFields,
       String obfuscator) {
     OpenAEVObfuscationMap obfuscationMap = new OpenAEVObfuscationMap(executor);
+
     String computedCommand = command;
     // cmd-specific rewrites are applied to the TEMPLATE only: running them after substitution would
     // let an argument value smuggle a %VAR% / newline through them.

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -9,7 +9,6 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.hasText;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
@@ -20,20 +19,15 @@ import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.payload.service.PayloadService;
 import io.openaev.service.InjectExpectationService;
 import io.openaev.utils.command.CommandArgumentBinder;
-import jakarta.annotation.Resource;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,8 +44,6 @@ public class ExecutableInjectService {
   private final InjectStatusService injectStatusService;
   private final InjectExpectationService injectExpectationService;
   private final PayloadService payloadService;
-
-  @Resource protected ObjectMapper mapper;
 
   private static final Set<String> RESERVED_PLACEHOLDERS = Set.of("location", "payload_location");
   private static final Pattern argumentsRegex = Pattern.compile("#\\{([^#{}]+)}");
@@ -115,7 +107,7 @@ public class ExecutableInjectService {
       List<PayloadArgument> defaultPayloadArguments,
       List<ObjectNode> injectorContractContentFields,
       ObjectNode injectContent,
-      ResolutionMode mode) {
+      boolean enforceMandatory) {
 
     List<PayloadArgument> payloadArguments =
         defaultPayloadArguments != null ? defaultPayloadArguments : List.of();
@@ -124,52 +116,38 @@ public class ExecutableInjectService {
     ObjectNode safeInjectContent =
         injectContent != null ? injectContent : JsonNodeFactory.instance.objectNode();
 
-    Map<String, PayloadArgument> payloadArgumentByKey =
-        payloadArguments.stream()
-            .filter(arg -> arg.getKey() != null)
-            .collect(
-                Collectors.toMap(
-                    PayloadArgument::getKey, Function.identity(), (first, second) -> first));
-    Map<String, FieldPolicy> policiesByKey = buildFieldPolicies(contractFields);
     Set<String> argumentKeys = getArgumentsFromCommandLines(command);
-    Set<String> missingOptionalKeys = new HashSet<>();
 
     for (String argumentKey : argumentKeys) {
       if (RESERVED_PLACEHOLDERS.contains(argumentKey)) {
         continue;
       }
 
-      PayloadArgument defaultPayloadArgument = payloadArgumentByKey.get(argumentKey);
-      FieldPolicy policy =
-          policiesByKey.getOrDefault(
-              argumentKey,
-              new FieldPolicy(
-                  false,
-                  defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : ""));
+      PayloadArgument defaultPayloadArgument = findPayloadArgument(argumentKey, payloadArguments);
+      boolean mandatory = isMandatoryField(argumentKey, contractFields);
+      String defaultValue =
+          resolveDefaultValue(argumentKey, defaultPayloadArgument, contractFields);
       ResolvedArgument resolvedArgument =
           resolveArgumentValue(
-              argumentKey, defaultPayloadArgument, policy, contractFields, safeInjectContent);
+              argumentKey,
+              defaultPayloadArgument,
+              defaultValue,
+              mandatory,
+              contractFields,
+              safeInjectContent);
 
       if (resolvedArgument.missing()) {
-        if (mode.enforceMandatory() && resolvedArgument.policy().mandatory()) {
+        if (enforceMandatory && resolvedArgument.mandatory()) {
           log.error(
               "[Inject execution] Missing mandatory input '{}' -> step run can not be created/executed",
               argumentKey);
           throw new IllegalStateException(
               "Missing mandatory input '%s' for inject execution".formatted(argumentKey));
         }
-        if (mode.pruneMissingOptionalFlags() && !resolvedArgument.policy().mandatory()) {
-          missingOptionalKeys.add(argumentKey);
-        }
       }
       binder.bind(argumentKey, resolvedArgument.value());
     }
-
-    String commandToRender = command;
-    if (mode.pruneMissingOptionalFlags() && !missingOptionalKeys.isEmpty()) {
-      commandToRender = pruneOptionalFlagSegments(command, missingOptionalKeys);
-    }
-    return binder.render(commandToRender);
+    return binder.render(command);
   }
 
   /**
@@ -193,18 +171,18 @@ public class ExecutableInjectService {
         defaultPayloadArguments,
         injectorContractContentFields,
         injectContent,
-        ResolutionMode.DISPLAY_PERMISSIVE);
+        false);
   }
 
   /** Resolves the effective value of a single argument, before any shell escaping. */
   private ResolvedArgument resolveArgumentValue(
       String argumentKey,
       PayloadArgument defaultPayloadArgument,
-      FieldPolicy policy,
+      String defaultValue,
+      boolean mandatory,
       List<ObjectNode> injectorContractContentFields,
       ObjectNode injectContent) {
     PrimitiveType type = defaultPayloadArgument != null ? defaultPayloadArgument.getType() : null;
-    String defaultValue = resolveDefaultValue(defaultPayloadArgument, policy);
     String value = "";
     boolean missing = true;
 
@@ -235,7 +213,7 @@ public class ExecutableInjectService {
         log.error("Payload argument target unexisting document", e);
       }
     }
-    return new ResolvedArgument(value, missing, policy);
+    return new ResolvedArgument(value, missing, mandatory);
   }
 
   public static String replaceCmdVariables(String cmd) {
@@ -277,12 +255,14 @@ public class ExecutableInjectService {
     return formattedCommand.toString();
   }
 
-  String renderCommandForExecution(
+  private String processAndEncodeCommand(
       String command,
       String executor,
       List<PayloadArgument> defaultPayloadArguments,
       ObjectNode injectContent,
-      List<ObjectNode> injectorContractContentFields) {
+      List<ObjectNode> injectorContractContentFields,
+      String obfuscator) {
+    OpenAEVObfuscationMap obfuscationMap = new OpenAEVObfuscationMap(executor);
     String computedCommand = command;
     // cmd-specific rewrites are applied to the TEMPLATE only: running them after substitution would
     // let an argument value smuggle a %VAR% / newline through them.
@@ -298,26 +278,7 @@ public class ExecutableInjectService {
             defaultPayloadArguments,
             injectorContractContentFields,
             injectContent,
-            ResolutionMode.EXECUTION_STRICT);
-
-    return computedCommand;
-  }
-
-  private String processAndEncodeCommand(
-      String command,
-      String executor,
-      List<PayloadArgument> defaultPayloadArguments,
-      ObjectNode injectContent,
-      List<ObjectNode> injectorContractContentFields,
-      String obfuscator) {
-    OpenAEVObfuscationMap obfuscationMap = new OpenAEVObfuscationMap(executor);
-    String computedCommand =
-        renderCommandForExecution(
-            command,
-            executor,
-            defaultPayloadArguments,
-            injectContent,
-            injectorContractContentFields);
+            true);
 
     computedCommand = obfuscationMap.executeObfuscation(obfuscator, computedCommand, executor);
 
@@ -498,74 +459,48 @@ public class ExecutableInjectService {
             dnsResolution.getArguments(),
             null,
             inject.getContent(),
-            ResolutionMode.DNS_LITERAL));
+            false));
     return dnsResolution;
   }
 
-  private String resolveDefaultValue(PayloadArgument defaultPayloadArgument, FieldPolicy policy) {
+  private PayloadArgument findPayloadArgument(
+      String argumentKey, List<PayloadArgument> payloadArguments) {
+    return payloadArguments.stream()
+        .filter(arg -> argumentKey.equals(arg.getKey()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private ObjectNode findFieldByKey(
+      String argumentKey, List<ObjectNode> injectorContractContentFields) {
+    return injectorContractContentFields.stream()
+        .filter(field -> field.has(CONTRACT_ELEMENT_CONTENT_KEY))
+        .filter(field -> argumentKey.equals(field.get(CONTRACT_ELEMENT_CONTENT_KEY).asText()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private boolean isMandatoryField(
+      String argumentKey, List<ObjectNode> injectorContractContentFields) {
+    ObjectNode field = findFieldByKey(argumentKey, injectorContractContentFields);
+    return field != null
+        && field.has(CONTRACT_ELEMENT_CONTENT_MANDATORY)
+        && field.get(CONTRACT_ELEMENT_CONTENT_MANDATORY).asBoolean(false);
+  }
+
+  private String resolveDefaultValue(
+      String argumentKey,
+      PayloadArgument defaultPayloadArgument,
+      List<ObjectNode> injectorContractContentFields) {
     if (defaultPayloadArgument != null && hasText(defaultPayloadArgument.getDefaultValue())) {
       return defaultPayloadArgument.getDefaultValue();
     }
-    return policy.defaultValue() != null
-        ? policy.defaultValue()
-        : defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : "";
+    ObjectNode field = findFieldByKey(argumentKey, injectorContractContentFields);
+    if (field != null && field.has(DEFAULT_VALUE_FIELD)) {
+      return field.get(DEFAULT_VALUE_FIELD).asText("");
+    }
+    return defaultPayloadArgument != null ? defaultPayloadArgument.getDefaultValue() : "";
   }
 
-  private String pruneOptionalFlagSegments(String command, Set<String> missingOptionalKeys) {
-    String pruned = command;
-    for (String key : missingOptionalKeys) {
-      String placeholder = "#\\{" + Pattern.quote(key) + "\\}";
-      pruned = pruned.replaceAll("\\s+--[\\w-]+\\s+(?:\"|')?" + placeholder + "(?:\"|')?", "");
-      pruned = pruned.replaceAll("\\s+-[A-Za-z0-9]\\s+(?:\"|')?" + placeholder + "(?:\"|')?", "");
-      pruned = pruned.replaceAll("\\s+--[\\w-]+=((?:\"|')?)" + placeholder + "\\1", "");
-      pruned = pruned.replaceAll("\\s+-[A-Za-z0-9]=((?:\"|')?)" + placeholder + "\\1", "");
-    }
-    return pruned.replaceAll("\\s{2,}", " ").trim();
-  }
-
-  private Map<String, FieldPolicy> buildFieldPolicies(
-      List<ObjectNode> injectorContractContentFields) {
-    if (injectorContractContentFields == null || injectorContractContentFields.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    return injectorContractContentFields.stream()
-        .filter(field -> field.has(CONTRACT_ELEMENT_CONTENT_KEY))
-        .collect(
-            Collectors.toMap(
-                field -> field.get(CONTRACT_ELEMENT_CONTENT_KEY).asText(),
-                field ->
-                    new FieldPolicy(
-                        field.has(CONTRACT_ELEMENT_CONTENT_MANDATORY)
-                            && field.get(CONTRACT_ELEMENT_CONTENT_MANDATORY).asBoolean(false),
-                        field.has(DEFAULT_VALUE_FIELD)
-                            ? field.get(DEFAULT_VALUE_FIELD).asText("")
-                            : ""),
-                (first, second) -> first));
-  }
-
-  private record FieldPolicy(boolean mandatory, String defaultValue) {}
-
-  private record ResolvedArgument(String value, boolean missing, FieldPolicy policy) {}
-
-  private enum ResolutionMode {
-    EXECUTION_STRICT(true, true),
-    DISPLAY_PERMISSIVE(false, true),
-    DNS_LITERAL(false, false);
-
-    private final boolean enforceMandatory;
-    private final boolean pruneMissingOptionalFlags;
-
-    ResolutionMode(boolean enforceMandatory, boolean pruneMissingOptionalFlags) {
-      this.enforceMandatory = enforceMandatory;
-      this.pruneMissingOptionalFlags = pruneMissingOptionalFlags;
-    }
-
-    boolean enforceMandatory() {
-      return enforceMandatory;
-    }
-
-    boolean pruneMissingOptionalFlags() {
-      return pruneMissingOptionalFlags;
-    }
-  }
+  private record ResolvedArgument(String value, boolean missing, boolean mandatory) {}
 }

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/ExecutableInjectService.java
@@ -142,7 +142,7 @@ public class ExecutableInjectService {
         log.error(
             "[Inject execution] Missing mandatory input '{}' -> step run can not be created/executed",
             argumentKey);
-        throw new IllegalStateException(
+        throw new IllegalArgumentException(
             "Missing mandatory input '%s' for inject execution".formatted(argumentKey));
       }
       binder.bind(argumentKey, resolvedArgument.value());

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -33,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Transactional(rollbackFor = Exception.class)
 public class ConditionService {
+  private static final String OPTIONAL_MISSING_SOURCE_KEY = "OPTIONAL_MISSING";
+
   private final WorkflowStateService workflowStateService;
 
   private final ConditionUtils conditionUtils;
@@ -1245,7 +1247,9 @@ public class ConditionService {
    */
   private Map<String, String> toComboMap(List<WorkflowStateEntries.Pair> pairs) {
     Map<String, String> combo = new TreeMap<>();
-    pairs.forEach(pair -> combo.put(pair.key(), pair.value()));
+    pairs.stream()
+        .filter(pair -> pair.value() != null)
+        .forEach(pair -> combo.put(pair.key(), pair.value()));
     return combo;
   }
 
@@ -1299,6 +1303,14 @@ public class ConditionService {
       pairs.add(
           new WorkflowStateEntries.Pair(
               targetKey != null ? targetKey : "DEFINED_VALUE", definedValue));
+    }
+
+    if (pairs.isEmpty()) {
+      String sourceKey =
+          mapperContext.sourceKeys().isEmpty()
+              ? OPTIONAL_MISSING_SOURCE_KEY
+              : mapperContext.sourceKeys().getFirst();
+      pairs.add(new WorkflowStateEntries.Pair(sourceKey, null));
     }
 
     return pairs;

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -1279,9 +1279,16 @@ public class ConditionService {
     List<WorkflowStateEntries.Pair> pairs = new ArrayList<>();
     Set<String> seenValues = new HashSet<>();
     for (String sourceKey : mapperContext.sourceKeys()) {
-      Set<String> values =
+      Set<String> values = new LinkedHashSet<>();
+      Set<String> directValues =
           resolveValuesByMappingType(
               sourceKey, mapperContext.mappingType(), localEntries, globalEntries);
+      if (directValues != null) {
+        values.addAll(directValues);
+      }
+      values.addAll(
+          resolveCorrelatedValuesByMappingType(
+              sourceKey, mapperContext.mappingType(), localEntries, globalEntries));
       if (values == null || values.isEmpty()) {
         continue;
       }
@@ -1314,6 +1321,25 @@ public class ConditionService {
     }
 
     return pairs;
+  }
+
+  private Set<String> resolveCorrelatedValuesByMappingType(
+      String key,
+      MappingType mappingType,
+      WorkflowStateEntries localEntries,
+      WorkflowStateEntries globalEntries) {
+    WorkflowStateEntries sourceEntries =
+        mappingType == MappingType.GLOBAL ? globalEntries : localEntries;
+    if (sourceEntries.getCorrelated() == null || sourceEntries.getCorrelated().isEmpty()) {
+      return Set.of();
+    }
+    return sourceEntries.getCorrelated().stream()
+        .flatMap(tuple -> tuple.getValues().stream())
+        .filter(pair -> key.equals(pair.key()))
+        .map(WorkflowStateEntries.Pair::value)
+        .filter(Objects::nonNull)
+        .filter(value -> !value.isBlank())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -1,11 +1,15 @@
 package io.openaev.rest.inject.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.PayloadArgument;
 import io.openaev.database.model.PrimitiveType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +36,69 @@ class ExecutableInjectServiceTest {
 
     // Assert
     assertThat(result)
-        .isEqualTo("cat #{payload_location}/linpeas.sh && cd #{location} && echo hello ");
+        .isEqualTo("cat #{payload_location}/linpeas.sh && cd #{location} && echo hello");
+  }
+
+  @Test
+  @DisplayName("Should prune optional flag segment when optional value is missing")
+  void given_optionalMissingArgument_should_pruneRelatedFlagSegment() {
+    // Arrange
+    ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
+    injectContent.put("IP", "10.10.10.10");
+    String command = "nxc smb #{IP} -u #{username} --shares";
+
+    ObjectNode usernameField = JsonNodeFactory.instance.objectNode();
+    usernameField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY, "username");
+    usernameField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_MANDATORY, false);
+    usernameField.put(InjectorContract.DEFAULT_VALUE_FIELD, "");
+
+    // Act
+    String result =
+        service.resolveArgumentsForDisplay(
+            command,
+            List.of(payloadArgument("IP", ""), payloadArgument("username", "")),
+            List.of(usernameField),
+            injectContent);
+
+    // Assert
+    assertThat(result).isEqualTo("nxc smb 10.10.10.10 --shares");
+  }
+
+  @Test
+  @DisplayName("Should block execution when mandatory value is missing")
+  void given_mandatoryMissingArgument_should_blockExecution() throws Exception {
+    // Arrange
+    Method method =
+        ExecutableInjectService.class.getDeclaredMethod(
+            "processAndEncodeCommand",
+            String.class,
+            String.class,
+            List.class,
+            ObjectNode.class,
+            List.class,
+            String.class);
+    method.setAccessible(true);
+
+    ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
+    ObjectNode usernameField = JsonNodeFactory.instance.objectNode();
+    usernameField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY, "username");
+    usernameField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_MANDATORY, true);
+    usernameField.put(InjectorContract.DEFAULT_VALUE_FIELD, "");
+
+    // Act / Assert
+    assertThatThrownBy(
+            () ->
+                method.invoke(
+                    service,
+                    "nxc smb -u #{username}",
+                    "sh",
+                    List.of(payloadArgument("username", "")),
+                    injectContent,
+                    List.of(usernameField),
+                    "plain-text"))
+        .isInstanceOf(InvocationTargetException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasRootCauseMessage("Missing mandatory input 'username' for inject execution");
   }
 
   private static PayloadArgument payloadArgument(String key, String defaultValue) {

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.PayloadArgument;
 import io.openaev.database.model.PrimitiveType;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,19 +64,8 @@ class ExecutableInjectServiceTest {
 
   @Test
   @DisplayName("Should block execution when mandatory value is missing")
-  void given_mandatoryMissingArgument_should_blockExecution() throws Exception {
+  void given_mandatoryMissingArgument_should_blockExecution() {
     // Arrange
-    Method method =
-        ExecutableInjectService.class.getDeclaredMethod(
-            "processAndEncodeCommand",
-            String.class,
-            String.class,
-            List.class,
-            ObjectNode.class,
-            List.class,
-            String.class);
-    method.setAccessible(true);
-
     ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
     ObjectNode usernameField = JsonNodeFactory.instance.objectNode();
     usernameField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY, "username");
@@ -88,17 +75,35 @@ class ExecutableInjectServiceTest {
     // Act / Assert
     assertThatThrownBy(
             () ->
-                method.invoke(
-                    service,
+                service.renderCommandForExecution(
                     "nxc smb -u #{username}",
                     "sh",
                     List.of(payloadArgument("username", "")),
                     injectContent,
-                    List.of(usernameField),
-                    "plain-text"))
-        .isInstanceOf(InvocationTargetException.class)
-        .hasCauseInstanceOf(IllegalStateException.class)
-        .hasRootCauseMessage("Missing mandatory input 'username' for inject execution");
+                    List.of(usernameField)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Missing mandatory input 'username' for inject execution");
+  }
+
+  @Test
+  @DisplayName("Should keep positional placeholders when optional value is missing")
+  void given_optionalMissingPositional_should_notPrunePlaceholderOutsideFlags() {
+    // Arrange
+    ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
+    String command = "tool run #{mode}";
+
+    ObjectNode modeField = JsonNodeFactory.instance.objectNode();
+    modeField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY, "mode");
+    modeField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_MANDATORY, false);
+    modeField.put(InjectorContract.DEFAULT_VALUE_FIELD, "");
+
+    // Act
+    String result =
+        service.resolveArgumentsForDisplay(
+            command, List.of(payloadArgument("mode", "")), List.of(modeField), injectContent);
+
+    // Assert
+    assertThat(result).isEqualTo("tool run ");
   }
 
   private static PayloadArgument payloadArgument(String key, String defaultValue) {

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -97,7 +97,7 @@ class ExecutableInjectServiceTest {
                     List.of(usernameField),
                     "plain-text"))
         .isInstanceOf(InvocationTargetException.class)
-        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
         .hasRootCauseMessage("Missing mandatory input 'username' for inject execution");
   }
 

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/ExecutableInjectServiceTest.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.PayloadArgument;
 import io.openaev.database.model.PrimitiveType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,12 +36,12 @@ class ExecutableInjectServiceTest {
 
     // Assert
     assertThat(result)
-        .isEqualTo("cat #{payload_location}/linpeas.sh && cd #{location} && echo hello");
+        .isEqualTo("cat #{payload_location}/linpeas.sh && cd #{location} && echo hello ");
   }
 
   @Test
-  @DisplayName("Should prune optional flag segment when optional value is missing")
-  void given_optionalMissingArgument_should_pruneRelatedFlagSegment() {
+  @DisplayName("Should keep command structure when optional value is missing")
+  void given_optionalMissingArgument_should_keepFlagWithEmptyValue() {
     // Arrange
     ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
     injectContent.put("IP", "10.10.10.10");
@@ -59,13 +61,24 @@ class ExecutableInjectServiceTest {
             injectContent);
 
     // Assert
-    assertThat(result).isEqualTo("nxc smb 10.10.10.10 --shares");
+    assertThat(result).isEqualTo("nxc smb 10.10.10.10 -u  --shares");
   }
 
   @Test
   @DisplayName("Should block execution when mandatory value is missing")
-  void given_mandatoryMissingArgument_should_blockExecution() {
+  void given_mandatoryMissingArgument_should_blockExecution() throws Exception {
     // Arrange
+    Method method =
+        ExecutableInjectService.class.getDeclaredMethod(
+            "processAndEncodeCommand",
+            String.class,
+            String.class,
+            List.class,
+            ObjectNode.class,
+            List.class,
+            String.class);
+    method.setAccessible(true);
+
     ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
     ObjectNode usernameField = JsonNodeFactory.instance.objectNode();
     usernameField.put(InjectorContract.CONTRACT_ELEMENT_CONTENT_KEY, "username");
@@ -75,19 +88,22 @@ class ExecutableInjectServiceTest {
     // Act / Assert
     assertThatThrownBy(
             () ->
-                service.renderCommandForExecution(
+                method.invoke(
+                    service,
                     "nxc smb -u #{username}",
                     "sh",
                     List.of(payloadArgument("username", "")),
                     injectContent,
-                    List.of(usernameField)))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Missing mandatory input 'username' for inject execution");
+                    List.of(usernameField),
+                    "plain-text"))
+        .isInstanceOf(InvocationTargetException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasRootCauseMessage("Missing mandatory input 'username' for inject execution");
   }
 
   @Test
-  @DisplayName("Should keep positional placeholders when optional value is missing")
-  void given_optionalMissingPositional_should_notPrunePlaceholderOutsideFlags() {
+  @DisplayName("Should keep positional placeholder as empty value when optional input is missing")
+  void given_optionalMissingPositional_should_keepEmptyValue() {
     // Arrange
     ObjectNode injectContent = JsonNodeFactory.instance.objectNode();
     String command = "tool run #{mode}";

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -934,11 +934,18 @@ public class ConditionServiceTest {
       assertEquals("admin", json.get("Text").getAsString());
       assertFalse(json.has("Host"));
 
-      Map<String, String> mapperValuesByKey =
+      Condition textMapper =
           batches.getFirst().usedMappers().stream()
-              .collect(java.util.stream.Collectors.toMap(Condition::getKey, Condition::getValue));
-      assertEquals("admin", mapperValuesByKey.get("Text"));
-      assertNull(mapperValuesByKey.get("Host"));
+              .filter(mapper -> "Text".equals(mapper.getKey()))
+              .findFirst()
+              .orElseThrow();
+      Condition hostMapper =
+          batches.getFirst().usedMappers().stream()
+              .filter(mapper -> "Host".equals(mapper.getKey()))
+              .findFirst()
+              .orElseThrow();
+      assertEquals("admin", textMapper.getValue());
+      assertNull(hostMapper.getValue());
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -906,6 +906,70 @@ public class ConditionServiceTest {
               .collect(java.util.stream.Collectors.toSet());
       assertEquals(Set.of("pool-a", "pool-b"), values);
     }
+
+    @Test
+    void given_defaultMapperAndMissingLinkedMapper_should_generateSingleBatchWithDefaultOnly() {
+      // -------- Arrange --------
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-default-plus-missing-linked");
+
+      List<Condition> mappers =
+          List.of(
+              mapper(MappingType.DEFAULT, PrimitiveType.Text, "admin"),
+              mapper(MappingType.LOCAL, PrimitiveType.Host, null));
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-default-plus-missing-linked"))
+          .thenReturn(stateFromEntries(entries(List.of(), List.of())));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(entries(List.of(), List.of())));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      assertEquals(1, batches.size());
+      JsonObject json = inputJson(batches.getFirst());
+      assertEquals("admin", json.get("Text").getAsString());
+      assertFalse(json.has("Host"));
+
+      Map<String, String> mapperValuesByKey =
+          batches.getFirst().usedMappers().stream()
+              .collect(java.util.stream.Collectors.toMap(Condition::getKey, Condition::getValue));
+      assertEquals("admin", mapperValuesByKey.get("Text"));
+      assertNull(mapperValuesByKey.get("Host"));
+    }
+
+    @Test
+    void given_allLinkedMappersMissingValues_should_generateSingleEmptyInputBatch() {
+      // -------- Arrange --------
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-all-linked-missing");
+
+      List<Condition> mappers =
+          List.of(
+              mapper(MappingType.LOCAL, PrimitiveType.IPv4, null),
+              mapper(MappingType.GLOBAL, PrimitiveType.Port, null));
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-all-linked-missing"))
+          .thenReturn(stateFromEntries(entries(List.of(), List.of())));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(entries(List.of(), List.of())));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      assertEquals(1, batches.size());
+      JsonObject json = inputJson(batches.getFirst());
+      assertEquals(0, json.size());
+      assertEquals(2, batches.getFirst().usedMappers().size());
+      assertTrue(
+          batches.getFirst().usedMappers().stream().allMatch(mapper -> mapper.getValue() == null));
+    }
   }
 
   /* ============================================================


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Unblock execution when input are not mandatories

### Testing Instructions
1. Create an netexec 
2. Link some input not mandatories
3. Create un nextexec witjout links
4. Create other netexec with osome default values
5. Execute => It should create 3 netexet executions, check command executed

<img width="1045" height="824" alt="image" src="https://github.com/user-attachments/assets/cc43f482-7caf-4cb4-bd89-ccbad75b44b1" />
<img width="1202" height="494" alt="image" src="https://github.com/user-attachments/assets/43c5578b-3d67-462b-a20e-742ae3f6fd7c" />
<img width="854" height="446" alt="image" src="https://github.com/user-attachments/assets/241f7cd9-f5f4-442b-949b-9205206f5460" />
<img width="873" height="489" alt="image" src="https://github.com/user-attachments/assets/e626fa90-e3fb-47e4-b8e3-0b6a67000654" />
<img width="827" height="516" alt="image" src="https://github.com/user-attachments/assets/fc568ac8-e25c-4e8f-940c-51c5ab27dbe2" />

### Related issues


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
