### PR TITLE
feat(autonomous): render live orchestrator activity in the reasoning window (#7446)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/autonomous/autonomousEventVisuals.test.ts
+++ b/openaev-front/src/__tests__/admin/components/autonomous/autonomousEventVisuals.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { type AutonomousEvent, type AutonomousEventType } from '../../../../actions/autonomous/autonomous-types';
+import { isHeartbeatEvent, isLiveActivityEvent } from '../../../../admin/components/autonomous/autonomousEventVisuals';
+
+// Minimal AutonomousEvent factory: the classification predicates only read `type` + `data`, but the
+// interface requires id/run_id/sequence, so default those to keep the fixtures readable.
+let sequence = 0;
+const makeEvent = (
+  type: AutonomousEventType,
+  data?: string | null,
+): AutonomousEvent => ({
+  autonomous_event_id: `evt-${(sequence += 1)}`,
+  autonomous_event_run_id: 'run-1',
+  autonomous_event_sequence: sequence,
+  autonomous_event_type: type,
+  autonomous_event_data: data ?? null,
+});
+
+describe('isLiveActivityEvent', () => {
+  it('is true for a NARRATION whose data JSON has live === true (compact serialization)', () => {
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"live":true,"iteration":3}'))).toBe(true);
+  });
+
+  it('is true regardless of key spacing (Python json.dumps style)', () => {
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"live": true, "iteration": 3}'))).toBe(true);
+  });
+
+  it('is false when live is present but not the boolean true', () => {
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"live":false}'))).toBe(false);
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"live":"yes"}'))).toBe(false);
+  });
+
+  it('is false for a genuine NARRATION with no live flag (never hides real narration)', () => {
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"iteration":3}'))).toBe(false);
+    expect(isLiveActivityEvent(makeEvent('NARRATION', 'Compromised the domain controller.'))).toBe(false);
+  });
+
+  it('is false when the substring "live" is not present as a JSON key', () => {
+    // Guards the cheap pre-check: a value that merely contains the letters "live" must not match.
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"liveness":"high"}'))).toBe(false);
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"note":"went live"}'))).toBe(false);
+  });
+
+  it('is false for the live flag on a non-NARRATION event type', () => {
+    expect(isLiveActivityEvent(makeEvent('DECISION', '{"live":true}'))).toBe(false);
+    expect(isLiveActivityEvent(makeEvent('STATUS', '{"live":true}'))).toBe(false);
+  });
+
+  it('is false when data is missing or malformed JSON', () => {
+    expect(isLiveActivityEvent(makeEvent('NARRATION', null))).toBe(false);
+    expect(isLiveActivityEvent(makeEvent('NARRATION', '{"live":true'))).toBe(false);
+  });
+
+  it('is false for an undefined event', () => {
+    expect(isLiveActivityEvent(undefined)).toBe(false);
+  });
+
+  it('returns a stable result across repeated calls on the same event (cached parse)', () => {
+    const event = makeEvent('NARRATION', '{"live":true}');
+    expect(isLiveActivityEvent(event)).toBe(true);
+    expect(isLiveActivityEvent(event)).toBe(true);
+  });
+});
+
+describe('isHeartbeatEvent', () => {
+  it('is true for a STATUS whose data JSON has heartbeat === true', () => {
+    expect(isHeartbeatEvent(makeEvent('STATUS', '{"heartbeat":true}'))).toBe(true);
+  });
+
+  it('is false when heartbeat is not the boolean true', () => {
+    expect(isHeartbeatEvent(makeEvent('STATUS', '{"heartbeat":false}'))).toBe(false);
+    expect(isHeartbeatEvent(makeEvent('STATUS', '{"phase":"engaged"}'))).toBe(false);
+  });
+
+  it('is false for the heartbeat flag on a non-STATUS event type', () => {
+    expect(isHeartbeatEvent(makeEvent('NARRATION', '{"heartbeat":true}'))).toBe(false);
+  });
+
+  it('is false when data is missing or malformed JSON', () => {
+    expect(isHeartbeatEvent(makeEvent('STATUS', null))).toBe(false);
+    expect(isHeartbeatEvent(makeEvent('STATUS', '{"heartbeat":true'))).toBe(false);
+  });
+
+  it('is false for an undefined event', () => {
+    expect(isHeartbeatEvent(undefined)).toBe(false);
+  });
+});
+
+describe('isHeartbeatEvent and isLiveActivityEvent are mutually exclusive', () => {
+  it('a live NARRATION is not a heartbeat, and a heartbeat STATUS is not live-activity', () => {
+    const liveNarration = makeEvent('NARRATION', '{"live":true,"iteration":7}');
+    const heartbeat = makeEvent('STATUS', '{"heartbeat":true}');
+    expect(isLiveActivityEvent(liveNarration)).toBe(true);
+    expect(isHeartbeatEvent(liveNarration)).toBe(false);
+    expect(isHeartbeatEvent(heartbeat)).toBe(true);
+    expect(isLiveActivityEvent(heartbeat)).toBe(false);
+  });
+});

