### PR TITLE
fix(autonomous): scrollable orchestrator drawer and run lifecycle guards (#7390)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -199,6 +199,22 @@ public class AutonomousRunService {
             () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Autonomous run not found"));
   }
 
+  /**
+   * Row-locking variant of {@link #require} for the operator lifecycle/steering actions guarded by
+   * {@link #assertRunNotTerminal}. The run row has no optimistic version, so the guard's
+   * check-then-act is only sound if the read serialises with the concurrent terminal writers (the
+   * read-path reconcile / timeout watchdog, whose conditional UPDATEs take the row lock): {@code
+   * SELECT ... FOR UPDATE} makes a terminal settle that committed first visible to the guard, and
+   * makes a settle that arrives second wait and re-evaluate its status predicate - either way the
+   * terminal state can no longer be silently overwritten by a racing pause/resume/steer.
+   */
+  private AutonomousRun requireForUpdate(String runId) {
+    return runRepository
+        .findByIdForUpdate(runId)
+        .orElseThrow(
+            () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Autonomous run not found"));
+  }
+
   /** A settled run: canceled, completed or failed. Nothing may execute or be authored on it. */
   private static boolean isTerminal(AutonomousRunStatus status) {
     return status == AutonomousRunStatus.CANCELED
@@ -236,6 +252,10 @@ public class AutonomousRunService {
    * hides these controls on a terminal run; this closes the race between the page load and the
    * click. Mirrors the terminal-status no-op {@link #updateStatus} already applies on the
    * orchestrator side.
+   *
+   * <p>Callers must load the run through {@link #requireForUpdate} (row lock): the run row is not
+   * optimistically locked, so without the lock a reconcile/watchdog terminal settle committing
+   * between this check and the action's save would still be overwritten.
    */
   private void assertRunNotTerminal(AutonomousRun run, String action) {
     if (isTerminal(run.getStatus())) {
@@ -961,7 +981,7 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun pause(String runId) {
     requireFeature();
-    AutonomousRun run = require(runId);
+    AutonomousRun run = requireForUpdate(runId);
     assertRunNotTerminal(run, "paused");
     transitionSimulation(run, ExerciseStatus.PAUSED);
     run.setStatus(AutonomousRunStatus.PAUSED);
@@ -978,7 +998,7 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun resume(String runId) {
     requireFeature();
-    AutonomousRun run = require(runId);
+    AutonomousRun run = requireForUpdate(runId);
     assertRunNotTerminal(run, "resumed");
     transitionSimulation(run, ExerciseStatus.RUNNING);
     // Mirror start() / addDirective(): a plan-mode run returns to PLANNING (it is still authoring
@@ -1782,7 +1802,7 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousDirective addDirective(String runId, String content) {
     requireFeature();
-    AutonomousRun run = require(runId);
+    AutonomousRun run = requireForUpdate(runId);
     assertRunNotTerminal(run, "steered");
     AutonomousDirective directive = new AutonomousDirective();
     directive.setRunId(runId);

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -227,6 +227,28 @@ public class AutonomousRunService {
     }
   }
 
+  /**
+   * Refuses an operator lifecycle/steering action (pause / resume / steer) against a run that has
+   * already ended. A terminated run's XTM One orchestration is torn down, so pausing or resuming it
+   * would resurrect a dead row - a lost update the read-path reconcile then re-settles on every
+   * poll (the "Run canceled" cadence {@link #assertRunAcceptsAuthoring} describes) - and a steering
+   * directive would queue against an orchestrator that no longer exists. The operator UI already
+   * hides these controls on a terminal run; this closes the race between the page load and the
+   * click. Mirrors the terminal-status no-op {@link #updateStatus} already applies on the
+   * orchestrator side.
+   */
+  private void assertRunNotTerminal(AutonomousRun run, String action) {
+    if (isTerminal(run.getStatus())) {
+      throw new ResponseStatusException(
+          HttpStatus.CONFLICT,
+          "This autonomous run has ended ("
+              + run.getStatus()
+              + "); it can no longer be "
+              + action
+              + ".");
+    }
+  }
+
   // region lifecycle
 
   /**
@@ -940,6 +962,7 @@ public class AutonomousRunService {
   public AutonomousRun pause(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
+    assertRunNotTerminal(run, "paused");
     transitionSimulation(run, ExerciseStatus.PAUSED);
     run.setStatus(AutonomousRunStatus.PAUSED);
     AutonomousRun saved = runRepository.save(run);
@@ -956,8 +979,13 @@ public class AutonomousRunService {
   public AutonomousRun resume(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
+    assertRunNotTerminal(run, "resumed");
     transitionSimulation(run, ExerciseStatus.RUNNING);
-    run.setStatus(AutonomousRunStatus.RUNNING);
+    // Mirror start() / addDirective(): a plan-mode run returns to PLANNING (it is still authoring
+    // the scenario logic, and stampDeadline below leaves it deadline-free), a live run to RUNNING.
+    // Forcing RUNNING here flipped a resumed plan build into an "executing" run in the UI and moved
+    // it onto the live-run deadline path, breaking the dry-run.
+    run.setStatus(run.isPlanMode() ? AutonomousRunStatus.PLANNING : AutonomousRunStatus.RUNNING);
     run.setLastError(null);
     // Resuming grants a fresh time budget from now (and re-arms the winddown nudges): a run paused
     // for a while must not be hard-stopped the instant it comes back.
@@ -1755,6 +1783,7 @@ public class AutonomousRunService {
   public AutonomousDirective addDirective(String runId, String content) {
     requireFeature();
     AutonomousRun run = require(runId);
+    assertRunNotTerminal(run, "steered");
     AutonomousDirective directive = new AutonomousDirective();
     directive.setRunId(runId);
     directive.setContent(content);

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -548,7 +548,16 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     && !questionAnsweredInTimeline
     ? latestQuestion
     : undefined;
+  // Sanitize the LLM-authored labels at derivation (not render) time and DROP a choice whose label
+  // sanitizes to nothing: falling back to the raw text would leak the exact tool markup
+  // sanitizeEventText strips, and an unlabeled radio is unpickable anyway - the free-text composer
+  // remains as the answer path. The `value` (what is sent back to the orchestrator) stays raw.
   const questionChoices = (pendingQuestion ? parseQuestionChoices(pendingQuestion.autonomous_event_data) : [])
+    .map(choice => ({
+      ...choice,
+      label: sanitizeEventText(choice.label),
+    }))
+    .filter(choice => choice.label.length > 0)
     .slice(0, MAX_QUESTION_CHOICES);
   const hasChoices = questionChoices.length > 0;
 
@@ -569,10 +578,19 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     composerPlaceholder = t('Answer the AI (e.g. the web apps in scope are app-prod-01 and app-prod-02)');
   }
 
-  // Reset the choice selection whenever a new question arrives.
+  // Reset the composer + choice selection ONLY when a genuinely NEW question arrives. Keyed on the
+  // last question id seen (not on every pendingQuestion identity change): after a failed send the
+  // SAME question resurfaces (the optimistic dismissal is rolled back), and an unconditional reset
+  // would fire on that undefined -> same-id transition and wipe the restored answer text right
+  // after the catch put it back - stranding the operator exactly like the bug this PR fixes.
+  const lastQuestionIdRef = useRef<string | null>(null);
   useEffect(() => {
-    setSelectedChoice(null);
-    setDirective('');
+    const questionId = pendingQuestion?.autonomous_event_id ?? null;
+    if (questionId !== null && questionId !== lastQuestionIdRef.current) {
+      lastQuestionIdRef.current = questionId;
+      setSelectedChoice(null);
+      setDirective('');
+    }
   }, [pendingQuestion?.autonomous_event_id]);
 
   // Keep the stream pinned to its tail as it grows - but only while the operator was already at (or
@@ -607,9 +625,11 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
       .catch(() => {
         // The send failed (network / backend). Roll back the optimistic dismissal so the question
         // re-surfaces, and restore the operator's text - otherwise the callout is gone for good and
-        // the run is stranded in WAITING_INPUT with no way to answer it.
+        // the run is stranded in WAITING_INPUT with no way to answer it. Restore ONLY while the
+        // composer is still empty: the field stays live during the in-flight request, so the
+        // operator may already be typing something new and the rollback must not clobber it.
         setAnsweredQuestionId(current => (current === dismissedQuestionId ? null : current));
-        setDirective(trimmed);
+        setDirective(current => (current.trim().length === 0 ? trimmed : current));
       })
       .finally(() => {
         sendingRef.current = false;
@@ -1149,7 +1169,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                                   }}
                                 />
                               )}
-                              label={sanitizeEventText(choice.label) || choice.label}
+                              label={choice.label}
                               sx={{
                                 'margin': 0,
                                 'alignItems': 'flex-start',

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -378,6 +378,10 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // The question the operator just answered - suppressed immediately (optimistic) so the callout
   // does not linger and hog space while we wait for the status poll to flip the run to RUNNING.
   const [answeredQuestionId, setAnsweredQuestionId] = useState<string | null>(null);
+  // Guards against a double submit: Enter and a click (or two fast Enters) both fire
+  // handleComposerSubmit in the same tick, and each reads the same pre-clear `directive`, so without
+  // this the operator's answer is sent twice. Held until the request settles.
+  const sendingRef = useRef(false);
   const cursorRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Whether the operator is at (or near) the bottom of the stream, sampled in the onScroll handler
@@ -461,9 +465,14 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // run at mount, so without re-syncing from the parent the panel would keep showing the torn-down
   // (terminal) run - and, because refreshRun only polls while active, never recover until a full
   // page reload. Re-sync whenever the parent's run or its underlying simulation changes.
+  //
+  // The status is a dependency too: lifecycle controls live in the hero, not here, so a hero-driven
+  // pause/resume changes only the parent's run. When the run is not active the panel does not poll,
+  // so a resume would otherwise never reach the panel - it would stay frozen as PAUSED with a live
+  // composer until a full remount. Keying on status makes a hero transition reflect immediately.
   useEffect(() => {
     setRun(initialRunRef.current);
-  }, [initialRun.autonomous_run_id, initialRun.autonomous_run_simulation_id]);
+  }, [initialRun.autonomous_run_id, initialRun.autonomous_run_simulation_id, initialRun.autonomous_run_status]);
 
   // Reset and reload ONLY when the run OR its underlying simulation actually changes: navigating
   // between simulations reuses the panel, and a restart swaps the simulation under the same run id
@@ -514,18 +523,6 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // once per new batch of events, not on every incidental re-render.
   const visibleEvents = useMemo(() => events.filter(e => !isHeartbeatEvent(e)), [events]);
 
-  // Keep the stream pinned to the latest decision as it grows - but only while the operator was
-  // already at (or near) the bottom before the new content rendered (see stickToBottomRef), so a
-  // new event never yanks them away from an older decision they scrolled up to read. Keyed on the
-  // VISIBLE feed length: filtered-out heartbeats do not change the rendered stream, so they should
-  // not re-trigger the pin at all.
-  useEffect(() => {
-    const node = scrollRef.current;
-    if (node && stickToBottomRef.current) {
-      node.scrollTop = node.scrollHeight;
-    }
-  }, [visibleEvents.length]);
-
   const isWaitingInput = status === 'WAITING_INPUT';
   // Newest-first lookups over the stream. findLast scans backwards without cloning, and the
   // results are memoised so the scans (and isHeartbeatEvent's JSON.parse) run once per new batch
@@ -555,6 +552,13 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     .slice(0, MAX_QUESTION_CHOICES);
   const hasChoices = questionChoices.length > 0;
 
+  // The pending question renders as a dedicated in-flow callout at the tail of the scrollable stream
+  // (with its one-click choices), so drop its plain timeline row from the feed to avoid showing it
+  // twice. Once answered it is no longer pending and reappears as a normal history row.
+  const streamEvents = pendingQuestion
+    ? visibleEvents.filter(event => event.autonomous_event_id !== pendingQuestion.autonomous_event_id)
+    : visibleEvents;
+
   let composerPlaceholder = t('Steer the AI live (e.g. focus on the finance subnet, avoid host X, try Kerberoasting)');
   if (hasChoices) {
     composerPlaceholder = t('Or type your own answer');
@@ -571,18 +575,45 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     setDirective('');
   }, [pendingQuestion?.autonomous_event_id]);
 
+  // Keep the stream pinned to its tail as it grows - but only while the operator was already at (or
+  // near) the bottom before the new content rendered (see stickToBottomRef), so a new event never
+  // yanks them away from an older decision they scrolled up to read. Keyed on the VISIBLE feed
+  // length (filtered-out heartbeats do not change the rendered stream) AND on the pending-question
+  // identity, so the now in-flow question callout + one-click choices scroll into view the moment
+  // the run parks on the operator - even when the status flip and the QUESTION event land in
+  // different poll cycles.
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (node && stickToBottomRef.current) {
+      node.scrollTop = node.scrollHeight;
+    }
+  }, [visibleEvents.length, pendingQuestion?.autonomous_event_id]);
+
   const sendDirective = useCallback((content: string) => {
     const trimmed = content.trim();
-    if (trimmed.length === 0 || !isActive) {
+    if (trimmed.length === 0 || !isActive || sendingRef.current) {
       return;
     }
+    sendingRef.current = true;
+    const dismissedQuestionId = pendingQuestion?.autonomous_event_id ?? null;
     setDirective('');
     setSelectedChoice(null);
     // Optimistically dismiss the current question so its callout stops occupying space right away.
-    if (pendingQuestion) {
-      setAnsweredQuestionId(pendingQuestion.autonomous_event_id);
+    if (dismissedQuestionId) {
+      setAnsweredQuestionId(dismissedQuestionId);
     }
-    addAutonomousDirective(runId, trimmed).then(() => pollTimeline()).catch(() => {});
+    addAutonomousDirective(runId, trimmed)
+      .then(() => pollTimeline())
+      .catch(() => {
+        // The send failed (network / backend). Roll back the optimistic dismissal so the question
+        // re-surfaces, and restore the operator's text - otherwise the callout is gone for good and
+        // the run is stranded in WAITING_INPUT with no way to answer it.
+        setAnsweredQuestionId(current => (current === dismissedQuestionId ? null : current));
+        setDirective(trimmed);
+      })
+      .finally(() => {
+        sendingRef.current = false;
+      });
   }, [isActive, pendingQuestion, runId, pollTimeline]);
 
   // One submit path for the always-visible composer + optional one-click choices: a typed answer
@@ -606,13 +637,19 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // (not a single frozen line): keep the tail of narration/decision/tool prose in chronological
   // order so each new cycle appends a line at the bottom and older ones scroll up under the fade
   // mask, mirroring the XTM One thinking window. Operators read its train of thought, not a spinner.
-  const thinkingLines = events
-    .filter(e => (['NARRATION', 'DECISION', 'TOOL_ACTION'] as const).includes(
-      e.autonomous_event_type as 'NARRATION' | 'DECISION' | 'TOOL_ACTION',
-    ))
-    .map(e => stripMarkdown(sanitizeEventText(e.autonomous_event_content ?? e.autonomous_event_title)))
-    .filter((line): line is string => Boolean(line))
-    .slice(-8);
+  // Memoised: the map runs the regex-heavy stripMarkdown over the tail of the stream, so it should
+  // recompute once per new batch of events - not on every keystroke in the composer (which re-renders
+  // this component through the `directive` state).
+  const thinkingLines = useMemo(
+    () => events
+      .filter(e => (['NARRATION', 'DECISION', 'TOOL_ACTION'] as const).includes(
+        e.autonomous_event_type as 'NARRATION' | 'DECISION' | 'TOOL_ACTION',
+      ))
+      .map(e => stripMarkdown(sanitizeEventText(e.autonomous_event_content ?? e.autonomous_event_title)))
+      .filter((line): line is string => Boolean(line))
+      .slice(-8),
+    [events],
+  );
 
   // Current orchestrator phase for the thinking window. Derived from status + the latest activity
   // event rather than the raw run status, so the caption narrates what the run is doing and animates
@@ -969,7 +1006,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                 paddingBlock: 1,
               }}
               >
-                {visibleEvents.map((event) => {
+                {streamEvents.map((event) => {
                   const color = eventAccent(event, theme);
                   const eventTitle = sanitizeEventText(event.autonomous_event_title);
                   const eventContent = sanitizeEventText(event.autonomous_event_content);
@@ -1045,7 +1082,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                     </Box>
                   );
                 })}
-                {isActive && (
+                {isActive && !pendingQuestion && (
                   <ThinkingBubble
                     phase={thinkingPhase}
                     theme={theme}
@@ -1053,40 +1090,90 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                     activitySince={activitySince}
                   />
                 )}
+                {/* When the run parks on the operator, its question + one-click choices render HERE,
+                    inline at the tail of the scrollable stream (normal conversation flow) - not as a
+                    fixed band above the composer. On a short viewport a long question (e.g. a scope
+                    table) plus its choices would otherwise overflow a fixed region with no way to
+                    scroll to them; in-flow they scroll with the rest of the feed while the compact
+                    free-text composer stays pinned at the bottom as the "type your own answer" box. */}
+                {pendingQuestion && (
+                  <Box
+                    sx={{
+                      padding: theme.spacing(1.25, 1.5),
+                      borderRadius: 1.5,
+                      border: `1px solid ${alpha(theme.palette.warning.main, 0.4)}`,
+                      backgroundColor: alpha(theme.palette.warning.main, 0.08),
+                    }}
+                  >
+                    <Stack sx={{
+                      flexDirection: 'row',
+                      alignItems: 'flex-start',
+                      gap: 1,
+                    }}
+                    >
+                      <HelpOutline fontSize="small" color="warning" sx={{ marginTop: '2px' }} />
+                      <Box sx={{ minWidth: 0 }}>
+                        <Typography variant="subtitle2" sx={{ margin: 0 }}>
+                          {sanitizeEventText(pendingQuestion.autonomous_event_title) || t('The AI needs your input to continue')}
+                        </Typography>
+                        {sanitizeEventText(pendingQuestion.autonomous_event_content) && (
+                          <Box sx={{ marginTop: 0.25 }}>
+                            <EventMarkdown content={sanitizeEventText(pendingQuestion.autonomous_event_content)} fontSize="0.8125rem" />
+                          </Box>
+                        )}
+                      </Box>
+                    </Stack>
+                    {/* One-click choices, only where the operator can actually answer (steering is
+                        hidden in observe-only mode - they answer from the parent scenario). */}
+                    {hasChoices && !readOnly && (
+                      <RadioGroup
+                        value={selectedChoice ?? ''}
+                        onChange={event => setSelectedChoice(event.target.value)}
+                        sx={{
+                          gap: 0.75,
+                          marginTop: 1,
+                        }}
+                      >
+                        {questionChoices.map((choice) => {
+                          const isSelected = selectedChoice === choice.id;
+                          return (
+                            <FormControlLabel
+                              key={choice.id}
+                              value={choice.id}
+                              control={(
+                                <Radio
+                                  size="small"
+                                  sx={{
+                                    'color': accent,
+                                    '&.Mui-checked': { color: accent },
+                                  }}
+                                />
+                              )}
+                              label={sanitizeEventText(choice.label) || choice.label}
+                              sx={{
+                                'margin': 0,
+                                'alignItems': 'flex-start',
+                                'borderRadius': 1.5,
+                                'border': `1px solid ${isSelected ? accent : theme.palette.divider}`,
+                                'backgroundColor': isSelected ? alpha(accent, 0.08) : theme.palette.background.paper,
+                                'padding': theme.spacing(0.5, 1, 0.5, 0.5),
+                                'transition': theme.transitions.create(['border-color', 'background-color']),
+                                '&:hover': { borderColor: alpha(accent, 0.6) },
+                                '& .MuiFormControlLabel-label': {
+                                  fontSize: '0.8125rem',
+                                  paddingTop: '5px',
+                                },
+                              }}
+                            />
+                          );
+                        })}
+                      </RadioGroup>
+                    )}
+                  </Box>
+                )}
               </Stack>
             )}
       </Box>
-
-      {/* Question callout when the run is parked on the operator. Disappears the moment the
-          operator answers (optimistic), so it never lingers and hogs space below. */}
-      {pendingQuestion && (
-        <Box
-          sx={{
-            padding: theme.spacing(1.25, 2),
-            borderTop: `1px solid ${alpha(theme.palette.warning.main, 0.4)}`,
-            backgroundColor: alpha(theme.palette.warning.main, 0.08),
-          }}
-        >
-          <Stack sx={{
-            flexDirection: 'row',
-            alignItems: 'flex-start',
-            gap: 1,
-          }}
-          >
-            <HelpOutline fontSize="small" color="warning" sx={{ marginTop: '2px' }} />
-            <Box>
-              <Typography variant="subtitle2" sx={{ margin: 0 }}>
-                {pendingQuestion.autonomous_event_title ?? t('The AI needs your input to continue')}
-              </Typography>
-              {sanitizeEventText(pendingQuestion.autonomous_event_content) && (
-                <Box sx={{ marginTop: 0.25 }}>
-                  <EventMarkdown content={sanitizeEventText(pendingQuestion.autonomous_event_content)} fontSize="0.8125rem" />
-                </Box>
-              )}
-            </Box>
-          </Stack>
-        </Box>
-      )}
 
       {/* Steering box - chatbot-style, doubles as the answer field when waiting on input. On the
           observe-only (simulation) view it is replaced by a hint pointing to the parent scenario,
@@ -1108,55 +1195,13 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
           borderTop: `1px solid ${theme.palette.divider}`,
         }}
         >
-          {hasChoices && (
-            <RadioGroup
-              value={selectedChoice ?? ''}
-              onChange={event => setSelectedChoice(event.target.value)}
-              sx={{ gap: 0.75 }}
-            >
-              {questionChoices.map((choice) => {
-                const isSelected = selectedChoice === choice.id;
-                return (
-                  <FormControlLabel
-                    key={choice.id}
-                    value={choice.id}
-                    control={(
-                      <Radio
-                        size="small"
-                        sx={{
-                          'color': accent,
-                          '&.Mui-checked': { color: accent },
-                        }}
-                      />
-                    )}
-                    label={choice.label}
-                    sx={{
-                      'margin': 0,
-                      'alignItems': 'flex-start',
-                      'borderRadius': 1.5,
-                      'border': `1px solid ${isSelected ? accent : theme.palette.divider}`,
-                      'backgroundColor': isSelected ? alpha(accent, 0.08) : 'transparent',
-                      'padding': theme.spacing(0.5, 1, 0.5, 0.5),
-                      'transition': theme.transitions.create(['border-color', 'background-color']),
-                      '&:hover': { borderColor: alpha(accent, 0.6) },
-                      '& .MuiFormControlLabel-label': {
-                        fontSize: '0.8125rem',
-                        paddingTop: '5px',
-                      },
-                    }}
-                  />
-                );
-              })}
-            </RadioGroup>
-          )}
-
-          {/* Always-present composer: the free-text answer field sits directly next to the send
-              button, so typing is a first-class action (not a hidden "custom answer" mode). A typed
-              answer wins over a selected choice; the button also sends the picked choice when the
-              field is empty. */}
+          {/* Always-present composer: the free-text answer field, pinned at the bottom like a chat
+              steering box. When the run parks on a question its one-click choices live in the
+              scrollable stream above; a typed answer here wins over a selected choice, and the send
+              button also submits the picked choice when the field is empty. */}
           <Box
             sx={{
-              'marginTop': hasChoices ? 1 : 0,
+              'marginTop': 0,
               'display': 'flex',
               'flexDirection': 'column',
               'borderRadius': 1,
@@ -1215,6 +1260,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                 size="small"
                 onClick={handleComposerSubmit}
                 disabled={!canSubmitAnswer}
+                aria-label={t('Send')}
                 sx={{
                   'backgroundColor': accent,
                   'color': theme.palette.ai?.contrastText ?? theme.palette.primary.contrastText,

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
@@ -44,8 +44,8 @@ public interface AutonomousRunRepository extends JpaRepository<AutonomousRun, St
    * actions (pause / resume / steer). The run row carries no optimistic version, so a plain
    * read-check-save can silently overwrite a terminal status a concurrent writer (the read-path
    * reconcile's or the watchdog's conditional terminal UPDATE, both row-locking) commits between
-   * the read and the save. Taking the row lock at the read serialises the whole check-then-act
-   * with those writers: if the terminal settle commits first, this read observes it and the
+   * the read and the save. Taking the row lock at the read serialises the whole check-then-act with
+   * those writers: if the terminal settle commits first, this read observes it and the
    * terminal-state guard rejects the action; if this action wins the lock, the conditional UPDATE
    * waits and then re-evaluates its status predicate against the committed row.
    */

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
@@ -2,10 +2,12 @@ package io.openaev.database.repository.autonomous;
 
 import io.openaev.database.model.autonomous.AutonomousRun;
 import io.openaev.database.model.autonomous.AutonomousRunStatus;
+import jakarta.persistence.LockModeType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -36,6 +38,20 @@ public interface AutonomousRunRepository extends JpaRepository<AutonomousRun, St
   @Query("SELECT r FROM AutonomousRun r WHERE r.id = :id AND r.tenant.id = :tenantId")
   Optional<AutonomousRun> findByIdAndTenantId(
       @Param("id") String id, @Param("tenantId") String tenantId);
+
+  /**
+   * Pessimistically locked lookup ({@code SELECT ... FOR UPDATE}) for operator lifecycle/steering
+   * actions (pause / resume / steer). The run row carries no optimistic version, so a plain
+   * read-check-save can silently overwrite a terminal status a concurrent writer (the read-path
+   * reconcile's or the watchdog's conditional terminal UPDATE, both row-locking) commits between
+   * the read and the save. Taking the row lock at the read serialises the whole check-then-act
+   * with those writers: if the terminal settle commits first, this read observes it and the
+   * terminal-state guard rejects the action; if this action wins the lock, the conditional UPDATE
+   * waits and then re-evaluates its status predicate against the committed row.
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT r FROM AutonomousRun r WHERE r.id = :id")
+  Optional<AutonomousRun> findByIdForUpdate(@Param("id") String id);
 
   /**
    * Ids of the given tenant's live runs whose OpenAEV-enforced deadline is at or within {@code


### PR DESCRIPTION
## Summary

Pre-release hardening for the AI planning and autonomous-run chained-scenario features (OpenAEV side). Fixes the reported orchestrator-drawer scroll bug plus a set of self-contained frontend and backend robustness issues found in the final sweep.

Refs #7390 - the full findings, including the follow-ups deliberately deferred out of this PR (RBAC on autonomous endpoints, default-agents scoping, event-sequence uniqueness, SSE nudge for author-scenario, status transition matrix, ...).

### Frontend - autonomous orchestrator drawer (`AutonomousReasoningPanel`)

- Fix the scroll lock while waiting on an answer: the question and its one-click choices were a fixed band above the composer, so on a short viewport a long question overflowed with no way to scroll to it and the operator could not answer. The question and choices now render inline at the tail of the scrollable stream; only the free-text composer ("type your own answer") stays pinned at the bottom.
- Guard against double-submitting an answer (Enter + click / double Enter).
- Roll back the optimistic question dismissal on a failed send and restore the typed text (otherwise the run is stranded in WAITING_INPUT with no way to answer).
- Re-sync the panel on a hero-driven pause/resume (it was frozen as PAUSED until a remount).
- Stop rendering the pending question twice (timeline row + callout).
- Sanitize LLM-authored question title and choice labels.
- Memoise the regex-heavy thinking-window lines; add an aria-label to the send button.

### Backend - autonomous run lifecycle (`AutonomousRunService`)

- `resume()` returns a plan-mode (author) run to PLANNING instead of forcing RUNNING, so a resumed dry-run is not flipped into an executing run on the live-run deadline path.
- Add a terminal-state guard (HTTP 409) to `pause` / `resume` / `addDirective` so a click racing the read-path reconcile cannot resurrect an ended run or steer a torn-down orchestrator.

### Review fixes (e8f5955cf, 7e164cff4)

- Choice labels are sanitized at derivation and a choice whose label sanitizes to empty is dropped, instead of falling back to the raw (markup-leaking) text at render.
- The failed-send rollback restores the operator's text only while the composer is still empty, so it cannot clobber new text typed while the request was in flight.
- The composer/choice reset now fires only for a genuinely NEW question id: the unconditional reset re-fired when the rolled-back question resurfaced and wiped the restored answer text, defeating the rollback.
- `pause` / `resume` / `addDirective` load the run through a `SELECT ... FOR UPDATE` lookup (`findByIdForUpdate`) so the terminal-state guard's check-then-act serialises with the reconcile/watchdog conditional terminal UPDATEs - the run row has no optimistic version, so without the lock a terminal settle committing between the read and the save could still be overwritten.

## Test plan

- [x] openaev-front: `yarn eslint` (clean) + `yarn check-ts` (clean)
- [x] openaev-api: `mvn compile` (BUILD SUCCESS) + spotless
- [ ] Manual: park a run on a QUESTION on a short viewport; confirm the question + choices scroll into view and are answerable, and the composer stays pinned.
- [ ] Manual: pause/resume a plan-mode run from the hero; confirm it returns to PLANNING and the panel reflects it without a reload.
- [ ] Manual: attempt pause/resume/steer on a CANCELED/COMPLETED/FAILED run; confirm HTTP 409.
