### PR TITLE
fix(chaining): harden inject deserialization and step authoring against desyncs and deleted contracts (#7414, #7418)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
+++ b/openaev-api/src/main/java/io/openaev/api/chaining/InjectExecutionStep.java
@@ -25,6 +25,7 @@ import io.openaev.execution.ExecutionContext;
 import io.openaev.execution.ExecutionContextService;
 import io.openaev.executors.Executor;
 import io.openaev.rest.document.DocumentService;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.rest.inject.service.ExecutableInjectService;
@@ -650,6 +651,16 @@ public class InjectExecutionStep implements ActionStep {
           "Data step of new step (TEMPLATE) do not contain injector contract");
     }
 
+    // #7418: verify the referenced injector contract still exists in this tenant BEFORE baking it
+    // into the step snapshot, under a pessimistic share lock so authoring serializes with the
+    // contract-delete transaction (there is no FK from step_data to the contract for a database
+    // cascade to protect this). Resolve the id straight from the step data (InjectInput carries the
+    // scalar inject_injector_contract) - the same id run() bakes and resolves - so authoring and
+    // execution can never drift. A missing contract is an invalid client-provided reference, so it
+    // is rejected as a 400 (BadRequestException), matching the threat-arsenal 400-not-404
+    // precedent.
+    assertInjectorContractExists(data.getInjectorContract());
+
     if ((simulation == null && scenario == null) || (simulation != null && scenario != null)) {
       throw new IllegalArgumentException("Exactly one of exercise or scenario should be present");
     }
