### PR TITLE
fix(autonomous): authorize orchestrator callbacks from the parent run tenant (#7450)

### DIFF
--- a/.github/skills/activate-tenant-table/SKILL.md
+++ b/.github/skills/activate-tenant-table/SKILL.md
@@ -655,11 +655,12 @@ inefficiency). The two forms behave very differently once the table is active:
   covered shape or postpone the activation; never bypass the inspector.
 - **Raw JDBC** (`JdbcTemplate`, `NamedParameterJdbcOperations`, a direct
   `Connection`/`Statement`) BYPASSES Hibernate entirely, so the inspector never
-  sees it: a silent cross-tenant read and an unattributed write. This is already
+  sees it: a silent cross-tenant read and an unattributed write.   This is already
   guarded by `TenantNonOrmAccessArchTest`
   (`no_raw_jdbc_outside_the_allowlist`), which fails the build on any new raw
   JDBC in production code outside the audited `@AllowRawJdbc` allowlist (which
-  covers non-tenant tables only). A raw-JDBC path touching the table you are
+  covers non-tenant tables, plus the two narrow test-enforced exceptions
+  below). A raw-JDBC path touching the table you are
   activating is a HARD BLOCKER: convert it to go through Hibernate (so it gets
   inspected) before go-live. Never `@AllowRawJdbc` a tenant table to make a job
   compile.
@@ -673,6 +674,18 @@ inefficiency). The two forms behave very differently once the table is active:
   build so the exemption cannot silently widen. The seed generator for the
   attack-path tables is the reference (`AttackPathSeedServiceTest`). Absent that
   enforced insert-only proof, the HARD BLOCKER stands.
+- **Narrow exception — a provably read-only scope-bootstrap lookup.** Deriving
+  a service-identity scope FROM a row (an orchestrator callback scoped by its
+  parent run's own tenant) is a chicken-and-egg: the read that decides the
+  scope cannot run under the scope it is deciding, and the inspector would
+  fail-close it. A raw-JDBC path may keep `@AllowRawJdbc` for that bootstrap
+  ONLY when all three hold: it emits nothing but a single-row `SELECT` of the
+  row's own immutable `tenant_id` addressed by primary key, it projects no
+  other column, and a test pins the bypass class list and the exact statement
+  on every build so the exemption cannot silently widen. The autonomous-run
+  callback locator is the reference (`AutonomousRunTenantLocator` /
+  `AutonomousRunTenantLocatorTest`). Absent that enforced read-only proof, the
+  HARD BLOCKER stands.
 
 Add a grep for both to the inventory and read each hit:
 

--- a/.github/skills/activate-tenant-table/SKILL.md
+++ b/.github/skills/activate-tenant-table/SKILL.md
@@ -682,7 +682,11 @@ inefficiency). The two forms behave very differently once the table is active:
   ONLY when all three hold: it emits nothing but a single-row `SELECT` of the
   row's own immutable `tenant_id` addressed by primary key, it projects no
   other column, and a test pins the bypass class list and the exact statement
-  on every build so the exemption cannot silently widen. The autonomous-run
+  on every build so the exemption cannot silently widen. The bootstrap read
+  must also respect tenant liveness (filter on `tenant_deleted_at IS NULL`):
+  a soft-deleted tenant is excluded from every caller scope for its whole
+  grace period, so a row-derived scope that ignored the flag would quietly
+  re-admit a tenant no caller can reach. The autonomous-run
   callback locator is the reference (`AutonomousRunTenantLocator` /
   `AutonomousRunTenantLocatorTest`). Absent that enforced read-only proof, the
   HARD BLOCKER stands.

--- a/.github/skills/activate-tenant-table/SKILL.md
+++ b/.github/skills/activate-tenant-table/SKILL.md
@@ -655,7 +655,7 @@ inefficiency). The two forms behave very differently once the table is active:
   covered shape or postpone the activation; never bypass the inspector.
 - **Raw JDBC** (`JdbcTemplate`, `NamedParameterJdbcOperations`, a direct
   `Connection`/`Statement`) BYPASSES Hibernate entirely, so the inspector never
-  sees it: a silent cross-tenant read and an unattributed write.   This is already
+  sees it: a silent cross-tenant read and an unattributed write. This is already
   guarded by `TenantNonOrmAccessArchTest`
   (`no_raw_jdbc_outside_the_allowlist`), which fails the build on any new raw
   JDBC in production code outside the audited `@AllowRawJdbc` allowlist (which

--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -62,11 +62,12 @@ import org.springframework.web.bind.annotation.RestController;
  * autonomous_directives} tables are tenant-active (multi-tenancy v2): handlers that touch them take
  * a {@code TxCtx} so the transaction aspect sets the request scope. Operator handlers resolve that
  * scope from the caller's memberships / {@code X-Tenant-Ids}; the orchestrator CALLBACK handlers
