### PR TITLE
fix(api): guard null inject content in DNS indicator coverage (#7422)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -9,6 +9,7 @@ import static io.openaev.utils.constants.StixConstants.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.aop.lock.Lock;
 import io.openaev.aop.lock.LockResourceType;
 import io.openaev.config.OpenAEVConfig;
@@ -738,13 +739,14 @@ public class SecurityCoverageService {
         hostnames ->
             simulation.getInjects().stream()
                 .filter(
-                    inject ->
-                        inject.getContent().has(DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY)
-                            && hostnames.contains(
-                                (inject
-                                    .getContent()
-                                    .get(DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY)
-                                    .textValue())))
+                    inject -> {
+                      // injects created without content cannot match a DNS resolution hostname
+                      ObjectNode content = inject.getContent();
+                      return content != null
+                          && content.has(DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY)
+                          && hostnames.contains(
+                              content.get(DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY).textValue());
+                    })
                 .toList(),
         inject ->
             Optional.ofNullable(inject)

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -1060,7 +1060,7 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
   @Test
   @DisplayName(
       "When a simulation inject has no content, DNS indicator coverage is still computed without failing")
-  public void whenSimulationInjectHasNoContent_dnsIndicatorCoverageIsStillComputed()
+  public void given_simulationWithContentlessInject_should_computeDnsIndicatorCoverage()
       throws ParsingException, JsonProcessingException {
     String hostname = "malicious.example.com";
     String indicatorStixRef = "indicator--%s".formatted(UUID.randomUUID());

--- a/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/stix/SecurityCoverageServiceTest.java
@@ -1,5 +1,6 @@
 package io.openaev.service.stix;
 
+import static io.openaev.rest.payload.service.PayloadService.DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -1054,6 +1055,105 @@ public class SecurityCoverageServiceTest extends IntegrationTest {
           .isEqualTo(new Timestamp(sroStartTime));
       assertThat(sro.hasProperty(RelationshipObject.Properties.STOP_TIME.toString())).isFalse();
     }
+  }
+
+  @Test
+  @DisplayName(
+      "When a simulation inject has no content, DNS indicator coverage is still computed without failing")
+  public void whenSimulationInjectHasNoContent_dnsIndicatorCoverageIsStillComputed()
+      throws ParsingException, JsonProcessingException {
+    String hostname = "malicious.example.com";
+    String indicatorStixRef = "indicator--%s".formatted(UUID.randomUUID());
+    SecurityPlatformComposer.Composer securityPlatformWrapper =
+        securityPlatformComposer
+            .forSecurityPlatform(
+                SecurityPlatformFixture.createDefault(
+                    "Bad EDR", SecurityPlatform.SECURITY_PLATFORM_TYPE.EDR.name()))
+            .persist();
+
+    // an inject resolving the hostname carried by the indicator
+    InjectComposer.Composer dnsInjectWrapper =
+        injectComposer
+            .forInject(
+                InjectFixture.createInjectWithPayloadArg(
+                    Map.of(DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY, hostname)))
+            .withInjectorContract(
+                injectorContractComposer
+                    .forInjectorContract(InjectorContractFixture.createDefaultInjectorContract())
+                    .withInjector(injectorFixture.getWellKnownOaevImplantInjector()))
+            .withExpectation(
+                injectExpectationComposer
+                    .forExpectation(
+                        InjectExpectationFixture.createExpectationWithTypeAndStatus(
+                            BaseInjectExpectation.EXPECTATION_TYPE.DETECTION,
+                            BaseInjectExpectation.EXPECTATION_STATUS.SUCCESS))
+                    .withEndpoint(endpointComposer.forEndpoint(EndpointFixture.createEndpoint())));
+
+    // an inject without an injector contract keeps a null content once persisted
+    InjectComposer.Composer contentlessInjectWrapper =
+        injectComposer.forInject(InjectFixture.getDefaultInject());
+
+    SecurityCoverageComposer.Composer securityCoverageWrapper =
+        securityCoverageComposer.forSecurityCoverage(
+            SecurityCoverageFixture.createDefaultSecurityCoverage());
+    securityCoverageWrapper
+        .get()
+        .setIndicatorsRefs(
+            new HashSet<>(
+                Set.of(
+                    new StixRefToExternalRef(
+                        indicatorStixRef, new ArrayList<>(List.of(hostname))))));
+
+    ExerciseComposer.Composer exerciseWrapper =
+        exerciseComposer
+            .forExercise(ExerciseFixture.createDefaultExercise())
+            .withSecurityCoverage(securityCoverageWrapper)
+            .withInject(dnsInjectWrapper)
+            .withInject(contentlessInjectWrapper);
+    exerciseWrapper.get().setStart(Instant.parse("2024-09-23T14:09:43Z"));
+    exerciseWrapper.get().setStatus(ExerciseStatus.FINISHED);
+
+    injectExpectationComposer.generatedItems.forEach(
+        exp ->
+            exp.setResults(
+                List.of(
+                    InjectExpectationResult.builder()
+                        .score(100.0)
+                        .sourceId(securityPlatformWrapper.get().getId())
+                        .sourceName("Unit Tests")
+                        .sourceType("manual")
+                        .sourcePlatform(SecurityPlatform.SECURITY_PLATFORM_TYPE.EDR.name())
+                        .sourceAssetId(UUID.randomUUID().toString())
+                        .build())));
+
+    scenarioComposer
+        .forScenario(ScenarioFixture.createDefaultCrisisScenario())
+        .withSimulation(exerciseWrapper)
+        .persist();
+    entityManager.flush();
+    entityManager.refresh(exerciseWrapper.get());
+
+    // intermediate assert: the simulation really does carry a content-less inject
+    assertThat(contentlessInjectWrapper.get().getContent()).isNull();
+
+    Optional<SecurityCoverageSendJob> job =
+        securityCoverageSendJobService.createOrUpdateCoverageSendJobForSimulationIfReady(
+            exerciseWrapper.get());
+    assertThat(job).isNotEmpty();
+
+    // act
+    Bundle bundle = securityCoverageService.createBundleFromSendJobs(List.of(job.orElseThrow()));
+
+    // assert the indicator is reported as covered by the DNS inject
+    List<RelationshipObject> indicatorSros =
+        bundle.findRelationshipsByTargetRef(new Identifier(indicatorStixRef));
+    assertThat(indicatorSros).hasSize(1);
+
+    RelationshipObject indicatorSro = indicatorSros.getFirst();
+    assertThat(indicatorSro.getProperty(ExtendedProperties.COVERED.toString()))
+        .isEqualTo(new io.openaev.stix.types.Boolean(true));
+    assertThatJson(indicatorSro.getProperty(ExtendedProperties.COVERAGE.toString()).toStix(mapper))
+        .isEqualTo(predictCoverageFromInjects(List.of(dnsInjectWrapper.get())).toStix(mapper));
   }
 
   private List<DomainObject> getExpectedPlatformIdentities() {


### PR DESCRIPTION
## Summary

Fixes #7422.

`SecurityCoverageService.getDnsIndicatorCoverage` dereferenced `Inject.getContent()` without a null check. Injects can legitimately be persisted with a null `inject_content` (for example an inject that has no injector contract), so as soon as a simulation carrying such an inject also had indicator refs on its security coverage, building the STIX bundle threw:

```
java.lang.NullPointerException: Cannot invoke
"com.fasterxml.jackson.databind.node.ObjectNode.has(String)" because the return value
of "io.openaev.database.model.Inject.getContent()" is null
```

The DNS hostname filter runs over *every* inject of the simulation, not only DNS injects, so a single content-less inject was enough to fail the whole bundle.

Because the exception escaped `createBundleFromSendJobs`, the send job was never marked as processed and stayed `PENDING`, so the scheduler kept retrying it forever - which is what produced the endless message loop observed on the OpenCTI side.

## Changes

- `SecurityCoverageService.getDnsIndicatorCoverage`: read `inject.getContent()` once into a local and short-circuit when it is null, so content-less injects simply do not match a DNS resolution hostname instead of blowing up. Matching behaviour for injects that *do* have content is unchanged.
- Added a regression test `given_simulationWithContentlessInject_should_computeDnsIndicatorCoverage` in `SecurityCoverageServiceTest` that builds a simulation containing a content-less inject alongside a matching DNS inject, and asserts the bundle is produced with the indicator correctly reported as covered (named per the `given_X_should_Y` convention from `testing.instructions.md`).

Note: the sibling call site `SecurityCoverageInjectService.hasDnsResolutionFor` already had the `inject.getContent() != null` guard, and the other coverage extractors (`getAttackPatternCoverage`, `getVulnerabilityCoverage`, `getArtifactCoverage`) only use Optional-based accessors (`getInjectorContract()`, `getPayload()`), so this was the only unguarded `Inject.getContent()` reachable from `createBundleFromSendJobs`.

## Test plan

- [x] `mvn -pl openaev-api -am test -Dtest=SecurityCoverageServiceTest` - 8/8 pass (re-run after the test rename).
- [x] Verified the new test genuinely reproduces the bug: with the fix reverted it fails with the exact production NPE (`Cannot invoke "...ObjectNode.has(String)" because the return value of "io.openaev.database.model.Inject.getContent()" is null`).
- [x] Spotless clean (CI Spotless Check).
