### PR TITLE
fix(autonomous): collapse duplicate captions in the cockpit thinking window (#7452)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/autonomous/AutonomousThinkingBubble.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/autonomous/AutonomousThinkingBubble.test.tsx
@@ -1,0 +1,153 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ThinkingPhase, type ThinkingStep } from '../../../../admin/components/autonomous/autonomousEventVisuals';
+import ThinkingBubble from '../../../../admin/components/autonomous/AutonomousThinkingBubble';
+
+// The thinking window renders the orchestrator's live reasoning off `theme` PROPS (not context), but
+// MUI components under it still resolve styling from context - so wrap AND pass the same theme.
+const theme = createTheme();
+
+const renderBubble = (
+  phase: ThinkingPhase,
+  steps: ThinkingStep[],
+  activitySince?: string | number | null,
+): void => {
+  render(
+    <ThemeProvider theme={theme}>
+      <ThinkingBubble phase={phase} theme={theme} steps={steps} activitySince={activitySince} />
+    </ThemeProvider>,
+  );
+};
+
+const workingPhase = (label: string, key = 'engaging'): ThinkingPhase => ({
+  key,
+  label,
+  color: '#00bcd4',
+  active: true,
+});
+
+// Middot / multiplication sign the renderer uses inline (kept as escapes so the test source stays
+// ASCII and matches the component's `\u00b7` / `\u00d7` output exactly).
+const REPEAT = (n: number) => `\u00d7${n}`;
+
+describe('ThinkingBubble', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('collapses a same-caption burst to ONE line that advances a monotonic timer (never a frozen wall)', () => {
+    const base = Date.now();
+    // A 12-iteration same-caption burst arrives pre-collapsed as a single live step that started 5s ago.
+    const steps: ThinkingStep[] = [
+      {
+        text: 'Searching arsenal for contracts',
+        count: 12,
+        since: base - 5000,
+      },
+    ];
+    renderBubble(workingPhase('Searching arsenal for contracts'), steps, base);
+
+    // Exactly one rendered line despite 12 collapsed events - not a wall of identical glowing lines.
+    expect(screen.getAllByTestId('autonomous-thinking-step')).toHaveLength(1);
+    const line = () => screen.getByTestId('autonomous-thinking-step');
+    expect(line().textContent).toContain('Searching arsenal for contracts');
+    // The repeat count and the per-caption elapsed clock are both shown (visible motion sources).
+    expect(line().textContent).toContain(REPEAT(12));
+    expect(line().textContent).toContain('5s');
+
+    // Advancing the clock ticks the timer UP monotonically, in place - still one line, no reset.
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(screen.getAllByTestId('autonomous-thinking-step')).toHaveLength(1);
+    expect(line().textContent).toContain('9s');
+    expect(line().textContent).not.toContain('5s');
+
+    act(() => {
+      vi.advanceTimersByTime(60000);
+    });
+    // Crosses the minute boundary and keeps climbing (69s -> "1m 09s"): strictly monotonic.
+    expect(line().textContent).toContain('1m 09s');
+  });
+
+  it('anchors the bold label to the caption the panel passes in (label follows the live caption)', () => {
+    const base = Date.now();
+    renderBubble(
+      workingPhase('Searching arsenal for contracts'),
+      [{
+        text: 'Searching arsenal for contracts',
+        count: 1,
+        since: base,
+      }],
+      base,
+    );
+    // The header renders the caption as the bold phase label - not a generic "Analyzing the results".
+    expect(screen.getAllByText('Searching arsenal for contracts').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Analyzing the results')).toBeNull();
+  });
+
+  it('starts a fresh live line on a caption change; only the live (last) line carries the timer', () => {
+    const base = Date.now();
+    const steps: ThinkingStep[] = [
+      {
+        text: 'Searching arsenal for contracts',
+        count: 4,
+        since: base - 20000,
+      },
+      {
+        text: 'Authoring the attack path',
+        count: 1,
+        since: base - 3000,
+      },
+    ];
+    renderBubble(workingPhase('Authoring the attack path'), steps, base);
+
+    const lines = screen.getAllByTestId('autonomous-thinking-step');
+    expect(lines).toHaveLength(2);
+    // The finalized (older) step keeps its repeat count but shows NO ticking timer.
+    expect(lines[0].textContent).toContain('Searching arsenal for contracts');
+    expect(lines[0].textContent).toContain(REPEAT(4));
+    expect(lines[0].textContent).not.toMatch(/\d+s/);
+    // The live (last) step shows the per-caption timer and no count (count === 1).
+    expect(lines[1].textContent).toContain('Authoring the attack path');
+    expect(lines[1].textContent).toContain('3s');
+    expect(lines[1].textContent).not.toContain(REPEAT(1));
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    const advanced = screen.getAllByTestId('autonomous-thinking-step');
+    // Only the live line's clock moves; the finalized line stays static.
+    expect(advanced[1].textContent).toContain('5s');
+    expect(advanced[0].textContent).not.toMatch(/\d+s/);
+  });
+
+  it('shows no thought echo when the phase is idle/parked (calm wait, not a working stream)', () => {
+    const base = Date.now();
+    renderBubble(
+      {
+        key: 'parked',
+        label: 'Awaiting the next event',
+        color: '#888888',
+        active: false,
+      },
+      [{
+        text: 'Searching arsenal for contracts',
+        count: 3,
+        since: base - 5000,
+      }],
+      base,
+    );
+    // An idle phase renders the calm caption but streams no step lines and no ticking timer.
+    expect(screen.queryAllByTestId('autonomous-thinking-step')).toHaveLength(0);
+    expect(screen.getByText('Awaiting the next event')).toBeDefined();
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/autonomous/AutonomousThinkingBubble.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/autonomous/AutonomousThinkingBubble.test.tsx
@@ -13,10 +13,17 @@ const renderBubble = (
   phase: ThinkingPhase,
   steps: ThinkingStep[],
   activitySince?: string | number | null,
+  lastStepLive = true,
 ): void => {
   render(
     <ThemeProvider theme={theme}>
-      <ThinkingBubble phase={phase} theme={theme} steps={steps} activitySince={activitySince} />
+      <ThinkingBubble
+        phase={phase}
+        theme={theme}
+        steps={steps}
+        activitySince={activitySince}
+        lastStepLive={lastStepLive}
+      />
     </ThemeProvider>,
   );
 };
@@ -51,6 +58,7 @@ describe('ThinkingBubble', () => {
         text: 'Searching arsenal for contracts',
         count: 12,
         since: base - 5000,
+        sequence: 12,
       },
     ];
     renderBubble(workingPhase('Searching arsenal for contracts'), steps, base);
@@ -86,6 +94,7 @@ describe('ThinkingBubble', () => {
         text: 'Searching arsenal for contracts',
         count: 1,
         since: base,
+        sequence: 1,
       }],
       base,
     );
@@ -101,11 +110,13 @@ describe('ThinkingBubble', () => {
         text: 'Searching arsenal for contracts',
         count: 4,
         since: base - 20000,
+        sequence: 4,
       },
       {
         text: 'Authoring the attack path',
         count: 1,
         since: base - 3000,
+        sequence: 5,
       },
     ];
     renderBubble(workingPhase('Authoring the attack path'), steps, base);
@@ -143,11 +154,41 @@ describe('ThinkingBubble', () => {
         text: 'Searching arsenal for contracts',
         count: 3,
         since: base - 5000,
+        sequence: 3,
       }],
       base,
     );
     // An idle phase renders the calm caption but streams no step lines and no ticking timer.
     expect(screen.queryAllByTestId('autonomous-thinking-step')).toHaveLength(0);
     expect(screen.getByText('Awaiting the next event')).toBeDefined();
+  });
+
+  it('demotes the last step to dimmed history (no timer, no motion) when it is not live (resume boundary)', () => {
+    // The resume regression: the panel passes lastStepLive=false when a newer non-pulse boundary (a
+    // fresh "engaged" STATUS on the retained timeline) has superseded the last thinking step. Even
+    // though the phase is active, the stale step must NOT tick a per-caption timer that would span
+    // the paused interval - it renders as calm history with only its repeat count.
+    const base = Date.now();
+    const steps: ThinkingStep[] = [
+      {
+        text: 'Searching arsenal for contracts',
+        count: 6,
+        since: base - 600000,
+        sequence: 6,
+      },
+    ];
+    renderBubble(workingPhase('Getting to work'), steps, base, false);
+
+    const line = screen.getByTestId('autonomous-thinking-step');
+    expect(line.textContent).toContain('Searching arsenal for contracts');
+    // Repeat count is still shown (it is real history), but NO per-caption timer (would be "10m 00s").
+    expect(line.textContent).toContain(REPEAT(6));
+    expect(line.textContent).not.toMatch(/\d+m\s|\d+s/);
+
+    // Ticking the clock must not start a timer on the stale line - it stays frozen history.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByTestId('autonomous-thinking-step').textContent).not.toMatch(/\d+m\s|\d+s/);
   });
 });

