### PR TITLE
fix(autonomous): RBAC, event-sequence serialization, status validation, IPv6 scope (#7390)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -492,8 +492,9 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousRun evaluateAttackPath(@PathVariable String runId) {
-    autonomousRunService.evaluateAttackPath(runId);
-    return autonomousRunService.get(runId);
+    // The service returns the reconciled run itself: this is an orchestrator CALLBACK, and reading
+    // back through the operator-gated get() would 403 a valid service-identity callback.
+    return autonomousRunService.evaluateAttackPath(runId);
   }
 
   @Operation(

--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -62,9 +62,11 @@ import org.springframework.web.bind.annotation.RestController;
  * </ul>
  *
  * <p>The controller is deliberately thin: all lifecycle, callback, steering, and read logic lives
- * in {@link AutonomousRunService}. Tenant isolation is enforced by the statement inspector on the
- * {@code autonomous_*} tables; RBAC is skipped at the annotation level because the run's authority
- * derives from its bound simulation, checked in-service.
+ * in {@link AutonomousRunService}. RBAC is skipped at the annotation level because the run's
+ * authority derives from its bound simulation, checked in-service through {@code
+ * AutonomousRunAccessControl}. The {@code autonomous_*} tables are not yet onboarded to the tenant
+ * statement inspector; their activation (and a service-identity check on the orchestrator
+ * callbacks) is tracked in issue #7396.
  *
  * <p>Endpoints split into three audiences: the operator UI (create / start / pause / resume /
  * cancel / steer / read), the XTM One orchestrator callbacks (events / status / directive

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
@@ -19,10 +19,14 @@ import org.springframework.stereotype.Component;
  * serialise (each succeeds with N and N+1) rather than one hitting the unique constraint; the index
  * is the backstop that makes a duplicate impossible even if that lock is ever bypassed.
  *
- * <p>Additive and idempotent: any pre-existing duplicate rows are collapsed first (keeping the
- * physically-first row of each group), then the old index is dropped and the unique index created
- * with {@code IF [NOT] EXISTS}, so re-running is a no-op. The {@code autonomous_events} table is a
- * new, preview-flag-gated, human-review-cadence store, so the brief index build lock is safe.
+ * <p>Additive and idempotent: any run holding duplicate sequences is deterministically resequenced
+ * first - every event row is KEPT (each duplicate narrates a distinct decision / audit entry, so
+ * deleting one would lose append-only timeline data) and the whole run timeline is renumbered 1..N
+ * in its existing order (sequence, then creation time, then event id as the tie-break). Then the
+ * old index is dropped and the unique index created with {@code IF [NOT] EXISTS}. On a clean table
+ * every sequence already equals its row number, so re-running is a no-op. The {@code
+ * autonomous_events} table is a new, preview-flag-gated, human-review-cadence store, so the brief
+ * index build lock is safe.
  */
 @Component
 public class V6_20260813100000000__Autonomous_event_sequence_unique extends BaseJavaMigration {
@@ -30,16 +34,28 @@ public class V6_20260813100000000__Autonomous_event_sequence_unique extends Base
   @Override
   public void migrate(Context context) throws Exception {
     try (Statement statement = context.getConnection().createStatement()) {
-      // Collapse any pre-existing (run_id, sequence) duplicates so the unique index can be built.
-      // Keeps the physically-first row of each group (lowest ctid) and drops the rest; a no-op on a
-      // clean table.
+      // Resequence any run carrying (run_id, sequence) duplicates so the unique index can be
+      // built WITHOUT deleting timeline rows: each duplicate is a distinct decision/audit event,
+      // so all rows are kept and the run's timeline is renumbered 1..N in deterministic order
+      // (existing sequence, then creation time, then event id). A no-op on a clean table, where
+      // every sequence already equals its row number.
       statement.execute(
           """
-          DELETE FROM autonomous_events a
-                USING autonomous_events b
-           WHERE a.autonomous_event_run_id = b.autonomous_event_run_id
-             AND a.autonomous_event_sequence = b.autonomous_event_sequence
-             AND a.ctid > b.ctid;
+          WITH ranked AS (
+              SELECT autonomous_event_id,
+                     ROW_NUMBER() OVER (
+                         PARTITION BY autonomous_event_run_id
+                         ORDER BY autonomous_event_sequence,
+                                  autonomous_event_created_at,
+                                  autonomous_event_id
+                     ) AS new_sequence
+                FROM autonomous_events
+          )
+          UPDATE autonomous_events e
+             SET autonomous_event_sequence = r.new_sequence
+            FROM ranked r
+           WHERE e.autonomous_event_id = r.autonomous_event_id
+             AND e.autonomous_event_sequence <> r.new_sequence;
           """);
       // Replace the non-unique run/sequence index with a unique one: it enforces the per-run
       // sequence invariant AND still serves the run-scoped ordered + since-sequence reads.

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
@@ -26,12 +26,17 @@ import org.springframework.stereotype.Component;
  * old index is dropped and the unique index created with {@code IF [NOT] EXISTS}. On a clean table
  * every sequence already equals its row number, so re-running is a no-op.
  *
- * <p>The whole pass runs behind a {@code SHARE ROW EXCLUSIVE} table lock held for the migration's
+ * <p>The whole pass runs behind an {@code ACCESS EXCLUSIVE} table lock held for the migration's
  * single transaction: during a rolling deployment an old application node (without the per-run
  * advisory lock) could otherwise insert a fresh duplicate between the resequencing and the index
- * build and fail it. Writers queue behind the lock, reads stay unblocked; the {@code
- * autonomous_events} table is a new, preview-flag-gated, human-review-cadence store, so the brief
- * write stall is safe.
+ * build and fail it. The strongest mode is deliberate - it is acquired as the FIRST statement, so
+ * the migration never upgrades its lock later: {@code DROP INDEX} needs {@code ACCESS EXCLUSIVE}
+ * anyway, and upgrading from a weaker table lock while an in-flight appender holds {@code ACCESS
+ * SHARE} (from its max-sequence read) with its INSERT queued behind us is a textbook lock-upgrade
+ * deadlock that would abort the migration mid-deployment. Taken up front, an in-flight appender
+ * simply finishes first (the migration holds nothing while it waits) and everything else queues for
+ * the migration's brief duration; the {@code autonomous_events} table is a new, preview-flag-gated,
+ * human-review-cadence store, so the momentary stall is safe.
  */
 @Component
 public class V6_20260813100000000__Autonomous_event_sequence_unique extends BaseJavaMigration {
@@ -42,11 +47,15 @@ public class V6_20260813100000000__Autonomous_event_sequence_unique extends Base
       // Shield the repair + enforcement from live writers: during a rolling deployment an OLD
       // application node (without the per-run advisory lock) can still append while this runs, so
       // an insert landing between the resequencing CTE and the index build could re-introduce a
-      // duplicate and fail the unique-index creation. SHARE ROW EXCLUSIVE conflicts with every
-      // INSERT/UPDATE/DELETE (writers queue behind the migration) while still allowing reads, and
-      // Flyway runs this migration in a single transaction, so the lock spans both statements and
-      // makes repair + enforcement atomic with respect to concurrent appenders.
-      statement.execute("LOCK TABLE autonomous_events IN SHARE ROW EXCLUSIVE MODE;");
+      // duplicate and fail the unique-index creation. Flyway runs this migration in a single
+      // transaction, so the lock spans every statement below. ACCESS EXCLUSIVE (not a weaker
+      // write-blocking mode) because the DROP INDEX below requires it anyway and it must be the
+      // FIRST lock taken: with only SHARE ROW EXCLUSIVE held, an old-node appender that already
+      // did its max-sequence read (holding ACCESS SHARE) queues its INSERT behind us, and our
+      // later DROP INDEX then waits on its ACCESS SHARE - a mutual wait on granted locks, i.e. a
+      // deadlock that aborts the migration mid-deployment. Acquired up front, the migration holds
+      // nothing while it waits (in-flight appenders finish first), then never upgrades.
+      statement.execute("LOCK TABLE autonomous_events IN ACCESS EXCLUSIVE MODE;");
       // Resequence any run carrying (run_id, sequence) duplicates so the unique index can be
       // built WITHOUT deleting timeline rows: each duplicate is a distinct decision/audit event,
       // so all rows are kept and the run's timeline is renumbered 1..N in deterministic order

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
@@ -1,0 +1,52 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Makes an autonomous run's decision-timeline sequence unique per run. {@code
+ * AutonomousEventService} assigns each event {@code sequence = max(sequence) + 1} for its run;
+ * backed only by the non-unique {@code idx_autonomous_events_run_seq} index, two appenders writing
+ * to the same run concurrently could read the same max and persist a duplicate sequence, corrupting
+ * timeline order and the "since sequence" incremental reads the live cockpit relies on.
+ *
+ * <p>This replaces that index with a UNIQUE one on {@code (autonomous_event_run_id,
+ * autonomous_event_sequence)}: it enforces the per-run invariant at the database and still serves
+ * the run-scoped ordered + since-sequence reads (same leading columns). The service additionally
+ * takes a per-run transaction advisory lock before its read-max-then-insert so concurrent appenders
+ * serialise (each succeeds with N and N+1) rather than one hitting the unique constraint; the index
+ * is the backstop that makes a duplicate impossible even if that lock is ever bypassed.
+ *
+ * <p>Additive and idempotent: any pre-existing duplicate rows are collapsed first (keeping the
+ * physically-first row of each group), then the old index is dropped and the unique index created
+ * with {@code IF [NOT] EXISTS}, so re-running is a no-op. The {@code autonomous_events} table is a
+ * new, preview-flag-gated, human-review-cadence store, so the brief index build lock is safe.
+ */
+@Component
+public class V6_20260813100000000__Autonomous_event_sequence_unique extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // Collapse any pre-existing (run_id, sequence) duplicates so the unique index can be built.
+      // Keeps the physically-first row of each group (lowest ctid) and drops the rest; a no-op on a
+      // clean table.
+      statement.execute(
+          """
+          DELETE FROM autonomous_events a
+                USING autonomous_events b
+           WHERE a.autonomous_event_run_id = b.autonomous_event_run_id
+             AND a.autonomous_event_sequence = b.autonomous_event_sequence
+             AND a.ctid > b.ctid;
+          """);
+      // Replace the non-unique run/sequence index with a unique one: it enforces the per-run
+      // sequence invariant AND still serves the run-scoped ordered + since-sequence reads.
+      statement.execute("DROP INDEX IF EXISTS idx_autonomous_events_run_seq;");
+      statement.execute(
+          "CREATE UNIQUE INDEX IF NOT EXISTS idx_autonomous_events_run_seq_unique "
+              + "ON autonomous_events (autonomous_event_run_id, autonomous_event_sequence);");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260813100000000__Autonomous_event_sequence_unique.java
@@ -24,9 +24,14 @@ import org.springframework.stereotype.Component;
  * deleting one would lose append-only timeline data) and the whole run timeline is renumbered 1..N
  * in its existing order (sequence, then creation time, then event id as the tie-break). Then the
  * old index is dropped and the unique index created with {@code IF [NOT] EXISTS}. On a clean table
- * every sequence already equals its row number, so re-running is a no-op. The {@code
+ * every sequence already equals its row number, so re-running is a no-op.
+ *
+ * <p>The whole pass runs behind a {@code SHARE ROW EXCLUSIVE} table lock held for the migration's
+ * single transaction: during a rolling deployment an old application node (without the per-run
+ * advisory lock) could otherwise insert a fresh duplicate between the resequencing and the index
+ * build and fail it. Writers queue behind the lock, reads stay unblocked; the {@code
  * autonomous_events} table is a new, preview-flag-gated, human-review-cadence store, so the brief
- * index build lock is safe.
+ * write stall is safe.
  */
 @Component
 public class V6_20260813100000000__Autonomous_event_sequence_unique extends BaseJavaMigration {
@@ -34,6 +39,14 @@ public class V6_20260813100000000__Autonomous_event_sequence_unique extends Base
   @Override
   public void migrate(Context context) throws Exception {
     try (Statement statement = context.getConnection().createStatement()) {
+      // Shield the repair + enforcement from live writers: during a rolling deployment an OLD
+      // application node (without the per-run advisory lock) can still append while this runs, so
+      // an insert landing between the resequencing CTE and the index build could re-introduce a
+      // duplicate and fail the unique-index creation. SHARE ROW EXCLUSIVE conflicts with every
+      // INSERT/UPDATE/DELETE (writers queue behind the migration) while still allowing reads, and
+      // Flyway runs this migration in a single transaction, so the lock spans both statements and
+      // makes repair + enforcement atomic with respect to concurrent appenders.
+      statement.execute("LOCK TABLE autonomous_events IN SHARE ROW EXCLUSIVE MODE;");
       // Resequence any run carrying (run_id, sequence) duplicates so the unique index can be
       // built WITHOUT deleting timeline rows: each duplicate is a distinct decision/audit event,
       // so all rows are kept and the run's timeline is renumbered 1..N in deterministic order

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousEventService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousEventService.java
@@ -146,9 +146,27 @@ public class AutonomousEventService {
         runId, sinceSequence);
   }
 
-  /** Purges a run's entire decision timeline (used when the run itself is deleted). */
+  /**
+   * Purges a run's entire decision timeline (used when the run itself is deleted, or reset by
+   * restart / promote).
+   *
+   * <p>The purge participates in the same per-run advisory-lock protocol as the appenders: without
+   * it, a purge racing an in-flight terminal append could interleave so the old life's "Run
+   * canceled" row commits AFTER the reset wiped the timeline, resurrecting a stale terminal line
+   * inside a freshly reset (or about-to-be-deleted) timeline. Holding the lock serialises the two:
+   * an append that wins commits first and is then purged with everything else; a purge that wins
+   * leaves the late appender to re-check against the run's committed state (its callers gate on a
+   * row-locked status read, so a stale settle no longer narrates at all).
+   *
+   * <p>LOCK ORDER: every caller that also writes the {@code autonomous_runs} row takes the run ROW
+   * lock BEFORE this advisory lock (restart / promote read through {@code requireForUpdate}; the
+   * teardown paths re-read through the row-locking lookup) - the same {@code row -> advisory} order
+   * the settle paths use (conditional row-locking UPDATE, then terminal append). Acquiring in the
+   * opposite order would deadlock a purge against a concurrent settle.
+   */
   @Transactional(rollbackFor = Exception.class)
   public void deleteByRun(String runId) {
+    eventRepository.lockRunEventSequence(sequenceLockKey(runId));
     eventRepository.deleteByRunId(runId);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousEventService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousEventService.java
@@ -71,11 +71,11 @@ public class AutonomousEventService {
       String content,
       String data) {
     // Serialise concurrent appenders to THIS run before the read-max-then-insert below: two
-    // decision
-    // cycles (or a cycle racing an operator directive) writing to the same run must not both
-    // compute
-    // the same next sequence. The transaction advisory lock makes both succeed as N and N+1; the
-    // UNIQUE (run_id, sequence) index is the backstop that makes a duplicate impossible regardless.
+    // decision cycles (or a cycle racing an operator directive) writing to the same run must not
+    // both compute the same next sequence. The transaction advisory lock makes both succeed as N
+    // and N+1; the UNIQUE (run_id, sequence) index is the backstop that makes a duplicate
+    // impossible regardless. Re-acquiring the same key inside one transaction (the terminal-once
+    // path locks before its existence check, then reaches this) is a cheap no-op.
     eventRepository.lockRunEventSequence(sequenceLockKey(runId));
     AutonomousEvent event = new AutonomousEvent();
     event.setRunId(runId);
@@ -122,6 +122,13 @@ public class AutonomousEventService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousEvent appendTerminalStatusOnce(
       String runId, String simulationId, String title, String content) {
+    // Take the per-run advisory lock BEFORE the existence check, not only inside doAppend: two
+    // racing settle paths could otherwise both observe "no terminal event yet", then serialise on
+    // the append lock and write two distinct terminal lines as N and N+1 - which the unique
+    // (run_id, sequence) index cannot prevent. Holding the lock across check + append makes the
+    // second transaction wait, then (READ COMMITTED) observe the first one's committed terminal
+    // event and drop its duplicate.
+    eventRepository.lockRunEventSequence(sequenceLockKey(runId));
     if (eventRepository.existsTerminalStatusEvent(runId, TERMINAL_STATUS_TITLES)) {
       return null;
     }

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousEventService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousEventService.java
@@ -40,6 +40,13 @@ public class AutonomousEventService {
   public static final Set<String> TERMINAL_STATUS_TITLES =
       Set.of("Run canceled", "Run completed", "Run timed out", "Run failed");
 
+  /**
+   * High 32 bits of the per-run advisory-lock key, namespacing autonomous event-sequence locks so
+   * they can never collide with any other advisory lock the platform might take. The value is
+   * arbitrary but stable ("AE" = autonomous event).
+   */
+  private static final long EVENT_SEQUENCE_LOCK_NAMESPACE = 0x4145_0001L;
+
   @Transactional(rollbackFor = Exception.class)
   public AutonomousEvent append(
       String runId,
@@ -63,6 +70,13 @@ public class AutonomousEventService {
       String title,
       String content,
       String data) {
+    // Serialise concurrent appenders to THIS run before the read-max-then-insert below: two
+    // decision
+    // cycles (or a cycle racing an operator directive) writing to the same run must not both
+    // compute
+    // the same next sequence. The transaction advisory lock makes both succeed as N and N+1; the
+    // UNIQUE (run_id, sequence) index is the backstop that makes a duplicate impossible regardless.
+    eventRepository.lockRunEventSequence(sequenceLockKey(runId));
     AutonomousEvent event = new AutonomousEvent();
     event.setRunId(runId);
     event.setSequence(eventRepository.findMaxSequence(runId) + 1);
@@ -85,6 +99,16 @@ public class AutonomousEventService {
       }
     }
     return saved;
+  }
+
+  /**
+   * Builds the 64-bit advisory-lock key for a run: the fixed {@link #EVENT_SEQUENCE_LOCK_NAMESPACE}
+   * in the high 32 bits and the run id's hash in the low 32 bits. A hash collision across two
+   * different runs merely serialises their (independent) appends for an instant - never a
+   * correctness issue - while an exact per-run match is what actually closes the sequence race.
+   */
+  private static long sequenceLockKey(String runId) {
+    return (EVENT_SEQUENCE_LOCK_NAMESPACE << 32) | (runId.hashCode() & 0xFFFF_FFFFL);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
@@ -43,7 +43,10 @@ import org.springframework.web.server.ResponseStatusException;
  * single configured XTM One service token - one identity for every run, never the operator's - so a
  * resource check would break live orchestration for any run whose operator differs from the token
  * owner. They stay behind the Enterprise-Edition license + the {@code INJECT_CHAINING} preview
- * feature + tenant isolation on the {@code autonomous_*} tables.
+ * feature. Restricting them to the actual service identity (today any authenticated EE user can
+ * reach them) and activating tenant isolation on the {@code autonomous_*} tables are tracked as
+ * follow-up hardening in issue #7396 - both need infrastructure work (a callback service identity;
+ * the v2 tenant-table activation procedure) beyond this gate.
  */
 @org.springframework.stereotype.Component
 @RequiredArgsConstructor

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
@@ -4,10 +4,12 @@ import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.model.User;
 import io.openaev.database.model.autonomous.AutonomousRun;
+import io.openaev.service.GrantService;
 import io.openaev.service.PermissionService;
 import io.openaev.service.UserService;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
@@ -54,6 +56,7 @@ public class AutonomousRunAccessControl {
 
   private final UserService userService;
   private final PermissionService permissionService;
+  private final GrantService grantService;
 
   /** Throws 403 unless the caller can READ the run's bound simulation / scenario. */
   public void assertCanRead(AutonomousRun run) {
@@ -74,13 +77,62 @@ public class AutonomousRunAccessControl {
   }
 
   /**
-   * Keeps only the runs the caller can READ. Resolves the current user ONCE (it is DB-backed for
-   * non-admins) rather than per row, mirroring {@link
-   * io.openaev.service.attackpath.AttackPathAccessControl#retainReadable}.
+   * Keeps only the runs the caller can READ, without issuing a per-run query. This backs the
+   * UNBOUNDED run-list endpoint, so the {@link PermissionService#hasPermission} composition is
+   * decomposed into its two halves and each is resolved in O(1) queries for the whole list:
+   *
+   * <ul>
+   *   <li>the resource-id-independent half (open-resource / admin / BYPASS / capability) depends
+   *       only on the resource TYPE - resolved once per type, in memory, instead of per row;
+   *   <li>the per-resource half (a read grant on the run's bound simulation / scenario) is
+   *       batch-fetched with a SINGLE query ({@link GrantService#findReadGrantedResourceIds}) and
+   *       checked by containment, instead of one exists-lookup per run - for a grant-only caller
+   *       the previous shape was an N+1 on the size of the tenant's run list.
+   * </ul>
+   *
+   * <p>The current user is likewise resolved ONCE (it is DB-backed for non-admins). {@link
+   * #granted} remains the single-run authority used by the point gates; this is the same decision
+   * decomposed for a list, kept semantically identical for the grant-managed SIMULATION / SCENARIO
+   * types.
    */
   public List<AutonomousRun> retainReadable(List<AutonomousRun> runs) {
+    if (runs.isEmpty()) {
+      return runs;
+    }
     User user = userService.currentUser();
-    return runs.stream().filter(run -> granted(user, run, Action.READ)).toList();
+    boolean simulationsReadable = typeReadable(user, ResourceType.SIMULATION);
+    boolean scenariosReadable = typeReadable(user, ResourceType.SCENARIO);
+    // Only a grant-only caller needs the grant set; a capability-level reader never queries it.
+    Set<String> readGrantedIds =
+        simulationsReadable && scenariosReadable
+            ? Set.of()
+            : Set.copyOf(grantService.findReadGrantedResourceIds(user));
+    return runs.stream()
+        .filter(
+            run -> {
+              String simulationId = run.getSimulationId();
+              if (StringUtils.hasText(simulationId)) {
+                return simulationsReadable || readGrantedIds.contains(simulationId);
+              }
+              String scenarioId = run.getScenarioId();
+              if (StringUtils.hasText(scenarioId)) {
+                return scenariosReadable || readGrantedIds.contains(scenarioId);
+              }
+              // Same fallback as granted(): a run bound to neither is a capability-only check.
+              return permissionService.hasCapabilityPermission(
+                  user, ResourceType.SIMULATION, Action.READ);
+            })
+        .toList();
+  }
+
+  /**
+   * The resource-id-independent half of {@link PermissionService#hasPermission} for READ on a
+   * grant-managed type: the open-resource shortcut plus admin / BYPASS / capability. A caller
+   * passing this can read every resource of the type, so no per-resource grant lookup is needed.
+   */
+  private boolean typeReadable(User user, ResourceType resourceType) {
+    return PermissionService.isOpenResource(resourceType, Action.READ)
+        || permissionService.hasCapabilityPermission(user, resourceType, Action.READ);
   }
 
   /** Requires READ on a scenario before an operator reads an AI-run configuration through it. */

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
@@ -1,0 +1,156 @@
+package io.openaev.service.autonomous;
+
+import io.openaev.database.model.Action;
+import io.openaev.database.model.ResourceType;
+import io.openaev.database.model.User;
+import io.openaev.database.model.autonomous.AutonomousRun;
+import io.openaev.service.PermissionService;
+import io.openaev.service.UserService;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Resource-level RBAC for autonomous (AI-driven) attack-path runs.
+ *
+ * <p>The {@link io.openaev.api.autonomous.AutonomousRunApi} endpoints keep
+ * {@code @AccessControl(skipRBAC = true)} because a run's authority is not a resource the
+ * declarative aspect can name: it DERIVES from the run's bound simulation (a live run) or, for a
+ * plan / author-scenario run that provisions no simulation, its scenario. This guard is the real
+ * gate - it maps a run operation onto the SIMULATION / SCENARIO permission the operator already
+ * holds:
+ *
+ * <ul>
+ *   <li>a READ operation (open the cockpit, read the timeline / directives) requires {@code READ}
+ *       on the bound simulation (or scenario);
+ *   <li>a MANAGE operation (start / pause / resume / cancel / restart / promote / convert / steer /
+ *       edit scope) requires {@code LAUNCH} - controlling an autonomous run is a launch-class
+ *       action, the same capability that authorizes running the underlying simulation.
+ * </ul>
+ *
+ * <p>Without this, every Enterprise-Edition user could drive ANY tenant run through the
+ * skipRBAC-annotated controller (and {@link AutonomousRunService#list()} leaked every run's
+ * objective + status tenant-wide). Enforcement mirrors {@link
+ * io.openaev.service.attackpath.AttackPathAccessControl}: the same current-user source as {@link
+ * io.openaev.aop.AccessControlAspect} ({@link UserService#currentUser()}), and admins / bypass
+ * short-circuit inside {@link PermissionService#hasPermission}.
+ *
+ * <p>The orchestrator CALLBACK endpoints (events / status / directive consumption / attack-path
+ * authoring / scope) are deliberately NOT gated here. They are authenticated with the tenant's
+ * single configured XTM One service token - one identity for every run, never the operator's - so a
+ * resource check would break live orchestration for any run whose operator differs from the token
+ * owner. They stay behind the Enterprise-Edition license + the {@code INJECT_CHAINING} preview
+ * feature + tenant isolation on the {@code autonomous_*} tables.
+ */
+@org.springframework.stereotype.Component
+@RequiredArgsConstructor
+public class AutonomousRunAccessControl {
+
+  private final UserService userService;
+  private final PermissionService permissionService;
+
+  /** Throws 403 unless the caller can READ the run's bound simulation / scenario. */
+  public void assertCanRead(AutonomousRun run) {
+    if (!granted(userService.currentUser(), run, Action.READ)) {
+      throw denied(run);
+    }
+  }
+
+  /**
+   * Throws 403 unless the caller can control (LAUNCH) the run's bound simulation / scenario. Guards
+   * every lifecycle + steering mutation (start / pause / resume / cancel / restart / promote /
+   * convert / directive / live-configuration / scope).
+   */
+  public void assertCanManage(AutonomousRun run) {
+    if (!granted(userService.currentUser(), run, Action.LAUNCH)) {
+      throw denied(run);
+    }
+  }
+
+  /**
+   * Keeps only the runs the caller can READ. Resolves the current user ONCE (it is DB-backed for
+   * non-admins) rather than per row, mirroring {@link
+   * io.openaev.service.attackpath.AttackPathAccessControl#retainReadable}.
+   */
+  public List<AutonomousRun> retainReadable(List<AutonomousRun> runs) {
+    User user = userService.currentUser();
+    return runs.stream().filter(run -> granted(user, run, Action.READ)).toList();
+  }
+
+  /** Requires READ on a scenario before an operator reads an AI-run configuration through it. */
+  public void assertCanReadScenario(String scenarioId) {
+    assertScenario(scenarioId, Action.READ);
+  }
+
+  /**
+   * Requires LAUNCH on a scenario before an operator launches / plans / configures an autonomous
+   * run on it (the scenario the operator already sees in the UI and holds a grant or capability
+   * for).
+   */
+  public void assertCanManageScenario(String scenarioId) {
+    assertScenario(scenarioId, Action.LAUNCH);
+  }
+
+  /**
+   * Requires the launch-assessment capability before provisioning a brand-new autonomous run + its
+   * auto-created scenario (there is no pre-existing resource to grant-check against). A user who
+   * cannot launch assessments must not be able to spin up an autonomous run they could then drive.
+   */
+  public void assertCanCreate() {
+    if (!permissionService.hasCapabilityPermission(
+        userService.currentUser(), ResourceType.SIMULATION, Action.LAUNCH)) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Missing capability to launch an autonomous run");
+    }
+  }
+
+  /**
+   * Throws 403 unless the caller is a platform administrator. Gates the tenant-global default-agent
+   * writes ({@code PUT /autonomous-runs/default-agents}), which persist a {@code tenant IS NULL}
+   * setting and must not be writable by every Enterprise-Edition user.
+   */
+  public void assertAdmin() {
+    if (!userService.currentUser().isAdmin()) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Only an administrator can change the default agents");
+    }
+  }
+
+  private void assertScenario(String scenarioId, Action action) {
+    if (!StringUtils.hasText(scenarioId)) {
+      // The caller validates presence and returns 400 itself; nothing to gate here.
+      return;
+    }
+    if (!permissionService.hasPermission(
+        userService.currentUser(), Optional.empty(), scenarioId, ResourceType.SCENARIO, action)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied on scenario");
+    }
+  }
+
+  /**
+   * The single definition of "this user may act on this run at this level": checked against the
+   * run's simulation when it has one, else its scenario (plan / author-scenario runs), else - for a
+   * malformed run bound to neither - a capability-only check, so it is never a silent open door.
+   */
+  private boolean granted(User user, AutonomousRun run, Action action) {
+    String simulationId = run.getSimulationId();
+    if (StringUtils.hasText(simulationId)) {
+      return permissionService.hasPermission(
+          user, Optional.empty(), simulationId, ResourceType.SIMULATION, action);
+    }
+    String scenarioId = run.getScenarioId();
+    if (StringUtils.hasText(scenarioId)) {
+      return permissionService.hasPermission(
+          user, Optional.empty(), scenarioId, ResourceType.SCENARIO, action);
+    }
+    return permissionService.hasCapabilityPermission(user, ResourceType.SIMULATION, action);
+  }
+
+  private static ResponseStatusException denied(AutonomousRun run) {
+    return new ResponseStatusException(
+        HttpStatus.FORBIDDEN, "Access denied on autonomous run " + run.getId());
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -1737,10 +1737,12 @@ public class AutonomousRunService {
    * transition matrix for the one status source that is not OpenAEV itself, on both sides:
    *
    * <ul>
-   *   <li>SOURCE: a run sitting in an operator-owned state may not be driven at all. CREATED means
-   *       pre-handoff or just-restarted (only {@code start()} engages), PAUSED means the operator
-   *       suspended it (only {@code resume()} releases) - a callback observing either is stale and
-   *       must not resurrect or advance the run past the operator's intent.
+   *   <li>SOURCE: a run sitting in an operator-owned or settled state may not be driven at all.
+   *       CREATED means pre-handoff or just-restarted (only {@code start()} engages), PAUSED means
+   *       the operator suspended it (only {@code resume()} releases), and PLANNED means the plan
+   *       design settled - only the operator transitions away from it (promote / refine reset to
+   *       CREATED and re-engage, supersede) and a late callback must not reopen or overwrite a
+   *       promotable plan. A callback observing any of these is stale.
    *   <li>TARGET: CREATED (initial), PAUSED (operator) and CANCELED (OpenAEV-authoritative) are
    *       never orchestrator-driven, and the dry-run-only (PLANNING / PLANNED) versus execute-only
    *       (RUNNING) states may not be crossed against the run's mode.
@@ -1748,11 +1750,12 @@ public class AutonomousRunService {
    *
    * <p>Terminal-source runs are already short-circuited before this is reached, so every remaining
    * legitimate push (RUNNING/WAITING_INPUT/COMPLETED/FAILED for a live run;
-   * PLANNING/PLANNED/WAITING_INPUT/COMPLETED/FAILED for a plan run) is allowed.
+   * PLANNING/PLANNED/WAITING_INPUT/COMPLETED/FAILED for a plan run still designing) is allowed.
    */
   private boolean isOrchestratorStatusAllowed(AutonomousRun run, AutonomousRunStatus target) {
     if (run.getStatus() == AutonomousRunStatus.CREATED
-        || run.getStatus() == AutonomousRunStatus.PAUSED) {
+        || run.getStatus() == AutonomousRunStatus.PAUSED
+        || run.getStatus() == AutonomousRunStatus.PLANNED) {
       return false;
     }
     if (target == AutonomousRunStatus.CREATED
@@ -1796,13 +1799,15 @@ public class AutonomousRunService {
     }
     // Validate the transition instead of accepting any target. This callback is the ONE status
     // source that is not OpenAEV itself, so it must only drive the run through states the
-    // orchestrator actually owns - on both sides. Source: a run parked in an operator-owned state
-    // (CREATED pre-handoff / post-restart, PAUSED by the operator) may not be driven at all - only
-    // start()/resume() release it. Target: CREATED, PAUSED and CANCELED (OpenAEV-authoritative,
-    // via cancel()) are never orchestrator-set, and the dry-run-only planning states
-    // (PLANNING/PLANNED) versus the execute-only RUNNING state may not be crossed against the
-    // run's mode. A disallowed push is a stale or confused write - ignore it (idempotent no-op) so
-    // it can neither resurrect an operator state nor flip a run across the plan/live divide.
+    // orchestrator actually owns - on both sides. Source: a run parked in an operator-owned or
+    // settled state (CREATED pre-handoff / post-restart, PAUSED by the operator, PLANNED once the
+    // plan design settled) may not be driven at all - only start()/resume()/promote()/refine
+    // release it. Target: CREATED, PAUSED and CANCELED (OpenAEV-authoritative, via cancel()) are
+    // never orchestrator-set, and the dry-run-only planning states (PLANNING/PLANNED) versus the
+    // execute-only RUNNING state may not be crossed against the run's mode. A disallowed push is a
+    // stale or confused write - ignore it (idempotent no-op) so it can neither resurrect an
+    // operator state, reopen or overwrite a promotable plan, nor flip a run across the plan/live
+    // divide.
     if (!isOrchestratorStatusAllowed(run, status)) {
       log.warn(
           "[Autonomous] Ignoring illegal orchestrator status transition {} -> {} for run {}",

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -495,12 +495,14 @@ public class AutonomousRunService {
     if (!hasText(scenarioId)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A scenario id is required");
     }
+    // Authorize BEFORE inspecting the scenario's workflow: an unauthorized caller must get the
+    // same 403 whether or not the scenario is chained, never a 400 that leaks its shape.
+    accessControl.assertCanManageScenario(scenarioId);
     if (!workflowService.isScenarioChaining(scenarioId)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,
           "The scenario must define a chaining (attack path) workflow to run autonomously");
     }
-    accessControl.assertCanManageScenario(scenarioId);
     // Relaunching is first-class: a scenario whose previous autonomous run (or plan) has settled
     // can be launched again. The settled run row is superseded so the new run can bind (one run
     // per scenario); a still-active run is refused instead.
@@ -554,12 +556,14 @@ public class AutonomousRunService {
     if (!hasText(scenarioId)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A scenario id is required");
     }
+    // Authorize BEFORE inspecting the scenario's workflow: an unauthorized caller must get the
+    // same 403 whether or not the scenario is chained, never a 400 that leaks its shape.
+    accessControl.assertCanManageScenario(scenarioId);
     if (!workflowService.isScenarioChaining(scenarioId)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,
           "The scenario must be a chained scenario to be planned by the orchestrator");
     }
-    accessControl.assertCanManageScenario(scenarioId);
     AutonomousRunCreateInput effective = input != null ? input : new AutonomousRunCreateInput();
     Scenario scenario = scenarioService.scenario(scenarioId);
     // Refine (follow-up) vs rebuild (from scratch): refine keeps the existing logic + history and
@@ -1730,14 +1734,27 @@ public class AutonomousRunService {
 
   /**
    * Whether the orchestrator status callback may move {@code run} to {@code target}. Encodes the
-   * transition matrix for the one status source that is not OpenAEV itself: CREATED (initial),
-   * PAUSED (operator) and CANCELED (OpenAEV-authoritative) are never orchestrator-driven, and the
-   * dry-run-only (PLANNING / PLANNED) versus execute-only (RUNNING) states may not be crossed
-   * against the run's mode. Terminal-source runs are already short-circuited before this is
-   * reached, so every remaining legitimate push (RUNNING/WAITING_INPUT/COMPLETED/FAILED for a live
-   * run; PLANNING/PLANNED/WAITING_INPUT/COMPLETED/FAILED for a plan run) is allowed.
+   * transition matrix for the one status source that is not OpenAEV itself, on both sides:
+   *
+   * <ul>
+   *   <li>SOURCE: a run sitting in an operator-owned state may not be driven at all. CREATED means
+   *       pre-handoff or just-restarted (only {@code start()} engages), PAUSED means the operator
+   *       suspended it (only {@code resume()} releases) - a callback observing either is stale and
+   *       must not resurrect or advance the run past the operator's intent.
+   *   <li>TARGET: CREATED (initial), PAUSED (operator) and CANCELED (OpenAEV-authoritative) are
+   *       never orchestrator-driven, and the dry-run-only (PLANNING / PLANNED) versus execute-only
+   *       (RUNNING) states may not be crossed against the run's mode.
+   * </ul>
+   *
+   * <p>Terminal-source runs are already short-circuited before this is reached, so every remaining
+   * legitimate push (RUNNING/WAITING_INPUT/COMPLETED/FAILED for a live run;
+   * PLANNING/PLANNED/WAITING_INPUT/COMPLETED/FAILED for a plan run) is allowed.
    */
   private boolean isOrchestratorStatusAllowed(AutonomousRun run, AutonomousRunStatus target) {
+    if (run.getStatus() == AutonomousRunStatus.CREATED
+        || run.getStatus() == AutonomousRunStatus.PAUSED) {
+      return false;
+    }
     if (target == AutonomousRunStatus.CREATED
         || target == AutonomousRunStatus.PAUSED
         || target == AutonomousRunStatus.CANCELED) {
@@ -1759,7 +1776,12 @@ public class AutonomousRunService {
   public AutonomousRun updateStatus(
       String runId, AutonomousRunStatus status, String lastError, String title, String content) {
     requireFeature();
-    AutonomousRun run = require(runId);
+    // Row-locked read: the terminal + transition validation below is a check-then-write on a row
+    // with no optimistic version, so it must serialise with the operator lifecycle writers
+    // (pause/resume take the same lock; cancel/reconcile/watchdog settle via row-locking
+    // conditional UPDATEs). Without the lock, a callback that read a pre-pause state could pass
+    // validation and overwrite a concurrently committed PAUSED or terminal transition.
+    AutonomousRun run = requireForUpdate(runId);
     // A terminal status is final: CANCELED (operator Stop / OpenAEV timeout hard-stop) and
     // COMPLETED / FAILED (settled orchestration) all tear the run down. A late status callback from
     // the orchestrator - a COMPLETED it emits after we already hard-stopped, the gap-1 completion
@@ -1774,13 +1796,13 @@ public class AutonomousRunService {
     }
     // Validate the transition instead of accepting any target. This callback is the ONE status
     // source that is not OpenAEV itself, so it must only drive the run through states the
-    // orchestrator actually owns: CREATED is the pre-handoff initial state, PAUSED is operator-only
-    // (pause/resume), CANCELED is OpenAEV-authoritative (operator Stop / timeout hard-stop, via
-    // cancel()); and the dry-run-only planning states (PLANNING/PLANNED) versus the execute-only
-    // RUNNING state may not be crossed against the run's mode. A callback naming a disallowed
-    // target
-    // is a stale or confused write - ignore it (idempotent no-op) so it can neither resurrect an
-    // operator state nor flip a run across the plan/live divide.
+    // orchestrator actually owns - on both sides. Source: a run parked in an operator-owned state
+    // (CREATED pre-handoff / post-restart, PAUSED by the operator) may not be driven at all - only
+    // start()/resume() release it. Target: CREATED, PAUSED and CANCELED (OpenAEV-authoritative,
+    // via cancel()) are never orchestrator-set, and the dry-run-only planning states
+    // (PLANNING/PLANNED) versus the execute-only RUNNING state may not be crossed against the
+    // run's mode. A disallowed push is a stale or confused write - ignore it (idempotent no-op) so
+    // it can neither resurrect an operator state nor flip a run across the plan/live divide.
     if (!isOrchestratorStatusAllowed(run, status)) {
       log.warn(
           "[Autonomous] Ignoring illegal orchestrator status transition {} -> {} for run {}",
@@ -3070,17 +3092,36 @@ public class AutonomousRunService {
   /**
    * Matches a scope rule value against a candidate: case-insensitive exact, or IP-in-CIDR for both
    * IPv4 and IPv6. Containment is delegated to {@link IpAddressUtils#isIpInSubnet} (the same helper
-   * the rest of the platform's scope resolution uses), which returns false when the address
-   * families differ or either side fails to parse - so an IPv6 host is now correctly matched
+   * the rest of the platform's scope resolution uses) - so an IPv6 host is now correctly matched
    * against an IPv6 CIDR rule instead of silently falling through as it did with the old IPv4-only
-   * check.
+   * check - but only after both sides are validated as literals:
+   *
+   * <ul>
+   *   <li>the candidate must be a literal IPv4/IPv6 address ({@link IpAddressUtils#isIpv4Address} /
+   *       {@link IpAddressUtils#isIpv6Address}, both DNS-safe). Discovered values can be hostnames,
+   *       and {@code isIpInSubnet} resolves names through {@code InetAddress.getByName}, so an
+   *       unguarded call would trigger DNS lookups and could match a hostname against a CIDR rule
+   *       through its resolved address;
+   *   <li>the rule must be a well-formed subnet with an in-range prefix ({@link
+   *       IpAddressUtils#isIpv4Subnet} / {@link IpAddressUtils#isIpv6Subnet}). {@code isIpInSubnet}
+   *       does not bound the prefix itself, and a malformed rule such as {@code 10.0.0.0/-1} would
+   *       otherwise match every address of its family - turning a typo into scope authorization.
+   * </ul>
+   *
+   * <p>Package-private for direct unit testing (same pattern as {@link #stampDeadline}).
    */
-  private boolean networkValueMatches(String ruleValue, String candidate) {
+  boolean networkValueMatches(String ruleValue, String candidate) {
     if (ruleValue.equalsIgnoreCase(candidate)) {
       return true;
     }
     if (ruleValue.contains("/")) {
-      return IpAddressUtils.isIpInSubnet(candidate, ruleValue);
+      boolean literalIpCandidate =
+          IpAddressUtils.isIpv4Address(candidate) || IpAddressUtils.isIpv6Address(candidate);
+      boolean wellFormedSubnet =
+          IpAddressUtils.isIpv4Subnet(ruleValue) || IpAddressUtils.isIpv6Subnet(ruleValue);
+      return literalIpCandidate
+          && wellFormedSubnet
+          && IpAddressUtils.isIpInSubnet(candidate, ruleValue);
     }
     return false;
   }

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -69,6 +69,7 @@ import io.openaev.service.ScenarioToExerciseService;
 import io.openaev.service.account.ReservedKeyValidator;
 import io.openaev.service.chaining.WorkflowService;
 import io.openaev.service.scenario.ScenarioService;
+import io.openaev.utils.IpAddressUtils;
 import io.openaev.xtmone.XtmOneClient;
 import java.time.Duration;
 import java.time.Instant;
@@ -186,6 +187,12 @@ public class AutonomousRunService {
   // writing inside the caller's (read-only) transaction, and mark it rollback-only.
   private final AutonomousRunReconciliationWriter reconciliationWriter;
 
+  // Resource-level RBAC for the operator control surface. The controller keeps skipRBAC (the run's
+  // authority derives from its bound simulation/scenario, which the declarative aspect cannot
+  // name),
+  // so every operator-facing read/mutation gates in-service through this component.
+  private final AutonomousRunAccessControl accessControl;
+
   private void requireFeature() {
     if (!previewFeatureService.isAutonomousAttackPathEnabled()) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
@@ -281,6 +288,14 @@ public class AutonomousRunService {
    */
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun create(AutonomousRunCreateInput input) {
+    requireFeature();
+    // A caller-provided scenario must be one the operator can launch; a bare (auto-provisioned) run
+    // only needs the launch-assessment capability floor.
+    if (input != null && hasText(input.getScenarioId())) {
+      accessControl.assertCanManageScenario(input.getScenarioId());
+    } else {
+      accessControl.assertCanCreate();
+    }
     return doCreate(input);
   }
 
@@ -485,6 +500,7 @@ public class AutonomousRunService {
           HttpStatus.BAD_REQUEST,
           "The scenario must define a chaining (attack path) workflow to run autonomously");
     }
+    accessControl.assertCanManageScenario(scenarioId);
     // Relaunching is first-class: a scenario whose previous autonomous run (or plan) has settled
     // can be launched again. The settled run row is superseded so the new run can bind (one run
     // per scenario); a still-active run is refused instead.
@@ -543,6 +559,7 @@ public class AutonomousRunService {
           HttpStatus.BAD_REQUEST,
           "The scenario must be a chained scenario to be planned by the orchestrator");
     }
+    accessControl.assertCanManageScenario(scenarioId);
     AutonomousRunCreateInput effective = input != null ? input : new AutonomousRunCreateInput();
     Scenario scenario = scenarioService.scenario(scenarioId);
     // Refine (follow-up) vs rebuild (from scratch): refine keeps the existing logic + history and
@@ -775,6 +792,8 @@ public class AutonomousRunService {
    */
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun start(String runId) {
+    requireFeature();
+    accessControl.assertCanManage(require(runId));
     return doStart(runId);
   }
 
@@ -982,6 +1001,7 @@ public class AutonomousRunService {
   public AutonomousRun pause(String runId) {
     requireFeature();
     AutonomousRun run = requireForUpdate(runId);
+    accessControl.assertCanManage(run);
     assertRunNotTerminal(run, "paused");
     transitionSimulation(run, ExerciseStatus.PAUSED);
     run.setStatus(AutonomousRunStatus.PAUSED);
@@ -999,6 +1019,7 @@ public class AutonomousRunService {
   public AutonomousRun resume(String runId) {
     requireFeature();
     AutonomousRun run = requireForUpdate(runId);
+    accessControl.assertCanManage(run);
     assertRunNotTerminal(run, "resumed");
     transitionSimulation(run, ExerciseStatus.RUNNING);
     // Mirror start() / addDirective(): a plan-mode run returns to PLANNING (it is still authoring
@@ -1035,6 +1056,7 @@ public class AutonomousRunService {
   public AutonomousRun cancel(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
+    accessControl.assertCanManage(run);
     if (run.getStatus() == AutonomousRunStatus.CANCELED) {
       return run;
     }
@@ -1260,6 +1282,7 @@ public class AutonomousRunService {
   public AutonomousRun restart(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
+    accessControl.assertCanManage(run);
     // Stop the previous XTM One orchestration before tearing its simulation down, so a lingering
     // decision cycle can't dispatch injects against the simulation we are about to delete. The
     // subsequent start() re-engages the run cleanly (upstream start resets the same execution).
@@ -1342,6 +1365,7 @@ public class AutonomousRunService {
   public AutonomousRun promoteToRealRun(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
+    accessControl.assertCanManage(run);
     if (!run.isPlanMode()) {
       throw new ResponseStatusException(
           HttpStatus.CONFLICT, "Only built (non-executed) logic can be launched as a live run");
@@ -1433,6 +1457,7 @@ public class AutonomousRunService {
   public Scenario convertToManual(String runId, ConvertToManualMode mode) {
     requireFeature();
     AutonomousRun run = require(runId);
+    accessControl.assertCanManage(run);
     String scenarioId = run.getScenarioId();
     if (!hasText(scenarioId)) {
       throw new ResponseStatusException(
@@ -1704,6 +1729,29 @@ public class AutonomousRunService {
   }
 
   /**
+   * Whether the orchestrator status callback may move {@code run} to {@code target}. Encodes the
+   * transition matrix for the one status source that is not OpenAEV itself: CREATED (initial),
+   * PAUSED (operator) and CANCELED (OpenAEV-authoritative) are never orchestrator-driven, and the
+   * dry-run-only (PLANNING / PLANNED) versus execute-only (RUNNING) states may not be crossed
+   * against the run's mode. Terminal-source runs are already short-circuited before this is
+   * reached, so every remaining legitimate push (RUNNING/WAITING_INPUT/COMPLETED/FAILED for a live
+   * run; PLANNING/PLANNED/WAITING_INPUT/COMPLETED/FAILED for a plan run) is allowed.
+   */
+  private boolean isOrchestratorStatusAllowed(AutonomousRun run, AutonomousRunStatus target) {
+    if (target == AutonomousRunStatus.CREATED
+        || target == AutonomousRunStatus.PAUSED
+        || target == AutonomousRunStatus.CANCELED) {
+      return false;
+    }
+    if (run.isPlanMode()) {
+      // A dry-run authors a plan and never executes, so RUNNING is not a state it can be driven to.
+      return target != AutonomousRunStatus.RUNNING;
+    }
+    // A live run executes; the dry-run-only planning states are not part of its lifecycle.
+    return target != AutonomousRunStatus.PLANNING && target != AutonomousRunStatus.PLANNED;
+  }
+
+  /**
    * Applies a run-status transition pushed by the orchestrator (waiting-input, completed,
    * failed...).
    */
@@ -1722,6 +1770,23 @@ public class AutonomousRunService {
     if (run.getStatus() == AutonomousRunStatus.CANCELED
         || run.getStatus() == AutonomousRunStatus.COMPLETED
         || run.getStatus() == AutonomousRunStatus.FAILED) {
+      return run;
+    }
+    // Validate the transition instead of accepting any target. This callback is the ONE status
+    // source that is not OpenAEV itself, so it must only drive the run through states the
+    // orchestrator actually owns: CREATED is the pre-handoff initial state, PAUSED is operator-only
+    // (pause/resume), CANCELED is OpenAEV-authoritative (operator Stop / timeout hard-stop, via
+    // cancel()); and the dry-run-only planning states (PLANNING/PLANNED) versus the execute-only
+    // RUNNING state may not be crossed against the run's mode. A callback naming a disallowed
+    // target
+    // is a stale or confused write - ignore it (idempotent no-op) so it can neither resurrect an
+    // operator state nor flip a run across the plan/live divide.
+    if (!isOrchestratorStatusAllowed(run, status)) {
+      log.warn(
+          "[Autonomous] Ignoring illegal orchestrator status transition {} -> {} for run {}",
+          run.getStatus(),
+          status,
+          runId);
       return run;
     }
     run.setStatus(status);
@@ -1803,6 +1868,7 @@ public class AutonomousRunService {
   public AutonomousDirective addDirective(String runId, String content) {
     requireFeature();
     AutonomousRun run = requireForUpdate(runId);
+    accessControl.assertCanManage(run);
     assertRunNotTerminal(run, "steered");
     AutonomousDirective directive = new AutonomousDirective();
     directive.setRunId(runId);
@@ -1885,6 +1951,7 @@ public class AutonomousRunService {
   public List<Workflow> applyLiveConfiguration(String runId, WorkflowConfigurationInput input) {
     requireFeature();
     AutonomousRun run = require(runId);
+    accessControl.assertCanManage(run);
     List<Workflow> updated =
         workflowService.updateRunWorkflowConfiguration(run.getSimulationId(), input);
     eventService.append(
@@ -2977,7 +3044,10 @@ public class AutonomousRunService {
     return source == ScopeRuleSource.MANUAL || source == ScopeRuleSource.CSV;
   }
 
-  /** True when {@code value} matches any MANUAL/CSV rule of the given mode (exact or IPv4 CIDR). */
+  /**
+   * True when {@code value} matches any MANUAL/CSV rule of the given mode (exact or IPv4/IPv6
+   * CIDR).
+   */
   private boolean matchesNetworkRules(
       List<WorkflowScopeRule> rules, ScopeRuleSelectedMode mode, String value) {
     if (!hasText(value)) {
@@ -2997,60 +3067,22 @@ public class AutonomousRunService {
     return false;
   }
 
-  /** Matches a scope rule value against a candidate: case-insensitive exact, or IPv4-in-CIDR. */
+  /**
+   * Matches a scope rule value against a candidate: case-insensitive exact, or IP-in-CIDR for both
+   * IPv4 and IPv6. Containment is delegated to {@link IpAddressUtils#isIpInSubnet} (the same helper
+   * the rest of the platform's scope resolution uses), which returns false when the address
+   * families differ or either side fails to parse - so an IPv6 host is now correctly matched
+   * against an IPv6 CIDR rule instead of silently falling through as it did with the old IPv4-only
+   * check.
+   */
   private boolean networkValueMatches(String ruleValue, String candidate) {
     if (ruleValue.equalsIgnoreCase(candidate)) {
       return true;
     }
     if (ruleValue.contains("/")) {
-      return ipv4InCidr(candidate, ruleValue);
+      return IpAddressUtils.isIpInSubnet(candidate, ruleValue);
     }
     return false;
-  }
-
-  /** Minimal IPv4 CIDR containment check; returns false for anything it cannot parse as IPv4. */
-  private boolean ipv4InCidr(String ip, String cidr) {
-    try {
-      String[] parts = cidr.split("/");
-      if (parts.length != 2) {
-        return false;
-      }
-      long base = ipv4ToLong(parts[0]);
-      long addr = ipv4ToLong(ip);
-      if (base < 0 || addr < 0) {
-        return false;
-      }
-      int prefix = Integer.parseInt(parts[1].trim());
-      if (prefix < 0 || prefix > 32) {
-        return false;
-      }
-      long mask = prefix == 0 ? 0L : (0xFFFFFFFFL << (32 - prefix)) & 0xFFFFFFFFL;
-      return (base & mask) == (addr & mask);
-    } catch (RuntimeException e) {
-      return false;
-    }
-  }
-
-  /** IPv4 dotted-quad to unsigned long, or -1 when not a valid IPv4 literal. */
-  private long ipv4ToLong(String ip) {
-    String[] octets = ip.trim().split("\\.");
-    if (octets.length != 4) {
-      return -1;
-    }
-    long value = 0;
-    for (String octet : octets) {
-      int n;
-      try {
-        n = Integer.parseInt(octet);
-      } catch (NumberFormatException e) {
-        return -1;
-      }
-      if (n < 0 || n > 255) {
-        return -1;
-      }
-      value = (value << 8) | n;
-    }
-    return value;
   }
 
   // endregion
@@ -3062,13 +3094,18 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun get(String runId) {
     requireFeature();
-    return reconcileWithSimulation(require(runId));
+    AutonomousRun run = require(runId);
+    accessControl.assertCanRead(run);
+    return reconcileWithSimulation(run);
   }
 
   @Transactional(readOnly = true)
   public List<AutonomousRun> list() {
     requireFeature();
-    return runRepository.findAllByOrderByCreatedAtDesc();
+    // Filter the tenant-wide list to runs the caller can READ: without this, every run's objective
+    // and status leaked to any Enterprise-Edition user regardless of their simulation/scenario
+    // access.
+    return accessControl.retainReadable(runRepository.findAllByOrderByCreatedAtDesc());
   }
 
   /**
@@ -3080,13 +3117,15 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun getBySimulation(String simulationId) {
     requireFeature();
-    return reconcileWithSimulation(
+    AutonomousRun run =
         runRepository
             .findBySimulationId(simulationId)
             .orElseThrow(
                 () ->
                     new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "No autonomous run drives this simulation")));
+                        HttpStatus.NOT_FOUND, "No autonomous run drives this simulation"));
+    accessControl.assertCanRead(run);
+    return reconcileWithSimulation(run);
   }
 
   /**
@@ -3099,13 +3138,15 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun getByScenario(String scenarioId) {
     requireFeature();
-    return reconcileWithSimulation(
+    AutonomousRun run =
         runRepository
             .findByScenarioId(scenarioId)
             .orElseThrow(
                 () ->
                     new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "No autonomous run drives this scenario")));
+                        HttpStatus.NOT_FOUND, "No autonomous run drives this scenario"));
+    accessControl.assertCanRead(run);
+    return reconcileWithSimulation(run);
   }
 
   /**
@@ -3119,6 +3160,7 @@ public class AutonomousRunService {
     if (!hasText(scenarioId)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A scenario id is required");
     }
+    accessControl.assertCanReadScenario(scenarioId);
     Scenario scenario = scenarioService.scenario(scenarioId);
     Map<String, Object> stored = scenario.getAutonomousConfig();
     if (stored == null || stored.isEmpty()) {
@@ -3140,6 +3182,7 @@ public class AutonomousRunService {
     if (!hasText(scenarioId)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A scenario id is required");
     }
+    accessControl.assertCanManageScenario(scenarioId);
     if (!workflowService.isScenarioChaining(scenarioId)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,
@@ -3163,7 +3206,7 @@ public class AutonomousRunService {
   @Transactional(readOnly = true)
   public List<AutonomousEvent> timeline(String runId, long sinceSequence) {
     requireFeature();
-    require(runId);
+    accessControl.assertCanRead(require(runId));
     return sinceSequence > 0
         ? eventService.timelineSince(runId, sinceSequence)
         : eventService.timeline(runId);
@@ -3172,7 +3215,7 @@ public class AutonomousRunService {
   @Transactional(readOnly = true)
   public List<AutonomousDirective> directives(String runId) {
     requireFeature();
-    require(runId);
+    accessControl.assertCanRead(require(runId));
     return directiveRepository.findByRunIdOrderByCreatedAtAsc(runId);
   }
 
@@ -3204,6 +3247,7 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public List<String> updateDefaultAdditionalAgentIds(List<String> agentIds) {
     requireFeature();
+    accessControl.assertAdmin();
     List<String> cleaned = new ArrayList<>();
     if (agentIds != null) {
       for (String id : agentIds) {
@@ -3278,6 +3322,7 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public Map<String, String> updateDefaultAdditionalAgentModes(Map<String, String> agentModes) {
     requireFeature();
+    accessControl.assertAdmin();
     Map<String, String> cleaned = normalizeAgentModes(agentModes, null);
     String key = TenantSettingKeys.AUTONOMOUS_ADDITIONAL_AGENT_MODES.key();
     Setting setting =

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -2569,34 +2569,37 @@ public class AutonomousRunService {
 
   /**
    * Re-evaluates the run's live workflow so freshly authored steps ready and execute now. The
-   * orchestrator calls this after appending one or more steps in a decision cycle.
+   * orchestrator calls this after appending one or more steps in a decision cycle. Returns the
+   * reconciled run so the CALLBACK endpoint can answer with the fresh state directly: routing its
+   * response through the operator-gated {@link #get} would 403 a valid orchestrator callback, since
+   * the XTM One service identity is deliberately not required to hold the operator's
+   * simulation/scenario grant.
    */
   @Transactional(rollbackFor = Exception.class)
-  public void evaluateAttackPath(String runId) {
+  public AutonomousRun evaluateAttackPath(String runId) {
     requireFeature();
     AutonomousRun run = require(runId);
-    if (!hasText(run.getSimulationId())) {
-      return;
-    }
     // Belt-and-suspenders for dry-run: a plan run never starts a RUN workflow, so there is nothing
     // to ready here anyway, but guard explicitly so a stray evaluate call can never dispatch an
-    // inject while planning.
-    if (run.isPlanMode()) {
-      return;
-    }
-    // Re-evaluate the run's live workflow(s) so freshly authored step templates ready and execute
-    // now instead of waiting for an in-flight step. Done here (cross-bean to WorkflowService)
-    // rather
-    // than through a WorkflowService helper so we never self-invoke its @Transactional evaluator.
-    try {
-      for (Workflow runWorkflow :
-          workflowService.findWorkflowRunBySimulationId(run.getSimulationId())) {
-        workflowService.saveWorkflowRun(workflowService.evaluateWorkflowProgress(runWorkflow));
+    // inject while planning. An author-scenario run has no simulation, so nothing to evaluate
+    // either.
+    if (hasText(run.getSimulationId()) && !run.isPlanMode()) {
+      // Re-evaluate the run's live workflow(s) so freshly authored step templates ready and
+      // execute now instead of waiting for an in-flight step. Done here (cross-bean to
+      // WorkflowService) rather than through a WorkflowService helper so we never self-invoke its
+      // @Transactional evaluator.
+      try {
+        for (Workflow runWorkflow :
+            workflowService.findWorkflowRunBySimulationId(run.getSimulationId())) {
+          workflowService.saveWorkflowRun(workflowService.evaluateWorkflowProgress(runWorkflow));
+        }
+      } catch (ChainingException e) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Failed to evaluate the attack path: " + e.getMessage(), e);
       }
-    } catch (ChainingException e) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Failed to evaluate the attack path: " + e.getMessage(), e);
     }
+    // Same reconciled read the operator get() returns, without its RBAC gate (callback-safe).
+    return reconcileWithSimulation(run);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -222,6 +222,19 @@ public class AutonomousRunService {
             () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Autonomous run not found"));
   }
 
+  /**
+   * Re-reads {@code run} through the row-locking lookup before a teardown purges its timeline:
+   * {@link AutonomousEventService#deleteByRun} takes the per-run event advisory lock, and every
+   * path that combines it with a run-row write must acquire the run ROW lock first (the settle
+   * paths' {@code row -> advisory} order - conditional row-locking UPDATE, then terminal append) -
+   * or a purge and a concurrent settle would deadlock on the two locks. When the row is already
+   * gone (a concurrent teardown won), the stale entity is returned unchanged: the purge and delete
+   * that follow are idempotent no-ops.
+   */
+  private AutonomousRun lockForPurge(AutonomousRun run) {
+    return runRepository.findByIdForUpdate(run.getId()).orElse(run);
+  }
+
   /** A settled run: canceled, completed or failed. Nothing may execute or be authored on it. */
   private static boolean isTerminal(AutonomousRunStatus status) {
     return status == AutonomousRunStatus.CANCELED
@@ -1285,7 +1298,11 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun restart(String runId) {
     requireFeature();
-    AutonomousRun run = require(runId);
+    // Row-locked read: the reset purges the decision timeline (deleteByRun takes the per-run event
+    // advisory lock) and rewrites the run row, so it must hold the run ROW lock FIRST - the same
+    // row -> advisory acquisition order as the settle paths (conditional row-locking UPDATE, then
+    // terminal append). It also serialises the whole hard reset with a concurrent pause / settle.
+    AutonomousRun run = requireForUpdate(runId);
     accessControl.assertCanManage(run);
     // Stop the previous XTM One orchestration before tearing its simulation down, so a lingering
     // decision cycle can't dispatch injects against the simulation we are about to delete. The
@@ -1368,7 +1385,11 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun promoteToRealRun(String runId) {
     requireFeature();
-    AutonomousRun run = require(runId);
+    // Row-locked read, like restart(): the promotion purges the decision timeline (deleteByRun
+    // takes the per-run event advisory lock) and rewrites the run row, so the run ROW lock comes
+    // first (row -> advisory, the settle paths' order). The plan-settled gate below also becomes
+    // a locked check-then-act instead of racing a concurrent status write.
+    AutonomousRun run = requireForUpdate(runId);
     accessControl.assertCanManage(run);
     if (!run.isPlanMode()) {
       throw new ResponseStatusException(
@@ -1490,8 +1511,13 @@ public class AutonomousRunService {
       }
       return duplicate;
     }
-    // IN_PLACE (irreversible). Halt + purge the orchestration first so no lingering decision cycle
-    // keeps authoring against a scenario that is about to be manual.
+    // IN_PLACE (irreversible). Row-locked re-read first: this branch purges the timeline
+    // (deleteByRun takes the per-run event advisory lock) and deletes the run row, so the run ROW
+    // lock must come first (row -> advisory, the settle paths' order). Also serialises the
+    // status-based simulation transition below with a concurrent settle.
+    run = lockForPurge(run);
+    // Halt + purge the orchestration first so no lingering decision cycle keeps authoring against
+    // a scenario that is about to be manual.
     cancelOrchestratorAfterCommit(runId, "converted to a manual chained scenario", true);
     // Converting a still-active run leaves its simulation parked in a keep-alive RUNNING state
     // with no orchestrator left to ever feed or end it - settle it exactly like a cancel would.
@@ -1593,6 +1619,11 @@ public class AutonomousRunService {
    * results) is deleted with the run.
    */
   private void tearDownRun(AutonomousRun run) {
+    // Row-locked re-read first: the teardown purges the timeline (deleteByRun takes the per-run
+    // event advisory lock) and deletes the run row, so the run ROW lock must come first
+    // (row -> advisory, the settle paths' order) or this teardown could deadlock a concurrent
+    // settle narrating its terminal event.
+    run = lockForPurge(run);
     // Halt the XTM One orchestration first: once the run row is gone OpenAEV can no longer be
     // driven, but a still-live durable execution would keep self-resuming and dispatching injects.
     // Fired after commit (the run id is captured now) so the upstream cancel resolves the same
@@ -1657,6 +1688,10 @@ public class AutonomousRunService {
       // active run intact (the hero already hides the manual launch while a run is active).
       return;
     }
+    // Row-locked re-read first: the supersession purges the timeline (deleteByRun takes the
+    // per-run event advisory lock) and deletes the run row, so the run ROW lock must come first
+    // (row -> advisory, the settle paths' order).
+    prior = lockForPurge(prior);
     String priorId = prior.getId();
     cancelOrchestratorAfterCommit(priorId, reason, true);
     if (prior.isPlanMode() && hasText(prior.getSimulationId())) {

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousEventServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousEventServiceTest.java
@@ -1,0 +1,85 @@
+package io.openaev.service.autonomous;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.autonomous.AutonomousEvent;
+import io.openaev.database.model.autonomous.AutonomousEventType;
+import io.openaev.database.repository.autonomous.AutonomousEventRepository;
+import io.openaev.service.attackpath.ingestion.AttackPathVersionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the per-run advisory-lock protocol of {@link AutonomousEventService}: every write
+ * to a run's timeline - append, terminal-once append, and purge - must serialise on the SAME
+ * per-run lock, each acquiring it BEFORE its first read of shared timeline state. These orderings
+ * are what close the duplicate-sequence race (two appenders reading the same max), the duplicate
+ * terminal-narration race (two settle paths both observing "no terminal event yet"), and the
+ * purge/append race (an in-flight terminal append committing an old-life row into a freshly reset
+ * timeline).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AutonomousEventService advisory-lock protocol")
+class AutonomousEventServiceTest {
+
+  @Mock private AutonomousEventRepository eventRepository;
+  @Mock private AttackPathVersionService attackPathVersionService;
+  @InjectMocks private AutonomousEventService eventService;
+
+  @Test
+  @DisplayName("An append takes the per-run lock BEFORE computing the next sequence")
+  void given_append_when_writing_then_lockPrecedesMaxSequenceRead() {
+    when(eventRepository.findMaxSequence("run-1")).thenReturn(4L);
+    when(eventRepository.save(any(AutonomousEvent.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    AutonomousEvent saved =
+        eventService.append("run-1", null, AutonomousEventType.STATUS, "title", "content", null);
+
+    assertThat(saved.getSequence()).isEqualTo(5L);
+    InOrder inOrder = inOrder(eventRepository);
+    inOrder.verify(eventRepository).lockRunEventSequence(anyLong());
+    inOrder.verify(eventRepository).findMaxSequence("run-1");
+    inOrder.verify(eventRepository).save(any(AutonomousEvent.class));
+  }
+
+  @Test
+  @DisplayName("The terminal-once guard locks BEFORE its existence check and drops the duplicate")
+  void given_terminalAlreadyNarrated_when_appendTerminalStatusOnce_then_lockedCheckDrops() {
+    when(eventRepository.existsTerminalStatusEvent(
+            "run-1", AutonomousEventService.TERMINAL_STATUS_TITLES))
+        .thenReturn(true);
+
+    AutonomousEvent result =
+        eventService.appendTerminalStatusOnce("run-1", "sim-1", "Run canceled", "content");
+
+    assertThat(result).isNull();
+    InOrder inOrder = inOrder(eventRepository);
+    inOrder.verify(eventRepository).lockRunEventSequence(anyLong());
+    inOrder
+        .verify(eventRepository)
+        .existsTerminalStatusEvent("run-1", AutonomousEventService.TERMINAL_STATUS_TITLES);
+    verify(eventRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("A timeline purge takes the per-run lock BEFORE deleting (reset vs append race)")
+  void given_deleteByRun_when_purging_then_lockPrecedesDelete() {
+    eventService.deleteByRun("run-1");
+
+    InOrder inOrder = inOrder(eventRepository);
+    inOrder.verify(eventRepository).lockRunEventSequence(anyLong());
+    inOrder.verify(eventRepository).deleteByRunId("run-1");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunAccessControlTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunAccessControlTest.java
@@ -1,0 +1,173 @@
+package io.openaev.service.autonomous;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.database.model.Action;
+import io.openaev.database.model.ResourceType;
+import io.openaev.database.model.User;
+import io.openaev.database.model.autonomous.AutonomousRun;
+import io.openaev.service.PermissionService;
+import io.openaev.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Unit tests for {@link AutonomousRunAccessControl}: the resource-level gate that replaces the
+ * controller's {@code skipRBAC} for the operator surface. Verifies a run's authority is derived
+ * from its bound simulation (preferred) or scenario, that read maps to {@code READ} and manage to
+ * {@code LAUNCH}, that a run bound to neither degrades to a capability-only check (never a silent
+ * open door), and that the tenant-global default-agent write is admin-only.
+ */
+@ExtendWith(MockitoExtension.class)
+class AutonomousRunAccessControlTest {
+
+  @Mock private UserService userService;
+  @Mock private PermissionService permissionService;
+  @InjectMocks private AutonomousRunAccessControl accessControl;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User();
+    lenient().when(userService.currentUser()).thenReturn(user);
+  }
+
+  private static AutonomousRun run(String simulationId, String scenarioId) {
+    AutonomousRun run = new AutonomousRun();
+    run.setId("run-1");
+    run.setSimulationId(simulationId);
+    run.setScenarioId(scenarioId);
+    return run;
+  }
+
+  @Test
+  @DisplayName("read on a live run checks READ on its bound simulation")
+  void readChecksSimulationRead() {
+    when(permissionService.hasPermission(
+            any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+        .thenReturn(true);
+
+    assertThatCode(() -> accessControl.assertCanRead(run("sim-1", "scenario-1")))
+        .doesNotThrowAnyException();
+    // The scenario is never consulted when a simulation is bound.
+    verify(permissionService, never()).hasPermission(any(), any(), eq("scenario-1"), any(), any());
+  }
+
+  @Test
+  @DisplayName("read is denied (403) when the caller lacks READ on the bound simulation")
+  void readDeniedWithoutSimulationRead() {
+    when(permissionService.hasPermission(
+            any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> accessControl.assertCanRead(run("sim-1", "scenario-1")))
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  @DisplayName("manage on a live run checks LAUNCH on its bound simulation")
+  void manageChecksSimulationLaunch() {
+    when(permissionService.hasPermission(
+            any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
+        .thenReturn(true);
+
+    assertThatCode(() -> accessControl.assertCanManage(run("sim-1", null)))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("a plan run with no simulation derives its authority from the scenario (LAUNCH)")
+  void manageFallsBackToScenarioForPlanRun() {
+    when(permissionService.hasPermission(
+            any(), any(), eq("scenario-1"), eq(ResourceType.SCENARIO), eq(Action.LAUNCH)))
+        .thenReturn(true);
+
+    assertThatCode(() -> accessControl.assertCanManage(run(null, "scenario-1")))
+        .doesNotThrowAnyException();
+    verify(permissionService, never())
+        .hasPermission(any(), any(), any(), eq(ResourceType.SIMULATION), any());
+  }
+
+  @Test
+  @DisplayName("a malformed run bound to neither sim nor scenario degrades to a capability check")
+  void managerFallsBackToCapabilityWhenUnbound() {
+    when(permissionService.hasCapabilityPermission(
+            any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> accessControl.assertCanManage(run(null, null)))
+        .isInstanceOf(ResponseStatusException.class);
+    // Never a silent open door: it consulted the capability, not returned true by default.
+    verify(permissionService)
+        .hasCapabilityPermission(any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH));
+  }
+
+  @Test
+  @DisplayName("retainReadable keeps only the runs the caller can READ")
+  void retainReadableFiltersUnreadableRuns() {
+    AutonomousRun readable = run("sim-ok", null);
+    AutonomousRun hidden = run("sim-nope", null);
+    when(permissionService.hasPermission(
+            any(), any(), eq("sim-ok"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+        .thenReturn(true);
+    when(permissionService.hasPermission(
+            any(), any(), eq("sim-nope"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+        .thenReturn(false);
+
+    List<AutonomousRun> kept = accessControl.retainReadable(List.of(readable, hidden));
+
+    assertThat(kept).containsExactly(readable);
+  }
+
+  @Test
+  @DisplayName("assertCanCreate requires the launch-assessment capability floor")
+  void createRequiresLaunchCapability() {
+    when(permissionService.hasCapabilityPermission(
+            any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> accessControl.assertCanCreate())
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+  }
+
+  @Test
+  @DisplayName("assertCanManageScenario is a no-op for a blank scenario id (caller validates)")
+  void manageScenarioNoOpForBlankId() {
+    assertThatCode(() -> accessControl.assertCanManageScenario(" ")).doesNotThrowAnyException();
+    verify(permissionService, never()).hasPermission(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("default-agents write is admin-only")
+  void adminGateForDefaultAgents() {
+    user.setAdmin(false);
+    assertThatThrownBy(() -> accessControl.assertAdmin())
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+
+    user.setAdmin(true);
+    assertThatCode(() -> accessControl.assertAdmin()).doesNotThrowAnyException();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunAccessControlTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunAccessControlTest.java
@@ -8,12 +8,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.model.User;
 import io.openaev.database.model.autonomous.AutonomousRun;
+import io.openaev.service.GrantService;
 import io.openaev.service.PermissionService;
 import io.openaev.service.UserService;
 import java.util.List;
@@ -41,6 +43,7 @@ class AutonomousRunAccessControlTest {
 
   @Mock private UserService userService;
   @Mock private PermissionService permissionService;
+  @Mock private GrantService grantService;
   @InjectMocks private AutonomousRunAccessControl accessControl;
 
   private User user;
@@ -136,20 +139,38 @@ class AutonomousRunAccessControlTest {
   class ListFiltering {
 
     @Test
-    @DisplayName("retainReadable keeps only the runs the caller can READ")
-    void given_mixedReadability_when_retainReadable_then_keepsOnlyReadableRuns() {
-      AutonomousRun readable = run("sim-ok", null);
-      AutonomousRun hidden = run("sim-nope", null);
-      when(permissionService.hasPermission(
-              any(), any(), eq("sim-ok"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+    @DisplayName("A capability-level reader keeps every run without any grant query")
+    void given_capabilityReader_when_retainReadable_then_keepsAllWithoutGrantQuery() {
+      when(permissionService.hasCapabilityPermission(any(), any(), eq(Action.READ)))
           .thenReturn(true);
-      when(permissionService.hasPermission(
-              any(), any(), eq("sim-nope"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+
+      List<AutonomousRun> kept =
+          accessControl.retainReadable(List.of(run("sim-1", null), run(null, "scenario-1")));
+
+      assertThat(kept).hasSize(2);
+      verifyNoInteractions(grantService);
+    }
+
+    @Test
+    @DisplayName("A grant-only reader filters through ONE batched grant fetch, no per-run lookups")
+    void given_grantOnlyReader_when_retainReadable_then_filtersWithSingleBatchedGrantFetch() {
+      AutonomousRun grantedSimulation = run("sim-ok", null);
+      AutonomousRun hiddenSimulation = run("sim-nope", null);
+      AutonomousRun grantedScenario = run(null, "scenario-ok");
+      AutonomousRun unboundRun = run(null, null);
+      when(permissionService.hasCapabilityPermission(any(), any(), eq(Action.READ)))
           .thenReturn(false);
+      when(grantService.findReadGrantedResourceIds(user))
+          .thenReturn(List.of("sim-ok", "scenario-ok"));
 
-      List<AutonomousRun> kept = accessControl.retainReadable(List.of(readable, hidden));
+      List<AutonomousRun> kept =
+          accessControl.retainReadable(
+              List.of(grantedSimulation, hiddenSimulation, grantedScenario, unboundRun));
 
-      assertThat(kept).containsExactly(readable);
+      assertThat(kept).containsExactly(grantedSimulation, grantedScenario);
+      // The N+1 regression guard: one batched fetch, zero per-run permission lookups.
+      verify(grantService).findReadGrantedResourceIds(user);
+      verify(permissionService, never()).hasPermission(any(), any(), any(), any(), any());
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunAccessControlTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunAccessControlTest.java
@@ -19,6 +19,7 @@ import io.openaev.service.UserService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -35,6 +36,7 @@ import org.springframework.web.server.ResponseStatusException;
  * open door), and that the tenant-global default-agent write is admin-only.
  */
 @ExtendWith(MockitoExtension.class)
+@DisplayName("AutonomousRunAccessControl")
 class AutonomousRunAccessControlTest {
 
   @Mock private UserService userService;
@@ -57,117 +59,141 @@ class AutonomousRunAccessControlTest {
     return run;
   }
 
-  @Test
-  @DisplayName("read on a live run checks READ on its bound simulation")
-  void readChecksSimulationRead() {
-    when(permissionService.hasPermission(
-            any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.READ)))
-        .thenReturn(true);
+  @Nested
+  @DisplayName("Run authority derivation (simulation first, then scenario, then capability)")
+  class RunAuthorityDerivation {
 
-    assertThatCode(() -> accessControl.assertCanRead(run("sim-1", "scenario-1")))
-        .doesNotThrowAnyException();
-    // The scenario is never consulted when a simulation is bound.
-    verify(permissionService, never()).hasPermission(any(), any(), eq("scenario-1"), any(), any());
+    @Test
+    @DisplayName("Read on a live run checks READ on its bound simulation, never the scenario")
+    void given_runBoundToSimulation_when_read_then_checksSimulationReadOnly() {
+      when(permissionService.hasPermission(
+              any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+          .thenReturn(true);
+
+      assertThatCode(() -> accessControl.assertCanRead(run("sim-1", "scenario-1")))
+          .doesNotThrowAnyException();
+
+      verify(permissionService, never())
+          .hasPermission(any(), any(), eq("scenario-1"), any(), any());
+    }
+
+    @Test
+    @DisplayName("Read is denied (403) when the caller lacks READ on the bound simulation")
+    void given_noSimulationRead_when_read_then_denied() {
+      when(permissionService.hasPermission(
+              any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+          .thenReturn(false);
+
+      assertThatThrownBy(() -> accessControl.assertCanRead(run("sim-1", "scenario-1")))
+          .isInstanceOfSatisfying(
+              ResponseStatusException.class,
+              ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("Manage on a live run checks LAUNCH on its bound simulation")
+    void given_runBoundToSimulation_when_manage_then_checksSimulationLaunch() {
+      when(permissionService.hasPermission(
+              any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
+          .thenReturn(true);
+
+      assertThatCode(() -> accessControl.assertCanManage(run("sim-1", null)))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("A plan run with no simulation derives its authority from the scenario (LAUNCH)")
+    void given_planRunWithoutSimulation_when_manage_then_fallsBackToScenarioLaunch() {
+      when(permissionService.hasPermission(
+              any(), any(), eq("scenario-1"), eq(ResourceType.SCENARIO), eq(Action.LAUNCH)))
+          .thenReturn(true);
+
+      assertThatCode(() -> accessControl.assertCanManage(run(null, "scenario-1")))
+          .doesNotThrowAnyException();
+
+      verify(permissionService, never())
+          .hasPermission(any(), any(), any(), eq(ResourceType.SIMULATION), any());
+    }
+
+    @Test
+    @DisplayName("A malformed run bound to neither sim nor scenario degrades to a capability check")
+    void given_runBoundToNothing_when_manage_then_fallsBackToCapabilityCheck() {
+      when(permissionService.hasCapabilityPermission(
+              any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
+          .thenReturn(false);
+
+      assertThatThrownBy(() -> accessControl.assertCanManage(run(null, null)))
+          .isInstanceOf(ResponseStatusException.class);
+
+      // Never a silent open door: it consulted the capability, not returned true by default.
+      verify(permissionService)
+          .hasCapabilityPermission(any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH));
+    }
   }
 
-  @Test
-  @DisplayName("read is denied (403) when the caller lacks READ on the bound simulation")
-  void readDeniedWithoutSimulationRead() {
-    when(permissionService.hasPermission(
-            any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.READ)))
-        .thenReturn(false);
+  @Nested
+  @DisplayName("List filtering")
+  class ListFiltering {
 
-    assertThatThrownBy(() -> accessControl.assertCanRead(run("sim-1", "scenario-1")))
-        .isInstanceOfSatisfying(
-            ResponseStatusException.class,
-            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+    @Test
+    @DisplayName("retainReadable keeps only the runs the caller can READ")
+    void given_mixedReadability_when_retainReadable_then_keepsOnlyReadableRuns() {
+      AutonomousRun readable = run("sim-ok", null);
+      AutonomousRun hidden = run("sim-nope", null);
+      when(permissionService.hasPermission(
+              any(), any(), eq("sim-ok"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+          .thenReturn(true);
+      when(permissionService.hasPermission(
+              any(), any(), eq("sim-nope"), eq(ResourceType.SIMULATION), eq(Action.READ)))
+          .thenReturn(false);
+
+      List<AutonomousRun> kept = accessControl.retainReadable(List.of(readable, hidden));
+
+      assertThat(kept).containsExactly(readable);
+    }
   }
 
-  @Test
-  @DisplayName("manage on a live run checks LAUNCH on its bound simulation")
-  void manageChecksSimulationLaunch() {
-    when(permissionService.hasPermission(
-            any(), any(), eq("sim-1"), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
-        .thenReturn(true);
+  @Nested
+  @DisplayName("Creation and scenario gates")
+  class CreationAndScenarioGates {
 
-    assertThatCode(() -> accessControl.assertCanManage(run("sim-1", null)))
-        .doesNotThrowAnyException();
+    @Test
+    @DisplayName("assertCanCreate requires the launch-assessment capability floor")
+    void given_noLaunchCapability_when_create_then_denied() {
+      when(permissionService.hasCapabilityPermission(
+              any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
+          .thenReturn(false);
+
+      assertThatThrownBy(() -> accessControl.assertCanCreate())
+          .isInstanceOfSatisfying(
+              ResponseStatusException.class,
+              ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("assertCanManageScenario is a no-op for a blank scenario id (caller validates)")
+    void given_blankScenarioId_when_manageScenario_then_noPermissionCheck() {
+      assertThatCode(() -> accessControl.assertCanManageScenario(" ")).doesNotThrowAnyException();
+
+      verify(permissionService, never()).hasPermission(any(), any(), any(), any(), any());
+    }
   }
 
-  @Test
-  @DisplayName("a plan run with no simulation derives its authority from the scenario (LAUNCH)")
-  void manageFallsBackToScenarioForPlanRun() {
-    when(permissionService.hasPermission(
-            any(), any(), eq("scenario-1"), eq(ResourceType.SCENARIO), eq(Action.LAUNCH)))
-        .thenReturn(true);
+  @Nested
+  @DisplayName("Admin gate")
+  class AdminGate {
 
-    assertThatCode(() -> accessControl.assertCanManage(run(null, "scenario-1")))
-        .doesNotThrowAnyException();
-    verify(permissionService, never())
-        .hasPermission(any(), any(), any(), eq(ResourceType.SIMULATION), any());
-  }
+    @Test
+    @DisplayName("Default-agents write is denied for a non-admin and allowed for an admin")
+    void given_nonAdminThenAdmin_when_assertAdmin_then_deniedThenAllowed() {
+      user.setAdmin(false);
+      assertThatThrownBy(() -> accessControl.assertAdmin())
+          .isInstanceOfSatisfying(
+              ResponseStatusException.class,
+              ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
 
-  @Test
-  @DisplayName("a malformed run bound to neither sim nor scenario degrades to a capability check")
-  void managerFallsBackToCapabilityWhenUnbound() {
-    when(permissionService.hasCapabilityPermission(
-            any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
-        .thenReturn(false);
-
-    assertThatThrownBy(() -> accessControl.assertCanManage(run(null, null)))
-        .isInstanceOf(ResponseStatusException.class);
-    // Never a silent open door: it consulted the capability, not returned true by default.
-    verify(permissionService)
-        .hasCapabilityPermission(any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH));
-  }
-
-  @Test
-  @DisplayName("retainReadable keeps only the runs the caller can READ")
-  void retainReadableFiltersUnreadableRuns() {
-    AutonomousRun readable = run("sim-ok", null);
-    AutonomousRun hidden = run("sim-nope", null);
-    when(permissionService.hasPermission(
-            any(), any(), eq("sim-ok"), eq(ResourceType.SIMULATION), eq(Action.READ)))
-        .thenReturn(true);
-    when(permissionService.hasPermission(
-            any(), any(), eq("sim-nope"), eq(ResourceType.SIMULATION), eq(Action.READ)))
-        .thenReturn(false);
-
-    List<AutonomousRun> kept = accessControl.retainReadable(List.of(readable, hidden));
-
-    assertThat(kept).containsExactly(readable);
-  }
-
-  @Test
-  @DisplayName("assertCanCreate requires the launch-assessment capability floor")
-  void createRequiresLaunchCapability() {
-    when(permissionService.hasCapabilityPermission(
-            any(), eq(ResourceType.SIMULATION), eq(Action.LAUNCH)))
-        .thenReturn(false);
-
-    assertThatThrownBy(() -> accessControl.assertCanCreate())
-        .isInstanceOfSatisfying(
-            ResponseStatusException.class,
-            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
-  }
-
-  @Test
-  @DisplayName("assertCanManageScenario is a no-op for a blank scenario id (caller validates)")
-  void manageScenarioNoOpForBlankId() {
-    assertThatCode(() -> accessControl.assertCanManageScenario(" ")).doesNotThrowAnyException();
-    verify(permissionService, never()).hasPermission(any(), any(), any(), any(), any());
-  }
-
-  @Test
-  @DisplayName("default-agents write is admin-only")
-  void adminGateForDefaultAgents() {
-    user.setAdmin(false);
-    assertThatThrownBy(() -> accessControl.assertAdmin())
-        .isInstanceOfSatisfying(
-            ResponseStatusException.class,
-            ex -> assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
-
-    user.setAdmin(true);
-    assertThatCode(() -> accessControl.assertAdmin()).doesNotThrowAnyException();
+      user.setAdmin(true);
+      assertThatCode(() -> accessControl.assertAdmin()).doesNotThrowAnyException();
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -106,7 +106,7 @@ class AutonomousRunServiceTest {
     AutonomousRun run = new AutonomousRun();
     run.setPlanMode(false);
     run.setStatus(AutonomousRunStatus.RUNNING);
-    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
 
     assertThatThrownBy(() -> service.promoteToRealRun("run-1"))
         .isInstanceOf(ResponseStatusException.class);
@@ -119,7 +119,7 @@ class AutonomousRunServiceTest {
     AutonomousRun run = new AutonomousRun();
     run.setPlanMode(true);
     run.setStatus(AutonomousRunStatus.PLANNING);
-    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
 
     assertThatThrownBy(() -> service.promoteToRealRun("run-1"))
         .isInstanceOf(ResponseStatusException.class);
@@ -486,7 +486,7 @@ class AutonomousRunServiceTest {
     run.setStartedAt(Instant.now().minusSeconds(600));
     run.setDeadlineAt(Instant.now().minusSeconds(5));
     run.setWinddownPhase("WINDDOWN_1M");
-    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
     stubRestartCollaborators();
 
     AutonomousRun restarted = service.restart("run-1");
@@ -517,7 +517,7 @@ class AutonomousRunServiceTest {
   @DisplayName("restart from WAITING_INPUT no longer 409s: the parked run is reset like any other")
   void restartFromWaitingInputIsAllowed() throws Exception {
     AutonomousRun run = restartableRun(AutonomousRunStatus.WAITING_INPUT);
-    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
     stubRestartCollaborators();
 
     AutonomousRun restarted = service.restart("run-1");
@@ -533,7 +533,7 @@ class AutonomousRunServiceTest {
   @DisplayName("restart from a settled status keeps working exactly as before")
   void restartFromSettledStatusStillWorks() throws Exception {
     AutonomousRun run = restartableRun(AutonomousRunStatus.COMPLETED);
-    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
     stubRestartCollaborators();
 
     AutonomousRun restarted = service.restart("run-1");
@@ -549,7 +549,7 @@ class AutonomousRunServiceTest {
   void restartOfPlanModeReprovisionsTemplateOnly() throws Exception {
     AutonomousRun run = restartableRun(AutonomousRunStatus.PLANNED);
     run.setPlanMode(true);
-    when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+    when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
     stubRestartCollaborators();
 
     AutonomousRun restarted = service.restart("run-1");

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -76,6 +76,9 @@ class AutonomousRunServiceTest {
   @Mock private ScenarioToExerciseService scenarioToExerciseService;
   @Mock private XtmOneClient xtmOneClient;
   @Mock private OpenAEVConfig openAEVConfig;
+  // Lenient by default (void asserts are no-ops): these unit tests exercise lifecycle logic, not
+  // authorization. The deny paths are covered by AutonomousRunAccessControlTest.
+  @Mock private AutonomousRunAccessControl accessControl;
 
   @InjectMocks private AutonomousRunService service;
 

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -186,6 +186,19 @@ class AutonomousRunServiceTest {
     }
 
     @Test
+    @DisplayName("A settled plan (PLANNED) cannot be reopened or overwritten by a late callback")
+    void given_plannedPlanRun_when_orchestratorPushesAnyStatus_then_noOp() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.PLANNED, true);
+
+      service.updateStatus("run-1", AutonomousRunStatus.PLANNING, null, null, null);
+      service.updateStatus("run-1", AutonomousRunStatus.FAILED, null, null, null);
+
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.PLANNED);
+      verify(runRepository, never()).save(any());
+      verifyNoInteractions(eventService);
+    }
+
+    @Test
     @DisplayName("A live run cannot be flipped across the plan/live divide (PLANNED target)")
     void given_liveRun_when_orchestratorPushesPlanned_then_noOp() {
       AutonomousRun run = lockedRun(AutonomousRunStatus.RUNNING, false);

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -123,6 +124,170 @@ class AutonomousRunServiceTest {
     assertThatThrownBy(() -> service.promoteToRealRun("run-1"))
         .isInstanceOf(ResponseStatusException.class);
   }
+
+  // region orchestrator status callback validation
+
+  /**
+   * Regression tests for the orchestrator status-callback transition matrix: a stale callback must
+   * never resurrect an operator-owned state (CREATED pre-handoff / post-restart, PAUSED) or cross
+   * the plan/live divide, and every rejected push is an idempotent no-op (never a save).
+   */
+  @Nested
+  @DisplayName("Orchestrator status callback validation")
+  class OrchestratorStatusValidation {
+
+    private AutonomousRun lockedRun(AutonomousRunStatus status, boolean planMode) {
+      AutonomousRun run = new AutonomousRun();
+      run.setId("run-1");
+      run.setSimulationId("sim-1");
+      run.setStatus(status);
+      run.setPlanMode(planMode);
+      when(previewFeatureService.isAutonomousAttackPathEnabled()).thenReturn(true);
+      // updateStatus reads through the row-locking lookup so its check-then-write serialises with
+      // the operator lifecycle writers.
+      when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
+      return run;
+    }
+
+    @Test
+    @DisplayName("A stale callback cannot resurrect an operator pause (PAUSED source is a no-op)")
+    void given_pausedRun_when_orchestratorPushesAnyStatus_then_noOp() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.PAUSED, false);
+
+      AutonomousRun result =
+          service.updateStatus("run-1", AutonomousRunStatus.RUNNING, null, null, null);
+
+      assertThat(result.getStatus()).isEqualTo(AutonomousRunStatus.PAUSED);
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.PAUSED);
+      verify(runRepository, never()).save(any());
+      verifyNoInteractions(eventService);
+    }
+
+    @Test
+    @DisplayName("A stale callback cannot settle a paused run to a terminal state")
+    void given_pausedRun_when_orchestratorPushesCompleted_then_noOp() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.PAUSED, false);
+
+      service.updateStatus("run-1", AutonomousRunStatus.COMPLETED, null, null, null);
+
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.PAUSED);
+      verify(runRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("A stale callback cannot drive a not-yet-started (CREATED) run")
+    void given_createdRun_when_orchestratorPushesRunning_then_noOp() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.CREATED, false);
+
+      service.updateStatus("run-1", AutonomousRunStatus.RUNNING, null, null, null);
+
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.CREATED);
+      verify(runRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("A live run cannot be flipped across the plan/live divide (PLANNED target)")
+    void given_liveRun_when_orchestratorPushesPlanned_then_noOp() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.RUNNING, false);
+
+      service.updateStatus("run-1", AutonomousRunStatus.PLANNED, null, null, null);
+
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.RUNNING);
+      verify(runRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("A plan run cannot be driven to the execute-only RUNNING state")
+    void given_planRun_when_orchestratorPushesRunning_then_noOp() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.PLANNING, true);
+
+      service.updateStatus("run-1", AutonomousRunStatus.RUNNING, null, null, null);
+
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.PLANNING);
+      verify(runRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("A legitimate live-run push (RUNNING -> COMPLETED) is applied and narrated")
+    void given_liveRun_when_orchestratorPushesCompleted_then_applied() {
+      AutonomousRun run = lockedRun(AutonomousRunStatus.RUNNING, false);
+      when(runRepository.save(run)).thenReturn(run);
+
+      AutonomousRun result =
+          service.updateStatus("run-1", AutonomousRunStatus.COMPLETED, null, null, null);
+
+      assertThat(result.getStatus()).isEqualTo(AutonomousRunStatus.COMPLETED);
+      verify(runRepository).save(run);
+      verify(eventService)
+          .append(
+              eq("run-1"),
+              eq("sim-1"),
+              eq(AutonomousEventType.STATUS),
+              anyString(),
+              isNull(),
+              isNull());
+    }
+  }
+
+  // endregion
+
+  // region network scope-rule matching (dual-stack CIDR)
+
+  /**
+   * Direct tests of the network scope-rule matcher: dual-stack CIDR containment must work for IPv6
+   * (the original bug), never resolve a hostname through DNS, and never let a malformed rule (an
+   * out-of-range prefix) match everything.
+   */
+  @Nested
+  @DisplayName("Network scope-rule matching")
+  class NetworkScopeRuleMatching {
+
+    @Test
+    @DisplayName("An IPv4 host matches an IPv4 CIDR rule")
+    void given_ipv4Candidate_when_insideIpv4Cidr_then_matches() {
+      assertThat(service.networkValueMatches("10.0.0.0/24", "10.0.0.42")).isTrue();
+      assertThat(service.networkValueMatches("10.0.0.0/24", "10.0.1.42")).isFalse();
+    }
+
+    @Test
+    @DisplayName("An IPv6 host matches an IPv6 CIDR rule (the original silent fall-through)")
+    void given_ipv6Candidate_when_insideIpv6Cidr_then_matches() {
+      assertThat(service.networkValueMatches("2001:db8::/32", "2001:db8::1")).isTrue();
+      assertThat(service.networkValueMatches("2001:db8::/32", "2001:db9::1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Mismatched address families never match")
+    void given_familyMismatch_when_matching_then_false() {
+      assertThat(service.networkValueMatches("10.0.0.0/8", "2001:db8::1")).isFalse();
+      assertThat(service.networkValueMatches("2001:db8::/32", "10.0.0.1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("A hostname candidate is never evaluated against a CIDR rule (no DNS lookup)")
+    void given_hostnameCandidate_when_ruleIsCidr_then_falseWithoutResolution() {
+      assertThat(service.networkValueMatches("10.0.0.0/8", "intranet.example.org")).isFalse();
+    }
+
+    @Test
+    @DisplayName("A malformed rule prefix (out of range) never matches anything")
+    void given_outOfRangePrefix_when_matching_then_false() {
+      assertThat(service.networkValueMatches("10.0.0.0/-1", "10.0.0.1")).isFalse();
+      assertThat(service.networkValueMatches("10.0.0.0/33", "10.0.0.1")).isFalse();
+      assertThat(service.networkValueMatches("2001:db8::/-1", "2001:db8::1")).isFalse();
+      assertThat(service.networkValueMatches("2001:db8::/129", "2001:db8::1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("A non-CIDR rule still matches case-insensitively on the exact value")
+    void given_exactRule_when_candidateDiffersOnlyByCase_then_matches() {
+      assertThat(service.networkValueMatches("HOST.example.org", "host.example.org")).isTrue();
+      assertThat(service.networkValueMatches("10.0.0.1", "10.0.0.1")).isTrue();
+      assertThat(service.networkValueMatches("10.0.0.1", "10.0.0.2")).isFalse();
+    }
+  }
+
+  // endregion
 
   // region OpenAEV-owned timeout: deadline stamping, winddown nudges, hard stop
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousEventRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousEventRepository.java
@@ -23,6 +23,19 @@ public interface AutonomousEventRepository extends JpaRepository<AutonomousEvent
   long findMaxSequence(@Param("runId") String runId);
 
   /**
+   * Takes a PostgreSQL transaction-scoped advisory lock keyed on {@code key} and returns once it is
+   * held. {@code AutonomousEventService} calls this before its {@link #findMaxSequence} +1 insert
+   * so two appenders writing to the same run serialise instead of both computing the same next
+   * sequence. The lock auto-releases at commit/rollback and is cluster-wide (it holds across API
+   * nodes), unlike a JVM lock; it complements the UNIQUE {@code (run_id, sequence)} index, which is
+   * the hard backstop. Wrapped as {@code SELECT 1 FROM (...)} so the {@code void} lock function
+   * maps to a plain scalar (the volatile function is still evaluated to produce the row). Must run
+   * inside a transaction.
+   */
+  @Query(value = "SELECT 1 FROM (SELECT pg_advisory_xact_lock(:key)) AS locked", nativeQuery = true)
+  Integer lockRunEventSequence(@Param("key") long key);
+
+  /**
    * True when the run already carries a STATUS event whose title is one of {@code titles}. Used to
    * narrate a run's END (canceled / completed / timed out / failed) at most once per run life: an
    * operator Stop, the timeout watchdog and the read-path reconcile can all reach a run, and a

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
@@ -14,9 +14,10 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
- * Tenant-active store for autonomous runs. The tenant predicate on {@code autonomous_runs} is added
- * by the statement inspector, so these derived queries stay tenant-scoped without an explicit
- * clause.
+ * Store for autonomous runs. {@code autonomous_runs} is NOT yet onboarded to the tenant statement
+ * inspector (tracked in issue #7396), so derived queries here are not tenant-scoped on their own;
+ * the queries that must be tenant-correct today carry an explicit {@code tenant_id} predicate, and
+ * resource-level access is gated by {@code AutonomousRunAccessControl}.
  */
 @Repository
 public interface AutonomousRunRepository extends JpaRepository<AutonomousRun, String> {


### PR DESCRIPTION
## Summary

Second pre-release hardening pass for AI planning and autonomous runs of chained scenarios, stacked on #7391 (merged). It closes the CRITICAL and HIGH backend items deferred from #7390.

- **RBAC enforcement (CRITICAL).** `AutonomousRunApi` carries `skipRBAC = true` on every endpoint and the service performed no in-service capability check, so any authenticated user could read or drive any run. A new `AutonomousRunAccessControl` becomes the enforcement point: reads require `READ` and mutations require `LAUNCH` on the run's bound simulation/scenario, and the global default-agent settings are admin-only. The scenario gate runs BEFORE the workflow-shape read in `launchFromScenario`/`planScenario`, so an unauthorized caller gets a uniform 403 and cannot use the 400/403 difference as an oracle on whether a scenario is chained. The unbounded run list filters through ONE batched read-grant fetch (`GrantService.findReadGrantedResourceIds`) plus per-TYPE capability checks instead of a per-run grant lookup, so grant-only callers do not turn the listing into an N+1. The orchestrator status/timeline callbacks stay ungated - they are driven by the tenant's XTM One service credential and must be able to drive a live run (the evaluate callback answers through a callback-safe reconciled read, not the operator-gated `get()`); restricting them to that service identity is tracked in #7396.
- **Event-sequence race (HIGH).** `AutonomousEventService` assigned `sequence = max(sequence) + 1` behind a non-unique index, so a decision cycle racing an operator directive could persist a duplicate sequence and corrupt timeline order and the since-sequence incremental reads the live cockpit relies on. Appenders now serialise on a per-run PostgreSQL transaction advisory lock, backed by a UNIQUE `(run_id, sequence)` index as the hard backstop. The terminal-once guard (`appendTerminalStatusOnce`) takes the same lock BEFORE its existence check, so two racing settle paths can no longer narrate two terminal lines. Timeline purges participate in the same protocol: restart / promote / convert-to-manual / teardown / supersession take the run ROW lock first and then the advisory lock inside `deleteByRun` (the settle paths' existing row -> advisory order), so a reset can never interleave with an in-flight terminal narration and resurrect an old-life terminal row - nor deadlock a concurrent settle. The migration preserves every timeline row: pre-existing duplicates are deterministically resequenced with `ROW_NUMBER()` (never deleted) and the pass stays idempotent; it runs behind an `ACCESS EXCLUSIVE` table lock taken as the FIRST statement, because `DROP INDEX` requires that lock anyway and upgrading from a weaker write-blocking mode while an old node's in-flight append holds `ACCESS SHARE` is a lock-upgrade deadlock that would abort the migration mid-rolling-deploy.
- **Status transition validation (HIGH).** The orchestrator status callback accepted any target on an unlocked read. It now loads the run with the same pessimistic lock as the operator lifecycle methods (so the validation serialises with a concurrent pause/terminal write) and validates the transition on both sides: `CREATED` / `PAUSED` / `CANCELED` are never orchestrator-driven targets, a run parked in an operator-owned or settled source state (`CREATED`, `PAUSED`, `PLANNED`) cannot be driven at all, and the dry-run planning states (`PLANNING` / `PLANNED`) versus the live `RUNNING` state may not be crossed. An illegal push is an idempotent no-op instead of resurrecting an operator state, reopening a promotable plan, or flipping a run across the plan/live divide.
- **IPv6 scope matching (HIGH).** Manual/CSV network scope rules only matched IPv4 CIDRs; an IPv6 host silently fell through. Containment now delegates to the shared `IpAddressUtils.isIpInSubnet` (dual-stack, family-aware), guarded so only a literal IPv4/IPv6 candidate is evaluated against a well-formed subnet: a discovered hostname can never trigger a DNS lookup or match a CIDR through resolution, and a malformed rule prefix (e.g. `/-1`) matches nothing instead of everything. The dead IPv4-only helpers are removed.

## Follow-ups (tracked in #7396)

- Restrict the orchestrator callback endpoints to the actual XTM One service identity (today any authenticated EE user can reach them).
- Onboard `autonomous_runs` / `autonomous_events` / `autonomous_directives` to the tenant statement inspector (v2 activation with `TxCtx` wiring). The docs no longer claim this coverage exists.

## Test plan

- [x] `mvn -pl openaev-api -am compile -DskipTests -Pdev` - BUILD SUCCESS
- [x] `AutonomousRunServiceTest` - 54 passed (incl. status-matrix and dual-stack CIDR tests)
- [x] `AutonomousRunAccessControlTest` - 10 passed (incl. batched list-filtering: capability short-circuit without a grant query, single batched grant fetch, no per-run lookups)
- [x] `AutonomousEventServiceTest` - 3 passed (new; pins the advisory-lock protocol: lock before the max-sequence read, before the terminal-once existence check, before the purge delete)
- [x] Full CI green
- [ ] Manual: non-privileged user is denied read/manage on a run they do not own
- [ ] Manual: IPv6 host is matched against an IPv6 CIDR scope rule

Closes #7390
