### PR TITLE
fix(chaining): cascade-delete template steps when their injector contract or payload is deleted (#7412)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -52,6 +52,7 @@ import io.openaev.rest.domain.enums.PresetDomain;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.inject.service.InjectIndexCleanupService;
+import io.openaev.service.chaining.ChainingStepCleanupService;
 import io.openaev.service.organization.OrganizationService;
 import io.openaev.utils.FilterUtilsJpa;
 import io.openaev.utils.pagination.SearchPaginationInput;
@@ -110,6 +111,7 @@ public class PhishingLandingPageService {
   private final InjectorRepository injectorRepository;
   private final InjectorContractRepository injectorContractRepository;
   private final InjectIndexCleanupService injectIndexCleanupService;
+  private final ChainingStepCleanupService chainingStepCleanupService;
   private final AttackPatternRepository attackPatternRepository;
   private final ExpectationBuilderService expectationBuilderService;
   private final PhishingContract phishingContract;
@@ -412,6 +414,11 @@ public class PhishingLandingPageService {
           injectIndexCleanupService.injectIdsByContractIds(List.of(landingPage.getId()), tenantId);
       injectorContractRepository.deleteById(contractId);
       injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+      // Chaining steps reference the contract only through a JSON snapshot in step_data (no FK to
+      // cascade on), so sweep the orphaned step templates explicitly, mirroring the inject
+      // de-index.
+      chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+          List.of(landingPage.getId()));
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -416,9 +416,9 @@ public class PhishingLandingPageService {
       injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
       // Chaining steps reference the contract only through a JSON snapshot in step_data (no FK to
       // cascade on), so sweep the orphaned step templates explicitly, mirroring the inject
-      // de-index.
+      // de-index. The sweep is tenant-scoped to never touch another tenant's logic maps.
       chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
-          List.of(landingPage.getId()));
+          List.of(landingPage.getId()), tenantId);
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -584,6 +584,20 @@ public class InjectorContractService implements DependenciesManager {
   }
 
   /**
+   * Returns the injector contract ids of the given tenant backed by the given payload - the service
+   * pass-through for {@code InjectorContractRepository#findContractIdsByPayloadId} so consumers
+   * outside this service (the payload-delete path) never touch the repository directly.
+   *
+   * @param payloadId the payload whose contract ids are resolved
+   * @param tenantId the tenant whose contracts are considered (the payload's own tenant)
+   * @return the injector contract ids (usually one), empty when the payload backs no contract
+   */
+  @Transactional(readOnly = true)
+  public List<String> findContractIdsByPayloadId(String payloadId, String tenantId) {
+    return this.injectorContractRepository.findContractIdsByPayloadId(payloadId, tenantId);
+  }
+
+  /**
    * Deletes an injector contract by its ID using a direct DELETE query (no entity loading).
    *
    * @param injectorContractId the contract ID to delete

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -20,6 +20,7 @@ import io.openaev.config.OpenAEVAnonymous;
 import io.openaev.config.SessionHelper;
 import io.openaev.context.TenantContext;
 import io.openaev.database.model.*;
+import io.openaev.database.raw.RawContractTenant;
 import io.openaev.database.raw.RawInjectorsContracts;
 import io.openaev.database.repository.AttackPatternRepository;
 import io.openaev.database.repository.InjectorContractRepository;
@@ -584,17 +585,27 @@ public class InjectorContractService implements DependenciesManager {
   }
 
   /**
-   * Returns the injector contract ids of the given tenant backed by the given payload - the service
-   * pass-through for {@code InjectorContractRepository#findContractIdsByPayloadId} so consumers
-   * outside this service (the payload-delete path) never touch the repository directly.
+   * Returns the injector contract ids backed by the given payload, grouped by tenant - the service
+   * pass-through for {@code InjectorContractRepository#findContractTenantPairsByPayloadId} so
+   * consumers outside this service (the payload-delete path) never touch the repository directly.
+   *
+   * <p>The result deliberately spans all tenants so the payload-delete path sweeps exactly what the
+   * database cascade removes, each tenant with its own tenant-scoped call. Today {@code
+   * unique_injector_contract_payload} guarantees a payload backs at most one contract
+   * platform-wide, so the map holds at most one entry - the grouped shape simply keeps the delete
+   * path correct if that 1:1 constraint is ever relaxed.
    *
    * @param payloadId the payload whose contract ids are resolved
-   * @param tenantId the tenant whose contracts are considered (the payload's own tenant)
-   * @return the injector contract ids (usually one), empty when the payload backs no contract
+   * @return contract ids grouped by tenant id, empty when the payload backs no contract
    */
   @Transactional(readOnly = true)
-  public List<String> findContractIdsByPayloadId(String payloadId, String tenantId) {
-    return this.injectorContractRepository.findContractIdsByPayloadId(payloadId, tenantId);
+  public Map<String, List<String>> findContractIdsByPayloadIdPerTenant(String payloadId) {
+    return this.injectorContractRepository.findContractTenantPairsByPayloadId(payloadId).stream()
+        .collect(
+            Collectors.groupingBy(
+                RawContractTenant::getTenant_id,
+                Collectors.mapping(
+                    RawContractTenant::getInjector_contract_id, Collectors.toList())));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -527,6 +527,7 @@ public class InjectorContractService implements DependenciesManager {
    * @throws ElementNotFoundException if not found
    * @throws IllegalArgumentException if the contract is neither custom nor payload-based
    */
+  @Transactional(rollbackFor = Exception.class)
   public void deleteInjectorContract(final String injectorContractId) {
     InjectorContract injectorContract =
         this.injectorContractRepository
@@ -543,6 +544,9 @@ public class InjectorContractService implements DependenciesManager {
     deleteInjectorContract(injectorContract);
   }
 
+  // Transactional so the contract delete and the chaining step sweep commit or roll back
+  // together (a sweep failure must not strand ghost steps behind an already-deleted contract).
+  @Transactional(rollbackFor = Exception.class)
   public void deleteInjectorContract(InjectorContract injectorContract) {
     // Same compensation as deleteInjectorContractById: the injects FK on injectors_contracts is ON
     // DELETE CASCADE, so the injects (and, one hop further, their expectations and findings) vanish
@@ -582,6 +586,7 @@ public class InjectorContractService implements DependenciesManager {
    *
    * @param injectorContractId the contract ID to delete
    */
+  @Transactional(rollbackFor = Exception.class)
   public void deleteInjectorContractById(String injectorContractId) {
     // The injects FK on injectors_contracts is ON DELETE CASCADE: collect the doomed inject ids
     // before the delete and de-index them explicitly (no JPA lifecycle fires for DB cascades).

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -49,6 +49,7 @@ import io.openaev.rest.payload.output.PayloadSimple;
 import io.openaev.rest.vulnerability.service.VulnerabilityService;
 import io.openaev.service.InjectorService;
 import io.openaev.service.UserService;
+import io.openaev.service.chaining.ChainingStepCleanupService;
 import io.openaev.service.organization.OrganizationService;
 import io.openaev.utils.TargetType;
 import io.openaev.utils.pagination.SearchPaginationInput;
@@ -109,6 +110,7 @@ public class InjectorContractService implements DependenciesManager {
   private final OrganizationService organizationService;
   private final InjectIndexCleanupService injectIndexCleanupService;
   private final StepRepository stepRepository;
+  private final ChainingStepCleanupService chainingStepCleanupService;
 
   private final List<String> listDefaultInjectorContract =
       List.of(
@@ -557,6 +559,10 @@ public class InjectorContractService implements DependenciesManager {
             List.of(injectorContract.getId()), tenantId);
     this.injectorContractRepository.delete(injectorContract);
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+    // Chaining steps reference the contract only through a JSON snapshot in step_data (no FK to
+    // cascade on), so sweep the orphaned step templates explicitly, mirroring the inject de-index.
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+        List.of(injectorContract.getId()));
   }
 
   /**
@@ -583,6 +589,10 @@ public class InjectorContractService implements DependenciesManager {
     this.injectorContractRepository.deleteById(
         new InjectorContractId(injectorContractId, TenantContext.getCurrentTenant()));
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+    // Chaining steps reference the contract only through a JSON snapshot in step_data (no FK to
+    // cascade on), so sweep the orphaned step templates explicitly, mirroring the inject de-index.
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+        List.of(injectorContractId));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -544,9 +544,11 @@ public class InjectorContractService implements DependenciesManager {
     deleteInjectorContract(injectorContract);
   }
 
-  // Transactional so the contract delete and the chaining step sweep commit or roll back
-  // together (a sweep failure must not strand ghost steps behind an already-deleted contract).
-  @Transactional(rollbackFor = Exception.class)
+  // Deliberately NOT annotated @Transactional: this overload is only reached through the
+  // transactional deleteInjectorContract(String) entry point, and annotating it would create a
+  // proxy-bypassing intra-class call (TenantBackgroundTransactionArchTest
+  // no_transactional_self_invocation). The entry point's transaction makes the contract delete
+  // and the chaining step sweep commit or roll back together.
   public void deleteInjectorContract(InjectorContract injectorContract) {
     // Same compensation as deleteInjectorContractById: the injects FK on injectors_contracts is ON
     // DELETE CASCADE, so the injects (and, one hop further, their expectations and findings) vanish

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractService.java
@@ -561,8 +561,10 @@ public class InjectorContractService implements DependenciesManager {
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
     // Chaining steps reference the contract only through a JSON snapshot in step_data (no FK to
     // cascade on), so sweep the orphaned step templates explicitly, mirroring the inject de-index.
+    // The sweep is tenant-scoped: default contracts share their ids across tenants, so an unscoped
+    // sweep would wipe other tenants' authored logic-map nodes.
     chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
-        List.of(injectorContract.getId()));
+        List.of(injectorContract.getId()), tenantId);
   }
 
   /**
@@ -583,16 +585,18 @@ public class InjectorContractService implements DependenciesManager {
   public void deleteInjectorContractById(String injectorContractId) {
     // The injects FK on injectors_contracts is ON DELETE CASCADE: collect the doomed inject ids
     // before the delete and de-index them explicitly (no JPA lifecycle fires for DB cascades).
+    String tenantId = TenantContext.getCurrentTenant();
     List<String> cascadeDeletedInjectIds =
-        injectIndexCleanupService.injectIdsByContractIds(
-            List.of(injectorContractId), TenantContext.getCurrentTenant());
+        injectIndexCleanupService.injectIdsByContractIds(List.of(injectorContractId), tenantId);
     this.injectorContractRepository.deleteById(
-        new InjectorContractId(injectorContractId, TenantContext.getCurrentTenant()));
+        new InjectorContractId(injectorContractId, tenantId));
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
     // Chaining steps reference the contract only through a JSON snapshot in step_data (no FK to
     // cascade on), so sweep the orphaned step templates explicitly, mirroring the inject de-index.
+    // The sweep is tenant-scoped: default contracts share their ids across tenants, so an unscoped
+    // sweep would wipe other tenants' authored logic-map nodes.
     chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
-        List.of(injectorContractId));
+        List.of(injectorContractId), tenantId);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -599,19 +599,22 @@ public class PayloadService {
             .orElseThrow(() -> new ElementNotFoundException("Payload not found: " + payloadId));
     // Payload deletion cascades at the DB level to its injector contract and then to the injects
     // (both FKs are ON DELETE CASCADE): de-index the doomed injects explicitly, no JPA lifecycle
-    // event fires for them. Chaining steps referencing that contract have no FK to cascade on (the
-    // contract is only a JSON snapshot in step_data), so resolve the contract ids BEFORE the delete
-    // and sweep the orphaned step templates explicitly too. Both lookups and the sweep are scoped
-    // to the payload's tenant: native SQL bypasses the Hibernate tenantFilter, and the default
-    // contracts share their ids (and this payload row) across every tenant.
+    // event fires for them. Chaining steps referencing that contract have no FK to cascade on
+    // (the contract is only a JSON snapshot in step_data), so inventory the doomed contract rows
+    // BEFORE the delete and sweep the orphaned step templates explicitly too. The inventory is
+    // grouped by tenant and each sweep stays scoped to its own tenant: today a payload backs at
+    // most one contract platform-wide (unique_injector_contract_payload), the grouping simply
+    // keeps this path correct if that 1:1 constraint is ever relaxed.
     String tenantId = payload.getTenant().getId();
-    List<String> cascadeDeletedContractIds =
-        injectorContractService.findContractIdsByPayloadId(payloadId, tenantId);
+    Map<String, List<String>> cascadeDeletedContractIdsPerTenant =
+        injectorContractService.findContractIdsByPayloadIdPerTenant(payloadId);
     List<String> cascadeDeletedInjectIds =
         injectIndexCleanupService.injectIdsByPayloadId(payloadId, tenantId);
     payloadRepository.deleteById(payloadId);
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
-    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
-        cascadeDeletedContractIds, tenantId);
+    cascadeDeletedContractIdsPerTenant.forEach(
+        (contractTenantId, contractIds) ->
+            chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+                contractIds, contractTenantId));
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -60,6 +60,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -585,6 +586,10 @@ public class PayloadService {
     return saved;
   }
 
+  // Transactional so the payload delete and the chaining step sweep commit or roll back together:
+  // without it the deleteById commits first and a sweep failure would leave the ghost steps this
+  // cleanup exists to prevent. Same pattern as InjectorService.deleteInjector.
+  @Transactional(rollbackFor = Exception.class)
   public void delete(String payloadId) {
     Payload payload =
         payloadRepository

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -41,6 +41,7 @@ import io.openaev.rest.domain.DomainService;
 import io.openaev.rest.domain.enums.PresetDomain;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.inject.service.InjectIndexCleanupService;
+import io.openaev.rest.injector_contract.InjectorContractService;
 import io.openaev.rest.injector_contract.form.InjectorContractDomainDTO;
 import io.openaev.rest.payload.PayloadUtils;
 import io.openaev.rest.payload.output.PayloadOutput;
@@ -86,6 +87,7 @@ public class PayloadService {
   private final TagService tagService;
   private final InjectIndexCleanupService injectIndexCleanupService;
   private final ChainingStepCleanupService chainingStepCleanupService;
+  private final InjectorContractService injectorContractService;
 
   private final PayloadMapper payloadMapper;
 
@@ -604,7 +606,7 @@ public class PayloadService {
     // contracts share their ids (and this payload row) across every tenant.
     String tenantId = payload.getTenant().getId();
     List<String> cascadeDeletedContractIds =
-        injectorContractRepository.findContractIdsByPayloadId(payloadId, tenantId);
+        injectorContractService.findContractIdsByPayloadId(payloadId, tenantId);
     List<String> cascadeDeletedInjectIds =
         injectIndexCleanupService.injectIdsByPayloadId(payloadId, tenantId);
     payloadRepository.deleteById(payloadId);

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -46,6 +46,7 @@ import io.openaev.rest.payload.PayloadUtils;
 import io.openaev.rest.payload.output.PayloadOutput;
 import io.openaev.rest.tag.TagService;
 import io.openaev.service.UserService;
+import io.openaev.service.chaining.ChainingStepCleanupService;
 import io.openaev.telemetry.metric_collectors.ResultsMetricCollector;
 import io.openaev.utils.mapper.PayloadMapper;
 import io.openaev.utils.pagination.SearchPaginationInput;
@@ -83,6 +84,7 @@ public class PayloadService {
   private final DomainService domainService;
   private final TagService tagService;
   private final InjectIndexCleanupService injectIndexCleanupService;
+  private final ChainingStepCleanupService chainingStepCleanupService;
 
   private final PayloadMapper payloadMapper;
 
@@ -590,10 +592,15 @@ public class PayloadService {
             .orElseThrow(() -> new ElementNotFoundException("Payload not found: " + payloadId));
     // Payload deletion cascades at the DB level to its injector contract and then to the injects
     // (both FKs are ON DELETE CASCADE): de-index the doomed injects explicitly, no JPA lifecycle
-    // event fires for them.
+    // event fires for them. Chaining steps referencing that contract have no FK to cascade on (the
+    // contract is only a JSON snapshot in step_data), so resolve the contract ids BEFORE the delete
+    // and sweep the orphaned step templates explicitly too.
+    List<String> cascadeDeletedContractIds =
+        injectorContractRepository.findContractIdsByPayloadId(payloadId);
     List<String> cascadeDeletedInjectIds =
         injectIndexCleanupService.injectIdsByPayloadId(payloadId, payload.getTenant().getId());
     payloadRepository.deleteById(payloadId);
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(cascadeDeletedContractIds);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -594,13 +594,17 @@ public class PayloadService {
     // (both FKs are ON DELETE CASCADE): de-index the doomed injects explicitly, no JPA lifecycle
     // event fires for them. Chaining steps referencing that contract have no FK to cascade on (the
     // contract is only a JSON snapshot in step_data), so resolve the contract ids BEFORE the delete
-    // and sweep the orphaned step templates explicitly too.
+    // and sweep the orphaned step templates explicitly too. Both lookups and the sweep are scoped
+    // to the payload's tenant: native SQL bypasses the Hibernate tenantFilter, and the default
+    // contracts share their ids (and this payload row) across every tenant.
+    String tenantId = payload.getTenant().getId();
     List<String> cascadeDeletedContractIds =
-        injectorContractRepository.findContractIdsByPayloadId(payloadId);
+        injectorContractRepository.findContractIdsByPayloadId(payloadId, tenantId);
     List<String> cascadeDeletedInjectIds =
-        injectIndexCleanupService.injectIdsByPayloadId(payloadId, payload.getTenant().getId());
+        injectIndexCleanupService.injectIdsByPayloadId(payloadId, tenantId);
     payloadRepository.deleteById(payloadId);
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
-    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(cascadeDeletedContractIds);
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+        cascadeDeletedContractIds, tenantId);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/InjectorService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectorService.java
@@ -23,6 +23,7 @@ import io.openaev.rest.injector.response.InjectorRegistration;
 import io.openaev.rest.injector_contract.InjectorContractService;
 import io.openaev.rest.injector_contract.form.InjectorContractInput;
 import io.openaev.service.catalog_connectors.CatalogConnectorService;
+import io.openaev.service.chaining.ChainingStepCleanupService;
 import io.openaev.service.connector_instances.ConnectorInstanceService;
 import io.openaev.service.connectors.AbstractConnectorService;
 import io.openaev.service.connectors.PlatformConnectors;
@@ -71,6 +72,8 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
 
   private final InjectIndexCleanupService injectIndexCleanupService;
 
+  private final ChainingStepCleanupService chainingStepCleanupService;
+
   @Autowired
   public InjectorService(
       InjectorRepository injectorRepository,
@@ -87,7 +90,8 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
       CatalogConnectorMapper catalogConnectorMapper,
       RabbitmqService rabbitmqService,
       EntityManager entityManager,
-      InjectIndexCleanupService injectIndexCleanupService) {
+      InjectIndexCleanupService injectIndexCleanupService,
+      ChainingStepCleanupService chainingStepCleanupService) {
     super(
         ConnectorType.INJECTOR,
         connectorInstanceConfigurationRepository,
@@ -105,6 +109,7 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
     this.rabbitmqService = rabbitmqService;
     this.entityManager = entityManager;
     this.injectIndexCleanupService = injectIndexCleanupService;
+    this.chainingStepCleanupService = chainingStepCleanupService;
   }
 
   @Override
@@ -179,6 +184,11 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
       injectorRepository.deleteByIdAndTenantId(injectorId, tenantId);
     }
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+    // Chaining steps reference contracts only through a JSON snapshot in step_data (no FK to
+    // cascade on): sweep the orphaned step templates of this tenant explicitly, mirroring the
+    // inject de-index above.
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+        orphanedContractIds, tenantId);
   }
 
   public Injector injector(String id) {
@@ -372,6 +382,10 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
     injectorContractRepository.deleteAllByIdAndTenantId(
         toDeletes.toArray(new String[0]), injector.getTenantId());
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+    // Contracts retired from the external catalog also leave chaining step templates behind (the
+    // step -> contract link is only a JSON snapshot in step_data): sweep them for this tenant.
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+        toDeletes, injector.getTenantId());
     // Unlink deleted contracts via the join entity
     injector.getContracts().stream()
         .filter(c -> toDeletes.contains(c.getId()))
@@ -602,6 +616,11 @@ public class InjectorService extends AbstractConnectorService<Injector, Injector
     injectorContractRepository.deleteAllByIdAndTenantId(
         toDelete.toArray(new String[0]), injector.getTenantId());
     injectIndexCleanupService.notifyEngineOfDeletedInjects(cascadeDeletedInjectIds);
+    // Built-in contracts retired from the static catalog also leave chaining step templates
+    // behind (the step -> contract link is only a JSON snapshot in step_data): sweep them for
+    // this tenant.
+    chainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(
+        toDelete, injector.getTenantId());
     toCreate = fromIterable(injectorContractRepository.saveAll(toCreate));
 
     // Link new contracts to the injector via idempotent native INSERT (ON CONFLICT DO NOTHING).

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ChainingStepCleanupService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ChainingStepCleanupService.java
@@ -4,6 +4,7 @@ import io.openaev.database.model.Step;
 import io.openaev.database.repository.StepRepository;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,11 @@ import org.springframework.transaction.annotation.Transactional;
  * semantics ("the inject no longer makes sense", migration {@code V4_88}) for TEMPLATE steps. It is
  * wired into every path that removes a contract or payload ({@code PayloadService}, {@code
  * InjectorContractService}, {@code PhishingLandingPageService}), the same way {@code
- * InjectIndexCleanupService} compensates the search index for those same cascades.
+ * InjectIndexCleanupService} compensates the search index for those same cascades. The tenant
+ * offboarding path ({@code InjectorContractService#deleteDependencyForTenant}) is deliberately NOT
+ * wired: it deletes the per-tenant copies of the default contracts while the rest of the tenant is
+ * being torn down, and the tenant's workflows and steps already die wholesale with their scenarios
+ * and simulations through the {@code ON DELETE CASCADE} chain.
  *
  * <p>Only TEMPLATE steps are swept: RUN steps carry immutable execution history and must survive
  * their contract's deletion, following the TEMPLATE-only rule of {@code
@@ -41,9 +46,16 @@ public class ChainingStepCleanupService {
   private final ConditionService conditionService;
 
   /**
-   * Deletes every TEMPLATE step - and the conditions left dangling by its removal - whose frozen
-   * {@code step_data} references any of the given injector contract ids. No-op for a null or empty
-   * input.
+   * Deletes every TEMPLATE step of the given tenant - and the conditions left dangling by its
+   * removal - whose frozen {@code step_data} references any of the given injector contract ids.
+   * No-op for a null or empty input.
+   *
+   * <p>The tenant is mandatory: {@code InjectorContract} has a composite {@code (id, tenant_id)}
+   * key and the default contracts are provisioned id-for-id into every tenant, so the same contract
+   * id exists in several tenants at once. Sweeping by contract id alone would delete OTHER tenants'
+   * authored logic-map nodes; the caller must pass the tenant the contract was deleted in (the
+   * entity's own tenant, or {@code TenantContext} for by-id deletes), mirroring {@code
+   * InjectIndexCleanupService#injectIdsByContractIds(Collection, String)}.
    *
    * <p>Each step is torn down the same way a manual logic-map delete is ({@link
    * ConditionService#deleteAllConditionsByStepId(String)} then the step itself), so edges are
@@ -52,14 +64,18 @@ public class ChainingStepCleanupService {
    * not a user edit, and must never be blocked by a workflow's editability state.
    *
    * @param injectorContractIds the deleted injector contract ids to sweep from chaining logic maps
+   * @param tenantId the tenant the contracts were deleted in (scopes the sweep)
    * @return the number of step templates removed
    */
-  @Transactional
-  public int deleteTemplateStepsByInjectorContractIds(Collection<String> injectorContractIds) {
+  @Transactional(rollbackFor = Exception.class)
+  public int deleteTemplateStepsByInjectorContractIds(
+      Collection<String> injectorContractIds, String tenantId) {
     if (injectorContractIds == null || injectorContractIds.isEmpty()) {
       return 0;
     }
-    List<Step> steps = stepRepository.findTemplateStepsByInjectorContractIds(injectorContractIds);
+    Objects.requireNonNull(tenantId, "tenantId is required to scope the chaining step sweep");
+    List<Step> steps =
+        stepRepository.findTemplateStepsByInjectorContractIds(injectorContractIds, tenantId);
     for (Step step : steps) {
       conditionService.deleteAllConditionsByStepId(step.getId());
       stepRepository.delete(step);

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ChainingStepCleanupService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ChainingStepCleanupService.java
@@ -1,0 +1,76 @@
+package io.openaev.service.chaining;
+
+import io.openaev.database.model.Step;
+import io.openaev.database.repository.StepRepository;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Cascade-cleans chaining step templates when their injector contract - or the payload behind it -
+ * is deleted from the threat arsenal.
+ *
+ * <p>A regular inject references its injector contract through the {@code inject_injector_contract}
+ * foreign key, declared {@code ON DELETE CASCADE}, so the inject row dies with the contract (and
+ * transitively with the payload) at the database level. A chaining step has no such link: the
+ * contract is frozen as a JSON snapshot inside {@code step_data}, with no foreign key for the
+ * database cascade to act on. Nothing therefore removed the authored logic-map nodes when their
+ * contract disappeared - the Logic graph kept rendering the stale snapshot and the edit drawer
+ * 404'd on the (now missing) live-contract fetch, leaving an un-runnable ghost step that also fails
+ * the chain at run time.
+ *
+ * <p>This service is the application-level compensation for that gap, mirroring the inject
+ * semantics ("the inject no longer makes sense", migration {@code V4_88}) for TEMPLATE steps. It is
+ * wired into every path that removes a contract or payload ({@code PayloadService}, {@code
+ * InjectorContractService}, {@code PhishingLandingPageService}), the same way {@code
+ * InjectIndexCleanupService} compensates the search index for those same cascades.
+ *
+ * <p>Only TEMPLATE steps are swept: RUN steps carry immutable execution history and must survive
+ * their contract's deletion, following the TEMPLATE-only rule of {@code
+ * WorkflowScopeRuleCascadeListener}.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChainingStepCleanupService {
+
+  private final StepRepository stepRepository;
+  private final ConditionService conditionService;
+
+  /**
+   * Deletes every TEMPLATE step - and the conditions left dangling by its removal - whose frozen
+   * {@code step_data} references any of the given injector contract ids. No-op for a null or empty
+   * input.
+   *
+   * <p>Each step is torn down the same way a manual logic-map delete is ({@link
+   * ConditionService#deleteAllConditionsByStepId(String)} then the step itself), so edges are
+   * unlinked and orphaned condition trees are pruned. The logic-map editability assertion is
+   * deliberately skipped: this is a system-driven cascade triggered by a threat-arsenal deletion,
+   * not a user edit, and must never be blocked by a workflow's editability state.
+   *
+   * @param injectorContractIds the deleted injector contract ids to sweep from chaining logic maps
+   * @return the number of step templates removed
+   */
+  @Transactional
+  public int deleteTemplateStepsByInjectorContractIds(Collection<String> injectorContractIds) {
+    if (injectorContractIds == null || injectorContractIds.isEmpty()) {
+      return 0;
+    }
+    List<Step> steps = stepRepository.findTemplateStepsByInjectorContractIds(injectorContractIds);
+    for (Step step : steps) {
+      conditionService.deleteAllConditionsByStepId(step.getId());
+      stepRepository.delete(step);
+    }
+    if (!steps.isEmpty()) {
+      log.debug(
+          "[Chaining] Cascade-removed {} orphaned step template(s) referencing deleted injector"
+              + " contract(s): {}",
+          steps.size(),
+          injectorContractIds);
+    }
+    return steps.size();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
@@ -274,6 +274,80 @@ class StepRepositoryTest extends IntegrationTest {
   }
 
   @Test
+  void whenFindTemplateStepsByInjectorContractIds_thenMatchesBothShapesAndExcludesRunSteps() {
+    // GIVEN: two TEMPLATE steps referencing the doomed contracts (one per serialized shape), a
+    // TEMPLATE step on an unrelated contract, and a RUN step on the same doomed contract.
+    String objectContractId = "cascade-contract-object";
+    String stringContractId = "cascade-contract-string";
+    String otherContractId = "cascade-contract-other";
+
+    Step objectShapeTemplate =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data(
+                "{\"inject_injector_contract\": {\"injector_contract_id\": \""
+                    + objectContractId
+                    + "\"}}")
+            .build();
+    Step stringShapeTemplate =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data("{\"inject_injector_contract\": \"" + stringContractId + "\"}")
+            .build();
+    Step unrelatedTemplate =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data(
+                "{\"inject_injector_contract\": {\"injector_contract_id\": \""
+                    + otherContractId
+                    + "\"}}")
+            .build();
+    // A RUN step references the doomed contract too, but carries immutable execution history and
+    // must survive: it is excluded by the step_status = 'TEMPLATE' guard even though its
+    // step_template_id is also null here.
+    Step runStepSameContract =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.RUN)
+            .data(
+                "{\"inject_injector_contract\": {\"injector_contract_id\": \""
+                    + objectContractId
+                    + "\"}}")
+            .build();
+
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+        .withStep(stepComposer.forStep(objectShapeTemplate))
+        .withStep(stepComposer.forStep(stringShapeTemplate))
+        .withStep(stepComposer.forStep(unrelatedTemplate))
+        .withStep(stepComposer.forStep(runStepSameContract))
+        .persist();
+
+    // WHEN
+    List<Step> matched =
+        stepRepository.findTemplateStepsByInjectorContractIds(
+            List.of(objectContractId, stringContractId));
+
+    // THEN
+    Set<String> matchedIds =
+        matched.stream().map(Step::getId).collect(java.util.stream.Collectors.toSet());
+    Assertions.assertEquals(
+        2, matchedIds.size(), "Only the two TEMPLATE steps on the doomed contracts match");
+    Assertions.assertTrue(
+        matchedIds.contains(objectShapeTemplate.getId()), "object-shape TEMPLATE matches");
+    Assertions.assertTrue(
+        matchedIds.contains(stringShapeTemplate.getId()), "string-shape TEMPLATE matches");
+    Assertions.assertFalse(
+        matchedIds.contains(unrelatedTemplate.getId()), "unrelated contract is excluded");
+    Assertions.assertFalse(
+        matchedIds.contains(runStepSameContract.getId()), "RUN step is preserved");
+  }
+
+  @Test
   void whenExistsInjectorContractByWorkflowIdAndInjectorContractId_thenChecksBothJsonShapes() {
     // GIVEN
     String objectContractId = "contract-object";

--- a/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
@@ -277,7 +277,7 @@ class StepRepositoryTest extends IntegrationTest {
   }
 
   @Test
-  void whenFindTemplateStepsByInjectorContractIds_thenMatchesBothShapesAndExcludesRunSteps() {
+  void given_bothStepDataShapesAcrossTenants_should_matchOnlyTenantTemplateSteps() {
     // GIVEN: two TEMPLATE steps referencing the doomed contracts (one per serialized shape), a
     // TEMPLATE step on an unrelated contract, and a RUN step on the same doomed contract.
     String objectContractId = "cascade-contract-object";

--- a/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/StepRepositoryTest.java
@@ -6,6 +6,8 @@ import io.openaev.IntegrationTest;
 import io.openaev.database.repository.StepRepository;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.*;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,7 @@ class StepRepositoryTest extends IntegrationTest {
   @Autowired private InjectComposer injectComposer;
   @Autowired private InjectExpectationComposer injectExpectationComposer;
   @Autowired private EndpointComposer endpointComposer;
+  @Autowired private TenantComposer tenantComposer;
 
   @Test
   void whenFindAllByStepTemplateIdIsNullAndWorkflowId_thenReturnsStepsTemplateForWorkflow() {
@@ -318,19 +321,44 @@ class StepRepositoryTest extends IntegrationTest {
                     + "\"}}")
             .build();
 
+    ExerciseComposer.Composer exerciseWrapper =
+        simulationComposer.forExercise(ExerciseFixture.createDefaultExercise());
     workflowComposer
         .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
-        .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+        .withSimulation(exerciseWrapper)
         .withStep(stepComposer.forStep(objectShapeTemplate))
         .withStep(stepComposer.forStep(stringShapeTemplate))
         .withStep(stepComposer.forStep(unrelatedTemplate))
         .withStep(stepComposer.forStep(runStepSameContract))
         .persist();
+    String tenantId = exerciseWrapper.get().getTenant().getId();
+
+    // AND: another tenant authored a TEMPLATE step referencing the SAME contract id - default
+    // contracts are provisioned id-for-id into every tenant, so this is a legitimate state. The
+    // sweep scoped to the deleting tenant must never touch it.
+    Tenant otherTenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("chaining-sweep-other")).persist().get();
+    Exercise otherTenantExercise = ExerciseFixture.createDefaultExercise();
+    otherTenantExercise.setTenant(otherTenant);
+    Step otherTenantTemplate =
+        Step.builder()
+            .stepAction(StepActionClass.INJECT_EXECUTION)
+            .status(StepStatus.TEMPLATE)
+            .data(
+                "{\"inject_injector_contract\": {\"injector_contract_id\": \""
+                    + objectContractId
+                    + "\"}}")
+            .build();
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withSimulation(simulationComposer.forExercise(otherTenantExercise))
+        .withStep(stepComposer.forStep(otherTenantTemplate))
+        .persist();
 
     // WHEN
     List<Step> matched =
         stepRepository.findTemplateStepsByInjectorContractIds(
-            List.of(objectContractId, stringContractId));
+            List.of(objectContractId, stringContractId), tenantId);
 
     // THEN
     Set<String> matchedIds =
@@ -345,6 +373,22 @@ class StepRepositoryTest extends IntegrationTest {
         matchedIds.contains(unrelatedTemplate.getId()), "unrelated contract is excluded");
     Assertions.assertFalse(
         matchedIds.contains(runStepSameContract.getId()), "RUN step is preserved");
+    Assertions.assertFalse(
+        matchedIds.contains(otherTenantTemplate.getId()),
+        "another tenant's TEMPLATE step on the same contract id must be out of scope");
+
+    // AND: the same sweep scoped to the other tenant only sees that tenant's own step.
+    Set<String> otherTenantMatchedIds =
+        stepRepository
+            .findTemplateStepsByInjectorContractIds(
+                List.of(objectContractId, stringContractId), otherTenant.getId())
+            .stream()
+            .map(Step::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    Assertions.assertEquals(
+        Set.of(otherTenantTemplate.getId()),
+        otherTenantMatchedIds,
+        "the sweep scoped to the other tenant matches exactly its own TEMPLATE step");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
@@ -41,6 +41,7 @@ import io.openaev.rest.document.DocumentService;
 import io.openaev.rest.domain.DomainService;
 import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.inject.service.InjectIndexCleanupService;
+import io.openaev.service.chaining.ChainingStepCleanupService;
 import io.openaev.service.organization.OrganizationService;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,7 @@ class PhishingLandingPageServiceTest {
   @Mock private InjectorRepository injectorRepository;
   @Mock private InjectorContractRepository injectorContractRepository;
   @Mock private InjectIndexCleanupService injectIndexCleanupService;
+  @Mock private ChainingStepCleanupService chainingStepCleanupService;
   @Mock private AttackPatternRepository attackPatternRepository;
   @Mock private ExpectationBuilderService expectationBuilderService;
   @Mock private PhishingContract phishingContract;
@@ -255,6 +257,9 @@ class PhishingLandingPageServiceTest {
     // -- ASSERT --
     verify(injectorContractRepository).deleteById(any(InjectorContractId.class));
     verify(landingPageRepository).deleteById("lp-1");
+    // The chaining logic maps are swept for the deleted contract, scoped to the resolved tenant.
+    verify(chainingStepCleanupService)
+        .deleteTemplateStepsByInjectorContractIds(eq(List.of("lp-1")), any());
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
@@ -107,7 +107,7 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
 
   @Test
   @DisplayName("Deleting the injector contract wipes the TEMPLATE step but keeps the RUN step")
-  void whenContractDeleted_thenTemplateStepIsWipedAndRunStepSurvives() {
+  void given_contractDeletedById_should_wipeTemplateStepAndKeepRunStep() {
     Fixture fixture = persistContractAndScenarioSteps();
 
     // Sanity: both steps exist before the deletion.
@@ -130,7 +130,7 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
 
   @Test
   @DisplayName("Deleting the payload cascades through its contract to wipe the TEMPLATE step")
-  void whenPayloadDeleted_thenTemplateStepIsWiped() {
+  void given_payloadDeleted_should_wipeTemplateStep() {
     Fixture fixture = persistContractAndScenarioSteps();
 
     Assertions.assertTrue(stepRepository.findById(fixture.templateStepId()).isPresent());
@@ -152,7 +152,7 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
 
   @Test
   @DisplayName("Deleting a custom contract through the user-facing path wipes the TEMPLATE step")
-  void whenCustomContractDeletedThroughApiPath_thenTemplateStepIsWipedAndRunStepSurvives() {
+  void given_customContractDeletedThroughUserFacingPath_should_wipeTemplateStepAndKeepRunStep() {
     Fixture fixture = persistContractAndScenarioSteps();
 
     Assertions.assertTrue(stepRepository.findById(fixture.templateStepId()).isPresent());
@@ -175,7 +175,7 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
 
   @Test
   @DisplayName("Deleting the injector sweeps the TEMPLATE steps of its orphaned contracts")
-  void whenInjectorDeleted_thenTemplateStepIsWipedAndRunStepSurvives()
+  void given_injectorDeleted_should_wipeTemplateStepAndKeepRunStep()
       throws ConnectorStatusException {
     Fixture fixture = persistContractAndScenarioSteps();
 

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
@@ -76,9 +76,13 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
     PayloadComposer.Composer payloadWrapper =
         payloadComposer.forPayload(PayloadFixture.createDefaultCommand());
     Injector payloadInjector = InjectorFixture.createDefaultPayloadInjector();
+    // Custom so the user-facing deleteInjectorContract(String) path (custom-only guard) can be
+    // exercised against the same fixture graph; the other delete paths ignore the flag.
+    InjectorContract customContract = InjectorContractFixture.createDefaultInjectorContract();
+    customContract.setCustom(true);
     InjectorContractComposer.Composer contractWrapper =
         injectorContractComposer
-            .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+            .forInjectorContract(customContract)
             .withDomain(domainComposer.forDomain(DomainFixture.getRandomDomain()))
             .withInjector(payloadInjector)
             .withPayload(payloadWrapper);
@@ -141,6 +145,29 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
     Assertions.assertTrue(
         stepRepository.findById(fixture.templateStepId()).isEmpty(),
         "TEMPLATE step must be wiped when the payload behind its contract is deleted");
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.runStepId()).isPresent(),
+        "RUN step carries immutable execution history and must survive");
+  }
+
+  @Test
+  @DisplayName("Deleting a custom contract through the user-facing path wipes the TEMPLATE step")
+  void whenCustomContractDeletedThroughApiPath_thenTemplateStepIsWipedAndRunStepSurvives() {
+    Fixture fixture = persistContractAndScenarioSteps();
+
+    Assertions.assertTrue(stepRepository.findById(fixture.templateStepId()).isPresent());
+
+    // WHEN: the user-facing delete path is used - deleteInjectorContract(String) resolves the
+    // entity, enforces the custom-only guard and tears it down through the JPA entity delete,
+    // a different code path from the by-id delete covered above.
+    injectorContractService.deleteInjectorContract(fixture.contractId());
+    entityManager.flush();
+    entityManager.clear();
+
+    // THEN
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.templateStepId()).isEmpty(),
+        "TEMPLATE step must be wiped when the contract is deleted through the user-facing path");
     Assertions.assertTrue(
         stepRepository.findById(fixture.runStepId()).isPresent(),
         "RUN step carries immutable execution history and must survive");

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
@@ -7,6 +7,8 @@ import io.openaev.database.model.*;
 import io.openaev.database.repository.StepRepository;
 import io.openaev.rest.injector_contract.InjectorContractService;
 import io.openaev.rest.payload.service.PayloadService;
+import io.openaev.service.InjectorService;
+import io.openaev.service.exception.ConnectorStatusException;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.*;
 import jakarta.persistence.EntityManager;
@@ -48,9 +50,14 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
   @Autowired private DomainComposer domainComposer;
   @Autowired private InjectorContractService injectorContractService;
   @Autowired private PayloadService payloadService;
+  @Autowired private InjectorService injectorService;
 
   private record Fixture(
-      String contractId, String payloadId, String templateStepId, String runStepId) {}
+      String contractId,
+      String payloadId,
+      String injectorId,
+      String templateStepId,
+      String runStepId) {}
 
   private Step contractStep(StepStatus status, String contractId) {
     return Step.builder()
@@ -68,11 +75,12 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
   private Fixture persistContractAndScenarioSteps() {
     PayloadComposer.Composer payloadWrapper =
         payloadComposer.forPayload(PayloadFixture.createDefaultCommand());
+    Injector payloadInjector = InjectorFixture.createDefaultPayloadInjector();
     InjectorContractComposer.Composer contractWrapper =
         injectorContractComposer
             .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
             .withDomain(domainComposer.forDomain(DomainFixture.getRandomDomain()))
-            .withInjector(InjectorFixture.createDefaultPayloadInjector())
+            .withInjector(payloadInjector)
             .withPayload(payloadWrapper);
     contractWrapper.persist();
     String contractId = contractWrapper.get().getId();
@@ -89,7 +97,8 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
 
     entityManager.flush();
     entityManager.clear();
-    return new Fixture(contractId, payloadId, templateStep.getId(), runStep.getId());
+    return new Fixture(
+        contractId, payloadId, payloadInjector.getId(), templateStep.getId(), runStep.getId());
   }
 
   @Test
@@ -132,6 +141,29 @@ class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
     Assertions.assertTrue(
         stepRepository.findById(fixture.templateStepId()).isEmpty(),
         "TEMPLATE step must be wiped when the payload behind its contract is deleted");
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.runStepId()).isPresent(),
+        "RUN step carries immutable execution history and must survive");
+  }
+
+  @Test
+  @DisplayName("Deleting the injector sweeps the TEMPLATE steps of its orphaned contracts")
+  void whenInjectorDeleted_thenTemplateStepIsWipedAndRunStepSurvives()
+      throws ConnectorStatusException {
+    Fixture fixture = persistContractAndScenarioSteps();
+
+    Assertions.assertTrue(stepRepository.findById(fixture.templateStepId()).isPresent());
+
+    // WHEN: the injector is deleted - its contracts are linked to no other injector, so they are
+    // orphaned and removed with it, and their authored TEMPLATE steps must be swept too.
+    injectorService.deleteInjector(fixture.injectorId());
+    entityManager.flush();
+    entityManager.clear();
+
+    // THEN
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.templateStepId()).isEmpty(),
+        "TEMPLATE step must be wiped when the injector behind its contract is deleted");
     Assertions.assertTrue(
         stepRepository.findById(fixture.runStepId()).isPresent(),
         "RUN step carries immutable execution history and must survive");

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCascadeCleanupIntegrationTest.java
@@ -1,0 +1,139 @@
+package io.openaev.service.chaining;
+
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.*;
+import io.openaev.database.repository.StepRepository;
+import io.openaev.rest.injector_contract.InjectorContractService;
+import io.openaev.rest.payload.service.PayloadService;
+import io.openaev.utils.fixtures.*;
+import io.openaev.utils.fixtures.composers.*;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * End-to-end reproduction of the "ghost chaining step" bug: deleting a threat-arsenal payload (or
+ * its injector contract) must wipe the authored TEMPLATE steps that reference it from every
+ * scenario logic map, while RUN steps (execution history) survive.
+ *
+ * <p>A chaining step freezes its injector contract as a JSON snapshot inside {@code step_data} with
+ * no foreign key, so the database {@code ON DELETE CASCADE} that removes regular injects never
+ * touched these steps - they lingered as un-editable, un-runnable ghosts. {@link
+ * ChainingStepCleanupService} is the application-level compensation wired into every contract /
+ * payload delete path.
+ *
+ * <p>The fixture graph is flushed and detached ({@code em.clear()}) before each delete so the
+ * delete runs against a clean persistence context, exactly like a real HTTP request - otherwise the
+ * in-session contract-&gt;payload graph fights the delete cascade at flush time.
+ */
+@SpringBootTest
+@TestInstance(PER_CLASS)
+@Transactional
+class ChainingStepCascadeCleanupIntegrationTest extends IntegrationTest {
+
+  @Autowired private EntityManager entityManager;
+  @Autowired private StepRepository stepRepository;
+  @Autowired private StepComposer stepComposer;
+  @Autowired private WorkflowComposer workflowComposer;
+  @Autowired private ScenarioComposer scenarioComposer;
+  @Autowired private InjectorContractComposer injectorContractComposer;
+  @Autowired private PayloadComposer payloadComposer;
+  @Autowired private DomainComposer domainComposer;
+  @Autowired private InjectorContractService injectorContractService;
+  @Autowired private PayloadService payloadService;
+
+  private record Fixture(
+      String contractId, String payloadId, String templateStepId, String runStepId) {}
+
+  private Step contractStep(StepStatus status, String contractId) {
+    return Step.builder()
+        .stepAction(StepActionClass.INJECT_EXECUTION)
+        .status(status)
+        .data("{\"inject_injector_contract\": {\"injector_contract_id\": \"" + contractId + "\"}}")
+        .build();
+  }
+
+  /**
+   * Persists a payload-backed custom injector contract and a scenario workflow that references it
+   * through one TEMPLATE step (authored node) and one RUN step (execution history), then detaches
+   * everything so the subsequent delete runs against a clean session.
+   */
+  private Fixture persistContractAndScenarioSteps() {
+    PayloadComposer.Composer payloadWrapper =
+        payloadComposer.forPayload(PayloadFixture.createDefaultCommand());
+    InjectorContractComposer.Composer contractWrapper =
+        injectorContractComposer
+            .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+            .withDomain(domainComposer.forDomain(DomainFixture.getRandomDomain()))
+            .withInjector(InjectorFixture.createDefaultPayloadInjector())
+            .withPayload(payloadWrapper);
+    contractWrapper.persist();
+    String contractId = contractWrapper.get().getId();
+    String payloadId = payloadWrapper.get().getId();
+
+    Step templateStep = contractStep(StepStatus.TEMPLATE, contractId);
+    Step runStep = contractStep(StepStatus.RUN, contractId);
+    workflowComposer
+        .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+        .withScenario(scenarioComposer.forScenario(ScenarioFixture.createDefaultCrisisScenario()))
+        .withStep(stepComposer.forStep(templateStep))
+        .withStep(stepComposer.forStep(runStep))
+        .persist();
+
+    entityManager.flush();
+    entityManager.clear();
+    return new Fixture(contractId, payloadId, templateStep.getId(), runStep.getId());
+  }
+
+  @Test
+  @DisplayName("Deleting the injector contract wipes the TEMPLATE step but keeps the RUN step")
+  void whenContractDeleted_thenTemplateStepIsWipedAndRunStepSurvives() {
+    Fixture fixture = persistContractAndScenarioSteps();
+
+    // Sanity: both steps exist before the deletion.
+    Assertions.assertTrue(stepRepository.findById(fixture.templateStepId()).isPresent());
+    Assertions.assertTrue(stepRepository.findById(fixture.runStepId()).isPresent());
+
+    // WHEN: the contract is removed from the threat arsenal.
+    injectorContractService.deleteInjectorContractById(fixture.contractId());
+    entityManager.flush();
+    entityManager.clear();
+
+    // THEN: the authored TEMPLATE node is gone, the execution-history RUN step survives.
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.templateStepId()).isEmpty(),
+        "TEMPLATE step referencing the deleted contract must be wiped");
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.runStepId()).isPresent(),
+        "RUN step carries immutable execution history and must survive");
+  }
+
+  @Test
+  @DisplayName("Deleting the payload cascades through its contract to wipe the TEMPLATE step")
+  void whenPayloadDeleted_thenTemplateStepIsWiped() {
+    Fixture fixture = persistContractAndScenarioSteps();
+
+    Assertions.assertTrue(stepRepository.findById(fixture.templateStepId()).isPresent());
+
+    // WHEN: the underlying payload is deleted - the contract id is resolved BEFORE the DB cascade
+    // removes the contract row, then the chaining steps are swept.
+    payloadService.delete(fixture.payloadId());
+    entityManager.flush();
+    entityManager.clear();
+
+    // THEN
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.templateStepId()).isEmpty(),
+        "TEMPLATE step must be wiped when the payload behind its contract is deleted");
+    Assertions.assertTrue(
+        stepRepository.findById(fixture.runStepId()).isPresent(),
+        "RUN step carries immutable execution history and must survive");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCleanupServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCleanupServiceTest.java
@@ -19,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ChainingStepCleanupServiceTest {
 
+  private static final String TENANT_ID = "tenant-1";
+
   @Mock private StepRepository stepRepository;
   @Mock private ConditionService conditionService;
   @InjectMocks private ChainingStepCleanupService service;
@@ -35,26 +37,37 @@ class ChainingStepCleanupServiceTest {
   @Test
   @DisplayName("null contract ids is a no-op that never touches the repositories")
   void nullInput_isNoOp() {
-    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(null));
+    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(null, TENANT_ID));
     verifyNoInteractions(stepRepository, conditionService);
   }
 
   @Test
   @DisplayName("empty contract ids is a no-op that never touches the repositories")
   void emptyInput_isNoOp() {
-    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(List.of()));
+    Assertions.assertEquals(
+        0, service.deleteTemplateStepsByInjectorContractIds(List.of(), TENANT_ID));
+    verifyNoInteractions(stepRepository, conditionService);
+  }
+
+  @Test
+  @DisplayName("a null tenant fails fast instead of silently sweeping nothing")
+  void nullTenant_failsFast() {
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> service.deleteTemplateStepsByInjectorContractIds(List.of("c1"), null));
     verifyNoInteractions(stepRepository, conditionService);
   }
 
   @Test
   @DisplayName("no matching steps returns 0 and deletes nothing")
   void noMatches_returnsZero() {
-    when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1")))
+    when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1"), TENANT_ID))
         .thenReturn(List.of());
 
-    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(List.of("c1")));
+    Assertions.assertEquals(
+        0, service.deleteTemplateStepsByInjectorContractIds(List.of("c1"), TENANT_ID));
 
-    verify(stepRepository).findTemplateStepsByInjectorContractIds(List.of("c1"));
+    verify(stepRepository).findTemplateStepsByInjectorContractIds(List.of("c1"), TENANT_ID);
     verify(conditionService, never()).deleteAllConditionsByStepId(anyString());
     verify(stepRepository, never()).delete(any());
   }
@@ -64,10 +77,10 @@ class ChainingStepCleanupServiceTest {
   void matches_pruneConditionsThenDeleteSteps() {
     Step s1 = templateStep("step-1");
     Step s2 = templateStep("step-2");
-    when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1", "c2")))
+    when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1", "c2"), TENANT_ID))
         .thenReturn(List.of(s1, s2));
 
-    int removed = service.deleteTemplateStepsByInjectorContractIds(List.of("c1", "c2"));
+    int removed = service.deleteTemplateStepsByInjectorContractIds(List.of("c1", "c2"), TENANT_ID);
 
     Assertions.assertEquals(2, removed);
     // The conditions (graph edges) must be unlinked/pruned BEFORE the owning step is deleted, per

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCleanupServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCleanupServiceTest.java
@@ -1,0 +1,81 @@
+package io.openaev.service.chaining;
+
+import static org.mockito.Mockito.*;
+
+import io.openaev.database.model.Step;
+import io.openaev.database.model.StepActionClass;
+import io.openaev.database.model.StepStatus;
+import io.openaev.database.repository.StepRepository;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChainingStepCleanupServiceTest {
+
+  @Mock private StepRepository stepRepository;
+  @Mock private ConditionService conditionService;
+  @InjectMocks private ChainingStepCleanupService service;
+
+  private Step templateStep(String id) {
+    return Step.builder()
+        .id(id)
+        .stepAction(StepActionClass.INJECT_EXECUTION)
+        .status(StepStatus.TEMPLATE)
+        .data("{}")
+        .build();
+  }
+
+  @Test
+  @DisplayName("null contract ids is a no-op that never touches the repositories")
+  void nullInput_isNoOp() {
+    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(null));
+    verifyNoInteractions(stepRepository, conditionService);
+  }
+
+  @Test
+  @DisplayName("empty contract ids is a no-op that never touches the repositories")
+  void emptyInput_isNoOp() {
+    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(List.of()));
+    verifyNoInteractions(stepRepository, conditionService);
+  }
+
+  @Test
+  @DisplayName("no matching steps returns 0 and deletes nothing")
+  void noMatches_returnsZero() {
+    when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1")))
+        .thenReturn(List.of());
+
+    Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(List.of("c1")));
+
+    verify(stepRepository).findTemplateStepsByInjectorContractIds(List.of("c1"));
+    verify(conditionService, never()).deleteAllConditionsByStepId(anyString());
+    verify(stepRepository, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("each matched step has its conditions pruned before the step row is removed")
+  void matches_pruneConditionsThenDeleteSteps() {
+    Step s1 = templateStep("step-1");
+    Step s2 = templateStep("step-2");
+    when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1", "c2")))
+        .thenReturn(List.of(s1, s2));
+
+    int removed = service.deleteTemplateStepsByInjectorContractIds(List.of("c1", "c2"));
+
+    Assertions.assertEquals(2, removed);
+    // The conditions (graph edges) must be unlinked/pruned BEFORE the owning step is deleted, per
+    // step - the same teardown order as a manual logic-map delete.
+    InOrder inOrder = inOrder(conditionService, stepRepository);
+    inOrder.verify(conditionService).deleteAllConditionsByStepId("step-1");
+    inOrder.verify(stepRepository).delete(s1);
+    inOrder.verify(conditionService).deleteAllConditionsByStepId("step-2");
+    inOrder.verify(stepRepository).delete(s2);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCleanupServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ChainingStepCleanupServiceTest.java
@@ -36,14 +36,14 @@ class ChainingStepCleanupServiceTest {
 
   @Test
   @DisplayName("null contract ids is a no-op that never touches the repositories")
-  void nullInput_isNoOp() {
+  void given_nullContractIds_should_noOp() {
     Assertions.assertEquals(0, service.deleteTemplateStepsByInjectorContractIds(null, TENANT_ID));
     verifyNoInteractions(stepRepository, conditionService);
   }
 
   @Test
   @DisplayName("empty contract ids is a no-op that never touches the repositories")
-  void emptyInput_isNoOp() {
+  void given_emptyContractIds_should_noOp() {
     Assertions.assertEquals(
         0, service.deleteTemplateStepsByInjectorContractIds(List.of(), TENANT_ID));
     verifyNoInteractions(stepRepository, conditionService);
@@ -51,7 +51,7 @@ class ChainingStepCleanupServiceTest {
 
   @Test
   @DisplayName("a null tenant fails fast instead of silently sweeping nothing")
-  void nullTenant_failsFast() {
+  void given_nullTenant_should_failFast() {
     Assertions.assertThrows(
         NullPointerException.class,
         () -> service.deleteTemplateStepsByInjectorContractIds(List.of("c1"), null));
@@ -60,7 +60,7 @@ class ChainingStepCleanupServiceTest {
 
   @Test
   @DisplayName("no matching steps returns 0 and deletes nothing")
-  void noMatches_returnsZero() {
+  void given_noMatchingSteps_should_returnZero() {
     when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1"), TENANT_ID))
         .thenReturn(List.of());
 
@@ -74,7 +74,7 @@ class ChainingStepCleanupServiceTest {
 
   @Test
   @DisplayName("each matched step has its conditions pruned before the step row is removed")
-  void matches_pruneConditionsThenDeleteSteps() {
+  void given_matchingSteps_should_pruneConditionsThenDeleteSteps() {
     Step s1 = templateStep("step-1");
     Step s2 = templateStep("step-2");
     when(stepRepository.findTemplateStepsByInjectorContractIds(List.of("c1", "c2"), TENANT_ID))

--- a/openaev-model/src/main/java/io/openaev/database/raw/RawContractTenant.java
+++ b/openaev-model/src/main/java/io/openaev/database/raw/RawContractTenant.java
@@ -1,10 +1,12 @@
 package io.openaev.database.raw;
 
 /**
- * (injector_contract_id, tenant_id) pair of an injector contract row. Used by cross-tenant cascade
- * inventories: default contracts are provisioned id-for-id into every tenant while keeping the
- * payload FK of the original row, so a payload deletion cascades contract rows across tenants and
- * each affected tenant must be swept separately.
+ * (injector_contract_id, tenant_id) pair of an injector contract row. A forward-compatible
+ * inventory shape for cascade cleanups that must sweep exactly the rows a database cascade deletes,
+ * each pair's tenant swept with its own tenant-scoped call. Today {@code
+ * unique_injector_contract_payload} (V4_98) guarantees a payload backs at most one contract row
+ * platform-wide, so payload-driven inventories hold at most one pair; the pair shape keeps those
+ * paths correct if that 1:1 constraint is ever relaxed.
  */
 public interface RawContractTenant {
 

--- a/openaev-model/src/main/java/io/openaev/database/raw/RawContractTenant.java
+++ b/openaev-model/src/main/java/io/openaev/database/raw/RawContractTenant.java
@@ -1,0 +1,14 @@
+package io.openaev.database.raw;
+
+/**
+ * (injector_contract_id, tenant_id) pair of an injector contract row. Used by cross-tenant cascade
+ * inventories: default contracts are provisioned id-for-id into every tenant while keeping the
+ * payload FK of the original row, so a payload deletion cascades contract rows across tenants and
+ * each affected tenant must be swept separately.
+ */
+public interface RawContractTenant {
+
+  String getInjector_contract_id();
+
+  String getTenant_id();
+}

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -2,6 +2,7 @@ package io.openaev.database.repository;
 
 import io.openaev.database.model.*;
 import io.openaev.database.model.attackpath.projection.AttackPathInjectorPatternRow;
+import io.openaev.database.raw.RawContractTenant;
 import io.openaev.database.raw.RawInjectorsContracts;
 import io.openaev.database.raw.RawPayloadRelatedIds;
 import jakarta.validation.constraints.NotNull;
@@ -191,27 +192,29 @@ public interface InjectorContractRepository
   Optional<RawPayloadRelatedIds> findRelatedIdsByPayloadId(@Param("payloadId") String payloadId);
 
   /**
-   * Returns the injector contract ids of the given tenant backed by the given payload. Deleting a
-   * payload cascades to its contract at the database level ({@code injector_contract_payload ... ON
-   * DELETE CASCADE}), so the payload-delete path must resolve these ids BEFORE the delete to
-   * cascade-clean the chaining steps that reference the doomed contract (the step -> contract link
-   * lives only inside {@code step_data}, with no FK to cascade on).
+   * Returns the (injector_contract_id, tenant_id) pair of EVERY contract row backed by the given
+   * payload, across all tenants. Deleting a payload cascades to its contracts at the database level
+   * ({@code injector_contract_payload ... ON DELETE CASCADE}), so the payload-delete path must
+   * resolve these pairs BEFORE the delete to cascade-clean the chaining steps that reference the
+   * doomed contracts (the step -> contract link lives only inside {@code step_data}, with no FK to
+   * cascade on).
    *
-   * <p>The explicit tenant clause is required because native SQL bypasses the Hibernate {@code
-   * tenantFilter} on this table: default contracts provisioned per tenant all point at the same
-   * payload row, so an unscoped lookup would return one contract id per tenant instead of only the
-   * deleting tenant's contract.
+   * <p>Deliberately NOT tenant-scoped, unlike the other native queries here: the sweep set must be
+   * exactly what the database cascade deletes, whatever tenant it lives in. Today the schema
+   * guarantees at most one row - {@code unique_injector_contract_payload} (V4_98) is a
+   * single-column unique on the payload FK, so a payload backs one contract platform-wide - but
+   * returning the (contract, tenant) pair keeps the delete path correct even if that 1:1 constraint
+   * is ever relaxed. The caller sweeps each returned tenant separately; the sweep itself stays
+   * strictly tenant-scoped per pair.
    *
-   * @param payloadId the payload whose contract ids are resolved
-   * @param tenantId the tenant whose contracts are considered (the payload's own tenant)
-   * @return the injector contract ids (usually one), empty when the payload backs no contract
+   * @param payloadId the payload whose contract rows are enumerated
+   * @return one (contract id, tenant id) pair per contract row referencing the payload
    */
   @Query(
       value =
-          "SELECT ic.injector_contract_id FROM injectors_contracts ic WHERE ic.injector_contract_payload = :payloadId AND ic.tenant_id = :tenantId",
+          "SELECT ic.injector_contract_id AS injector_contract_id, ic.tenant_id AS tenant_id FROM injectors_contracts ic WHERE ic.injector_contract_payload = :payloadId",
       nativeQuery = true)
-  List<String> findContractIdsByPayloadId(
-      @Param("payloadId") String payloadId, @Param("tenantId") String tenantId);
+  List<RawContractTenant> findContractTenantPairsByPayloadId(@Param("payloadId") String payloadId);
 
   @Query(
       "SELECT CASE WHEN COUNT(ic) > 0 THEN true ELSE false END "

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -191,20 +191,27 @@ public interface InjectorContractRepository
   Optional<RawPayloadRelatedIds> findRelatedIdsByPayloadId(@Param("payloadId") String payloadId);
 
   /**
-   * Returns the injector contract ids backed by the given payload. Deleting a payload cascades to
-   * its contract at the database level ({@code injector_contract_payload ... ON DELETE CASCADE}),
-   * so the payload-delete path must resolve these ids BEFORE the delete to cascade-clean the
-   * chaining steps that reference the doomed contract (the step -> contract link lives only inside
-   * {@code step_data}, with no FK to cascade on).
+   * Returns the injector contract ids of the given tenant backed by the given payload. Deleting a
+   * payload cascades to its contract at the database level ({@code injector_contract_payload ... ON
+   * DELETE CASCADE}), so the payload-delete path must resolve these ids BEFORE the delete to
+   * cascade-clean the chaining steps that reference the doomed contract (the step -> contract link
+   * lives only inside {@code step_data}, with no FK to cascade on).
+   *
+   * <p>The explicit tenant clause is required because native SQL bypasses the Hibernate {@code
+   * tenantFilter} on this table: default contracts provisioned per tenant all point at the same
+   * payload row, so an unscoped lookup would return one contract id per tenant instead of only the
+   * deleting tenant's contract.
    *
    * @param payloadId the payload whose contract ids are resolved
+   * @param tenantId the tenant whose contracts are considered (the payload's own tenant)
    * @return the injector contract ids (usually one), empty when the payload backs no contract
    */
   @Query(
       value =
-          "SELECT ic.injector_contract_id FROM injectors_contracts ic WHERE ic.injector_contract_payload = :payloadId",
+          "SELECT ic.injector_contract_id FROM injectors_contracts ic WHERE ic.injector_contract_payload = :payloadId AND ic.tenant_id = :tenantId",
       nativeQuery = true)
-  List<String> findContractIdsByPayloadId(@Param("payloadId") String payloadId);
+  List<String> findContractIdsByPayloadId(
+      @Param("payloadId") String payloadId, @Param("tenantId") String tenantId);
 
   @Query(
       "SELECT CASE WHEN COUNT(ic) > 0 THEN true ELSE false END "

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -190,6 +190,22 @@ public interface InjectorContractRepository
       nativeQuery = true)
   Optional<RawPayloadRelatedIds> findRelatedIdsByPayloadId(@Param("payloadId") String payloadId);
 
+  /**
+   * Returns the injector contract ids backed by the given payload. Deleting a payload cascades to
+   * its contract at the database level ({@code injector_contract_payload ... ON DELETE CASCADE}),
+   * so the payload-delete path must resolve these ids BEFORE the delete to cascade-clean the
+   * chaining steps that reference the doomed contract (the step -> contract link lives only inside
+   * {@code step_data}, with no FK to cascade on).
+   *
+   * @param payloadId the payload whose contract ids are resolved
+   * @return the injector contract ids (usually one), empty when the payload backs no contract
+   */
+  @Query(
+      value =
+          "SELECT ic.injector_contract_id FROM injectors_contracts ic WHERE ic.injector_contract_payload = :payloadId",
+      nativeQuery = true)
+  List<String> findContractIdsByPayloadId(@Param("payloadId") String payloadId);
+
   @Query(
       "SELECT CASE WHEN COUNT(ic) > 0 THEN true ELSE false END "
           + "FROM InjectorContract ic WHERE ic.compositeId.id = :id AND ic.payload IS NOT NULL")

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -288,8 +288,8 @@ public interface StepRepository extends JpaRepository<Step, String> {
       @Param("injectorContractId") String injectorContractId);
 
   /**
-   * Returns the TEMPLATE steps (authored logic-map nodes) whose frozen {@code step_data} references
-   * any of the given injector contract ids, across every workflow.
+   * Returns the TEMPLATE steps (authored logic-map nodes) of the given tenant whose frozen {@code
+   * step_data} references any of the given injector contract ids.
    *
    * <p>Unlike regular injects, a chaining step has NO foreign key to its injector contract - the
    * contract lives only as a JSON snapshot inside {@code step_data}, so there is nothing for the
@@ -298,22 +298,35 @@ public interface StepRepository extends JpaRepository<Step, String> {
    * Both serialized shapes are matched: the full contract object (UI steps, {@code
    * inject_injector_contract.injector_contract_id}) and the legacy plain-string contract id.
    *
+   * <p>Tenant scoping is mandatory here: {@code InjectorContract} has a composite {@code (id,
+   * tenant_id)} key and the default contracts are provisioned id-for-id into every tenant, so the
+   * same contract id string legitimately exists in several tenants at once. Native SQL bypasses the
+   * Hibernate {@code tenantFilter}, and the {@code steps} table has no {@code tenant_id} of its
+   * own, so the tenant is resolved through the owning workflow's scenario or simulation ({@code
+   * COALESCE} - a workflow is attached to exactly one of the two). A workflow attached to neither
+   * is unreachable from any tenant UI and is deliberately left alone rather than risk sweeping
+   * another tenant's graph.
+   *
    * <p>Scoped to TEMPLATE steps on purpose: RUN steps carry immutable execution history and must
    * survive their contract's deletion, mirroring the TEMPLATE-only rule of {@code
-   * WorkflowScopeRuleCascadeListener}. The canonical {@code step_status = 'TEMPLATE'} check (the
-   * {@code step_status} named enum is cast to text for native SQL) is the primary guard; the
-   * redundant {@code step_template_id IS NULL} belt guarantees an orphaned run artifact with a null
-   * template link can never be mistaken for an authored node.
+   * WorkflowScopeRuleCascadeListener}. The canonical {@code step_status = 'TEMPLATE'} check is the
+   * primary guard; the redundant {@code step_template_id IS NULL} belt guarantees an orphaned run
+   * artifact with a null template link can never be mistaken for an authored node.
    *
    * @param injectorContractIds the deleted injector contract ids to look for
+   * @param tenantId the tenant whose logic maps are swept (the tenant the contract was deleted in)
    * @return the matching TEMPLATE steps (empty when the input is empty)
    */
   @Query(
       value =
           """
-        SELECT * FROM steps s
-        WHERE s.step_status::text = 'TEMPLATE'
+        SELECT s.* FROM steps s
+        JOIN workflows w ON w.workflow_id = s.step_workflow_id
+        LEFT JOIN scenarios sc ON sc.scenario_id = w.workflow_scenario_id
+        LEFT JOIN exercises e ON e.exercise_id = w.workflow_simulation_id
+        WHERE s.step_status = 'TEMPLATE'
           AND s.step_template_id IS NULL
+          AND COALESCE(sc.tenant_id, e.tenant_id) = :tenantId
           AND (
             (jsonb_typeof(s.step_data -> 'inject_injector_contract') = 'object'
               AND s.step_data -> 'inject_injector_contract' ->> 'injector_contract_id' IN (:injectorContractIds))
@@ -324,5 +337,6 @@ public interface StepRepository extends JpaRepository<Step, String> {
         """,
       nativeQuery = true)
   List<Step> findTemplateStepsByInjectorContractIds(
-      @Param("injectorContractIds") Collection<String> injectorContractIds);
+      @Param("injectorContractIds") Collection<String> injectorContractIds,
+      @Param("tenantId") String tenantId);
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/StepRepository.java
@@ -286,4 +286,43 @@ public interface StepRepository extends JpaRepository<Step, String> {
   boolean existsInjectorContractByWorkflowIdAndInjectorContractId(
       @Param("workflowId") String workflowId,
       @Param("injectorContractId") String injectorContractId);
+
+  /**
+   * Returns the TEMPLATE steps (authored logic-map nodes) whose frozen {@code step_data} references
+   * any of the given injector contract ids, across every workflow.
+   *
+   * <p>Unlike regular injects, a chaining step has NO foreign key to its injector contract - the
+   * contract lives only as a JSON snapshot inside {@code step_data}, so there is nothing for the
+   * database {@code ON DELETE CASCADE} to act on. This query is the JSONB counterpart used to
+   * cascade-clean those steps when their contract / payload is deleted from the threat arsenal.
+   * Both serialized shapes are matched: the full contract object (UI steps, {@code
+   * inject_injector_contract.injector_contract_id}) and the legacy plain-string contract id.
+   *
+   * <p>Scoped to TEMPLATE steps on purpose: RUN steps carry immutable execution history and must
+   * survive their contract's deletion, mirroring the TEMPLATE-only rule of {@code
+   * WorkflowScopeRuleCascadeListener}. The canonical {@code step_status = 'TEMPLATE'} check (the
+   * {@code step_status} named enum is cast to text for native SQL) is the primary guard; the
+   * redundant {@code step_template_id IS NULL} belt guarantees an orphaned run artifact with a null
+   * template link can never be mistaken for an authored node.
+   *
+   * @param injectorContractIds the deleted injector contract ids to look for
+   * @return the matching TEMPLATE steps (empty when the input is empty)
+   */
+  @Query(
+      value =
+          """
+        SELECT * FROM steps s
+        WHERE s.step_status::text = 'TEMPLATE'
+          AND s.step_template_id IS NULL
+          AND (
+            (jsonb_typeof(s.step_data -> 'inject_injector_contract') = 'object'
+              AND s.step_data -> 'inject_injector_contract' ->> 'injector_contract_id' IN (:injectorContractIds))
+            OR
+            (jsonb_typeof(s.step_data -> 'inject_injector_contract') = 'string'
+              AND s.step_data ->> 'inject_injector_contract' IN (:injectorContractIds))
+          )
+        """,
+      nativeQuery = true)
+  List<Step> findTemplateStepsByInjectorContractIds(
+      @Param("injectorContractIds") Collection<String> injectorContractIds);
 }


### PR DESCRIPTION
## Proposed changes

Fixes #7412 - deleting a payload from the Threat Arsenal (or an injector contract directly) left the chaining steps referencing it in every scenario logic map: still displayed with their frozen labels, edit drawer 404ing on the live-contract fetch (only the initial source assets could render), and un-runnable at execution time.

### Root cause

A regular inject references its injector contract through the `inject_injector_contract` foreign key, declared `ON DELETE CASCADE`, so the inject row dies with the contract (and transitively with the payload) at the database level.

A chaining step has no such link: the contract is frozen as a JSON snapshot inside the `step_data` JSONB column (either an object carrying `injector_contract_id`, or a plain contract id string), with no foreign key for the database cascade to act on. Nothing removed the authored TEMPLATE steps when their contract disappeared.

### Fix

Application-level cascade, mirroring `InjectIndexCleanupService` (which already compensates the search index on these same delete paths):

- New `ChainingStepCleanupService.deleteTemplateStepsByInjectorContractIds(ids, tenantId)`: finds every TEMPLATE step of the deleting tenant whose frozen `step_data` references a deleted contract id, prunes its conditions (same teardown as a manual logic-map delete: `ConditionService.deleteAllConditionsByStepId` then the step), and deletes it. RUN steps are preserved - they carry immutable execution history, following the TEMPLATE-only rule of `WorkflowScopeRuleCascadeListener`.
- `StepRepository.findTemplateStepsByInjectorContractIds`: native JSONB query matching both serialized shapes (object with `injector_contract_id`, plain string), restricted to `step_status = 'TEMPLATE'` and `step_template_id IS NULL`. The sweep is tenant-scoped through the owning workflow's scenario or simulation (`COALESCE(sc.tenant_id, e.tenant_id) = :tenantId`): `InjectorContract` has a composite `(id, tenant_id)` key and the default contracts are provisioned id-for-id into every tenant, so the same contract id exists in several tenants at once and native SQL bypasses the Hibernate `tenantFilter`.
- `InjectorContractRepository.findContractTenantPairsByPayloadId`: inventories the (contract id, tenant id) pairs of a payload BEFORE the DB cascade removes the contract rows, exposed to the payload-delete path through the owning `InjectorContractService` per the backend layering rule (grouped by tenant). Deliberately unscoped so the sweep set is exactly what the cascade deletes: today `unique_injector_contract_payload` guarantees a payload backs one contract platform-wide, and the pair shape keeps the path correct if that 1:1 constraint is ever relaxed. Each sweep call stays tenant-scoped.
- Wired into every path that removes a contract or payload, each passing the deleting tenant: `PayloadService.delete`, `InjectorContractService.deleteInjectorContract` / `deleteInjectorContractById`, `PhishingLandingPageService.deleteInjectorContract`, and the three `InjectorService` paths that delete contracts (`deleteInjector` orphaned contracts, external and built-in registration refreshes retiring catalog contracts). These delete paths are transactional (`rollbackFor = Exception.class`), so the entity delete and the step sweep commit or roll back together. The tenant offboarding path (`deleteDependencyForTenant`) is deliberately not wired: the tenant's workflows and steps die wholesale with their scenarios and simulations through the DB cascade chain.

### Tests

- `ChainingStepCascadeCleanupIntegrationTest` (new, end-to-end): payload-backed custom contract referenced by one TEMPLATE and one RUN step; deleting the contract by id, through the user-facing custom-contract path, through the payload, or with the whole injector wipes the TEMPLATE step and keeps the RUN step. 4/4 green.
- `StepRepositoryTest`: new test for the JSONB query - matches both serialized shapes, excludes unrelated contracts and RUN steps, and a cross-tenant regression: the same contract id referenced by TEMPLATE steps in two tenants is only swept in the deleting tenant.
- `ChainingStepCleanupServiceTest` (new, unit): no-op on null/empty input, null-tenant fail-fast, zero matches, conditions pruned before each step delete. 5/5 green.
- spotless applied, openaev-model + openaev-api compile.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