--- a/openaev-front/src/__tests__/admin/components/autonomous/autonomousEventVisuals.test.ts
+++ b/openaev-front/src/__tests__/admin/components/autonomous/autonomousEventVisuals.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { type AutonomousEvent, type AutonomousEventType } from '../../../../actions/autonomous/autonomous-types';
-import { isHeartbeatEvent, isLiveActivityEvent } from '../../../../admin/components/autonomous/autonomousEventVisuals';
+import {
+  collapseThinkingSteps,
+  isHeartbeatEvent,
+  isLiveActivityEvent,
+  resolveLiveLabel,
+} from '../../../../admin/components/autonomous/autonomousEventVisuals';
 
 // Minimal AutonomousEvent factory: the classification predicates only read `type` + `data`, but the
 // interface requires id/run_id/sequence, so default those to keep the fixtures readable.
@@ -15,6 +20,21 @@ const makeEvent = (
   autonomous_event_sequence: sequence,
   autonomous_event_type: type,
   autonomous_event_data: data ?? null,
+});
+
+// Richer factory for the thinking-window collapse tests: those read the event content + created_at
+// (the caption text and its timestamp), which the predicate factory above does not set.
+const makeStreamEvent = (
+  type: AutonomousEventType,
+  content: string,
+  createdAt?: string,
+): AutonomousEvent => ({
+  autonomous_event_id: `evt-${(sequence += 1)}`,
+  autonomous_event_run_id: 'run-1',
+  autonomous_event_sequence: sequence,
+  autonomous_event_type: type,
+  autonomous_event_content: content,
+  autonomous_event_created_at: createdAt,
 });
 
 describe('isLiveActivityEvent', () => {
@@ -95,5 +115,143 @@ describe('isHeartbeatEvent and isLiveActivityEvent are mutually exclusive', () =
     expect(isHeartbeatEvent(liveNarration)).toBe(false);
     expect(isHeartbeatEvent(heartbeat)).toBe(true);
     expect(isLiveActivityEvent(heartbeat)).toBe(false);
+  });
+});
+
+describe('collapseThinkingSteps', () => {
+  it('collapses a consecutive same-caption burst into ONE step (no wall of identical lines)', () => {
+    // The confirmed bug: a same-caption burst (e.g. the arsenal build) rendered N identical glowing
+    // lines. Collapse must fold them into a single step carrying the repeat count.
+    const burst = Array.from({ length: 12 }, () => makeStreamEvent('NARRATION', 'Searching arsenal for contracts'));
+    const steps = collapseThinkingSteps(burst);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].text).toBe('Searching arsenal for contracts');
+    expect(steps[0].count).toBe(12);
+  });
+
+  it('keeps the FIRST timestamp of the run as `since` so the per-caption clock never resets mid-burst', () => {
+    const steps = collapseThinkingSteps([
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts', '2026-01-01T00:00:00.000Z'),
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts', '2026-01-01T00:00:05.000Z'),
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts', '2026-01-01T00:00:10.000Z'),
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].count).toBe(3);
+    // First event's timestamp - NOT the latest - so `now - since` measures the whole burst monotonically.
+    expect(steps[0].since).toBe(new Date('2026-01-01T00:00:00.000Z').getTime());
+  });
+
+  it('starts a fresh step when the caption changes, and the last step is the live one', () => {
+    const steps = collapseThinkingSteps([
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts'),
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts'),
+      makeStreamEvent('DECISION', 'Authoring the attack path'),
+    ]);
+    expect(steps.map(s => s.text)).toEqual([
+      'Searching arsenal for contracts',
+      'Authoring the attack path',
+    ]);
+    expect(steps[0].count).toBe(2);
+    expect(steps[1].count).toBe(1);
+    // The last step is the live one (the caption the orchestrator is narrating right now).
+    expect(steps[steps.length - 1].text).toBe('Authoring the attack path');
+  });
+
+  it('treats a caption that recurs after a different one as a NEW step (only adjacent dupes merge)', () => {
+    const steps = collapseThinkingSteps([
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts'),
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts'),
+      makeStreamEvent('NARRATION', 'Resolving contract capabilities'),
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts'),
+    ]);
+    expect(steps.map(s => ({
+      text: s.text,
+      count: s.count,
+    }))).toEqual([
+      {
+        text: 'Searching arsenal for contracts',
+        count: 2,
+      },
+      {
+        text: 'Resolving contract capabilities',
+        count: 1,
+      },
+      {
+        text: 'Searching arsenal for contracts',
+        count: 1,
+      },
+    ]);
+  });
+
+  it('dedupes on the RENDERED caption so markdown-only differences still collapse', () => {
+    // stripMarkdown('**Searching arsenal for contracts**') === 'Searching arsenal for contracts'.
+    const steps = collapseThinkingSteps([
+      makeStreamEvent('NARRATION', '**Searching arsenal for contracts**'),
+      makeStreamEvent('NARRATION', 'Searching arsenal for contracts'),
+    ]);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].count).toBe(2);
+  });
+
+  it('ignores non-stream event types and empty captions', () => {
+    const steps = collapseThinkingSteps([
+      makeStreamEvent('STATUS', 'Run engaged'),
+      makeStreamEvent('QUESTION', 'Which subnet is in scope?'),
+      makeStreamEvent('NARRATION', '   '),
+      makeStreamEvent('TOOL_ACTION', 'Launching the payload'),
+    ]);
+    expect(steps.map(s => s.text)).toEqual(['Launching the payload']);
+  });
+
+  it('falls back to the title when there is no content', () => {
+    const titleOnly: AutonomousEvent = {
+      autonomous_event_id: `evt-${(sequence += 1)}`,
+      autonomous_event_run_id: 'run-1',
+      autonomous_event_sequence: sequence,
+      autonomous_event_type: 'DECISION',
+      autonomous_event_title: 'Deciding the next move',
+    };
+    const steps = collapseThinkingSteps([titleOnly]);
+    expect(steps).toEqual([{
+      text: 'Deciding the next move',
+      count: 1,
+      since: null,
+    }]);
+  });
+
+  it('keeps at most `limit` steps, always retaining the live (last) one', () => {
+    const events = Array.from({ length: 10 }, (_, i) => makeStreamEvent('NARRATION', `caption ${i}`));
+    const steps = collapseThinkingSteps(events, 8);
+    expect(steps).toHaveLength(8);
+    // Oldest distinct captions drop off the top; the newest is retained as the live step.
+    expect(steps[0].text).toBe('caption 2');
+    expect(steps[steps.length - 1].text).toBe('caption 9');
+  });
+});
+
+describe('resolveLiveLabel', () => {
+  it('shows the live caption for a generic working phase (label follows the live stream)', () => {
+    expect(resolveLiveLabel('engaging', true, 'Getting to work', 'Searching arsenal for contracts'))
+      .toBe('Searching arsenal for contracts');
+    expect(resolveLiveLabel('analyzing', true, 'Analyzing the results', 'Correlating the findings'))
+      .toBe('Correlating the findings');
+    expect(resolveLiveLabel('thinking', true, 'Thinking through the next move', 'Mapping the perimeter'))
+      .toBe('Mapping the perimeter');
+  });
+
+  it('keeps the specific label for a meaningful phase even when a live caption exists', () => {
+    expect(resolveLiveLabel('deciding', true, 'Deciding the next move', 'Searching arsenal for contracts'))
+      .toBe('Deciding the next move');
+    expect(resolveLiveLabel('delegating-working', true, 'Consulting the payload specialist', 'noise'))
+      .toBe('Consulting the payload specialist');
+    expect(resolveLiveLabel('waiting_input', false, 'Waiting for your input', 'noise'))
+      .toBe('Waiting for your input');
+  });
+
+  it('keeps the fallback label when inactive or when there is no live caption', () => {
+    expect(resolveLiveLabel('engaging', false, 'Getting to work', 'Searching arsenal for contracts'))
+      .toBe('Getting to work');
+    expect(resolveLiveLabel('engaging', true, 'Getting to work', null)).toBe('Getting to work');
+    expect(resolveLiveLabel('engaging', true, 'Getting to work', '')).toBe('Getting to work');
   });
 });

