### PR TITLE
fix(chaining): deserialize inject document attachments in step data (#7410)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -1086,6 +1086,16 @@ public class InjectExecutionStep implements ActionStep {
         inject.setDependsDuration(0L);
       }
 
+      // Re-parent the document links deserialized from the step data: the element deserializer
+      // resolves only the Document side (the owning inject does not exist mid-deserialization,
+      // and a deleted document yields a null element), while the @MapsId composite id needs both
+      // associations before run() cascade-persists this inject.
+      List<InjectDocument> injectDocuments = inject.getDocuments();
+      if (injectDocuments != null) {
+        injectDocuments.removeIf(Objects::isNull);
+        injectDocuments.forEach(injectDocument -> injectDocument.setInject(inject));
+      }
+
       ObjectMapper mapper = new ObjectMapper();
       JsonNode root = mapper.readTree(step.getData());
 

--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -50,6 +50,7 @@ import jakarta.annotation.Resource;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -1086,14 +1087,38 @@ public class InjectExecutionStep implements ActionStep {
         inject.setDependsDuration(0L);
       }
 
-      // Re-parent the document links deserialized from the step data: the element deserializer
-      // resolves only the Document side (the owning inject does not exist mid-deserialization,
-      // and a deleted document yields a null element), while the @MapsId composite id needs both
-      // associations before run() cascade-persists this inject.
+      // Resolve and re-parent the document links deserialized from the step data. The element
+      // deserializer only produces id-carrying stubs (a query inside it would cost one database
+      // round trip per attachment), so all referenced documents are resolved here through a
+      // single JPQL query: unlike a primary-key find, the query goes through Hibernate's enabled
+      // filters, so tenantFilter applies and a stale or crafted step referencing a deleted or
+      // foreign-tenant document degrades to "no attachment" instead of failing the step.
+      // Surviving links are re-parented because the @MapsId composite id needs both associations
+      // before run() cascade-persists this inject.
       List<InjectDocument> injectDocuments = inject.getDocuments();
