### PR TITLE
fix(api): threat arsenal action 500s, security coverage log noise and tenant resolver connection leak (#7417)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionCreateInput.java
+++ b/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionCreateInput.java
@@ -14,6 +14,7 @@ import io.openaev.database.model.SecurityPlatform;
 import io.openaev.rest.payload.form.DetectionRemediationInput;
 import io.openaev.rest.payload.output_parser.OutputParserInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -56,7 +57,7 @@ public record ThreatArsenalActionCreateInput(
     @JsonProperty("action_detection_remediations")
         @Schema(description = "List of detection remediation gaps for collectors")
         List<DetectionRemediationInput> detectionRemediations,
-    @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
+    @Valid @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
         Set<OutputParserInput> outputParsers,
     @NotNull(message = MANDATORY_MESSAGE)
         @JsonProperty("action_domains")

--- a/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionUpdateInput.java
+++ b/openaev-api/src/main/java/io/openaev/api/threat_arsenal/dto/ThreatArsenalActionUpdateInput.java
@@ -12,6 +12,7 @@ import io.openaev.database.model.SecurityPlatform;
 import io.openaev.rest.payload.form.DetectionRemediationInput;
 import io.openaev.rest.payload.output_parser.OutputParserInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -48,7 +49,7 @@ public record ThreatArsenalActionUpdateInput(
     @JsonProperty("action_detection_remediations")
         @Schema(description = "List of detection remediation gaps for collectors")
         List<DetectionRemediationInput> detectionRemediations,
-    @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
+    @Valid @JsonProperty("action_output_parsers") @Schema(description = "Set of output parsers")
         Set<OutputParserInput> outputParsers,
     @NotNull(message = MANDATORY_MESSAGE)
         @JsonProperty("action_domains")

--- a/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
+++ b/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
@@ -51,10 +51,14 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
     Set<String> selector = extractSelector(webRequest);
+    // Read only the ids via a light read-only projection. Argument resolution runs before the
+    // controller's transaction and, under open-in-view, the request-scoped session keeps the first
+    // connection it touches bound for the whole request - so this lookup used to be flagged as a
+    // HikariCP "apparent connection leak" and it pinned managed Tenant entities in that long-lived
+    // persistence context. See TenantService#findTenantIdsByUserId.
     Set<String> authorized =
-        tenantService.findTenantsByUserId(SessionHelper.currentUser().getId()).stream()
-            .map(Tenant::getId)
-            .collect(Collectors.toSet());
+        new LinkedHashSet<>(
+            tenantService.findTenantIdsByUserId(SessionHelper.currentUser().getId()));
     if (selector.isEmpty() && parameter.hasParameterAnnotation(RequireTenantSelector.class)) {
       selector = fallbackSelector(authorized);
     }

--- a/openaev-api/src/main/java/io/openaev/opencti/connectors/service/OpenCTIConnectorService.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/connectors/service/OpenCTIConnectorService.java
@@ -10,7 +10,10 @@ import io.openaev.stix.objects.Bundle;
 import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotNull;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +27,16 @@ public class OpenCTIConnectorService {
   private final XtmConfig xtmConfig;
   private final OpenAEVConfig openAEVConfig;
   private final OpenCTIService openCTIService;
+
+  /**
+   * When a connector cannot register/ping (OpenCTI unreachable or its token not yet authorized),
+   * the register-ping job runs every cycle and used to log a full ERROR stack each time. This is an
+   * expected, self-healing transient condition, so we log one concise WARN per connector and then
+   * stay silent for this backoff window until it recovers (a success resets the throttle).
+   */
+  private static final Duration REGISTER_FAILURE_WARN_BACKOFF = Duration.ofMinutes(30);
+
+  private final Map<String, Instant> lastRegisterFailureWarnAt = new ConcurrentHashMap<>();
 
   /** Creates one {@link SecurityCoverageConnector} per tenant entry in the config map. */
   @PostConstruct
@@ -91,10 +104,48 @@ public class OpenCTIConnectorService {
         } else {
           openCTIService.pingConnector(c);
         }
+        // Recovered (or never failed): reset the throttle so the next real failure warns at once.
+        lastRegisterFailureWarnAt.remove(c.getId());
       } catch (Exception e) {
-        log.error("Error at OpenCTI connector registration or ping", e);
+        logRegisterOrPingFailureThrottled(c, e);
       }
     }
+  }
+
+  /**
+   * Logs a connector register/ping failure at most once per {@link #REGISTER_FAILURE_WARN_BACKOFF}
+   * per connector: a concise WARN (message only) instead of a full ERROR stack every cycle. The
+   * full stack stays available at DEBUG for troubleshooting, and genuine, non-transient failures
+   * still surface (one WARN per backoff window) rather than being hidden entirely.
+   */
+  private void logRegisterOrPingFailureThrottled(ConnectorBase connector, Exception e) {
+    Instant now = Instant.now();
+    Instant lastWarn = lastRegisterFailureWarnAt.get(connector.getId());
+    boolean withinBackoff =
+        lastWarn != null
+            && Duration.between(lastWarn, now).compareTo(REGISTER_FAILURE_WARN_BACKOFF) < 0;
+    if (withinBackoff) {
+      log.debug("OpenCTI connector {} still failing to register or ping", connector.getName(), e);
+      return;
+    }
+    lastRegisterFailureWarnAt.put(connector.getId(), now);
+    log.warn(
+        "OpenCTI connector {} (tenant {}) could not register or ping: {}. This is expected while"
+            + " OpenCTI is unreachable or its token is not yet authorized; retrying every cycle,"
+            + " next warning in at most {} min.",
+        connector.getName(),
+        connector.getTenantId(),
+        conciseReason(e),
+        REGISTER_FAILURE_WARN_BACKOFF.toMinutes());
+  }
+
+  /** First non-blank line of the failure message, or the exception type when it carries none. */
+  private static String conciseReason(Throwable e) {
+    String message = e.getMessage();
+    if (message == null || message.isBlank()) {
+      return e.getClass().getSimpleName();
+    }
+    return message.strip().lines().findFirst().orElse(message.strip());
   }
 
   public void pushSecurityCoverageStixBundle(Bundle bundle, final String tenantId)

--- a/openaev-api/src/main/java/io/openaev/rest/payload/contract_output_element/ContractOutputElementInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/contract_output_element/ContractOutputElementInput.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.openaev.database.model.ContractOutputType;
 import io.openaev.rest.payload.regex_group.RegexGroupInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -58,5 +59,6 @@ public class ContractOutputElementInput {
   @JsonProperty("contract_output_element_regex_groups")
   @Schema(description = "Set of regex groups")
   @NotNull
+  @Valid
   private Set<RegexGroupInput> regexGroups = new HashSet<>();
 }

--- a/openaev-api/src/main/java/io/openaev/rest/payload/output_parser/OutputParserInput.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/output_parser/OutputParserInput.java
@@ -5,6 +5,7 @@ import io.openaev.database.model.ParserMode;
 import io.openaev.database.model.ParserType;
 import io.openaev.rest.payload.contract_output_element.ContractOutputElementInput;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,5 +30,6 @@ public class OutputParserInput {
   @JsonProperty("output_parser_contract_output_elements")
   @Schema(description = "List of Contract output elements")
   @NotNull
+  @Valid
   private Set<ContractOutputElementInput> contractOutputElements = new HashSet<>();
 }

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/SecurityCoverageJob.java
@@ -7,6 +7,7 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.Exercise;
 import io.openaev.database.model.SecurityCoverageSendJob;
 import io.openaev.database.model.Tenant;
+import io.openaev.opencti.connectors.ConnectorBase;
 import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
 import io.openaev.service.SecurityCoverageSendJobService;
 import io.openaev.service.stix.SecurityCoverageService;
@@ -14,6 +15,7 @@ import io.openaev.stix.objects.Bundle;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,9 +44,12 @@ public class SecurityCoverageJob implements Job {
     List<SecurityCoverageSendJob> jobs =
         securityCoverageSendJobService.getPendingSecurityCoverageSendJobs();
     List<SecurityCoverageSendJob> successfulJobs = new ArrayList<>();
-    // Tenants without an active Security Coverage connector: skip their jobs upfront (before any
-    // bundle creation) and log a single concise warning per tenant instead of one ERROR with a
-    // full stack trace per pending simulation on every run (log flooding + useless DB load).
+    // Tenants without an active, registered Security Coverage connector: skip their jobs upfront
+    // (before any bundle creation) and log a single concise warning per tenant instead of one
+    // ERROR with a full stack trace per pending simulation on every run (log flooding + useless
+    // DB load). "Not registered yet" is the common transient case (OpenCTI unreachable or the
+    // connector token not authorized): pushing anyway would throw ConnectorError and land in the
+    // catch below, spamming ERROR every cycle - so it must be treated like a missing connector.
     Set<String> tenantsWithoutConnector = new HashSet<>();
     for (SecurityCoverageSendJob securityCoverageSendJob : jobs) {
       try {
@@ -56,7 +61,8 @@ public class SecurityCoverageJob implements Job {
         if (tenantsWithoutConnector.contains(tenantId)) {
           continue;
         }
-        if (openCTIConnectorService.getConnectorBase(tenantId).isEmpty()) {
+        Optional<ConnectorBase> connector = openCTIConnectorService.getConnectorBase(tenantId);
+        if (connector.isEmpty() || !connector.get().isRegistered()) {
           tenantsWithoutConnector.add(tenantId);
           continue;
         }
@@ -93,7 +99,7 @@ public class SecurityCoverageJob implements Job {
     }
     if (!tenantsWithoutConnector.isEmpty()) {
       log.warn(
-          "Security coverage bundles not sent: no active Security Coverage connector for tenant(s) {}. Jobs stay pending until a connector is configured.",
+          "Security coverage bundles not sent: no active/registered Security Coverage connector for tenant(s) {}. Jobs stay pending until a connector is configured and registered with OpenCTI.",
           tenantsWithoutConnector);
     }
     if (!successfulJobs.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantService.java
@@ -120,6 +120,26 @@ public class TenantService {
     return tenantRepository.findTenantsByUserId(userId);
   }
 
+  /**
+   * Returns just the ids of the tenants accessible by a given user, as a read-only scalar
+   * projection.
+   *
+   * <p>Called by {@code TxCtxArgumentResolver} during Spring MVC argument resolution. With {@code
+   * spring.jpa.open-in-view} enabled (the default this platform relies on for lazy serialization)
+   * the request-scoped session keeps the connection it first touches bound for the whole request,
+   * so on a slow request HikariCP's leak detector flagged the resolver's lookup - the first DB
+   * access - as an "apparent connection leak". Reading only the ids keeps this lookup a light
+   * read-only query and, unlike {@link #findTenantsByUserId}, does not materialise managed {@link
+   * Tenant} entities into that long-lived persistence context. Propagation stays the default
+   * (REQUIRED): in production no transaction is active during argument resolution, so this runs in
+   * its own short read-only transaction; joining an ambient one when present keeps read-your-writes
+   * visibility intact.
+   */
+  @Transactional(readOnly = true)
+  public List<String> findTenantIdsByUserId(@NotNull String userId) {
+    return tenantRepository.findTenantIdsByUserId(userId);
+  }
+
   @Transactional(readOnly = true)
   public List<String> findActiveTenantIds() {
     return tenantRepository.findAllIdsByDeletedAtIsNull();

--- a/openaev-api/src/main/java/io/openaev/utils/StringUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/StringUtils.java
@@ -54,6 +54,13 @@ public class StringUtils {
    * @return {@code true} if the regex compiles successfully, {@code false} otherwise
    */
   public static boolean isValidRegex(String regex) {
+    // A null/blank rule is invalid input, not a server fault: returning false lets the caller
+    // raise a 400. Without this guard `regex.length()` threw a raw NullPointerException that
+    // surfaced as a 500 whenever a contract output element reached this method with no rule
+    // (e.g. a malformed output parser slipping past bean validation).
+    if (regex == null || regex.isBlank()) {
+      return false;
+    }
     if (regex.length() > 100) {
       throw new IllegalArgumentException("Regex too long");
     }

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -26,6 +26,8 @@ import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.PayloadRepository;
 import io.openaev.ee.EnterpriseEditionService;
 import io.openaev.integration.impl.injectors.openaev.OpenaevInjectorIntegrationFactory;
+import io.openaev.rest.payload.contract_output_element.ContractOutputElementInput;
+import io.openaev.rest.payload.output_parser.OutputParserInput;
 import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.*;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
@@ -337,6 +339,101 @@ public class ThreatArsenalApiTest extends IntegrationTest {
       assertNotNull(payload);
       assertEquals(1, payload.getOutputParsers().size());
       ;
+    }
+
+    @Test
+    @DisplayName(
+        "Creating an action carrying a credentials output parser should succeed and persist the credentials finding element")
+    void given_credentialsOutputParser_should_createPayloadWithCredentialsFinding()
+        throws Exception {
+      // The AI orchestrator forks a crack action and attaches a credentials output parser so the
+      // action produces a credentials finding. `credentials` is a valid ContractOutputType on the
+      // contract output element (the parser type stays REGEX); a well-formed request must succeed
+      // and yield a finding-flagged credentials element, never a 500.
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+      ThreatArsenalActionCreateInput input =
+          ThreatArsenalInputFixture.createCommandLineActionWithCredentialsOutputParser(
+              List.of(domain.getId()));
+
+      String response =
+          mvc.perform(
+                  post(THREAT_ARSENAL_URI)
+                      .with(csrf())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(asJsonString(input)))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      String payloadId = JsonPath.read(response, "$.action_payload.payload_id");
+      Payload payload = payloadRepository.findById(payloadId).orElse(null);
+      assertNotNull(payload);
+      assertEquals(1, payload.getOutputParsers().size());
+      OutputParser outputParser = payload.getOutputParsers().iterator().next();
+      assertEquals(ParserType.REGEX, outputParser.getType());
+      Set<ContractOutputElement> elements = outputParser.getContractOutputElements();
+      assertEquals(1, elements.size());
+      ContractOutputElement credentialsElement = elements.iterator().next();
+      assertEquals(ContractOutputType.Credentials, credentialsElement.getType());
+      assertTrue(
+          credentialsElement.isFinding(),
+          "the credentials contract output element must be flagged as a finding");
+    }
+
+    @Test
+    @DisplayName(
+        "Creating an action with a malformed output parser (blank contract output element rule) should return 400, not 500")
+    void given_outputParserWithBlankRule_should_returnBadRequest() throws Exception {
+      // Regression: a contract output element with no rule slipped past validation (the nested
+      // output-parser inputs were not @Valid-cascaded) and reached StringUtils.isValidRegex(null),
+      // which threw a raw NullPointerException surfaced as a 500. Malformed user input must be a
+      // clean 4xx.
+      Domain domain = domainComposer.forDomain(DomainFixture.getRandomDomain()).persist().get();
+
+      ContractOutputElementInput malformedElement = new ContractOutputElementInput();
+      malformedElement.setFinding(true);
+      malformedElement.setName("creds");
+      malformedElement.setKey("creds");
+      malformedElement.setType(ContractOutputType.Credentials);
+      malformedElement.setRule(null); // missing rule: must be rejected with 400, never a 500
+      OutputParserInput malformedParser = new OutputParserInput();
+      malformedParser.setMode(ParserMode.STDOUT);
+      malformedParser.setType(ParserType.REGEX);
+      malformedParser.setContractOutputElements(Set.of(malformedElement));
+
+      ThreatArsenalActionCreateInput input =
+          new ThreatArsenalActionCreateInput(
+              Command.COMMAND_TYPE,
+              "Command line payload with malformed parser",
+              Payload.PAYLOAD_SOURCE.MANUAL,
+              Payload.PAYLOAD_STATUS.VERIFIED,
+              new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux},
+              Payload.PAYLOAD_EXECUTION_ARCH.ALL_ARCHITECTURES,
+              new BaseInjectExpectation.EXPECTATION_TYPE[] {},
+              Collections.emptyMap(),
+              null,
+              "bash",
+              "echo hello",
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              Collections.emptyList(),
+              Collections.emptyList(),
+              null,
+              Set.of(malformedParser),
+              List.of(domain.getId()));
+
+      mvc.perform(
+              post(THREAT_ARSENAL_URI)
+                  .with(csrf())
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().is4xxClientError());
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
@@ -9,7 +9,6 @@ import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
 import io.openaev.service.tenants.TenantService;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,8 +57,7 @@ class TxCtxArgumentResolverTest {
   }
 
   private void authorizeTenants(String... tenantIds) {
-    List<Tenant> tenants = Arrays.stream(tenantIds).map(Tenant::new).toList();
-    when(tenantService.findTenantsByUserId(USER_ID)).thenReturn(tenants);
+    when(tenantService.findTenantIdsByUserId(USER_ID)).thenReturn(List.of(tenantIds));
   }
 
   private void requireSelector() {

--- a/openaev-api/src/test/java/io/openaev/database/model/ContractOutputTypeTest.java
+++ b/openaev-api/src/test/java/io/openaev/database/model/ContractOutputTypeTest.java
@@ -1,0 +1,83 @@
+package io.openaev.database.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards the {@code contract_output_element_type} wire contract: every token the client (the AI
+ * orchestrator, forking payloads and adding output parsers) emits must deserialize to a {@link
+ * ContractOutputType}. A missing or renamed {@link com.fasterxml.jackson.annotation.JsonProperty}
+ * used to turn an authored {@code credentials} finding into a rejected request; this test fails
+ * fast if any token stops being accepted.
+ */
+@DisplayName("ContractOutputType accepts every client-emitted token")
+class ContractOutputTypeTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  static Stream<Arguments> clientEmittedTokens() {
+    return Stream.of(
+        Arguments.of("credentials", ContractOutputType.Credentials),
+        Arguments.of("username", ContractOutputType.Username),
+        Arguments.of("admin_username", ContractOutputType.AdminUsername),
+        Arguments.of("sid", ContractOutputType.Sid),
+        Arguments.of("asset", ContractOutputType.Asset),
+        Arguments.of("computer", ContractOutputType.Computer),
+        Arguments.of("share", ContractOutputType.Share),
+        Arguments.of("cve", ContractOutputType.CVE),
+        Arguments.of("vulnerability", ContractOutputType.Vulnerability),
+        Arguments.of("group", ContractOutputType.Group),
+        Arguments.of("file", ContractOutputType.File),
+        Arguments.of("delegation", ContractOutputType.Delegation),
+        Arguments.of("password_policy", ContractOutputType.PasswordPolicy),
+        Arguments.of("asreproastable_account", ContractOutputType.AsreproastableAccount),
+        Arguments.of("kerberoastable_account", ContractOutputType.KerberoastableAccount),
+        Arguments.of(
+            "account_with_password_not_required",
+            ContractOutputType.AccountWithPasswordNotRequired),
+        Arguments.of("port", ContractOutputType.Port),
+        Arguments.of("portscan", ContractOutputType.PortsScan),
+        Arguments.of("ipv4", ContractOutputType.IPv4),
+        Arguments.of("ipv6", ContractOutputType.IPv6),
+        Arguments.of("number", ContractOutputType.Number),
+        Arguments.of("text", ContractOutputType.Text),
+        Arguments.of("expectation_signature", ContractOutputType.ExpectationSignature),
+        Arguments.of("action_output", ContractOutputType.ActionOutput));
+  }
+
+  @ParameterizedTest(name = "\"{0}\" deserializes to {1}")
+  @MethodSource("clientEmittedTokens")
+  void given_clientToken_should_deserializeToExpectedType(String token, ContractOutputType expected)
+      throws Exception {
+    ContractOutputType parsed = MAPPER.readValue('"' + token + '"', ContractOutputType.class);
+    assertEquals(expected, parsed, "token '" + token + "' must map to " + expected);
+    assertThat(parsed.getLabel()).isEqualTo(token);
+  }
+
+  @ParameterizedTest(name = "\"{0}\" round-trips through JSON")
+  @MethodSource("clientEmittedTokens")
+  void given_type_should_serializeToItsToken(String token, ContractOutputType type)
+      throws Exception {
+    assertEquals('"' + token + '"', MAPPER.writeValueAsString(type));
+  }
+
+  @org.junit.jupiter.api.Test
+  @DisplayName("every enum constant is covered by the client-token contract test")
+  void everyConstantIsCovered() {
+    long tokenCount = clientEmittedTokens().count();
+    // The enum also declares "email", which is not in the client-emitted set exercised above.
+    long expectedCovered = Arrays.stream(ContractOutputType.values()).count() - 1;
+    assertEquals(
+        expectedCovered,
+        tokenCount,
+        "add any new ContractOutputType to clientEmittedTokens() so the wire contract stays tested");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/SecurityCoverageJobTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/SecurityCoverageJobTest.java
@@ -1,0 +1,112 @@
+package io.openaev.scheduler.jobs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TenantContext;
+import io.openaev.database.model.Exercise;
+import io.openaev.database.model.SecurityCoverageSendJob;
+import io.openaev.database.model.Tenant;
+import io.openaev.opencti.connectors.ConnectorBase;
+import io.openaev.opencti.connectors.service.OpenCTIConnectorService;
+import io.openaev.service.SecurityCoverageSendJobService;
+import io.openaev.service.stix.SecurityCoverageService;
+import io.openaev.stix.objects.Bundle;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit coverage for the "skip push when the connector is not usable" path that keeps the scheduler
+ * from logging a full ERROR stack every cycle while an OpenCTI connector is configured but not yet
+ * registered (OpenCTI unreachable / token not authorized).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SecurityCoverageJob skips jobs without an active, registered connector")
+class SecurityCoverageJobTest {
+
+  private static final String TENANT_ID = "tenant-1";
+
+  @Mock private SecurityCoverageSendJobService securityCoverageSendJobService;
+  @Mock private SecurityCoverageService securityCoverageService;
+  @Mock private OpenCTIConnectorService openCTIConnectorService;
+
+  @InjectMocks private SecurityCoverageJob job;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clearCurrentTenant();
+  }
+
+  private SecurityCoverageSendJob pendingJobForTenant() {
+    Tenant tenant = new Tenant();
+    tenant.setId(TENANT_ID);
+    Exercise simulation = new Exercise();
+    simulation.setTenant(tenant);
+    SecurityCoverageSendJob sendJob = new SecurityCoverageSendJob();
+    sendJob.setSimulation(simulation);
+    return sendJob;
+  }
+
+  @Test
+  @DisplayName("a configured but not-yet-registered connector short-circuits before any push")
+  void given_connectorNotRegistered_should_skipBundleCreationAndPush() throws Exception {
+    when(securityCoverageSendJobService.getPendingSecurityCoverageSendJobs())
+        .thenReturn(List.of(pendingJobForTenant()));
+    ConnectorBase connector = org.mockito.Mockito.mock(ConnectorBase.class);
+    when(connector.isRegistered()).thenReturn(false);
+    when(openCTIConnectorService.getConnectorBase(TENANT_ID)).thenReturn(Optional.of(connector));
+
+    job.execute(null);
+
+    // No bundle is built, nothing is pushed (so no ConnectorError -> no ERROR stack), and the job
+    // stays pending until the connector registers.
+    verify(securityCoverageService, never()).createBundleFromSendJobs(anyList());
+    verify(openCTIConnectorService, never()).pushSecurityCoverageStixBundle(any(), any());
+    verify(securityCoverageSendJobService, never()).consumeJobs(anyList());
+  }
+
+  @Test
+  @DisplayName("no connector at all is also skipped without a push")
+  void given_noConnector_should_skip() throws Exception {
+    when(securityCoverageSendJobService.getPendingSecurityCoverageSendJobs())
+        .thenReturn(List.of(pendingJobForTenant()));
+    when(openCTIConnectorService.getConnectorBase(TENANT_ID)).thenReturn(Optional.empty());
+
+    job.execute(null);
+
+    verify(securityCoverageService, never()).createBundleFromSendJobs(anyList());
+    verify(openCTIConnectorService, never()).pushSecurityCoverageStixBundle(any(), any());
+    verify(securityCoverageSendJobService, never()).consumeJobs(anyList());
+  }
+
+  @Test
+  @DisplayName("a registered connector still gets its bundle built, pushed and the job consumed")
+  void given_registeredConnector_should_pushAndConsume() throws Exception {
+    SecurityCoverageSendJob sendJob = pendingJobForTenant();
+    when(securityCoverageSendJobService.getPendingSecurityCoverageSendJobs())
+        .thenReturn(List.of(sendJob));
+    ConnectorBase connector = org.mockito.Mockito.mock(ConnectorBase.class);
+    when(connector.isRegistered()).thenReturn(true);
+    when(openCTIConnectorService.getConnectorBase(TENANT_ID)).thenReturn(Optional.of(connector));
+    // getId() is only used for a log line; leaving the mock default (null) keeps the test focused.
+    Bundle bundle = org.mockito.Mockito.mock(Bundle.class);
+    when(securityCoverageService.createBundleFromSendJobs(anyList())).thenReturn(bundle);
+
+    job.execute(null);
+
+    verify(securityCoverageService).createBundleFromSendJobs(anyList());
+    verify(openCTIConnectorService).pushSecurityCoverageStixBundle(eq(bundle), eq(TENANT_ID));
+    verify(securityCoverageSendJobService).consumeJobs(anyList());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/fixtures/ThreatArsenalInputFixture.java
+++ b/openaev-api/src/test/java/io/openaev/utils/fixtures/ThreatArsenalInputFixture.java
@@ -1,7 +1,9 @@
 package io.openaev.utils.fixtures;
 
+import static io.openaev.utils.fixtures.payload_fixture.ContractOutputElementInputFixture.createDefaultContractOutputElementInputCredentials;
 import static io.openaev.utils.fixtures.payload_fixture.ContractOutputElementInputFixture.createDefaultContractOutputElementInputIPV6;
 import static io.openaev.utils.fixtures.payload_fixture.OutputParserInputFixture.createDefaultOutputParseInput;
+import static io.openaev.utils.fixtures.payload_fixture.RegexGroupInputFixture.createDefaultRegexGroupInputCredentials;
 import static io.openaev.utils.fixtures.payload_fixture.RegexGroupInputFixture.createDefaultRegexGroupInputIPV6;
 
 import io.openaev.api.threat_arsenal.dto.ThreatArsenalActionCreateInput;
@@ -96,6 +98,41 @@ public class ThreatArsenalInputFixture {
         "This does something, maybe",
         "bash",
         "echo hello",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        null,
+        Set.of(outputParserInput),
+        domainIds);
+  }
+
+  public static ThreatArsenalActionCreateInput createCommandLineActionWithCredentialsOutputParser(
+      List<String> domainIds) {
+    RegexGroupInput regexGroupInput = createDefaultRegexGroupInputCredentials();
+    ContractOutputElementInput contractOutputElementInput =
+        createDefaultContractOutputElementInputCredentials();
+    contractOutputElementInput.setRegexGroups(Set.of(regexGroupInput));
+    OutputParserInput outputParserInput = createDefaultOutputParseInput();
+    outputParserInput.setContractOutputElements(Set.of(contractOutputElementInput));
+
+    return new ThreatArsenalActionCreateInput(
+        Command.COMMAND_TYPE,
+        "Hashcat crack action",
+        PAYLOAD_SOURCE.MANUAL,
+        PAYLOAD_STATUS.VERIFIED,
+        new Endpoint.PLATFORM_TYPE[] {Endpoint.PLATFORM_TYPE.Linux},
+        PAYLOAD_EXECUTION_ARCH.ALL_ARCHITECTURES,
+        new EXPECTATION_TYPE[] {},
+        Collections.emptyMap(),
+        "Cracks a hash and emits a credentials finding",
+        "bash",
+        "hashcat -m 1000 hash.txt wordlist.txt",
         null,
         null,
         null,

--- a/openaev-model/src/main/java/io/openaev/database/repository/TenantRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TenantRepository.java
@@ -38,6 +38,20 @@ public interface TenantRepository
       nativeQuery = true)
   List<Tenant> findTenantsByUserId(@Param("userId") String userId);
 
+  /**
+   * Returns just the ids of the tenants a given user has access to. Scalar projection used by
+   * {@code TxCtxArgumentResolver} during Spring MVC argument resolution, where only the ids are
+   * needed and materializing full {@link Tenant} entities into the request-scoped persistence
+   * context would pin them (and the connection) for the whole request.
+   */
+  @Query(
+      value =
+          "SELECT t.tenant_id FROM tenants t"
+              + " JOIN users_tenants ut ON ut.tenant_id = t.tenant_id"
+              + " WHERE ut.user_id = :userId AND t.tenant_deleted_at IS NULL",
+      nativeQuery = true)
+  List<String> findTenantIdsByUserId(@Param("userId") String userId);
+
   /** Counts active (non-soft-deleted) tenants. */
   long countByDeletedAtIsNull();
 


### PR DESCRIPTION
## Summary

Fixes three independent backend regressions surfaced by the autonomous attack-path orchestrator hammering the API and by the worker scheduler.

- **threat_arsenal 500 -> 400 on malformed output parsers.** The nested output-parser inputs (`action_output_parsers` -> contract output elements -> regex groups) were not validation-cascaded, so a malformed element (for example a missing `contract_output_element_rule`) bypassed bean validation and reached `StringUtils.isValidRegex(rule)`, where `rule.length()` threw a raw NullPointerException surfaced as a 500. Added a validation cascade on the chain and null-guarded `isValidRegex`. A well-formed action carrying a `credentials` output parser is created and yields a credentials finding element; `credentials` and every client-emitted token remain valid `ContractOutputType` values (the parser type itself stays REGEX).
- **SecurityCoverageJob / OpenCTI ERROR log spam.** A configured-but-unregistered connector slipped past the "no connector" skip, attempted the push, threw `ConnectorError: connector hasn't registered yet` and logged a full ERROR stack per pending simulation every cycle; the register/ping job did the same. The coverage push is now skipped when the connector is missing or not registered (one concise WARN per tenant per run), and register/ping failures are throttled to one WARN per connector per backoff window (no repeated stack traces), resetting on recovery.
- **HikariCP apparent connection leak in TxCtxArgumentResolver.** The resolver loaded managed `Tenant` entities during argument resolution; under open-in-view the request-scoped session keeps its first connection for the whole request, so the resolver's lookup (the first DB access) was flagged as the leak holder and the entities were pinned in that long-lived session. The resolver now reads a light read-only id projection.

## Changes

- `ThreatArsenalActionCreateInput`, `ThreatArsenalActionUpdateInput`, `OutputParserInput`, `ContractOutputElementInput`: validation cascade on the output-parser input chain.
- `StringUtils.isValidRegex`: treat null/blank as invalid (return false) instead of throwing NPE.
- `SecurityCoverageJob`: skip when the connector is empty or not registered; keep the single per-tenant WARN.
- `OpenCTIConnectorService`: throttled per-connector WARN with backoff for register/ping failures; reset on success.
- `TenantRepository.findTenantIdsByUserId` + `TenantService.findTenantIdsByUserId`: read-only id projection used by the resolver.
- Tests: `ContractOutputTypeTest`, `SecurityCoverageJobTest`, new `ThreatArsenalApiTest` cases (credentials parser create succeeds and yields the finding; malformed parser returns 4xx); `TxCtxArgumentResolverTest` updated to the id-projection lookup.

## Test plan

- [x] `mvn -pl openaev-api -am spotless:apply` clean
- [x] `mvn -pl openaev-api -am compile -DskipTests` compiles
- [x] Unit: `ContractOutputTypeTest` (49), `SecurityCoverageJobTest` (3), `TxCtxArgumentResolverTest` (4) pass
- [x] Integration (local Docker infra): `ThreatArsenalApiTest` (46), `TxCtxArgumentResolverIntegrationTest` (13), `TenantServiceTest` (15) pass
- [ ] CI green

Closes #7417
