### PR TITLE
fix(api): return 400 not 404 when duplicating a native threat arsenal item (#7423)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ThreatArsenalService.java
+++ b/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ThreatArsenalService.java
@@ -11,6 +11,7 @@ import io.openaev.database.model.Injector;
 import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.Payload;
 import io.openaev.database.model.SecurityPlatform;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.injector_contract.InjectorContractService;
 import io.openaev.rest.injector_contract.form.InjectorContractUpdateMappingInput;
@@ -311,10 +312,13 @@ public class ThreatArsenalService {
    * Duplicates an existing threat arsenal action.
    *
    * <p>Delegates the duplication to the payload service and maps the result back to a {@link
-   * ThreatArsenalAction}.
+   * ThreatArsenalAction}. Native injector contracts (no payload) cannot be duplicated: they must
+   * be reused by id. Returning 404 here used to look like a missing id and sent agents hunting for
+   * a different contract or inventing a weaker original Command.
    *
    * @param actionId the ID of the action to duplicate
    * @return the newly created threat arsenal action copy
+   * @throws BadRequestException if the injector contract is not payload-based
    */
   @Transactional(rollbackFor = Exception.class)
   public ThreatArsenalAction duplicate(String actionId) {
@@ -322,8 +326,11 @@ public class ThreatArsenalService {
     InjectorContract injectorContract = injectorContractService.injectorContract(actionId);
     Payload payload = injectorContract.getPayload();
     if (payload == null) {
-      throw new ElementNotFoundException(
-          "Only threat arsenal items based on a payload can be duplicated.");
+      throw new BadRequestException(
+          "This threat arsenal item is a native injector (not payload-based) and cannot be"
+              + " duplicated. Reuse its injector contract id as-is. Only payload-based actions"
+              + " (Command, FileDrop, Executable, DnsResolution, and other payload types) can be"
+              + " duplicated so parsers can be added on the copy.");
     }
 
     PayloadCreationService.PayloadInjectorContractCreationResult result =

--- a/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ThreatArsenalService.java
+++ b/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ThreatArsenalService.java
@@ -312,9 +312,9 @@ public class ThreatArsenalService {
    * Duplicates an existing threat arsenal action.
    *
    * <p>Delegates the duplication to the payload service and maps the result back to a {@link
-   * ThreatArsenalAction}. Native injector contracts (no payload) cannot be duplicated: they must
-   * be reused by id. Returning 404 here used to look like a missing id and sent agents hunting for
-   * a different contract or inventing a weaker original Command.
+   * ThreatArsenalAction}. Native injector contracts (no payload) cannot be duplicated: they must be
+   * reused by id. Returning 404 here used to look like a missing id and sent agents hunting for a
+   * different contract or inventing a weaker original Command.
    *
    * @param actionId the ID of the action to duplicate
    * @return the newly created threat arsenal action copy

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -1735,14 +1735,16 @@ public class ThreatArsenalApiTest extends IntegrationTest {
 
       // Act & Assert - 404 used to look like a missing id; agents then invented
       // weaker original Commands instead of reusing the native injector as-is.
+      // BadRequestException renders as an ErrorMessage payload, so pin the
+      // assertions on its "message" field rather than on the raw body.
       mvc.perform(
               post(THREAT_ARSENAL_URI + "/" + nonPayloadContract.getId() + "/duplicate")
                   .with(csrf())
                   .contentType(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest())
-          .andExpect(content().string(containsString("native injector")))
-          .andExpect(content().string(containsString("cannot be duplicated")))
-          .andExpect(content().string(containsString("Reuse")));
+          .andExpect(jsonPath("$.message", containsString("native injector")))
+          .andExpect(jsonPath("$.message", containsString("cannot be duplicated")))
+          .andExpect(jsonPath("$.message", containsString("injector contract id")));
     }
 
     @Test

--- a/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/threat_arsenal/ThreatArsenalApiTest.java
@@ -1721,8 +1721,9 @@ public class ThreatArsenalApiTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("Duplicating a non-payload injector contract should fail with NOT FOUND")
-    void given_nonPayloadContract_should_returnNotFound() throws Exception {
+    @DisplayName(
+        "Duplicating a non-payload injector contract should fail with BAD REQUEST, not NOT FOUND")
+    void given_nonPayloadContract_should_returnBadRequestExplainingReuse() throws Exception {
       // Arrange
       InjectorContract nonPayloadContract =
           injectorContractComposer
@@ -1732,12 +1733,16 @@ public class ThreatArsenalApiTest extends IntegrationTest {
               .persist()
               .get();
 
-      // Act & Assert
+      // Act & Assert - 404 used to look like a missing id; agents then invented
+      // weaker original Commands instead of reusing the native injector as-is.
       mvc.perform(
               post(THREAT_ARSENAL_URI + "/" + nonPayloadContract.getId() + "/duplicate")
                   .with(csrf())
                   .contentType(MediaType.APPLICATION_JSON))
-          .andExpect(status().isNotFound());
+          .andExpect(status().isBadRequest())
+          .andExpect(content().string(containsString("native injector")))
+          .andExpect(content().string(containsString("cannot be duplicated")))
+          .andExpect(content().string(containsString("Reuse")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #7423

## Summary

- Duplicating a native (non-payload) threat arsenal item now returns HTTP 400 with an actionable message: this is a native injector, it cannot be duplicated, reuse the injector contract id as-is.
- Payload-based actions remain duplicable so parsers can be added on the copy.
- Stops agents treating the old 404 as a missing id and inventing a weaker original Command.
- Review round: the test now asserts `jsonPath("$.message", ...)` (the ErrorMessage contract produced by `RestBehavior#handleBadRequestException`) instead of substring-matching the raw body, and the service javadoc was reflowed to fix the Spotless Check job.

Companion XTM One: XTM-One-Platform/xtm-one#2873 / https://github.com/XTM-One-Platform/xtm-one/pull/2874

## Test plan

- [x] `given_nonPayloadContract_should_returnBadRequestExplainingReuse` (ThreatArsenalApiTest) - green locally and in CI
- [x] POST /api/threat_arsenals/{id}/duplicate on a native (email) contract returns 400 with a message mentioning native injector / cannot be duplicated / injector contract id (covered by the test above)
- [x] Duplicate of a payload-based Command still returns 200 with a new action id (`given_existingPayloadAction_should_createDuplicate`, unchanged and green)

## Notes for reviewers

- The UI never hits the new 400: the Duplicate menu item is already disabled for native items (`action_payload == null`), so the message only surfaces to direct API callers and agents - which is exactly the audience it was written for.
- Sibling service methods (`delete`, `getSecurityPlatformsForActionRemediation`) still map the same "not payload-based" business rule to 404; aligning them on 400 is a possible follow-up, kept out of this fix on purpose.