--- a/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
@@ -9,7 +9,7 @@ import { type AutonomousEvent, type AutonomousRun, type AutonomousRunStatus } fr
 import { HeroStat, HeroStats, SectionBlock } from '../../../components/common/detail/EntityDetailCommon';
 import { useFormatter } from '../../../components/i18n';
 import SamplePreview from '../workspaces/custom_dashboards/widgets/viz/sample/SamplePreview';
-import { eventAccent, eventIcon, EventMarkdown, eventTypeLabel, isHeartbeatEvent, sanitizeEventText, stripMarkdown } from './autonomousEventVisuals';
+import { eventAccent, eventIcon, EventMarkdown, eventTypeLabel, isHeartbeatEvent, isLiveActivityEvent, sanitizeEventText, stripMarkdown } from './autonomousEventVisuals';
 import AutonomousOutcomeDialog, { type OutcomeKind } from './AutonomousOutcomeDialog';
 
 const ACTIVE_STATUSES: AutonomousRunStatus[] = ['PLANNING', 'RUNNING', 'WAITING_INPUT'];
@@ -303,11 +303,16 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
 
   const proofEvents = useMemo(() => events.filter(e => e.autonomous_event_type === 'PROOF'), [events]);
   const capabilityGaps = useMemo(() => events.filter(e => e.autonomous_event_type === 'GAP'), [events]);
-  // Heartbeats are ~45s freshness pings the orchestrator emits while a cycle runs, not decisions.
-  // They must never appear as "Working" nodes on the decision timeline nor inflate the decision
-  // count, so every timeline-facing read works off the heartbeat-free stream (the reasoning panel
-  // filters them the same way).
-  const decisionEvents = useMemo(() => events.filter(e => !isHeartbeatEvent(e)), [events]);
+  // Heartbeats (~45s freshness pings) and live-activity NARRATIONs (the per-iteration "what it is
+  // doing right now" lines the worker streams to keep the cockpit thinking window scrolling) are
+  // both cockpit-liveness signals, not decisions. Neither must appear as a node on the decision
+  // timeline nor inflate the decision count, so every timeline-facing read works off the filtered
+  // stream (the reasoning panel filters them the same way - single source of truth in
+  // autonomousEventVisuals).
+  const decisionEvents = useMemo(
+    () => events.filter(e => !isHeartbeatEvent(e) && !isLiveActivityEvent(e)),
+    [events],
+  );
 
   const buildProofReport = (): string => {
     const lines: string[] = [];

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -25,7 +25,7 @@ import { useFormatter } from '../../../components/i18n';
 import { computeBannerSettings } from '../../../public/components/systembanners/utils';
 import useAuth from '../../../utils/hooks/useAuth';
 import { useChatbot, useChatbotContentMargin } from '../ariane/useChatbotHooks';
-import { eventAccent, eventIcon, EventMarkdown, eventTypeLabel, isHeartbeatEvent, sanitizeEventText, stripMarkdown } from './autonomousEventVisuals';
+import { eventAccent, eventIcon, EventMarkdown, eventTypeLabel, isHeartbeatEvent, isLiveActivityEvent, sanitizeEventText, stripMarkdown } from './autonomousEventVisuals';
 import { AUTONOMOUS_PANEL_WIDTH } from './useAutonomousPanelWidth';
 
 // An "active" run is one the orchestrator is currently driving, so the panel keeps polling the
@@ -518,12 +518,18 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
     return () => clearInterval(interval);
   }, [isActive, refreshRun, pollTimeline]);
 
-  // The operator-facing decision feed excludes heartbeats (they are freshness pings, not
-  // decisions), so a long silent burst does not fill the timeline with "Working" rows. The
-  // freshness/caption logic below still keys off the raw `events` (including heartbeats) so the
-  // cockpit stays animated. Memoised: the predicate JSON-parses STATUS payloads, so it should run
-  // once per new batch of events, not on every incidental re-render.
-  const visibleEvents = useMemo(() => events.filter(e => !isHeartbeatEvent(e)), [events]);
+  // The operator-facing decision feed excludes heartbeats (freshness pings, not decisions) AND
+  // live-activity NARRATIONs (the per-iteration "what it is doing right now" lines the worker
+  // streams). Both keep the cockpit alive without being decisions: heartbeats drive the freshness
+  // clock, live-activity lines flow into `thinkingLines` below (the scrolling thinking window) - so
+  // neither should ever appear as a row in the operator decision feed, or a long silent burst would
+  // fill the timeline with "Working"/activity noise. The freshness/caption logic below still keys
+  // off the raw `events` (including both) so the cockpit stays animated. Memoised: the predicates
+  // JSON-parse the payloads, so they should run once per new batch of events, not on every render.
+  const visibleEvents = useMemo(
+    () => events.filter(e => !isHeartbeatEvent(e) && !isLiveActivityEvent(e)),
+    [events],
+  );
 
   const isWaitingInput = status === 'WAITING_INPUT';
   // Newest-first lookups over the stream. findLast scans backwards without cloning, and the