-      if (injectDocuments != null) {
+      if (injectDocuments != null && !injectDocuments.isEmpty()) {
         injectDocuments.removeIf(Objects::isNull);
-        injectDocuments.forEach(injectDocument -> injectDocument.setInject(inject));
+        Set<String> documentIds =
+            injectDocuments.stream()
+                .map(link -> link.getDocument() == null ? null : link.getDocument().getId())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        Map<String, Document> resolvedDocuments =
+            documentIds.isEmpty()
+                ? Map.of()
+                : em.createQuery("select d from Document d where d.id in :ids", Document.class)
+                    .setParameter("ids", documentIds)
+                    .getResultStream()
+                    .collect(Collectors.toMap(Document::getId, document -> document));
+        injectDocuments.removeIf(
+            link ->
+                link.getDocument() == null
+                    || !resolvedDocuments.containsKey(link.getDocument().getId()));
+        injectDocuments.forEach(
+            link -> {
+              link.setDocument(resolvedDocuments.get(link.getDocument().getId()));
+              link.setInject(inject);
+            });
       }
 
       ObjectMapper mapper = new ObjectMapper();

--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -3454,22 +3454,26 @@ public class V1_DataImporter implements Importer {
 
   /**
    * Resolves a step_data document reference to a TARGET-instance document id: the {@code baseIds}
-   * mapping seeded by the document import first, then a tenant-scoped existence check (re-import on
-   * the same instance where the export did not bundle the file), {@code null} when the id resolves
-   * to nothing. The fallback is tenant-scoped on purpose: the raw id comes from the import file and
-   * a bare {@code findById} could match another tenant's document.
+   * mapping seeded by the document import first, then a tenant-scoped lookup (re-import on the same
+   * instance where the export did not bundle the file), {@code null} when the id resolves to
+   * nothing. The fallback is tenant-scoped on purpose: the raw id comes from the import file and a
+   * bare {@code findById} could match another tenant's document. A successful fallback is cached
+   * back into {@code baseIds}, so an id referenced by several links or steps costs at most one
+   * query per import instead of one per occurrence.
    */
   private String resolveImportedDocumentId(String rawId, Map<String, Base> baseIds) {
     if (baseIds.get(rawId) instanceof Document resolvedDocument
         && resolvedDocument.getId() != null) {
       return resolvedDocument.getId();
     }
-    if (documentRepository
+    return documentRepository
         .findByIdAndTenantId(rawId, TenantContext.getCurrentTenant())
-        .isPresent()) {
-      return rawId;
-    }
-    return null;
+        .map(
+            document -> {
+              baseIds.put(rawId, document);
+              return document.getId();
+            })
+        .orElse(null);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -3326,6 +3326,10 @@ public class V1_DataImporter implements Importer {
     // (exercise_tags / scenario_tags / payload_tags), so every exported tag is already resolved
     // here; any unresolved id is dropped (degraded but non-blocking) rather than left dangling.
     rewriteImportedTagIds(dataObject, "inject_tags", baseIds);
+    // Rewrite the inject_documents attachment references: documents are recreated with a NEW UUID
+    // on the target instance, so the source ids serialized in step_data must be mapped to the
+    // resolved target documents or the imported step silently loses valid attachments at run time.
+    rewriteImportedInjectDocuments(dataObject, baseIds);
     JsonNode injectContractNode = dataObject.get("inject_injector_contract");
     if (injectContractNode instanceof ObjectNode injectContractObject) {
       rewriteImportedTagIds(injectContractObject, "injector_contract_tags", baseIds);
@@ -3399,6 +3403,73 @@ public class V1_DataImporter implements Importer {
       }
     }
     parent.set(field, rewritten);
+  }
+
+  /**
+   * Rewrites the {@code inject_documents} array of a serialized step_data inject in place, mapping
+   * each SOURCE-instance document id to the resolved TARGET document id via {@code baseIds}
+   * (populated by {@link #importDocuments} before the workflow import). Documents are recreated
+   * with a NEW UUID on the target instance, so without this rewrite an imported chaining step
+   * queries the stale source UUID at run time and silently drops a valid attachment.
+   *
+   * <p>Elements keep their serialized shape: link objects ({@code MultiModelSerializer} output,
+   * matched on {@code document_id}) are rewritten in place, scalar id entries (the defensive shape
+   * also accepted by {@code InjectDocumentDeserializer}) are replaced by the resolved id. An id not
+   * seeded in {@code baseIds} but already present on the target tenant (re-import on the same
+   * instance without a bundled file) is kept as-is. An id that resolves to nothing is dropped: the
+   * run-time lookup in {@code InjectExecutionStep#getInjectFromDataStep} is tenant-filtered and
+   * would drop the attachment anyway, so dropping here keeps the persisted step data free of dead
+   * references.
+   */
+  private void rewriteImportedInjectDocuments(ObjectNode dataObject, Map<String, Base> baseIds) {
+    JsonNode documentsNode = dataObject.get("inject_documents");
+    if (documentsNode == null || !documentsNode.isArray()) {
+      return;
+    }
+    ArrayNode rewritten = mapper.createArrayNode();
+    for (JsonNode linkNode : documentsNode) {
+      String rawId = null;
+      if (linkNode instanceof ObjectNode linkObject) {
+        JsonNode idNode = linkObject.get("document_id");
+        rawId = idNode != null && idNode.isTextual() ? idNode.asText() : null;
+      } else if (linkNode != null && linkNode.isTextual()) {
+        rawId = linkNode.asText();
+      }
+      if (!hasText(rawId)) {
+        continue;
+      }
+      String resolvedId = resolveImportedDocumentId(rawId, baseIds);
+      if (resolvedId == null) {
+        continue;
+      }
+      if (linkNode instanceof ObjectNode linkObject) {
+        linkObject.put("document_id", resolvedId);
+        rewritten.add(linkObject);
+      } else {
+        rewritten.add(resolvedId);
+      }
+    }
+    dataObject.set("inject_documents", rewritten);
+  }
+
+  /**
+   * Resolves a step_data document reference to a TARGET-instance document id: the {@code baseIds}
+   * mapping seeded by the document import first, then a tenant-scoped existence check (re-import on
+   * the same instance where the export did not bundle the file), {@code null} when the id resolves
+   * to nothing. The fallback is tenant-scoped on purpose: the raw id comes from the import file and
+   * a bare {@code findById} could match another tenant's document.
+   */
+  private String resolveImportedDocumentId(String rawId, Map<String, Base> baseIds) {
+    if (baseIds.get(rawId) instanceof Document resolvedDocument
+        && resolvedDocument.getId() != null) {
+      return resolvedDocument.getId();
+    }
+    if (documentRepository
+        .findByIdAndTenantId(rawId, TenantContext.getCurrentTenant())
+        .isPresent()) {
+      return rawId;
+    }
+    return null;
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -18,12 +18,14 @@ import com.google.gson.JsonPrimitive;
 import io.openaev.IntegrationTest;
 import io.openaev.api.chaining.dto.ConditionCreateInput;
 import io.openaev.api.chaining.dto.StepsCreateInput;
+import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
 import io.openaev.database.repository.DocumentRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.TeamRepository;
+import io.openaev.database.repository.TenantRepository;
 import io.openaev.execution.ExecutionContext;
 import io.openaev.execution.ExecutionContextService;
 import io.openaev.rest.exception.ChainingException;
@@ -39,8 +41,11 @@ import io.openaev.service.chaining.ConditionService;
 import io.openaev.service.chaining.ScopeService;
 import io.openaev.service.chaining.StepService;
 import io.openaev.utils.ConditionUtils;
+import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.*;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import io.openaev.utils.helpers.InjectTestHelper;
+import jakarta.persistence.EntityManager;
 import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,11 +71,14 @@ public class InjectExecutionStepTest extends IntegrationTest {
   @Autowired private InjectorRepository injectorRepository;
   @Autowired private InjectRepository injectRepository;
   @Autowired private TeamRepository teamRepository;
+  @Autowired private TenantRepository tenantRepository;
   @Autowired private DocumentRepository documentRepository;
   @Autowired InjectExecutionStep injectExecutionStep;
   @Autowired AttackPathExecutionIngestionService attackPathExecutionIngestionService;
   ObjectMapper mapper = new ObjectMapper();
   @Autowired private InjectTestHelper injectTestHelper;
+  @Autowired private TenantIsolationTestHelper tenantIsolationTestHelper;
+  @Autowired private EntityManager entityManager;
   String injectInputJson;
   InjectorContract injectorContractSaved;
   Asset savedAsset;
@@ -1164,6 +1172,45 @@ public class InjectExecutionStepTest extends IntegrationTest {
         ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
 
     // Assert: a deleted attachment degrades to "no attachment" instead of failing the step.
+    assertNotNull(inject);
+    assertTrue(inject.getDocuments().isEmpty());
+  }
+
+  @Test
+  void given_stepDataWithForeignTenantDocument_whenBuildingInject_thenAttachmentIsDropped()
+      throws Exception {
+    // Arrange: the step is authored under the current tenant, but its data references a document
+    // persisted under ANOTHER tenant (stale or crafted step id). The document resolution goes
+    // through a JPQL query precisely so Hibernate's tenantFilter applies; this test pins that
+    // guarantee - a future primary-key lookup (filters never apply to those) or a disabled filter
+    // would resolve the foreign document and fail here.
+    Step readyStep = emailReadyStep(List.of());
+    String currentTenantId = TenantContext.getCurrentTenant();
+    // A bare tenant row is enough here (no provisioning side effects): the document only needs a
+    // foreign tenant to be stamped with, and the run-path lookup only reads documents.
+    Tenant foreignTenant =
+        tenantRepository.save(TenantFixture.getTenant("inject-doc-isolation-" + UUID.randomUUID()));
+    Document foreignDocument;
+    tenantIsolationTestHelper.switchToTenant(foreignTenant.getId(), entityManager);
+    try {
+      foreignDocument = documentRepository.save(DocumentFixture.getDocumentJpeg());
+    } finally {
+      tenantIsolationTestHelper.switchToTenant(currentTenantId, entityManager);
+    }
+    ObjectNode data = (ObjectNode) mapper.readTree(readyStep.getData());
+    ObjectNode link = mapper.createObjectNode();
+    link.put("document_id", foreignDocument.getId());
+    link.put("document_attached", true);
+    data.putArray("inject_documents").add(link);
+    readyStep.setData(mapper.writeValueAsString(data));
+
+    // Act: deserialize through the real scoped run path (the helper re-enabled the tenantFilter
+    // for the current tenant on this session, as the transaction aspect does for the queue run).
+    Inject inject =
+        ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
+
+    // Assert: the foreign-tenant attachment degrades exactly like a deleted one - dropped, with
+    // the step still executable - instead of leaking another tenant's document.
     assertNotNull(inject);
     assertTrue(inject.getDocuments().isEmpty());
   }

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -19,6 +19,7 @@ import io.openaev.IntegrationTest;
 import io.openaev.api.chaining.dto.ConditionCreateInput;
 import io.openaev.api.chaining.dto.StepsCreateInput;
 import io.openaev.database.model.*;
+import io.openaev.database.repository.DocumentRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
@@ -65,6 +66,7 @@ public class InjectExecutionStepTest extends IntegrationTest {
   @Autowired private InjectorRepository injectorRepository;
   @Autowired private InjectRepository injectRepository;
   @Autowired private TeamRepository teamRepository;
+  @Autowired private DocumentRepository documentRepository;
   @Autowired InjectExecutionStep injectExecutionStep;
   @Autowired AttackPathExecutionIngestionService attackPathExecutionIngestionService;
   ObjectMapper mapper = new ObjectMapper();
@@ -989,6 +991,15 @@ public class InjectExecutionStepTest extends IntegrationTest {
    * serialized inject and contract snapshot, with the given teams picked in the drawer.
    */
   private Step emailReadyStep(List<String> drawerTeamIds) throws Exception {
+    return emailReadyStep(drawerTeamIds, List.of());
+  }
+
+  /**
+   * Same as {@link #emailReadyStep(List)} with attachment documents picked in the drawer, so the
+   * step data carries {@code inject_documents} link objects serialized from the inject entity.
+   */
+  private Step emailReadyStep(List<String> drawerTeamIds, List<Document> drawerDocuments)
+      throws Exception {
     Injector emailInjector =
         injectorRepository.save(
             InjectorFixture.createInjector(
@@ -1008,6 +1019,10 @@ public class InjectExecutionStepTest extends IntegrationTest {
         drawerTeamIds.stream()
             .map(id -> "\"" + id + "\"")
             .collect(java.util.stream.Collectors.joining(","));
+    String documentsJson =
+        drawerDocuments.stream()
+            .map(d -> "{\"document_id\":\"" + d.getId() + "\",\"document_attached\":true}")
+            .collect(java.util.stream.Collectors.joining(","));
     String emailInputJson =
         """
         {"type":"inject","inject_title":"tabletop email","inject_description":"",
@@ -1015,9 +1030,9 @@ public class InjectExecutionStepTest extends IntegrationTest {
          "inject_content":{"subject":"Subject","body":"Body"},
          "inject_depends_on":[],"inject_depends_duration":0,
          "inject_teams":[%s],"inject_assets":[],"inject_asset_groups":[],
-         "inject_documents":[],"inject_all_teams":false,"inject_tags":[],"inject_enabled":true}
+         "inject_documents":[%s],"inject_all_teams":false,"inject_tags":[],"inject_enabled":true}
         """
-            .formatted(emailContractSaved.getId(), emailInjector.getId(), teamsJson);
+            .formatted(emailContractSaved.getId(), emailInjector.getId(), teamsJson, documentsJson);
     InjectInput injectInput = mapper.readValue(emailInputJson, InjectInput.class);
     StepsCreateInput.StepInput step = InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
 
@@ -1087,6 +1102,70 @@ public class InjectExecutionStepTest extends IntegrationTest {
     assertNotNull(inject);
     assertEquals(List.of(drawerTeam.getId()), inject.getTeams().stream().map(Team::getId).toList());
     verify(scopeService, never()).getValidTeams(any());
+  }
+
+  // ---------------------------------------------------------------------------
+  // getInjectFromDataStep document attachments (inject_documents round-trip)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void given_emailStepWithAttachment_whenBuildingInject_thenDocumentLinkSurvivesRoundTrip()
+      throws Exception {
+    // Arrange: the step data serializes the inject entity, so inject_documents holds full link
+    // objects ({inject_id, document_id, document_attached, document_name}), not scalar ids.
+    Document attachment = documentRepository.save(DocumentFixture.getDocumentJpeg());
+    Step readyStep = emailReadyStep(List.of(), List.of(attachment));
+
+    // Act
+    Inject inject =
+        ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
+
+    // Assert: the attachment round-trips and is re-parented onto the deserialized inject so the
+    // cascade persist in run() can derive the @MapsId composite key.
+    assertNotNull(inject);
+    assertEquals(1, inject.getDocuments().size());
+    InjectDocument link = inject.getDocuments().getFirst();
+    assertEquals(attachment.getId(), link.getDocument().getId());
+    assertTrue(link.isAttached());
+    assertSame(inject, link.getInject());
+  }
+
+  @Test
+  void given_stepDataWithScalarDocumentId_whenBuildingInject_thenDocumentIsResolved()
+      throws Exception {
+    // Arrange: defensive shape - a plain string document id instead of the link object.
+    Document attachment = documentRepository.save(DocumentFixture.getDocumentJpeg());
+    Step readyStep = emailReadyStep(List.of());
+    ObjectNode data = (ObjectNode) mapper.readTree(readyStep.getData());
+    data.putArray("inject_documents").add(attachment.getId());
+    readyStep.setData(mapper.writeValueAsString(data));
+
+    // Act
+    Inject inject =
+        ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
+
+    // Assert: the scalar form resolves too, with document_attached defaulting to true.
+    assertNotNull(inject);
+    assertEquals(1, inject.getDocuments().size());
+    assertEquals(attachment.getId(), inject.getDocuments().getFirst().getDocument().getId());
+    assertTrue(inject.getDocuments().getFirst().isAttached());
+  }
+
+  @Test
+  void given_stepDataWithDeletedDocument_whenBuildingInject_thenAttachmentIsDropped()
+      throws Exception {
+    // Arrange: the document is deleted between step authoring and execution.
+    Document attachment = documentRepository.save(DocumentFixture.getDocumentJpeg());
+    Step readyStep = emailReadyStep(List.of(), List.of(attachment));
+    documentRepository.delete(attachment);
+
+    // Act
+    Inject inject =
+        ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
+
+    // Assert: a deleted attachment degrades to "no attachment" instead of failing the step.
+    assertNotNull(inject);
+    assertTrue(inject.getDocuments().isEmpty());
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -21,7 +21,9 @@ import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
 import io.openaev.rest.domain.DomainService;
 import io.openaev.rest.domain.enums.PresetDomain;
+import io.openaev.service.ImportEntry;
 import io.openaev.utils.constants.Constants;
+import io.openaev.utils.fixtures.DocumentFixture;
 import io.openaev.utils.fixtures.InjectorFixture;
 import io.openaev.utils.fixtures.PayloadFixture;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
@@ -30,11 +32,13 @@ import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotNull;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.zip.ZipEntry;
 import org.hibernate.Session;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,6 +71,7 @@ class V1_DataImporterTest extends IntegrationTest {
   @Autowired private WorkflowRepository workflowRepository;
   @Autowired private StepRepository stepRepository;
   @Autowired private ConditionRepository conditionRepository;
+  @Autowired private DocumentRepository documentRepository;
   @Autowired private OpenaevInjectorIntegrationFactory openaevInjectorIntegrationFactory;
   @MockitoBean private EnterpriseEditionService enterpriseEditionService;
 
@@ -1141,6 +1146,105 @@ class V1_DataImporterTest extends IntegrationTest {
 
     // WITH the fix, the persisted step_data deserializes without crashing at run time.
     assertDoesNotThrow(() -> deserializeStepDataAsRun(storedData.toString()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // step_data inject_documents id rewriting (imported attachments)
+  //
+  // Documents are recreated with a NEW UUID on the target instance and the source -> target
+  // mapping is recorded in baseIds by the document import. Without a rewrite, an imported
+  // chaining step keeps the stale SOURCE document id in its inject_documents step_data: the
+  // run-time lookup in InjectExecutionStep.getInjectFromDataStep() (tenant-filtered) then misses
+  // it and a VALID attachment is silently dropped.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  @Transactional
+  @WithMockUser
+  void given_stepDataWithDocumentAttachment_when_importing_should_rewriteDocumentIdsViaBaseIds()
+      throws Exception {
+    // -- Arrange --
+    // The export bundles the attachment file and the same target already exists on the TARGET
+    // instance, so the document import maps the SOURCE document id onto the existing document
+    // (updateExistingDocument path) without re-uploading. A second document exists on the target
+    // tenant only (not part of the export): its id must be kept as-is. A third id resolves to
+    // nothing and must be dropped.
+    String target = "v1-import-attachment-" + UUID.randomUUID() + ".jpg";
+    Document existingDocument = DocumentFixture.getDocumentJpeg();
+    existingDocument.setTarget(target);
+    existingDocument = documentRepository.save(existingDocument);
+
+    Document tenantOnlyDocument = documentRepository.save(DocumentFixture.getDocumentJpeg());
+
+    String sourceDocumentId = UUID.randomUUID().toString();
+    String unknownDocumentId = UUID.randomUUID().toString();
+
+    ObjectMapper om = new ObjectMapper();
+    String scenarioName = "wf document attachment " + UUID.randomUUID();
+    ObjectNode importData =
+        buildScenarioWorkflowWithStepTags(
+            om, scenarioName, om.createArrayNode(), om.createArrayNode(), om.createArrayNode());
+
+    ObjectNode documentNode = om.createObjectNode();
+    documentNode.put("document_id", sourceDocumentId);
+    documentNode.put("document_target", target);
+    documentNode.put("document_name", "attachment.jpg");
+    documentNode.put("document_description", "");
+    documentNode.set("document_tags", om.createArrayNode());
+    ArrayNode documents = om.createArrayNode();
+    documents.add(documentNode);
+    importData.set("scenario_documents", documents);
+
+    ObjectNode stepData =
+        (ObjectNode)
+            importData.get("scenario_workflow").get("workflow_steps").get(0).get("step_data");
+    ArrayNode injectDocuments = om.createArrayNode();
+    // Full link-object shape, as MultiModelSerializer writes it into step_data.
+    ObjectNode importedLink = om.createObjectNode();
+    importedLink.put("inject_id", UUID.randomUUID().toString());
+    importedLink.put("document_id", sourceDocumentId);
+    importedLink.put("document_attached", true);
+    importedLink.put("document_name", "attachment.jpg");
+    injectDocuments.add(importedLink);
+    ObjectNode unknownLink = om.createObjectNode();
+    unknownLink.put("document_id", unknownDocumentId);
+    unknownLink.put("document_attached", true);
+    injectDocuments.add(unknownLink);
+    // Scalar defensive shape referencing a document already on the target tenant.
+    injectDocuments.add(tenantOnlyDocument.getId());
+    stepData.set("inject_documents", injectDocuments);
+
+    Map<String, ImportEntry> docReferences =
+        Map.of(
+            target,
+            new ImportEntry(
+                new ZipEntry(target), new ByteArrayInputStream(new byte[] {1, 2, 3}), 3));
+
+    // -- Act --
+    this.importer.importData(
+        importData, docReferences, null, null, null, null, Constants.IMPORTED_OBJECT_NAME_SUFFIX);
+
+    // -- Assert --
+    JsonNode storedData = readStoredStepData(scenarioName, om);
+    JsonNode storedDocuments = storedData.get("inject_documents");
+    assertNotNull(storedDocuments);
+    assertEquals(2, storedDocuments.size(), "resolvable links kept, unresolvable link dropped");
+    JsonNode rewrittenLink = storedDocuments.get(0);
+    assertEquals(
+        existingDocument.getId(),
+        rewrittenLink.get("document_id").asText(),
+        "the SOURCE document id must be rewritten to the resolved TARGET document id");
+    assertTrue(rewrittenLink.get("document_attached").asBoolean());
+    assertEquals(
+        tenantOnlyDocument.getId(),
+        storedDocuments.get(1).asText(),
+        "an id already present on the target tenant is kept (scalar shape preserved)");
+
+    // Run-time deserialization carries the rewritten attachment references.
+    Inject runInject = deserializeStepDataAsRun(storedData.toString());
+    assertEquals(
+        List.of(existingDocument.getId(), tenantOnlyDocument.getId()),
+        runInject.getDocuments().stream().map(link -> link.getDocument().getId()).toList());
   }
 
   @Test

--- a/openaev-model/src/main/java/io/openaev/database/model/Inject.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Inject.java
@@ -352,7 +352,9 @@ public class Inject implements GrantableBase, Injection, TenantBase {
   @Fetch(FetchMode.SUBSELECT)
   @JsonProperty("inject_documents")
   @JsonSerialize(using = MultiModelSerializer.class)
-  @JsonDeserialize(contentUsing = MonoIdDeserializerHelper.class)
+  // Not MonoIdDeserializerHelper: InjectDocument has a composite id and is serialized above as a
+  // full object, so it needs a dedicated element deserializer to round-trip (chaining step data).
+  @JsonDeserialize(contentUsing = InjectDocumentDeserializer.class)
   private List<InjectDocument> documents = new ArrayList<>();
 
   // CascadeType.ALL is required here because communications are embedded

--- a/openaev-model/src/main/java/io/openaev/database/repository/DocumentRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/DocumentRepository.java
@@ -21,6 +21,14 @@ public interface DocumentRepository
   @NotNull
   Optional<Document> findById(@NotNull String id);
 
+  /**
+   * Tenant-scoped primary-key lookup. Hibernate's {@code tenantFilter} does not apply to {@code
+   * findById} (filters never apply to primary-key loads), so callers resolving an id received from
+   * user input (e.g. import files) must use this method to avoid reading another tenant's document.
+   */
+  @NotNull
+  Optional<Document> findByIdAndTenantId(@NotNull String id, @NotNull String tenantId);
+
   List<Document> removeById(@NotNull String id);
 
   // document_target and document_name are not unique (concurrent uploads can create

--- a/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
+++ b/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
@@ -1,0 +1,87 @@
+package io.openaev.helper;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.openaev.database.model.Document;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectDocument;
+import jakarta.persistence.EntityManager;
+import java.io.IOException;
+
+/**
+ * Deserializes one element of an {@code inject_documents} array back into an {@link InjectDocument}
+ * link.
+ *
+ * <p>{@link MonoIdDeserializerHelper} cannot be used here: {@link InjectDocument} has a composite
+ * primary key ({@code InjectDocumentId}), so it can never be resolved through {@code
+ * EntityManager#getReference} with a single raw id - and the serialized form is not a scalar id in
+ * the first place. {@link MultiModelSerializer} writes the full link object (as produced when an
+ * inject is serialized into a chaining step's data), so the scalar-only helper returned {@code
+ * null} without consuming the object's tokens and then misread the following field name as an id,
+ * failing the whole step execution.
+ *
+ * <p>Two element shapes are accepted:
+ *
+ * <ul>
+ *   <li>an object carrying {@code document_id} - the entity serialization ({@code inject_id},
+ *       {@code document_id}, {@code document_attached}, {@code document_name}) or the action
+ *       drawer's {@code {document_id, document_attached}} input shape; {@code document_attached}
+ *       defaults to {@code true};
+ *   <li>a plain string, treated as the document id.
+ * </ul>
+ *
+ * <p>The {@link Document} side is resolved against the injected {@link EntityManager}; a document
+ * that no longer exists yields {@code null} so a deleted attachment degrades to "no attachment"
+ * instead of failing the step. Without an EntityManager a stub carrying only the id is returned.
+ * The owning {@link Inject} cannot be known mid-deserialization, so the {@code inject} side is left
+ * null - consumers must re-parent the link (and prune {@code null} elements) before persisting.
+ */
+public class InjectDocumentDeserializer extends JsonDeserializer<InjectDocument> {
+
+  @Override
+  public InjectDocument deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String documentId = null;
+    boolean attached = true;
+
+    if (p.currentToken() == JsonToken.START_OBJECT) {
+      JsonNode node = p.readValueAsTree();
+      JsonNode idNode = node.get("document_id");
+      if (idNode != null && idNode.isTextual()) {
+        documentId = idNode.asText();
+      }
+      attached = node.path("document_attached").asBoolean(true);
+    } else if (p.currentToken() == JsonToken.VALUE_STRING) {
+      documentId = p.getValueAsString();
+    } else {
+      p.skipChildren();
+      return null;
+    }
+
+    if (documentId == null || documentId.isBlank()) {
+      return null;
+    }
+
+    EntityManager em =
+        (EntityManager) ctxt.findInjectableValue(EntityManager.class.getName(), null, null);
+
+    Document document;
+    if (em != null) {
+      document = em.find(Document.class, documentId);
+      if (document == null) {
+        return null;
+      }
+    } else {
+      document = new Document();
+      document.setId(documentId);
+    }
+
+    InjectDocument injectDocument = new InjectDocument();
+    injectDocument.setDocument(document);
+    injectDocument.setAttached(attached);
+    injectDocument.getCompositeId().setDocumentId(documentId);
+    return injectDocument;
+  }
+}

--- a/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
+++ b/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.openaev.database.model.Document;
 import io.openaev.database.model.InjectDocument;
-import jakarta.persistence.EntityManager;
 import java.io.IOException;
 
 /**
@@ -32,13 +31,15 @@ import java.io.IOException;
  *   <li>a plain string, treated as the document id.
  * </ul>
  *
- * <p>The {@link Document} side is resolved against the injected {@link EntityManager} through a
- * JPQL query, so Hibernate's {@code tenantFilter} applies when enabled; a document that no longer
- * exists - or belongs to another tenant - yields {@code null} so the attachment degrades to "no
- * attachment" instead of failing the step. Without an EntityManager a stub carrying only the id is
- * returned. The owning {@link io.openaev.database.model.Inject} cannot be known
- * mid-deserialization, so the {@code inject} side is left null - consumers must re-parent the link
- * (and prune {@code null} elements) before persisting.
+ * <p>The returned link carries an id-only {@link Document} stub, never a database-resolved entity:
+ * this deserializer runs once per element, so querying here would cost one database round trip per
+ * attachment (an unbounded N+1 inside the queue transaction). Consumers must batch-resolve the
+ * referenced documents afterwards - through a filtered JPQL query so Hibernate's {@code
+ * tenantFilter} applies and a deleted or foreign-tenant document degrades to "no attachment"
+ * instead of failing the step - as {@code InjectExecutionStep#getInjectFromDataStep} does. The
+ * owning {@link io.openaev.database.model.Inject} cannot be known mid-deserialization either, so
+ * the {@code inject} side is left null - consumers must re-parent the link (and prune {@code null}
+ * elements) before persisting.
  */
 public class InjectDocumentDeserializer extends JsonDeserializer<InjectDocument> {
 
@@ -65,27 +66,8 @@ public class InjectDocumentDeserializer extends JsonDeserializer<InjectDocument>
       return null;
     }
 
-    EntityManager em =
-        (EntityManager) ctxt.findInjectableValue(EntityManager.class.getName(), null, null);
-
-    Document document;
-    if (em != null) {
-      // A JPQL query - unlike EntityManager#find by primary key - goes through Hibernate's
-      // enabled filters, so Document's tenantFilter applies and a stale or crafted step
-      // referencing another tenant's document id degrades like a deleted document.
-      document =
-          em.createQuery("select d from Document d where d.id = :id", Document.class)
-              .setParameter("id", documentId)
-              .getResultStream()
-              .findFirst()
-              .orElse(null);
-      if (document == null) {
-        return null;
-      }
-    } else {
-      document = new Document();
-      document.setId(documentId);
-    }
+    Document document = new Document();
+    document.setId(documentId);
 
     InjectDocument injectDocument = new InjectDocument();
     injectDocument.setDocument(document);

--- a/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
+++ b/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.openaev.database.model.Document;
-import io.openaev.database.model.Inject;
 import io.openaev.database.model.InjectDocument;
 import jakarta.persistence.EntityManager;
 import java.io.IOException;
@@ -36,8 +35,9 @@ import java.io.IOException;
  * <p>The {@link Document} side is resolved against the injected {@link EntityManager}; a document
  * that no longer exists yields {@code null} so a deleted attachment degrades to "no attachment"
  * instead of failing the step. Without an EntityManager a stub carrying only the id is returned.
- * The owning {@link Inject} cannot be known mid-deserialization, so the {@code inject} side is left
- * null - consumers must re-parent the link (and prune {@code null} elements) before persisting.
+ * The owning {@link io.openaev.database.model.Inject} cannot be known mid-deserialization, so the
+ * {@code inject} side is left null - consumers must re-parent the link (and prune {@code null}
+ * elements) before persisting.
  */
 public class InjectDocumentDeserializer extends JsonDeserializer<InjectDocument> {
 

--- a/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
+++ b/openaev-model/src/main/java/io/openaev/helper/InjectDocumentDeserializer.java
@@ -32,12 +32,13 @@ import java.io.IOException;
  *   <li>a plain string, treated as the document id.
  * </ul>
  *
- * <p>The {@link Document} side is resolved against the injected {@link EntityManager}; a document
- * that no longer exists yields {@code null} so a deleted attachment degrades to "no attachment"
- * instead of failing the step. Without an EntityManager a stub carrying only the id is returned.
- * The owning {@link io.openaev.database.model.Inject} cannot be known mid-deserialization, so the
- * {@code inject} side is left null - consumers must re-parent the link (and prune {@code null}
- * elements) before persisting.
+ * <p>The {@link Document} side is resolved against the injected {@link EntityManager} through a
+ * JPQL query, so Hibernate's {@code tenantFilter} applies when enabled; a document that no longer
+ * exists - or belongs to another tenant - yields {@code null} so the attachment degrades to "no
+ * attachment" instead of failing the step. Without an EntityManager a stub carrying only the id is
+ * returned. The owning {@link io.openaev.database.model.Inject} cannot be known
+ * mid-deserialization, so the {@code inject} side is left null - consumers must re-parent the link
+ * (and prune {@code null} elements) before persisting.
  */
 public class InjectDocumentDeserializer extends JsonDeserializer<InjectDocument> {
 
@@ -69,7 +70,15 @@ public class InjectDocumentDeserializer extends JsonDeserializer<InjectDocument>
 
     Document document;
     if (em != null) {
-      document = em.find(Document.class, documentId);
+      // A JPQL query - unlike EntityManager#find by primary key - goes through Hibernate's
+      // enabled filters, so Document's tenantFilter applies and a stale or crafted step
+      // referencing another tenant's document id degrades like a deleted document.
+      document =
+          em.createQuery("select d from Document d where d.id = :id", Document.class)
+              .setParameter("id", documentId)
+              .getResultStream()
+              .findFirst()
+              .orElse(null);
       if (document == null) {
         return null;
       }


### PR DESCRIPTION
## Proposed changes

Fixes #7410 - a chaining logic with an email action carrying a document attachment never executes: the READY step dies with `Error processing JSON to Inject` / `Supplied id had wrong type: entity 'InjectDocument' has id type 'InjectDocumentId' but supplied id was of type 'String'`, and the event is dropped after 5 retries. Without the attachment the logic works.

### Root cause

The step data stores the FULL serialized inject (`InjectExecutionStep.stepData`), and `Inject.documents` serializes with `MultiModelSerializer` - each `inject_documents` element is a full link object (`inject_id`, `document_id`, `document_attached`, `document_name`). The read side deserialized the collection with `MonoIdDeserializerHelper`, which only understands scalar id strings:

- on the object element it returned null WITHOUT consuming the object's tokens;
- the collection deserializer then read the next token - the `inject_id` FIELD NAME - as a string id and called `em.getReference(InjectDocument.class, "inject_id")`;
- `InjectDocument` has a composite primary key (`InjectDocumentId`), so Hibernate threw `TypeMismatchException` and the whole step failed.

`MonoIdDeserializerHelper` can never resolve `InjectDocument`: a composite id cannot be built from one raw string (the `CompositeIdResolvableI` escape hatch works for `InjectorContract` because the missing half is the tenant id, available statically - the missing inject id here is not).

### Fix

- New `InjectDocumentDeserializer` (openaev-model) for `inject_documents` elements. Accepts both shapes: the full link object (entity serialization or the drawer's `{document_id, document_attached}` input shape, `document_attached` defaulting to true) and a plain string document id (defensive). It emits an id-only `InjectDocument` stub and never queries the database: the element deserializer runs once per element, so a per-element lookup would be an unbounded N+1 inside the queue transaction.
- `Inject.documents` now uses it as `contentUsing` instead of `MonoIdDeserializerHelper`.
- `InjectExecutionStep.getInjectFromDataStep` batch-resolves all referenced documents with a SINGLE JPQL `where d.id in :ids` query - unlike a primary-key `find`, the query goes through Hibernate's enabled filters, so `tenantFilter` applies and a stale or crafted step referencing a deleted or another tenant's document id degrades to "no attachment" instead of failing the step or leaking cross-tenant data. Missing/foreign links are pruned and survivors are re-parented (`setInject(inject)`): the owning inject does not exist mid-deserialization, and the `@MapsId` composite id needs both associations before `run()` cascade-persists the inject. The persisted inject then carries its `InjectDocument` rows, and `EmailExecutor` picks the attachment up from `inject.getDocuments()` as usual.
- `V1_DataImporter.sanitizateStepData` now rewrites `inject_documents` document ids through `baseIds`: documents are recreated with a NEW UUID on the target instance, so an imported chaining step used to keep the stale SOURCE document id and silently dropped a valid attachment at run time. Ids already present on the target tenant are kept (new tenant-scoped `DocumentRepository#findByIdAndTenantId`, mirroring the tag rewrite), unresolvable ids are dropped.

### Tests

`InjectExecutionStepTest` (through the real create/ready step path, so the data carries the exact serialized shape that broke):

- attachment round-trips through step data: 1 link, right document id, attached, re-parented onto the deserialized inject;
- scalar document id shape resolves with `document_attached` defaulting to true;
- document deleted between authoring and execution drops the attachment instead of failing the step;
- tenant isolation: a document persisted under ANOTHER tenant is dropped by the filtered run-path lookup (a future primary-key lookup or disabled `tenantFilter` fails this test).

`V1_DataImporterTest`:

- imported step_data with a bundled attachment: the SOURCE document id is rewritten to the resolved TARGET document id, an id already on the target tenant is kept (scalar shape preserved), an unresolvable id is dropped, and the persisted step data deserializes through the run path.

- InjectExecutionStepTest: 37/37 green
- V1_DataImporterTest: 78/78 green
- spotless applied, openaev-model + openaev-api compile

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
