### PR TITLE
fix(endpoint): pin the OpenAEV executor lookup to the tenant on agent registration (#7404)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/exception/TenantConnectorNotReadyException.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exception/TenantConnectorNotReadyException.java
@@ -1,0 +1,12 @@
+package io.openaev.rest.exception;
+
+/**
+ * A built-in connector row is missing for the tenant serving the request: its registration never
+ * ran or failed. Transient, so callers are told to retry (503) rather than to fix their request.
+ */
+public class TenantConnectorNotReadyException extends RuntimeException {
+
+  public TenantConnectorNotReadyException(String message) {
+    super(message);
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -354,6 +354,19 @@ public class RestBehavior {
         new ErrorMessage("TENANT_FILTERING_REFUSED"), HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
+  // -- 503 SERVICE_UNAVAILABLE --
+
+  @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+  @ExceptionHandler(TenantConnectorNotReadyException.class)
+  public ResponseEntity<ErrorMessage> handleTenantConnectorNotReadyException(
+      TenantConnectorNotReadyException ex) {
+    // Agents and connectors poll: a retryable status keeps them from treating a tenant still being
+    // provisioned as a permanent failure.
+    log.warn("Tenant connector not ready: {}", ex.getMessage());
+    return new ResponseEntity<>(
+        new ErrorMessage("TENANT_CONNECTOR_NOT_READY"), HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
   // -- 404 NOT_FOUND --
 
   @ResponseStatus(HttpStatus.NOT_FOUND)

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -360,8 +360,7 @@ public class RestBehavior {
   @ExceptionHandler(TenantConnectorNotReadyException.class)
   public ResponseEntity<ErrorMessage> handleTenantConnectorNotReadyException(
       TenantConnectorNotReadyException ex) {
-    // Agents and connectors poll: a retryable status keeps them from treating a tenant still being
-    // provisioned as a permanent failure.
+    // Agents and connectors poll: a tenant still being provisioned must read as retryable.
     log.warn("Tenant connector not ready: {}", ex.getMessage());
     return new ResponseEntity<>(
         new ErrorMessage("TENANT_CONNECTOR_NOT_READY"), HttpStatus.SERVICE_UNAVAILABLE);

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -33,6 +33,7 @@ import io.openaev.rest.asset.endpoint.form.EndpointOutput;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.rest.exception.TenantConnectorNotReadyException;
 import io.openaev.service.account.ServiceAccountPrivilegeService;
 import io.openaev.utils.AgentUtils;
 import io.openaev.utils.FilterUtilsJpa;
@@ -524,7 +525,7 @@ public class EndpointService implements AuditLoggedService {
   @Transactional
   public Endpoint register(final EndpointRegisterInput input, @NotNull final String tenantId)
       throws IOException {
-    AgentRegisterInput agentInput = toAgentEndpoint(input);
+    AgentRegisterInput agentInput = toAgentEndpoint(input, tenantId);
     Agent agent;
     // Check if agents exist (because we can find X openaev agent on an endpoint)
     List<Agent> existingAgents =
@@ -849,9 +850,19 @@ public class EndpointService implements AuditLoggedService {
     agent.setTenant(new Tenant(input.getExecutor().getTenantId()));
   }
 
-  private AgentRegisterInput toAgentEndpoint(EndpointRegisterInput input) {
+  private AgentRegisterInput toAgentEndpoint(EndpointRegisterInput input, String tenantId) {
     AgentRegisterInput agentInput = new AgentRegisterInput();
-    agentInput.setExecutor(executorRepository.findByExecutorId(OPENAEV_EXECUTOR_ID).orElse(null));
+    // Pinned to the tenant instead of relying on the ambient filter: executor_id is shared by every
+    // tenant, and a null executor used to surface as an NPE (500) on every registration path.
+    agentInput.setExecutor(
+        executorRepository
+            .findByExecutorIdAndTenantId(OPENAEV_EXECUTOR_ID, tenantId)
+            .orElseThrow(
+                () ->
+                    new TenantConnectorNotReadyException(
+                        "The OpenAEV Agent executor is not registered for tenant "
+                            + tenantId
+                            + ", the agent cannot be attached to an endpoint")));
     agentInput.setLastSeen(Instant.now());
     agentInput.setExternalReference(input.getExternalReference());
     agentInput.setIps(input.getIps());

--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -852,8 +852,8 @@ public class EndpointService implements AuditLoggedService {
 
   private AgentRegisterInput toAgentEndpoint(EndpointRegisterInput input, String tenantId) {
     AgentRegisterInput agentInput = new AgentRegisterInput();
-    // Pinned to the tenant instead of relying on the ambient filter: executor_id is shared by every
-    // tenant, and a null executor used to surface as an NPE (500) on every registration path.
+    // Pinned to the tenant rather than left to the ambient filter: executor_id is shared by every
+    // tenant, so an unpinned lookup either misses or matches several rows.
     agentInput.setExecutor(
         executorRepository
             .findByExecutorIdAndTenantId(OPENAEV_EXECUTOR_ID, tenantId)

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
@@ -1,5 +1,6 @@
 package io.openaev.service.endpoint;
 
+import static io.openaev.integration.impl.executors.openaev.OpenAEVExecutorIntegration.OPENAEV_EXECUTOR_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,12 +17,14 @@ import io.openaev.rest.asset.endpoint.form.EndpointInput;
 import io.openaev.rest.asset.endpoint.form.EndpointOutput;
 import io.openaev.rest.asset.endpoint.form.EndpointRegisterInput;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.rest.exception.TenantConnectorNotReadyException;
 import io.openaev.service.AgentService;
 import io.openaev.service.AssetService;
 import io.openaev.service.EndpointService;
 import io.openaev.service.account.ServiceAccountPrivilegeService;
 import io.openaev.utils.fixtures.AgentFixture;
 import io.openaev.utils.fixtures.AssetAgentJobFixture;
+import io.openaev.utils.fixtures.EndpointRegisterInputFixture;
 import io.openaev.utils.mapper.EndpointMapper;
 import java.util.Collections;
 import java.util.List;
@@ -320,6 +323,29 @@ class EndpointServiceTest {
       // -------- Assert --------
       assertThat(result).hasSize(1);
       verify(endpointRepository).findByHostnameAndAtleastOneIp("host-explicit", ips, "tenant-z");
+    }
+  }
+
+  @Nested
+  @DisplayName("Register")
+  class RegisterEndpoint {
+
+    @Test
+    @DisplayName("Registration is refused as retryable when the tenant has no OpenAEV executor")
+    void given_tenantWithoutOpenAEVExecutor_should_throwTenantConnectorNotReady() {
+      // -------- Prepare --------
+      when(executorRepository.findByExecutorIdAndTenantId(
+              OPENAEV_EXECUTOR_ID, "tenant-without-executor"))
+          .thenReturn(Optional.empty());
+      EndpointRegisterInput input = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+
+      // -------- Act / Assert --------
+      // Used to NPE into a 500 that agents retried forever without a usable reason.
+      assertThrows(
+          TenantConnectorNotReadyException.class,
+          () -> endpointService.register(input, "tenant-without-executor"));
+      verify(executorRepository)
+          .findByExecutorIdAndTenantId(OPENAEV_EXECUTOR_ID, "tenant-without-executor");
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceTest.java
@@ -340,7 +340,7 @@ class EndpointServiceTest {
       EndpointRegisterInput input = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
 
       // -------- Act / Assert --------
-      // Used to NPE into a 500 that agents retried forever without a usable reason.
+      // Used to NPE into a 500 that agents retried forever.
       assertThrows(
           TenantConnectorNotReadyException.class,
           () -> endpointService.register(input, "tenant-without-executor"));

--- a/openaev-model/src/main/java/io/openaev/database/repository/ExecutorRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ExecutorRepository.java
@@ -16,6 +16,12 @@ public interface ExecutorRepository extends CrudRepository<Executor, ConnectorCo
   @Query("SELECT e FROM Executor e WHERE e.id = :id")
   Optional<Executor> findByExecutorId(@Param("id") @NotNull String id);
 
+  // executor_id alone is not unique (composite PK with tenant_id): pin the tenant when the caller
+  // knows it, so the Optional cannot blow up on several tenants owning the same built-in executor.
+  @Query("SELECT e FROM Executor e WHERE e.id = :id AND e.tenantId = :tenantId")
+  Optional<Executor> findByExecutorIdAndTenantId(
+      @Param("id") @NotNull String id, @Param("tenantId") @NotNull String tenantId);
+
   Optional<Executor> findByType(@NotNull String type);
 
   @Modifying

--- a/openaev-model/src/main/java/io/openaev/database/repository/ExecutorRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ExecutorRepository.java
@@ -16,8 +16,8 @@ public interface ExecutorRepository extends CrudRepository<Executor, ConnectorCo
   @Query("SELECT e FROM Executor e WHERE e.id = :id")
   Optional<Executor> findByExecutorId(@Param("id") @NotNull String id);
 
-  // executor_id alone is not unique (composite PK with tenant_id): pin the tenant when the caller
-  // knows it, so the Optional cannot blow up on several tenants owning the same built-in executor.
+  // executor_id alone is not unique (composite PK with tenant_id), so an Optional return needs the
+  // tenant to be pinned whenever the caller knows it.
   @Query("SELECT e FROM Executor e WHERE e.id = :id AND e.tenantId = :tenantId")
   Optional<Executor> findByExecutorIdAndTenantId(
       @Param("id") @NotNull String id, @Param("tenantId") @NotNull String tenantId);


### PR DESCRIPTION
Fixes #7404

Agent registration returned `500` with an empty `message`, and the agent ping thread retried the same call forever.

`executors` has a composite PK (`executor_id`, `tenant_id`), but the lookup feeding every registration path was keyed on `executor_id` alone:

```java
executorRepository.findByExecutorId(OPENAEV_EXECUTOR_ID).orElse(null)
```

Two ways to fail, both unhandled 500s: no row visible for the request's tenant → `null` → NPE on the next dereference (`getExecutor().getTenantId()`, `getExecutor().getType()`); or several rows across tenants → the `Optional` return breaks. `CollectorApi` already documents the second hazard for collectors.

## Changes

- `ExecutorRepository.findByExecutorIdAndTenantId` — lookup on the full composite key.
- `EndpointService.toAgentEndpoint` uses the `tenantId` that `register` already receives, instead of relying on the ambient filter.
- Missing row → `TenantConnectorNotReadyException` → **503 `TENANT_CONNECTOR_NOT_READY`**. 503 rather than a 4xx because the caller is a polling agent and a tenant mid-provisioning is a transient state.

## Tests

`EndpointServiceTest.RegisterEndpoint` covers the refusal. Integration tests on this path (`EndpointCrossTenantRegistrationTest`, `EndpointServiceIntegrationTest`, `AgentRuntimeAccessControlTest`) run in CI.

## Out of scope

`ExecutorService.register` does the same unpinned lookup before deciding create-vs-update, so it can update another tenant's row instead of inserting one — a plausible way for a tenant to end up with no executor row at all. Noted in #7404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
