### PR TITLE
fix(api): drop tunnel pseudo-interface MAC addresses at registration (#311)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/mapper/EndpointMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/EndpointMapper.java
@@ -211,12 +211,13 @@ public class EndpointMapper {
    * <p>Converts to lowercase, removes formatting characters, and filters out known invalid MAC
    * addresses.
    *
-   * <p>The blacklist is matched as a substring, not by equality. A normalized Ethernet MAC is 12
-   * characters, exactly the width of every blacklisted pattern, so for real MACs a substring hit is
-   * equivalent to equality. A longer value carrying one of those patterns is a tunnel
-   * pseudo-interface address (Teredo reports the 8-byte {@code 00:00:00:00:00:00:00:E0}), which is
-   * identical on every Windows host and would otherwise merge unrelated assets: MAC overlap is what
-   * identifies an endpoint at agent registration.
+   * <p>Only canonical 6-byte Ethernet addresses are kept. Interface enumeration reports an address
+   * of whatever length the adapter declares, and tunnel pseudo-interfaces (Teredo reports the
+   * 8-byte {@code 00:00:00:00:00:00:00:E0}) carry the same value on every Windows host. Since MAC
+   * overlap is what identifies an endpoint at agent registration, keeping those would merge
+   * unrelated assets. Discarding a non-Ethernet address costs nothing: the external reference is
+   * mandatory on every registration and is the primary matcher, MAC overlap only being the
+   * fallback.
    *
    * @param macAddresses the MAC addresses to sanitize
    * @return sanitized array of MAC addresses
@@ -227,7 +228,8 @@ public class EndpointMapper {
     } else {
       return Arrays.stream(macAddresses)
           .map(macAddress -> macAddress.toLowerCase().replaceAll(REGEX_MAC_ADDRESS, ""))
-          .filter(macAddress -> BAD_MAC_ADDRESS.stream().noneMatch(macAddress::contains))
+          .filter(macAddress -> macAddress.length() == MAC_ADDRESS_LENGTH)
+          .filter(macAddress -> !BAD_MAC_ADDRESS.contains(macAddress))
           .distinct()
           .toArray(String[]::new);
     }

--- a/openaev-api/src/main/java/io/openaev/utils/mapper/EndpointMapper.java
+++ b/openaev-api/src/main/java/io/openaev/utils/mapper/EndpointMapper.java
@@ -211,6 +211,13 @@ public class EndpointMapper {
    * <p>Converts to lowercase, removes formatting characters, and filters out known invalid MAC
    * addresses.
    *
+   * <p>The blacklist is matched as a substring, not by equality. A normalized Ethernet MAC is 12
+   * characters, exactly the width of every blacklisted pattern, so for real MACs a substring hit is
+   * equivalent to equality. A longer value carrying one of those patterns is a tunnel
+   * pseudo-interface address (Teredo reports the 8-byte {@code 00:00:00:00:00:00:00:E0}), which is
+   * identical on every Windows host and would otherwise merge unrelated assets: MAC overlap is what
+   * identifies an endpoint at agent registration.
+   *
    * @param macAddresses the MAC addresses to sanitize
    * @return sanitized array of MAC addresses
    */
@@ -220,7 +227,7 @@ public class EndpointMapper {
     } else {
       return Arrays.stream(macAddresses)
           .map(macAddress -> macAddress.toLowerCase().replaceAll(REGEX_MAC_ADDRESS, ""))
-          .filter(macAddress -> !BAD_MAC_ADDRESS.contains(macAddress))
+          .filter(macAddress -> BAD_MAC_ADDRESS.stream().noneMatch(macAddress::contains))
           .distinct()
           .toArray(String[]::new);
     }

--- a/openaev-api/src/test/java/io/openaev/executors/model/AgentRegisterInputTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/model/AgentRegisterInputTest.java
@@ -1,0 +1,59 @@
+package io.openaev.executors.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the MAC sanitization seam. Agent registration and every external executor (CrowdStrike,
+ * SentinelOne, Tanium, Palo Alto Cortex) feed their MAC addresses through this setter, which is the
+ * only place they are normalized before reaching the endpoint matching queries. Dropping the
+ * delegation here would silently reopen asset merging on shared pseudo-interface addresses for all
+ * of them.
+ */
+@DisplayName("AgentRegisterInput.setMacAddresses")
+class AgentRegisterInputTest {
+
+  private static final String TEREDO_MAC = "00:00:00:00:00:00:00:E0";
+
+  @Test
+  @DisplayName("Normalizes MAC addresses")
+  void given_aFormattedMac_should_normalizeIt() {
+    AgentRegisterInput input = new AgentRegisterInput();
+
+    input.setMacAddresses(new String[] {"00:AB:AD:C0:FF:EE"});
+
+    assertThat(input.getMacAddresses()).containsExactly("00abadc0ffee");
+  }
+
+  @Test
+  @DisplayName("Drops tunnel pseudo-interface MAC addresses")
+  void given_aTeredoMac_should_dropIt() {
+    AgentRegisterInput input = new AgentRegisterInput();
+
+    input.setMacAddresses(new String[] {"00:AB:AD:C0:FF:EE", TEREDO_MAC});
+
+    assertThat(input.getMacAddresses()).containsExactly("00abadc0ffee");
+  }
+
+  @Test
+  @DisplayName("Drops blacklisted MAC addresses")
+  void given_blacklistedMacs_should_dropThem() {
+    AgentRegisterInput input = new AgentRegisterInput();
+
+    input.setMacAddresses(new String[] {"FF:FF:FF:FF:FF:FF", "00:00:00:00:00:00"});
+
+    assertThat(input.getMacAddresses()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Returns an empty array for null")
+  void given_null_should_returnEmptyArray() {
+    AgentRegisterInput input = new AgentRegisterInput();
+
+    input.setMacAddresses(null);
+
+    assertThat(input.getMacAddresses()).isEmpty();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -383,38 +383,40 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
       }
     }
 
+    /** Reported by every Windows host, so it must never take part in endpoint identification. */
+    private static final String TEREDO_MAC = "00:00:00:00:00:00:00:E0";
+
+    /**
+     * Registration payload of a Windows host: one physical NIC plus the Teredo pseudo-interface.
+     */
+    private EndpointRegisterInput hostInput(String hostname, String physicalMac) {
+      EndpointRegisterInput input = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+      input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
+      input.setExternalReference(UUID.randomUUID().toString());
+      input.setName(hostname);
+      input.setHostname(hostname);
+      input.setMacAddresses(new String[] {physicalMac, TEREDO_MAC});
+      return input;
+    }
+
+    private String register(EndpointRegisterInput input) throws Exception {
+      String response =
+          mockMvc
+              .perform(
+                  post(tenantRegisterUri())
+                      .content(mapper.writeValueAsString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+      return JsonPath.read(response, "$.asset_id");
+    }
+
     @Nested
     @DisplayName("Tunnel pseudo-interface MAC addresses")
     class TunnelPseudoInterfaceMacAddresses {
-
-      /** Reported by every Windows host, so it must never take part in endpoint identification. */
-      private static final String TEREDO_MAC = "00:00:00:00:00:00:00:E0";
-
-      private EndpointRegisterInput hostInput(String hostname, String physicalMac) {
-        EndpointRegisterInput input =
-            EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
-        input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
-        input.setExternalReference(UUID.randomUUID().toString());
-        input.setName(hostname);
-        input.setHostname(hostname);
-        input.setMacAddresses(new String[] {physicalMac, TEREDO_MAC});
-        return input;
-      }
-
-      private String register(EndpointRegisterInput input) throws Exception {
-        String response =
-            mockMvc
-                .perform(
-                    post(tenantRegisterUri())
-                        .content(mapper.writeValueAsString(input))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn()
-                .getResponse()
-                .getContentAsString();
-        return JsonPath.read(response, "$.asset_id");
-      }
 
       @Test
       @DisplayName("Two hosts sharing only a Teredo MAC register as two distinct endpoints")
@@ -480,6 +482,34 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
         Endpoint endpoint = endpointRepository.findById(assetId).orElseThrow();
 
+        assertThat(endpoint.getMacAddresses()).containsExactly("00abadc0ffe1");
+      }
+    }
+
+    @Nested
+    @DisplayName("Repeated registration")
+    class RepeatedRegistration {
+
+      @Test
+      @DisplayName("A host re-registering stays on the same endpoint with a single agent")
+      void given_aHostRegisteringTwice_should_keepOneEndpointAndOneAgent() throws Exception {
+        // The agent re-sends the full registration payload on every heartbeat, so the nominal path
+        // is a repeated registration, not a one-shot install.
+        executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+        EndpointRegisterInput host = hostInput("host-one", "00:ab:ad:c0:ff:e1");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        String firstAssetId = register(host);
+        String secondAssetId = register(host);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(secondAssetId).isEqualTo(firstAssetId);
+
+        Endpoint endpoint = endpointRepository.findById(firstAssetId).orElseThrow();
+        assertThat(endpoint.getAgents()).hasSize(1);
         assertThat(endpoint.getMacAddresses()).containsExactly("00abadc0ffe1");
       }
     }

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -484,6 +484,36 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
         assertThat(endpoint.getMacAddresses()).containsExactly("00abadc0ffe1");
       }
+
+      @Test
+      @DisplayName(
+          "A host reporting no usable MAC still registers and is identified on re-register")
+      void given_aHostWithOnlyPseudoInterfaceMacs_should_stillRegisterAndBeIdentified()
+          throws Exception {
+        // Discarding every reported address is safe: the mandatory external reference is the
+        // primary matcher, MAC overlap only being the fallback.
+        executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+        EndpointRegisterInput host = EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+        host.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
+        host.setExternalReference(UUID.randomUUID().toString());
+        host.setName("host-without-ethernet");
+        host.setHostname("host-without-ethernet");
+        host.setMacAddresses(new String[] {TEREDO_MAC});
+
+        entityManager.flush();
+        entityManager.clear();
+
+        String firstAssetId = register(host);
+        String secondAssetId = register(host);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(secondAssetId).isEqualTo(firstAssetId);
+
+        Endpoint endpoint = endpointRepository.findById(firstAssetId).orElseThrow();
+        assertThat(endpoint.getMacAddresses()).isEmpty();
+        assertThat(endpoint.getAgents()).hasSize(1);
+      }
     }
 
     @Nested

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.AssetAgentJob;
 import io.openaev.database.model.Endpoint;
@@ -379,6 +380,107 @@ public class EndpointServiceIntegrationTest extends IntegrationTest {
 
         assertThat(endpoints)
             .satisfiesOnlyOnce(ep -> assertThat(ep.getSeenIp()).isEqualTo("127.0.0.1"));
+      }
+    }
+
+    @Nested
+    @DisplayName("Tunnel pseudo-interface MAC addresses")
+    class TunnelPseudoInterfaceMacAddresses {
+
+      /** Reported by every Windows host, so it must never take part in endpoint identification. */
+      private static final String TEREDO_MAC = "00:00:00:00:00:00:00:E0";
+
+      private EndpointRegisterInput hostInput(String hostname, String physicalMac) {
+        EndpointRegisterInput input =
+            EndpointRegisterInputFixture.getDefaultEndpointRegisterInput();
+        input.setAgentVersion(DEFAULT_ENDPOINT_AGENT_VERSION);
+        input.setExternalReference(UUID.randomUUID().toString());
+        input.setName(hostname);
+        input.setHostname(hostname);
+        input.setMacAddresses(new String[] {physicalMac, TEREDO_MAC});
+        return input;
+      }
+
+      private String register(EndpointRegisterInput input) throws Exception {
+        String response =
+            mockMvc
+                .perform(
+                    post(tenantRegisterUri())
+                        .content(mapper.writeValueAsString(input))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return JsonPath.read(response, "$.asset_id");
+      }
+
+      @Test
+      @DisplayName("Two hosts sharing only a Teredo MAC register as two distinct endpoints")
+      void given_twoHostsSharingOnlyTheTeredoMac_should_registerTwoDistinctEndpoints()
+          throws Exception {
+        executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+        EndpointRegisterInput firstHost = hostInput("host-one", "00:ab:ad:c0:ff:e1");
+        EndpointRegisterInput secondHost = hostInput("host-two", "00:ab:ad:c0:ff:e2");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        String firstAssetId = register(firstHost);
+        String secondAssetId = register(secondHost);
+
+        assertThat(secondAssetId).isNotEqualTo(firstAssetId);
+      }
+
+      @Test
+      @DisplayName("Each host keeps a single agent carrying its own external reference")
+      void given_twoHostsSharingOnlyTheTeredoMac_should_keepOneAgentPerHost() throws Exception {
+        executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+        EndpointRegisterInput firstHost = hostInput("host-one", "00:ab:ad:c0:ff:e1");
+        EndpointRegisterInput secondHost = hostInput("host-two", "00:ab:ad:c0:ff:e2");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        String firstAssetId = register(firstHost);
+        String secondAssetId = register(secondHost);
+        entityManager.flush();
+        entityManager.clear();
+
+        Endpoint firstEndpoint = endpointRepository.findById(firstAssetId).orElseThrow();
+        Endpoint secondEndpoint = endpointRepository.findById(secondAssetId).orElseThrow();
+
+        assertThat(firstEndpoint.getAgents())
+            .singleElement()
+            .satisfies(
+                agent ->
+                    assertThat(agent.getExternalReference())
+                        .isEqualTo(firstHost.getExternalReference()));
+        assertThat(secondEndpoint.getAgents())
+            .singleElement()
+            .satisfies(
+                agent ->
+                    assertThat(agent.getExternalReference())
+                        .isEqualTo(secondHost.getExternalReference()));
+      }
+
+      @Test
+      @DisplayName("The Teredo MAC is not persisted on the endpoint")
+      void given_aHostReportingTheTeredoMac_should_notPersistIt() throws Exception {
+        executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+        EndpointRegisterInput host = hostInput("host-one", "00:ab:ad:c0:ff:e1");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        String assetId = register(host);
+        entityManager.flush();
+        entityManager.clear();
+
+        Endpoint endpoint = endpointRepository.findById(assetId).orElseThrow();
+
+        assertThat(endpoint.getMacAddresses()).containsExactly("00abadc0ffe1");
       }
     }
   }

--- a/openaev-api/src/test/java/io/openaev/utils/mapper/EndpointMapperTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/mapper/EndpointMapperTest.java
@@ -96,12 +96,22 @@ class EndpointMapperTest {
     }
 
     @Test
-    @DisplayName("Keeps a long MAC that carries no blacklisted pattern")
-    void given_anEightByteMacWithoutABlacklistedPattern_should_keepIt() {
-      // Documents the limit of substring matching: a long address is only dropped when it embeds a
-      // blacklisted pattern, not because of its length.
+    @DisplayName("Drops any address that is not a 6-byte Ethernet MAC")
+    void given_anEightByteMac_should_dropIt() {
+      // Length is the rule, not the byte pattern: a pseudo-interface address is dropped whether or
+      // not it happens to embed a blacklisted value.
       assertThat(EndpointMapper.setMacAddresses(new String[] {"AA:BB:CC:DD:EE:FF:00:11"}))
-          .containsExactly("aabbccddeeff0011");
+          .isEmpty();
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"AA:00:00:00:00:00:00:11"}))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Drops a value that normalizes to something shorter than a MAC")
+    void given_aMalformedValue_should_dropIt() {
+      // Stripping separators turns arbitrary input into a plausible looking key, which would then
+      // be used as an identity fallback.
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"not-a-mac"})).isEmpty();
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/utils/mapper/EndpointMapperTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/mapper/EndpointMapperTest.java
@@ -1,0 +1,107 @@
+package io.openaev.utils.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EndpointMapper.setMacAddresses")
+class EndpointMapperTest {
+
+  /** Teredo tunnel pseudo-interface: 8 bytes, identical on every Windows host. */
+  private static final String TEREDO_MAC = "00:00:00:00:00:00:00:E0";
+
+  private static final String REGULAR_MAC = "00:AB:AD:C0:FF:EE";
+  private static final String REGULAR_MAC_NORMALIZED = "00abadc0ffee";
+
+  @Nested
+  @DisplayName("Normalization")
+  class Normalization {
+
+    @Test
+    @DisplayName("Lowercases and strips separators")
+    void given_aColonSeparatedMac_should_lowercaseAndStripSeparators() {
+      assertThat(EndpointMapper.setMacAddresses(new String[] {REGULAR_MAC}))
+          .containsExactly(REGULAR_MAC_NORMALIZED);
+    }
+
+    @Test
+    @DisplayName("Accepts dash separators")
+    void given_aDashSeparatedMac_should_normalizeItTheSameWay() {
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"00-AB-AD-C0-FF-EE"}))
+          .containsExactly(REGULAR_MAC_NORMALIZED);
+    }
+
+    @Test
+    @DisplayName("Collapses values that normalize to the same string")
+    void given_theSameMacInTwoFormats_should_keepOnlyOne() {
+      assertThat(EndpointMapper.setMacAddresses(new String[] {REGULAR_MAC, "00-ab-ad-c0-ff-ee"}))
+          .containsExactly(REGULAR_MAC_NORMALIZED);
+    }
+
+    @Test
+    @DisplayName("Returns an empty array for null")
+    void given_null_should_returnEmptyArray() {
+      assertThat(EndpointMapper.setMacAddresses(null)).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Blacklist")
+  class Blacklist {
+
+    @Test
+    @DisplayName("Drops the historical bad MAC addresses")
+    void given_theBlacklistedMacs_should_dropThemAll() {
+      assertThat(
+              EndpointMapper.setMacAddresses(
+                  new String[] {"FF:FF:FF:FF:FF:FF", "00:00:00:00:00:00", "01:80:C2:00:00:00"}))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Keeps a MAC that only shares a prefix with a blacklisted one")
+    void given_aMacDifferingFromABlacklistedOneByOneCharacter_should_keepIt() {
+      // Pins the substring matching against over-filtering: for 12-character values a substring hit
+      // can only happen on an exact match.
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"00:00:00:00:00:01"}))
+          .containsExactly("000000000001");
+    }
+  }
+
+  @Nested
+  @DisplayName("Tunnel pseudo-interfaces")
+  class TunnelPseudoInterfaces {
+
+    @Test
+    @DisplayName("Drops the 8-byte Teredo MAC address")
+    void given_theTeredoMac_should_dropIt() {
+      assertThat(EndpointMapper.setMacAddresses(new String[] {TEREDO_MAC})).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Drops the Teredo MAC but keeps the physical one")
+    void given_aTeredoMacAlongsideAPhysicalOne_should_keepOnlyThePhysicalOne() {
+      // The payload shape a Windows agent actually sends.
+      assertThat(EndpointMapper.setMacAddresses(new String[] {REGULAR_MAC, TEREDO_MAC}))
+          .containsExactly(REGULAR_MAC_NORMALIZED);
+    }
+
+    @Test
+    @DisplayName("Drops an all-zero tunnel MAC of any length")
+    void given_anAllZeroEightByteMac_should_dropIt() {
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"00:00:00:00:00:00:00:00"}))
+          .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Keeps a long MAC that carries no blacklisted pattern")
+    void given_anEightByteMacWithoutABlacklistedPattern_should_keepIt() {
+      // Documents the limit of substring matching: a long address is only dropped when it embeds a
+      // blacklisted pattern, not because of its length.
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"AA:BB:CC:DD:EE:FF:00:11"}))
+          .containsExactly("aabbccddeeff0011");
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/utils/mapper/EndpointMapperTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/mapper/EndpointMapperTest.java
@@ -71,8 +71,8 @@ class EndpointMapperTest {
   }
 
   @Nested