--- a/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
+++ b/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
@@ -111,6 +111,37 @@ export const eventTypeLabel = (type?: AutonomousEventType | string | null): stri
   }
 };
 
+// Parsed-JSON cache for an event's `autonomous_event_data`, keyed on the event object itself. The
+// timeline is append-only and each event object is an immutable snapshot (pollTimeline only ever
+// appends never-before-seen ids, carrying the existing objects across by reference), so any given
+// event is parsed at most once for its whole lifetime - even though the classification predicates
+// below re-run over the WHOLE array on every 3s poll batch (visibleEvents / decisionEvents /
+// thinkingLines each re-filter it). A WeakMap lets a dropped event (on a stream reset) be
+// garbage-collected together with its cache entry. `null` is cached too (unparseable payload, or a
+// non-object like a bare string/number) so a malformed payload is never re-parsed on every poll.
+const parsedEventData = new WeakMap<AutonomousEvent, Record<string, unknown> | null>();
+
+const parseEventData = (event: AutonomousEvent): Record<string, unknown> | null => {
+  const cached = parsedEventData.get(event);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let parsed: Record<string, unknown> | null = null;
+  const raw = event.autonomous_event_data;
+  if (raw) {
+    try {
+      const value = JSON.parse(raw) as unknown;
+      if (value !== null && typeof value === 'object') {
+        parsed = value as Record<string, unknown>;
+      }
+    } catch {
+      parsed = null;
+    }
+  }
+  parsedEventData.set(event, parsed);
+  return parsed;
+};
+
 // A heartbeat is a lightweight STATUS event the XTM One orchestrator emits every ~45s WHILE a
 // decision cycle is actively running (flagged {"heartbeat": true} in its data). It exists ONLY to
 // keep the cockpit's "working" indicator honest and to nudge the graph poll during a long silent
@@ -122,16 +153,12 @@ export const isHeartbeatEvent = (event: AutonomousEvent | undefined): boolean =>
   if (!event || event.autonomous_event_type !== 'STATUS' || !event.autonomous_event_data) {
     return false;
   }
-  // Cheap substring pre-check before the JSON.parse: this runs for every event on every render of
-  // the feed, and most STATUS payloads never mention "heartbeat" at all.
+  // Cheap substring pre-check before the (cached) JSON.parse: most STATUS payloads never mention
+  // "heartbeat" at all, so this skips the parse entirely for them.
   if (!event.autonomous_event_data.includes('"heartbeat"')) {
     return false;
   }
-  try {
-    return (JSON.parse(event.autonomous_event_data) as { heartbeat?: boolean }).heartbeat === true;
-  } catch {
-    return false;
-  }
+  return parseEventData(event)?.heartbeat === true;
 };
 
 // A live-activity NARRATION is a per-iteration "what the orchestrator is doing right now" line the
@@ -141,21 +168,18 @@ export const isHeartbeatEvent = (event: AutonomousEvent | undefined): boolean =>
 // across the many iterations where the LLM narrates nothing. Every surface that renders the operator
 // decision feed (the reasoning-panel rows AND the overview decision timeline/count) filters it out so
 // it never shows as a decision row/node - only as streaming text in the thinking window. Single
-// source of truth so the two surfaces can never drift, mirroring isHeartbeatEvent.
+// source of truth so the two surfaces can never drift, mirroring isHeartbeatEvent (same substring
+// pre-check + shared cached parse).
 export const isLiveActivityEvent = (event: AutonomousEvent | undefined): boolean => {
   if (!event || event.autonomous_event_type !== 'NARRATION' || !event.autonomous_event_data) {
     return false;
   }
-  // Cheap substring pre-check before the JSON.parse: this runs for every event on every render of
-  // the feed, and the vast majority of NARRATION payloads never mention "live" at all.
+  // Cheap substring pre-check before the (cached) JSON.parse: the vast majority of NARRATION
+  // payloads never mention "live" at all, so this skips the parse entirely for them.
   if (!event.autonomous_event_data.includes('"live"')) {
     return false;
   }
-  try {
-    return (JSON.parse(event.autonomous_event_data) as { live?: boolean }).live === true;
-  } catch {
-    return false;
-  }
+  return parseEventData(event)?.live === true;
 };
 
 // Defensive display-time cleanup: the orchestrator (an LLM) occasionally leaks its own tool-call