@@ -723,6 +734,31 @@ public class InjectExecutionStep implements ActionStep {
       return om.writeValueAsString(inject);
     } catch (JsonProcessingException e) {
       throw new ChainingException("New step (TEMPLATE): Error processing Inject to JSON", e);
+    }
+  }
+
+  /**
+   * Rejects authoring a chaining step against an injector contract that no longer exists in the
+   * current tenant (#7418). The existence check takes a pessimistic share lock ({@code FOR SHARE})
+   * so it serializes with the contract-delete transaction: if the delete committed first the lookup
+   * finds nothing and we reject; if authoring locks the row first, the delete - and its #7413
+   * chaining-step sweep - waits for this transaction to commit and then sees the new step. The lock
+   * only serializes when the row exists, which is exactly the window that mattered.
+   *
+   * @param injectorContractId the injector contract id referenced by the step data
+   * @throws BadRequestException if no such contract exists in the current tenant (400, not 404: an
+   *     invalid client-provided reference, per the threat-arsenal precedent)
+   */
+  private void assertInjectorContractExists(String injectorContractId) {
+    boolean exists =
+        injectorContractRepository
+            .lockContractIdForAuthoring(injectorContractId, TenantContext.getCurrentTenant())
+            .isPresent();
+    if (!exists) {
+      throw new BadRequestException(
+          "Injector contract not found: "
+              + injectorContractId
+              + ". It may have been deleted; refresh and rebuild the step.");
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/AttackPathRunWiringTest.java
@@ -31,6 +31,7 @@ import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.StepRepository;
 import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.executors.Executor;
+import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.rest.inject.service.InjectService;
 import io.openaev.rest.injector_contract.InjectorContractService;
@@ -66,6 +67,8 @@ import org.springframework.cache.CacheManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * End-to-end wiring contract: driving the real {@code InjectExecutionStep.run(step)} drives the
@@ -125,6 +128,7 @@ class AttackPathRunWiringTest extends IntegrationTest {
   @Autowired private InjectorContractRepository injectorContractRepository;
   @Autowired private PayloadComposer payloadComposer;
   @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private PlatformTransactionManager transactionManager;
 
   private JdbcTemplate jdbc;
   private Tenant tenant;
@@ -409,7 +413,7 @@ class AttackPathRunWiringTest extends IntegrationTest {
     InjectInput injectInput = new ObjectMapper().readValue(injectInputJson, InjectInput.class);
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
-    Step stepTemplate = injectExecutionStep.create(stepInput, workflowTemplate).orElseThrow();
+    Step stepTemplate = createTemplateInTransaction(stepInput, workflowTemplate);
     Workflow workflowRun = WorkflowFixture.getDefaultWorkflowExecution(WorkflowStatus.RUN);
     return injectExecutionStep
         .ready(stepTemplate, "{\"input\":\"do defined\"}", workflowRun)
@@ -436,7 +440,7 @@ class AttackPathRunWiringTest extends IntegrationTest {
     InjectInput injectInput = new ObjectMapper().readValue(injectInputJson, InjectInput.class);
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
-    Step template = injectExecutionStep.create(stepInput, workflowRun).orElseThrow();
+    Step template = createTemplateInTransaction(stepInput, workflowRun);
     template.setWorkflow(workflowRun);
     template.setLimitExecution(0);
     template = stepRepository.save(template);
@@ -448,6 +452,25 @@ class AttackPathRunWiringTest extends IntegrationTest {
     ready.setWorkflow(workflowRun);
     ready.setLimitExecution(0);
     return stepRepository.save(ready);
+  }
+
+  // Authoring (InjectExecutionStep.create -> stepData) now verifies the injector contract exists
+  // under a pessimistic share lock (#7418), which requires an active transaction - production
+  // always
+  // calls create() from a @Transactional StepService method. This IT is deliberately NOT
+  // @Transactional (see the class javadoc), so wrap just the authoring call in a transaction, the
+  // same way production does; the returned template is transient and persisted afterwards.
+  private Step createTemplateInTransaction(
+      StepsCreateInput.StepInput stepInput, Workflow workflow) {
+    return new TransactionTemplate(transactionManager)
+        .execute(
+            status -> {
+              try {
+                return injectExecutionStep.create(stepInput, workflow).orElseThrow();
+              } catch (ChainingException e) {
+                throw new IllegalStateException(e);
+              }
+            });
   }
 
   private void setAttackPathFeature(boolean enabled) {

--- a/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/chaining/InjectExecutionStepTest.java
@@ -28,6 +28,7 @@ import io.openaev.database.repository.TeamRepository;
 import io.openaev.database.repository.TenantRepository;
 import io.openaev.execution.ExecutionContext;
 import io.openaev.execution.ExecutionContextService;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.rest.inject.output.AgentsAndAssetsAgentless;
@@ -1213,6 +1214,125 @@ public class InjectExecutionStepTest extends IntegrationTest {
     // the step still executable - instead of leaking another tenant's document.
     assertNotNull(inject);
     assertTrue(inject.getDocuments().isEmpty());
+  }
+
+  // ---------------------------------------------------------------------------
+  // getInjectFromDataStep mono-id collections (inject_communications /
+  // inject_expectations round-trip) - #7414
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void
+      given_stepDataWithObjectShapedCommunicationsAndExpectations_whenBuildingInject_thenNoDesyncAndTrailingFieldBinds()
+          throws Exception {
+    // Arrange: MultiModelSerializer writes inject_communications and inject_expectations as FULL
+    // objects (each starting with its id property), yet both are read back through the scalar-only
+    // MonoIdDeserializerHelper. Before #7414 the object was not consumed, so the collection
+    // deserializer misread the object's first field name as the next element's id and desynced the
+    // whole stream - corrupting every field that came after the collections. Craft that exact
+    // shape and put a scalar field (inject_title) AFTER both collections: the trailing field is the
+    // observable desync symptom.
+    Step readyStep = emailReadyStep(List.of());
+    ObjectNode data = (ObjectNode) mapper.readTree(readyStep.getData());
+    data.remove("inject_communications");
+    data.remove("inject_expectations");
+    data.remove("inject_title");
+    data.putArray("inject_communications")
+        .addObject()
+        .put("communication_id", "comm-1")
+        .put("communication_subject", "Subject")
+        .put("communication_from", "from@openaev.io")
+        .put("communication_to", "to@openaev.io");
+    data.putArray("inject_expectations")
+        .addObject()
+        .put("inject_expectation_id", "exp-1")
+        .put("inject_expectation_name", "Prevention")
+        .put("inject_expectation_type", "PREVENTION");
+    // Trailing field, placed AFTER both object-shaped collections on purpose.
+    data.put("inject_title", "desync sentinel title");
+    readyStep.setData(mapper.writeValueAsString(data));
+
+    // Act
+    Inject inject =
+        ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
+
+    // Assert: no desync - the elements resolve by their id and the field AFTER the collections
+    // still binds to its own value instead of being consumed by the misaligned array parsing.
+    assertNotNull(inject);
+    assertEquals("desync sentinel title", inject.getTitle());
+    assertEquals(1, inject.getCommunications().size());
+    assertEquals("comm-1", inject.getCommunications().getFirst().getId());
+    assertEquals(1, inject.getExpectations().size());
+    assertEquals("exp-1", inject.getExpectations().getFirst().getId());
+  }
+
+  @Test
+  void
+      given_stepDataWithScalarCommunicationAndExpectationIds_whenBuildingInject_thenElementsResolve()
+          throws Exception {
+    // Arrange: the defensive scalar shape (a plain string id per element) must keep working exactly
+    // as before - the scalar path in the deserializer is unchanged by #7414.
+    Step readyStep = emailReadyStep(List.of());
+    ObjectNode data = (ObjectNode) mapper.readTree(readyStep.getData());
+    data.remove("inject_communications");
+    data.remove("inject_expectations");
+    data.putArray("inject_communications").add("comm-scalar");
+    data.putArray("inject_expectations").add("exp-scalar");
+    // Trailing field, to prove the scalar path leaves the stream aligned too.
+    data.remove("inject_title");
+    data.put("inject_title", "scalar sentinel title");
+    readyStep.setData(mapper.writeValueAsString(data));
+
+    // Act
+    Inject inject =
+        ReflectionTestUtils.invokeMethod(injectExecutionStep, "getInjectFromDataStep", readyStep);
+
+    // Assert
+    assertNotNull(inject);
+    assertEquals("scalar sentinel title", inject.getTitle());
+    assertEquals(1, inject.getCommunications().size());
+    assertEquals("comm-scalar", inject.getCommunications().getFirst().getId());
+    assertEquals(1, inject.getExpectations().size());
+    assertEquals("exp-scalar", inject.getExpectations().getFirst().getId());
+  }
+
+  // ---------------------------------------------------------------------------
+  // create - injector contract existence validation at authoring time (#7418)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void create_shouldRejectWith400_whenInjectorContractDoesNotExist() throws Exception {
+    // #7418: a stale client (or one racing the contract-delete tx) can reference an injector
+    // contract that no longer exists. Authoring must reject it (BadRequestException -> 400) instead
+    // of baking it into an un-runnable ghost step; the existence check is real (repository) so the
+    // mocked injectorContractService return value is irrelevant here.
+    String missingContractId = "missing-" + UUID.randomUUID();
+    InjectInput injectInput =
+        mapper.readValue(
+            injectInputJson.replace(injectorContractSaved.getId(), missingContractId),
+            InjectInput.class);
+    StepsCreateInput.StepInput step = InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
+
+    Workflow workflowTemplate = WorkflowFixture.getDefaultWorkflowTemplate();
+    workflowTemplate.setSimulation(ExerciseFixture.createDefaultExercise());
+
+    BadRequestException ex =
+        assertThrows(
+            BadRequestException.class, () -> injectExecutionStep.create(step, workflowTemplate));
+    assertTrue(ex.getMessage().contains(missingContractId));
+  }
+
+  @Test
+  void create_shouldSucceed_whenInjectorContractExists() throws Exception {
+    // #7418: the happy path - the referenced contract exists in the tenant, so authoring proceeds.
+    InjectInput injectInput = mapper.readValue(injectInputJson, InjectInput.class);
+    StepsCreateInput.StepInput step = InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
+
+    Workflow workflowTemplate = WorkflowFixture.getDefaultWorkflowTemplate();
+    workflowTemplate.setSimulation(ExerciseFixture.createDefaultExercise());
+
+    Optional<Step> created = injectExecutionStep.create(step, workflowTemplate);
+    assertTrue(created.isPresent());
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -1721,15 +1721,19 @@ class V1_DataImporterTest extends IntegrationTest {
       given_stepDataContractAttackPatternAsFullObject_when_importing_should_normalizeAndNotCrashAtRun()
           throws Exception {
     // -- Arrange --
-    // Reproduces the original bug: injector_contract_attack_patterns carries FULL OBJECTS (as the
-    // export writes them). Left as-is they crash the run-time deserialization with a NPE in
-    // Base.collectIds via InjectorContract.setAttackPatterns.
+    // injector_contract_attack_patterns carries FULL OBJECTS (as the export writes them). The
+    // importer still normalizes them to resolved TARGET scalar ids (asserted below) so a
+    // cross-instance source id is remapped rather than left dangling.
     String externalId = "T1055-" + UUID.randomUUID();
     String sourceId = UUID.randomUUID().toString();
     ObjectMapper om = new ObjectMapper();
 
-    // Sanity check: WITHOUT the fix, a full-object attack pattern crashes the run-time
-    // deserialization (MonoIdDeserializerHelper -> null element -> NPE on getId()).
+    // Post-#7414 a full-object element no longer crashes run-time deserialization: the
+    // MonoIdDeserializerHelper now consumes the object and extracts its scalar id
+    // (attack_pattern_id)
+    // instead of leaving a null element that NPE'd in Base.collectIds via
+    // InjectorContract.setAttackPatterns. The raw full-object therefore deserializes cleanly to an
+    // id-only reference - the importer normalization below is what still matters for a foreign id.
     ObjectNode rawUnsanitized = om.createObjectNode();
     rawUnsanitized.put("inject_title", "raw");
     ObjectNode rawContract = om.createObjectNode();
@@ -1738,11 +1742,9 @@ class V1_DataImporterTest extends IntegrationTest {
         "injector_contract_attack_patterns",
         attackPatternObjectArray(om, sourceId, externalId, "Process Injection"));
     rawUnsanitized.set("inject_injector_contract", rawContract);
-    Exception bug =
-        assertThrows(Exception.class, () -> deserializeStepDataAsRun(rawUnsanitized.toString()));
-    assertTrue(
-        hasCause(bug, NullPointerException.class),
-        "A full-object attack pattern must trigger a NullPointerException at run-time deserialization");
+    assertDoesNotThrow(
+        () -> deserializeStepDataAsRun(rawUnsanitized.toString()),
+        "post-#7414 a full-object attack pattern is consumed to an id-only reference, not a NPE");
 
     String scenarioName = "wf ap object " + UUID.randomUUID();
     ObjectNode importData =

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
@@ -18,6 +18,7 @@ import io.openaev.database.repository.InjectorContractRepository;
 import io.openaev.database.repository.InjectorRepository;
 import io.openaev.database.repository.StepRepository;
 import io.openaev.rest.document.DocumentService;
+import io.openaev.rest.exception.BadRequestException;
 import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.rest.inject.service.InjectService;
@@ -34,6 +35,7 @@ import io.openaev.utils.mockUser.WithMockUser;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -288,6 +290,64 @@ class StepServiceIntegrationTest extends IntegrationTest {
     Condition survivingRoot = conditionRepository.findById(rootId).orElse(null);
     assertNotNull(survivingRoot, "the preserved event survives");
     assertEquals(1, survivingRoot.getConditionChildren().size(), "and keeps its child");
+  }
+
+  @Test
+  void createStepTemplate_shouldReject_whenInjectorContractDoesNotExist()
+      throws JsonProcessingException {
+    // #7418: authoring a template step whose baked data references a contract that no longer exists
+    // in the tenant is rejected with a 400 (BadRequestException), never persisted as a ghost step.
+    // The existence check hits the real repository, so the mocked injectorContractService return
+    // value does not mask the missing row.
+    String missingContractId = "missing-" + UUID.randomUUID();
+    InjectInput injectInput =
+        mapper.readValue(
+            injectInputJson.replace(injectorContractSaved.getId(), missingContractId),
+            InjectInput.class);
+    Workflow workflow =
+        workflowComposer
+            .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+            .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+            .persist()
+            .get();
+    StepsCreateInput.StepInput input = buildInvalidInput();
+    input.setDataStep(injectInput);
+
+    long countBefore = stepRepository.count();
+    BadRequestException ex =
+        assertThrows(
+            BadRequestException.class, () -> spyStepService.createStepTemplate(workflow, input));
+    assertTrue(ex.getMessage().contains(missingContractId));
+    assertEquals(countBefore, stepRepository.count(), "no ghost step persisted");
+  }
+
+  @Test
+  void createInjectStepTemplateIdempotent_shouldReject_whenInjectorContractDoesNotExist()
+      throws JsonProcessingException {
+    // #7418: the autonomous author path (idempotent) must reject a deleted contract too, so a stale
+    // orchestrator cannot recreate the ghost-step state fixed by #7413.
+    String missingContractId = "missing-" + UUID.randomUUID();
+    InjectInput injectInput =
+        mapper.readValue(
+            injectInputJson.replace(injectorContractSaved.getId(), missingContractId),
+            InjectInput.class);
+    Workflow workflow =
+        workflowComposer
+            .forWorkflow(WorkflowFixture.getDefaultWorkflowTemplate())
+            .withSimulation(simulationComposer.forExercise(ExerciseFixture.createDefaultExercise()))
+            .persist()
+            .get();
+    StepsCreateInput.StepInput input = new StepsCreateInput.StepInput();
+    input.setStepAction(StepActionClass.INJECT_EXECUTION);
+    input.setDataStep(injectInput);
+
+    long countBefore = stepRepository.count();
+    BadRequestException ex =
+        assertThrows(
+            BadRequestException.class,
+            () -> spyStepService.createInjectStepTemplateIdempotent(workflow, input, null));
+    assertTrue(ex.getMessage().contains(missingContractId));
+    assertEquals(countBefore, stepRepository.count(), "no ghost step persisted");
   }
 
   private StepsCreateInput.StepInput buildInvalidInputCondition() {

--- a/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/InjectorContractRepository.java
@@ -5,12 +5,14 @@ import io.openaev.database.model.attackpath.projection.AttackPathInjectorPattern
 import io.openaev.database.raw.RawContractTenant;
 import io.openaev.database.raw.RawInjectorsContracts;
 import io.openaev.database.raw.RawPayloadRelatedIds;
+import jakarta.persistence.LockModeType;
 import jakarta.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -116,6 +118,36 @@ public interface InjectorContractRepository
   @Query(
       "SELECT COUNT(ic) > 0 FROM InjectorContract ic WHERE ic.compositeId.id = :id AND ic.compositeId.tenantId = :tenantId")
   boolean existsByContractIdAndTenant(
+      @Param("id") @NotNull String id, @Param("tenantId") @NotNull String tenantId);
+
+  /**
+   * Existence check taken under a pessimistic share lock ({@code SELECT ... FOR SHARE} on
+   * Postgres), used at chaining step authoring time to serialize with the contract-delete
+   * transaction (#7418).
+   *
+   * <p>A chaining step references its injector contract only through the JSON snapshot in {@code
+   * step_data} - there is no foreign key for a database cascade to act on - so nothing otherwise
+   * stops a stale (or racing) client from authoring a step against a contract that is being
+   * deleted, recreating the ghost-step state that {@code ChainingStepCleanupService} (#7413)
+   * sweeps. FOR SHARE makes the two transactions serialize: if the delete committed first the row
+   * is gone and authoring is rejected; if authoring takes the lock first, the delete (and its #7413
+   * sweep) waits for authoring to commit and then sees the newly created step.
+   *
+   * <p>Deliberately a scalar id projection, not an entity select: {@link InjectorContract} eagerly
+   * loads several collections, and a {@code SELECT ic ... FOR SHARE} would outer-join them and fail
+   * on Postgres ("FOR SHARE cannot be applied to the nullable side of an outer join"). Projecting a
+   * single column keeps the locking query on the {@code injectors_contracts} row alone. Tenant-
+   * scoped JPQL (so Hibernate's {@code tenantFilter} also applies) because the default contracts
+   * share their ids across every tenant.
+   *
+   * @param id the injector contract id referenced by the step being authored
+   * @param tenantId the current tenant
+   * @return the contract id if it exists in the tenant, empty otherwise
+   */
+  @Lock(LockModeType.PESSIMISTIC_READ)
+  @Query(
+      "SELECT ic.compositeId.id FROM InjectorContract ic WHERE ic.compositeId.id = :id AND ic.compositeId.tenantId = :tenantId")
+  Optional<String> lockContractIdForAuthoring(
       @Param("id") @NotNull String id, @Param("tenantId") @NotNull String tenantId);
 
   /**

--- a/openaev-model/src/main/java/io/openaev/helper/MonoIdDeserializerHelper.java
+++ b/openaev-model/src/main/java/io/openaev/helper/MonoIdDeserializerHelper.java
@@ -1,20 +1,36 @@
 package io.openaev.helper;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import io.openaev.database.model.Base;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Id;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MonoIdDeserializerHelper<T extends Base> extends JsonDeserializer<T>
     implements ContextualDeserializer {
+
+  /**
+   * Per-entity cache of the JSON property that carries the scalar id, resolved by reflection. An
+   * empty {@link Optional} marks an entity with no single {@code @Id} field (e.g. an
+   * {@code @EmbeddedId} composite): its object form cannot yield a scalar id, so such elements are
+   * consumed and dropped rather than misread.
+   */
+  private static final ConcurrentHashMap<Class<?>, Optional<String>> ID_PROPERTY_CACHE =
+      new ConcurrentHashMap<>();
 
   private Class<? extends Base> entityClass;
 
@@ -52,7 +68,13 @@ public class MonoIdDeserializerHelper<T extends Base> extends JsonDeserializer<T
     EntityManager em =
         (EntityManager) ctxt.findInjectableValue(EntityManager.class.getName(), null, null);
 
-    String id = p.getValueAsString();
+    // The scalar-only form (getValueAsString) returned null on a START_OBJECT without consuming the
+    // object's tokens, so the collection deserializer then read the object's first field name as
+    // the next element's id - a whole-stream desync that dangled em.getReference proxies and
+    // corrupted every field after the collection. Consume the current element whatever its shape
+    // before resolving, so no token layout can ever misalign the stream (#7414 - same asymmetry as
+    // inject_documents #7410/#7411, which has its own dedicated deserializer).
+    String id = extractElementId(p);
     if (id == null || id.isBlank()) return null;
 
     if (em != null) {
@@ -82,5 +104,65 @@ public class MonoIdDeserializerHelper<T extends Base> extends JsonDeserializer<T
         throw new IOException("Cannot instantiate " + entityClass.getSimpleName(), e);
       }
     }
+  }
+
+  /**
+   * Reads exactly one collection element and returns its scalar id, always consuming the element's
+   * tokens so the stream stays aligned on the next element (the core of #7414):
+   *
+   * <ul>
+   *   <li>a scalar value is returned verbatim (behaviour unchanged from the original helper);
+   *   <li>an object (the shape {@code MultiModelSerializer} writes for these collections) is fully
+   *       consumed with {@code readValueAsTree}, then its entity id property is extracted;
+   *   <li>any other structured token is skipped whole and yields no id.
+   * </ul>
+   *
+   * @return the scalar id, or {@code null} when none could be extracted (tokens already consumed)
+   */
+  private String extractElementId(JsonParser p) throws IOException {
+    JsonToken token = p.currentToken();
+    if (token == JsonToken.START_OBJECT) {
+      JsonNode node = p.readValueAsTree();
+      String idProperty = idPropertyName(entityClass);
+      if (idProperty == null) {
+        return null;
+      }
+      JsonNode idNode = node.get(idProperty);
+      return (idNode != null && idNode.isValueNode() && !idNode.isNull()) ? idNode.asText() : null;
+    }
+    if (token != null && token.isStructStart()) {
+      // START_ARRAY (or any other container): consume it whole so it cannot desync the stream.
+      p.skipChildren();
+      return null;
+    }
+    return p.getValueAsString();
+  }
+
+  /**
+   * Resolves (and caches) the JSON property name carrying the scalar id of {@code entityClass}: the
+   * {@code @JsonProperty} value of the field annotated {@link Id} anywhere in the class hierarchy,
+   * falling back to the field name. Entities with no single {@code @Id} field yield {@code null}.
+   */
+  private static String idPropertyName(Class<?> entityClass) {
+    return ID_PROPERTY_CACHE
+        .computeIfAbsent(entityClass, MonoIdDeserializerHelper::resolveIdPropertyName)
+        .orElse(null);
+  }
+
+  private static Optional<String> resolveIdPropertyName(Class<?> entityClass) {
+    for (Class<?> current = entityClass;
+        current != null && current != Object.class;
+        current = current.getSuperclass()) {
+      for (Field field : current.getDeclaredFields()) {
+        if (field.isAnnotationPresent(Id.class)) {
+          JsonProperty jsonProperty = field.getAnnotation(JsonProperty.class);
+          if (jsonProperty != null && !jsonProperty.value().isEmpty()) {
+            return Optional.of(jsonProperty.value());
+          }
+          return Optional.of(field.getName());
+        }
+      }
+    }
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project!
-->

### Proposed changes

This PR hardens two chaining-engine paths against the same class of stale/desync bugs.

**#7414 - inject_communications / inject_expectations deserialization desync on object-shaped elements**

* `MonoIdDeserializerHelper.deserialize()` read each collection element with `p.getValueAsString()`. On a `START_OBJECT` element that returns `null` WITHOUT consuming the object's tokens, so the collection deserializer then read the object's first field name as the next element's id - dangling `em.getReference` proxies or corrupted collections, and every field serialized AFTER the collection was mis-parsed. This is the same asymmetry that broke `inject_documents` (#7410, fixed by the dedicated `InjectDocumentDeserializer` in #7411): `Inject.communications` / `Inject.expectations` are written as FULL objects by `MultiModelSerializer` but read back by the scalar-only helper.
* Fix (generic, option A): the element is now always consumed before resolving. A `START_OBJECT` is consumed with `readValueAsTree()` and the entity's scalar id is extracted by reflecting the `@Id` field's `@JsonProperty` (cached per class); any other structured token is skipped whole; the scalar path is unchanged. Entities with no single `@Id` field (e.g. `@EmbeddedId` composites) yield no id and are dropped instead of desyncing. `InjectDocument` keeps its dedicated deserializer (composite id) - untouched.

**#7418 - a chaining step can be authored against a deleted injector contract (stale client / create-delete race)**

* A chaining step references its injector contract only through the JSON snapshot in `step_data` (no FK), so nothing stopped a stale client - or one racing the contract-delete transaction - from authoring a step against a contract being deleted, recreating the ghost-step state that `ChainingStepCleanupService` (#7413) sweeps.
* Fix: `InjectExecutionStep.stepData()` (the single choke point behind create / createStepTemplates / createInjectStepTemplateIdempotent / the two update paths) now verifies the referenced contract exists in the current tenant BEFORE baking it, under a pessimistic share lock (`SELECT ... FOR SHARE`) via a new tenant-scoped JPQL finder on `InjectorContractRepository`. FOR SHARE serializes authoring with the contract-delete tx: if the delete committed first the row is gone and authoring is rejected; if authoring locks first, the delete (and its #7413 sweep) waits for the step to commit and then sees it. A missing contract is an invalid client-provided reference, so it is rejected with a 400 (`BadRequestException`), matching the threat-arsenal 400-not-404 precedent (dfe1fc034f). The finder is a scalar id projection on purpose: `InjectorContract` eagerly loads several collections, and a `SELECT ic ... FOR SHARE` would outer-join them and fail on Postgres.
* `copyStepsTemplate` and the ready/run paths are intentionally NOT affected (they do not call `create`).

### Testing Instructions

1. `mvn -pl openaev-model,openaev-api -am -DskipTests -Pdev test-compile`
2. `mvn -pl openaev-api -am -Dtest=InjectExecutionStepTest,StepServiceIntegrationTest,V1_DataImporterTest -Dsurefire.failIfNoSpecifiedTests=false -Pdev test` (Testcontainers/Docker required)

### Related issues

* Closes #7414
* Closes #7418

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

### Further comments

Regression tests added:

* `InjectExecutionStepTest`: object-shaped `inject_communications` + `inject_expectations` round-trip without desync (a trailing field still binds), the scalar-id element shape still resolves, authoring rejects a missing injector contract with a 400 and succeeds with a valid one.
* `StepServiceIntegrationTest`: `createStepTemplate` and the idempotent autonomous path both reject a deleted injector contract with a 400 and persist no ghost step.
* `V1_DataImporterTest`: the full-object attack-pattern case is updated - post-#7414 the raw full object is consumed to an id-only reference (no NPE); the importer still normalizes it to a resolved target scalar id.
