### PR TITLE
fix(api): stop connection leaks and OpenCTI coverage spam during AI arsenal writes (#7415)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionCreateInput.java
+++ b/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionCreateInput.java
@@ -14,6 +14,7 @@ import io.openaev.database.model.SecurityPlatform;
 import io.openaev.rest.payload.form.DetectionRemediationInput;
 import io.openaev.rest.payload.output_parser.OutputParserInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -56,7 +57,7 @@ public record ThreatArsenalActionCreateInput(
     @JsonProperty("action_detection_remediations")
         @Schema(description = "List of detection remediation gaps for collectors")
         List<DetectionRemediationInput> detectionRemediations,
-    @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
+    @Valid @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
         Set<OutputParserInput> outputParsers,
     @NotNull(message = MANDATORY_MESSAGE)
         @JsonProperty("action_domains")

--- a/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionUpdateInput.java
+++ b/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionUpdateInput.java
@@ -12,6 +12,7 @@ import io.openaev.database.model.SecurityPlatform;
 import io.openaev.rest.payload.form.DetectionRemediationInput;
 import io.openaev.rest.payload.output_parser.OutputParserInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -48,7 +49,7 @@ public record ThreatArsenalActionUpdateInput(
     @JsonProperty("action_detection_remediations")
         @Schema(description = "List of detection remediation gaps for collectors")
         List<DetectionRemediationInput> detectionRemediations,
-    @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
+    @Valid @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
         Set<OutputParserInput> outputParsers,
     @NotNull(message = MANDATORY_MESSAGE)
         @JsonProperty("action_domains")

--- a/openaev-api/src/main/java/io/openaev/config/CachingConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/CachingConfig.java
@@ -26,7 +26,8 @@ public class CachingConfig {
      * everytime helps for the RBAC
      */
     CaffeineCacheManager cacheManager =
-        new CaffeineCacheManager("license", "global", "adminUsers", "tenantMembership");
+        new CaffeineCacheManager(
+            "license", "global", "adminUsers", "tenantMembership", "userTenantIds");
 
     cacheManager.setCaffeine(
         Caffeine.newBuilder().expireAfterWrite(Duration.ofDays(1)).maximumSize(100));
@@ -34,6 +35,11 @@ public class CachingConfig {
     // Tenant membership cache: short TTL, higher capacity (keyed by userId:tenantId)
     cacheManager.registerCustomCache(
         "tenantMembership",
+        Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(5)).maximumSize(10_000).build());
+
+    // User tenant-id list: same TTL/capacity as membership (keyed by userId)
+    cacheManager.registerCustomCache(
+        "userTenantIds",
         Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(5)).maximumSize(10_000).build());
 
     return cacheManager;

--- a/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
+++ b/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
@@ -1,9 +1,9 @@
 package io.openaev.config;
 
+import io.openaev.config.cache.TenantMembershipCacheManager;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
-import io.openaev.service.tenants.TenantService;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -37,7 +37,7 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
   static final String TENANT_IDS_HEADER = "X-Tenant-Ids";
 
   private final TenantScopeResolver scopeResolver;
-  private final TenantService tenantService;
+  private final TenantMembershipCacheManager membershipCache;
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
@@ -52,9 +52,8 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       WebDataBinderFactory binderFactory) {
     Set<String> selector = extractSelector(webRequest);
     Set<String> authorized =
-        tenantService.findTenantsByUserId(SessionHelper.currentUser().getId()).stream()
-            .map(Tenant::getId)
-            .collect(Collectors.toSet());
+        new LinkedHashSet<>(
+            membershipCache.findTenantIdsByUserId(SessionHelper.currentUser().getId()));
     if (selector.isEmpty() && parameter.hasParameterAnnotation(RequireTenantSelector.class)) {
       selector = fallbackSelector(authorized);
     }

--- a/openaev-api/src/main/java/io/openaev/config/cache/TenantMembershipCacheManager.java
+++ b/openaev-api/src/main/java/io/openaev/config/cache/TenantMembershipCacheManager.java
@@ -4,6 +4,8 @@ import io.openaev.annotation.AllowRawJdbc;
 import io.openaev.database.repository.TenantRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
@@ -24,23 +26,34 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @AllowRawJdbc(
     reason =
-        "reads only users_tenants.tenant_id for an explicit user_id bind so TxCtx argument"
-            + " resolution can return ids without a Hibernate session; OSIV would otherwise hold"
-            + " the pool connection for the whole HTTP request. No other tenant rows are touched.")
+        "reads users_tenants.tenant_id joined to tenants.tenant_deleted_at for an explicit user_id"
+            + " bind so TxCtx argument resolution can return ids without a Hibernate session; OSIV"
+            + " would otherwise hold the pool connection for the whole HTTP request. Same"
+            + " soft-delete predicate as TenantRepository.findTenantsByUserId; no tenant row"
+            + " payloads are returned.")
 public class TenantMembershipCacheManager {
 
+  static final String TENANT_MEMBERSHIP_CACHE = "tenantMembership";
+  static final String USER_TENANT_IDS_CACHE = "userTenantIds";
+
+  /** Must stay aligned with {@code TenantRepository.findTenantsByUserId} (active tenants only). */
   static final String USER_TENANT_IDS_SQL =
-      "select ut.tenant_id from users_tenants ut where ut.user_id = ?";
+      "select ut.tenant_id from users_tenants ut"
+          + " join tenants t on t.tenant_id = ut.tenant_id"
+          + " where ut.user_id = ?"
+          + " and t.tenant_deleted_at is null"
+          + " order by t.tenant_name";
 
   private final TenantRepository tenantRepository;
   private final JdbcTemplate jdbcTemplate;
+  private final CacheManager cacheManager;
 
   /**
    * Returns whether the given user belongs to the given tenant (cached). The cache is explicitly
    * evicted when users are added to or removed from tenants, so membership changes take effect
    * immediately.
    */
-  @Cacheable(value = "tenantMembership", key = "#userId + ':' + #tenantId")
+  @Cacheable(value = TENANT_MEMBERSHIP_CACHE, key = "#userId + ':' + #tenantId")
   public boolean existsByUserIdAndTenantId(String userId, String tenantId) {
     return tenantRepository.existsByUserIdAndTenantId(userId, tenantId);
   }
@@ -49,9 +62,9 @@ public class TenantMembershipCacheManager {
    * Returns the tenant ids the user belongs to (cached). Uses JDBC so the connection is borrowed
    * and returned immediately, independent of Hibernate open-in-view.
    */
-  @Cacheable(value = "userTenantIds", key = "#userId")
+  @Cacheable(value = USER_TENANT_IDS_CACHE, key = "#userId")
   public List<String> findTenantIdsByUserId(String userId) {
-    return jdbcTemplate.queryForList(USER_TENANT_IDS_SQL, String.class, userId);
+    return List.copyOf(jdbcTemplate.queryForList(USER_TENANT_IDS_SQL, String.class, userId));
   }
 
   /**
@@ -60,8 +73,8 @@ public class TenantMembershipCacheManager {
    */
   @Caching(
       evict = {
-        @CacheEvict(value = "tenantMembership", key = "#userId + ':' + #tenantId"),
-        @CacheEvict(value = "userTenantIds", key = "#userId")
+        @CacheEvict(value = TENANT_MEMBERSHIP_CACHE, key = "#userId + ':' + #tenantId"),
+        @CacheEvict(value = USER_TENANT_IDS_CACHE, key = "#userId")
       })
   public void evict(String userId, String tenantId) {
     // eviction only
@@ -69,12 +82,20 @@ public class TenantMembershipCacheManager {
 
   /**
    * Evicts all cached tenant membership entries for a given user, including the cached tenant-id
-   * list.
+   * list. Membership keys are evicted through {@link CacheManager} because calling {@link
+   * #evict(String, String)} from this method would be a self-invocation and skip the cache
+   * interceptor.
    */
-  @CacheEvict(value = "userTenantIds", key = "#userId")
   public void evictForUser(String userId, List<String> tenantIds) {
-    for (String tenantId : tenantIds) {
-      evict(userId, tenantId);
+    Cache tenantIdsCache = cacheManager.getCache(USER_TENANT_IDS_CACHE);
+    if (tenantIdsCache != null) {
+      tenantIdsCache.evict(userId);
+    }
+    Cache membershipCache = cacheManager.getCache(TENANT_MEMBERSHIP_CACHE);
+    if (membershipCache != null) {
+      for (String tenantId : tenantIds) {
+        membershipCache.evict(userId + ":" + tenantId);
+      }
     }
   }
 }

--- a/openaev-api/src/main/java/io/openaev/config/cache/TenantMembershipCacheManager.java
+++ b/openaev-api/src/main/java/io/openaev/config/cache/TenantMembershipCacheManager.java
@@ -1,22 +1,39 @@
 package io.openaev.config.cache;
 
+import io.openaev.annotation.AllowRawJdbc;
 import io.openaev.database.repository.TenantRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 /**
  * Caches tenant membership checks to avoid hitting the database on every HTTP request. The cache
  * has a short TTL (5 minutes) and is explicitly evicted when users are added to or removed from
  * tenants.
+ *
+ * <p>{@link #findTenantIdsByUserId(String)} is a JDBC id-only lookup so argument resolution (and
+ * other request-scoped callers) do not open a Hibernate session. Combined with open-in-view, a
+ * Hibernate query here would hold a pool connection for the whole HTTP request and trip Hikari leak
+ * detection on long POSTs.
  */
 @Service
 @RequiredArgsConstructor
+@AllowRawJdbc(
+    reason =
+        "reads only users_tenants.tenant_id for an explicit user_id bind so TxCtx argument"
+            + " resolution can return ids without a Hibernate session; OSIV would otherwise hold"
+            + " the pool connection for the whole HTTP request. No other tenant rows are touched.")
 public class TenantMembershipCacheManager {
 
+  static final String USER_TENANT_IDS_SQL =
+      "select ut.tenant_id from users_tenants ut where ut.user_id = ?";
+
   private final TenantRepository tenantRepository;
+  private final JdbcTemplate jdbcTemplate;
 
   /**
    * Returns whether the given user belongs to the given tenant (cached). The cache is explicitly
@@ -28,13 +45,33 @@ public class TenantMembershipCacheManager {
     return tenantRepository.existsByUserIdAndTenantId(userId, tenantId);
   }
 
-  /** Evicts a specific user–tenant entry after membership changes. */
-  @CacheEvict(value = "tenantMembership", key = "#userId + ':' + #tenantId")
+  /**
+   * Returns the tenant ids the user belongs to (cached). Uses JDBC so the connection is borrowed
+   * and returned immediately, independent of Hibernate open-in-view.
+   */
+  @Cacheable(value = "userTenantIds", key = "#userId")
+  public List<String> findTenantIdsByUserId(String userId) {
+    return jdbcTemplate.queryForList(USER_TENANT_IDS_SQL, String.class, userId);
+  }
+
+  /**
+   * Evicts a specific user-tenant membership entry and the user's cached tenant-id list after
+   * membership changes.
+   */
+  @Caching(
+      evict = {
+        @CacheEvict(value = "tenantMembership", key = "#userId + ':' + #tenantId"),
+        @CacheEvict(value = "userTenantIds", key = "#userId")
+      })
   public void evict(String userId, String tenantId) {
     // eviction only
   }
 
-  /** Evicts all cached tenant membership entries for a given user. */
+  /**
+   * Evicts all cached tenant membership entries for a given user, including the cached tenant-id
+   * list.
+   */
+  @CacheEvict(value = "userTenantIds", key = "#userId")
   public void evictForUser(String userId, List<String> tenantIds) {
     for (String tenantId : tenantIds) {
       evict(userId, tenantId);

--- a/openaev-api/src/main/java/io/openaev/opencti/connectors/service/OpenCTIConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/connectors/service/OpenCTIConnectorService.java
@@ -10,7 +10,10 @@ import io.openaev.stix.objects.Bundle;
 import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,10 +23,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class OpenCTIConnectorService {
+  private static final Duration REGISTER_OR_PING_BACKOFF = Duration.ofMinutes(5);
+
   @Getter private List<ConnectorBase> connectors = Collections.emptyList();
   private final XtmConfig xtmConfig;
   private final OpenAEVConfig openAEVConfig;
   private final OpenCTIService openCTIService;
+  private final ConcurrentHashMap<String, Instant> registerOrPingBackoffUntil =
+      new ConcurrentHashMap<>();
 
   /** Creates one {@link SecurityCoverageConnector} per tenant entry in the config map. */
   @PostConstruct
@@ -85,16 +92,42 @@ public class OpenCTIConnectorService {
     }
 
     for (ConnectorBase c : enabledConnectors) {
+      String backoffKey = registerOrPingBackoffKey(c);
+      Instant backoffUntil = registerOrPingBackoffUntil.get(backoffKey);
+      if (backoffUntil != null && Instant.now().isBefore(backoffUntil)) {
+        continue;
+      }
       try {
         if (!c.isRegistered()) {
           openCTIService.registerConnector(c);
         } else {
           openCTIService.pingConnector(c);
         }
+        registerOrPingBackoffUntil.remove(backoffKey);
       } catch (Exception e) {
-        log.error("Error at OpenCTI connector registration or ping", e);
+        registerOrPingBackoffUntil.put(backoffKey, Instant.now().plus(REGISTER_OR_PING_BACKOFF));
+        logRegisterOrPingFailure(c, e);
       }
     }
+  }
+
+  private static String registerOrPingBackoffKey(ConnectorBase connector) {
+    return connector.getTenantId() + "/" + connector.getId();
+  }
+
+  private void logRegisterOrPingFailure(ConnectorBase connector, Exception e) {
+    String detail =
+        e.getMessage() != null && !e.getMessage().isBlank() ? e.getMessage() : e.toString();
+    log.warn(
+        "OpenCTI connector registration or ping failed for tenant {} / connector {} (retry in 5"
+            + " minutes): {}",
+        connector.getTenantId(),
+        connector.getId(),
+        detail);
+  }
+
+  void clearRegisterBackoff() {
+    registerOrPingBackoffUntil.clear();
   }
 
   public void pushSecurityCoverageStixBundle(Bundle bundle, final String tenantId)
@@ -103,7 +136,8 @@ public class OpenCTIConnectorService {
 
     if (connector.isEmpty()) {
       throw new ConnectorError(
-          "No instance of Security Coverage connector is currently active to send security coverage bundles for tenant id: "
+          "No instance of Security Coverage connector is currently active to send security coverage"
+              + " bundles for tenant id: "
               + tenantId);
     }
 

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -102,7 +102,7 @@ public class RestBehavior {
     StringBuilder pathBuilder = new StringBuilder();
     for (var ref : ife.getPath()) {
       if (ref.getFieldName() != null) {
-        if (!pathBuilder.isEmpty()) {
+        if (pathBuilder.length() > 0) {
           pathBuilder.append('.');
         }
         pathBuilder.append(ref.getFieldName());

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -83,14 +83,14 @@ public class RestBehavior {
   }
 
   private static String unreadableBodyDetail(HttpMessageNotReadableException ex) {
-    InvalidFormatException ife = findCause(ex, InvalidFormatException.class);
+    InvalidFormatException ife = findDeepestCause(ex, InvalidFormatException.class);
     if (ife != null) {
       return invalidFormatDetail(ife);
     }
     // @JsonCreator methods throw IllegalArgumentException; Jackson wraps that in
     // ValueInstantiationException / JsonMappingException. Surface the creator message so clients
     // get an actionable 400 instead of the generic "Malformed or unreadable request body".
-    IllegalArgumentException iae = findCause(ex, IllegalArgumentException.class);
+    IllegalArgumentException iae = findDeepestCause(ex, IllegalArgumentException.class);
     if (iae != null && iae.getMessage() != null && !iae.getMessage().isBlank()) {
       return abbreviateMessage(iae.getMessage());
     }
@@ -120,15 +120,20 @@ public class RestBehavior {
         : message.substring(0, MAX_UNREADABLE_DETAIL_LENGTH) + "...";
   }
 
-  private static <T extends Throwable> T findCause(Throwable throwable, Class<T> type) {
+  // Returns the deepest matching cause: outer wrappers (Spring, Jackson) restate the original
+  // message with framework noise, so the root cause carries the actionable text. The
+  // identity-based visited set guards against cyclic cause chains.
+  private static <T extends Throwable> T findDeepestCause(Throwable throwable, Class<T> type) {
+    T deepest = null;
+    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
     Throwable current = throwable;
-    while (current != null) {
+    while (current != null && visited.add(current)) {
       if (type.isInstance(current)) {
-        return type.cast(current);
+        deepest = type.cast(current);
       }
       current = current.getCause();
     }
-    return null;
+    return deepest;
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -63,6 +63,7 @@ public class RestBehavior {
   // -- 400 BAD_REQUEST --
 
   private static final int MAX_REJECTED_VALUE_LENGTH = 100;
+  private static final int MAX_UNREADABLE_DETAIL_LENGTH = 300;
 
   // Bound the caller-supplied rejected value echoed back in the 400 body / logs
   private static String abbreviateRejectedValue(Object value) {
@@ -76,29 +77,58 @@ public class RestBehavior {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ErrorMessage> handleHttpMessageNotReadable(
       HttpMessageNotReadableException ex) {
-    String detail;
-    if (ex.getCause() instanceof InvalidFormatException ife) {
-      // Render array indices attached to their parent segment: filters[0].operator
-      StringBuilder pathBuilder = new StringBuilder();
-      for (var ref : ife.getPath()) {
-        if (ref.getFieldName() != null) {
-          if (!pathBuilder.isEmpty()) {
-            pathBuilder.append('.');
-          }
-          pathBuilder.append(ref.getFieldName());
-        } else {
-          pathBuilder.append('[').append(ref.getIndex()).append(']');
-        }
-      }
-      String path = pathBuilder.toString();
-      detail =
-          "Invalid value '%s' for field '%s'"
-              .formatted(abbreviateRejectedValue(ife.getValue()), path);
-    } else {
-      detail = "Malformed or unreadable request body";
-    }
+    String detail = unreadableBodyDetail(ex);
     log.warn("HttpMessageNotReadableException: {}", detail, ex);
     return new ResponseEntity<>(new ErrorMessage(detail), HttpStatus.BAD_REQUEST);
+  }
+
+  private static String unreadableBodyDetail(HttpMessageNotReadableException ex) {
+    InvalidFormatException ife = findCause(ex, InvalidFormatException.class);
+    if (ife != null) {
+      return invalidFormatDetail(ife);
+    }
+    // @JsonCreator methods throw IllegalArgumentException; Jackson wraps that in
+    // ValueInstantiationException / JsonMappingException. Surface the creator message so clients
+    // get an actionable 400 instead of the generic "Malformed or unreadable request body".
+    IllegalArgumentException iae = findCause(ex, IllegalArgumentException.class);
+    if (iae != null && iae.getMessage() != null && !iae.getMessage().isBlank()) {
+      return abbreviateMessage(iae.getMessage());
+    }
+    return "Malformed or unreadable request body";
+  }
+
+  private static String invalidFormatDetail(InvalidFormatException ife) {
+    // Render array indices attached to their parent segment: filters[0].operator
+    StringBuilder pathBuilder = new StringBuilder();
+    for (var ref : ife.getPath()) {
+      if (ref.getFieldName() != null) {
+        if (!pathBuilder.isEmpty()) {
+          pathBuilder.append('.');
+        }
+        pathBuilder.append(ref.getFieldName());
+      } else {
+        pathBuilder.append('[').append(ref.getIndex()).append(']');
+      }
+    }
+    return "Invalid value '%s' for field '%s'"
+        .formatted(abbreviateRejectedValue(ife.getValue()), pathBuilder.toString());
+  }
+
+  private static String abbreviateMessage(String message) {
+    return message.length() <= MAX_UNREADABLE_DETAIL_LENGTH
+        ? message
+        : message.substring(0, MAX_UNREADABLE_DETAIL_LENGTH) + "...";
+  }
+
+  private static <T extends Throwable> T findCause(Throwable throwable, Class<T> type) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (type.isInstance(current)) {
+        return type.cast(current);
+      }
+      current = current.getCause();
+    }
+    return null;
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/openaev-api/src/main/java/io/openaev/rest/payload/contract_output_element/ContractOutputElementInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/contract_output_element/ContractOutputElementInput.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.database.model.ContractOutputType;
 import io.openaev.rest.payload.regex_group.RegexGroupInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -58,5 +59,6 @@ public class ContractOutputElementInput {
   @JsonProperty("contract_output_element_regex_groups")
   @Schema(description = "Set of regex groups")
   @NotNull
+  @Valid
   private Set<RegexGroupInput> regexGroups = new HashSet<>();
 }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/output_parser/OutputParserInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/output_parser/OutputParserInput.java
@@ -5,6 +5,7 @@ import io.openaev.database.model.ParserMode;
 import io.openaev.database.model.ParserType;
 import io.openaev.rest.payload.contract_output_element.ContractOutputElementInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,5 +30,6 @@ public class OutputParserInput {
   @JsonProperty("output_parser_contract_output_elements")
   @Schema(description = "List of Contract output elements")
   @NotNull
+  @Valid
   private Set<ContractOutputElementInput> contractOutputElements = new HashSet<>();
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
@@ -8,6 +8,7 @@ import io.openaev.database.model.Exercise;
 import io.openaev.database.model.SecurityCoverageSendJob;
 import io.openaev.database.model.Tenant;
 import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
+import io.openaev.opencti.errors.ConnectorError;
 import io.openaev.service.SecurityCoverageSendJobService;
 import io.openaev.service.stix.SecurityCoverageService;
 import io.openaev.stix.objects.Bundle;
@@ -46,6 +47,7 @@ public class SecurityCoverageJob implements Job {
     // bundle creation) and log a single concise warning per tenant instead of one ERROR with a
     // full stack trace per pending simulation on every run (log flooding + useless DB load).
     Set<String> tenantsWithoutConnector = new HashSet<>();
+    Set<String> tenantsNotRegistered = new HashSet<>();
     for (SecurityCoverageSendJob securityCoverageSendJob : jobs) {
       try {
         String tenantId =
@@ -53,11 +55,16 @@ public class SecurityCoverageJob implements Job {
                 .map(Exercise::getTenant)
                 .map(Tenant::getId)
                 .orElseThrow(() -> new IllegalStateException("Simulation or tenant not found"));
-        if (tenantsWithoutConnector.contains(tenantId)) {
+        if (tenantsWithoutConnector.contains(tenantId) || tenantsNotRegistered.contains(tenantId)) {
           continue;
         }
-        if (openCTIConnectorService.getConnectorBase(tenantId).isEmpty()) {
+        var connector = openCTIConnectorService.getConnectorBase(tenantId);
+        if (connector.isEmpty()) {
           tenantsWithoutConnector.add(tenantId);
+          continue;
+        }
+        if (!connector.get().isRegistered()) {
+          tenantsNotRegistered.add(tenantId);
           continue;
         }
         // Set tenant context for downstream Hibernate filters and audit
@@ -78,23 +85,44 @@ public class SecurityCoverageJob implements Job {
         successfulJobs.add(securityCoverageSendJob);
       } catch (Exception e) {
         // don't crash the job; getSimulation() can be null (that very case throws above)
-        log.error(
-            "Could not create the STIX bundle for coverage {} of simulation {} and tenant {}",
-            securityCoverageSendJob.getId(),
-            ofNullable(securityCoverageSendJob.getSimulation()).map(Exercise::getId).orElse("?"),
-            ofNullable(securityCoverageSendJob.getSimulation())
-                .map(Exercise::getTenant)
-                .map(Tenant::getId)
-                .orElse("?"),
-            e);
+        if (e instanceof ConnectorError
+            && e.getMessage() != null
+            && e.getMessage().contains("hasn't registered yet")) {
+          log.warn(
+              "Could not create the STIX bundle for coverage {} of simulation {} and tenant {}: {}",
+              securityCoverageSendJob.getId(),
+              ofNullable(securityCoverageSendJob.getSimulation()).map(Exercise::getId).orElse("?"),
+              ofNullable(securityCoverageSendJob.getSimulation())
+                  .map(Exercise::getTenant)
+                  .map(Tenant::getId)
+                  .orElse("?"),
+              e.getMessage());
+        } else {
+          log.error(
+              "Could not create the STIX bundle for coverage {} of simulation {} and tenant {}",
+              securityCoverageSendJob.getId(),
+              ofNullable(securityCoverageSendJob.getSimulation()).map(Exercise::getId).orElse("?"),
+              ofNullable(securityCoverageSendJob.getSimulation())
+                  .map(Exercise::getTenant)
+                  .map(Tenant::getId)
+                  .orElse("?"),
+              e);
+        }
       } finally {
         TenantContext.clearCurrentTenant();
       }
     }
     if (!tenantsWithoutConnector.isEmpty()) {
       log.warn(
-          "Security coverage bundles not sent: no active Security Coverage connector for tenant(s) {}. Jobs stay pending until a connector is configured.",
+          "Security coverage bundles not sent: no active Security Coverage connector for tenant(s)"
+              + " {}. Jobs stay pending until a connector is configured.",
           tenantsWithoutConnector);
+    }
+    if (!tenantsNotRegistered.isEmpty()) {
+      log.warn(
+          "Security coverage bundles not sent: OpenCTI connector for tenant(s) {} is configured but"
+              + " not registered (check URL/token). Jobs stay pending.",
+          tenantsNotRegistered);
     }
     if (!successfulJobs.isEmpty()) {
       securityCoverageSendJobService.consumeJobs(successfulJobs);

--- a/openaev-api/src/main/java/io/openaev/utils/StringUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/StringUtils.java
@@ -54,6 +54,13 @@ public class StringUtils {
    * @return {@code true} if the regex compiles successfully, {@code false} otherwise
    */
   public static boolean isValidRegex(String regex) {
+    // A null/blank rule is invalid input, not a server fault: returning false lets the caller
+    // raise a 400. Without this guard regex.length() threw a raw NullPointerException that
+    // surfaced as a 500 whenever a contract output element reached this method with no rule
+    // (e.g. a malformed output parser slipping past bean validation).
+    if (regex == null || regex.isBlank()) {
+      return false;
+    }
     if (regex.length() > 100) {
       throw new IllegalArgumentException("Regex too long");
     }

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -360,6 +360,29 @@ public class ThreatArsenalApiTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Creating an action with an unknown output_parser_mode should return 400 not 500")
+    void given_unknownOutputParserMode_should_returnBadRequest() throws Exception {
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+      ThreatArsenalActionCreateInput input =
+          ThreatArsenalInputFixture.createCommandLineActionWithOutputParser(
+              List.of(domain.getId()));
+      String json =
+          asJsonString(input)
+              .replace("\"output_parser_mode\":\"STDOUT\"", "\"output_parser_mode\":\"pipe\"");
+
+      mvc.perform(
+              post(THREAT_ARSENAL_URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(json)
+                  .with(csrf()))
+          .andExpect(status().isBadRequest())
+          .andExpect(
+              jsonPath(
+                  "$.message",
+                  containsString("output_parser_mode must be STDOUT, STDERR, or READ_FILE")));
+    }
+
+    @Test
     @DisplayName("Creating an action with tags should create injectorContract with tags")
     void given_inputWithTags_should_createInjectorContractWithTags() throws Exception {
       Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -336,7 +336,26 @@ public class ThreatArsenalApiTest extends IntegrationTest {
       Payload payload = payloadRepository.findById(payloadId).orElse(null);
       assertNotNull(payload);
       assertEquals(1, payload.getOutputParsers().size());
-      ;
+    }
+
+    @Test
+    @DisplayName("Creating an action with output_parser_type=credentials should return 400 not 500")
+    void given_outputParserTypeCredentials_should_returnBadRequest() throws Exception {
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+      ThreatArsenalActionCreateInput input =
+          ThreatArsenalInputFixture.createCommandLineActionWithOutputParser(
+              List.of(domain.getId()));
+      String json =
+          asJsonString(input)
+              .replace(
+                  "\"output_parser_type\":\"REGEX\"", "\"output_parser_type\":\"credentials\"");
+
+      mvc.perform(
+              post(THREAT_ARSENAL_URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(json)
+                  .with(csrf()))
+          .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -613,7 +632,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "given action_domains not_eq with AND and two values should return no result for search and domain counts")
+        "given action_domains not_eq with AND and two values should return no result for search and"
+            + " domain counts")
     void given_actionDomainsNotEqAndWithTwoValues_should_returnNoResultForSearchAndDomainCounts()
         throws Exception {
       // Arrange
@@ -665,7 +685,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "given action_domains not_eq with AND and one value should keep contracts from other domains")
+        "given action_domains not_eq with AND and one value should keep contracts from other"
+            + " domains")
     void given_actionDomainsNotEqAndWithOneValue_should_keepOtherDomains() throws Exception {
       // Arrange
       SearchPaginationInput input =
@@ -848,7 +869,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "given a providing (findings) filter the search must not fail with a SELECT DISTINCT / ORDER BY SQL error")
+        "given a providing (findings) filter the search must not fail with a SELECT DISTINCT /"
+            + " ORDER BY SQL error")
     void given_providingFilter_should_returnOkAndNotFailWithDistinctOrderBy() throws Exception {
       // A providing filter (injector_contract_providing) forces query.distinct(true).
       // Combined with the default composite-id sort, whose ORDER BY expands to
@@ -1095,7 +1117,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "Searching non-tabletop threat arsenal with domain filter should return only matching non-tabletop contracts")
+        "Searching non-tabletop threat arsenal with domain filter should return only matching"
+            + " non-tabletop contracts")
     void given_nonTabletopSearchWithDomainFilter_should_returnFilteredResults() throws Exception {
       // Arrange
       SearchPaginationInput input =
@@ -1131,7 +1154,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
 
     @Test
     @DisplayName(
-        "Searching non-tabletop threat arsenal with tag filter should return only matching non-tabletop contracts")
+        "Searching non-tabletop threat arsenal with tag filter should return only matching"
+            + " non-tabletop contracts")
     void given_nonTabletopSearchWithTagFilter_should_returnFilteredResults() throws Exception {
       // Arrange
       SearchPaginationInput input =
@@ -1770,12 +1794,14 @@ public class ThreatArsenalApiTest extends IntegrationTest {
               content()
                   .string(
                       containsString(
-                          "Only payload-based threat arsenal items can provide security platforms for action remediation.")));
+                          "Only payload-based threat arsenal items can provide security platforms"
+                              + " for action remediation.")));
     }
 
     @Test
     @DisplayName(
-        "Getting security platforms for a payload-based action should return the associated security platforms")
+        "Getting security platforms for a payload-based action should return the associated"
+            + " security platforms")
     void given_payloadContract_should_returnSecurityPlatformsForActionRemediation()
         throws Exception {
       // Arrange

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -355,7 +355,8 @@ public class ThreatArsenalApiTest extends IntegrationTest {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(json)
                   .with(csrf()))
-          .andExpect(status().isBadRequest());
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message", containsString("output_parser_type must be REGEX")));
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -26,6 +26,8 @@ import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.PayloadRepository;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
+import io.openaev.rest.payload.contract_output_element.ContractOutputElementInput;
+import io.openaev.rest.payload.output_parser.OutputParserInput;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.*;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
@@ -380,6 +382,101 @@ public class ThreatArsenalApiTest extends IntegrationTest {
               jsonPath(
                   "$.message",
                   containsString("output_parser_mode must be STDOUT, STDERR, or READ_FILE")));
+    }
+
+    @Test
+    @DisplayName(
+        "Creating an action carrying a credentials output parser should succeed and persist the"
+            + " credentials finding element")
+    void given_credentialsOutputParser_should_createPayloadWithCredentialsFinding()
+        throws Exception {
+      // credentials is a valid ContractOutputType on the contract output element; the parser type
+      // stays REGEX. A well-formed request must succeed and yield a finding-flagged credentials
+      // element (the AI orchestrator forks crack actions this way).
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+      ThreatArsenalActionCreateInput input =
+          ThreatArsenalInputFixture.createCommandLineActionWithCredentialsOutputParser(
+              List.of(domain.getId()));
+
+      String response =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI)
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String payloadId = JsonPath.read(response, "$.action_payload.payload_id");
+      Payload payload = payloadRepository.findById(payloadId).orElse(null);
+      assertNotNull(payload);
+      assertEquals(1, payload.getOutputParsers().size());
+      OutputParser outputParser = payload.getOutputParsers().iterator().next();
+      assertEquals(ParserType.REGEX, outputParser.getType());
+      Set<ContractOutputElement> elements = outputParser.getContractOutputElements();
+      assertEquals(1, elements.size());
+      ContractOutputElement credentialsElement = elements.iterator().next();
+      assertEquals(ContractOutputType.Credentials, credentialsElement.getType());
+      assertTrue(
+          credentialsElement.isFinding(),
+          "the credentials contract output element must be flagged as a finding");
+    }
+
+    @Test
+    @DisplayName(
+        "Creating an action with a malformed output parser (blank contract output element rule)"
+            + " should return 400, not 500")
+    void given_outputParserWithBlankRule_should_returnBadRequest() throws Exception {
+      // Regression: a contract output element with no rule slipped past validation (nested
+      // output-parser inputs were not @Valid-cascaded) and reached StringUtils.isValidRegex(null),
+      // which threw a raw NullPointerException surfaced as a 500.
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+
+      ContractOutputElementInput malformedElement = new ContractOutputElementInput();
+      malformedElement.setFinding(true);
+      malformedElement.setName("creds");
+      malformedElement.setKey("creds");
+      malformedElement.setType(ContractOutputType.Credentials);
+      malformedElement.setRule(null);
+      OutputParserInput malformedParser = new OutputParserInput();
+      malformedParser.setMode(ParserMode.STDOUT);
+      malformedParser.setType(ParserType.REGEX);
+      malformedParser.setContractOutputElements(Set.of(malformedElement));
+
+      ThreatArsenalActionCreateInput input =
+          new ThreatArsenalActionCreateInput(
+              Command.COMMAND_TYPE,
+              "Command line payload with malformed parser",
+              Payload.PAYLOAD_SOURCE.MANUAL,
+              Payload.PAYLOAD_STATUS.VERIFIED,
+              new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux},
+              Payload.PAYLOAD_EXECUTION_ARCH.ALL_ARCHITECTURES,
+              new BaseInjectExpectation.EXPECTATION_TYPE[] {},
+              Collections.emptyMap(),
+              null,
+              "bash",
+              "echo hello",
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              Collections.emptyList(),
+              Collections.emptyList(),
+              null,
+              Set.of(malformedParser),
+              List.of(domain.getId()));
+
+      mvc.perform(
+              post(THREAT_ARSENAL_URI)
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().is4xxClientError());
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
@@ -5,12 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.openaev.config.cache.TenantMembershipCacheManager;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
-import io.openaev.service.tenants.TenantService;
 import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +35,7 @@ class TxCtxArgumentResolverTest {
 
   private static final String USER_ID = "user-id";
 
-  @Mock private TenantService tenantService;
+  @Mock private TenantMembershipCacheManager membershipCache;
   @Mock private MethodParameter parameter;
   @Mock private NativeWebRequest webRequest;
 
@@ -44,7 +43,7 @@ class TxCtxArgumentResolverTest {
 
   @BeforeEach
   void setUp() {
-    resolver = new TxCtxArgumentResolver(new TenantScopeResolver(), tenantService);
+    resolver = new TxCtxArgumentResolver(new TenantScopeResolver(), membershipCache);
     OpenAEVPrincipal principal = mock(OpenAEVPrincipal.class);
     when(principal.getId()).thenReturn(USER_ID);
     Authentication authentication = mock(Authentication.class);
@@ -58,8 +57,7 @@ class TxCtxArgumentResolverTest {
   }
 
   private void authorizeTenants(String... tenantIds) {
-    List<Tenant> tenants = Arrays.stream(tenantIds).map(Tenant::new).toList();
-    when(tenantService.findTenantsByUserId(USER_ID)).thenReturn(tenants);
+    when(membershipCache.findTenantIdsByUserId(USER_ID)).thenReturn(Arrays.asList(tenantIds));
   }
 
   private void requireSelector() {

--- a/openaev-api/src/test/java/io/openaev/config/cache/TenantMembershipCacheManagerTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/cache/TenantMembershipCacheManagerTest.java
@@ -5,10 +5,12 @@ import static org.mockito.Mockito.*;
 
 import io.openaev.config.CachingConfig;
 import io.openaev.database.repository.TenantRepository;
+import java.util.List;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.CacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
@@ -25,15 +27,20 @@ class TenantMembershipCacheManagerTest {
   @Autowired private TenantMembershipCacheManager tenantMembershipCacheManager;
   @Autowired private CacheManager cacheManager;
   @MockitoBean private TenantRepository tenantRepository;
+  @MockitoBean private JdbcTemplate jdbcTemplate;
 
   @BeforeEach
   void setUp() {
     // Arrange — clear cache before each test
-    var cache = cacheManager.getCache("tenantMembership");
-    if (cache != null) {
-      cache.clear();
+    var membershipCache = cacheManager.getCache("tenantMembership");
+    if (membershipCache != null) {
+      membershipCache.clear();
     }
-    reset(tenantRepository);
+    var userTenantIdsCache = cacheManager.getCache("userTenantIds");
+    if (userTenantIdsCache != null) {
+      userTenantIdsCache.clear();
+    }
+    reset(tenantRepository, jdbcTemplate);
   }
 
   @Nested
@@ -148,6 +155,52 @@ class TenantMembershipCacheManagerTest {
       // Assert — evicted key hit DB twice, other key only once
       verify(tenantRepository, times(2)).existsByUserIdAndTenantId(USER_ID, TENANT_ID);
       verify(tenantRepository, times(1)).existsByUserIdAndTenantId(USER_ID, otherTenantId);
+    }
+
+    @Test
+    @DisplayName("given_cached_tenant_ids_should_call_jdbc_again_after_eviction")
+    void given_cached_tenant_ids_should_call_jdbc_again_after_eviction() {
+      // Arrange
+      when(jdbcTemplate.queryForList(
+              TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID))
+          .thenReturn(List.of(TENANT_ID));
+
+      // Act — populate cache
+      tenantMembershipCacheManager.findTenantIdsByUserId(USER_ID);
+
+      // Act — evict membership also busts userTenantIds
+      tenantMembershipCacheManager.evict(USER_ID, TENANT_ID);
+
+      // Act — should hit jdbc again
+      tenantMembershipCacheManager.findTenantIdsByUserId(USER_ID);
+
+      // Assert
+      verify(jdbcTemplate, times(2))
+          .queryForList(TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID);
+    }
+  }
+
+  @Nested
+  @DisplayName("findTenantIdsByUserId")
+  class FindTenantIdsByUserId {
+
+    @Test
+    @DisplayName("given_cached_result_should_not_call_jdbc_on_second_call")
+    void given_cached_result_should_not_call_jdbc_on_second_call() {
+      // Arrange
+      when(jdbcTemplate.queryForList(
+              TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID))
+          .thenReturn(List.of(TENANT_ID));
+
+      // Act
+      List<String> firstResult = tenantMembershipCacheManager.findTenantIdsByUserId(USER_ID);
+      List<String> secondResult = tenantMembershipCacheManager.findTenantIdsByUserId(USER_ID);
+
+      // Assert
+      assertThat(firstResult).containsExactly(TENANT_ID);
+      assertThat(secondResult).containsExactly(TENANT_ID);
+      verify(jdbcTemplate, times(1))
+          .queryForList(TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID);
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/cache/TenantMembershipCacheManagerTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/cache/TenantMembershipCacheManagerTest.java
@@ -203,4 +203,33 @@ class TenantMembershipCacheManagerTest {
           .queryForList(TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID);
     }
   }
+
+  @Nested
+  @DisplayName("evictForUser")
+  class EvictForUser {
+
+    @Test
+    @DisplayName("given_cached_membership_and_ids_should_call_backends_again_after_evictForUser")
+    void given_cached_membership_and_ids_should_call_backends_again_after_evictForUser() {
+      // Arrange
+      when(tenantRepository.existsByUserIdAndTenantId(USER_ID, TENANT_ID)).thenReturn(true);
+      when(jdbcTemplate.queryForList(
+              TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID))
+          .thenReturn(List.of(TENANT_ID));
+
+      tenantMembershipCacheManager.existsByUserIdAndTenantId(USER_ID, TENANT_ID);
+      tenantMembershipCacheManager.findTenantIdsByUserId(USER_ID);
+
+      // Act - must bust both caches without relying on self-invocation of evict()
+      tenantMembershipCacheManager.evictForUser(USER_ID, List.of(TENANT_ID));
+
+      tenantMembershipCacheManager.existsByUserIdAndTenantId(USER_ID, TENANT_ID);
+      tenantMembershipCacheManager.findTenantIdsByUserId(USER_ID);
+
+      // Assert
+      verify(tenantRepository, times(2)).existsByUserIdAndTenantId(USER_ID, TENANT_ID);
+      verify(jdbcTemplate, times(2))
+          .queryForList(TenantMembershipCacheManager.USER_TENANT_IDS_SQL, String.class, USER_ID);
+    }
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/database/model/ContractOutputTypeTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/ContractOutputTypeTest.java
@@ -1,0 +1,83 @@
+package io.openaev.database.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards the {@code contract_output_element_type} wire contract: every token the client (the AI
+ * orchestrator, forking payloads and adding output parsers) emits must deserialize to a {@link
+ * ContractOutputType}. A missing or renamed {@link com.fasterxml.jackson.annotation.JsonProperty}
+ * used to turn an authored {@code credentials} finding into a rejected request; this test fails
+ * fast if any token stops being accepted.
+ */
+@DisplayName("ContractOutputType accepts every client-emitted token")
+class ContractOutputTypeTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  static Stream<Arguments> clientEmittedTokens() {
+    return Stream.of(
+        Arguments.of("credentials", ContractOutputType.Credentials),
+        Arguments.of("username", ContractOutputType.Username),
+        Arguments.of("admin_username", ContractOutputType.AdminUsername),
+        Arguments.of("sid", ContractOutputType.Sid),
+        Arguments.of("asset", ContractOutputType.Asset),
+        Arguments.of("computer", ContractOutputType.Computer),
+        Arguments.of("share", ContractOutputType.Share),
+        Arguments.of("cve", ContractOutputType.CVE),
+        Arguments.of("vulnerability", ContractOutputType.Vulnerability),
+        Arguments.of("group", ContractOutputType.Group),
+        Arguments.of("file", ContractOutputType.File),
+        Arguments.of("delegation", ContractOutputType.Delegation),
+        Arguments.of("password_policy", ContractOutputType.PasswordPolicy),
+        Arguments.of("asreproastable_account", ContractOutputType.AsreproastableAccount),
+        Arguments.of("kerberoastable_account", ContractOutputType.KerberoastableAccount),
+        Arguments.of(
+            "account_with_password_not_required",
+            ContractOutputType.AccountWithPasswordNotRequired),
+        Arguments.of("port", ContractOutputType.Port),
+        Arguments.of("portscan", ContractOutputType.PortsScan),
+        Arguments.of("ipv4", ContractOutputType.IPv4),
+        Arguments.of("ipv6", ContractOutputType.IPv6),
+        Arguments.of("number", ContractOutputType.Number),
+        Arguments.of("text", ContractOutputType.Text),
+        Arguments.of("expectation_signature", ContractOutputType.ExpectationSignature),
+        Arguments.of("action_output", ContractOutputType.ActionOutput));
+  }
+
+  @ParameterizedTest(name = "\"{0}\" deserializes to {1}")
+  @MethodSource("clientEmittedTokens")
+  void given_clientToken_should_deserializeToExpectedType(String token, ContractOutputType expected)
+      throws Exception {
+    ContractOutputType parsed = MAPPER.readValue('"' + token + '"', ContractOutputType.class);
+    assertEquals(expected, parsed, "token '" + token + "' must map to " + expected);
+    assertThat(parsed.getLabel()).isEqualTo(token);
+  }
+
+  @ParameterizedTest(name = "\"{0}\" round-trips through JSON")
+  @MethodSource("clientEmittedTokens")
+  void given_type_should_serializeToItsToken(String token, ContractOutputType type)
+      throws Exception {
+    assertEquals('"' + token + '"', MAPPER.writeValueAsString(type));
+  }
+
+  @org.junit.jupiter.api.Test
+  @DisplayName("every enum constant is covered by the client-token contract test")
+  void everyConstantIsCovered() {
+    long tokenCount = clientEmittedTokens().count();
+    // The enum also declares "email", which is not in the client-emitted set exercised above.
+    long expectedCovered = Arrays.stream(ContractOutputType.values()).count() - 1;
+    assertEquals(
+        expectedCovered,
+        tokenCount,
+        "add any new ContractOutputType to clientEmittedTokens() so the wire contract stays tested");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/opencti/connectors/service/OpenCTIConnectorServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/opencti/connectors/service/OpenCTIConnectorServiceTest.java
@@ -48,6 +48,7 @@ public class OpenCTIConnectorServiceTest extends IntegrationTest {
   @BeforeEach
   public void setup() {
     reset(mockOpenCTIClient);
+    openCTIConnectorService.clearRegisterBackoff();
   }
 
   @Nested
@@ -69,6 +70,25 @@ public class OpenCTIConnectorServiceTest extends IntegrationTest {
       openCTIConnectorService.registerOrPingAllConnectors();
 
       assertThat(connector.isRegistered()).isFalse();
+    }
+
+    @Test
+    @DisplayName("When API return is error, a second immediate register is skipped (backoff)")
+    public void whenApiReturnIsError_secondImmediateRegisterIsSkipped() throws IOException {
+      ConnectorBase connector = getInstanceOfSecurityCoverageConnector().get();
+      connector.setRegistered(false);
+
+      Response jwksSchemaResponse = ResponseFixture.getSchemaResponseWithJwks();
+      when(mockOpenCTIClient.execute(any(), any(), any(QueryTypeFields.class)))
+          .thenReturn(jwksSchemaResponse);
+      when(mockOpenCTIClient.execute(any(), any(), any(RegisterConnector.class)))
+          .thenReturn(ResponseFixture.getErrorResponse());
+
+      openCTIConnectorService.registerOrPingAllConnectors();
+      openCTIConnectorService.registerOrPingAllConnectors();
+
+      assertThat(connector.isRegistered()).isFalse();
+      verify(mockOpenCTIClient, times(1)).execute(any(), any(), any(RegisterConnector.class));
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
@@ -3,15 +3,19 @@ package io.openaev.rest.helper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import io.openaev.config.TenantFilteringException;
 import io.openaev.database.model.Filters.FilterOperator;
+import io.openaev.helper.ObjectMapperHelper;
 import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exception.ChainingOperationNotSupportedException;
+import io.openaev.rest.payload.output_parser.OutputParserInput;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -248,6 +252,90 @@ class RestBehaviorTest {
       assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals(iae.getMessage(), response.getBody().getMessage());
+    }
+
+    @Test
+    @DisplayName(
+        "a real Jackson enum @JsonCreator failure surfaces the allowed values in the 400 message")
+    void given_realJacksonEnumCreatorFailure_should_surfaceAllowedValues() {
+      // GIVEN - the exact server-side failure shape: the application mapper deserializing the
+      // real input DTO with an unknown enum value (Jackson wraps the creator
+      // IllegalArgumentException in a ValueInstantiationException)
+      JacksonException jacksonFailure =
+          assertThrows(
+              JacksonException.class,
+              () ->
+                  ObjectMapperHelper.openAEVJsonMapper()
+                      .readValue(
+                          "{\"output_parser_mode\":\"STDOUT\","
+                              + "\"output_parser_type\":\"credentials\"}",
+                          OutputParserInput.class));
+      HttpMessageNotReadableException ex =
+          new HttpMessageNotReadableException("JSON parse error", jacksonFailure, null);
+
+      // WHEN
+      ResponseEntity<ErrorMessage> response = new RestBehavior().handleHttpMessageNotReadable(ex);
+
+      // THEN
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      assertNotNull(response.getBody());
+      assertTrue(response.getBody().getMessage().contains("output_parser_type must be REGEX"));
+    }
+
+    @Test
+    @DisplayName("the deepest IllegalArgumentException in the cause chain provides the 400 message")
+    void given_nestedIllegalArguments_should_surfaceDeepestMessage() {
+      // GIVEN - an intermediate IAE wrapper restating the root creator message with noise
+      IllegalArgumentException root =
+          new IllegalArgumentException(
+              "output_parser_mode must be STDOUT, STDERR, or READ_FILE. Got: pipe");
+      IllegalArgumentException outer = new IllegalArgumentException("Cannot deserialize", root);
+      HttpMessageNotReadableException ex =
+          new HttpMessageNotReadableException("JSON parse error", outer, null);
+
+      // WHEN
+      ResponseEntity<ErrorMessage> response = new RestBehavior().handleHttpMessageNotReadable(ex);
+
+      // THEN
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      assertNotNull(response.getBody());
+      assertEquals(root.getMessage(), response.getBody().getMessage());
+    }
+
+    @Test
+    @DisplayName("a cyclic cause chain terminates and falls back to the generic message")
+    void given_cyclicCauseChain_should_fallBackToGenericMessage() {
+      // GIVEN - two exceptions referencing each other as causes
+      RuntimeException first = new RuntimeException("first");
+      RuntimeException second = new RuntimeException("second", first);
+      first.initCause(second);
+      HttpMessageNotReadableException ex =
+          new HttpMessageNotReadableException("JSON parse error", first, null);
+
+      // WHEN
+      ResponseEntity<ErrorMessage> response = new RestBehavior().handleHttpMessageNotReadable(ex);
+
+      // THEN
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      assertNotNull(response.getBody());
+      assertEquals("Malformed or unreadable request body", response.getBody().getMessage());
+    }
+
+    @Test
+    @DisplayName("a blank IllegalArgumentException message falls back to the generic message")
+    void given_blankIllegalArgumentMessage_should_fallBackToGenericMessage() {
+      // GIVEN
+      HttpMessageNotReadableException ex =
+          new HttpMessageNotReadableException(
+              "JSON parse error", new IllegalArgumentException("   "), null);
+
+      // WHEN
+      ResponseEntity<ErrorMessage> response = new RestBehavior().handleHttpMessageNotReadable(ex);
+
+      // THEN
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      assertNotNull(response.getBody());
+      assertEquals("Malformed or unreadable request body", response.getBody().getMessage());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
@@ -224,5 +224,30 @@ class RestBehaviorTest {
       assertNotNull(response.getBody());
       assertTrue(response.getBody().getMessage().contains("Malformed"));
     }
+
+    @Test
+    @DisplayName(
+        "IllegalArgumentException from @JsonCreator (wrapped by Jackson) is returned as the 400"
+            + " message")
+    void given_jsonCreatorIllegalArgument_should_surfaceCreatorMessage() {
+      // GIVEN - Jackson wraps @JsonCreator IAE in JsonMappingException /
+      // ValueInstantiationException
+      IllegalArgumentException iae =
+          new IllegalArgumentException(
+              "output_parser_type must be REGEX; finding types like credentials belong in"
+                  + " contract_output_element_type, not output_parser_type. Got: credentials");
+      JsonMappingException wrapped =
+          JsonMappingException.from((JsonParser) null, "Cannot construct instance", iae);
+      HttpMessageNotReadableException ex =
+          new HttpMessageNotReadableException("JSON parse error", wrapped, null);
+
+      // WHEN
+      ResponseEntity<ErrorMessage> response = new RestBehavior().handleHttpMessageNotReadable(ex);
+
+      // THEN
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      assertNotNull(response.getBody());
+      assertEquals(iae.getMessage(), response.getBody().getMessage());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/SecurityCoverageJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/SecurityCoverageJobTest.java
@@ -1,0 +1,112 @@
+package io.openaev.scheduler.jobs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Exercise;
+import io.openaev.database.model.SecurityCoverageSendJob;
+import io.openaev.database.model.Tenant;
+import io.openaev.opencti.connectors.ConnectorBase;
+import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
+import io.openaev.service.SecurityCoverageSendJobService;
+import io.openaev.service.stix.SecurityCoverageService;
+import io.openaev.stix.objects.Bundle;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit coverage for the "skip push when the connector is not usable" path that keeps the scheduler
+ * from logging a full ERROR stack every cycle while an OpenCTI connector is configured but not yet
+ * registered (OpenCTI unreachable / token not authorized).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SecurityCoverageJob skips jobs without an active, registered connector")
+class SecurityCoverageJobTest {
+
+  private static final String TENANT_ID = "tenant-1";
+
+  @Mock private SecurityCoverageSendJobService securityCoverageSendJobService;
+  @Mock private SecurityCoverageService securityCoverageService;
+  @Mock private OpenCTIConnectorService openCTIConnectorService;
+
+  @InjectMocks private SecurityCoverageJob job;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clearCurrentTenant();
+  }
+
+  private SecurityCoverageSendJob pendingJobForTenant() {
+    Tenant tenant = new Tenant();
+    tenant.setId(TENANT_ID);
+    Exercise simulation = new Exercise();
+    simulation.setTenant(tenant);
+    SecurityCoverageSendJob sendJob = new SecurityCoverageSendJob();
+    sendJob.setSimulation(simulation);
+    return sendJob;
+  }
+
+  @Test
+  @DisplayName("a configured but not-yet-registered connector short-circuits before any push")
+  void given_connectorNotRegistered_should_skipBundleCreationAndPush() throws Exception {
+    when(securityCoverageSendJobService.getPendingSecurityCoverageSendJobs())
+        .thenReturn(List.of(pendingJobForTenant()));
+    ConnectorBase connector = org.mockito.Mockito.mock(ConnectorBase.class);
+    when(connector.isRegistered()).thenReturn(false);
+    when(openCTIConnectorService.getConnectorBase(TENANT_ID)).thenReturn(Optional.of(connector));
+
+    job.execute(null);
+
+    // No bundle is built, nothing is pushed (so no ConnectorError -> no ERROR stack), and the job
+    // stays pending until the connector registers.
+    verify(securityCoverageService, never()).createBundleFromSendJobs(anyList());
+    verify(openCTIConnectorService, never()).pushSecurityCoverageStixBundle(any(), any());
+    verify(securityCoverageSendJobService, never()).consumeJobs(anyList());
+  }
+
+  @Test
+  @DisplayName("no connector at all is also skipped without a push")
+  void given_noConnector_should_skip() throws Exception {
+    when(securityCoverageSendJobService.getPendingSecurityCoverageSendJobs())
+        .thenReturn(List.of(pendingJobForTenant()));
+    when(openCTIConnectorService.getConnectorBase(TENANT_ID)).thenReturn(Optional.empty());
+
+    job.execute(null);
+
+    verify(securityCoverageService, never()).createBundleFromSendJobs(anyList());
+    verify(openCTIConnectorService, never()).pushSecurityCoverageStixBundle(any(), any());
+    verify(securityCoverageSendJobService, never()).consumeJobs(anyList());
+  }
+
+  @Test
+  @DisplayName("a registered connector still gets its bundle built, pushed and the job consumed")
+  void given_registeredConnector_should_pushAndConsume() throws Exception {
+    SecurityCoverageSendJob sendJob = pendingJobForTenant();
+    when(securityCoverageSendJobService.getPendingSecurityCoverageSendJobs())
+        .thenReturn(List.of(sendJob));
+    ConnectorBase connector = org.mockito.Mockito.mock(ConnectorBase.class);
+    when(connector.isRegistered()).thenReturn(true);
+    when(openCTIConnectorService.getConnectorBase(TENANT_ID)).thenReturn(Optional.of(connector));
+    // getId() is only used for a log line; leaving the mock default (null) keeps the test focused.
+    Bundle bundle = org.mockito.Mockito.mock(Bundle.class);
+    when(securityCoverageService.createBundleFromSendJobs(anyList())).thenReturn(bundle);
+
+    job.execute(null);
+
+    verify(securityCoverageService).createBundleFromSendJobs(anyList());
+    verify(openCTIConnectorService).pushSecurityCoverageStixBundle(eq(bundle), eq(TENANT_ID));
+    verify(securityCoverageSendJobService).consumeJobs(anyList());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/ThreatArsenalInputFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/ThreatArsenalInputFixture.java
@@ -1,7 +1,9 @@
 package io.openaev.utils.fixtures;
 
+import static io.openaev.utils.fixtures.payload_fixture.ContractOutputElementInputFixture.createDefaultContractOutputElementInputCredentials;
 import static io.openaev.utils.fixtures.payload_fixture.ContractOutputElementInputFixture.createDefaultContractOutputElementInputIPV6;
 import static io.openaev.utils.fixtures.payload_fixture.OutputParserInputFixture.createDefaultOutputParseInput;
+import static io.openaev.utils.fixtures.payload_fixture.RegexGroupInputFixture.createDefaultRegexGroupInputCredentials;
 import static io.openaev.utils.fixtures.payload_fixture.RegexGroupInputFixture.createDefaultRegexGroupInputIPV6;
 
 import io.openaev.api.threat_arsenal.dto.ThreatArsenalActionCreateInput;
@@ -96,6 +98,41 @@ public class ThreatArsenalInputFixture {
         "This does something, maybe",
         "bash",
         "echo hello",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        null,
+        Set.of(outputParserInput),
+        domainIds);
+  }
+
+  public static ThreatArsenalActionCreateInput createCommandLineActionWithCredentialsOutputParser(
+      List<String> domainIds) {
+    RegexGroupInput regexGroupInput = createDefaultRegexGroupInputCredentials();
+    ContractOutputElementInput contractOutputElementInput =
+        createDefaultContractOutputElementInputCredentials();
+    contractOutputElementInput.setRegexGroups(Set.of(regexGroupInput));
+    OutputParserInput outputParserInput = createDefaultOutputParseInput();
+    outputParserInput.setContractOutputElements(Set.of(contractOutputElementInput));
+
+    return new ThreatArsenalActionCreateInput(
+        Command.COMMAND_TYPE,
+        "Hashcat crack action",
+        PAYLOAD_SOURCE.MANUAL,
+        PAYLOAD_STATUS.VERIFIED,
+        new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux},
+        PAYLOAD_EXECUTION_ARCH.ALL_ARCHITECTURES,
+        new EXPECTATION_TYPE[] {},
+        Collections.emptyMap(),
+        "Cracks a hash and emits a credentials finding",
+        "bash",
+        "hashcat -m 1000 hash.txt wordlist.txt",
         null,
         null,
         null,

--- a/openaev-model/src/main/java/io/openaev/database/model/ParserMode.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ParserMode.java
@@ -1,7 +1,23 @@
 package io.openaev.database.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum ParserMode {
   STDOUT,
   STDERR,
-  READ_FILE
+  READ_FILE;
+
+  @JsonCreator
+  public static ParserMode fromValue(String value) {
+    if (value == null) {
+      return null;
+    }
+    for (ParserMode mode : values()) {
+      if (mode.name().equalsIgnoreCase(value)) {
+        return mode;
+      }
+    }
+    throw new IllegalArgumentException(
+        "output_parser_mode must be STDOUT, STDERR, or READ_FILE. Got: " + value);
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/database/model/ParserType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ParserType.java
@@ -1,5 +1,21 @@
 package io.openaev.database.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum ParserType {
-  REGEX
+  REGEX;
+
+  @JsonCreator
+  public static ParserType fromValue(String value) {
+    if (value == null) {
+      return null;
+    }
+    if ("REGEX".equalsIgnoreCase(value)) {
+      return REGEX;
+    }
+    throw new IllegalArgumentException(
+        "output_parser_type must be REGEX; finding types like credentials belong in"
+            + " contract_output_element_type, not output_parser_type. Got: "
+            + value);
+  }
 }

--- a/openaev-model/src/main/java/io/openaev/database/model/ParserType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ParserType.java
@@ -10,8 +10,10 @@ public enum ParserType {
     if (value == null) {
       return null;
     }
-    if ("REGEX".equalsIgnoreCase(value)) {
-      return REGEX;
+    for (ParserType type : values()) {
+      if (type.name().equalsIgnoreCase(value)) {
+        return type;
+      }
     }
     throw new IllegalArgumentException(
         "output_parser_type must be REGEX; finding types like credentials belong in"


### PR DESCRIPTION
### Proposed changes

- Stop `TxCtxArgumentResolver` from loading Tenant entities through a class-level `@Transactional` service. Authorized tenant ids now come from a cached JDBC lookup that joins `users_tenants` to `tenants` and excludes `tenant_deleted_at IS NOT NULL`, matching `TenantRepository.findTenantsByUserId`, so the pool connection is returned immediately instead of being held for the whole HTTP request (Hikari leak on any POST over 30s, including Threat Arsenal create/update from XTM One). `evictForUser` evicts both membership caches through `CacheManager` so Spring AOP self-invocation cannot leave stale ids after membership changes.
- OpenCTI register/ping logs WARN once (no stack) and back offs 5 minutes after failure. Security coverage jobs skip bundle create and push when the connector is configured but not registered.
- `ParserType` / `ParserMode` `@JsonCreator` reject unknown values (for example `output_parser_type: credentials`) as HTTP 400 with an actionable message. `RestBehavior#handleHttpMessageNotReadable` unwraps the deepest root-cause `IllegalArgumentException` (cycle-safe) so the creator message reaches the client instead of the generic "Malformed or unreadable request body".

Companion XTM One change: XTM-One-Platform/xtm-one#2869 (orchestrator consult gate, plan-mode cycle budget, parser validation before the request leaves XTM One).

### Testing Instructions

1. Long Threat Arsenal POST (>30s): confirm no Hikari "Apparent connection leak" from `TxCtxArgumentResolver`.
2. OpenCTI connector with a URL/token that cannot register: confirm coverage jobs skip with one WARN per tenant, not ERROR+stack every 15s.
3. POST a threat arsenal action with `output_parser_type: credentials`: expect 400, not 500.
4. After removing a user from a tenant (or soft-deleting a tenant), confirm the next request no longer authorizes that tenant id.

### Related issues

* Closes #7415

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