--- a/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
+++ b/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
@@ -134,6 +134,30 @@ export const isHeartbeatEvent = (event: AutonomousEvent | undefined): boolean =>
   }
 };
 
+// A live-activity NARRATION is a per-iteration "what the orchestrator is doing right now" line the
+// XTM One worker streams to the timeline WHILE a decision cycle runs (flagged {"live": true} in its
+// data). Unlike a genuine recorded NARRATION/DECISION, it is NOT an operator-facing decision: it
+// exists ONLY to keep the cockpit's dimmed "thinking" window scrolling (it flows into thinkingLines)
+// across the many iterations where the LLM narrates nothing. Every surface that renders the operator
+// decision feed (the reasoning-panel rows AND the overview decision timeline/count) filters it out so
+// it never shows as a decision row/node - only as streaming text in the thinking window. Single
+// source of truth so the two surfaces can never drift, mirroring isHeartbeatEvent.
+export const isLiveActivityEvent = (event: AutonomousEvent | undefined): boolean => {
+  if (!event || event.autonomous_event_type !== 'NARRATION' || !event.autonomous_event_data) {
+    return false;
+  }
+  // Cheap substring pre-check before the JSON.parse: this runs for every event on every render of
+  // the feed, and the vast majority of NARRATION payloads never mention "live" at all.
+  if (!event.autonomous_event_data.includes('"live"')) {
+    return false;
+  }
+  try {
+    return (JSON.parse(event.autonomous_event_data) as { live?: boolean }).live === true;
+  } catch {
+    return false;
+  }
+};
+
 // Defensive display-time cleanup: the orchestrator (an LLM) occasionally leaks its own tool-call
 // framing into an event's title/content - operator prose followed by literal </content>, <invoke ...>,
 // <parameter ...> markup of the next calls. XTM One now strips this at the source, but runs recorded


### PR DESCRIPTION
## Summary

- Fixes the frozen autonomous cockpit reasoning window (#7446): the dimmed "thinking" window sat frozen for 6-11 minutes across 60-80 orchestrator iterations because its text is rebuilt only from LLM-authored NARRATION / DECISION / TOOL_ACTION events, which the orchestrator emits about once per 80 iterations.
- The XTM One worker now streams a deterministic per-iteration NARRATION line to the run timeline (companion PR XTM-One-Platform/xtm-one#2898). This PR renders those live lines in the thinking window and keeps them out of the operator decision surfaces.

## Changes

- `autonomousEventVisuals.tsx`: add and export `isLiveActivityEvent(event)` - true for a NARRATION whose parsed JSON `data` has `live === true`, mirroring `isHeartbeatEvent` (same `"live"` substring pre-check + strict parsed-JSON check). Single source of truth for both consuming surfaces.
- `AutonomousReasoningPanel.tsx`: `visibleEvents` now also excludes live-activity NARRATIONs, so they never render as operator decision rows. `thinkingLines` is intentionally unchanged - it already includes NARRATION, so the live lines now stream into the dimmed window (last 8, giving the scrolling effect). The freshness/caption logic still keys off the raw events so the cockpit animates.
- `AutonomousOutcome.tsx`: `decisionEvents` now also excludes live-activity NARRATIONs, so they never appear as nodes on the overview decision timeline nor inflate the decision count.

## Review follow-ups

- Shared a module-level WeakMap parse cache (`parseEventData`) between `isHeartbeatEvent` and `isLiveActivityEvent` so each immutable, append-only timeline event is JSON-parsed at most once for its whole lifetime, even though `visibleEvents` / `decisionEvents` / `thinkingLines` re-filter the whole array on every 3s poll batch. Addresses the reviewer's render-cost note about re-parsing per-iteration live NARRATIONs and DRYs the shared parse + guard; the strict JSON check is unchanged and `null` is cached for unparseable / non-object payloads.
- Added vitest coverage for both classification predicates (there was none) in `autonomousEventVisuals.test.ts`: live true/false and non-boolean, genuine narration never hidden, the `"live"` substring guard, wrong event type, missing / malformed data, undefined event, and that heartbeat and live-activity are mutually exclusive.

## Shared contract with the XTM One worker

- Event: type = "NARRATION"; data JSON contains `{"live": true, "iteration": <int>}`.

## Test plan

- [x] `yarn check-ts` clean.
- [x] `yarn lint` clean (`--max-warnings 0`).
- [x] `yarn i18n-checker` clean - no new i18n keys (the live text is authored by the backend, not the frontend).
- [x] `yarn vitest run autonomousEventVisuals.test.ts` - 15 assertions pass.
- [ ] Manual: during a long autonomous run the cockpit thinking window scrolls per-iteration activity captions, while the operator decision feed and the overview timeline/count show no live-activity rows or nodes.

Closes #7446