--- a/openaev-front/src/__tests__/admin/components/autonomous/autonomousEventVisuals.test.ts
+++ b/openaev-front/src/__tests__/admin/components/autonomous/autonomousEventVisuals.test.ts
@@ -5,7 +5,9 @@ import {
   collapseThinkingSteps,
   isHeartbeatEvent,
   isLiveActivityEvent,
+  resolveLiveCaption,
   resolveLiveLabel,
+  type ThinkingStep,
 } from '../../../../admin/components/autonomous/autonomousEventVisuals';
 
 // Minimal AutonomousEvent factory: the classification predicates only read `type` + `data`, but the
@@ -216,7 +218,21 @@ describe('collapseThinkingSteps', () => {
       text: 'Deciding the next move',
       count: 1,
       since: null,
+      sequence: titleOnly.autonomous_event_sequence,
     }]);
+  });
+
+  it('advances `sequence` to the NEWEST folded event so staleness is measured from the latest occurrence', () => {
+    // The per-step `sequence` drives resolveLiveCaption: it must track the LAST folded event, not
+    // the first, so a caption that is still recurring stays newer than an older cycle boundary.
+    const first = makeStreamEvent('NARRATION', 'Searching arsenal for contracts');
+    const second = makeStreamEvent('NARRATION', 'Searching arsenal for contracts');
+    const third = makeStreamEvent('NARRATION', 'Searching arsenal for contracts');
+    const steps = collapseThinkingSteps([first, second, third]);
+    expect(steps).toHaveLength(1);
+    // Newest folded event's sequence (not the first), while `since` stays anchored to the first.
+    expect(steps[0].sequence).toBe(third.autonomous_event_sequence);
+    expect(steps[0].since).toBe(null);
   });
 
   it('keeps at most `limit` steps, always retaining the live (last) one', () => {
@@ -253,5 +269,44 @@ describe('resolveLiveLabel', () => {
       .toBe('Getting to work');
     expect(resolveLiveLabel('engaging', true, 'Getting to work', null)).toBe('Getting to work');
     expect(resolveLiveLabel('engaging', true, 'Getting to work', '')).toBe('Getting to work');
+  });
+});
+
+describe('resolveLiveCaption', () => {
+  const step = (text: string, sequence: number): ThinkingStep => ({
+    text,
+    count: 1,
+    since: null,
+    sequence,
+  });
+
+  it('returns the last step caption while it is at least as new as the newest non-pulse event', () => {
+    const steps = [step('Searching arsenal for contracts', 10), step('Authoring the attack path', 14)];
+    // The live step (seq 14) is the newest non-pulse event (14): current -> live caption.
+    expect(resolveLiveCaption(steps, 14)).toBe('Authoring the attack path');
+    // A fresh live pulse (step seq 15) newer than the newest non-pulse boundary (14) is still live.
+    expect(resolveLiveCaption([step('Mapping the perimeter', 15)], 14)).toBe('Mapping the perimeter');
+  });
+
+  it('returns null when a newer non-pulse boundary has superseded the last step (resume regression guard)', () => {
+    // The exact resume case: the last thinking step is pre-pause (seq 13); on resume the backend
+    // appends a fresh "engaged" STATUS (a non-pulse event, seq 14) that never becomes a step. The
+    // last step is now stale history, so it must NOT be exposed as the live caption - otherwise the
+    // bold label would resurrect the pre-pause caption and the per-caption timer would span the
+    // paused interval, regressing the resume-safe behavior #7449 established.
+    const steps = [step('Searching arsenal for contracts', 13)];
+    expect(resolveLiveCaption(steps, 14)).toBeNull();
+  });
+
+  it('treats the last step as live when there is no non-pulse boundary at all', () => {
+    // All-pulse stream (only live-activity narrations / heartbeats): nothing can supersede the step.
+    const steps = [step('Searching arsenal for contracts', 5)];
+    expect(resolveLiveCaption(steps, null)).toBe('Searching arsenal for contracts');
+    expect(resolveLiveCaption(steps, undefined)).toBe('Searching arsenal for contracts');
+  });
+
+  it('returns null when there are no steps', () => {
+    expect(resolveLiveCaption([], 10)).toBeNull();
+    expect(resolveLiveCaption([], null)).toBeNull();
   });
 });

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -7,7 +7,6 @@ import {
   WarningAmber,
 } from '@mui/icons-material';
 import { Box, Chip, CircularProgress, FormControlLabel, IconButton, Radio, RadioGroup, Stack, TextField, Typography } from '@mui/material';
