### PR TITLE
fix(chaining): update targets on action when adding an asset (#5045)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StepService {
 
   private final InjectExecutionStep injectExecutionStep;
+  private final StepTargetingService stepTargetingService;
 
   private final InjectService injectService;
   private final ConditionService conditionService;
@@ -733,7 +734,7 @@ public class StepService {
     for (Step template : findAllStepTemplateByWorkflow(workflow.getId())) {
       if (!StepActionClass.INJECT_EXECUTION.equals(template.getStepAction())
           || template.getData() == null
-          || !injectExecutionStep.stepSupportsAssetTargeting(template)) {
+          || !stepTargetingService.isAssetCentric(template)) {
         continue;
       }
       String newData = withScopeAssets(template, scopedAssetIds);

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -716,6 +716,67 @@ public class StepService {
   }
 
   /**
+   * Re-aligns the asset perimeter baked into every asset-centric INJECT_EXECUTION step template of
+   * a workflow with the workflow scope.
+   *
+   * <p>Actions do not own their asset targets: in the chaining logic map the asset perimeter is
+   * defined once by the workflow scope and merely <i>copied</i> into {@code
+   * step.data.inject_assets} when the action is configured.
+   *
+   * @param workflow the workflow whose step templates must be realigned
+   * @param scopedAssetIds the current in-scope asset IDs (denylist already applied)
+   * @return the number of step templates actually rewritten
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public int syncScopeAssetsOnStepTemplates(Workflow workflow, List<String> scopedAssetIds) {
+    List<Step> updated = new ArrayList<>();
+    for (Step template : findAllStepTemplateByWorkflow(workflow.getId())) {
+      if (!StepActionClass.INJECT_EXECUTION.equals(template.getStepAction())
+          || template.getData() == null
+          || !injectExecutionStep.stepSupportsAssetTargeting(template)) {
+        continue;
+      }
+      String newData = withScopeAssets(template, scopedAssetIds);
+      if (newData != null) {
+        template.setData(newData);
+        updated.add(template);
+      }
+    }
+    if (!updated.isEmpty()) {
+      saveSteps(updated);
+      log.debug(
+          "[Chaining] Realigned {} step template(s) of workflow {} on the {} in-scope asset(s)",
+          updated.size(),
+          workflow.getId(),
+          scopedAssetIds.size());
+    }
+    return updated.size();
+  }
+
+  /**
+   * Returns the step data with {@code inject_assets} replaced by the given asset IDs, or {@code
+   * null} when the data is already up to date (or cannot be parsed) so the caller skips the write.
+   */
+  private String withScopeAssets(Step template, List<String> scopedAssetIds) {
+    try {
+      JsonObject dataObject = JsonParser.parseString(template.getData()).getAsJsonObject();
+      JsonArray assets = new JsonArray();
+      scopedAssetIds.forEach(assets::add);
+      if (assets.equals(dataObject.get("inject_assets"))) {
+        return null;
+      }
+      dataObject.add("inject_assets", assets);
+      return dataObject.toString();
+    } catch (Exception e) {
+      log.warn(
+          "[Chaining] Failed to realign scope assets on step template {}: {}",
+          template.getId(),
+          e.getMessage());
+      return null;
+    }
+  }
+
+  /**
    * Find all step templates.
    *
    * @return list of all step templates

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -52,6 +52,7 @@ public class WorkflowService {
   private final StepDelayQueueService stepDelayQueueService;
   private final SimulationRateLimitService simulationRateLimitService;
   private final ScopeSnapshotService scopeSnapshotService;
+  private final ScopeService scopeService;
 
   private final WorkflowRepository workflowRepository;
   private final WorkflowScopeRuleRepository workflowScopeRuleRepository;
@@ -188,11 +189,21 @@ public class WorkflowService {
       @NotBlank String workflowId, WorkflowConfigurationInput input) {
     Workflow workflow = getWorkflowByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE);
     WorkflowEditability.assertLogicMapEditable(workflow);
-    boolean changed = applyConfigurationInput(input, workflow);
-    if (changed) {
+    ConfigurationChange change = applyConfigurationInput(input, workflow);
+    if (change.changed()) {
       boolean workflowExecutedNotEmpty = !workflow.getWorkflowsExecuted().isEmpty();
       workflow.setEdited(workflowExecutedNotEmpty);
       workflowRepository.save(workflow);
+    }
+    if (change.scopeRulesChanged()) {
+      // The asset perimeter of an action is a copy of the workflow scope, so an action authored
+      // before (or between) scope edits must follow the new scope instead of keeping its stale
+      // snapshot. Flush first so the scope rules just written are visible to ScopeService, which
+      // re-reads them from the repository.
+      workflowRepository.flush();
+      List<String> scopedAssetIds =
+          scopeService.getValidAssets(workflow.getId()).stream().map(Asset::getId).toList();
+      stepService.syncScopeAssetsOnStepTemplates(workflow, scopedAssetIds);
     }
     return workflow;
   }
@@ -216,7 +227,7 @@ public class WorkflowService {
       @NotBlank String simulationId, WorkflowConfigurationInput input) {
     List<Workflow> runs = findWorkflowRunBySimulationId(simulationId);
     for (Workflow run : runs) {
-      if (applyConfigurationInput(input, run)) {
+      if (applyConfigurationInput(input, run).changed()) {
         workflowRepository.save(run);
       }
     }
@@ -866,10 +877,10 @@ public class WorkflowService {
   // -- Configuration Update --
 
   /**
-   * Copies all fields from {@code input} onto {@code workflow} and returns {@code true} when at
-   * least one value changed.
+   * Copies all fields from {@code input} onto {@code workflow} and reports what actually changed.
    */
-  private boolean applyConfigurationInput(WorkflowConfigurationInput input, Workflow workflow) {
+  private ConfigurationChange applyConfigurationInput(
+      WorkflowConfigurationInput input, Workflow workflow) {
     boolean changed = false;
     boolean rateLimitChanged = false;
     boolean timeoutChanged = false;
@@ -919,8 +930,14 @@ public class WorkflowService {
           attempts, seconds, !input.isRateLimitEnabled());
     }
 
-    return rulesChanged || variablesChanged || changed;
+    return new ConfigurationChange(rulesChanged || variablesChanged || changed, rulesChanged);
   }
+
+  /**
+   * Outcome of a configuration update: whether anything changed at all, and whether the scope rules
+   * specifically changed (which requires realigning the step templates' asset perimeter).
+   */
+  private record ConfigurationChange(boolean changed, boolean scopeRulesChanged) {}
 
   /**
    * Reconciles the workflow's scope-rule collection against the provided inputs: removes rules not

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -196,14 +196,7 @@ public class WorkflowService {
       workflowRepository.save(workflow);
     }
     if (change.scopeRulesChanged()) {
-      // The asset perimeter of an action is a copy of the workflow scope, so an action authored
-      // before (or between) scope edits must follow the new scope instead of keeping its stale
-      // snapshot. Flush first so the scope rules just written are visible to ScopeService, which
-      // re-reads them from the repository.
-      workflowRepository.flush();
-      List<String> scopedAssetIds =
-          scopeService.getValidAssets(workflow.getId()).stream().map(Asset::getId).toList();
-      stepService.syncScopeAssetsOnStepTemplates(workflow, scopedAssetIds);
+      realignTemplateActionTargets(workflow);
     }
     return workflow;
   }
@@ -264,7 +257,12 @@ public class WorkflowService {
     if (hasText(scenarioId)) {
       try {
         findWorkflowTemplateByScenarioId(scenarioId)
-            .ifPresent(w -> writeAllowlistRules(w, rules, replaceExisting));
+            .ifPresent(
+                w -> {
+                  if (writeAllowlistRules(w, rules, replaceExisting)) {
+                    realignTemplateActionTargets(w);
+                  }
+                });
       } catch (ChainingException e) {
         log.warn(
             "[Chaining] Could not write scope on scenario {} template workflow", scenarioId, e);
@@ -297,8 +295,11 @@ public class WorkflowService {
           if (current == null) rulesToRemove.add(rule);
         }
       }
-      template.getWorkflowScopeRules().removeAll(rulesToRemove);
-      workflowRepository.save(template);
+      if (!rulesToRemove.isEmpty()) {
+        template.getWorkflowScopeRules().removeAll(rulesToRemove);
+        workflowRepository.save(template);
+        realignTemplateActionTargets(template);
+      }
     }
   }
 
@@ -317,7 +318,13 @@ public class WorkflowService {
     }
     if (hasText(scenarioId)) {
       try {
-        findWorkflowTemplateByScenarioId(scenarioId).ifPresent(w -> appendScopeRules(w, rules));
+        findWorkflowTemplateByScenarioId(scenarioId)
+            .ifPresent(
+                w -> {
+                  if (appendScopeRules(w, rules)) {
+                    realignTemplateActionTargets(w);
+                  }
+                });
       } catch (ChainingException e) {
         log.warn("[Chaining] Could not seed scope on scenario {} template workflow", scenarioId, e);
       }
@@ -327,7 +334,7 @@ public class WorkflowService {
     }
   }
 
-  private void appendScopeRules(Workflow workflow, List<WorkflowScopeRuleInput> ruleInputs) {
+  private boolean appendScopeRules(Workflow workflow, List<WorkflowScopeRuleInput> ruleInputs) {
     List<WorkflowScopeRule> existing = workflow.getWorkflowScopeRules();
     Set<String> existingKeys =
         existing.stream()
@@ -347,9 +354,10 @@ public class WorkflowService {
     if (changed) {
       workflowRepository.save(workflow);
     }
+    return changed;
   }
 
-  private void writeAllowlistRules(
+  private boolean writeAllowlistRules(
       Workflow workflow, List<WorkflowScopeRuleInput> ruleInputs, boolean replaceExisting) {
     List<WorkflowScopeRule> existing = workflow.getWorkflowScopeRules();
     boolean changed = false;
@@ -371,6 +379,27 @@ public class WorkflowService {
     if (changed) {
       workflowRepository.save(workflow);
     }
+    return changed;
+  }
+
+  /**
+   * Re-aligns all asset-centric step templates with the workflow's current scope assets.
+   *
+   * <p>ScopeService resolves from persisted rules, so pending workflow updates must be flushed
+   * first.
+   */
+  private void realignTemplateActionTargets(Workflow workflow) {
+    if (workflow == null || !WorkflowStatus.TEMPLATE.equals(workflow.getStatus())) {
+      return;
+    }
+    workflowRepository.flush();
+    List<String> scopedAssetIds =
+        Optional.ofNullable(scopeService.getValidAssets(workflow.getId()))
+            .orElse(List.of())
+            .stream()
+            .map(Asset::getId)
+            .toList();
+    stepService.syncScopeAssetsOnStepTemplates(workflow, scopedAssetIds);
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -43,6 +43,7 @@ class StepServiceTest {
   @Mock private ActionStep actionStep;
   @Mock private WorkflowService workflowService;
   @Mock private ConditionService conditionService;
+  @Mock private StepTargetingService stepTargetingService;
   @Mock private StepAutoLinkService stepAutoLinkService;
   @Mock private QueueChainingService queueChainingService;
   @Mock private StepDelayQueueService stepDelayQueueService;
@@ -1823,7 +1824,7 @@ class StepServiceTest {
           injectStepTemplate("step-1", "{\"inject_title\":\"nmap\",\"inject_assets\":[]}");
       when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
           .thenReturn(List.of(template));
-      when(injectExecutionStep.stepSupportsAssetTargeting(template)).thenReturn(true);
+      when(stepTargetingService.isAssetCentric(template)).thenReturn(true);
 
       // Act — an asset is added to the allowlist afterwards
       int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
@@ -1844,7 +1845,7 @@ class StepServiceTest {
       Step template = injectStepTemplate("step-1", data);
       when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
           .thenReturn(List.of(template));
-      when(injectExecutionStep.stepSupportsAssetTargeting(template)).thenReturn(false);
+      when(stepTargetingService.isAssetCentric(template)).thenReturn(false);
 
       // Act
       int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
@@ -1864,7 +1865,7 @@ class StepServiceTest {
       Step template = injectStepTemplate("step-1", data);
       when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
           .thenReturn(List.of(template));
-      when(injectExecutionStep.stepSupportsAssetTargeting(template)).thenReturn(true);
+      when(stepTargetingService.isAssetCentric(template)).thenReturn(true);
 
       // Act
       int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
@@ -1890,7 +1891,7 @@ class StepServiceTest {
 
       // Assert
       assertEquals(0, updated);
-      verify(injectExecutionStep, never()).stepSupportsAssetTargeting(any());
+      verify(stepTargetingService, never()).isAssetCentric(any());
       verify(stepRepository, never()).saveAll(anyList());
     }
   }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -1797,6 +1798,100 @@ class StepServiceTest {
       assertEquals(ConditionType.AND, savedConditions.get(0).getType());
       assertEquals(ConditionType.MAPPER, savedConditions.get(1).getType());
       assertEquals("leaf", savedConditions.get(2).getValue());
+    }
+  }
+
+  @Nested
+  @DisplayName("syncScopeAssetsOnStepTemplates")
+  class SyncScopeAssetsOnStepTemplates {
+
+    private Step injectStepTemplate(String id, String data) {
+      Step step = new Step();
+      step.setId(id);
+      step.setStepAction(StepActionClass.INJECT_EXECUTION);
+      step.setData(data);
+      return step;
+    }
+
+    @Test
+    @DisplayName(
+        "given an asset-centric step template, should rewrite inject_assets with the scope")
+    void given_assetCentricStepTemplate_should_rewriteInjectAssetsWithScope() {
+      // Arrange — action authored while the allowlist was still empty
+      when(workflow.getId()).thenReturn("wf-1");
+      Step template =
+          injectStepTemplate("step-1", "{\"inject_title\":\"nmap\",\"inject_assets\":[]}");
+      when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
+          .thenReturn(List.of(template));
+      when(injectExecutionStep.stepSupportsAssetTargeting(template)).thenReturn(true);
+
+      // Act — an asset is added to the allowlist afterwards
+      int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
+
+      // Assert
+      assertEquals(1, updated);
+      assertEquals(
+          "{\"inject_title\":\"nmap\",\"inject_assets\":[\"asset-1\"]}", template.getData());
+      verify(stepRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("given an audience-centric step template, should leave its data untouched")
+    void given_audienceCentricStepTemplate_should_leaveDataUntouched() {
+      // Arrange — an email action targets teams, never the scope assets
+      when(workflow.getId()).thenReturn("wf-1");
+      String data = "{\"inject_title\":\"email\",\"inject_assets\":[]}";
+      Step template = injectStepTemplate("step-1", data);
+      when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
+          .thenReturn(List.of(template));
+      when(injectExecutionStep.stepSupportsAssetTargeting(template)).thenReturn(false);
+
+      // Act
+      int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
+
+      // Assert
+      assertEquals(0, updated);
+      assertEquals(data, template.getData());
+      verify(stepRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("given step data already aligned on the scope, should not write anything")
+    void given_alreadyAlignedStepData_should_notWriteAnything() {
+      // Arrange
+      when(workflow.getId()).thenReturn("wf-1");
+      String data = "{\"inject_assets\":[\"asset-1\"]}";
+      Step template = injectStepTemplate("step-1", data);
+      when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
+          .thenReturn(List.of(template));
+      when(injectExecutionStep.stepSupportsAssetTargeting(template)).thenReturn(true);
+
+      // Act
+      int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
+
+      // Assert
+      assertEquals(0, updated);
+      assertEquals(data, template.getData());
+      verify(stepRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("given a step template without inject action, should be ignored")
+    void given_stepTemplateWithoutInjectAction_should_beIgnored() {
+      // Arrange
+      when(workflow.getId()).thenReturn("wf-1");
+      Step template = injectStepTemplate("step-1", "{\"inject_assets\":[]}");
+      template.setStepAction(null);
+      when(stepRepository.findAllByStepTemplateIdIsNullAndWorkflowId("wf-1"))
+          .thenReturn(List.of(template));
+
+      // Act
+      int updated = stepService.syncScopeAssetsOnStepTemplates(workflow, List.of("asset-1"));
+
+      // Assert
+      assertEquals(0, updated);
+      verify(injectExecutionStep, never()).stepSupportsAssetTargeting(any());
+      verify(stepRepository, never()).saveAll(anyList());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -52,6 +52,7 @@ class WorkflowServiceTest {
   @Mock private StepDelayQueueService stepDelayQueueService;
   @Mock private SimulationRateLimitService simulationRateLimitService;
   @Mock private ScopeSnapshotService scopeSnapshotService;
+  @Mock private ScopeService scopeService;
   @Mock private WorkflowStateService workflowStateService;
   @Mock private ScopeMetricCollector scopeMetricCollector;
   @Mock private ChainingSafetyPolicyMetricCollector chainingSafetyPolicyMetricCollector;
@@ -792,6 +793,53 @@ class WorkflowServiceTest {
               .orElseThrow();
       assertEquals(ScopeRuleValueType.ASSET_GROUP_ID, mappedAssetGroupRule.getValueType());
     }
+
+    @Test
+    @DisplayName("should realign step templates on the new scope when scope rules changed")
+    void given_changedScopeRules_should_realignStepTemplatesOnNewScope() {
+      // Arrange — an action was authored before the asset was added to the allowlist
+      String workflowId = UUID.randomUUID().toString();
+      Workflow workflow =
+          Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+      WorkflowConfigurationInput input = new WorkflowConfigurationInput();
+      input.setWorkflowScopeRules(WorkflowFixture.getDefaultWorkflowScopeRuleInputList());
+      Asset asset = new Asset();
+      asset.setId("asset-123");
+
+      when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
+          .thenReturn(Optional.of(workflow));
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+      when(scopeService.getValidAssets(workflowId)).thenReturn(List.of(asset));
+
+      // Act
+      workflowService.updateWorkflowConfiguration(workflowId, input);
+
+      // Assert — the scope is pushed onto the already-authored step templates
+      verify(workflowRepository).flush();
+      verify(stepService).syncScopeAssetsOnStepTemplates(workflow, List.of("asset-123"));
+    }
+
+    @Test
+    @DisplayName("should not realign step templates when no scope rule changed")
+    void given_unchangedScopeRules_should_notRealignStepTemplates() {
+      // Arrange — only a rate-limit field changes
+      String workflowId = UUID.randomUUID().toString();
+      Workflow workflow =
+          Workflow.builder().id(workflowId).status(WorkflowStatus.TEMPLATE).version(0).build();
+      WorkflowConfigurationInput input = new WorkflowConfigurationInput();
+      input.setRateLimitEnabled(true);
+
+      when(workflowRepository.findByIdAndStatus(workflowId, WorkflowStatus.TEMPLATE))
+          .thenReturn(Optional.of(workflow));
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+
+      // Act
+      workflowService.updateWorkflowConfiguration(workflowId, input);
+
+      // Assert
+      verify(stepService, never()).syncScopeAssetsOnStepTemplates(any(), any());
+      verify(scopeService, never()).getValidAssets(any());
+    }
   }
 
   @Nested
@@ -974,6 +1022,7 @@ class WorkflowServiceTest {
               stepDelayQueueService,
               simulationRateLimitService,
               scopeSnapshotService,
+              scopeService,
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
@@ -1255,6 +1304,7 @@ class WorkflowServiceTest {
               stepDelayQueueService,
               simulationRateLimitService,
               scopeSnapshotService,
+              scopeService,
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
@@ -1442,6 +1492,7 @@ class WorkflowServiceTest {
               stepDelayQueueService,
               simulationRateLimitService,
               scopeSnapshotService,
+              scopeService,
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,
@@ -1664,6 +1715,7 @@ class WorkflowServiceTest {
               stepDelayQueueService,
               simulationRateLimitService,
               scopeSnapshotService,
+              scopeService,
               workflowRepository,
               workflowScopeRuleRepository,
               scopeVariableRepository,

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -843,6 +843,138 @@ class WorkflowServiceTest {
   }
 
   @Nested
+  @DisplayName("template scope writes should realign action targets")
+  class TemplateScopeRealignmentTests {
+
+    @Test
+    @DisplayName("writeAllowlistScope should realign scenario template when rules changed")
+    void writeAllowlistScope_should_realignScenarioTemplate_whenRulesChanged() {
+      // Arrange
+      Workflow template =
+          Workflow.builder().id("wf-template").status(WorkflowStatus.TEMPLATE).version(0).build();
+      WorkflowScopeRuleInput rule =
+          WorkflowScopeRuleInput.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-1")
+              .build();
+      Asset asset = new Asset();
+      asset.setId("asset-1");
+
+      when(workflowRepository.findByScenario_IdAndStatus("scenario-1", WorkflowStatus.TEMPLATE))
+          .thenReturn(List.of(template));
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+      when(scopeService.getValidAssets("wf-template")).thenReturn(List.of(asset));
+
+      // Act
+      workflowService.writeAllowlistScope("scenario-1", null, List.of(rule), false);
+
+      // Assert
+      verify(workflowRepository).flush();
+      verify(stepService).syncScopeAssetsOnStepTemplates(template, List.of("asset-1"));
+    }
+
+    @Test
+    @DisplayName("writeScopeRules should realign scenario template when rules changed")
+    void writeScopeRules_should_realignScenarioTemplate_whenRulesChanged() {
+      // Arrange
+      Workflow template =
+          Workflow.builder().id("wf-template").status(WorkflowStatus.TEMPLATE).version(0).build();
+      WorkflowScopeRuleInput rule =
+          WorkflowScopeRuleInput.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET_GROUP)
+              .ruleValue("group-1")
+              .build();
+      Asset asset = new Asset();
+      asset.setId("asset-2");
+
+      when(workflowRepository.findByScenario_IdAndStatus("scenario-1", WorkflowStatus.TEMPLATE))
+          .thenReturn(List.of(template));
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+      when(scopeService.getValidAssets("wf-template")).thenReturn(List.of(asset));
+
+      // Act
+      workflowService.writeScopeRules("scenario-1", null, List.of(rule));
+
+      // Assert
+      verify(workflowRepository).flush();
+      verify(stepService).syncScopeAssetsOnStepTemplates(template, List.of("asset-2"));
+    }
+
+    @Test
+    @DisplayName("writeScopeRules should not realign when nothing changed")
+    void writeScopeRules_should_notRealign_whenNoRuleChanged() {
+      // Arrange
+      Workflow template =
+          Workflow.builder().id("wf-template").status(WorkflowStatus.TEMPLATE).version(0).build();
+      WorkflowScopeRule existing =
+          WorkflowScopeRule.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-1")
+              .workflow(template)
+              .build();
+      template.getWorkflowScopeRules().add(existing);
+
+      WorkflowScopeRuleInput sameRule =
+          WorkflowScopeRuleInput.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-1")
+              .build();
+
+      when(workflowRepository.findByScenario_IdAndStatus("scenario-1", WorkflowStatus.TEMPLATE))
+          .thenReturn(List.of(template));
+
+      // Act
+      workflowService.writeScopeRules("scenario-1", null, List.of(sameRule));
+
+      // Assert
+      verify(stepService, never()).syncScopeAssetsOnStepTemplates(any(), any());
+      verify(scopeService, never()).getValidAssets(any());
+      verify(workflowRepository, never()).flush();
+    }
+
+    @Test
+    @DisplayName("cleanScopeRulesSimulation should realign when ghost rules are removed")
+    void cleanScopeRulesSimulation_should_realign_whenGhostRulesRemoved() {
+      // Arrange
+      Workflow template =
+          Workflow.builder()
+              .id("wf-template")
+              .status(WorkflowStatus.TEMPLATE)
+              .version(0)
+              .simulation(new Exercise())
+              .build();
+      WorkflowScopeRule ghostRule =
+          WorkflowScopeRule.builder()
+              .selectedMode(ScopeRuleSelectedMode.ALLOWLIST)
+              .ruleSource(ScopeRuleSource.ASSET)
+              .ruleValue("asset-ghost")
+              .workflow(template)
+              .build();
+      template.getWorkflowScopeRules().add(ghostRule);
+
+      Asset asset = new Asset();
+      asset.setId("asset-1");
+
+      when(workflowRepository.findBySimulation_IdAndStatus("sim-1", WorkflowStatus.TEMPLATE))
+          .thenReturn(template);
+      when(scopeSnapshotService.buildCurrentSnapshot(ghostRule)).thenReturn(null);
+      when(workflowRepository.save(any(Workflow.class))).thenAnswer(i -> i.getArgument(0));
+      when(scopeService.getValidAssets("wf-template")).thenReturn(List.of(asset));
+
+      // Act
+      workflowService.cleanScopeRulesSimulation("sim-1");
+
+      // Assert
+      verify(workflowRepository).flush();
+      verify(stepService).syncScopeAssetsOnStepTemplates(template, List.of("asset-1"));
+    }
+  }
+
+  @Nested
   @DisplayName("scope rule value type detection")
   class ScopeRuleValueTypeTests {
 

--- a/openaev-front/src/admin/components/chaining/ScopeInventoryBox.tsx
+++ b/openaev-front/src/admin/components/chaining/ScopeInventoryBox.tsx
@@ -79,6 +79,7 @@ const ScopeInventoryBox = ({
   return (
     <Box>
       <Typography
+        component="div"
         sx={{
           ...SECTION_LABEL_SX,
           m: 0,

--- a/openaev-front/src/admin/components/chaining/logic/Logic.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/Logic.tsx
@@ -71,6 +71,9 @@ const Logic = ({ workflowId, context, scenarioId, exerciseId, readOnly = false, 
   // Latest event metas
   const [eventMetas, setEventMetas] = useState<Record<string, EventMeta>>({});
 
+  // Re-read the scope perimeter whenever the workflow changes and after each graph refresh, so an
+  // action configured right after a scope edit inherits the current assets/teams (the backend
+  // realigns the already-authored steps on its side).
   useEffect(() => {
     if (workflowId) {
       fetchValidAssets(workflowId).then((assets: ScopeAssetOutput[]) => {
@@ -80,7 +83,7 @@ const Logic = ({ workflowId, context, scenarioId, exerciseId, readOnly = false, 
         setValidTeams(teams);
       });
     }
-  }, [workflowId]);
+  }, [workflowId, refreshKey]);
 
   // Fingerprint of the workflow's shape (which steps/triggers exist and when each last changed) so a
   // live poll can tell a real edit from a no-op tick: it re-draws the graph on an add, a delete or an


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*Adding an asset in the allowlist after configuring the logic is not updating the “targets” so the action will not be triggered. 


### Testing Instructions

1. Create a chaining simulation
2. First add an action 
3. Then add an asset in the allowlist
4. The action should updat the "targets" on the logic map (frontend) and on the steps table in step_data column (backend)

### Related issues

* Related to #5045

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
