### PR TITLE
fix(platform): summarize validation 400s and fix attack-path grid UX (#7459)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -148,12 +148,23 @@ public class RestBehavior {
         .getAllErrors()
         .forEach(
             (error) -> {
-              String fieldName = ((FieldError) error).getField();
+              // Class-level constraints (cross-field validators) surface as ObjectError, not
+              // FieldError: an unconditional cast would turn this 400 into a 500. Label those
+              // with the validated object's name instead. The raw-name fallback also keeps the
+              // children key non-null for nested/indexed field paths absent from the flat JSON
+              // mapping - Jackson refuses to serialize a null map key, which was another 500.
+              String rawName =
+                  error instanceof FieldError fieldError
+                      ? fieldError.getField()
+                      : error.getObjectName();
+              String label = jsonFieldsMapping.getOrDefault(rawName, rawName);
               String errorMessage = error.getDefaultMessage();
-              errorsBag.put(jsonFieldsMapping.get(fieldName), new ValidationContent(errorMessage));
-              String label = jsonFieldsMapping.getOrDefault(fieldName, fieldName);
-              summaryParts.add(
-                  label == null || label.isBlank() ? errorMessage : label + ": " + errorMessage);
+              // getDefaultMessage() is nullable and ValidationContent wraps it in List.of(),
+              // which rejects null - degrade to a generic reason instead of a 500.
+              errorsBag.put(
+                  label,
+                  new ValidationContent(errorMessage == null ? "Invalid value" : errorMessage));
+              summaryParts.add(summaryPart(label, errorMessage));
             });
     errors.setChildren(errorsBag);
     bag.setErrors(errors);
@@ -170,23 +181,54 @@ public class RestBehavior {
   private static final int MAX_VALIDATION_SUMMARY_LENGTH = 300;
   private static final int MAX_VALIDATION_SUMMARY_PARTS = 8;
 
+  // One "label: reason" summary entry, degrading to whichever half is present so a
+  // constraint without a default message never renders as "field: null".
+  private static String summaryPart(String label, String message) {
+    boolean hasLabel = label != null && !label.isBlank();
+    boolean hasMessage = message != null && !message.isBlank();
+    if (hasLabel && hasMessage) {
+      return label + ": " + message;
+    }
+    if (hasLabel) {
+      return label;
+    }
+    return hasMessage ? message : null;
+  }
+
+  // Collapse control characters and whitespace runs to single spaces: the summary must
+  // stay a single line whatever a constraint message contains, so it is safe to log and
+  // to render in a toast.
+  private static String sanitizeSummaryText(String text) {
+    return text.replaceAll("[\\p{Cntrl}\\s]+", " ").trim();
+  }
+
   // Fold the per-field validation reasons into one human-readable top-level
   // message. Bounded in count and length so the response stays small and
   // log-safe; falls back to the generic message when nothing usable was
   // collected (so an empty binding result is never surfaced as a blank reason).
   private static String summarizeValidationErrors(List<String> parts) {
-    List<String> nonBlank = parts.stream().filter(p -> p != null && !p.isBlank()).toList();
-    if (nonBlank.isEmpty()) {
+    // Deduplicated and sorted: bean validation reports violations in no guaranteed order,
+    // so sorting keeps the message stable for identical payloads.
+    List<String> usable =
+        parts.stream()
+            .filter(Objects::nonNull)
+            .map(RestBehavior::sanitizeSummaryText)
+            .filter(p -> !p.isBlank())
+            .distinct()
+            .sorted()
+            .toList();
+    if (usable.isEmpty()) {
       return "Validation Failed";
     }
     String joined =
-        nonBlank.stream().limit(MAX_VALIDATION_SUMMARY_PARTS).collect(Collectors.joining("; "));
-    if (nonBlank.size() > MAX_VALIDATION_SUMMARY_PARTS) {
-      joined += "; ...";
+        usable.stream().limit(MAX_VALIDATION_SUMMARY_PARTS).collect(Collectors.joining("; "));
+    if (usable.size() > MAX_VALIDATION_SUMMARY_PARTS) {
+      joined += " (+" + (usable.size() - MAX_VALIDATION_SUMMARY_PARTS) + " more)";
     }
+    // Truncate INCLUDING the ellipsis so the advertised bound is a real bound.
     return joined.length() <= MAX_VALIDATION_SUMMARY_LENGTH
         ? joined
-        : joined.substring(0, MAX_VALIDATION_SUMMARY_LENGTH) + "...";
+        : joined.substring(0, MAX_VALIDATION_SUMMARY_LENGTH - 3) + "...";
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -143,6 +143,7 @@ public class RestBehavior {
     ValidationErrorBag bag = new ValidationErrorBag();
     ValidationError errors = new ValidationError();
     Map<String, ValidationContent> errorsBag = new HashMap<>();
+    List<String> summaryParts = new ArrayList<>();
     ex.getBindingResult()
         .getAllErrors()
         .forEach(
@@ -150,10 +151,42 @@ public class RestBehavior {
               String fieldName = ((FieldError) error).getField();
               String errorMessage = error.getDefaultMessage();
               errorsBag.put(jsonFieldsMapping.get(fieldName), new ValidationContent(errorMessage));
+              String label = jsonFieldsMapping.getOrDefault(fieldName, fieldName);
+              summaryParts.add(
+                  label == null || label.isBlank() ? errorMessage : label + ": " + errorMessage);
             });
     errors.setChildren(errorsBag);
     bag.setErrors(errors);
+    // Replace the generic "Validation Failed" top-level message with a concise
+    // summary of the per-field reasons. Those reasons otherwise live only in
+    // errors.children, so any client that reads just "message" - the frontend
+    // toast, a plain API caller, an AI agent's tool wrapper - gets an opaque 400
+    // and cannot self-correct (the exact "why did the arsenal fork bad-request"
+    // pain). The per-field children bag is left unchanged for structured clients.
+    bag.setMessage(summarizeValidationErrors(summaryParts));
     return bag;
+  }
+
+  private static final int MAX_VALIDATION_SUMMARY_LENGTH = 300;
+  private static final int MAX_VALIDATION_SUMMARY_PARTS = 8;
+
+  // Fold the per-field validation reasons into one human-readable top-level
+  // message. Bounded in count and length so the response stays small and
+  // log-safe; falls back to the generic message when nothing usable was
+  // collected (so an empty binding result is never surfaced as a blank reason).
+  private static String summarizeValidationErrors(List<String> parts) {
+    List<String> nonBlank = parts.stream().filter(p -> p != null && !p.isBlank()).toList();
+    if (nonBlank.isEmpty()) {
+      return "Validation Failed";
+    }
+    String joined =
+        nonBlank.stream().limit(MAX_VALIDATION_SUMMARY_PARTS).collect(Collectors.joining("; "));
+    if (nonBlank.size() > MAX_VALIDATION_SUMMARY_PARTS) {
+      joined += "; ...";
+    }
+    return joined.length() <= MAX_VALIDATION_SUMMARY_LENGTH
+        ? joined
+        : joined.substring(0, MAX_VALIDATION_SUMMARY_LENGTH) + "...";
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
@@ -1,11 +1,13 @@
 package io.openaev.rest.helper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -17,13 +19,19 @@ import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exception.ChainingOperationNotSupportedException;
 import io.openaev.rest.payload.output_parser.OutputParserInput;
 import java.lang.reflect.Method;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springdoc.api.ErrorMessage;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
 
 @DisplayName("RestBehavior exception mapping")
@@ -336,6 +344,184 @@ class RestBehaviorTest {
       assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
       assertNotNull(response.getBody());
       assertEquals("Malformed or unreadable request body", response.getBody().getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("MethodArgumentNotValidException handling (bean-validation 400 summary)")
+  class MethodArgumentNotValidHandling {
+
+    /** Input shape exercising the internal-name -> JSON-name mapping. */
+    static class SampleValidationInput {
+      @JsonProperty("sample_name")
+      public String name;
+
+      @JsonProperty("sample_description")
+      public String description;
+    }
+
+    @SuppressWarnings("unused")
+    private void sampleEndpoint(SampleValidationInput input) {}
+
+    private RestBehavior behavior() {
+      RestBehavior behavior = new RestBehavior();
+      behavior.mapper = ObjectMapperHelper.openAEVJsonMapper();
+      return behavior;
+    }
+
+    private BeanPropertyBindingResult emptyBinding() {
+      return new BeanPropertyBindingResult(new SampleValidationInput(), "input");
+    }
+
+    private MethodArgumentNotValidException exceptionFor(BeanPropertyBindingResult binding)
+        throws NoSuchMethodException {
+      MethodParameter parameter =
+          new MethodParameter(
+              MethodArgumentNotValidHandling.class.getDeclaredMethod(
+                  "sampleEndpoint", SampleValidationInput.class),
+              0);
+      return new MethodArgumentNotValidException(parameter, binding);
+    }
+
+    @Test
+    @DisplayName(
+        "field reasons are folded into the top-level message using JSON names, deterministically")
+    void given_fieldErrors_should_summarizeReasonsInTopLevelMessage() throws NoSuchMethodException {
+      // GIVEN - errors added out of alphabetical order to prove the summary is deterministic
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new FieldError("input", "name", "must not be blank"));
+      binding.addError(new FieldError("input", "description", "size must be between 1 and 255"));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals(
+          "sample_description: size must be between 1 and 255; sample_name: must not be blank",
+          bag.getMessage());
+      assertTrue(bag.getErrors().getChildren().containsKey("sample_name"));
+      assertTrue(bag.getErrors().getChildren().containsKey("sample_description"));
+    }
+
+    @Test
+    @DisplayName("a class-level ObjectError is labeled by object name instead of throwing")
+    void given_objectError_should_labelByObjectNameInsteadOfClassCast()
+        throws NoSuchMethodException {
+      // GIVEN - a cross-field validator reports on the object, not a field
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new ObjectError("input", "start date must precede end date"));
+
+      // WHEN - must not throw ClassCastException (which would turn the 400 into a 500)
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals("input: start date must precede end date", bag.getMessage());
+      assertTrue(bag.getErrors().getChildren().containsKey("input"));
+    }
+
+    @Test
+    @DisplayName("a nested field path absent from the JSON mapping keeps a non-null children key")
+    void given_unmappedNestedFieldPath_should_fallBackToRawFieldName()
+        throws NoSuchMethodException {
+      // GIVEN - @Valid nested/indexed paths are absent from the flat JSON mapping; a null map
+      // key would make Jackson fail to serialize the 400 body
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new FieldError("input", "items[0].name", "must not be blank"));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals("items[0].name: must not be blank", bag.getMessage());
+      assertTrue(bag.getErrors().getChildren().containsKey("items[0].name"));
+      assertFalse(bag.getErrors().getChildren().containsKey(null));
+    }
+
+    @Test
+    @DisplayName("a constraint without a default message degrades to the field label alone")
+    void given_nullDefaultMessage_should_useLabelWithoutNullText() throws NoSuchMethodException {
+      // GIVEN
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new FieldError("input", "name", null));
+
+      // WHEN - must not throw (ValidationContent wraps the message in List.of, which
+      // rejects null)
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals("sample_name", bag.getMessage());
+      assertEquals(
+          List.of("Invalid value"), bag.getErrors().getChildren().get("sample_name").getErrors());
+    }
+
+    @Test
+    @DisplayName("the summary is bounded in part count with an explicit overflow indicator")
+    void given_manyErrors_should_boundPartCountAndReportOverflow() throws NoSuchMethodException {
+      // GIVEN - 12 distinct reasons, 4 beyond the 8-part bound
+      BeanPropertyBindingResult binding = emptyBinding();
+      for (int i = 0; i < 12; i++) {
+        binding.addError(new FieldError("input", "items[" + i + "].name", "must not be blank"));
+      }
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertTrue(bag.getMessage().endsWith("(+4 more)"));
+    }
+
+    @Test
+    @DisplayName("the summary never exceeds the advertised length bound, ellipsis included")
+    void given_oversizedReason_should_truncateWithinBound() throws NoSuchMethodException {
+      // GIVEN - a reason far beyond the 300-char summary bound
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new FieldError("input", "name", "X".repeat(500)));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals(300, bag.getMessage().length());
+      assertTrue(bag.getMessage().endsWith("..."));
+    }
+
+    @Test
+    @DisplayName("an empty binding result falls back to the generic message")
+    void given_noErrors_should_fallBackToGenericMessage() throws NoSuchMethodException {
+      // GIVEN / WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(emptyBinding()));
+
+      // THEN
+      assertEquals("Validation Failed", bag.getMessage());
+    }
+
+    @Test
+    @DisplayName("control characters in constraint messages are flattened to a single line")
+    void given_multilineMessage_should_flattenToSingleLine() throws NoSuchMethodException {
+      // GIVEN
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new FieldError("input", "name", "line one\nline two\ttab"));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals("sample_name: line one line two tab", bag.getMessage());
+    }
+
+    @Test
+    @DisplayName("identical reasons reported by several constraints are deduplicated")
+    void given_duplicateReasons_should_deduplicate() throws NoSuchMethodException {
+      // GIVEN - e.g. @NotBlank and @Size both rejecting the same field with the same text
+      BeanPropertyBindingResult binding = emptyBinding();
+      binding.addError(new FieldError("input", "name", "must not be blank"));
+      binding.addError(new FieldError("input", "name", "must not be blank"));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleValidationExceptions(exceptionFor(binding));
+
+      // THEN
+      assertEquals("sample_name: must not be blank", bag.getMessage());
     }
   }
 }

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/PanZoom.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/PanZoom.tsx
@@ -235,6 +235,13 @@ const PanZoom = ({
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
+      // A pan is a pointer gesture, but the browser will happily reinterpret a press-and-drag that
+      // begins on an inner <img> (the injector/payload glyph, or its broken-image placeholder) or a
+      // run of selectable text as a native HTML5 drag / text selection. That hijack stops
+      // pointermove firing mid-gesture, so the pan silently dies and the cursor turns into the
+      // "no-drop" (forbidden) sign - the intermittent "can't drag the grid here" the operator hit.
+      // dragstart bubbles, so cancelling it once here disarms every draggable descendant at once.
+      onDragStart={e => e.preventDefault()}
       sx={{
         position: 'relative',
         width: '100%',
@@ -242,6 +249,8 @@ const PanZoom = ({
         overflow: 'hidden',
         cursor: panning ? 'grabbing' : 'grab',
         touchAction: 'none',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
         // Minimal low-opacity "paper" dot grid in screen space (does not clutter the graph).
         backgroundImage: `radial-gradient(${theme.palette.divider} 1px, transparent 1px)`,
         backgroundSize: '28px 28px',

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/SimulationAttackPath.tsx
@@ -2830,18 +2830,19 @@ const SimulationAttackPath = ({ scenarioExerciseIds, scenarioId, hideLaunchCta =
               </Alert>
             )}
             {!loading && !chainLoading && !forbidden && !error && !graphHasContent && (
-            // Inset the placeholder inside the (relative) graph Paper so its dashed frame sits
-            // within the Paper's own outline instead of doubling up against it.
+            // The graph Paper already draws the outline, so the placeholder fills it WITHOUT its own
+            // dashed frame (bordered={false}) - otherwise the two concentric borders read as a
+            // "double border" in the zero-state.
               <Box sx={{
                 position: 'absolute',
                 inset: 0,
-                p: 1.5,
               }}
               >
                 <EmptyPlaceholder
                   icon={<AccountTreeOutlined />}
                   title={emptyStateTitle}
                   message={emptyStateMessage}
+                  bordered={false}
                   action={scenarioHasNoSims && scenarioId && !hideLaunchCta
                     ? (
                         <Button

--- a/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathCanvas.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/attack_path/canvas/AttackPathCanvas.tsx
@@ -755,12 +755,21 @@ const AttackPathCanvas = ({
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
+      // A pan is a pointer gesture, but the browser will happily reinterpret a press-and-drag that
+      // begins on an inner <img> (an endpoint/finding/injector glyph or its broken-image
+      // placeholder) or a run of selectable text as a native HTML5 drag / text selection. That
+      // hijack stops pointermove firing mid-gesture, so the pan silently dies and the cursor turns
+      // into the "no-drop" (forbidden) sign. dragstart bubbles, so cancelling it once here disarms
+      // every draggable descendant at once (same fix as the Logic canvas' PanZoom).
+      onDragStart={e => e.preventDefault()}
       sx={{
         position: 'absolute',
         inset: 0,
         overflow: 'hidden',
         cursor: panning ? 'grabbing' : 'grab',
         touchAction: 'none',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
         backgroundColor: theme.palette.background.default,
         // Faint dot grid in screen space (the Logic canvas' paper texture, same metrics).
         backgroundImage: `radial-gradient(${theme.palette.divider} 1px, transparent 1px)`,


### PR DESCRIPTION
## Summary

- API: `handleValidationExceptions` now folds the per-field bean-validation reasons into the top-level `ValidationErrorBag.message` (bounded in count and length, log-safe). Clients that read only `message` - the frontend toast, a plain API caller, an AI agent's tool wrapper - get an actionable 400 instead of a generic "Validation Failed". The `errors.children` bag keeps its shape for structured clients.
- API: the handler is hardened against three latent 500s in the same block: class-level `ObjectError`s no longer hit the unconditional `FieldError` cast (they are labeled by object name), nested/indexed field paths absent from the flat JSON mapping no longer produce a null children key (Jackson refuses null map keys), and a null `getDefaultMessage()` no longer explodes `ValidationContent`'s `List.of` (degrades to "Invalid value").
- API: the summary is deterministic (sorted and deduplicated parts), single-line (control characters collapsed), bounded to 8 parts with an explicit " (+N more)" overflow indicator, and hard-capped at 300 chars including the ellipsis.
- Front: the Logic (`PanZoom`) and Attack Path (`AttackPathCanvas`) grids cancel `dragstart` and set `user-select: none`, so a pan is never hijacked by a native HTML5 drag or text selection (the intermittent "forbidden"/no-drop cursor mid-pan).
- Front: the attack path empty state renders `EmptyPlaceholder` with `bordered={false}` and no inset, so the zero-state shows a single border instead of a double one.

## Test plan

- [x] New plain-JUnit tests in `RestBehaviorTest` (no Spring context): JSON-name summary and deterministic ordering, ObjectError labeling, unmapped nested path key, null default message, part-count bound with overflow indicator, 300-char cap including ellipsis, empty-binding fallback, control-character flattening, duplicate deduplication.
- [ ] Trigger a bean-validation 400 (e.g. an invalid arsenal action payload) and confirm the response `message` names the offending field(s).
- [ ] Pan the Logic and Attack Path grids starting on an icon/glyph and on text; confirm the pan never turns into the "forbidden" cursor.
- [ ] Open a simulation with no attack path and confirm the empty state shows a single border.

Closes #7459