- * mark their {@code TxCtx} with {@link io.openaev.config.RunTenantScope} so the scope is derived
- * from the parent run's own tenant (a service-identity operation, independent of the caller's
- * memberships) - otherwise the legacy non-prefixed callback, whose per-user JWT carries no tenant
- * claim, would fail to write the run's own timeline once the caller's scope does not pin the run's
- * tenant.
+ * mark their {@code TxCtx} with {@link io.openaev.config.RunTenantScope} so, on the legacy
+ * non-prefixed route only, the scope is derived from the parent run's own tenant (a
+ * service-identity operation, independent of the caller's memberships) - otherwise that legacy
+ * callback, whose per-user JWT carries no tenant claim, would fail to write the run's own timeline
+ * once the caller's scope does not pin the run's tenant. On the tenant-prefixed route the same
+ * handlers stay caller-authorized like every other prefixed endpoint.
  *
  * <p>Endpoints split into three audiences: the operator UI (create / start / pause / resume /
  * cancel / steer / read), the XTM One orchestrator callbacks (events / status / directive
@@ -382,6 +383,10 @@ public class AutonomousRunApi extends RestBehavior {
     return autonomousRunService.applyLiveConfiguration(runId, input);
   }
 
+  // endregion
+
+  // region orchestrator callbacks
+
   @Operation(summary = "Orchestrator: read the run's live, resolved scope (allow-list + deny-list)")
   @GetMapping("/{runId}/scope")
   @Transactional(readOnly = true)
@@ -400,10 +405,6 @@ public class AutonomousRunApi extends RestBehavior {
       @Valid @RequestBody AutonomousScopeUpdateInput input) {
     return autonomousRunService.setRunScope(runId, input.getScope());
   }
-
-  // endregion
-
-  // region orchestrator callbacks
 
   @Operation(summary = "Orchestrator: append a timeline event")
   @PostMapping("/{runId}/events")

--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -22,6 +22,7 @@ import io.openaev.api.autonomous.dto.CapabilityQueryInput;
 import io.openaev.api.autonomous.dto.CapabilityReport;
 import io.openaev.api.chaining.dto.WorkflowConfigurationInput;
 import io.openaev.api.xtmone.dto.ChatbotAgentOutput;
+import io.openaev.config.RunTenantScope;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Scenario;
 import io.openaev.database.model.Workflow;
@@ -59,8 +60,13 @@ import org.springframework.web.bind.annotation.RestController;
  * authority derives from its bound simulation, checked in-service through {@code
  * AutonomousRunAccessControl}. The {@code autonomous_runs}, {@code autonomous_events} and {@code
  * autonomous_directives} tables are tenant-active (multi-tenancy v2): handlers that touch them take
- * a {@code TxCtx} so the transaction aspect sets the request scope. The orchestrator's legacy
- * non-prefixed path resolves that scope from the caller's memberships / {@code X-Tenant-Ids}.
+ * a {@code TxCtx} so the transaction aspect sets the request scope. Operator handlers resolve that
+ * scope from the caller's memberships / {@code X-Tenant-Ids}; the orchestrator CALLBACK handlers
+ * mark their {@code TxCtx} with {@link io.openaev.config.RunTenantScope} so the scope is derived
+ * from the parent run's own tenant (a service-identity operation, independent of the caller's
+ * memberships) - otherwise the legacy non-prefixed callback, whose per-user JWT carries no tenant
+ * claim, would fail to write the run's own timeline once the caller's scope does not pin the run's
+ * tenant.
  *
  * <p>Endpoints split into three audiences: the operator UI (create / start / pause / resume /
  * cancel / steer / read), the XTM One orchestrator callbacks (events / status / directive
@@ -380,7 +386,7 @@ public class AutonomousRunApi extends RestBehavior {
   @GetMapping("/{runId}/scope")
   @Transactional(readOnly = true)
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
-  public AutonomousScopeView getScope(TxCtx ctx, @PathVariable String runId) {
+  public AutonomousScopeView getScope(@RunTenantScope TxCtx ctx, @PathVariable String runId) {
     return autonomousRunService.getRunScopeView(runId);
   }
 
@@ -389,7 +395,9 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousRun setScope(
-      TxCtx ctx, @PathVariable String runId, @Valid @RequestBody AutonomousScopeUpdateInput input) {
+      @RunTenantScope TxCtx ctx,
+      @PathVariable String runId,
+      @Valid @RequestBody AutonomousScopeUpdateInput input) {
     return autonomousRunService.setRunScope(runId, input.getScope());
   }
 
@@ -402,7 +410,9 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousEvent recordEvent(
-      TxCtx ctx, @PathVariable String runId, @Valid @RequestBody AutonomousEventInput input) {
+      @RunTenantScope TxCtx ctx,
+      @PathVariable String runId,
+      @Valid @RequestBody AutonomousEventInput input) {
     return autonomousRunService.recordEvent(
         runId, input.getType(), input.getTitle(), input.getContent(), input.getData());
   }
@@ -412,7 +422,7 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousRun updateStatus(
-      TxCtx ctx,
+      @RunTenantScope TxCtx ctx,
       @PathVariable String runId,
       @Valid @RequestBody AutonomousStatusUpdateInput input) {
     return autonomousRunService.updateStatus(
@@ -423,7 +433,8 @@ public class AutonomousRunApi extends RestBehavior {
   @PostMapping("/{runId}/directives/consume")
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
-  public List<AutonomousDirective> consumeDirectives(TxCtx ctx, @PathVariable String runId) {
+  public List<AutonomousDirective> consumeDirectives(
+      @RunTenantScope TxCtx ctx, @PathVariable String runId) {
     return autonomousRunService.consumePendingDirectives(runId);
   }
 
@@ -441,7 +452,7 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousAttackPathStepResult appendAttackPathStep(
-      TxCtx ctx,
+      @RunTenantScope TxCtx ctx,
       @PathVariable String runId,
       @Valid @RequestBody AutonomousAttackPathStepInput input) {
     String stepTemplateId =
@@ -462,7 +473,7 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousAttackPathStepResult updateAttackPathStep(
-      TxCtx ctx,
+      @RunTenantScope TxCtx ctx,
       @PathVariable String runId,
       @PathVariable String stepTemplateId,
       @Valid @RequestBody AutonomousAttackPathStepInput input) {
@@ -482,7 +493,7 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional(readOnly = true)
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public List<AutonomousAttackPathStepState> attackPathState(
-      TxCtx ctx, @PathVariable String runId) {
+      @RunTenantScope TxCtx ctx, @PathVariable String runId) {
     return autonomousRunService.attackPathState(runId);
   }
 
@@ -495,7 +506,7 @@ public class AutonomousRunApi extends RestBehavior {
   @PostMapping("/{runId}/attack-path/evaluate")
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
-  public AutonomousRun evaluateAttackPath(TxCtx ctx, @PathVariable String runId) {
+  public AutonomousRun evaluateAttackPath(@RunTenantScope TxCtx ctx, @PathVariable String runId) {
     // The service returns the reconciled run itself: this is an orchestrator CALLBACK, and reading
     // back through the operator-gated get() would 403 a valid service-identity callback.
     return autonomousRunService.evaluateAttackPath(runId);
@@ -512,7 +523,7 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousPromotedAssetResult promoteFindingToAsset(
-      TxCtx ctx,
+      @RunTenantScope TxCtx ctx,
       @PathVariable String runId,
       @PathVariable String findingId,
       @RequestParam(name = "acting_agent_id", required = false) String actingAgentId) {
@@ -533,7 +544,9 @@ public class AutonomousRunApi extends RestBehavior {
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
   public AutonomousTargetTeamResult ensureTargetTeam(
-      TxCtx ctx, @PathVariable String runId, @Valid @RequestBody AutonomousTargetTeamInput input) {
+      @RunTenantScope TxCtx ctx,
+      @PathVariable String runId,
+      @Valid @RequestBody AutonomousTargetTeamInput input) {
     return autonomousRunService.ensureTargetTeam(
         runId, input.getPlayerIds(), input.getName(), input.getTeamId(), input.getActingAgentId());
   }

--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -63,10 +63,12 @@ import org.springframework.web.bind.annotation.RestController;
  * a {@code TxCtx} so the transaction aspect sets the request scope. Operator handlers resolve that
  * scope from the caller's memberships / {@code X-Tenant-Ids}; the orchestrator CALLBACK handlers
  * mark their {@code TxCtx} with {@link io.openaev.config.RunTenantScope} so, on the legacy
- * non-prefixed route only, the scope is derived from the parent run's own tenant (a
- * service-identity operation, independent of the caller's memberships) - otherwise that legacy
- * callback, whose per-user JWT carries no tenant claim, would fail to write the run's own timeline
- * once the caller's scope does not pin the run's tenant. On the tenant-prefixed route the same
+ * non-prefixed route and for the VERIFIED XTM One cross-platform service identity only (the bearer
+ * {@code io.openaev.security.token.XtmJwksExtractor} fully validated), the scope is derived from
+ * the parent run's own tenant - otherwise that legacy callback, whose per-user JWT carries no
+ * tenant claim, would fail to write the run's own timeline once the caller's scope does not pin the
+ * run's tenant. A non-service caller on the same handlers keeps the standard caller-authorized
+ * resolution (no cross-tenant reach from a known run id), and on the tenant-prefixed route the
  * handlers stay caller-authorized like every other prefixed endpoint.
  *
  * <p>Endpoints split into three audiences: the operator UI (create / start / pause / resume /

--- a/openaev-api/src/main/java/io/openaev/config/AutonomousRunTenantLocator.java
+++ b/openaev-api/src/main/java/io/openaev/config/AutonomousRunTenantLocator.java
@@ -23,6 +23,12 @@ import org.springframework.stereotype.Component;
  * connection ({@link JdbcTemplate} via {@code DataSourceUtils}); when a transaction is already
  * bound to the thread (integration tests) it joins it and sees the seeded run, and in production it
  * reads the already-committed run row.
+ *
+ * <p>This is the read-only scope-bootstrap exception of the tenant-activation runbook: the
+ * exemption stays legitimate only while the class emits nothing but this single-row,
+ * primary-key-addressed SELECT of the run's own {@code tenant_id}. {@code
+ * AutonomousRunTenantLocatorTest} pins the class list and the exact statement on every build, the
+ * same enforcement pattern as the insert-only seed exemption ({@code AttackPathSeedServiceTest}).
  */
 @Component
 @RequiredArgsConstructor
@@ -32,8 +38,17 @@ import org.springframework.stereotype.Component;
             + " service-identity scope for the orchestrator callback endpoints, BEFORE the"
             + " transaction (and thus the scope) is opened. This read is what SETS the scope, so it"
             + " cannot be tenant-scoped itself; it must bypass the inspector. It reads only the run's"
-            + " immutable tenant_id by primary key and never any other row.")
+            + " immutable tenant_id by primary key and never any other row or column; the exemption"
+            + " is pinned read-only by AutonomousRunTenantLocatorTest.")
 public class AutonomousRunTenantLocator {
+
+  /**
+   * The one statement this class may ever emit: a single-row read of the run's own tenant
+   * attribution, addressed by primary key, projecting nothing else. Pinned verbatim by {@code
+   * AutonomousRunTenantLocatorTest} so any widening fails the build.
+   */
+  static final String SELECT_RUN_TENANT =
+      "SELECT tenant_id FROM autonomous_runs WHERE autonomous_run_id = ?";
 
   private final JdbcTemplate jdbcTemplate;
 
@@ -45,12 +60,7 @@ public class AutonomousRunTenantLocator {
     if (runId == null || runId.isBlank()) {
       return Optional.empty();
     }
-    return jdbcTemplate
-        .query(
-            "SELECT tenant_id FROM autonomous_runs WHERE autonomous_run_id = ?",
-            (rs, rowNum) -> rs.getString(1),
-            runId)
-        .stream()
+    return jdbcTemplate.query(SELECT_RUN_TENANT, (rs, rowNum) -> rs.getString(1), runId).stream()
         .findFirst()
         .filter(tenant -> tenant != null && !tenant.isBlank());
   }

--- a/openaev-api/src/main/java/io/openaev/config/AutonomousRunTenantLocator.java
+++ b/openaev-api/src/main/java/io/openaev/config/AutonomousRunTenantLocator.java
@@ -16,8 +16,17 @@ import org.springframework.stereotype.Component;
  * (a tenant-active table) would be filtered by {@code can_access_tenant} against a scope that has
  * not been decided yet, and would return nothing for exactly the callers this feature must serve.
  * It therefore has to bypass the Hibernate statement inspector. No tenant guarantee is lost: it
- * reads only the run's own immutable {@code tenant_id} by its primary key and returns it for the
- * aspect to enforce for the rest of the transaction; it never reads or writes any other row.
+ * reads only the run's own immutable {@code tenant_id} by its primary key, plus the owning tenant's
+ * liveness flag, and returns it for the aspect to enforce for the rest of the transaction; it never
+ * reads or writes anything else.
+ *
+ * <p>The liveness filter ({@code tenant_deleted_at IS NULL}) keeps the derived scope aligned with
+ * every caller-authorized scope: a soft-deleted tenant is excluded from all memberships for its
+ * whole retention grace period ({@code TenantRepository#findTenantsByUserId}, {@code
+ * TenantMembershipCacheManager}), so no operator can reach the run - the run-derived service scope
+ * must not quietly re-admit it. A run in a soft-deleted tenant therefore resolves empty, exactly
+ * like an unknown run (fail-closed, 404 at the callback); reactivating the tenant within the grace
+ * period restores the callbacks with it.
  *
  * <p>Runs before the request's {@code @Transactional} boundary opens, so it acquires its own
  * connection ({@link JdbcTemplate} via {@code DataSourceUtils}); when a transaction is already
@@ -26,9 +35,10 @@ import org.springframework.stereotype.Component;
  *
  * <p>This is the read-only scope-bootstrap exception of the tenant-activation runbook: the
  * exemption stays legitimate only while the class emits nothing but this single-row,
- * primary-key-addressed SELECT of the run's own {@code tenant_id}. {@code
- * AutonomousRunTenantLocatorTest} pins the class list and the exact statement on every build, the
- * same enforcement pattern as the insert-only seed exemption ({@code AttackPathSeedServiceTest}).
+ * primary-key-addressed SELECT of the run's own {@code tenant_id}, filtered on the owning tenant's
+ * liveness. {@code AutonomousRunTenantLocatorTest} pins the class list and the exact statement on
+ * every build, the same enforcement pattern as the insert-only seed exemption ({@code
+ * AttackPathSeedServiceTest}).
  */
 @Component
 @RequiredArgsConstructor
@@ -38,23 +48,30 @@ import org.springframework.stereotype.Component;
             + " service-identity scope for the orchestrator callback endpoints, BEFORE the"
             + " transaction (and thus the scope) is opened. This read is what SETS the scope, so it"
             + " cannot be tenant-scoped itself; it must bypass the inspector. It reads only the run's"
-            + " immutable tenant_id by primary key and never any other row or column; the exemption"
-            + " is pinned read-only by AutonomousRunTenantLocatorTest.")
+            + " immutable tenant_id by primary key, filtered on the owning tenant's liveness"
+            + " (tenant_deleted_at IS NULL, the same predicate that keeps soft-deleted tenants out of"
+            + " every caller scope), and touches nothing else; the exemption is pinned read-only by"
+            + " AutonomousRunTenantLocatorTest.")
 public class AutonomousRunTenantLocator {
 
   /**
    * The one statement this class may ever emit: a single-row read of the run's own tenant
-   * attribution, addressed by primary key, projecting nothing else. Pinned verbatim by {@code
+   * attribution, addressed by primary key, projecting nothing else, and refusing a run whose owning
+   * tenant is soft-deleted (its grace period excludes it from every caller scope, so the
+   * run-derived scope must not re-admit it). Pinned verbatim by {@code
    * AutonomousRunTenantLocatorTest} so any widening fails the build.
    */
   static final String SELECT_RUN_TENANT =
-      "SELECT tenant_id FROM autonomous_runs WHERE autonomous_run_id = ?";
+      "SELECT r.tenant_id FROM autonomous_runs r JOIN tenants t ON t.tenant_id = r.tenant_id"
+          + " WHERE r.autonomous_run_id = ? AND t.tenant_deleted_at IS NULL";
 
   private final JdbcTemplate jdbcTemplate;
 
   /**
-   * The tenant that owns the run, or empty when no such run exists. A present-but-blank/null tenant
-   * is also returned as empty so the caller fails closed.
+   * The tenant that owns the run, or empty when no such run exists or its owning tenant is
+   * soft-deleted (grace-period tenants are out of every caller scope, so the run-derived scope
+   * refuses them too). A present-but-blank/null tenant is also returned as empty so the caller
+   * fails closed.
    */
   public Optional<String> findRunTenant(String runId) {
     if (runId == null || runId.isBlank()) {

--- a/openaev-api/src/main/java/io/openaev/config/AutonomousRunTenantLocator.java
+++ b/openaev-api/src/main/java/io/openaev/config/AutonomousRunTenantLocator.java
@@ -1,0 +1,57 @@
+package io.openaev.config;
+
+import io.openaev.annotation.AllowRawJdbc;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Reads an autonomous run's own {@code tenant_id} by primary key, scope-free, so {@link
+ * RunTenantScope} can derive the service-identity scope of an orchestrator callback from the run
+ * itself.
+ *
+ * <p>Raw JDBC on purpose: this lookup is what SETS the transaction's tenant scope, so it cannot
+ * itself run under that scope without a chicken-and-egg - a scoped read of {@code autonomous_runs}
+ * (a tenant-active table) would be filtered by {@code can_access_tenant} against a scope that has
+ * not been decided yet, and would return nothing for exactly the callers this feature must serve.
+ * It therefore has to bypass the Hibernate statement inspector. No tenant guarantee is lost: it
+ * reads only the run's own immutable {@code tenant_id} by its primary key and returns it for the
+ * aspect to enforce for the rest of the transaction; it never reads or writes any other row.
+ *
+ * <p>Runs before the request's {@code @Transactional} boundary opens, so it acquires its own
+ * connection ({@link JdbcTemplate} via {@code DataSourceUtils}); when a transaction is already
+ * bound to the thread (integration tests) it joins it and sees the seeded run, and in production it
+ * reads the already-committed run row.
+ */
+@Component
+@RequiredArgsConstructor
+@AllowRawJdbc(
+    reason =
+        "Resolves the parent autonomous run's own tenant_id by primary key to derive the"
+            + " service-identity scope for the orchestrator callback endpoints, BEFORE the"
+            + " transaction (and thus the scope) is opened. This read is what SETS the scope, so it"
+            + " cannot be tenant-scoped itself; it must bypass the inspector. It reads only the run's"
+            + " immutable tenant_id by primary key and never any other row.")
+public class AutonomousRunTenantLocator {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  /**
+   * The tenant that owns the run, or empty when no such run exists. A present-but-blank/null tenant
+   * is also returned as empty so the caller fails closed.
+   */
+  public Optional<String> findRunTenant(String runId) {
+    if (runId == null || runId.isBlank()) {
+      return Optional.empty();
+    }
+    return jdbcTemplate
+        .query(
+            "SELECT tenant_id FROM autonomous_runs WHERE autonomous_run_id = ?",
+            (rs, rowNum) -> rs.getString(1),
+            runId)
+        .stream()
+        .findFirst()
+        .filter(tenant -> tenant != null && !tenant.isBlank());
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
+++ b/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
@@ -24,7 +24,10 @@ import java.lang.annotation.Target;
  * acts on the run's tenant regardless of the caller's selector or memberships, and every write it
  * makes is stamped with that tenant. An unknown run resolves to {@link
  * io.openaev.context.TxCtx#missing()} (fail-closed), which the service then reports as a 404
- * through its own run lookup.
+ * through its own run lookup. A run whose owning tenant is soft-deleted resolves the same way: a
+ * grace-period tenant is excluded from every caller scope, so the run-derived scope refuses it too
+ * instead of quietly re-admitting a tenant no operator can reach (reactivation within the grace
+ * period restores the callbacks with it).
  *
  * <p>Run-authoritative scope is granted ONLY to the verified XTM One cross-platform SERVICE
  * identity: the request must carry the server-side marker ({@link

--- a/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
+++ b/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
@@ -26,6 +26,12 @@ import java.lang.annotation.Target;
  * io.openaev.context.TxCtx#missing()} (fail-closed), which the service then reports as a 404
  * through its own run lookup.
  *
+ * <p>The derivation applies ONLY on the legacy non-prefixed route (the one the orchestrator
+ * actually calls). On the tenant-prefixed operator route the handler keeps the standard
+ * caller-authorized resolution - the {@code {tenantId}} the URL names stays the boundary - so the
+ * annotation never turns the prefixed API into a second, caller-independent door to another
+ * tenant's run.
+ *
  * <p>Deliberately NOT applied to the operator-facing endpoints (create / list / get / timeline /
  * start-pause-resume-cancel-restart / queue-directive / configuration): those stay tenant-isolated
  * against the caller's scope exactly as multi-tenancy v2 made them. This annotation only restores

--- a/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
+++ b/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
@@ -26,6 +26,14 @@ import java.lang.annotation.Target;
  * io.openaev.context.TxCtx#missing()} (fail-closed), which the service then reports as a 404
  * through its own run lookup.
  *
+ * <p>Run-authoritative scope is granted ONLY to the verified XTM One cross-platform SERVICE
+ * identity: the request must carry the server-side marker ({@link
+ * io.openaev.security.token.XtmJwksExtractor#CROSS_PLATFORM_ATTRIBUTE}) that {@link
+ * io.openaev.security.token.XtmJwksExtractor} stamps after fully validating the cross-platform JWT
+ * (trusted issuer, JWKS signature, expected audience). Every other authenticated caller keeps the
+ * standard caller-authorized resolution on these handlers, so the annotation never lets a normal
+ * Enterprise-Edition user turn a known run id into cross-tenant reach.
+ *
  * <p>The derivation applies ONLY on the legacy non-prefixed route (the one the orchestrator
  * actually calls). On the tenant-prefixed operator route the handler keeps the standard
  * caller-authorized resolution - the {@code {tenantId}} the URL names stays the boundary - so the
@@ -36,9 +44,8 @@ import java.lang.annotation.Target;
  * start-pause-resume-cancel-restart / queue-directive / configuration): those stay tenant-isolated
  * against the caller's scope exactly as multi-tenancy v2 made them. This annotation only restores
  * the run-authoritative posture the callbacks had before the {@code autonomous_*} tables became
- * tenant-active, without weakening operator isolation. The EE-license gate and the run's existence
- * remain the callback's guardrails; restricting the callbacks to the actual service identity is a
- * separate hardening tracked apart from tenant correctness.
+ * tenant-active, without weakening operator isolation: the service-identity gate above means a
+ * non-orchestrator caller on an annotated handler is scoped exactly like on any other endpoint.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
+++ b/openaev-api/src/main/java/io/openaev/config/RunTenantScope.java
@@ -1,0 +1,39 @@
+package io.openaev.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code TxCtx} controller parameter as a SERVICE-IDENTITY scope derived from the parent
+ * autonomous run named by the {@code {runId}} path variable, instead of from the caller's tenant
+ * memberships.
+ *
+ * <p>The orchestrator callback endpoints (events / status / directive consumption / attack-path
+ * authoring, evaluation and state / scope get-set / target-teams / promote-finding-to-asset) are
+ * reached by XTM One with a per-user cross-platform JWT that carries NO tenant claim and NO {@code
+ * X-Tenant-Ids} header on the legacy non-prefixed path. Resolving that empty selector to the
+ * caller's memberships (the default {@link TxCtxArgumentResolver} behaviour) couples the callback
+ * to whichever tenants the caller happens to belong to: a member of the run's tenant works, but a
+ * caller whose scope does not pin the run's tenant reads nothing and the callback dies on the run
+ * lookup (404). That is wrong for a service callback whose authority is the run itself.
+ *
+ * <p>With this annotation the scope is taken from the run's own immutable {@code tenant_id} (looked
+ * up by primary key, scope-free, in {@link AutonomousRunTenantLocator}), so the callback always
+ * acts on the run's tenant regardless of the caller's selector or memberships, and every write it
+ * makes is stamped with that tenant. An unknown run resolves to {@link
+ * io.openaev.context.TxCtx#missing()} (fail-closed), which the service then reports as a 404
+ * through its own run lookup.
+ *
+ * <p>Deliberately NOT applied to the operator-facing endpoints (create / list / get / timeline /
+ * start-pause-resume-cancel-restart / queue-directive / configuration): those stay tenant-isolated
+ * against the caller's scope exactly as multi-tenancy v2 made them. This annotation only restores
+ * the run-authoritative posture the callbacks had before the {@code autonomous_*} tables became
+ * tenant-active, without weakening operator isolation. The EE-license gate and the run's existence
+ * remain the callback's guardrails; restricting the callbacks to the actual service identity is a
+ * separate hardening tracked apart from tenant correctness.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RunTenantScope {}

--- a/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
+++ b/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
@@ -28,16 +28,23 @@ import org.springframework.web.servlet.HandlerMapping;
  * addressed), otherwise from the {@code X-Tenant-Ids} header (one or more comma-separated ids),
  * otherwise empty (which resolves to the caller's full allowed set). The resolved {@code TxCtx} is
  * the value the transaction aspect writes into the tenant scope.
+ *
+ * <p>A {@link RunTenantScope}-annotated parameter is the one exception to "the caller decides": it
+ * is a service-identity callback whose scope is derived from the parent autonomous run named by the
+ * {@code {runId}} path variable, independent of the caller's selector or memberships (see the
+ * annotation for why).
  */
 @Component
 @RequiredArgsConstructor
 public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
 
   static final String TENANT_ID_PATH_VARIABLE = "tenantId";
+  static final String RUN_ID_PATH_VARIABLE = "runId";
   static final String TENANT_IDS_HEADER = "X-Tenant-Ids";
 
   private final TenantScopeResolver scopeResolver;
   private final TenantMembershipCacheManager membershipCache;
+  private final AutonomousRunTenantLocator runTenantLocator;
 
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
@@ -50,6 +57,9 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
+    if (parameter.hasParameterAnnotation(RunTenantScope.class)) {
+      return runTenantScope(webRequest);
+    }
     Set<String> selector = extractSelector(webRequest);
     Set<String> authorized =
         new LinkedHashSet<>(
@@ -58,6 +68,24 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       selector = fallbackSelector(authorized);
     }
     return scopeResolver.resolve(selector, authorized);
+  }
+
+  /**
+   * Service-identity scope for an orchestrator callback: the run's own tenant, read scope-free by
+   * its {@code {runId}} path variable, never the caller's memberships. An absent or unknown run
+   * yields {@link TxCtx#missing()} (fail-closed), which the callback then surfaces as a 404 through
+   * its own run lookup. Deliberately does NOT vary the response by {@code X-Tenant-Ids}: the scope
+   * depends only on the run id already in the path, so the header is ignored here.
+   */
+  private TxCtx runTenantScope(NativeWebRequest webRequest) {
+    String runId = pathVariable(webRequest, RUN_ID_PATH_VARIABLE);
+    if (runId == null || runId.isBlank()) {
+      return TxCtx.missing();
+    }
+    return runTenantLocator
+        .findRunTenant(runId.trim())
+        .map(TxCtx::forTenant)
+        .orElse(TxCtx.missing());
   }
 
   /**
@@ -108,12 +136,16 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private String pathTenant(NativeWebRequest webRequest) {
+    return pathVariable(webRequest, TENANT_ID_PATH_VARIABLE);
+  }
+
+  @SuppressWarnings("unchecked")
+  private String pathVariable(NativeWebRequest webRequest, String key) {
     Map<String, String> pathVariables =
         (Map<String, String>)
             webRequest.getAttribute(
                 HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
-    return pathVariables == null ? null : pathVariables.get(TENANT_ID_PATH_VARIABLE);
+    return pathVariables == null ? null : pathVariables.get(key);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
+++ b/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
@@ -32,7 +32,10 @@ import org.springframework.web.servlet.HandlerMapping;
  * <p>A {@link RunTenantScope}-annotated parameter is the one exception to "the caller decides": it
  * is a service-identity callback whose scope is derived from the parent autonomous run named by the
  * {@code {runId}} path variable, independent of the caller's selector or memberships (see the
- * annotation for why).
+ * annotation for why). The exception exists ONLY on the legacy non-prefixed route the orchestrator
+ * actually rides: when the request addresses a tenant through the {@code {tenantId}} path variable
+ * (the tenant-prefixed operator route), the standard caller-authorized resolution applies, so the
+ * prefixed API keeps its uniform "the URL names the tenant, rights are the boundary" contract.
  */
 @Component
 @RequiredArgsConstructor
@@ -57,7 +60,7 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
-    if (parameter.hasParameterAnnotation(RunTenantScope.class)) {
+    if (parameter.hasParameterAnnotation(RunTenantScope.class) && !hasPathTenant(webRequest)) {
       return runTenantScope(webRequest);
     }
     Set<String> selector = extractSelector(webRequest);
@@ -75,7 +78,10 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
    * its {@code {runId}} path variable, never the caller's memberships. An absent or unknown run
    * yields {@link TxCtx#missing()} (fail-closed), which the callback then surfaces as a 404 through
    * its own run lookup. Deliberately does NOT vary the response by {@code X-Tenant-Ids}: the scope
-   * depends only on the run id already in the path, so the header is ignored here.
+   * depends only on the run id already in the path, so the header is ignored here. Only reachable
+   * on the legacy non-prefixed route: {@link #resolveArgument} keeps the tenant-prefixed route on
+   * the caller-authorized resolution, so this derivation never overrides an explicitly addressed
+   * tenant.
    */
   private TxCtx runTenantScope(NativeWebRequest webRequest) {
     String runId = pathVariable(webRequest, RUN_ID_PATH_VARIABLE);
@@ -138,6 +144,12 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
 
   private String pathTenant(NativeWebRequest webRequest) {
     return pathVariable(webRequest, TENANT_ID_PATH_VARIABLE);
+  }
+
+  /** Whether the request addresses a tenant through the tenant-prefixed route. */
+  private boolean hasPathTenant(NativeWebRequest webRequest) {
+    String pathTenant = pathTenant(webRequest);
+    return pathTenant != null && !pathTenant.isBlank();
   }
 
   @SuppressWarnings("unchecked")

--- a/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
+++ b/openaev-api/src/main/java/io/openaev/config/TxCtxArgumentResolver.java
@@ -4,6 +4,7 @@ import io.openaev.config.cache.TenantMembershipCacheManager;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
+import io.openaev.security.token.XtmJwksExtractor;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -32,10 +33,16 @@ import org.springframework.web.servlet.HandlerMapping;
  * <p>A {@link RunTenantScope}-annotated parameter is the one exception to "the caller decides": it
  * is a service-identity callback whose scope is derived from the parent autonomous run named by the
  * {@code {runId}} path variable, independent of the caller's selector or memberships (see the
- * annotation for why). The exception exists ONLY on the legacy non-prefixed route the orchestrator
- * actually rides: when the request addresses a tenant through the {@code {tenantId}} path variable
- * (the tenant-prefixed operator route), the standard caller-authorized resolution applies, so the
- * prefixed API keeps its uniform "the URL names the tenant, rights are the boundary" contract.
+ * annotation for why). Run-authoritative scope is a SERVICE-IDENTITY privilege: it is granted only
+ * when the request authenticated as the verified XTM One cross-platform JWT caller (trusted issuer
+ * + JWKS signature + audience, stamped by {@link
+ * io.openaev.security.token.XtmJwksExtractor#CROSS_PLATFORM_ATTRIBUTE}). Any other authenticated
+ * caller keeps the caller-authorized resolution, so knowing a run id can never let a normal
+ * Enterprise-Edition user read or mutate a run in a tenant it does not belong to. The exception
+ * also exists ONLY on the legacy non-prefixed route the orchestrator actually rides: when the
+ * request addresses a tenant through the {@code {tenantId}} path variable (the tenant-prefixed
+ * operator route), the standard caller-authorized resolution applies, so the prefixed API keeps its
+ * uniform "the URL names the tenant, rights are the boundary" contract.
  */
 @Component
 @RequiredArgsConstructor
@@ -61,8 +68,17 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
       NativeWebRequest webRequest,
       WebDataBinderFactory binderFactory) {
     if (parameter.hasParameterAnnotation(RunTenantScope.class) && !hasPathTenant(webRequest)) {
-      return runTenantScope(webRequest);
+      return runTenantScope(parameter, webRequest);
     }
+    return callerScope(parameter, webRequest);
+  }
+
+  /**
+   * The standard caller-authorized resolution: the caller's rights, not the request, decide the
+   * scope. The selector (path tenant / {@code X-Tenant-Ids} / empty) is validated against the
+   * caller's memberships by {@link TenantScopeResolver}.
+   */
+  private TxCtx callerScope(MethodParameter parameter, NativeWebRequest webRequest) {
     Set<String> selector = extractSelector(webRequest);
     Set<String> authorized =
         new LinkedHashSet<>(
@@ -75,15 +91,24 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
 
   /**
    * Service-identity scope for an orchestrator callback: the run's own tenant, read scope-free by
-   * its {@code {runId}} path variable, never the caller's memberships. An absent or unknown run
-   * yields {@link TxCtx#missing()} (fail-closed), which the callback then surfaces as a 404 through
-   * its own run lookup. Deliberately does NOT vary the response by {@code X-Tenant-Ids}: the scope
-   * depends only on the run id already in the path, so the header is ignored here. Only reachable
-   * on the legacy non-prefixed route: {@link #resolveArgument} keeps the tenant-prefixed route on
-   * the caller-authorized resolution, so this derivation never overrides an explicitly addressed
-   * tenant.
+   * its {@code {runId}} path variable, never the caller's memberships. Run-authoritative scope is a
+   * privilege of the VERIFIED service identity: only a request authenticated as the XTM One
+   * cross-platform JWT caller (the marker {@link XtmJwksExtractor} stamps after validating issuer,
+   * JWKS signature and audience) derives from the run; every other caller falls back to {@link
+   * #callerScope} and stays inside its own tenant rights, which is what keeps a run id from acting
+   * as a cross-tenant capability token. For the service caller an absent or unknown run yields
+   * {@link TxCtx#missing()} (fail-closed), which the callback then surfaces as a 404 through its
+   * own run lookup. Deliberately does NOT vary the response by {@code X-Tenant-Ids}: the derived
+   * scope depends only on the run id already in the path, so the header is ignored here. Only
+   * reachable on the legacy non-prefixed route: {@link #resolveArgument} keeps the tenant-prefixed
+   * route on the caller-authorized resolution, so this derivation never overrides an explicitly
+   * addressed tenant.
    */
-  private TxCtx runTenantScope(NativeWebRequest webRequest) {
+  private TxCtx runTenantScope(MethodParameter parameter, NativeWebRequest webRequest) {
+    if (!isCrossPlatformServiceCaller(webRequest)) {
+      // Not the orchestrator: caller-authorized resolution, no cross-tenant reach.
+      return callerScope(parameter, webRequest);
+    }
     String runId = pathVariable(webRequest, RUN_ID_PATH_VARIABLE);
     if (runId == null || runId.isBlank()) {
       return TxCtx.missing();
@@ -92,6 +117,17 @@ public class TxCtxArgumentResolver implements HandlerMethodArgumentResolver {
         .findRunTenant(runId.trim())
         .map(TxCtx::forTenant)
         .orElse(TxCtx.missing());
+  }
+
+  /**
+   * Whether this request authenticated as the XTM One cross-platform service identity. The marker
+   * is a server-side request attribute set exclusively by {@link XtmJwksExtractor} after full JWT
+   * validation; it cannot be supplied by a client.
+   */
+  private boolean isCrossPlatformServiceCaller(NativeWebRequest webRequest) {
+    return Boolean.TRUE.equals(
+        webRequest.getAttribute(
+            XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/security/token/XtmJwksExtractor.java
+++ b/openaev-api/src/main/java/io/openaev/security/token/XtmJwksExtractor.java
@@ -50,6 +50,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class XtmJwksExtractor implements ExtractorBase {
 
+  /**
+   * Request attribute stamped (only) on a request whose bearer was validated as an XTM One
+   * cross-platform JWT: trusted issuer, JWKS signature, expected audience, resolved user. Request
+   * attributes are server-side only, so a client can never forge it. {@link
+   * io.openaev.config.TxCtxArgumentResolver} keys on it to grant run-authoritative tenant scope to
+   * the orchestrator callbacks - any caller without it keeps caller-authorized resolution.
+   */
+  public static final String CROSS_PLATFORM_ATTRIBUTE =
+      "io.openaev.security.xtmCrossPlatformAuthenticated";
+
   private static final Duration JWKS_CACHE_TTL = Duration.ofHours(1);
 
   private final XtmOneConfig xtmOneConfig;
@@ -63,7 +73,7 @@ public class XtmJwksExtractor implements ExtractorBase {
   private record CachedJwks(Instant fetchedAt, String jwksJson) {}
 
   @Override
-  public Optional<User> authUser(String value, HttpServletRequest _request)
+  public Optional<User> authUser(String value, HttpServletRequest request)
       throws JwtException, AuthenticationError {
     if (value == null) {
       throw new AuthenticationError("No bearer token found");
@@ -92,7 +102,13 @@ public class XtmJwksExtractor implements ExtractorBase {
       throw new AuthenticationError("The JWT does not contain the required 'email' claim.");
     }
 
-    return userService.findByEmailIgnoreCase(email);
+    Optional<User> user = userService.findByEmailIgnoreCase(email);
+    // Stamp the service-identity marker ONLY when this fully validated token resolved a user: a
+    // failed or unresolved authentication must never leave the request marked as the orchestrator.
+    if (user.isPresent() && request != null) {
+      request.setAttribute(CROSS_PLATFORM_ATTRIBUTE, Boolean.TRUE);
+    }
+    return user;
   }
 
   // -- PRIVATE --

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
@@ -41,13 +41,18 @@ import org.springframework.web.server.ResponseStatusException;
  * short-circuit inside {@link PermissionService#hasPermission}.
  *
  * <p>The orchestrator CALLBACK endpoints (events / status / directive consumption / attack-path
- * authoring / scope) are deliberately NOT gated here. They are authenticated with the tenant's
- * single configured XTM One service token - one identity for every run, never the operator's - so a
- * resource check would break live orchestration for any run whose operator differs from the token
- * owner. They stay behind the Enterprise-Edition license. Restricting them to the actual service
- * identity (today any authenticated EE user can reach them) is tracked separately from tenant
- * isolation. The {@code autonomous_runs}, {@code autonomous_events} and {@code
- * autonomous_directives} tables are tenant-active (multi-tenancy v2).
+ * authoring, evaluation and state / scope get-set / target-teams / promote-finding-to-asset) are
+ * deliberately NOT gated here. XTM One authenticates them with a per-user cross-platform JWT that
+ * carries no tenant claim and sends no {@code X-Tenant-Ids}; a resource check would break live
+ * orchestration for any run whose operator differs from the JWT owner, so they stay behind the
+ * Enterprise-Edition license alone. Restricting them to the actual service identity (today any
+ * authenticated EE user can reach them) is tracked separately from tenant isolation. The {@code
+ * autonomous_runs}, {@code autonomous_events} and {@code autonomous_directives} tables are
+ * tenant-active (multi-tenancy v2); because the callback JWT pins no tenant, these handlers derive
+ * their scope from the parent run instead of the caller (the {@link
+ * io.openaev.config.RunTenantScope} argument on {@link
+ * io.openaev.api.autonomous.AutonomousRunApi}), so a callback always writes the run's own tenant
+ * and never depends on whether the caller's scope happens to pin it.
  */
 @org.springframework.stereotype.Component
 @RequiredArgsConstructor

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
@@ -52,7 +52,9 @@ import org.springframework.web.server.ResponseStatusException;
  * their scope from the parent run instead of the caller (the {@link
  * io.openaev.config.RunTenantScope} argument on {@link
  * io.openaev.api.autonomous.AutonomousRunApi}), so a callback always writes the run's own tenant
- * and never depends on whether the caller's scope happens to pin it.
+ * and never depends on whether the caller's scope happens to pin it. That derivation exists only on
+ * the legacy non-prefixed route the orchestrator calls; the same handlers on the tenant-prefixed
+ * route stay caller-authorized like every other prefixed endpoint.
  */
 @org.springframework.stereotype.Component
 @RequiredArgsConstructor

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunAccessControl.java
@@ -45,16 +45,18 @@ import org.springframework.web.server.ResponseStatusException;
  * deliberately NOT gated here. XTM One authenticates them with a per-user cross-platform JWT that
  * carries no tenant claim and sends no {@code X-Tenant-Ids}; a resource check would break live
  * orchestration for any run whose operator differs from the JWT owner, so they stay behind the
- * Enterprise-Edition license alone. Restricting them to the actual service identity (today any
- * authenticated EE user can reach them) is tracked separately from tenant isolation. The {@code
- * autonomous_runs}, {@code autonomous_events} and {@code autonomous_directives} tables are
- * tenant-active (multi-tenancy v2); because the callback JWT pins no tenant, these handlers derive
- * their scope from the parent run instead of the caller (the {@link
- * io.openaev.config.RunTenantScope} argument on {@link
+ * Enterprise-Edition license. The {@code autonomous_runs}, {@code autonomous_events} and {@code
+ * autonomous_directives} tables are tenant-active (multi-tenancy v2); because the callback JWT pins
+ * no tenant, these handlers are authorized as the XTM One cross-platform SERVICE identity and
+ * scoped to the parent run's tenant: only a request whose bearer {@link
+ * io.openaev.security.token.XtmJwksExtractor} fully validated as a cross-platform JWT derives its
+ * scope from the run (the {@link io.openaev.config.RunTenantScope} argument on {@link
  * io.openaev.api.autonomous.AutonomousRunApi}), so a callback always writes the run's own tenant
- * and never depends on whether the caller's scope happens to pin it. That derivation exists only on
- * the legacy non-prefixed route the orchestrator calls; the same handlers on the tenant-prefixed
- * route stay caller-authorized like every other prefixed endpoint.
+ * and never depends on whether the caller's scope happens to pin it. A NON-service caller on the
+ * same handlers remains caller-isolated (standard caller-authorized resolution), so knowing a run
+ * id gives an ordinary EE user no cross-tenant reach. The derivation also exists only on the legacy
+ * non-prefixed route the orchestrator calls; the same handlers on the tenant-prefixed route stay
+ * caller-authorized like every other prefixed endpoint.
  */
 @org.springframework.stereotype.Component
 @RequiredArgsConstructor

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
@@ -18,14 +18,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * Pins WHICH {@link AutonomousRunApi} handlers derive their tenant scope from the parent run
  * ({@link RunTenantScope}) and which stay caller-scoped. The annotation trades the caller's tenant
- * boundary for the run's own on the legacy callback route, so its placement is a security decision,
- * not plumbing: adding it to an operator endpoint would let any authenticated EE caller act on
- * another tenant's run through that endpoint, and dropping it from a callback would break live
- * orchestration again (#7450). {@code TenantScopedEntrypointsTxCtxArchTest} already forces every
- * handler reaching the tenant-active {@code autonomous_*} tables to carry a {@code TxCtx}; this
- * test forces the NEXT decision - every {@code TxCtx} handler on this controller must be explicitly
- * classified as an orchestrator callback (run-scoped) or an operator endpoint (caller-scoped), so a
- * twelfth callback added later fails here instead of silently defaulting to a scope nobody chose.
+ * boundary for the run's own on the legacy callback route (and only for the verified XTM One
+ * cross-platform service identity), so its placement is a security decision, not plumbing: adding
+ * it to an operator endpoint would hand the service identity cross-tenant reach through that
+ * endpoint, and dropping it from a callback would break live orchestration again (#7450). {@code
+ * TenantScopedEntrypointsTxCtxArchTest} already forces every handler reaching the tenant-active
+ * {@code autonomous_*} tables to carry a {@code TxCtx}; this test forces the NEXT decision - every
+ * {@code TxCtx} handler on this controller must be explicitly classified as an orchestrator
+ * callback (run-scoped) or an operator endpoint (caller-scoped), so a twelfth callback added later
+ * fails here instead of silently defaulting to a scope nobody chose.
  *
  * <p>Each run-scoped handler must also name its run through the {@code {runId}} path variable: the
  * resolver derives the scope from exactly that variable and fails closed (404) when it is absent,
@@ -99,9 +100,9 @@ class AutonomousRunApiRunTenantScopeTest {
 
     assertThat(runScoped)
         .as(
-            "handlers deriving their scope from the parent run - adding one widens what any"
-                + " authenticated EE caller can do to another tenant's run, removing one breaks"
-                + " orchestration; classify the change deliberately here")
+            "handlers deriving their scope from the parent run - adding one widens what the"
+                + " verified XTM One service identity can do to another tenant's run, removing one"
+                + " breaks orchestration; classify the change deliberately here")
         .containsExactlyInAnyOrderElementsOf(RUN_SCOPED_CALLBACKS);
     assertThat(callerScoped)
         .as(

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
@@ -1,0 +1,177 @@
+package io.openaev.api.autonomous;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.config.RunTenantScope;
+import io.openaev.context.TxCtx;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+/**
+ * Pins WHICH {@link AutonomousRunApi} handlers derive their tenant scope from the parent run
+ * ({@link RunTenantScope}) and which stay caller-scoped. The annotation trades the caller's tenant
+ * boundary for the run's own on the legacy callback route, so its placement is a security decision,
+ * not plumbing: adding it to an operator endpoint would let any authenticated EE caller act on
+ * another tenant's run through that endpoint, and dropping it from a callback would break live
+ * orchestration again (#7450). {@code TenantScopedEntrypointsTxCtxArchTest} already forces every
+ * handler reaching the tenant-active {@code autonomous_*} tables to carry a {@code TxCtx}; this
+ * test forces the NEXT decision - every {@code TxCtx} handler on this controller must be explicitly
+ * classified as an orchestrator callback (run-scoped) or an operator endpoint (caller-scoped), so a
+ * twelfth callback added later fails here instead of silently defaulting to a scope nobody chose.
+ *
+ * <p>Each run-scoped handler must also name its run through the {@code {runId}} path variable: the
+ * resolver derives the scope from exactly that variable and fails closed (404) when it is absent,
+ * so a renamed variable would brick the callback silently in production but loudly here.
+ */
+@DisplayName("@RunTenantScope stays pinned to the eleven orchestrator callbacks")
+class AutonomousRunApiRunTenantScopeTest {
+
+  /** The orchestrator callbacks: scoped from the parent run on the legacy non-prefixed route. */
+  private static final Set<String> RUN_SCOPED_CALLBACKS =
+      Set.of(
+          "getScope",
+          "setScope",
+          "recordEvent",
+          "updateStatus",
+          "consumeDirectives",
+          "appendAttackPathStep",
+          "updateAttackPathStep",
+          "attackPathState",
+          "evaluateAttackPath",
+          "promoteFindingToAsset",
+          "ensureTargetTeam");
+
+  /** The operator endpoints: tenant-isolated against the caller's own scope, never the run's. */
+  private static final Set<String> CALLER_SCOPED_HANDLERS =
+      Set.of(
+          "create",
+          "launchFromScenario",
+          "planScenario",
+          "list",
+          "get",
+          "getBySimulation",
+          "getByScenario",
+          "start",
+          "pause",
+          "resume",
+          "cancel",
+          "restart",
+          "promote",
+          "convertToManual",
+          "timeline",
+          "directives",
+          "addDirective",
+          "updateConfiguration");
+
+  @Test
+  @DisplayName("every TxCtx handler is explicitly classified, and the classification is exact")
+  void everyTxCtxHandlerIsExplicitlyClassified() {
+    Set<String> runScoped = new TreeSet<>();
+    Set<String> callerScoped = new TreeSet<>();
+    for (Method handler : handlers()) {
+      if (!hasTxCtxParameter(handler)) {
+        continue;
+      }
+      if (hasRunTenantScopedParameter(handler)) {
+        runScoped.add(handler.getName());
+      } else {
+        callerScoped.add(handler.getName());
+      }
+    }
+
+    assertThat(runScoped)
+        .as(
+            "handlers deriving their scope from the parent run - adding one widens what any"
+                + " authenticated EE caller can do to another tenant's run, removing one breaks"
+                + " orchestration; classify the change deliberately here")
+        .containsExactlyInAnyOrderElementsOf(RUN_SCOPED_CALLBACKS);
+    assertThat(callerScoped)
+        .as(
+            "caller-scoped TxCtx handlers - a new handler must be pinned either here or in the"
+                + " run-scoped list, so its tenant boundary is a decision rather than a default")
+        .containsExactlyInAnyOrderElementsOf(CALLER_SCOPED_HANDLERS);
+  }
+
+  @Test
+  @DisplayName("every run-scoped callback names its run through the {runId} path variable")
+  void everyRunScopedCallbackCarriesTheRunIdPathVariable() {
+    for (Method handler : handlers()) {
+      if (!hasRunTenantScopedParameter(handler)) {
+        continue;
+      }
+      assertThat(mappingPath(handler))
+          .as(
+              "handler '%s' derives its scope from the {runId} path variable; renaming it would"
+                  + " fail every callback closed (404) in production",
+              handler.getName())
+          .contains("{runId}");
+    }
+  }
+
+  @Test
+  @DisplayName("the annotation only ever sits on a TxCtx parameter (anywhere else it is dead)")
+  void annotationOnlyAnnotatesTxCtxParameters() {
+    for (Method handler : handlers()) {
+      for (Parameter parameter : handler.getParameters()) {
+        if (parameter.isAnnotationPresent(RunTenantScope.class)) {
+          assertThat(parameter.getType())
+              .as(
+                  "@RunTenantScope on '%s' must annotate the TxCtx parameter; the resolver only"
+                      + " honours it there",
+                  handler.getName())
+              .isEqualTo(TxCtx.class);
+        }
+      }
+    }
+  }
+
+  private static List<Method> handlers() {
+    return Arrays.stream(AutonomousRunApi.class.getDeclaredMethods())
+        .filter(AutonomousRunApiRunTenantScopeTest::isHandler)
+        .toList();
+  }
+
+  private static boolean isHandler(Method method) {
+    return method.isAnnotationPresent(GetMapping.class)
+        || method.isAnnotationPresent(PostMapping.class)
+        || method.isAnnotationPresent(PutMapping.class);
+  }
+
+  private static boolean hasTxCtxParameter(Method method) {
+    return Arrays.stream(method.getParameterTypes()).anyMatch(TxCtx.class::equals);
+  }
+
+  private static boolean hasRunTenantScopedParameter(Method method) {
+    return Arrays.stream(method.getParameters())
+        .anyMatch(parameter -> parameter.isAnnotationPresent(RunTenantScope.class));
+  }
+
+  private static String mappingPath(Method method) {
+    GetMapping get = method.getAnnotation(GetMapping.class);
+    if (get != null) {
+      return first(get.value());
+    }
+    PostMapping post = method.getAnnotation(PostMapping.class);
+    if (post != null) {
+      return first(post.value());
+    }
+    PutMapping put = method.getAnnotation(PutMapping.class);
+    if (put != null) {
+      return first(put.value());
+    }
+    return "";
+  }
+
+  private static String first(String[] values) {
+    return values.length == 0 ? "" : values[0];
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
@@ -12,9 +12,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * Pins WHICH {@link AutonomousRunApi} handlers derive their tenant scope from the parent run
@@ -71,6 +70,16 @@ class AutonomousRunApiRunTenantScopeTest {
           "directives",
           "addDirective",
           "updateConfiguration");
+
+  @Test
+  @DisplayName("handler names stay unique, so the name-keyed classification cannot collapse")
+  void handlerNamesStayUnique() {
+    // The two pinned sets are keyed by method name. An overload sharing a pinned name could
+    // otherwise ride its sibling's classification, so overloads are rejected outright: a new
+    // variant of a handler must get its own name and its own explicit classification.
+    List<String> names = handlers().stream().map(Method::getName).toList();
+    assertThat(names).doesNotHaveDuplicates();
+  }
 
   @Test
   @DisplayName("every TxCtx handler is explicitly classified, and the classification is exact")
@@ -140,10 +149,14 @@ class AutonomousRunApiRunTenantScopeTest {
         .toList();
   }
 
+  /**
+   * Every request-mapped method, whatever the verb: {@code @RequestMapping} is the meta-annotation
+   * behind {@code @GetMapping}, {@code @PostMapping}, {@code @PutMapping}, {@code @DeleteMapping}
+   * and {@code @PatchMapping}, so a callback added with a verb this controller does not use yet
+   * still lands in the classification instead of bypassing the pin.
+   */
   private static boolean isHandler(Method method) {
-    return method.isAnnotationPresent(GetMapping.class)
-        || method.isAnnotationPresent(PostMapping.class)
-        || method.isAnnotationPresent(PutMapping.class);
+    return AnnotatedElementUtils.hasAnnotation(method, RequestMapping.class);
   }
 
   private static boolean hasTxCtxParameter(Method method) {
@@ -155,23 +168,14 @@ class AutonomousRunApiRunTenantScopeTest {
         .anyMatch(parameter -> parameter.isAnnotationPresent(RunTenantScope.class));
   }
 
+  /** The merged mapping path, alias-resolved so it works for every verb annotation. */
   private static String mappingPath(Method method) {
-    GetMapping get = method.getAnnotation(GetMapping.class);
-    if (get != null) {
-      return first(get.value());
+    RequestMapping mapping =
+        AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class);
+    if (mapping == null) {
+      return "";
     }
-    PostMapping post = method.getAnnotation(PostMapping.class);
-    if (post != null) {
-      return first(post.value());
-    }
-    PutMapping put = method.getAnnotation(PutMapping.class);
-    if (put != null) {
-      return first(put.value());
-    }
-    return "";
-  }
-
-  private static String first(String[] values) {
-    return values.length == 0 ? "" : values[0];
+    String[] paths = mapping.path();
+    return paths.length == 0 ? "" : paths[0];
   }
 }

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
@@ -15,6 +15,7 @@ import io.openaev.database.repository.autonomous.AutonomousDirectiveRepository;
 import io.openaev.database.repository.autonomous.AutonomousEventRepository;
 import io.openaev.database.repository.autonomous.AutonomousRunRepository;
 import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.security.token.XtmJwksExtractor;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.sql.PreparedStatement;
@@ -29,6 +30,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -42,15 +44,20 @@ import org.springframework.transaction.annotation.Transactional;
  * AttackPathHttpIsolationTest}.
  *
  * <p>The orchestrator CALLBACK endpoints are the deliberate exception, and the second half of this
- * suite pins their SERVICE-IDENTITY contract: on the legacy non-prefixed route they are scoped from
- * the parent run (the {@link io.openaev.config.RunTenantScope} argument), so a caller whose scope
- * does NOT pin the run's tenant still records the run's events, drives its status and consumes its
- * directives - every write stamped with the run's own tenant. XTM One reaches them with a per-user
- * JWT that carries no tenant claim, so this is what keeps a long run authoring and settling itself
- * once the caller's scope no longer pins the run's tenant. The derivation is route-scoped: the same
- * handlers on the TENANT-PREFIXED route stay caller-authorized (the URL names the tenant, rights
- * are the boundary), which this suite pins too. Operator isolation is proven unchanged alongside
- * it.
+ * suite pins their SERVICE-IDENTITY contract: on the legacy non-prefixed route, and ONLY for the
+ * VERIFIED XTM One cross-platform service identity (the server-side marker {@link
+ * XtmJwksExtractor#CROSS_PLATFORM_ATTRIBUTE} stamped after full JWT validation - the harness
+ * authenticates through {@code @WithMockUser}, so the tests stamp the validated marker directly),
+ * they are scoped from the parent run (the {@link io.openaev.config.RunTenantScope} argument), so a
+ * service caller whose scope does NOT pin the run's tenant still records the run's events, drives
+ * its status and consumes its directives - every write stamped with the run's own tenant. XTM One
+ * reaches them with a per-user JWT that carries no tenant claim, so this is what keeps a long run
+ * authoring and settling itself once the caller's scope no longer pins the run's tenant. A caller
+ * WITHOUT the verified marker keeps caller-authorized resolution on the same handlers - the
+ * cross-tenant IDOR case proves a normal EE user cannot reach a foreign tenant's run through a
+ * callback even knowing its id. The derivation is also route-scoped: the same handlers on the
+ * TENANT-PREFIXED route stay caller-authorized (the URL names the tenant, rights are the boundary),
+ * which this suite pins too. Operator isolation is proven unchanged alongside it.
  *
  * <p>Both scope routes are covered, because the orchestrator's callbacks ride the legacy
  * non-prefixed mapping: the tenant-prefixed path (operator UI) and the plain path where the scope
@@ -105,6 +112,17 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
     runId = seedRun(tenantA);
     eventId = seedEvent(tenantA, runId);
     directiveId = seedDirective(tenantA, runId);
+  }
+
+  // The orchestrator's own request shape: in production the callback bearer is an XTM One
+  // cross-platform JWT that XtmJwksExtractor fully validates (trusted issuer + JWKS signature +
+  // expected audience) before stamping this server-side marker, and TxCtxArgumentResolver grants
+  // run-authoritative scope on exactly that attribute. The MockMvc harness authenticates through
+  // @WithMockUser rather than the token filter, so the tests stamp the validated marker directly -
+  // a request attribute is server-side only and can never be supplied by a real client.
+  private static MockHttpServletRequestBuilder asVerifiedServiceIdentity(
+      MockHttpServletRequestBuilder request) {
+    return request.requestAttr(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE, Boolean.TRUE);
   }
 
   @Test
@@ -220,10 +238,11 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
   void recordEventViaCallbackRouteStampsParentRunTenant() throws Exception {
     // The exact callback write AutonomousEventService#doAppend serves: the tenant must come from
     // the parent run, never from a thread-local default (the orchestrator rides the non-prefixed
-    // route, where the legacy TenantContext default would misattribute the row).
+    // route as the verified service identity, where the legacy TenantContext default would
+    // misattribute the row).
     String response =
         mvc.perform(
-                post(PLAIN + "/{runId}/events", runId)
+                asVerifiedServiceIdentity(post(PLAIN + "/{runId}/events", runId))
                     .with(csrf())
                     .header("X-Tenant-Ids", tenantA)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -270,14 +289,15 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
   @DisplayName("POST event under a multi-tenant scope lands on the parent run's tenant")
   void recordEventUnderMultiTenantScopeStampsParentRunTenant() throws Exception {
     // A broad, multi-value X-Tenant-Ids header is a legitimate request state on the plain route (a
-    // service identity or an administrator can hold several memberships). The callback derives its
-    // scope from the run itself (@RunTenantScope), so the multi-value selector is simply ignored:
-    // the append must succeed and land on the run's own tenant - never on another selected tenant,
-    // never as a refusal. Only a create (an operator write) without a single-tenant selector is
-    // ambiguous under a broad scope (createOutsideValidWriteScopeIsRefusedAndWritesNothing).
+    // service identity or an administrator can hold several memberships). The verified service
+    // callback derives its scope from the run itself (@RunTenantScope), so the multi-value selector
+    // is simply ignored: the append must succeed and land on the run's own tenant - never on
+    // another selected tenant, never as a refusal. Only a create (an operator write) without a
+    // single-tenant selector is ambiguous under a broad scope
+    // (createOutsideValidWriteScopeIsRefusedAndWritesNothing).
     String response =
         mvc.perform(
-                post(PLAIN + "/{runId}/events", runId)
+                asVerifiedServiceIdentity(post(PLAIN + "/{runId}/events", runId))
                     .with(csrf())
                     .header("X-Tenant-Ids", tenantA + "," + tenantB)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -328,14 +348,15 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
   void recordEventFromForeignCallerScopeStampsParentRunTenant() throws Exception {
     // The regression fix: an orchestrator callback is a SERVICE-IDENTITY operation whose tenant is
     // the parent run's, not the caller's. XTM One rides the non-prefixed route with a per-user JWT
-    // that pins no tenant, so a callback must be able to write the run's own timeline even when the
-    // caller's scope does not include the run's tenant. Here the caller deliberately selects ONLY
-    // tenantB (which does NOT own the run), yet the event is recorded and stamped with the parent
-    // run's tenant (tenantA) - read at the raw column. Before the @RunTenantScope hardening this
-    // exact append 404'd on the tenant-filtered run lookup.
+    // that pins no tenant (validated as the cross-platform service identity), so a callback must be
+    // able to write the run's own timeline even when the caller's scope does not include the run's
+    // tenant. Here the verified service caller deliberately selects ONLY tenantB (which does NOT
+    // own the run), yet the event is recorded and stamped with the parent run's tenant (tenantA) -
+    // read at the raw column. Before the @RunTenantScope hardening this exact append 404'd on the
+    // tenant-filtered run lookup.
     String response =
         mvc.perform(
-                post(PLAIN + "/{runId}/events", runId)
+                asVerifiedServiceIdentity(post(PLAIN + "/{runId}/events", runId))
                     .with(csrf())
                     .header("X-Tenant-Ids", tenantB)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -359,12 +380,13 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
           + " (service-identity callback)")
   void updateStatusFromForeignCallerScopeDrivesParentRun() throws Exception {
     // The orchestrator settles / parks the run through this callback with the same per-user,
-    // no-tenant JWT. A live run under tenantA is driven to WAITING_INPUT by a caller selecting only
-    // tenantB; the transition lands on the run itself (raw status column), proving the write is
-    // scoped from the run rather than refused for being outside the caller's scope.
+    // no-tenant JWT (validated as the cross-platform service identity). A live run under tenantA is
+    // driven to WAITING_INPUT by a verified service caller selecting only tenantB; the transition
+    // lands on the run itself (raw status column), proving the write is scoped from the run rather
+    // than refused for being outside the caller's scope.
     String activeRunId = seedActiveRun(tenantA);
     mvc.perform(
-            post(PLAIN + "/{runId}/status", activeRunId)
+            asVerifiedServiceIdentity(post(PLAIN + "/{runId}/status", activeRunId))
                 .with(csrf())
                 .header("X-Tenant-Ids", tenantB)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -383,10 +405,11 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
           + " the run's directives (service-identity callback)")
   void consumeDirectivesFromForeignCallerScopeReadsParentRun() throws Exception {
     // The orchestrator consumes operator steering at the start of each cycle with the same
-    // no-tenant JWT. A caller selecting only tenantB still receives the run's seeded directive and
-    // marks it consumed (its raw status flips under the run's own tenant).
+    // no-tenant JWT (validated as the cross-platform service identity). A verified service caller
+    // selecting only tenantB still receives the run's seeded directive and marks it consumed (its
+    // raw status flips under the run's own tenant).
     mvc.perform(
-            post(PLAIN + "/{runId}/directives/consume", runId)
+            asVerifiedServiceIdentity(post(PLAIN + "/{runId}/directives/consume", runId))
                 .with(csrf())
                 .header("X-Tenant-Ids", tenantB))
         .andExpect(status().isOk())
@@ -399,6 +422,37 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
                 "autonomous_directive_id",
                 directiveId))
         .isEqualTo("CONSUMED");
+  }
+
+  @Test
+  @DisplayName(
+      "POST event WITHOUT the verified service identity, on a run outside the caller's tenants, is"
+          + " refused (404) and writes nothing - the cross-tenant IDOR is closed")
+  void recordEventWithoutServiceIdentityOutsideCallerTenantsIsClosed() throws Exception {
+    // The IDOR the service-identity gate closes: a NORMAL authenticated EE user (no validated
+    // cross-platform marker on the request) who learned a run id must not reach a run in a tenant
+    // they are not a member of through the callback endpoints. Without the marker the
+    // @RunTenantScope handler resolves the caller's own memberships exactly like any plain
+    // endpoint; the foreign run row stays invisible under that scope, the append dies on the run
+    // lookup (404), and nothing is written. Before the gate this exact request appended to the
+    // foreign tenant's timeline.
+    String foreignTenant = tenantHelper.createTenant("auto-iso-foreign").getId();
+    // Tenant creation auto-attaches the creating user (TenantUserService dependency manager);
+    // detach it so the tenant is genuinely foreign to the caller.
+    String userId = testUserHolder.get().getId();
+    tenantRepository.removeUserFromTenant(userId, foreignTenant);
+    tenantMembershipCacheManager.evict(userId, foreignTenant);
+    String foreignRunId = seedRun(foreignTenant);
+
+    mvc.perform(
+            post(PLAIN + "/{runId}/events", foreignRunId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\": \"DECISION\", \"title\": \"cross-tenant idor probe\"}"))
+        .andExpect(status().isNotFound());
+
+    assertThat(rawCount("autonomous_events", "autonomous_event_run_id", foreignRunId))
+        .isEqualTo(0L);
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
@@ -42,12 +42,15 @@ import org.springframework.transaction.annotation.Transactional;
  * AttackPathHttpIsolationTest}.
  *
  * <p>The orchestrator CALLBACK endpoints are the deliberate exception, and the second half of this
- * suite pins their SERVICE-IDENTITY contract: they are scoped from the parent run (the {@link
- * io.openaev.config.RunTenantScope} argument), so a caller whose scope does NOT pin the run's
- * tenant still records the run's events, drives its status and consumes its directives - every
- * write stamped with the run's own tenant. XTM One reaches them with a per-user JWT that carries no
- * tenant claim, so this is what keeps a long run authoring and settling itself once the caller's
- * scope no longer pins the run's tenant. Operator isolation is proven unchanged alongside it.
+ * suite pins their SERVICE-IDENTITY contract: on the legacy non-prefixed route they are scoped from
+ * the parent run (the {@link io.openaev.config.RunTenantScope} argument), so a caller whose scope
+ * does NOT pin the run's tenant still records the run's events, drives its status and consumes its
+ * directives - every write stamped with the run's own tenant. XTM One reaches them with a per-user
+ * JWT that carries no tenant claim, so this is what keeps a long run authoring and settling itself
+ * once the caller's scope no longer pins the run's tenant. The derivation is route-scoped: the same
+ * handlers on the TENANT-PREFIXED route stay caller-authorized (the URL names the tenant, rights
+ * are the boundary), which this suite pins too. Operator isolation is proven unchanged alongside
+ * it.
  *
  * <p>Both scope routes are covered, because the orchestrator's callbacks ride the legacy
  * non-prefixed mapping: the tenant-prefixed path (operator UI) and the plain path where the scope
@@ -396,6 +399,40 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
                 "autonomous_directive_id",
                 directiveId))
         .isEqualTo("CONSUMED");
+  }
+
+  @Test
+  @DisplayName(
+      "POST event via the tenant-prefixed route stays caller-scoped: a foreign tenant's path 404s"
+          + " and writes nothing")
+  void recordEventViaTenantPrefixedRouteOutsideRunTenantIsRefused() throws Exception {
+    // The service-identity derivation exists only on the legacy non-prefixed route. On the
+    // tenant-prefixed route the same handler keeps the operator contract: the URL names the
+    // tenant, so a caller addressing tenantB cannot reach (or write) tenantA's run through the
+    // @RunTenantScope-annotated endpoint - the run row is invisible under the addressed scope and
+    // the append dies on the run lookup, leaving the timeline untouched.
+    mvc.perform(
+            post(SCOPED + "/{runId}/events", tenantB, runId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\": \"DECISION\", \"title\": \"prefixed cross-tenant append\"}"))
+        .andExpect(status().isNotFound());
+
+    // Only the seeded event remains: nothing was written through the foreign tenant's path.
+    assertThat(rawCount("autonomous_events", "autonomous_event_run_id", runId)).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName(
+      "GET attack-path state via the owner tenant's path works caller-scoped (operator parity)")
+  void attackPathStateViaTenantPrefixedRouteUnderOwnerTenantIsVisible() throws Exception {
+    // The UI reads the attack-path state through the tenant-prefixed route (the tenant prefix is
+    // added centrally by the frontend's buildUri). With the derivation route-scoped, this read
+    // resolves the caller's addressed tenant like every other operator endpoint and must keep
+    // working; the seeded run has no simulation and no scenario, so the state is simply empty.
+    mvc.perform(get(SCOPED + "/{runId}/attack-path/state", tenantA, runId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray());
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
@@ -57,7 +57,10 @@ import org.springframework.transaction.annotation.Transactional;
  * cross-tenant IDOR case proves a normal EE user cannot reach a foreign tenant's run through a
  * callback even knowing its id. The derivation is also route-scoped: the same handlers on the
  * TENANT-PREFIXED route stay caller-authorized (the URL names the tenant, rights are the boundary),
- * which this suite pins too. Operator isolation is proven unchanged alongside it.
+ * which this suite pins too. Operator isolation is proven unchanged alongside it. The derived scope
+ * also respects tenant liveness: a run whose tenant is soft-deleted is refused even for the
+ * verified service identity (a grace-period tenant is out of every caller scope, and the
+ * run-derived scope must not re-admit it), and reactivating the tenant restores the callbacks.
  *
  * <p>Both scope routes are covered, because the orchestrator's callbacks ride the legacy
  * non-prefixed mapping: the tenant-prefixed path (operator UI) and the plain path where the scope
@@ -457,6 +460,39 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
 
   @Test
   @DisplayName(
+      "POST event on a run whose tenant is soft-deleted is refused (404) even for the verified"
+          + " service identity - and works again once the tenant is reactivated")
+  void recordEventOnSoftDeletedTenantRunIsFailClosedForServiceIdentity() throws Exception {
+    // A soft-deleted tenant is excluded from every caller scope for its whole retention grace
+    // period (TenantRepository.findTenantsByUserId and TenantMembershipCacheManager both filter on
+    // tenant_deleted_at IS NULL), so no operator can reach the run. The run-derived service scope
+    // must not quietly re-admit it: the locator's liveness predicate makes the derivation resolve
+    // empty exactly like an unknown run, the verified service caller gets a 404, and the timeline
+    // stays untouched.
+    softDeleteTenant(tenantA);
+    mvc.perform(
+            asVerifiedServiceIdentity(post(PLAIN + "/{runId}/events", runId))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\": \"DECISION\", \"title\": \"grace-period append\"}"))
+        .andExpect(status().isNotFound());
+    assertThat(rawCount("autonomous_events", "autonomous_event_run_id", runId)).isEqualTo(1L);
+
+    // The refusal is the tenant's liveness, not a permanent latch on the run: reactivating the
+    // tenant within the grace period (TenantService#reactivateTenant's contract) restores the
+    // callback path, so an admin undoing a deletion gets the run's autonomy back with the tenant.
+    reactivateTenant(tenantA);
+    mvc.perform(
+            asVerifiedServiceIdentity(post(PLAIN + "/{runId}/events", runId))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\": \"DECISION\", \"title\": \"post-reactivation append\"}"))
+        .andExpect(status().isOk());
+    assertThat(rawCount("autonomous_events", "autonomous_event_run_id", runId)).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName(
       "POST event via the tenant-prefixed route stays caller-scoped: a foreign tenant's path 404s"
           + " and writes nothing")
   void recordEventViaTenantPrefixedRouteOutsideRunTenantIsRefused() throws Exception {
@@ -605,6 +641,23 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
         .setParameter("tenant", tenantId)
         .executeUpdate();
     return id;
+  }
+
+  // Soft delete / reactivation at the column TenantService drives, on the test's own transaction:
+  // the tenants table is not tenant-active, so the native update is not rewritten, and the
+  // locator's DataSourceUtils connection joins this transaction and sees the flag flip.
+  private void softDeleteTenant(String tenantId) {
+    entityManager
+        .createNativeQuery("UPDATE tenants SET tenant_deleted_at = now() WHERE tenant_id = :id")
+        .setParameter("id", tenantId)
+        .executeUpdate();
+  }
+
+  private void reactivateTenant(String tenantId) {
+    entityManager
+        .createNativeQuery("UPDATE tenants SET tenant_deleted_at = NULL WHERE tenant_id = :id")
+        .setParameter("id", tenantId)
+        .executeUpdate();
   }
 
   private String seedDirective(String tenantId, String runId) {

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunHttpIsolationTest.java
@@ -33,12 +33,21 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * End-to-end proof that, with the {@code autonomous_*} tables activated, the tenant scope set from
- * the request isolates the autonomous-run endpoints: the owner tenant sees its run, timeline and
- * directives, a different tenant gets a 404 (the run row itself is invisible, so nothing hangs off
- * it), and a scope-less repository read is fail-closed. This exercises the whole chain (the {@code
- * TxCtx} binding, the transaction aspect, the {@code can_access_tenant} rewrite, and the JPA
- * reads), so it proves the isolation claim rather than the mere presence of a guard - the HTTP
- * complement to the inspector's own SQL-layer tests, mirroring {@code AttackPathHttpIsolationTest}.
+ * the request isolates the OPERATOR-facing autonomous-run endpoints: the owner tenant sees its run,
+ * timeline and directives, a different tenant gets a 404 (the run row itself is invisible, so
+ * nothing hangs off it), and a scope-less repository read is fail-closed. This exercises the whole
+ * chain (the {@code TxCtx} binding, the transaction aspect, the {@code can_access_tenant} rewrite,
+ * and the JPA reads), so it proves the isolation claim rather than the mere presence of a guard -
+ * the HTTP complement to the inspector's own SQL-layer tests, mirroring {@code
+ * AttackPathHttpIsolationTest}.
+ *
+ * <p>The orchestrator CALLBACK endpoints are the deliberate exception, and the second half of this
+ * suite pins their SERVICE-IDENTITY contract: they are scoped from the parent run (the {@link
+ * io.openaev.config.RunTenantScope} argument), so a caller whose scope does NOT pin the run's
+ * tenant still records the run's events, drives its status and consumes its directives - every
+ * write stamped with the run's own tenant. XTM One reaches them with a per-user JWT that carries no
+ * tenant claim, so this is what keeps a long run authoring and settling itself once the caller's
+ * scope no longer pins the run's tenant. Operator isolation is proven unchanged alongside it.
  *
  * <p>Both scope routes are covered, because the orchestrator's callbacks ride the legacy
  * non-prefixed mapping: the tenant-prefixed path (operator UI) and the plain path where the scope
@@ -257,11 +266,11 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
   @Test
   @DisplayName("POST event under a multi-tenant scope lands on the parent run's tenant")
   void recordEventUnderMultiTenantScopeStampsParentRunTenant() throws Exception {
-    // A broad scope is a legitimate request state on the plain route (a service identity or an
-    // administrator can hold several memberships, X-Tenant-Ids is multi-value by design).
-    // Parent-derived writes need no single-tenant scope: the run row, resolved under that scope,
-    // pins the attribution. The append must succeed and land on the run's own tenant - never on
-    // another selected tenant, never as a refusal. Only a create without a tenant selector is
+    // A broad, multi-value X-Tenant-Ids header is a legitimate request state on the plain route (a
+    // service identity or an administrator can hold several memberships). The callback derives its
+    // scope from the run itself (@RunTenantScope), so the multi-value selector is simply ignored:
+    // the append must succeed and land on the run's own tenant - never on another selected tenant,
+    // never as a refusal. Only a create (an operator write) without a single-tenant selector is
     // ambiguous under a broad scope (createOutsideValidWriteScopeIsRefusedAndWritesNothing).
     String response =
         mvc.perform(
@@ -310,20 +319,83 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("POST event under another tenant's scope is refused and writes nothing")
-  void recordEventOutsideParentTenantIsRefusedAndWritesNothing() throws Exception {
-    // The parent run is invisible outside its tenant, so the write dies on the run lookup: a
-    // foreign scope can never append into another tenant's timeline (fail-closed write).
+  @DisplayName(
+      "POST event from a caller scope that excludes the run's tenant still records it, stamped from"
+          + " the parent run (service-identity callback)")
+  void recordEventFromForeignCallerScopeStampsParentRunTenant() throws Exception {
+    // The regression fix: an orchestrator callback is a SERVICE-IDENTITY operation whose tenant is
+    // the parent run's, not the caller's. XTM One rides the non-prefixed route with a per-user JWT
+    // that pins no tenant, so a callback must be able to write the run's own timeline even when the
+    // caller's scope does not include the run's tenant. Here the caller deliberately selects ONLY
+    // tenantB (which does NOT own the run), yet the event is recorded and stamped with the parent
+    // run's tenant (tenantA) - read at the raw column. Before the @RunTenantScope hardening this
+    // exact append 404'd on the tenant-filtered run lookup.
+    String response =
+        mvc.perform(
+                post(PLAIN + "/{runId}/events", runId)
+                    .with(csrf())
+                    .header("X-Tenant-Ids", tenantB)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"type\": \"DECISION\", \"title\": \"service-identity append\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.autonomous_event_id").exists())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String createdEventId = JsonPath.read(response, "$.autonomous_event_id");
+
+    assertThat(rawTenantId("autonomous_events", "autonomous_event_id", createdEventId))
+        .isEqualTo(tenantA);
+    // The seeded event plus the one recorded through the foreign-scope callback.
+    assertThat(rawCount("autonomous_events", "autonomous_event_run_id", runId)).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName(
+      "POST status from a caller scope that excludes the run's tenant still drives the run"
+          + " (service-identity callback)")
+  void updateStatusFromForeignCallerScopeDrivesParentRun() throws Exception {
+    // The orchestrator settles / parks the run through this callback with the same per-user,
+    // no-tenant JWT. A live run under tenantA is driven to WAITING_INPUT by a caller selecting only
+    // tenantB; the transition lands on the run itself (raw status column), proving the write is
+    // scoped from the run rather than refused for being outside the caller's scope.
+    String activeRunId = seedActiveRun(tenantA);
     mvc.perform(
-            post(PLAIN + "/{runId}/events", runId)
+            post(PLAIN + "/{runId}/status", activeRunId)
                 .with(csrf())
                 .header("X-Tenant-Ids", tenantB)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"type\": \"DECISION\", \"title\": \"cross-tenant append\"}"))
-        .andExpect(status().isNotFound());
+                .content("{\"status\": \"WAITING_INPUT\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.autonomous_run_status").value("WAITING_INPUT"));
 
-    // Only the seeded event remains: nothing was written for the refused append.
-    assertThat(rawCount("autonomous_events", "autonomous_event_run_id", runId)).isEqualTo(1L);
+    assertThat(
+            rawColumn("autonomous_runs", "autonomous_run_status", "autonomous_run_id", activeRunId))
+        .isEqualTo("WAITING_INPUT");
+  }
+
+  @Test
+  @DisplayName(
+      "POST directives/consume from a caller scope that excludes the run's tenant reads and clears"
+          + " the run's directives (service-identity callback)")
+  void consumeDirectivesFromForeignCallerScopeReadsParentRun() throws Exception {
+    // The orchestrator consumes operator steering at the start of each cycle with the same
+    // no-tenant JWT. A caller selecting only tenantB still receives the run's seeded directive and
+    // marks it consumed (its raw status flips under the run's own tenant).
+    mvc.perform(
+            post(PLAIN + "/{runId}/directives/consume", runId)
+                .with(csrf())
+                .header("X-Tenant-Ids", tenantB))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].autonomous_directive_id").value(directiveId));
+
+    assertThat(
+            rawColumn(
+                "autonomous_directives",
+                "autonomous_directive_status",
+                "autonomous_directive_id",
+                directiveId))
+        .isEqualTo("CONSUMED");
   }
 
   @Test
@@ -463,6 +535,12 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
   // read over plain JDBC on the test's own connection (sees uncommitted rows, no inspector
   // rewrite). Null when the row does not exist, so a missing row fails the equality loudly.
   private String rawTenantId(String table, String idColumn, String id) {
+    return rawColumn(table, "tenant_id", idColumn, id);
+  }
+
+  // Ground truth for any string column of a row the API just wrote, over plain JDBC on the test's
+  // own connection (sees uncommitted rows, no inspector rewrite). Null when the row does not exist.
+  private String rawColumn(String table, String valueColumn, String idColumn, String id) {
     entityManager.flush();
     return entityManager
         .unwrap(Session.class)
@@ -470,7 +548,7 @@ class AutonomousRunHttpIsolationTest extends IntegrationTest {
             connection -> {
               try (PreparedStatement statement =
                   connection.prepareStatement(
-                      "SELECT tenant_id FROM " + table + " WHERE " + idColumn + " = ?")) {
+                      "SELECT " + valueColumn + " FROM " + table + " WHERE " + idColumn + " = ?")) {
                 statement.setString(1, id);
                 try (ResultSet rows = statement.executeQuery()) {
                   return rows.next() ? rows.getString(1) : null;

--- a/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
@@ -98,20 +98,38 @@ class AutonomousRunTenantLocatorTest {
   }
 
   /**
-   * Every production class that opts out of the inspector AND names an autonomous table. Scanning
-   * the tree rather than the one known file is the point: a new sibling bypass must show up here
-   * instead of slipping past a test that only ever looked at the locator.
+   * Every production class, in EVERY production module, that opts out of the inspector AND names an
+   * autonomous table. Scanning the trees rather than the one known file is the point: a new sibling
+   * bypass must show up here instead of slipping past a test that only ever looked at the locator -
+   * and {@code openaev-model} already hosts {@code @AllowRawJdbc} classes of its own, so a
+   * model-layer bypass must fail this pin exactly like an api-layer one.
    */
   private static List<Path> rawJdbcClassesTouchingAutonomousTables() throws Exception {
-    try (Stream<Path> tree = Files.walk(Path.of("src/main/java"))) {
-      return tree.filter(path -> path.toString().endsWith(".java"))
-          .filter(
-              path -> {
-                String body = read(path);
-                return body.contains("@AllowRawJdbc") && body.contains("autonomous_");
-              })
-          .toList();
+    // Surefire runs with the module directory as CWD, so sibling production roots sit one level up.
+    List<Path> roots =
+        Stream.of(
+                Path.of("src/main/java"),
+                Path.of("../openaev-model/src/main/java"),
+                Path.of("../openaev-framework/src/main/java"))
+            .filter(Files::isDirectory)
+            .toList();
+    assertThat(roots)
+        .as(
+            "the api and model production source roots must both be scannable, or this pin is blind")
+        .hasSizeGreaterThanOrEqualTo(2);
+    List<Path> bypasses = new ArrayList<>();
+    for (Path root : roots) {
+      try (Stream<Path> tree = Files.walk(root)) {
+        tree.filter(path -> path.toString().endsWith(".java"))
+            .filter(
+                path -> {
+                  String body = read(path);
+                  return body.contains("@AllowRawJdbc") && body.contains("autonomous_");
+                })
+            .forEach(bypasses::add);
+      }
     }
+    return bypasses;
   }
 
   private static String read(Path path) {

--- a/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
@@ -1,0 +1,141 @@
+package io.openaev.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Pins the read-only scope-bootstrap exemption of {@link AutonomousRunTenantLocator} and its
+ * fail-closed contract.
+ *
+ * <p>The tenant-activation runbook treats raw JDBC on a tenant-active table as a hard blocker,
+ * because it bypasses the statement inspector. The locator is the deliberate, narrow exception:
+ * deriving a callback's scope FROM the run is a chicken-and-egg (the read that decides the scope
+ * cannot run under the scope it is deciding, and the inspector would fail-close it), so it may
+ * bypass the inspector ONLY while it stays a single-row, primary-key-addressed SELECT of the run's
+ * own immutable {@code tenant_id}. A reason that lives only in a comment rots, so - like the
+ * insert-only seed exemption pinned by {@code AttackPathSeedServiceTest} - it is enforced here:
+ * widening the statement, adding a second statement, or adding a sibling bypass on the {@code
+ * autonomous_*} tables fails the build and forces the conversation.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("the run-tenant locator stays a pinned, fail-closed scope-bootstrap read")
+class AutonomousRunTenantLocatorTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  @Test
+  @DisplayName("the raw-JDBC exemption stays a single pinned PK read of tenant_id")
+  void theRawJdbcExemptionStaysThePinnedScopeBootstrapRead() throws Exception {
+    // Only the locator may bypass the inspector on the autonomous_* tables; a sibling bypass added
+    // later must show up in this tree scan and be argued for explicitly.
+    List<Path> bypasses = rawJdbcClassesTouchingAutonomousTables();
+    assertThat(bypasses)
+        .as("only the run-tenant locator may bypass the inspector on the autonomous_* tables")
+        .extracting(path -> path.getFileName().toString())
+        .containsExactly("AutonomousRunTenantLocator.java");
+
+    // The exemption is read-only and minimal by definition: one statement, SELECT-only, projecting
+    // the run's own tenant_id and addressing the row by primary key. Anything else must fail.
+    assertThat(sqlLiterals(Files.readString(bypasses.get(0))))
+        .as("the locator emits exactly one SQL statement")
+        .containsExactly(AutonomousRunTenantLocator.SELECT_RUN_TENANT);
+    assertThat(AutonomousRunTenantLocator.SELECT_RUN_TENANT)
+        .isEqualTo("SELECT tenant_id FROM autonomous_runs WHERE autonomous_run_id = ?");
+  }
+
+  @Test
+  @DisplayName("a known run resolves to its own tenant")
+  void aKnownRunResolvesToItsOwnTenant() {
+    AutonomousRunTenantLocator locator = new AutonomousRunTenantLocator(jdbcTemplate);
+    when(jdbcTemplate.query(
+            eq(AutonomousRunTenantLocator.SELECT_RUN_TENANT), any(RowMapper.class), eq("run-1")))
+        .thenReturn(List.of("run-owner-tenant"));
+
+    assertThat(locator.findRunTenant("run-1")).contains("run-owner-tenant");
+  }
+
+  @Test
+  @DisplayName("an unknown run and a blank stored tenant are both fail-closed (empty)")
+  void unknownRunAndBlankTenantAreFailClosed() {
+    AutonomousRunTenantLocator locator = new AutonomousRunTenantLocator(jdbcTemplate);
+    when(jdbcTemplate.query(
+            eq(AutonomousRunTenantLocator.SELECT_RUN_TENANT), any(RowMapper.class), eq("ghost")))
+        .thenReturn(List.of());
+    when(jdbcTemplate.query(
+            eq(AutonomousRunTenantLocator.SELECT_RUN_TENANT), any(RowMapper.class), eq("blank")))
+        .thenReturn(List.of(" "));
+
+    assertThat(locator.findRunTenant("ghost")).isEmpty();
+    assertThat(locator.findRunTenant("blank")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("a null or blank run id never reaches the database")
+  void nullOrBlankRunIdNeverReachesTheDatabase() {
+    AutonomousRunTenantLocator locator = new AutonomousRunTenantLocator(jdbcTemplate);
+
+    assertThat(locator.findRunTenant(null)).isEmpty();
+    assertThat(locator.findRunTenant("  ")).isEmpty();
+    verifyNoInteractions(jdbcTemplate);
+  }
+
+  /**
+   * Every production class that opts out of the inspector AND names an autonomous table. Scanning
+   * the tree rather than the one known file is the point: a new sibling bypass must show up here
+   * instead of slipping past a test that only ever looked at the locator.
+   */
+  private static List<Path> rawJdbcClassesTouchingAutonomousTables() throws Exception {
+    try (Stream<Path> tree = Files.walk(Path.of("src/main/java"))) {
+      return tree.filter(path -> path.toString().endsWith(".java"))
+          .filter(
+              path -> {
+                String body = read(path);
+                return body.contains("@AllowRawJdbc") && body.contains("autonomous_");
+              })
+          .toList();
+    }
+  }
+
+  private static String read(Path path) {
+    try {
+      return Files.readString(path);
+    } catch (Exception e) {
+      throw new IllegalStateException("cannot read " + path, e);
+    }
+  }
+
+  /** The full SQL string literals the source declares, recognised by their leading verb. */
+  private static List<String> sqlLiterals(String source) {
+    Matcher matcher =
+        Pattern.compile(
+                "\"((?:INSERT|SELECT|UPDATE|DELETE|TRUNCATE|MERGE)\\b[^\"]*)\"",
+                Pattern.CASE_INSENSITIVE)
+            .matcher(source);
+    List<String> found = new ArrayList<>();
+    while (matcher.find()) {
+      found.add(matcher.group(1));
+    }
+    assertThat(found)
+        .as("the scan must find the locator's statement, or it proves nothing")
+        .isNotEmpty();
+    return found;
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
@@ -34,8 +34,9 @@ import org.springframework.jdbc.core.RowMapper;
  * is out of every caller scope, so the run-derived scope refuses it too). A reason that lives only
  * in a comment rots, so - like the insert-only seed exemption pinned by {@code
  * AttackPathSeedServiceTest} - it is enforced here: widening the statement, adding a second
- * statement, or adding a sibling bypass on the {@code autonomous_*} tables fails the build and
- * forces the conversation.
+ * statement (whatever its command head), adding a second JdbcTemplate call site or any other JDBC
+ * surface, or adding a sibling bypass on the {@code autonomous_*} tables (in either annotation
+ * spelling) fails the build and forces the conversation.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("the run-tenant locator stays a pinned, fail-closed scope-bootstrap read")
@@ -77,9 +78,10 @@ class AutonomousRunTenantLocatorTest {
   @DisplayName("the literal scan counts every Java literal form, so no statement can hide")
   void theLiteralScanCountsEveryJavaLiteralForm() {
     // The pin above is only as strong as this scanner, so the scanner is pinned too: a statement
-    // in a text block, one led by a CTE, one led by whitespace, and one split across a
-    // +-concatenated chain (the formatter's long-string shape) must all be counted - the chain as
-    // the single folded string - while a prose literal mentioning the run must not be.
+    // in a text block, one led by a CTE, one led by whitespace, one split across a +-concatenated
+    // chain (the formatter's long-string shape), and a non-DML command (CALL - no DML verb
+    // anywhere in it) must all be counted - the chain as the single folded string - while a prose
+    // literal mentioning the run must not be.
     String sneakySource =
         """
         class Sneaky {
@@ -93,6 +95,7 @@ class AutonomousRunTenantLocatorTest {
           static final String CHAIN =
               "INSERT INTO autonomous_events (autonomous_event_id)"
                   + " VALUES (?)";
+          static final String PROC = "CALL mutate_autonomous_run(?)";
           static final String PROSE = "reads only the run's immutable tenant id";
         }
         """;
@@ -104,7 +107,44 @@ class AutonomousRunTenantLocatorTest {
             "UPDATE autonomous_runs SET tenant_id = 'x' WHERE autonomous_run_id = ?",
             "WITH last AS (SELECT 1) DELETE FROM autonomous_events",
             "Truncate autonomous_directives",
-            "INSERT INTO autonomous_events (autonomous_event_id) VALUES (?)");
+            "INSERT INTO autonomous_events (autonomous_event_id) VALUES (?)",
+            "CALL mutate_autonomous_run(?)");
+  }
+
+  @Test
+  @DisplayName("the locator's only database access is the single pinned query call")
+  void theLocatorsOnlyDatabaseAccessIsTheSinglePinnedQueryCall() throws Exception {
+    // Vocabulary can never carry the "exactly one statement" claim on its own: PostgreSQL has
+    // dozens of command heads and a list of words is a treadmill. This pin enforces the claim
+    // where it is decidable - the execution layer: with literals excised and comments stripped,
+    // the locator's code must contain exactly one JdbcTemplate invocation, it must be query, its
+    // statement must be the pinned constant BY NAME, and no other JDBC surface may appear. A
+    // second statement then cannot run at all, whatever its text looks like to the literal scan.
+    List<Path> bypasses = rawJdbcClassesTouchingAutonomousTables();
+    assertThat(bypasses).isNotEmpty();
+    String code = codeSkeleton(read(bypasses.get(0)));
+
+    List<String> jdbcCalls = new ArrayList<>();
+    Matcher calls = Pattern.compile("jdbcTemplate\\s*\\.\\s*(\\w+)").matcher(code);
+    while (calls.find()) {
+      jdbcCalls.add(calls.group(1));
+    }
+    assertThat(jdbcCalls)
+        .as("the locator makes exactly one JdbcTemplate call, and it is a read")
+        .containsExactly("query");
+    assertThat(code)
+        .as("the single query must execute the pinned statement, by name")
+        .containsPattern("jdbcTemplate\\s*\\.\\s*query\\s*\\(\\s*SELECT_RUN_TENANT\\b");
+    assertThat(code)
+        .as("no JDBC surface beyond the sanctioned template call may appear in code")
+        .doesNotContain("getConnection")
+        .doesNotContain("prepareStatement")
+        .doesNotContain("createStatement")
+        .doesNotContain("createNativeQuery")
+        .doesNotContain("NamedParameterJdbc")
+        .doesNotContain("SimpleJdbc")
+        .doesNotContain("DataSource")
+        .doesNotContain("EntityManager");
   }
 
   @Test
@@ -144,11 +184,21 @@ class AutonomousRunTenantLocatorTest {
   }
 
   /**
+   * Both source spellings a valid annotation use can take: the imported simple name and the fully
+   * qualified name (annotations cannot be static-imported or aliased, so there is no third). The
+   * bytecode-reading arch test accepts either spelling, so an inventory that only recognized the
+   * simple one would let a fully qualified bypass through the class-list pin.
+   */
+  private static final Pattern ALLOW_RAW_JDBC =
+      Pattern.compile("@\\s*(?:io\\.openaev\\.annotation\\.)?AllowRawJdbc\\b");
+
+  /**
    * Every production class, in EVERY production module, that opts out of the inspector AND names an
    * autonomous table. Scanning the trees rather than the one known file is the point: a new sibling
    * bypass must show up here instead of slipping past a test that only ever looked at the locator -
    * and {@code openaev-model} already hosts {@code @AllowRawJdbc} classes of its own, so a
-   * model-layer bypass must fail this pin exactly like an api-layer one.
+   * model-layer bypass must fail this pin exactly like an api-layer one. The opt-out is recognized
+   * in both spellings the language admits ({@link #ALLOW_RAW_JDBC}).
    */
   private static List<Path> rawJdbcClassesTouchingAutonomousTables() throws Exception {
     // Surefire runs with the module directory as CWD, so sibling production roots sit one level up.
@@ -170,7 +220,7 @@ class AutonomousRunTenantLocatorTest {
             .filter(
                 path -> {
                   String body = read(path);
-                  return body.contains("@AllowRawJdbc") && body.contains("autonomous_");
+                  return ALLOW_RAW_JDBC.matcher(body).find() && body.contains("autonomous_");
                 })
             .forEach(bypasses::add);
       }
@@ -186,21 +236,39 @@ class AutonomousRunTenantLocatorTest {
     }
   }
 
-  /** Matches a SQL verb appearing as a standalone word anywhere inside a literal. */
+  /** Matches a DML verb appearing as a standalone word anywhere inside a literal. */
   private static final Pattern SQL_VERB =
       Pattern.compile(
           "\\b(?:INSERT|SELECT|UPDATE|DELETE|TRUNCATE|MERGE)\\b", Pattern.CASE_INSENSITIVE);
 
   /**
+   * Matches a literal whose (folded, stripped) content STARTS with any other PostgreSQL command
+   * head - CALL, DO, COPY, DDL, transaction control, maintenance, and the rest - so a non-DML
+   * statement cannot hide from the scan on vocabulary grounds. Anchored at the start (a command
+   * head leads its statement by definition) so the {@code @AllowRawJdbc} reason prose cannot
+   * false-positive on everyday words like "do" or "with" in mid-sentence.
+   */
+  private static final Pattern SQL_COMMAND_HEAD =
+      Pattern.compile(
+          "^(?:CALL|DO|COPY|CREATE|ALTER|DROP|GRANT|REVOKE|VACUUM|ANALYZE|ANALYSE|REINDEX|CLUSTER"
+              + "|REFRESH|EXPLAIN|PREPARE|EXECUTE|DEALLOCATE|LOCK|LISTEN|UNLISTEN|NOTIFY|DISCARD"
+              + "|CHECKPOINT|SET|RESET|SHOW|WITH|VALUES|TABLE|COMMENT|IMPORT|BEGIN|COMMIT|ROLLBACK"
+              + "|SAVEPOINT|RELEASE|DECLARE|FETCH|MOVE|CLOSE|ABORT|START|END|LOAD|SECURITY)\\b",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
    * Every string literal the source declares, in BOTH Java literal forms (one-line and text block),
-   * that carries a SQL verb anywhere in its content. Anchoring on a verb right after the opening
-   * quote would miss a text block (its opening delimiter is always followed by a line terminator,
-   * never by the verb) and any statement led by whitespace or a CTE, so a second statement could
-   * hide from the pin; containing-verb matching over every literal form keeps the exact-statement
-   * claim honest. A chain of {@code +}-concatenated one-line literals is folded into the single
-   * string javac constant-folds it to, so the formatter splitting a long statement across fragments
-   * neither hides a verb-less fragment from the pin nor fails it spuriously. {@link
-   * #theLiteralScanCountsEveryJavaLiteralForm()} pins this scanner itself.
+   * that carries a DML verb anywhere in its content or leads with any other PostgreSQL command
+   * head. Anchoring on a verb right after the opening quote would miss a text block (its opening
+   * delimiter is always followed by a line terminator, never by the verb) and any statement led by
+   * whitespace or a CTE, so a second statement could hide from the pin; verb-anywhere plus
+   * head-at-start matching over every literal form keeps the exact-statement claim honest at the
+   * text level, and {@link #theLocatorsOnlyDatabaseAccessIsTheSinglePinnedQueryCall()} enforces it
+   * at the execution level, where vocabulary cannot matter at all. A chain of {@code
+   * +}-concatenated one-line literals is folded into the single string javac constant-folds it to,
+   * so the formatter splitting a long statement across fragments neither hides a verb-less fragment
+   * from the pin nor fails it spuriously. {@link #theLiteralScanCountsEveryJavaLiteralForm()} pins
+   * this scanner itself.
    */
   private static List<String> sqlLiterals(String source) {
     // A unicode-escaped delimiter (\u0022) is the one remaining way to hide a literal from a
@@ -246,8 +314,27 @@ class AutonomousRunTenantLocatorTest {
   }
 
   private static void collectWhenSql(List<String> found, String literal) {
-    if (SQL_VERB.matcher(literal).find()) {
-      found.add(literal.strip());
+    String stripped = literal.strip();
+    if (SQL_VERB.matcher(stripped).find() || SQL_COMMAND_HEAD.matcher(stripped).find()) {
+      found.add(stripped);
     }
+  }
+
+  /**
+   * The source with every string literal excised (text blocks first, then one-line literals, so
+   * literal content can never masquerade as code) and every comment stripped (so javadoc prose can
+   * never masquerade as an API call). What remains is the code whose database reach the call-site
+   * pin asserts on.
+   */
+  private static String codeSkeleton(String source) {
+    String withoutLiterals =
+        Pattern.compile("\"\"\"(.*?)\"\"\"", Pattern.DOTALL)
+            .matcher(source)
+            .replaceAll("\"\"")
+            .replaceAll("\"[^\"\\n]*\"", "\"\"");
+    return Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL)
+        .matcher(withoutLiterals)
+        .replaceAll(" ")
+        .replaceAll("//[^\\n]*", " ");
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
@@ -62,6 +62,35 @@ class AutonomousRunTenantLocatorTest {
   }
 
   @Test
+  @DisplayName("the literal scan counts every Java literal form, so no statement can hide")
+  void theLiteralScanCountsEveryJavaLiteralForm() {
+    // The pin above is only as strong as this scanner, so the scanner is pinned too: a statement
+    // in a text block, one led by a CTE, and one led by whitespace must all be counted, while a
+    // prose literal mentioning the run must not be.
+    String sneakySource =
+        """
+        class Sneaky {
+          static final String ONE_LINE = "SELECT a FROM b WHERE id = ?";
+          static final String TEXT_BLOCK =
+              \"""
+              UPDATE autonomous_runs SET tenant_id = 'x' WHERE autonomous_run_id = ?
+              \""";
+          static final String CTE = "WITH last AS (SELECT 1) DELETE FROM autonomous_events";
+          static final String PADDED = "  Truncate autonomous_directives";
+          static final String PROSE = "reads only the run's immutable tenant id";
+        }
+        """;
+
+    assertThat(sqlLiterals(sneakySource))
+        .as("both literal forms are counted, in any lead-in, and prose is not")
+        .containsExactlyInAnyOrder(
+            "SELECT a FROM b WHERE id = ?",
+            "UPDATE autonomous_runs SET tenant_id = 'x' WHERE autonomous_run_id = ?",
+            "WITH last AS (SELECT 1) DELETE FROM autonomous_events",
+            "Truncate autonomous_directives");
+  }
+
+  @Test
   @DisplayName("a known run resolves to its own tenant")
   void aKnownRunResolvesToItsOwnTenant() {
     AutonomousRunTenantLocator locator = new AutonomousRunTenantLocator(jdbcTemplate);
@@ -140,20 +169,50 @@ class AutonomousRunTenantLocatorTest {
     }
   }
 
-  /** The full SQL string literals the source declares, recognised by their leading verb. */
+  /** Matches a SQL verb appearing as a standalone word anywhere inside a literal. */
+  private static final Pattern SQL_VERB =
+      Pattern.compile(
+          "\\b(?:INSERT|SELECT|UPDATE|DELETE|TRUNCATE|MERGE)\\b", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Every string literal the source declares, in BOTH Java literal forms (one-line and text block),
+   * that carries a SQL verb anywhere in its content. Anchoring on a verb right after the opening
+   * quote would miss a text block (its opening delimiter is always followed by a line terminator,
+   * never by the verb) and any statement led by whitespace or a CTE, so a second statement could
+   * hide from the pin; containing-verb matching over every literal form keeps the exact-statement
+   * claim honest. {@link #theLiteralScanCountsEveryJavaLiteralForm()} pins this scanner itself.
+   */
   private static List<String> sqlLiterals(String source) {
-    Matcher matcher =
-        Pattern.compile(
-                "\"((?:INSERT|SELECT|UPDATE|DELETE|TRUNCATE|MERGE)\\b[^\"]*)\"",
-                Pattern.CASE_INSENSITIVE)
-            .matcher(source);
+    // A unicode-escaped delimiter (\u0022) is the one remaining way to hide a literal from a
+    // raw-text scan, and the locator has no legitimate use for unicode escapes at all.
+    assertThat(source)
+        .as("unicode escapes could hide a literal from this scan")
+        .doesNotContain("\\u");
     List<String> found = new ArrayList<>();
-    while (matcher.find()) {
-      found.add(matcher.group(1));
+    // Text blocks are consumed first and excised, so their bodies (which may contain quote
+    // characters) can never derail the one-line pass over the remainder.
+    Matcher textBlocks = Pattern.compile("\"\"\"(.*?)\"\"\"", Pattern.DOTALL).matcher(source);
+    StringBuilder remainder = new StringBuilder();
+    int copiedUpTo = 0;
+    while (textBlocks.find()) {
+      collectWhenSql(found, textBlocks.group(1));
+      remainder.append(source, copiedUpTo, textBlocks.start());
+      copiedUpTo = textBlocks.end();
+    }
+    remainder.append(source, copiedUpTo, source.length());
+    Matcher oneLiners = Pattern.compile("\"([^\"\\n]*)\"").matcher(remainder);
+    while (oneLiners.find()) {
+      collectWhenSql(found, oneLiners.group(1));
     }
     assertThat(found)
         .as("the scan must find the locator's statement, or it proves nothing")
         .isNotEmpty();
     return found;
+  }
+
+  private static void collectWhenSql(List<String> found, String literal) {
+    if (SQL_VERB.matcher(literal).find()) {
+      found.add(literal.strip());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AutonomousRunTenantLocatorTest.java
@@ -30,10 +30,12 @@ import org.springframework.jdbc.core.RowMapper;
  * deriving a callback's scope FROM the run is a chicken-and-egg (the read that decides the scope
  * cannot run under the scope it is deciding, and the inspector would fail-close it), so it may
  * bypass the inspector ONLY while it stays a single-row, primary-key-addressed SELECT of the run's
- * own immutable {@code tenant_id}. A reason that lives only in a comment rots, so - like the
- * insert-only seed exemption pinned by {@code AttackPathSeedServiceTest} - it is enforced here:
- * widening the statement, adding a second statement, or adding a sibling bypass on the {@code
- * autonomous_*} tables fails the build and forces the conversation.
+ * own immutable {@code tenant_id}, filtered on the owning tenant's liveness (a soft-deleted tenant
+ * is out of every caller scope, so the run-derived scope refuses it too). A reason that lives only
+ * in a comment rots, so - like the insert-only seed exemption pinned by {@code
+ * AttackPathSeedServiceTest} - it is enforced here: widening the statement, adding a second
+ * statement, or adding a sibling bypass on the {@code autonomous_*} tables fails the build and
+ * forces the conversation.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("the run-tenant locator stays a pinned, fail-closed scope-bootstrap read")
@@ -58,15 +60,26 @@ class AutonomousRunTenantLocatorTest {
         .as("the locator emits exactly one SQL statement")
         .containsExactly(AutonomousRunTenantLocator.SELECT_RUN_TENANT);
     assertThat(AutonomousRunTenantLocator.SELECT_RUN_TENANT)
-        .isEqualTo("SELECT tenant_id FROM autonomous_runs WHERE autonomous_run_id = ?");
+        .isEqualTo(
+            "SELECT r.tenant_id FROM autonomous_runs r JOIN tenants t ON t.tenant_id = r.tenant_id"
+                + " WHERE r.autonomous_run_id = ? AND t.tenant_deleted_at IS NULL");
+    // The liveness predicate is load-bearing, not decoration: a soft-deleted tenant is out of
+    // every caller scope for its whole grace period, so the run-derived scope must fail closed on
+    // it too instead of re-admitting a tenant no operator can reach. Pinned explicitly so a
+    // rewrite of the statement cannot drop it without meeting this assertion by name.
+    assertThat(AutonomousRunTenantLocator.SELECT_RUN_TENANT)
+        .as("the bootstrap read must refuse a run whose owning tenant is soft-deleted")
+        .contains("JOIN tenants")
+        .contains("tenant_deleted_at IS NULL");
   }
 
   @Test
   @DisplayName("the literal scan counts every Java literal form, so no statement can hide")
   void theLiteralScanCountsEveryJavaLiteralForm() {
     // The pin above is only as strong as this scanner, so the scanner is pinned too: a statement
-    // in a text block, one led by a CTE, and one led by whitespace must all be counted, while a
-    // prose literal mentioning the run must not be.
+    // in a text block, one led by a CTE, one led by whitespace, and one split across a
+    // +-concatenated chain (the formatter's long-string shape) must all be counted - the chain as
+    // the single folded string - while a prose literal mentioning the run must not be.
     String sneakySource =
         """
         class Sneaky {
@@ -77,17 +90,21 @@ class AutonomousRunTenantLocatorTest {
               \""";
           static final String CTE = "WITH last AS (SELECT 1) DELETE FROM autonomous_events";
           static final String PADDED = "  Truncate autonomous_directives";
+          static final String CHAIN =
+              "INSERT INTO autonomous_events (autonomous_event_id)"
+                  + " VALUES (?)";
           static final String PROSE = "reads only the run's immutable tenant id";
         }
         """;
 
     assertThat(sqlLiterals(sneakySource))
-        .as("both literal forms are counted, in any lead-in, and prose is not")
+        .as("both literal forms are counted, in any lead-in, chains folded, and prose is not")
         .containsExactlyInAnyOrder(
             "SELECT a FROM b WHERE id = ?",
             "UPDATE autonomous_runs SET tenant_id = 'x' WHERE autonomous_run_id = ?",
             "WITH last AS (SELECT 1) DELETE FROM autonomous_events",
-            "Truncate autonomous_directives");
+            "Truncate autonomous_directives",
+            "INSERT INTO autonomous_events (autonomous_event_id) VALUES (?)");
   }
 
   @Test
@@ -180,7 +197,10 @@ class AutonomousRunTenantLocatorTest {
    * quote would miss a text block (its opening delimiter is always followed by a line terminator,
    * never by the verb) and any statement led by whitespace or a CTE, so a second statement could
    * hide from the pin; containing-verb matching over every literal form keeps the exact-statement
-   * claim honest. {@link #theLiteralScanCountsEveryJavaLiteralForm()} pins this scanner itself.
+   * claim honest. A chain of {@code +}-concatenated one-line literals is folded into the single
+   * string javac constant-folds it to, so the formatter splitting a long statement across fragments
+   * neither hides a verb-less fragment from the pin nor fails it spuriously. {@link
+   * #theLiteralScanCountsEveryJavaLiteralForm()} pins this scanner itself.
    */
   private static List<String> sqlLiterals(String source) {
     // A unicode-escaped delimiter (\u0022) is the one remaining way to hide a literal from a
@@ -200,14 +220,29 @@ class AutonomousRunTenantLocatorTest {
       copiedUpTo = textBlocks.end();
     }
     remainder.append(source, copiedUpTo, source.length());
-    Matcher oneLiners = Pattern.compile("\"([^\"\\n]*)\"").matcher(remainder);
+    Matcher oneLiners =
+        Pattern.compile("\"[^\"\\n]*\"(?:\\s*\\+\\s*\"[^\"\\n]*\")*").matcher(remainder);
     while (oneLiners.find()) {
-      collectWhenSql(found, oneLiners.group(1));
+      collectWhenSql(found, joinLiteralChain(oneLiners.group()));
     }
     assertThat(found)
         .as("the scan must find the locator's statement, or it proves nothing")
         .isNotEmpty();
     return found;
+  }
+
+  /**
+   * Folds a chain of {@code +}-concatenated one-line literals into the single string javac
+   * constant-folds it to. Only directly adjacent literals join: a chain broken by any non-literal
+   * operand keeps its fragments separate, so dynamically composed SQL still fails the pin loudly.
+   */
+  private static String joinLiteralChain(String chain) {
+    StringBuilder joined = new StringBuilder();
+    Matcher segments = Pattern.compile("\"([^\"\\n]*)\"").matcher(chain);
+    while (segments.find()) {
+      joined.append(segments.group(1));
+    }
+    return joined.toString();
   }
 
   private static void collectWhenSql(List<String> found, String literal) {

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.openaev.config.cache.TenantMembershipCacheManager;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
+import io.openaev.rest.exception.TenantAccessDeniedException;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
 import java.util.Arrays;
 import java.util.Map;
@@ -120,9 +122,13 @@ class TxCtxArgumentResolverTest {
   }
 
   private void pathRunId(String runId) {
+    pathVariables(Map.of("runId", runId));
+  }
+
+  private void pathVariables(Map<String, String> variables) {
     when(webRequest.getAttribute(
             HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST))
-        .thenReturn(Map.of("runId", runId));
+        .thenReturn(variables);
   }
 
   @Test
@@ -146,5 +152,49 @@ class TxCtxArgumentResolverTest {
 
     // Missing scope denies every row, so the callback's own run lookup then reports a 404.
     assertThat(resolve()).isInstanceOf(TxCtx.Missing.class);
+  }
+
+  @Test
+  @DisplayName("a run-tenant-scoped callback without a {runId} path variable is fail-closed")
+  void runTenantScopeWithoutRunIdPathVariableIsFailClosed() {
+    // Defensive contract for a future handler that carries the annotation but names its path
+    // variable differently: the derivation cannot identify the run, so it must deny everything
+    // (the safe direction) rather than fall back to any caller-derived scope.
+    runTenantScoped();
+    pathVariables(Map.of());
+
+    assertThat(resolve()).isInstanceOf(TxCtx.Missing.class);
+    verifyNoInteractions(runTenantLocator);
+  }
+
+  @Test
+  @DisplayName(
+      "on the tenant-prefixed route the annotation is inert: the caller-authorized resolution"
+          + " applies")
+  void runTenantScopeOnTenantPrefixedRouteKeepsCallerAuthorizedResolution() {
+    // The service-identity derivation exists only for the legacy non-prefixed callback route. A
+    // request that addresses a tenant through the URL (the operator route) keeps the standard
+    // "rights are the boundary" resolution: the scope is the addressed tenant, validated against
+    // the caller's memberships, and the run's own tenant is never consulted.
+    runTenantScoped();
+    pathVariables(Map.of("tenantId", "tenant-1", "runId", "run-1"));
+    authorizeTenants("tenant-1", "tenant-2");
+
+    assertThat(resolve().toGuc()).isEqualTo("tenant-1");
+    verifyNoInteractions(runTenantLocator);
+  }
+
+  @Test
+  @DisplayName("on the tenant-prefixed route a tenant outside the caller's rights stays refused")
+  void runTenantScopeOnTenantPrefixedRouteRefusesForeignTenant() {
+    // The annotated handler must not become a caller-independent door on the prefixed route: a
+    // caller addressing a tenant it is not a member of is refused exactly like on any other
+    // prefixed endpoint, whatever tenant the run named by {runId} belongs to.
+    runTenantScoped();
+    pathVariables(Map.of("tenantId", "tenant-3", "runId", "run-1"));
+    authorizeTenants("tenant-1", "tenant-2");
+
+    assertThatThrownBy(this::resolve).isInstanceOf(TenantAccessDeniedException.class);
+    verifyNoInteractions(runTenantLocator);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
@@ -2,6 +2,7 @@ package io.openaev.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +11,8 @@ import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +24,8 @@ import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
 
 /**
  * Unit coverage for the no-selector fallback on selector-requiring endpoints. A selector is never
@@ -36,6 +41,7 @@ class TxCtxArgumentResolverTest {
   private static final String USER_ID = "user-id";
 
   @Mock private TenantMembershipCacheManager membershipCache;
+  @Mock private AutonomousRunTenantLocator runTenantLocator;
   @Mock private MethodParameter parameter;
   @Mock private NativeWebRequest webRequest;
 
@@ -43,11 +49,14 @@ class TxCtxArgumentResolverTest {
 
   @BeforeEach
   void setUp() {
-    resolver = new TxCtxArgumentResolver(new TenantScopeResolver(), membershipCache);
+    resolver =
+        new TxCtxArgumentResolver(new TenantScopeResolver(), membershipCache, runTenantLocator);
     OpenAEVPrincipal principal = mock(OpenAEVPrincipal.class);
-    when(principal.getId()).thenReturn(USER_ID);
+    // lenient: the run-tenant-scope path returns before it ever resolves the current user, so these
+    // are unused by those cases (and MockitoExtension strict stubbing would otherwise flag them).
+    lenient().when(principal.getId()).thenReturn(USER_ID);
     Authentication authentication = mock(Authentication.class);
-    when(authentication.getPrincipal()).thenReturn(principal);
+    lenient().when(authentication.getPrincipal()).thenReturn(principal);
     SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 
@@ -61,7 +70,10 @@ class TxCtxArgumentResolverTest {
   }
 
   private void requireSelector() {
-    when(parameter.hasParameterAnnotation(RequireTenantSelector.class)).thenReturn(true);
+    // lenient: the resolver now checks @RunTenantScope first, so hasParameterAnnotation is also
+    // invoked with RunTenantScope.class - which must not trip strict stubbing's PotentialStubbing
+    // guard on this RequireTenantSelector stub.
+    lenient().when(parameter.hasParameterAnnotation(RequireTenantSelector.class)).thenReturn(true);
   }
 
   private TxCtx resolve() {
@@ -101,5 +113,38 @@ class TxCtxArgumentResolverTest {
     authorizeTenants("tenant-1", "tenant-2");
 
     assertThat(resolve().toGuc()).isEqualTo("tenant-1,tenant-2");
+  }
+
+  private void runTenantScoped() {
+    when(parameter.hasParameterAnnotation(RunTenantScope.class)).thenReturn(true);
+  }
+
+  private void pathRunId(String runId) {
+    when(webRequest.getAttribute(
+            HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST))
+        .thenReturn(Map.of("runId", runId));
+  }
+
+  @Test
+  @DisplayName("a run-tenant-scoped callback derives the run's own tenant, ignoring the caller")
+  void runTenantScopeDerivesTheParentRunTenant() {
+    // The caller is a member of two OTHER tenants and selected none of the run's; the scope must
+    // still come from the run, so the callback acts on the run's tenant regardless of the caller.
+    runTenantScoped();
+    pathRunId("run-1");
+    when(runTenantLocator.findRunTenant("run-1")).thenReturn(Optional.of("run-owner-tenant"));
+
+    assertThat(resolve().toGuc()).isEqualTo("run-owner-tenant");
+  }
+
+  @Test
+  @DisplayName("a run-tenant-scoped callback for an unknown run is fail-closed (missing scope)")
+  void runTenantScopeUnknownRunIsFailClosed() {
+    runTenantScoped();
+    pathRunId("ghost-run");
+    when(runTenantLocator.findRunTenant("ghost-run")).thenReturn(Optional.empty());
+
+    // Missing scope denies every row, so the callback's own run lookup then reports a 404.
+    assertThat(resolve()).isInstanceOf(TxCtx.Missing.class);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TxCtxArgumentResolverTest.java
@@ -12,6 +12,7 @@ import io.openaev.context.TxCtx;
 import io.openaev.database.model.Tenant;
 import io.openaev.rest.exception.TenantAccessDeniedException;
 import io.openaev.rest.exception.TenantSelectorRequiredException;
+import io.openaev.security.token.XtmJwksExtractor;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -121,6 +122,21 @@ class TxCtxArgumentResolverTest {
     when(parameter.hasParameterAnnotation(RunTenantScope.class)).thenReturn(true);
   }
 
+  /**
+   * Marks the request as the VERIFIED XTM One cross-platform service identity - the server-side
+   * attribute {@link XtmJwksExtractor} stamps after fully validating the cross-platform JWT.
+   * Without it a run-tenant-scoped callback falls back to caller-authorized resolution.
+   */
+  private void crossPlatformCaller() {
+    // lenient: on the tenant-prefixed route the marker is never consulted (the route check wins
+    // first), so the same helper also proves the prefixed route ignores the service identity.
+    lenient()
+        .when(
+            webRequest.getAttribute(
+                XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST))
+        .thenReturn(Boolean.TRUE);
+  }
+
   private void pathRunId(String runId) {
     pathVariables(Map.of("runId", runId));
   }
@@ -132,11 +148,15 @@ class TxCtxArgumentResolverTest {
   }
 
   @Test
-  @DisplayName("a run-tenant-scoped callback derives the run's own tenant, ignoring the caller")
+  @DisplayName(
+      "a run-tenant-scoped callback from the verified service identity derives the run's own"
+          + " tenant, ignoring the caller")
   void runTenantScopeDerivesTheParentRunTenant() {
-    // The caller is a member of two OTHER tenants and selected none of the run's; the scope must
-    // still come from the run, so the callback acts on the run's tenant regardless of the caller.
+    // The verified orchestrator is a member of two OTHER tenants and selected none of the run's;
+    // the scope must still come from the run, so the callback acts on the run's tenant regardless
+    // of the caller's memberships.
     runTenantScoped();
+    crossPlatformCaller();
     pathRunId("run-1");
     when(runTenantLocator.findRunTenant("run-1")).thenReturn(Optional.of("run-owner-tenant"));
 
@@ -147,6 +167,7 @@ class TxCtxArgumentResolverTest {
   @DisplayName("a run-tenant-scoped callback for an unknown run is fail-closed (missing scope)")
   void runTenantScopeUnknownRunIsFailClosed() {
     runTenantScoped();
+    crossPlatformCaller();
     pathRunId("ghost-run");
     when(runTenantLocator.findRunTenant("ghost-run")).thenReturn(Optional.empty());
 
@@ -161,9 +182,27 @@ class TxCtxArgumentResolverTest {
     // variable differently: the derivation cannot identify the run, so it must deny everything
     // (the safe direction) rather than fall back to any caller-derived scope.
     runTenantScoped();
+    crossPlatformCaller();
     pathVariables(Map.of());
 
     assertThat(resolve()).isInstanceOf(TxCtx.Missing.class);
+    verifyNoInteractions(runTenantLocator);
+  }
+
+  @Test
+  @DisplayName(
+      "a run-tenant-scoped callback without the verified service identity is" + " caller-scoped")
+  void runTenantScopeWithoutServiceIdentityFallsBackToCallerScope() {
+    // The IDOR gate: @RunTenantScope means "derive from the run" only for the verified XTM One
+    // cross-platform caller (the marker XtmJwksExtractor stamps after full JWT validation). Any
+    // other authenticated caller resolves exactly like on a plain endpoint - its own memberships -
+    // and the run's tenant is never even looked up, so a known run id gives an ordinary
+    // Enterprise-Edition user no cross-tenant reach.
+    runTenantScoped();
+    pathRunId("run-1");
+    authorizeTenants("tenant-1", "tenant-2");
+
+    assertThat(resolve().toGuc()).isEqualTo("tenant-1,tenant-2");
     verifyNoInteractions(runTenantLocator);
   }
 
@@ -189,8 +228,10 @@ class TxCtxArgumentResolverTest {
   void runTenantScopeOnTenantPrefixedRouteRefusesForeignTenant() {
     // The annotated handler must not become a caller-independent door on the prefixed route: a
     // caller addressing a tenant it is not a member of is refused exactly like on any other
-    // prefixed endpoint, whatever tenant the run named by {runId} belongs to.
+    // prefixed endpoint, whatever tenant the run named by {runId} belongs to - even for the
+    // verified service identity (the route check wins before the marker is ever consulted).
     runTenantScoped();
+    crossPlatformCaller();
     pathVariables(Map.of("tenantId", "tenant-3", "runId", "run-1"));
     authorizeTenants("tenant-1", "tenant-2");
 

--- a/openaev-api/src/test/java/io/openaev/security/token/XtmJwksExtractorTest.java
+++ b/openaev-api/src/test/java/io/openaev/security/token/XtmJwksExtractorTest.java
@@ -1,0 +1,128 @@
+package io.openaev.security.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import io.openaev.authorisation.HttpClientFactory;
+import io.openaev.config.OpenAEVConfig;
+import io.openaev.database.model.User;
+import io.openaev.security.error.AuthenticationError;
+import io.openaev.service.UserService;
+import io.openaev.utils.fixtures.JwtFixture;
+import io.openaev.xtmone.XtmOneConfig;
+import java.util.Optional;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Unit coverage for the cross-platform service-identity marker: {@code authUser} must stamp {@link
+ * XtmJwksExtractor#CROSS_PLATFORM_ATTRIBUTE} ONLY when the bearer fully validated as an XTM One
+ * cross-platform JWT (trusted issuer, JWKS signature, expected audience) AND resolved a user -
+ * never on a refused issuer, a wrong audience, or an unresolved user. {@code TxCtxArgumentResolver}
+ * grants run-authoritative tenant scope on exactly this marker, so a stray stamp would be a
+ * cross-tenant privilege grant.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("XtmJwksExtractor cross-platform service-identity marker")
+class XtmJwksExtractorTest {
+
+  private static final String TRUSTED_ISSUER = "https://xtmone.test.filigran.io";
+  private static final String AUDIENCE = "https://openaev.test.filigran.io";
+  private static final String EMAIL = "orchestrator@filigran.io";
+
+  @Mock private XtmOneConfig xtmOneConfig;
+  @Mock private UserService userService;
+  @Mock private HttpClientFactory httpClientFactory;
+  @Mock private OpenAEVConfig openAEVConfig;
+  @Mock private CloseableHttpClient httpClient;
+
+  private XtmJwksExtractor extractor;
+  private MockHttpServletRequest request;
+
+  @BeforeEach
+  void setUp() {
+    extractor =
+        new XtmJwksExtractor(
+            xtmOneConfig, userService, httpClientFactory, new ObjectMapper(), openAEVConfig);
+    request = new MockHttpServletRequest();
+    // Reached by every case: the configured-check and the trusted-issuer list come first.
+    when(xtmOneConfig.isConfigured()).thenReturn(true);
+    when(xtmOneConfig.getUrl()).thenReturn(TRUSTED_ISSUER);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubJwks(String jwksJson) throws Exception {
+    when(httpClientFactory.httpClientCustom()).thenReturn(httpClient);
+    when(httpClient.execute((ClassicHttpRequest) any(), (HttpClientResponseHandler<String>) any()))
+        .thenReturn(jwksJson);
+  }
+
+  @Test
+  @DisplayName("a fully validated token that resolves a user stamps the marker")
+  void validatedTokenStampsMarker() throws Exception {
+    JwtFixture.Bundle bundle =
+        JwtFixture.generateXtmJwksJwtBundle(TRUSTED_ISSUER, EMAIL, AUDIENCE, false);
+    stubJwks(bundle.jwks());
+    when(openAEVConfig.getBaseUrl()).thenReturn(AUDIENCE);
+    when(userService.findByEmailIgnoreCase(EMAIL)).thenReturn(Optional.of(new User()));
+
+    Optional<User> user = extractor.authUser(bundle.jwtToken(), request);
+
+    assertThat(user).isPresent();
+    assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE))
+        .isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  @DisplayName("an untrusted issuer is refused and never stamps the marker")
+  void untrustedIssuerDoesNotStampMarker() throws Exception {
+    JwtFixture.Bundle bundle =
+        JwtFixture.generateXtmJwksJwtBundle(
+            "https://evil.attacker.example", EMAIL, AUDIENCE, false);
+
+    assertThatThrownBy(() -> extractor.authUser(bundle.jwtToken(), request))
+        .isInstanceOf(AuthenticationError.class);
+    assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE)).isNull();
+  }
+
+  @Test
+  @DisplayName("a token minted for another audience is refused and never stamps the marker")
+  void wrongAudienceDoesNotStampMarker() throws Exception {
+    JwtFixture.Bundle bundle =
+        JwtFixture.generateXtmJwksJwtBundle(
+            TRUSTED_ISSUER, EMAIL, "https://another-platform.example", false);
+    stubJwks(bundle.jwks());
+    when(openAEVConfig.getBaseUrl()).thenReturn(AUDIENCE);
+
+    assertThatThrownBy(() -> extractor.authUser(bundle.jwtToken(), request))
+        .isInstanceOf(JwtException.class);
+    assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE)).isNull();
+  }
+
+  @Test
+  @DisplayName("a valid token whose email resolves no user does not stamp the marker")
+  void unresolvedUserDoesNotStampMarker() throws Exception {
+    JwtFixture.Bundle bundle =
+        JwtFixture.generateXtmJwksJwtBundle(TRUSTED_ISSUER, EMAIL, AUDIENCE, false);
+    stubJwks(bundle.jwks());
+    when(openAEVConfig.getBaseUrl()).thenReturn(AUDIENCE);
+    when(userService.findByEmailIgnoreCase(EMAIL)).thenReturn(Optional.empty());
+
+    Optional<User> user = extractor.authUser(bundle.jwtToken(), request);
+
+    assertThat(user).isEmpty();
+    assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE)).isNull();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/security/token/XtmJwksExtractorTest.java
+++ b/openaev-api/src/test/java/io/openaev/security/token/XtmJwksExtractorTest.java
@@ -3,6 +3,7 @@ package io.openaev.security.token;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,9 +31,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
  * Unit coverage for the cross-platform service-identity marker: {@code authUser} must stamp {@link
  * XtmJwksExtractor#CROSS_PLATFORM_ATTRIBUTE} ONLY when the bearer fully validated as an XTM One
  * cross-platform JWT (trusted issuer, JWKS signature, expected audience) AND resolved a user -
- * never on a refused issuer, a wrong audience, or an unresolved user. {@code TxCtxArgumentResolver}
- * grants run-authoritative tenant scope on exactly this marker, so a stray stamp would be a
- * cross-tenant privilege grant.
+ * never on a refused issuer, a forged signature, a wrong audience, an expired token, or an
+ * unresolved user. {@code TxCtxArgumentResolver} grants run-authoritative tenant scope on exactly
+ * this marker, so a stray stamp would be a cross-tenant privilege grant.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("XtmJwksExtractor cross-platform service-identity marker")
@@ -109,6 +110,44 @@ class XtmJwksExtractorTest {
     assertThatThrownBy(() -> extractor.authUser(bundle.jwtToken(), request))
         .isInstanceOf(JwtException.class);
     assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE)).isNull();
+  }
+
+  @Test
+  @DisplayName("a forged token signed by a key outside the JWKS is refused and never stamps")
+  void forgedSignatureDoesNotStampMarker() throws Exception {
+    // The forged-token attack shape: the presented JWT claims the trusted issuer and reuses the
+    // fixture's kid, but is signed by the ATTACKER's key pair while the issuer's JWKS serves the
+    // legitimate key. Signature verification must refuse it before the user is even looked up, so
+    // the marker - and with it run-authoritative tenant scope - can never be minted from a
+    // signature the issuer does not vouch for.
+    JwtFixture.Bundle legitimate =
+        JwtFixture.generateXtmJwksJwtBundle(TRUSTED_ISSUER, EMAIL, AUDIENCE, false);
+    JwtFixture.Bundle forged =
+        JwtFixture.generateXtmJwksJwtBundle(TRUSTED_ISSUER, EMAIL, AUDIENCE, false);
+    stubJwks(legitimate.jwks());
+    when(openAEVConfig.getBaseUrl()).thenReturn(AUDIENCE);
+
+    assertThatThrownBy(() -> extractor.authUser(forged.jwtToken(), request))
+        .isInstanceOf(JwtException.class);
+    assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE)).isNull();
+    verifyNoInteractions(userService);
+  }
+
+  @Test
+  @DisplayName("an expired token is refused and never stamps the marker")
+  void expiredTokenDoesNotStampMarker() throws Exception {
+    // A replayed callback bearer past its lifetime: correctly signed by the trusted issuer, but
+    // expired. The parse must refuse it and the marker must stay absent, so an old captured JWT
+    // cannot be replayed into the service-identity privilege.
+    JwtFixture.Bundle bundle =
+        JwtFixture.generateXtmJwksJwtBundle(TRUSTED_ISSUER, EMAIL, AUDIENCE, true);
+    stubJwks(bundle.jwks());
+    when(openAEVConfig.getBaseUrl()).thenReturn(AUDIENCE);
+
+    assertThatThrownBy(() -> extractor.authUser(bundle.jwtToken(), request))
+        .isInstanceOf(JwtException.class);
+    assertThat(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE)).isNull();
+    verifyNoInteractions(userService);
   }
 
   @Test

--- a/openaev-model/src/main/java/io/openaev/annotation/AllowRawJdbc.java
+++ b/openaev-model/src/main/java/io/openaev/annotation/AllowRawJdbc.java
@@ -9,9 +9,12 @@ import java.lang.annotation.Target;
  * Marks a class as an audited, deliberate exception to the no-raw-JDBC rule (enforced by {@code
  * TenantNonOrmAccessArchTest}). Raw JDBC bypasses the tenant statement inspector, so it is
  * forbidden in production code by default; this annotation is the explicit, reviewable escape hatch
- * for the rare legitimate use (non-tenant tables, schema metadata). The {@code reason} must state
- * why bypassing the inspector is safe here, so the exception stays deliberate and reviewable rather
- * than hidden in a name list.
+ * for the rare legitimate use: non-tenant tables and schema metadata, plus the two narrow,
+ * test-enforced exceptions on tenant tables the activation runbook sanctions - a provably
+ * insert-only seed path (pinned by {@code AttackPathSeedServiceTest}) and the read-only
+ * scope-bootstrap lookup of a row's own {@code tenant_id} by primary key (pinned by {@code
+ * AutonomousRunTenantLocatorTest}). The {@code reason} must state why bypassing the inspector is
+ * safe here, so the exception stays deliberate and reviewable rather than hidden in a name list.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
## Summary

The orchestrator callback endpoints on `AutonomousRunApi` (events, status, directives/consume, attack-path steps append/update/evaluate/state, scope get/set, target-teams, promote-finding-to-asset) ride the legacy non-prefixed `/api/autonomous-runs/{runId}/...` path and are authenticated with a per-user cross-platform JWT that carries no tenant claim and no `X-Tenant-Ids` header.

After #7430 (#7396) activated multi-tenancy v2 on `autonomous_runs`, `autonomous_events` and `autonomous_directives`, the `TxCtx` on those handlers resolved the tenant scope from the CALLER's memberships. A callback whose caller scope does not pin the run's tenant then read nothing and died on the `require(runId)` lookup (404), so it could no longer record the run's events, author steps, or settle its status. This is the "Orchestrator callback service-identity hardening" #7430 explicitly descoped, tracked on #7396.

## Change

- Add a `@RunTenantScope` marker for a `TxCtx` controller parameter.
- `TxCtxArgumentResolver`, when it sees `@RunTenantScope` on the legacy non-prefixed route, derives the scope from the parent run's own immutable `tenant_id` - read scope-free by primary key in the new `@AllowRawJdbc` `AutonomousRunTenantLocator` - instead of the caller's selector / memberships. The sanctioned transaction aspect then scopes the whole callback to the run's tenant, and every write is stamped with it. An unknown run is fail-closed (`TxCtx.missing()` -> the service's own lookup returns 404). The bootstrap read also respects tenant liveness: it joins `tenants` on `tenant_deleted_at IS NULL`, so a run whose owning tenant is soft-deleted fails closed the same way - a grace-period tenant is excluded from every caller scope for its whole 30-day retention window, and the run-derived scope must not quietly re-admit it; reactivating the tenant within the grace period restores the callbacks with it.
- The derivation is GATED ON THE VERIFIED SERVICE IDENTITY (the previously-descoped orchestrator service-identity hardening is now IMPLEMENTED here): `XtmJwksExtractor` - the one authentication path that fully validates an XTM One cross-platform JWT (trusted issuer, JWKS signature, expected audience, resolved user) - stamps a server-side request attribute (`CROSS_PLATFORM_ATTRIBUTE`) after successful validation, and `TxCtxArgumentResolver` only derives from the run when that marker is present (`isCrossPlatformServiceCaller`). Any other authenticated caller falls back to the standard caller-authorized resolution on the same handlers, so knowing a run id can never give a normal Enterprise-Edition user cross-tenant reach. Request attributes are server-side only and cannot be supplied by a client.
- The derivation is also ROUTE-SCOPED: on the tenant-prefixed operator route (`/api/tenants/{tenantId}/autonomous-runs/...`, the one the UI rides) the same handlers keep the standard caller-authorized resolution, so the prefixed API keeps its "the URL names the tenant, rights are the boundary" contract and the annotation never opens a caller-independent door through the operator route.
- Annotate the eleven orchestrator callback handlers with `@RunTenantScope` and group them under the orchestrator-callbacks region. Operator-facing endpoints (create / list / get / timeline / start-pause-resume-cancel-restart / queue-directive / configuration) are untouched and stay tenant-isolated against the caller's scope.
- Pin the annotation placement with a reflection test (`AutonomousRunApiRunTenantScopeTest`): the exact set of eleven callbacks, every mapping carrying the `{runId}` path variable, the annotation only on `TxCtx` parameters - a twelfth TxCtx handler added later must be classified explicitly or the test fails.
- Pin the locator's raw-JDBC exemption the way the tenant-activation runbook demands (the insert-only seed precedent): the single sanctioned statement is a verbatim-pinned constant, `AutonomousRunTenantLocatorTest` scans every production module source root (api, model, framework) so only the locator may bypass the inspector on the `autonomous_*` tables and covers the fail-closed contract, and the runbook + `@AllowRawJdbc` javadoc now document the read-only scope-bootstrap exception next to the insert-only one.
- Refresh the stale `AutonomousRunAccessControl` / `AutonomousRunApi` docs (the old "single configured XTM One service token" claim was never true).

Only the aspect and the background primitive still set `app.current_tenants` (scope-channel tripwire unchanged); the new locator only reads a run's own `tenant_id` by primary key.

## Root cause / relationship to the production 403

The production symptom is an HTTP 403 on the callback retry after the 10-minute JWT re-mint. That 403 is a SEPARATE mechanism - a CSRF denial on the refreshed retry: XTM One's `AutoRefreshClient` reuses one HTTP client across the 401 and its retry, so the session cookie the 401 response emits rides the retry and defeats OpenAEV's bearer-without-cookies CSRF exemption (proven by `AppSecurityConfigTest.given_validBearerTokenAndNonAuthCookie_should_returnForbidden`). It is fixed by a companion XTM One change. This PR fixes the tenant-scope coupling #7430 introduced, which fails closed as a 404 (not a 403) and is the descoped #7396 hardening; together they make a long autonomous run able to author and settle itself again.

## Security posture

Run-authoritative scope is a SERVICE-IDENTITY privilege, not a property of the route: it is granted only to a request whose bearer `XtmJwksExtractor` fully validated as an XTM One cross-platform JWT. Every other authenticated caller - including any Enterprise-Edition user who knows or guesses a run id - keeps caller-authorized tenant resolution on the callback endpoints, so a foreign tenant's run stays invisible (404, nothing written). This implements the orchestrator service-identity hardening that #7430 had descoped (and closes the cross-tenant concern raised in review); validating the JWT subject against run ownership remains deliberately out of scope, since XTM One mints per-user JWTs whose owner can legitimately differ from the run operator. The callbacks otherwise stay behind authentication plus the EE license, with no resource-level gate for the verified service identity, because the run itself is its authority. Run ids are server-generated UUIDs, never accepted from input, never leaked cross-tenant through the operator reads (tenant-isolated and grant-gated), and the run's `tenant_id` is immutable (`updatable = false`, no raw-SQL writer).

## Test plan

- [x] `TxCtxArgumentResolverTest`: the derive-from-run cases now run as the verified cross-platform service caller; a `@RunTenantScope` callback WITHOUT the verified service identity falls back to caller-authorized resolution and never consults the run-tenant locator; fail-closed for an unknown run or an absent `{runId}` variable; on the tenant-prefixed route the annotation is inert even for the service identity (caller-authorized resolution, foreign tenant refused); existing selector cases unchanged.
- [x] `XtmJwksExtractorTest` (new): the cross-platform marker is stamped only by a fully validated token that resolves a user - never for an untrusted issuer, a forged signature (trusted issuer, key outside the served JWKS), a wrong audience, an expired token, or an unresolved user; the refused paths never even look the user up.
- [x] `AutonomousRunApiRunTenantScopeTest` (new): pins the eleven annotated callbacks, the `{runId}` mapping on each, and the exact caller-scoped operator set.
- [x] `AutonomousRunTenantLocatorTest` (new): pins the raw-JDBC exemption to the single verbatim SELECT-by-primary-key statement and the locator as the only bypass on the `autonomous_*` tables - the scan walks every production module source root (api, model, framework), since `openaev-model` hosts `@AllowRawJdbc` classes of its own; the literal scan counts both Java literal forms (one-line and text block) as well as CTE- or whitespace-led statements and non-DML command heads (CALL, DO, COPY, DDL, ...), folds +-concatenated literal chains the way javac constant-folds them, refuses unicode escapes, and is itself pinned by a synthetic-source test; the bypass inventory recognizes both annotation spellings the language admits (imported simple name and fully qualified); a call-site pin enforces the exactly-one-statement claim at the execution layer (exactly one JdbcTemplate invocation, it must be query, its statement must be the SELECT_RUN_TENANT constant by name, no other JDBC surface in comment-stripped code); pins the liveness predicate on the statement by name (JOIN tenants / tenant_deleted_at IS NULL); covers unknown-run / blank-tenant / blank-id fail-closed behavior.
- [x] `AutonomousRunHttpIsolationTest`: the service-identity callbacks run under the validated cross-platform marker - a verified service caller whose scope excludes the run's tenant still records an event / drives status / consumes directives on the plain route, each stamped with the parent run's tenant at the raw `tenant_id` column; NEW IDOR-closed proof: a normal authenticated EE user without the marker, targeting a run in a tenant it is not a member of, gets a 404 and writes nothing; the tenant-prefixed route stays caller-scoped (foreign path 404s and writes nothing, owner path keeps operator parity); operator reads / writes remain cross-tenant isolated (unchanged); NEW soft-deleted-tenant proof: a verified service callback on a run whose tenant was just soft-deleted gets a 404 and writes nothing, then works again once the tenant is reactivated within the grace period. Docker-backed (25 tests; the first 24 passed locally in earlier passes, the soft-delete case is CI-validated).
- [x] Tenant arch / tripwire suites (`TenantNonOrmAccessArchTest`, `ScopeChannelSourceTripwireTest`, `TenantActiveTableAccessArchTest`) pass locally.
- [x] `mvn spotless:apply`, compile, and the runnable tests above pass locally (JDK 21).
- [x] Branch rebased onto latest `main` (clean, no conflicts) and force-with-lease pushed; all commits signed.

Fixes #7450. Refs #7430, #7396.