-import type { Theme } from '@mui/material/styles';
 import { alpha, useTheme } from '@mui/material/styles';
 import { type FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -25,7 +24,19 @@ import { useFormatter } from '../../../components/i18n';
 import { computeBannerSettings } from '../../../public/components/systembanners/utils';
 import useAuth from '../../../utils/hooks/useAuth';
 import { useChatbot, useChatbotContentMargin } from '../ariane/useChatbotHooks';
-import { eventAccent, eventIcon, EventMarkdown, eventTypeLabel, isHeartbeatEvent, isLiveActivityEvent, sanitizeEventText, stripMarkdown } from './autonomousEventVisuals';
+import {
+  collapseThinkingSteps,
+  eventAccent,
+  eventIcon,
+  EventMarkdown,
+  eventTypeLabel,
+  isHeartbeatEvent,
+  isLiveActivityEvent,
+  resolveLiveLabel,
+  sanitizeEventText,
+  type ThinkingPhase,
+} from './autonomousEventVisuals';
+import ThinkingBubble from './AutonomousThinkingBubble';
 import { AUTONOMOUS_PANEL_WIDTH } from './useAutonomousPanelWidth';
 
 // An "active" run is one the orchestrator is currently driving, so the panel keeps polling the
@@ -117,211 +128,6 @@ const parseQuestionChoices = (data?: string | null): QuestionChoice[] => {
   } catch {
     return [];
   }
-};
-
-interface ThinkingPhase {
-  key: string;
-  label: string;
-  color: string;
-  // Whether the orchestrator is actively working (mid-cycle) vs. idle/parked (awaiting a
-  // human-timescale event or the operator's answer). Only an ACTIVE phase pulses and streams the
-  // live thought echo; an idle phase settles into a calm, static waiting indicator so a parked run
-  // does not look like it is still computing.
-  active: boolean;
-}
-
-// Tail-of-stream status window. While the orchestrator is actively working (active phase) it shows
-// three pulsing dots plus its most recent reasoning line, faintly shimmering, so the panel feels
-// alive between activity events (mirrors the XTM One scrolling thinking window). When the run is
-// idle - parked on a status awaiting a human-timescale event, or waiting on the operator - it
-// settles into a STATIC hourglass + calm caption with no pulsing and no thought echo, so a parked
-// run stops looking like it is still thinking. The label + colour reflect the CURRENT phase and
-// animate on every phase change.
-// Turn a millisecond gap into a compact "still working" clock: "12s", "1m 20s". Kept short so it
-// sits inline next to the phase caption without wrapping.
-const formatElapsed = (ms: number): string => {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-  if (totalSeconds < 60) return `${totalSeconds}s`;
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
-};
-
-const ThinkingBubble: FunctionComponent<{
-  phase: ThinkingPhase;
-  theme: Theme;
-  lines: string[];
-  /** Timestamp of the most recent activity, so the window can tick a live "working for Ns" clock.
-   *  This is what turns a silent stretch (e.g. the orchestrator grinding through tool retries with
-   *  no new narration) from a frozen caption into a visibly advancing counter. */
-  activitySince?: string | number | null;
-}> = ({
-  phase,
-  theme,
-  lines,
-  activitySince,
-}) => {
-  const accent = phase.color;
-  const active = phase.active;
-  // Tick a 1s clock ONLY while actively working, so the elapsed counter advances live and the
-  // interval is torn down the moment the run parks/waits.
-  const [now, setNow] = useState<number>(() => Date.now());
-  useEffect(() => {
-    if (!active) return undefined;
-    setNow(Date.now());
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(id);
-  }, [active, phase.key]);
-  const sinceMs = activitySince != null ? new Date(activitySince).getTime() : Number.NaN;
-  const elapsedLabel = active && Number.isFinite(sinceMs) ? formatElapsed(now - sinceMs) : null;
-  // A parked/waiting phase never streams the live thought echo (there is no live thought - the run
-  // is idle), and its dots do not pulse.
-  const showLatest = active && lines.length > 0;
-  // Keep the window pinned to the bottom as the reasoning grows, so it visibly "defiles" like the
-  // XTM One thinking window: each new thought line is appended at the bottom and older lines scroll
-  // up out of view under the fade mask, instead of a single static block that never moves.
-  const textRef = useRef<HTMLDivElement | null>(null);
-  const streamText = lines.join('\n');
-  useEffect(() => {
-    const node = textRef.current;
-    if (node) {
-      node.scrollTop = node.scrollHeight;
-    }
-  }, [streamText]);
-
-  return (
-    <Box
-      sx={{
-        'marginTop': 0.5,
-        'paddingLeft': 2,
-        'position': 'relative',
-        '@keyframes aevThinkingShimmer': {
-          '0%': { opacity: 0.35 },
-          '50%': { opacity: 0.9 },
-          '100%': { opacity: 0.35 },
-        },
-        '@keyframes aevThinkingDot': {
-          '0%, 80%, 100%': {
-            transform: 'scale(0.6)',
-            opacity: 0.3,
-          },
-          '40%': {
-            transform: 'scale(1)',
-            opacity: 1,
-          },
-        },
-        '@keyframes aevPhaseIn': {
-          '0%': {
-            opacity: 0,
-            transform: 'translateY(4px)',
-          },
-          '100%': {
-            opacity: 1,
-            transform: 'translateY(0)',
-          },
-        },
-      }}
-    >
-      <Stack sx={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 0.75,
-      }}
-      >
-        {active ? (
-          <Stack sx={{
-            flexDirection: 'row',
-            gap: 0.4,
-            alignItems: 'center',
-          }}
-          >
-            {[0, 1, 2].map(i => (
-              <Box
-                key={i}
-                sx={{
-                  width: 6,
-                  height: 6,
-                  borderRadius: '50%',
-                  backgroundColor: accent,
-                  transition: theme.transitions.create('background-color'),
-                  animation: 'aevThinkingDot 1.4s infinite ease-in-out both',
-                  animationDelay: `${i * 0.16}s`,
-                }}
-              />
-            ))}
-          </Stack>
-        ) : (
-          // Idle/parked: a still hourglass, not pulsing dots, so the run reads as waiting - not working.
-          <HourglassEmpty sx={{
-            fontSize: 16,
-            color: accent,
-          }}
-          />
-        )}
-        {/* Key on the phase so a new phase remounts and replays the fade/slide-in transition. */}
-        <Typography
-          key={phase.key}
-          variant="caption"
-          sx={{
-            color: accent,
-            fontWeight: 600,
-            letterSpacing: '0.02em',
-            transition: theme.transitions.create('color'),
-            animation: 'aevPhaseIn 0.35s ease',
-          }}
-        >
-          {phase.label}
-        </Typography>
-        {elapsedLabel && (
-          <Typography
-            variant="caption"
-            sx={{
-              color: alpha(theme.palette.text.secondary, 0.7),
-              fontVariantNumeric: 'tabular-nums',
-            }}
-          >
-            {`· ${elapsedLabel}`}
-          </Typography>
-        )}
-      </Stack>
-      {showLatest && (
-        <Box
-          ref={textRef}
-          sx={{
-            'maxHeight': 132,
-            'overflowY': 'auto',
-            'marginTop': 0.75,
-            // Fade the top edge so older lines appear to scroll up out of view; no visible scrollbar.
-            'maskImage': 'linear-gradient(to bottom, transparent 0, black 28px)',
-            'WebkitMaskImage': 'linear-gradient(to bottom, transparent 0, black 28px)',
-            'scrollbarWidth': 'none',
-            '&::-webkit-scrollbar': { display: 'none' },
-          }}
-        >
-          {lines.map((line, index) => {
-            const isLast = index === lines.length - 1;
-            return (
-              <Typography
-                key={`${index}-${line.slice(0, 24)}`}
-                variant="caption"
-                sx={{
-                  display: 'block',
-                  fontStyle: 'italic',
-                  lineHeight: 1.5,
-                  color: alpha(theme.palette.text.secondary, isLast ? 0.95 : 0.5),
-                  whiteSpace: 'pre-wrap',
-                  // Only the newest line shimmers - the "live" thought; older lines settle, dimmed.
-                  animation: isLast ? 'aevThinkingShimmer 2.4s ease-in-out infinite' : undefined,
-                }}
-              >
-                {line}
-              </Typography>
-            );
-          })}
-        </Box>
-      )}
-    </Box>
-  );
 };
 
 interface AutonomousReasoningPanelProps {
@@ -665,19 +471,18 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // (not a single frozen line): keep the tail of narration/decision/tool prose in chronological
   // order so each new cycle appends a line at the bottom and older ones scroll up under the fade
   // mask, mirroring the XTM One thinking window. Operators read its train of thought, not a spinner.
-  // Memoised: the map runs the regex-heavy stripMarkdown over the tail of the stream, so it should
-  // recompute once per new batch of events - not on every keystroke in the composer (which re-renders
-  // this component through the `directive` state).
-  const thinkingLines = useMemo(
-    () => events
-      .filter(e => (['NARRATION', 'DECISION', 'TOOL_ACTION'] as const).includes(
-        e.autonomous_event_type as 'NARRATION' | 'DECISION' | 'TOOL_ACTION',
-      ))
-      .map(e => stripMarkdown(sanitizeEventText(e.autonomous_event_content ?? e.autonomous_event_title)))
-      .filter((line): line is string => Boolean(line))
-      .slice(-8),
-    [events],
-  );
+  //
+  // Consecutive identical captions are COLLAPSED into a single step (see collapseThinkingSteps): a
+  // multi-minute same-caption burst (e.g. the arsenal build where every iteration narrates
+  // "Searching arsenal for contracts") would otherwise render as a wall of identical glowing lines
+  // that stops visibly moving - indistinguishable from a frozen cockpit. The collapsed live step
+  // keeps advancing via a per-caption ticking clock + repeat count instead. Memoised: the regex-heavy
+  // stripMarkdown runs over the tail of the stream, so it should recompute once per new batch of
+  // events - not on every keystroke in the composer (which re-renders this component via `directive`).
+  const thinkingSteps = useMemo(() => collapseThinkingSteps(events), [events]);
+  // The caption the orchestrator is narrating RIGHT NOW - the last (live) collapsed step. Drives the
+  // bold-label anchoring below so a generic phase label yields to what is actually happening live.
+  const liveCaption = thinkingSteps.length > 0 ? thinkingSteps[thinkingSteps.length - 1].text : null;
 
   // Current orchestrator phase for the thinking window. Derived from status + the latest activity
   // event rather than the raw run status, so the caption narrates what the run is doing and animates
@@ -947,6 +752,16 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
         };
     }
   })();