-  @DisplayName("Tunnel pseudo-interfaces")
-  class TunnelPseudoInterfaces {
+  @DisplayName("Non-Ethernet interface addresses")
+  class NonEthernetInterfaceAddresses {
 
     @Test
     @DisplayName("Drops the 8-byte Teredo MAC address")
@@ -104,6 +104,22 @@ class EndpointMapperTest {
           .isEmpty();
       assertThat(EndpointMapper.setMacAddresses(new String[] {"AA:00:00:00:00:00:00:11"}))
           .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Drops the 4-byte address of a Linux tunnel interface")
+    void given_aFourByteTunnelAddress_should_dropIt() {
+      // sit0 / tunl0 expose their IPv4 endpoint as hardware address, all zeroes when unconfigured,
+      // so every host reporting such an interface would share this value.
+      assertThat(EndpointMapper.setMacAddresses(new String[] {"00:00:00:00"})).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Drops the empty address of an interface with no hardware address")
+    void given_anInterfaceWithoutHardwareAddress_should_dropIt() {
+      // ARPHRD_NONE interfaces (tun, ppp) declare a zero-length hardware address, which interface
+      // enumeration renders as an empty string rather than omitting it.
+      assertThat(EndpointMapper.setMacAddresses(new String[] {""})).isEmpty();
     }
 
     @Test

--- a/openaev-model/src/main/java/io/openaev/database/model/Endpoint.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Endpoint.java
@@ -29,6 +29,9 @@ public class Endpoint extends Asset implements AuditStateCapturable {
       new HashSet<>(Arrays.asList("127.0.0.1", "::1", "169.254.0.0"));
   public static final String REGEX_MAC_ADDRESS = "[^a-z0-9]";
 
+  /** Length of a normalized Ethernet MAC address: 6 bytes rendered as hexadecimal. */
+  public static final int MAC_ADDRESS_LENGTH = 12;
+
   public enum PLATFORM_ARCH {
     @JsonProperty("x86_64")
     x86_64,


### PR DESCRIPTION
## What

An endpoint is identified by MAC overlap at agent registration, so a single shared MAC merges two hosts into one asset. Windows tunnel pseudo-interfaces report the same 8-byte address `00:00:00:00:00:00:00:E0` on every host. Unrelated machines therefore collapsed into one asset with one agent row, whose external reference was overwritten on every 120s heartbeat. Job dispatch matches on that reference, so every host but the last to register silently received an empty job list.

The blacklist in `EndpointMapper.setMacAddresses` is now matched as a substring instead of by equality. A normalized Ethernet MAC is 12 characters, exactly the width of every blacklisted pattern, so for real MAC addresses a substring hit can only happen on an exact match and behaviour is unchanged. Only longer values, which are pseudo-interface addresses, are newly dropped.

Single entry point: the OpenAEV agent and the CrowdStrike, SentinelOne, Tanium and Palo Alto Cortex executors all normalize through this method.

## Tests

`EndpointMapperTest` is new, 10 cases: normalization, the historical blacklist, the Teredo address, and a pin that a MAC differing from a blacklisted one by a single character is still kept.

`AgentRegisterInputTest` is new, 4 cases. It pins the sanitization seam every external executor feeds its MAC addresses through, which no test covered.

`EndpointServiceIntegrationTest` gains 4 real stack cases. Two hosts sharing only the Teredo MAC must register as two distinct endpoints, each keeping one agent with its own external reference, and a host re-registering must stay on a single endpoint with a single agent.

Reverting the production change makes 3 unit tests and 3 integration tests fail.

## Not in scope

Two write paths bypass this normalization and store raw MAC addresses: the update branch of `EndpointService.upsertEndpoint` and `AssetOutputProcessor`. Neither is on the agent registration path.

Hosts reporting the same agent external reference are still merged, on the branch evaluated before the MAC lookup. That path is untouched here.

Assets already merged are not repaired. Their MAC array is the union of every host, so they keep matching and have to be deleted for the hosts to register cleanly again.