### PR TITLE
fix(connectors): keep a deleted connector deleted while its container still runs

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
@@ -515,11 +515,14 @@ public class ConnectorInstanceService {
         HeartbeatWindow.forInstance(instance, instance.getCatalogConnector().getContainerType());
     if (lastHeartbeat != null && lastHeartbeat.isAfter(Instant.now().minus(heartbeatWindow))) {
       throw new BadRequestException(
-          "The connector "
+          "The "
+              + instance.getCatalogConnector().getContainerType().name().toLowerCase(Locale.ROOT)
+              + " "
               + connectorId
               + " is still running (last heartbeat "
               + lastHeartbeat
-              + "): stop it before deleting its instance");
+              + "): stop it before deleting its instance "
+              + instance.getId());
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connector_instances/ConnectorInstanceService.java
@@ -21,10 +21,13 @@ import io.openaev.rest.connector_instance.dto.CreateConnectorInstanceInput;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.service.EndpointService;
 import io.openaev.service.connectors.ConnectorOrchestrationService;
+import io.openaev.service.connectors.HeartbeatWindow;
 import io.openaev.service.exception.ConnectorStatusException;
 import io.openaev.utils.mapper.ConnectorInstanceMapper;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -431,6 +434,9 @@ public class ConnectorInstanceService {
 
     throwIfInstanceRunning(connectorInstance);
 
+    String connectorId = resolveConnectorId(connectorInstance);
+    throwIfConnectorStillPinging(connectorInstance, connectorId);
+
     if (managerFactory
             .getManager(connectorInstance.getTenant().getId())
             .getSpawnedIntegrations()
@@ -453,19 +459,6 @@ public class ConnectorInstanceService {
       }
     }
 
-    String connectorId =
-        connectorInstance.getConfigurations().stream()
-            .filter(
-                c ->
-                    connectorInstance
-                        .getCatalogConnector()
-                        .getContainerType()
-                        .getIdKeyName()
-                        .equals(c.getKey()))
-            .map(c -> c.getValue().asText())
-            .findFirst()
-            .orElse(null);
-
     if (connectorId != null) {
       String tenantId = connectorInstance.getTenant().getId();
       switch (connectorInstance.getCatalogConnector().getContainerType()) {
@@ -484,6 +477,50 @@ public class ConnectorInstanceService {
     }
 
     connectorInstanceRepository.deleteById(id);
+  }
+
+  /** The collector / injector / executor id this instance deploys. */
+  private String resolveConnectorId(ConnectorInstancePersisted instance) {
+    return instance.getConfigurations().stream()
+        .filter(
+            c ->
+                instance.getCatalogConnector().getContainerType().getIdKeyName().equals(c.getKey()))
+        .map(c -> c.getValue().asText())
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Mirrors {@code AbstractConnectorService#throwIfConnectorRunning} for this entry point: a stop
+   * is only ever requested, so a still-live container would put the connector row back, orphaned.
+   */
+  private void throwIfConnectorStillPinging(
+      ConnectorInstancePersisted instance, String connectorId) {
+    if (connectorId == null) {
+      return;
+    }
+    ConnectorCompositeId compositeId =
+        ConnectorCompositeId.of(connectorId, instance.getTenant().getId());
+    Instant lastHeartbeat =
+        switch (instance.getCatalogConnector().getContainerType()) {
+          case INJECTOR ->
+              injectorRepository.findById(compositeId).map(Injector::getUpdatedAt).orElse(null);
+          case COLLECTOR ->
+              collectorRepository.findById(compositeId).map(Collector::getUpdatedAt).orElse(null);
+          case EXECUTOR ->
+              executorRepository.findById(compositeId).map(Executor::getUpdatedAt).orElse(null);
+          default -> null;
+        };
+    Duration heartbeatWindow =
+        HeartbeatWindow.forInstance(instance, instance.getCatalogConnector().getContainerType());
+    if (lastHeartbeat != null && lastHeartbeat.isAfter(Instant.now().minus(heartbeatWindow))) {
+      throw new BadRequestException(
+          "The connector "
+              + connectorId
+              + " is still running (last heartbeat "
+              + lastHeartbeat
+              + "): stop it before deleting its instance");
+    }
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -19,11 +19,10 @@ public abstract class AbstractConnectorService<
     T extends BaseConnectorEntity & TenantIdBase, Output> {
 
   /**
-   * An external connector that pinged within this window is considered running. Mirrors the
-   * frontend liveliness threshold (LIVELINESS_THRESHOLD_MS): external connectors re-register every
-   * ~40s, so two minutes without a heartbeat means the process is down.
+   * An external connector that pinged within this window is considered running. Managed connectors
+   * refine it from their declared run period; see {@link HeartbeatWindow}.
    */
-  public static final Duration ACTIVE_HEARTBEAT_WINDOW = Duration.ofMinutes(2);
+  public static final Duration ACTIVE_HEARTBEAT_WINDOW = HeartbeatWindow.DEFAULT;
 
   protected final ConnectorType connectorType;
   protected final ConnectorInstanceConfigurationRepository connectorInstanceConfigurationRepository;
@@ -345,17 +344,9 @@ public abstract class AbstractConnectorService<
    * Rejects the deletion of a connector that is still running (OpenCTI parity: a started connector
    * can never be deleted, it must be stopped first).
    *
-   * <p>Two cases, mirroring the frontend gating:
-   *
-   * <ul>
-   *   <li>deployed through the Integration Manager: the owning instance decides - deletion is only
-   *       allowed once a stop has been requested ({@code requestedStatus == stopping}) or is
-   *       effective ({@code currentStatus == stopped});
-   *   <li>unmanaged external connector: the registration heartbeat decides - a ping within {@link
-   *       #ACTIVE_HEARTBEAT_WINDOW} means the container is alive and must be stopped (externally)
-   *       before the row can be removed. Deleting an active row is futile anyway: the connector
-   *       re-registers on its next heartbeat.
-   * </ul>
+   * <p>A managed connector must clear both the instance status and the heartbeat: on status alone
+   * it was deleted on the mere intention to stop it, and its still-live container put the row back,
+   * orphaned.
    *
    * @param connector the connector entity being deleted
    * @param lastHeartbeat the connector's last registration heartbeat ({@code updatedAt})
@@ -365,12 +356,15 @@ public abstract class AbstractConnectorService<
     ConnectorInstanceConfigurationRepository.ConnectorIdsFromDatabase relatedIds =
         connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
             this.connectorType.getIdKeyName(), connector.getId(), connector.getTenantId());
+    Duration heartbeatWindow = ACTIVE_HEARTBEAT_WINDOW;
     if (relatedIds != null && relatedIds.getConnectorInstanceId() != null) {
       connectorInstanceService.throwIfInstanceRunning(relatedIds.getConnectorInstanceId());
-      return;
+      heartbeatWindow =
+          HeartbeatWindow.forInstance(
+              connectorInstanceService.connectorInstanceById(relatedIds.getConnectorInstanceId()),
+              this.connectorType);
     }
-    if (lastHeartbeat != null
-        && lastHeartbeat.isAfter(Instant.now().minus(ACTIVE_HEARTBEAT_WINDOW))) {
+    if (lastHeartbeat != null && lastHeartbeat.isAfter(Instant.now().minus(heartbeatWindow))) {
       throw new BadRequestException(
           "The "
               + this.connectorType.name().toLowerCase(Locale.ROOT)

--- a/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/AbstractConnectorService.java
@@ -344,9 +344,10 @@ public abstract class AbstractConnectorService<
    * Rejects the deletion of a connector that is still running (OpenCTI parity: a started connector
    * can never be deleted, it must be stopped first).
    *
-   * <p>A managed connector must clear both the instance status and the heartbeat: on status alone
-   * it was deleted on the mere intention to stop it, and its still-live container put the row back,
-   * orphaned.
+   * <p>A managed connector (owned by an Integration Manager instance) must clear both the instance
+   * status and the heartbeat: on status alone it was deleted on the mere intention to stop it, and
+   * its still-live container put the row back, orphaned. Unmanaged connectors have no owning
+   * instance and are therefore gated by heartbeat only.
    *
    * @param connector the connector entity being deleted
    * @param lastHeartbeat the connector's last registration heartbeat ({@code updatedAt})

--- a/openaev-api/src/main/java/io/openaev/service/connectors/HeartbeatWindow.java
+++ b/openaev-api/src/main/java/io/openaev/service/connectors/HeartbeatWindow.java
@@ -1,0 +1,59 @@
+package io.openaev.service.connectors;
+
+import io.openaev.database.model.ConnectorInstance;
+import io.openaev.database.model.ConnectorType;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * How long a connector may stay silent before it counts as stopped. Derived from its declared run
+ * period, since collectors declare anything from PT1M to P7D and a fixed threshold reads the slow
+ * ones as dead between two runs. Capped, or P7D would make one undeletable for a fortnight.
+ */
+@Slf4j
+public final class HeartbeatWindow {
+
+  public static final Duration DEFAULT = Duration.ofMinutes(2);
+  public static final Duration MAX = Duration.ofMinutes(5);
+
+  private static final int SILENT_PERIODS_BEFORE_STOPPED = 2;
+
+  private HeartbeatWindow() {}
+
+  public static String periodKey(ConnectorType type) {
+    return type.name() + "_PERIOD";
+  }
+
+  public static Duration forInstance(ConnectorInstance instance, ConnectorType type) {
+    if (instance == null || type == null) {
+      return DEFAULT;
+    }
+    return instance
+        .configurationValue(periodKey(type))
+        .map(HeartbeatWindow::fromDeclaredPeriod)
+        .orElse(DEFAULT);
+  }
+
+  /** Anything unusable falls back to the default rather than failing a deletion. */
+  public static Duration fromDeclaredPeriod(String isoPeriod) {
+    if (isoPeriod == null || isoPeriod.isBlank()) {
+      return DEFAULT;
+    }
+    Duration period;
+    try {
+      period = Duration.parse(isoPeriod);
+    } catch (DateTimeParseException e) {
+      log.warn("Ignoring unparsable connector period '{}', falling back to {}", isoPeriod, DEFAULT);
+      return DEFAULT;
+    }
+    if (period.isNegative() || period.isZero()) {
+      return DEFAULT;
+    }
+    Duration window = period.multipliedBy(SILENT_PERIODS_BEFORE_STOPPED);
+    if (window.compareTo(DEFAULT) < 0) {
+      return DEFAULT;
+    }
+    return window.compareTo(MAX) > 0 ? MAX : window;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
@@ -7,6 +7,7 @@ import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static io.openaev.utils.fixtures.CatalogConnectorFixture.*;
 import static io.openaev.utils.fixtures.ConnectorInstanceFixture.*;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,6 +39,7 @@ import io.openaev.rest.connector_instance.dto.CreateConnectorInstanceInput;
 import io.openaev.rest.connector_instance.dto.UpdateConnectorInstanceRequestedStatus;
 import io.openaev.service.PlatformSettingsService;
 import io.openaev.service.connector_instances.XtmComposerEncryptionService;
+import io.openaev.service.connectors.HeartbeatWindow;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.CollectorFixture;
 import io.openaev.utils.fixtures.InjectorFixture;
@@ -527,6 +529,13 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
   @DisplayName("Delete connector instance")
   class DeleteConnectorInstanceTests {
 
+    /**
+     * The deletion is refused while the deployed connector still registers, so these fixtures date
+     * the last heartbeat well outside {@link HeartbeatWindow#MAX}: their subject is the teardown of
+     * the instance, not the guard (covered on its own below).
+     */
+    private static final Instant STOPPED_PINGING = Instant.now().minus(1, ChronoUnit.HOURS);
+
     @Test
     @DisplayName(
         "Given a collector connector instance with a spawned integration, deleting should stop the integration and remove the instance")
@@ -535,6 +544,7 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
       CatalogConnector catalogConnector = getCatalogConnector();
 
       Collector collector = CollectorFixture.createDefaultCollector(catalogConnector.getSlug());
+      collector.setUpdatedAt(STOPPED_PINGING);
       collectorComposer.forCollector(collector).persist();
 
       ConnectorInstanceConfiguration collectorIdConfig =
@@ -577,7 +587,7 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
       executor.setName("Test Executor");
       executor.setType(catalogConnector.getSlug());
       executor.setCreatedAt(Instant.now());
-      executor.setUpdatedAt(Instant.now());
+      executor.setUpdatedAt(STOPPED_PINGING);
       executor.setTenantId(TenantContext.getCurrentTenant());
       executorComposer.forExecutor(executor).persist();
 
@@ -620,6 +630,7 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
       Injector injector =
           InjectorFixture.createInjector(
               UUID.randomUUID().toString(), "Test Injector", catalogConnector.getSlug());
+      injector.setUpdatedAt(STOPPED_PINGING);
       injectorRepository.save(injector);
 
       ConnectorInstanceConfiguration injectorIdConfig =
@@ -645,6 +656,31 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
           injectorRepository
               .findByIdAndTenantId(injector.getId(), TenantContext.getCurrentTenant())
               .isPresent());
+    }
+
+    @Test
+    @DisplayName("Deleting an instance whose collector still registers should be refused")
+    void given_stillPingingCollector_should_refuseInstanceDeletion() throws Exception {
+      // Arrange: the container outlives the stop request, and its next heartbeat would put the
+      // collector row back — orphaned, since the owning instance would be gone.
+      CatalogConnector catalogConnector = getCatalogConnector();
+
+      Collector collector = CollectorFixture.createDefaultCollector(catalogConnector.getSlug());
+      collector.setUpdatedAt(Instant.now());
+      collectorComposer.forCollector(collector).persist();
+
+      ConnectorInstanceConfiguration collectorIdConfig =
+          createConnectorInstanceConfiguration("COLLECTOR_ID", collector.getId());
+      ConnectorInstancePersisted connectorInstance =
+          getConnectorInstance(catalogConnector, Set.of(collectorIdConfig));
+
+      // Act
+      mvc.perform(delete(CONNECTOR_INSTANCE_URI + "/" + connectorInstance.getId()).with(csrf()))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(containsString("still running")));
+
+      // Assert
+      assertTrue(connectorInstanceRepository.findById(connectorInstance.getId()).isPresent());
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/rest/InjectorApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/InjectorApiTest.java
@@ -25,9 +25,11 @@ import io.openaev.database.model.*;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.injector.form.InjectorCreateInput;
 import io.openaev.rest.injector_contract.form.InjectorContractInput;
 import io.openaev.service.FileService;
+import io.openaev.service.InjectorService;
 import io.openaev.utils.AgentUtils;
 import io.openaev.utils.HashUtils;
 import io.openaev.utils.TenantIsolationTestHelper;
@@ -41,6 +43,8 @@ import io.openaev.utils.fixtures.composers.ConnectorInstanceComposer;
 import io.openaev.utils.fixtures.composers.ConnectorInstanceConfigurationComposer;
 import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.persistence.EntityManager;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +73,7 @@ public class InjectorApiTest extends IntegrationTest {
   @Autowired private EntityManager em;
   @Autowired private TenantIsolationTestHelper tenantHelper;
   @Autowired private FileService fileService;
+  @Autowired private InjectorService injectorService;
 
   @Autowired private InjectComposer injectComposer;
   @Autowired private EndpointComposer endpointComposer;
@@ -785,6 +790,51 @@ public class InjectorApiTest extends IntegrationTest {
     void given_missingInjectorImage_should_return404() throws Exception {
       // -- Act / Assert --
       mvc.perform(get(INJECT0R_URI + "/nonexistent-type/image")).andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  @DisplayName("Deleting a managed injector")
+  class DeleteManagedInjector {
+
+    private Injector persistExternalInjector(String name, Instant lastHeartbeat) {
+      Injector injector = createDefaultInjector(name);
+      injector.setExternal(true);
+      injector.setUpdatedAt(lastHeartbeat);
+      return injectorRepository.save(injector);
+    }
+
+    @Test
+    @DisplayName(
+        "Is refused while its container is still registering, even once a stop is requested")
+    void givenStillPingingInjector_should_refuseDeletion() throws Exception {
+      // Instance stopped, but only the heartbeat says whether the container is really gone.
+      Injector injector = persistExternalInjector("nmap-alive", Instant.now());
+      getInjectorInstance(injector.getId(), injector.getName());
+
+      assertThatThrownBy(() -> injectorService.deleteInjector(injector.getId()))
+          .isInstanceOf(BadRequestException.class)
+          .hasMessageContaining("still running");
+
+      assertThat(
+              injectorRepository.findByIdAndTenantId(
+                  injector.getId(), TenantContext.getCurrentTenant()))
+          .isPresent();
+    }
+
+    @Test
+    @DisplayName("Goes through once the container has stopped pinging")
+    void givenSilentInjector_should_deleteIt() throws Exception {
+      Injector injector =
+          persistExternalInjector("nmap-silent", Instant.now().minus(Duration.ofHours(1)));
+      getInjectorInstance(injector.getId(), injector.getName());
+
+      injectorService.deleteInjector(injector.getId());
+
+      assertThat(
+              injectorRepository.findByIdAndTenantId(
+                  injector.getId(), TenantContext.getCurrentTenant()))
+          .isEmpty();
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/collector/service/CollectorServiceDeleteTest.java
@@ -32,7 +32,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * A started collector can never be deleted (OpenCTI parity): an unmanaged one must have stopped
- * pinging, a managed one must have a stop requested or effective on its owning instance.
+ * pinging, a managed one must have both a stop requested or effective on its owning instance and a
+ * container that stopped pinging — the stop is only ever an intention.
  */
 @ExtendWith(MockitoExtension.class)
 class CollectorServiceDeleteTest {
@@ -131,10 +132,26 @@ class CollectorServiceDeleteTest {
   }
 
   @Test
+  @DisplayName("A managed collector still pinging cannot be deleted, even with a stop requested")
+  void given_managedCollectorStillPinging_should_rejectDeletion() throws Exception {
+    collector(Instant.now());
+    when(owningInstanceIds.getConnectorInstanceId()).thenReturn(INSTANCE_ID);
+    when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
+            "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))
+        .thenReturn(owningInstanceIds);
+
+    assertThatThrownBy(() -> service.deleteCollector(COLLECTOR_ID, TENANT_ID))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("stop it before deleting it");
+    verify(connectorInstanceService, never()).deleteById(INSTANCE_ID);
+    verify(collectorRepository, never()).delete(any(Collector.class));
+  }
+
+  @Test
   @DisplayName("A managed collector whose instance has a stop requested is deleted via its owner")
   void given_managedCollectorWithStopRequestedInstance_should_deleteThroughItsInstance()
       throws Exception {
-    Collector managed = collector(Instant.now());
+    Collector managed = collector(Instant.now().minus(Duration.ofMinutes(10)));
     when(owningInstanceIds.getConnectorInstanceId()).thenReturn(INSTANCE_ID);
     when(connectorInstanceConfigurationRepository.findInstanceAndCatalogIdsByKeyValueAndTenantId(
             "COLLECTOR_ID", COLLECTOR_ID, TENANT_ID))

--- a/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
+++ b/openaev-front/src/admin/components/integrations/common/ConnectorPopover.tsx
@@ -10,6 +10,7 @@ import { useAppDispatch } from '../../../../utils/hooks';
 import { AbilityContext } from '../../../../utils/permissions/permissionsContext';
 import { ACTIONS, SUBJECTS } from '../../../../utils/permissions/types';
 import UpdateConnectorInstanceDrawer from '../connector_instance/UpdateConnectorInstanceDrawer';
+import { isHeartbeatFresh } from './connector-liveliness';
 import { ConnectorContext } from './ConnectorContext';
 import type { ConnectorContextLayoutType } from './ConnectorLayout';
 
@@ -56,12 +57,16 @@ const ConnectorPopover = ({ connectorInstanceId, connectorName, disabled = false
   const onOpenUpdateConnectorInstanceDrawer = () => setOpenCreateConnectorInstanceDrawer(true);
   const onCloseUpdateConnectorInstanceDrawer = () => setOpenCreateConnectorInstanceDrawer(false);
 
-  // OpenCTI parity: a started managed connector can never be deleted. Deletion
-  // is only allowed once a stop has been requested (requested status stopping)
-  // or is effective (current status stopped); the backend enforces the same
-  // rule. The entry stays visible but disabled, with the reason as tooltip.
-  const canDeleteInstance = instance?.connector_instance_requested_status === 'stopping'
+  // Deletable once nothing can bring it back: a stop asked for or done, and no recent heartbeat.
+  // The stop is only ever requested, so the container may well still be registering. Same rule
+  // server-side.
+  const stopRequestedOrEffective = instance?.connector_instance_requested_status === 'stopping'
     || instance?.connector_instance_current_status === 'stopped';
+  const stillPinging = connector?.isExternal === true && isHeartbeatFresh(connector?.updatedAt);
+  const canDeleteInstance = stopRequestedOrEffective && !stillPinging;
+  const deleteDisabledMessage = stopRequestedOrEffective
+    ? 'Wait until the connector stops pinging before deleting it'
+    : 'Stop the connector before deleting it';
 
   // Button Popover
   const entries = [
@@ -76,7 +81,7 @@ const ConnectorPopover = ({ connectorInstanceId, connectorName, disabled = false
       userRight: ability.can(ACTIONS.DELETE, SUBJECTS.TENANT_SETTINGS),
       disabled: !canDeleteInstance,
       // Raw i18n key: ButtonPopover translates disabledMessage itself (like label).
-      disabledMessage: 'Stop the connector before deleting it',
+      disabledMessage: deleteDisabledMessage,
     }];
 
   return (

--- a/openaev-front/src/admin/components/integrations/common/connector-liveliness.ts
+++ b/openaev-front/src/admin/components/integrations/common/connector-liveliness.ts
@@ -19,7 +19,7 @@ export interface ConnectorLiveliness {
   builtIn: boolean;
 }
 
-const isFresh = (heartbeat?: string): boolean =>
+export const isHeartbeatFresh = (heartbeat?: string): boolean =>
   heartbeat != null && Date.now() - new Date(heartbeat).getTime() < LIVELINESS_THRESHOLD_MS;
 
 /**
@@ -63,7 +63,7 @@ export const computeConnectorLiveliness = (connector: ConnectorOutput): Connecto
       };
     }
     if (external) {
-      const live = isFresh(heartbeat);
+      const live = isHeartbeatFresh(heartbeat);
       return {
         started: true,
         healthy: live,
@@ -81,7 +81,7 @@ export const computeConnectorLiveliness = (connector: ConnectorOutput): Connecto
   }
 
   if (external) {
-    const live = isFresh(heartbeat);
+    const live = isHeartbeatFresh(heartbeat);
     return {
       started: live,
       healthy: live,

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "Gefährdeter Endpunkt",
   "vulnerable-endpoint-plural": "verwundbare Endpunkte",
   "vulnerable-endpoint-singular": "verwundbarer Endpunkt",
+  "Wait until the connector stops pinging before deleting it": "Warten Sie, bis der Konnektor keine Signale mehr sendet, bevor Sie ihn löschen",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "Warten auf {count} Hintergrundaufgaben…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "Vulnerable endpoint",
   "vulnerable-endpoint-plural": "vulnerable endpoints",
   "vulnerable-endpoint-singular": "vulnerable endpoint",
+  "Wait until the connector stops pinging before deleting it": "Wait until the connector stops pinging before deleting it",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "Waiting for {count} background tasks…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "Extremo vulnerable",
   "vulnerable-endpoint-plural": "endpoints vulnerables",
   "vulnerable-endpoint-singular": "endpoint vulnerable",
+  "Wait until the connector stops pinging before deleting it": "Espere a que el conector deje de enviar señales antes de eliminarlo",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "Esperando {count} tareas en segundo plano…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "Endpoint vulnérable",
   "vulnerable-endpoint-plural": "endpoints vulnérables",
   "vulnerable-endpoint-singular": "endpoint vulnérable",
+  "Wait until the connector stops pinging before deleting it": "Attendez que le connecteur cesse d'émettre avant de le supprimer",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "En attente de {count} tâches en arrière-plan…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "Endpoint vulnerabile",
   "vulnerable-endpoint-plural": "endpoint vulnerabili",
   "vulnerable-endpoint-singular": "endpoint vulnerabile",
+  "Wait until the connector stops pinging before deleting it": "Attendi che il connettore smetta di inviare segnali prima di eliminarlo",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "In attesa di {count} attività in background…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "脆弱なエンドポイント",
   "vulnerable-endpoint-plural": "脆弱なエンドポイント",
   "vulnerable-endpoint-singular": "脆弱なエンドポイント",
+  "Wait until the connector stops pinging before deleting it": "コネクターが応答を停止するまで待ってから削除してください",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "{count} 件のバックグラウンドタスクを待っています…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "취약한 엔드포인트",
   "vulnerable-endpoint-plural": "취약한 엔드포인트",
   "vulnerable-endpoint-singular": "취약한 엔드포인트",
+  "Wait until the connector stops pinging before deleting it": "커넥터가 응답을 멈출 때까지 기다린 후 삭제하세요",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "백그라운드 작업 {count}건을 기다리는 중…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "Уязвимая конечная точка",
   "vulnerable-endpoint-plural": "уязвимые конечные точки",
   "vulnerable-endpoint-singular": "уязвимая конечная точка",
+  "Wait until the connector stops pinging before deleting it": "Дождитесь, пока коннектор перестанет отправлять сигналы, прежде чем удалять его",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "Ожидание {count} фоновых задач…",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -4047,6 +4047,7 @@
   "vulnerable-endpoint": "脆弱终端",
   "vulnerable-endpoint-plural": "脆弱终端",
   "vulnerable-endpoint-singular": "脆弱终端",
+  "Wait until the connector stops pinging before deleting it": "请等待连接器停止发送心跳后再删除",
   "Waiting for": "Waiting for",
   "Waiting for {count} background tasks…": "正在等待 {count} 个后台任务……",
   "Waiting for a specialist agent": "Waiting for a specialist agent",

--- a/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstance.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ConnectorInstance.java
@@ -1,5 +1,7 @@
 package io.openaev.database.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
 import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -46,4 +48,17 @@ public abstract class ConnectorInstance {
   public abstract String getClassName();
 
   public abstract String getHashIdentity();
+
+  public Optional<String> configurationValue(String key) {
+    Set<ConnectorInstanceConfiguration> configurations = getConfigurations();
+    if (configurations == null) {
+      return Optional.empty();
+    }
+    return configurations.stream()
+        .filter(configuration -> key.equals(configuration.getKey()))
+        .map(ConnectorInstanceConfiguration::getValue)
+        .filter(value -> value != null && value.isTextual())
+        .map(JsonNode::asText)
+        .findFirst();
+  }
 }


### PR DESCRIPTION
## Problem

Deleting a connector managed by the Integration Manager did not stick: the row came back a few seconds later, orphaned this time, and could not be removed for as long as its container lived.

The deletion only consulted the owning instance status, and that status is an *intention*, not a fact — `requestedStatus` is set to `stopping` the moment the user clicks stop, while the composer tears the container down asynchronously. So the container was usually still alive when the delete went through, and its next registration heartbeat (every ~40s, and the endpoint is an upsert) recreated the connector row. The owning instance had been deleted along with it, so what came back was an unmanaged connector — which is also why the UI then offers "Migrate" on something the user believed deleted.