+  // Anchor the bold label to the CURRENT live caption during a generic working phase, so it tracks
+  // what the orchestrator is narrating right now (e.g. "Searching arsenal for contracts") instead of
+  // freezing on a generic placeholder ("Getting to work" / "Analyzing the results" / "Thinking
+  // through the next move") for the whole live stream. Specific, meaningful phases (Consulting
+  // <agent>, Deciding the next move, Capturing proof, parked/waiting...) keep their own label. This
+  // runs BEFORE the staleness backstop below, which still gets the final say when the stream stalls.
+  thinkingPhase = {
+    ...thinkingPhase,
+    label: resolveLiveLabel(thinkingPhase.key, thinkingPhase.active, thinkingPhase.label, liveCaption),
+  };
   // How long the cockpit has been silent, in whole ELAPSED minutes, for the truthful stall
   // caption/notice. Floor (not round): a rounded value can overstate the silence (e.g. 3.6 min ->
   // 4), and the caption must never claim more elapsed time than has actually passed.
@@ -1216,7 +1031,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                   <ThinkingBubble
                     phase={thinkingPhase}
                     theme={theme}
-                    lines={thinkingLines}
+                    steps={thinkingSteps}
                     activitySince={activitySince}
                   />
                 )}

--- a/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousReasoningPanel.tsx
@@ -32,6 +32,7 @@ import {
   eventTypeLabel,
   isHeartbeatEvent,
   isLiveActivityEvent,
+  resolveLiveCaption,
   resolveLiveLabel,
   sanitizeEventText,
   type ThinkingPhase,
@@ -327,7 +328,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // The operator-facing decision feed excludes heartbeats (freshness pings, not decisions) AND
   // live-activity NARRATIONs (the per-iteration "what it is doing right now" lines the worker
   // streams). Both keep the cockpit alive without being decisions: heartbeats drive the freshness
-  // clock, live-activity lines flow into `thinkingLines` below (the scrolling thinking window) - so
+  // clock, live-activity lines flow into `thinkingSteps` below (the scrolling thinking window) - so
   // neither should ever appear as a row in the operator decision feed, or a long silent burst would
   // fill the timeline with "Working"/activity noise. The freshness/caption logic below still keys
   // off the raw `events` (including both) so the cockpit stays animated. Memoised: the predicates
@@ -480,9 +481,6 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // stripMarkdown runs over the tail of the stream, so it should recompute once per new batch of
   // events - not on every keystroke in the composer (which re-renders this component via `directive`).
   const thinkingSteps = useMemo(() => collapseThinkingSteps(events), [events]);
-  // The caption the orchestrator is narrating RIGHT NOW - the last (live) collapsed step. Drives the
-  // bold-label anchoring below so a generic phase label yields to what is actually happening live.
-  const liveCaption = thinkingSteps.length > 0 ? thinkingSteps[thinkingSteps.length - 1].text : null;
 
   // Current orchestrator phase for the thinking window. Derived from status + the latest activity
   // event rather than the raw run status, so the caption narrates what the run is doing and animates
@@ -490,7 +488,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   // to "Processing your answer" immediately -- the backend status stays WAITING_INPUT until the next
   // 3s poll, so keying off status alone would freeze on "Waiting for your input".
   // Deliberately excludes the per-iteration live-activity NARRATIONs: those keep the thinking
-  // window's BODY advancing (see thinkingLines), but the phase CAPTION and its elapsed clock must
+  // window's BODY advancing (see thinkingSteps / collapseThinkingSteps), but the phase CAPTION and its elapsed clock must
   // stay anchored to the run's real decisions / tool-actions / delegations. Otherwise a lightweight
   // pulse would override the specific "Consulting <agent>" / "Running the next action" captions with
   // the generic NARRATION one ("Analyzing the results") and reset the "working for Ns" clock every
@@ -535,6 +533,18 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
   );
   const activitySince = lastNonPulseEvent?.autonomous_event_created_at
     ?? (events.length > 0 ? events[0].autonomous_event_created_at : undefined);
+
+  // The caption the orchestrator is narrating RIGHT NOW - the last collapsed step, but ONLY while it
+  // is genuinely current. On a resume the retained timeline gets a fresh "engaged" STATUS appended
+  // after the pre-pause reasoning, leaving the last thinking step as stale history; anchoring the
+  // bold label or a live per-caption timer to it would resurrect a pre-pause caption and let its
+  // clock span the whole paused interval (regressing #7449's resume-safe behavior). resolveLiveCaption
+  // compares the last step's newest sequence against the newest non-pulse event, so a stale step
+  // yields no live caption (the label keeps "Getting to work" and the bubble renders it as dimmed
+  // history) while a fresh live pulse (newer than the boundary) stays live. Drives the bold-label
+  // anchoring below and the bubble's live-step treatment via lastStepLive.
+  const liveCaption = resolveLiveCaption(thinkingSteps, lastNonPulseEvent?.autonomous_event_sequence);
+  const lastStepLive = liveCaption !== null;
 
   // The latest agent-delegation event drives the "delegating to / waiting for <agent>" caption. A
   // 'start' phase with no following 'result' reads as waiting (static), mirroring the parked model.
@@ -1033,6 +1043,7 @@ const AutonomousReasoningPanel: FunctionComponent<AutonomousReasoningPanelProps>
                     theme={theme}
                     steps={thinkingSteps}
                     activitySince={activitySince}
+                    lastStepLive={lastStepLive}
                   />
                 )}
                 {/* Run-level notice: a terminal-failure/cancel error, or a client-side stall. It

--- a/openaev-front/src/admin/components/autonomous/AutonomousThinkingBubble.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousThinkingBubble.tsx
@@ -1,0 +1,246 @@
+import { HourglassEmpty } from '@mui/icons-material';
+import { Box, Stack, Typography } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
+import { type FunctionComponent, useEffect, useRef, useState } from 'react';
+
+import { type ThinkingPhase, type ThinkingStep } from './autonomousEventVisuals';
+
+// Turn a millisecond gap into a compact "still working" clock: "12s", "1m 20s". Kept short so it
+// sits inline next to the phase caption / on the live step without wrapping.
+const formatElapsed = (ms: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+};
+
+// Tail-of-stream status window. While the orchestrator is actively working (active phase) it shows
+// three pulsing dots plus its most recent reasoning, faintly shimmering, so the panel feels alive
+// between activity events (mirrors the XTM One scrolling thinking window). When the run is idle -
+// parked on a status awaiting a human-timescale event, or waiting on the operator - it settles into
+// a STATIC hourglass + calm caption with no pulsing and no thought echo, so a parked run stops
+// looking like it is still thinking. The label + colour reflect the CURRENT phase and animate on
+// every phase change.
+//
+// The body is a list of COLLAPSED steps (see collapseThinkingSteps): consecutive identical captions
+// are folded into a single line so a same-caption burst is not a wall of identical glowing lines.
+// The live (last) step keeps visibly moving even when its caption does not change, via a monotonic
+// per-caption elapsed clock (ticked once a second) and a repeat count - so the operator always sees
+// motion, never a frozen-looking window.
+const ThinkingBubble: FunctionComponent<{
+  phase: ThinkingPhase;
+  theme: Theme;
+  steps: ThinkingStep[];
+  /** Timestamp of the most recent NON-PULSE activity, so the header can tick a live "working for Ns"
+   *  clock anchored to the current move (not the per-iteration pulse cadence). This is what turns a
+   *  silent stretch (e.g. the orchestrator grinding through tool retries with no new narration) from
+   *  a frozen caption into a visibly advancing counter. */
+  activitySince?: string | number | null;
+}> = ({
+  phase,
+  theme,
+  steps,
+  activitySince,
+}) => {
+  const accent = phase.color;
+  const active = phase.active;
+  // Tick a single 1s clock ONLY while actively working, so every elapsed counter (the header
+  // "working for Ns" and the live step's per-caption timer) advances live off one interval, and the
+  // interval is torn down the moment the run parks/waits. Keyed on `active` alone: the anchors are
+  // stable timestamps, so `now - anchor` is monotonic and never needs a reset on a phase/caption
+  // change (which would make a counter jump backwards - the reported "clock resets every few
+  // seconds" symptom).
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (!active) return undefined;
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+  const sinceMs = activitySince != null ? new Date(activitySince).getTime() : Number.NaN;
+  const elapsedLabel = active && Number.isFinite(sinceMs) ? formatElapsed(now - sinceMs) : null;
+  // A parked/waiting phase never streams the live thought echo (there is no live thought - the run
+  // is idle), and its dots do not pulse.
+  const showLatest = active && steps.length > 0;
+  // Keep the window pinned to the bottom as the reasoning grows, so it visibly "defiles" like the
+  // XTM One thinking window: each new step is appended at the bottom and older steps scroll up out
+  // of view under the fade mask. Keyed on the step SIGNATURE (text + count), not on `now`, so a
+  // per-second timer tick never forces a scroll - only a genuinely new/updated step does.
+  const textRef = useRef<HTMLDivElement | null>(null);
+  const stepsSignature = steps.map(step => `${step.text}#${step.count}`).join('|');
+  useEffect(() => {
+    const node = textRef.current;
+    if (node) {
+      node.scrollTop = node.scrollHeight;
+    }
+  }, [stepsSignature]);
+
+  return (
+    <Box
+      sx={{
+        'marginTop': 0.5,
+        'paddingLeft': 2,
+        'position': 'relative',
+        '@keyframes aevThinkingShimmer': {
+          '0%': { opacity: 0.35 },
+          '50%': { opacity: 0.9 },
+          '100%': { opacity: 0.35 },
+        },
+        '@keyframes aevThinkingDot': {
+          '0%, 80%, 100%': {
+            transform: 'scale(0.6)',
+            opacity: 0.3,
+          },
+          '40%': {
+            transform: 'scale(1)',
+            opacity: 1,
+          },
+        },
+        '@keyframes aevPhaseIn': {
+          '0%': {
+            opacity: 0,
+            transform: 'translateY(4px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateY(0)',
+          },
+        },
+      }}
+    >
+      <Stack sx={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 0.75,
+      }}
+      >
+        {active ? (
+          <Stack sx={{
+            flexDirection: 'row',
+            gap: 0.4,
+            alignItems: 'center',
+          }}
+          >
+            {[0, 1, 2].map(i => (
+              <Box
+                key={i}
+                sx={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  backgroundColor: accent,
+                  transition: theme.transitions.create('background-color'),
+                  animation: 'aevThinkingDot 1.4s infinite ease-in-out both',
+                  animationDelay: `${i * 0.16}s`,
+                }}
+              />
+            ))}
+          </Stack>
+        ) : (
+          // Idle/parked: a still hourglass, not pulsing dots, so the run reads as waiting - not working.
+          <HourglassEmpty sx={{
+            fontSize: 16,
+            color: accent,
+          }}
+          />
+        )}
+        {/* Key on the phase so a new phase remounts and replays the fade/slide-in transition. */}
+        <Typography
+          key={phase.key}
+          variant="caption"
+          sx={{
+            color: accent,
+            fontWeight: 600,
+            letterSpacing: '0.02em',
+            transition: theme.transitions.create('color'),
+            animation: 'aevPhaseIn 0.35s ease',
+          }}
+        >
+          {phase.label}
+        </Typography>
+        {elapsedLabel && (
+          <Typography
+            variant="caption"
+            sx={{
+              color: alpha(theme.palette.text.secondary, 0.7),
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {`\u00b7 ${elapsedLabel}`}
+          </Typography>
+        )}
+      </Stack>
+      {showLatest && (
+        <Box
+          ref={textRef}
+          sx={{
+            'maxHeight': 132,
+            'overflowY': 'auto',
+            'marginTop': 0.75,
+            // Fade the top edge so older lines appear to scroll up out of view; no visible scrollbar.
+            'maskImage': 'linear-gradient(to bottom, transparent 0, black 28px)',
+            'WebkitMaskImage': 'linear-gradient(to bottom, transparent 0, black 28px)',
+            'scrollbarWidth': 'none',
+            '&::-webkit-scrollbar': { display: 'none' },
+          }}
+        >
+          {steps.map((step, index) => {
+            const isLast = index === steps.length - 1;
+            // The live (last) step keeps moving even on a static caption: a per-caption elapsed clock
+            // that ticks up from the caption-run start, plus the repeat count. Older steps are
+            // finalized history - dimmed, static, no timer.
+            const liveElapsed = isLast && active && step.since != null ? formatElapsed(now - step.since) : null;
+            return (
+              <Typography
+                key={`${index}-${step.text.slice(0, 24)}`}
+                data-testid="autonomous-thinking-step"
+                variant="caption"
+                sx={{
+                  display: 'block',
+                  fontStyle: 'italic',
+                  lineHeight: 1.5,
+                  color: alpha(theme.palette.text.secondary, isLast ? 0.95 : 0.5),
+                  whiteSpace: 'pre-wrap',
+                  // Only the newest line shimmers - the "live" thought; older lines settle, dimmed.
+                  animation: isLast ? 'aevThinkingShimmer 2.4s ease-in-out infinite' : undefined,
+                }}
+              >
+                {step.text}
+                {step.count > 1 && (
+                  <Box
+                    component="span"
+                    sx={{
+                      marginLeft: 0.5,
+                      fontStyle: 'normal',
+                      opacity: 0.6,
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {`\u00d7${step.count}`}
+                  </Box>
+                )}
+                {liveElapsed && (
+                  <Box
+                    component="span"
+                    sx={{
+                      marginLeft: 0.5,
+                      fontStyle: 'normal',
+                      opacity: 0.7,
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {`\u00b7 ${liveElapsed}`}
+                  </Box>
+                )}
+              </Typography>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ThinkingBubble;

--- a/openaev-front/src/admin/components/autonomous/AutonomousThinkingBubble.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousThinkingBubble.tsx
@@ -38,11 +38,18 @@ const ThinkingBubble: FunctionComponent<{
    *  silent stretch (e.g. the orchestrator grinding through tool retries with no new narration) from
    *  a frozen caption into a visibly advancing counter. */
   activitySince?: string | number | null;
+  /** Whether the LAST step is genuinely the live caption (default true). The panel sets this false
+   *  when a newer non-pulse boundary (e.g. an "engaged" STATUS the backend appends to the retained
+   *  timeline on a resume) has superseded the last thinking step: it is then stale history, so it
+   *  must render dimmed with NO shimmer and NO per-caption timer, otherwise its clock would span the
+   *  whole paused interval. When false no step is treated as live. */
+  lastStepLive?: boolean;
 }> = ({
   phase,
   theme,
   steps,
   activitySince,
+  lastStepLive = true,
 }) => {
   const accent = phase.color;
   const active = phase.active;
@@ -64,7 +71,12 @@ const ThinkingBubble: FunctionComponent<{
   // A parked/waiting phase never streams the live thought echo (there is no live thought - the run
   // is idle), and its dots do not pulse.
   const showLatest = active && steps.length > 0;
-  // Keep the window pinned to the bottom as the reasoning grows, so it visibly "defiles" like the
+  // Which step (if any) is the LIVE one - the only line that shimmers and carries the per-caption
+  // timer. Normally the last step, but the panel demotes it via lastStepLive=false when a newer
+  // boundary has superseded it (a resume leaves the last thinking step as stale history); then no
+  // step is live and every line renders as calm, dimmed history.
+  const liveIndex = lastStepLive ? steps.length - 1 : -1;
+  // Keep the window pinned to the bottom as the reasoning grows, so it visibly scrolls like the
   // XTM One thinking window: each new step is appended at the bottom and older steps scroll up out
   // of view under the fade mask. Keyed on the step SIGNATURE (text + count), not on `now`, so a
   // per-second timer tick never forces a scroll - only a genuinely new/updated step does.
@@ -187,24 +199,29 @@ const ThinkingBubble: FunctionComponent<{
           }}
         >
           {steps.map((step, index) => {
-            const isLast = index === steps.length - 1;
-            // The live (last) step keeps moving even on a static caption: a per-caption elapsed clock
-            // that ticks up from the caption-run start, plus the repeat count. Older steps are
+            const isLive = index === liveIndex;
+            // The live step keeps moving even on a static caption: a per-caption elapsed clock that
+            // ticks up from the caption-run start, plus the repeat count. Older (and stale) steps are
             // finalized history - dimmed, static, no timer.
-            const liveElapsed = isLast && active && step.since != null ? formatElapsed(now - step.since) : null;
+            const liveElapsed = isLive && active && step.since != null ? formatElapsed(now - step.since) : null;
             return (
+              // Stable key from the step identity (first-event timestamp + caption), NOT the array
+              // index: the 8-step window drops the oldest entry as the stream grows, which shifts
+              // every index and would remount all rows (resetting timers/animations). since + text are
+              // fixed for a step's lifetime (they do not change as duplicates fold in), so only a
+              // genuinely new step mounts.
               <Typography
-                key={`${index}-${step.text.slice(0, 24)}`}
+                key={`${step.since ?? 'na'}-${step.text.slice(0, 24)}`}
                 data-testid="autonomous-thinking-step"
                 variant="caption"
                 sx={{
                   display: 'block',
                   fontStyle: 'italic',
                   lineHeight: 1.5,
-                  color: alpha(theme.palette.text.secondary, isLast ? 0.95 : 0.5),
+                  color: alpha(theme.palette.text.secondary, isLive ? 0.95 : 0.5),
                   whiteSpace: 'pre-wrap',
-                  // Only the newest line shimmers - the "live" thought; older lines settle, dimmed.
-                  animation: isLast ? 'aevThinkingShimmer 2.4s ease-in-out infinite' : undefined,
+                  // Only the live line shimmers - the "live" thought; older lines settle, dimmed.
+                  animation: isLive ? 'aevThinkingShimmer 2.4s ease-in-out infinite' : undefined,
                 }}
               >
                 {step.text}

--- a/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
+++ b/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
@@ -223,6 +223,103 @@ export const stripMarkdown = (text?: string | null): string => {
     .trim();
 };
 
+// -- Thinking window: collapsed live steps --------------------------------------------------------
+
+// The dimmed "thinking" window streams the tail of the orchestrator's NARRATION / DECISION /
+// TOOL_ACTION prose so the operator watches its train of thought. These are the only event types
+// that carry live reasoning text; everything else (STATUS bookkeeping, QUESTION, DIRECTIVE) belongs
+// in the decision feed, not the thought echo.
+const THINKING_STREAM_EVENT_TYPES: ReadonlySet<string> = new Set(['NARRATION', 'DECISION', 'TOOL_ACTION']);
+
+// One collapsed line of the thinking window. Consecutive events that render to the SAME caption are
+// merged into a single step so a long same-caption burst (e.g. the multi-minute arsenal build where
+// every iteration narrates "Searching arsenal for contracts") is one advancing line instead of a
+// wall of identical glowing lines that stops visibly moving - the reported "never moves, just
+// glows" symptom.
+export interface ThinkingStep {
+  /** Caption text, already sanitized + markdown-stripped, ready to render. */
+  text: string;
+  /** How many consecutive source events collapsed into this step (>= 1). */
+  count: number;
+  /** Epoch-ms timestamp of the FIRST event in this consecutive run (the caption-run start), so the
+   *  live step can tick a monotonic per-caption elapsed clock. null when the source event carried no
+   *  parseable timestamp. */
+  since: number | null;
+}
+
+// Current phase of the thinking window (label + colour + whether the orchestrator is actively
+// working). Shared with the panel and the ThinkingBubble component so the phase shape has one
+// definition across the caption logic and the renderer.
+export interface ThinkingPhase {
+  key: string;
+  label: string;
+  color: string;
+  // Whether the orchestrator is actively working (mid-cycle) vs. idle/parked (awaiting a
+  // human-timescale event or the operator's answer). Only an ACTIVE phase pulses and streams the
+  // live thought echo; an idle phase settles into a calm, static waiting indicator so a parked run
+  // does not look like it is still computing.
+  active: boolean;
+}
+
+// Collapse the reasoning stream into thinking-window steps, merging CONSECUTIVE identical captions
+// into one step that carries a repeat count and the run-start timestamp. Only adjacent duplicates
+// are merged (a caption that recurs after a different one starts a fresh step), so genuine progress
+// still reads as a moving list while a same-caption burst becomes a single line the renderer can
+// advance with a ticking timer. The last returned step is the live one; earlier steps are finalized
+// history. Keeps at most `limit` steps (the most recent), matching the window's visible capacity.
+export const collapseThinkingSteps = (
+  events: AutonomousEvent[],
+  limit = 8,
+): ThinkingStep[] => {
+  const steps: ThinkingStep[] = [];
+  for (const event of events) {
+    if (!THINKING_STREAM_EVENT_TYPES.has(event.autonomous_event_type)) {
+      continue;
+    }
+    const text = stripMarkdown(sanitizeEventText(event.autonomous_event_content ?? event.autonomous_event_title));
+    if (!text) {
+      continue;
+    }
+    const at = event.autonomous_event_created_at ? new Date(event.autonomous_event_created_at).getTime() : Number.NaN;
+    const since = Number.isFinite(at) ? at : null;
+    const last = steps[steps.length - 1];
+    if (last && last.text === text) {
+      // Same caption as the current live step: fold it in and KEEP the first timestamp so the
+      // per-caption clock measures the whole burst (never resets while the caption holds).
+      last.count += 1;
+    } else {
+      steps.push({
+        text,
+        count: 1,
+        since,
+      });
+    }
+  }
+  return steps.slice(-limit);
+};
+
+// Phase keys whose label is a GENERIC placeholder ("Getting to work", "Analyzing the results",
+// "Thinking through the next move") rather than a specific, human-meaningful state. During a long
+// live burst these are the labels that freeze on-screen while the orchestrator is demonstrably
+// narrating changing captions, so for these phases the bold label should yield to the live caption.
+// The specific phases (Consulting <agent>, Capturing proof, Deciding the next move, parked/waiting,
+// stalled...) keep their own label because it conveys more than the raw narration line.
+export const GENERIC_WORKING_PHASE_KEYS: ReadonlySet<string> = new Set(['engaging', 'analyzing', 'thinking']);
+
+// Resolve the bold thinking-window label: for a generic working phase with a live caption available,
+// show what the orchestrator is narrating RIGHT NOW so the label tracks the live stream (instead of
+// freezing on a generic phrase for the whole burst); otherwise keep the phase's own label.
+export const resolveLiveLabel = (
+  phaseKey: string,
+  phaseActive: boolean,
+  fallbackLabel: string,
+  liveCaption: string | null | undefined,
+): string => (
+  phaseActive && !!liveCaption && GENERIC_WORKING_PHASE_KEYS.has(phaseKey)
+    ? liveCaption
+    : fallbackLabel
+);
+
 // The orchestrator authors its narration / decisions / proofs / gaps in GitHub-flavored Markdown
 // (bold, lists, tables, inline code, fenced code for commands). Render it through the platform's
 // standard MarkdownDisplay - the same renderer the rest of the app uses - so the reasoning reads like

--- a/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
+++ b/openaev-front/src/admin/components/autonomous/autonomousEventVisuals.tsx
@@ -164,8 +164,8 @@ export const isHeartbeatEvent = (event: AutonomousEvent | undefined): boolean =>
 // A live-activity NARRATION is a per-iteration "what the orchestrator is doing right now" line the
 // XTM One worker streams to the timeline WHILE a decision cycle runs (flagged {"live": true} in its
 // data). Unlike a genuine recorded NARRATION/DECISION, it is NOT an operator-facing decision: it
-// exists ONLY to keep the cockpit's dimmed "thinking" window scrolling (it flows into thinkingLines)
-// across the many iterations where the LLM narrates nothing. Every surface that renders the operator
+// exists ONLY to keep the cockpit's dimmed "thinking" window scrolling (it flows into the collapsed
+// thinking steps) across the many iterations where the LLM narrates nothing. Every surface that renders the operator
 // decision feed (the reasoning-panel rows AND the overview decision timeline/count) filters it out so
 // it never shows as a decision row/node - only as streaming text in the thinking window. Single
 // source of truth so the two surfaces can never drift, mirroring isHeartbeatEvent (same substring
@@ -245,6 +245,11 @@ export interface ThinkingStep {
    *  live step can tick a monotonic per-caption elapsed clock. null when the source event carried no
    *  parseable timestamp. */
   since: number | null;
+  /** Sequence of the NEWEST source event folded into this step. The panel compares the LAST step's
+   *  sequence against the newest non-pulse event to decide whether that step is still the live
+   *  caption or stale history left behind by a new cycle boundary (e.g. an "engaged" STATUS the
+   *  backend appends to the retained timeline on a resume) - see {@link resolveLiveCaption}. */
+  sequence: number;
 }
 
 // Current phase of the thinking window (label + colour + whether the orchestrator is actively
@@ -285,17 +290,50 @@ export const collapseThinkingSteps = (
     const last = steps[steps.length - 1];
     if (last && last.text === text) {
       // Same caption as the current live step: fold it in and KEEP the first timestamp so the
-      // per-caption clock measures the whole burst (never resets while the caption holds).
+      // per-caption clock measures the whole burst (never resets while the caption holds), but
+      // ADVANCE the sequence to the newest folded event so staleness stays measured from the most
+      // recent occurrence of the caption.
       last.count += 1;
+      last.sequence = event.autonomous_event_sequence;
     } else {
       steps.push({
         text,
         count: 1,
         since,
+        sequence: event.autonomous_event_sequence,
       });
     }
   }
   return steps.slice(-limit);
+};
+
+// Resolve the caption the orchestrator is narrating RIGHT NOW from the collapsed steps - but ONLY
+// while the last step is genuinely current. On a resume the timeline is RETAINED and the backend
+// appends a fresh "engaged" STATUS after the pre-pause reasoning; that STATUS is not a thinking-
+// stream type, so it never becomes a step and the LAST collapsed step is stale pre-pause history.
+// Left unchecked, that stale caption would (a) hijack the bold label away from "Getting to work"
+// and (b) drive a live per-caption timer that spans the whole paused interval - the exact resume-
+// safe behavior #7449 established and this window must preserve.
+//
+// The test is a sequence comparison, which is robust to the pulse stream: the last step's `sequence`
+// is its NEWEST folded event, so a fresh live-activity pulse (newer than the engaged STATUS) is
+// correctly still live, while a pre-boundary stale step (older than the newest non-pulse event) is
+// not. `newestNonPulseSequence` is the sequence of the newest event that is neither a live-activity
+// pulse nor a heartbeat (the panel already derives that event for the elapsed clock). null/undefined
+// means the stream is all pulses with no boundary to supersede the step, so the last step stands.
+// Returns the live caption text, or null when the last step is stale or there are no steps.
+export const resolveLiveCaption = (
+  steps: ThinkingStep[],
+  newestNonPulseSequence: number | null | undefined,
+): string | null => {
+  const last = steps[steps.length - 1];
+  if (!last) {
+    return null;
+  }
+  if (newestNonPulseSequence == null) {
+    return last.text;
+  }
+  return last.sequence >= newestNonPulseSequence ? last.text : null;
 };
 
 // Phase keys whose label is a GENERIC placeholder ("Getting to work", "Analyzing the results",


### PR DESCRIPTION
## Summary

Follow-up to #7448 / #7449, fixing the residual "the dimmed thinking text never moves, just glows" symptom that an audit confirmed still reproduced after #7449. Frontend-only (`openaev-front`).

- Collapse consecutive duplicate captions in the cockpit reasoning window (`AutonomousReasoningPanel`) into a single live line that keeps advancing: a monotonic per-caption timer (counting up from the caption-run start) plus a repeat count. A caption change finalizes the prior step and starts a fresh live line, so genuine progress still reads as a moving list.
- The bold label now reflects the current live caption during a generic working phase, instead of freezing on a generic placeholder ("Getting to work" / "Analyzing the results" / "Thinking through the next move").
- Preserves #7449: live-activity events stay out of the decision feed / overview, and the "working for Ns" clock stays monotonic.

## What reproduced after #7449 vs what this fixes

- Duplicate-caption wall (STILL REPRODUCED): the window rendered one line per event, so a same-caption burst (e.g. the multi-minute arsenal build) rendered up to 8 identical glowing lines and stopped visibly moving. -> Fixed by collapsing consecutive duplicates into one advancing live step.
- Bold label (PARTIALLY reproduced): #7449 stopped the specific "Analyzing the results" from sticking (it excluded live-activity from `lastActivityEvent`), but during a burst the label still showed a generic phase label rather than the live caption. -> Fixed: the label follows the live caption for generic working phases.
- Elapsed clock resetting every ~5s (ALREADY FIXED by #7449): the "working for Ns" clock anchors to the newest non-pulse event, so it is monotonic across a pulse burst. Preserved, plus a regression-guarding test.

## Implementation

- `collapseThinkingSteps` + `resolveLiveLabel` (and, after review, `resolveLiveCaption`) added to `autonomousEventVisuals.tsx` - pure, unit-tested.
- `ThinkingBubble` extracted to `AutonomousThinkingBubble.tsx`; it renders the collapsed steps with the per-caption timer + repeat count off a single 1s ticker anchored to stable timestamps, so both the header clock and the live line advance strictly monotonically (no per-few-seconds reset).

## Review round (resume-safety hardening)

The independent review and the Copilot re-review surfaced a real resume-safety regression, now fixed in 4fe1106c3:

- Stale live caption across a resume: on a resume the timeline is RETAINED and the backend appends a fresh "engaged" STATUS after the pre-pause reasoning. That STATUS is not a thinking-stream type, so the last collapsed step stayed the pre-pause caption - which would (a) hijack the bold label away from "Getting to work" and (b) drive a per-caption timer that spans the whole paused interval. A new pure helper `resolveLiveCaption` compares the last step's newest sequence against the newest non-pulse event, so a stale step yields no live caption (the label keeps "Getting to work" and the bubble renders it as dimmed history), while a fresh live pulse (newer than the boundary) stays live. `ThinkingStep` now carries the newest folded event's sequence; the bubble takes a `lastStepLive` prop. This restores the resume-safe behavior #7449 established.
- Stable React list key: the thinking-step key is now derived from the step identity (`since` + caption) instead of the array index, so the 8-step window dropping its oldest entry no longer remounts every surviving row (timer/animation churn).
- Comment cleanup: reworded a misleading "defiles" comment to "scrolls" and refreshed stale `thinkingLines` doc references to `collapseThinkingSteps` / `thinkingSteps`.

## Test plan

- [x] `yarn check-ts`
- [x] `yarn lint --max-warnings 0`
- [x] `yarn i18n-checker` (no new user-facing `t()` strings; the repeat count and timers are numeric, matching the existing elapsed-clock convention)
- [x] `yarn vitest run src/__tests__/admin/components/autonomous` - 36 passing: the existing predicate tests, plus new coverage that consecutive duplicate captions collapse to one advancing line, a caption change starts a new line, the label follows the live caption, the per-caption timer advances monotonically across a same-caption burst, `resolveLiveCaption` returns null for a stale post-resume step (regression guard) and stays live for a fresh pulse, `sequence` tracks the newest folded event, and the bubble renders a non-live last step as static dimmed history.

## Note on the audited "inflight_tasks" test seam

Investigated: there is no such seam on the merged #7449 head. Every `inflight` / `inFlight` reference in `openaev-front` is in the unrelated simulation inject-execution board (`ExecutionOverview` / `ExecutionHero` / `ExecutionBoard` / `useAttackPathLiveGraph`). Nothing to use or remove, so no dead test scaffolding ships.

Fixes #7452
