### PR TITLE
fix(expectations): resisted-outcome phishing step names and contract-declared ordering (#7463)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/expectations/dto/InjectExpectationOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/expectations/dto/InjectExpectationOutput.java
@@ -49,6 +49,13 @@ public record InjectExpectationOutput(
     @Schema(description = "Whether this expectation is a group expectation")
         @JsonProperty("inject_expectation_group")
         boolean expectationGroup,
+    @Schema(
+            description =
+                "Display order of the expectation within its inject, ascending. Declared by the"
+                    + " injector contract (e.g. phishing orders its steps email -> link ->"
+                    + " submission); null means unordered and readers fall back to name / id.")
+        @JsonProperty("inject_expectation_order")
+        Integer order,
     @Schema(description = "Computed status of the inject expectation")
         @JsonProperty("inject_expectation_status")
         EXPECTATION_STATUS status,

--- a/openaev-api/src/main/java/io/openaev/api/expectations/mapper/InjectExpectationMapper.java
+++ b/openaev-api/src/main/java/io/openaev/api/expectations/mapper/InjectExpectationMapper.java
@@ -21,6 +21,7 @@ public final class InjectExpectationMapper {
         expectation.getExpectedScore(),
         expectation.getExpirationTime(),
         expectation.isExpectationGroup(),
+        expectation.getOrder(),
         expectation.getResponse(),
         expectation.getCreatedAt(),
         expectation.getUpdatedAt(),

--- a/openaev-api/src/main/java/io/openaev/expectation/Expectation.java
+++ b/openaev-api/src/main/java/io/openaev/expectation/Expectation.java
@@ -64,6 +64,21 @@ public interface Expectation {
   String getName();
 
   /**
+   * Returns the optional display order of this expectation within its inject, ascending.
+   *
+   * <p>Lets an injector contract declare the logical sequence of its expectations (e.g. phishing
+   * orders its human steps email {@literal ->} link {@literal ->} submission) so both the chain
+   * timeline and the results list render them in that order rather than an incidental alphabetical
+   * one. {@code null} means unordered (the default for every expectation that does not set it), and
+   * readers fall back to name / id, leaving all other contracts unaffected.
+   *
+   * @return the display order, or {@code null} when unordered
+   */
+  default Integer getOrder() {
+    return null;
+  }
+
+  /**
    * Returns the time after which this expectation automatically expires.
    *
    * @return expiration time in seconds from creation, or null if no expiration

--- a/openaev-api/src/main/java/io/openaev/expectation/ManualExpectation.java
+++ b/openaev-api/src/main/java/io/openaev/expectation/ManualExpectation.java
@@ -60,6 +60,9 @@ public class ManualExpectation implements Expectation {
   /** Time in seconds after which this expectation expires. */
   private Long expirationTime;
 
+  /** Optional display order within the inject (ascending); {@code null} means unordered. */
+  private Integer order;
+
   /** Creates an empty manual expectation. */
   public ManualExpectation() {}
 
@@ -83,6 +86,7 @@ public class ManualExpectation implements Expectation {
     this.description = expectation.getDescription();
     this.expectationGroup = expectation.isExpectationGroup();
     this.expirationTime = expectation.getExpirationTime();
+    this.order = expectation.getOrder();
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingLandingPageService.java
@@ -516,7 +516,10 @@ public class PhishingLandingPageService {
    *       MANUAL expectation with inverted polarity (see {@link PhishingTrackingService}): GREEN
    *       ("resisted") while the recipient has not performed the step, flipping RED ("fell for it")
    *       the moment they do, so a recipient who never interacts keeps the green verdict through
-   *       expiration.
+   *       expiration. Named for the resisted outcome ("Email not opened", "Link not clicked",
+   *       "Credentials not submitted") so the row always reads true when green, and explicitly
+   *       ordered 1 {@literal ->} 2 {@literal ->} 3 to match the kill chain (email {@literal ->}
+   *       link {@literal ->} submission) in the results timeline and list.
    *   <li><b>Security control</b> - PREVENTION and DETECTION, exactly like most technical injector
    *       contracts: a phishing simulation is only complete if the platform can also score whether
    *       the lure was blocked (prevention) or detected (detection). Both are focused on {@link
@@ -542,23 +545,28 @@ public class PhishingLandingPageService {
         buildPhishingStep(
             PhishingTrackingService.STEP_OPENED,
             "Red once the recipient opens the lure email (tracking pixel loaded); green while the"
-                + " email is never opened."),
+                + " email is never opened.",
+            1),
         buildPhishingStep(
             PhishingTrackingService.STEP_CLICKED,
             "Red once the recipient opens the phishing landing page; green while the link is never"
-                + " followed."),
+                + " followed.",
+            2),
         buildPhishingStep(
             PhishingTrackingService.STEP_SUBMITTED,
             "Red once the recipient submits data on the phishing page; green while nothing is ever"
-                + " submitted."));
+                + " submitted.",
+            3));
   }
 
-  private Expectation buildPhishingStep(final String name, final String description) {
+  private Expectation buildPhishingStep(
+      final String name, final String description, final int order) {
     Expectation expectation = this.expectationBuilderService.buildManualExpectation();
     expectation.setName(name);
     expectation.setDescription(description);
     expectation.setPredefined(true);
     expectation.setMultiSelectable(false);
+    expectation.setOrder(order);
     return expectation;
   }
 }

--- a/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
+++ b/openaev-api/src/main/java/io/openaev/injectors/phishing/service/PhishingTrackingService.java
@@ -73,11 +73,16 @@ public class PhishingTrackingService {
    * Names of the three phishing-awareness expectation steps. Shared with {@code
    * PhishingLandingPageService} (which advertises them in the injector contract) so the contract
    * and the runtime scoring can never drift on which row represents which step.
+   *
+   * <p>The names are phrased as the RESISTED (green) outcome, matching the inverted phishing
+   * polarity: a step is green ("resisted") while the recipient has not performed it and only flips
+   * red the moment they do. A recipient who never interacts keeps a row of green "not opened / not
+   * clicked / not submitted" verdicts, so the name always reads true for the desired outcome.
    */
-  public static final String STEP_OPENED = "Email opened";
+  public static final String STEP_OPENED = "Email not opened";
 
-  public static final String STEP_CLICKED = "Phishing link clicked";
-  public static final String STEP_SUBMITTED = "Credentials submitted";
+  public static final String STEP_CLICKED = "Link not clicked";
+  public static final String STEP_SUBMITTED = "Credentials not submitted";
 
   private static final Set<String> PHISHING_STEP_NAMES =
       Set.of(STEP_OPENED, STEP_CLICKED, STEP_SUBMITTED);

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260816120000000__Add_expectation_order_and_rename_phishing_steps.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260816120000000__Add_expectation_order_and_rename_phishing_steps.java
@@ -1,0 +1,195 @@
+package io.openaev.migration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Phishing expectation naming + generic expectation ordering.
+ *
+ * <p>1. Adds the nullable {@code inject_expectation_order} column: the contract-declared display
+ * order of an expectation within its inject (phishing declares email -> link -> submission as 1 ->
+ * 2 -> 3). Nullable with no default, so the ALTER is metadata-only and every non-phishing
+ * expectation stays unordered.
+ *
+ * <p>2. Renames the three phishing human-step expectations to their resisted-outcome names ("Email
+ * opened" -> "Email not opened", "Phishing link clicked" -> "Link not clicked", "Credentials
+ * submitted" -> "Credentials not submitted") and backfills their order. The names are the join key
+ * between the persisted rows and the tracking constants in {@code PhishingTrackingService}, so
+ * in-flight injects would stop scoring after the rename without this realignment. Scoped to injects
+ * of the phishing injector so a user-defined manual expectation that happens to share a name is
+ * never touched.
+ *
+ * <p>3. Rewrites the {@code expectations} array inside {@code inject_content} of phishing injects
+ * the same way: pending injects re-create their expectation rows from that JSON at execution time,
+ * so stale content would resurrect the old names (which the tracking service no longer matches).
+ *
+ * <p>Injector contract rows are deliberately NOT migrated: {@code
+ * PhishingLandingPageService.resyncAllContracts()} rebuilds every landing-page contract at startup,
+ * which propagates the new names and orders there.
+ *
+ * <p>Idempotent: the ALTER is IF NOT EXISTS, the renames match only old names, and the order
+ * backfill / JSON rewrite converge to the same terminal state on re-run.
+ */
+@Component
+public class V6_20260816120000000__Add_expectation_order_and_rename_phishing_steps
+    extends BaseJavaMigration {
+
+  private static final String PHISHING_INJECTOR_TYPE = "openaev_phishing";
+
+  /** Old name -> new resisted-outcome name. */
+  private static final Map<String, String> RENAMES =
+      Map.of(
+          "Email opened", "Email not opened",
+          "Phishing link clicked", "Link not clicked",
+          "Credentials submitted", "Credentials not submitted");
+
+  /** New name -> contract-declared display order (email -> link -> submission). */
+  private static final Map<String, Integer> ORDERS =
+      Map.of(
+          "Email not opened", 1,
+          "Link not clicked", 2,
+          "Credentials not submitted", 3);
+
+  private static final int BATCH_SIZE = 500;
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // 1. Generic display-order column (nullable, no default: metadata-only ALTER).
+      statement.execute(
+          "ALTER TABLE injects_expectations "
+              + "ADD COLUMN IF NOT EXISTS inject_expectation_order int");
+
+      // 2. Rename persisted phishing steps and backfill their order. Old names are mapped to the
+      // new resisted-outcome names; rows already carrying a new name (idempotent re-run, or rows
+      // written between deploy and migration) only get the order backfill.
+      statement.execute(
+          """
+          UPDATE injects_expectations e
+          SET inject_expectation_name = CASE e.inject_expectation_name
+                WHEN 'Email opened' THEN 'Email not opened'
+                WHEN 'Phishing link clicked' THEN 'Link not clicked'
+                WHEN 'Credentials submitted' THEN 'Credentials not submitted'
+                ELSE e.inject_expectation_name
+              END,
+              inject_expectation_order = CASE e.inject_expectation_name
+                WHEN 'Email opened' THEN 1
+                WHEN 'Email not opened' THEN 1
+                WHEN 'Phishing link clicked' THEN 2
+                WHEN 'Link not clicked' THEN 2
+                WHEN 'Credentials submitted' THEN 3
+                WHEN 'Credentials not submitted' THEN 3
+                ELSE e.inject_expectation_order
+              END
+          FROM injects i
+          JOIN injectors_injector_contracts iic
+            ON iic.injector_contract_id = i.inject_injector_contract
+          JOIN injectors inj
+            ON inj.injector_id = iic.injector_id
+          WHERE e.inject_id = i.inject_id
+            AND inj.injector_type = 'openaev_phishing'
+            AND e.inject_expectation_name IN (
+              'Email opened', 'Phishing link clicked', 'Credentials submitted',
+              'Email not opened', 'Link not clicked', 'Credentials not submitted')
+          """);
+    }
+
+    // 3. Rewrite the expectations array in the content of phishing injects: rename old step names
+    // and stamp the display order, so a pending inject executed after the upgrade creates rows the
+    // tracking service can still match (and the UI can sort).
+    rewriteInjectContent(context);
+
+    try (Statement statement = context.getConnection().createStatement()) {
+      // 4. Expectation names are indexed in ES: force a full re-index of expectation documents.
+      statement.execute(
+          "DELETE FROM indexing_status WHERE indexing_status_type = 'expectation-inject'");
+    }
+  }
+
+  private void rewriteInjectContent(Context context) throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+
+    try (Statement select = context.getConnection().createStatement();
+        ResultSet results =
+            select.executeQuery(
+                "SELECT DISTINCT i.inject_id, i.inject_content "
+                    + "FROM injects i "
+                    + "JOIN injectors_injector_contracts iic "
+                    + "  ON iic.injector_contract_id = i.inject_injector_contract "
+                    + "JOIN injectors inj ON inj.injector_id = iic.injector_id "
+                    + "WHERE inj.injector_type = '"
+                    + PHISHING_INJECTOR_TYPE
+                    + "' AND i.inject_content IS NOT NULL");
+        PreparedStatement update =
+            context
+                .getConnection()
+                .prepareStatement("UPDATE injects SET inject_content = ? WHERE inject_id = ?")) {
+
+      int batchCount = 0;
+
+      while (results.next()) {
+        String injectId = results.getString("inject_id");
+        String content = results.getString("inject_content");
+        if (content == null || content.isBlank()) {
+          continue;
+        }
+
+        JsonNode root = mapper.readTree(content);
+        if (root == null || !root.isObject()) {
+          continue;
+        }
+        JsonNode expectations = root.get("expectations");
+        if (expectations == null || !expectations.isArray()) {
+          continue;
+        }
+
+        boolean modified = false;
+        for (JsonNode expectation : expectations) {
+          if (!(expectation instanceof ObjectNode expectationNode)) {
+            continue;
+          }
+          String name = expectationNode.path("expectation_name").asText(null);
+          if (name == null) {
+            continue;
+          }
+          String newName = RENAMES.get(name);
+          if (newName != null) {
+            expectationNode.put("expectation_name", newName);
+            name = newName;
+            modified = true;
+          }
+          Integer order = ORDERS.get(name);
+          if (order != null
+              && (!expectationNode.hasNonNull("expectation_order")
+                  || expectationNode.get("expectation_order").asInt() != order)) {
+            expectationNode.put("expectation_order", (int) order);
+            modified = true;
+          }
+        }
+
+        if (modified) {
+          update.setString(1, mapper.writeValueAsString(root));
+          update.setString(2, injectId);
+          update.addBatch();
+          batchCount++;
+          if (batchCount == BATCH_SIZE) {
+            update.executeBatch();
+            batchCount = 0;
+          }
+        }
+      }
+
+      if (batchCount != 0) {
+        update.executeBatch();
+      }
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectExpectationUtils.java
@@ -102,6 +102,7 @@ public class InjectExpectationUtils {
     baseInjectExpectation.setExpectedScore(expectation.getScore());
     baseInjectExpectation.setExpectationGroup(expectation.isExpectationGroup());
     baseInjectExpectation.setName(expectation.getName());
+    baseInjectExpectation.setOrder(expectation.getOrder());
     baseInjectExpectation.setExpirationTime(
         ofNullable(expectation.getExpirationTime())
             .orElse(expectationPropertiesConfig.getExpirationTimeByType(expectation.type())));

--- a/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/injectors/phishing/service/PhishingLandingPageServiceTest.java
@@ -33,6 +33,7 @@ import io.openaev.expectation.ExpectationBuilderService;
 import io.openaev.helper.SupportedLanguage;
 import io.openaev.injector_contract.Contract;
 import io.openaev.injector_contract.ContractConfig;
+import io.openaev.injector_contract.fields.ContractExpectations;
 import io.openaev.injector_contract.outputs.InjectorContractContentOutputElement;
 import io.openaev.injectors.phishing.PhishingContract;
 import io.openaev.injectors.phishing.form.PhishingLandingPageBulkProcessingInput;
@@ -203,6 +204,58 @@ class PhishingLandingPageServiceTest {
     verify(mapper).writeValueAsString(contractCaptor.capture());
     Contract serialized = (Contract) contractCaptor.getValue();
     assertTrue(serialized.getOutputs().isEmpty());
+  }
+
+  @Test
+  @DisplayName(
+      "synchroniseInjectorContract declares resisted-outcome step names ordered email -> link ->"
+          + " submission")
+  void synchronise_should_declareOrderedResistedOutcomeSteps() throws Exception {
+    // -- ARRANGE --
+    PhishingLandingPage landingPage = new PhishingLandingPage();
+    landingPage.setId("lp-1");
+    landingPage.setName("Login page");
+    arrangeSynchroniseStubs();
+    // Each human step mutates the instance the builder hands out; the shared-instance stub of
+    // arrangeSynchroniseStubs would alias the three steps into one object, so hand out fresh ones.
+    when(expectationBuilderService.buildManualExpectation())
+        .thenAnswer(invocation -> new Expectation());
+
+    ArgumentCaptor<Object> contractCaptor = ArgumentCaptor.forClass(Object.class);
+
+    // -- ACT --
+    phishingLandingPageService.synchroniseInjectorContract(landingPage);
+
+    // -- ASSERT --
+    // The human steps are the names the tracking service scores by (the join key with persisted
+    // expectation rows) and each carries its contract-declared display order: this is what lets
+    // the results UI render the chain as email -> link -> submission instead of alphabetically.
+    verify(mapper).writeValueAsString(contractCaptor.capture());
+    Contract serialized = (Contract) contractCaptor.getValue();
+    ContractExpectations expectationsField =
+        serialized.getFields().stream()
+            .filter(ContractExpectations.class::isInstance)
+            .map(ContractExpectations.class::cast)
+            .findFirst()
+            .orElseThrow();
+    // Detection/prevention are also available but carry no name (mocked builder) and no order.
+    List<Expectation> humanSteps =
+        expectationsField.getAvailableExpectations().stream()
+            .filter(expectation -> expectation.getName() != null)
+            .toList();
+    assertEquals(
+        List.of(
+            PhishingTrackingService.STEP_OPENED,
+            PhishingTrackingService.STEP_CLICKED,
+            PhishingTrackingService.STEP_SUBMITTED),
+        humanSteps.stream().map(Expectation::getName).toList());
+    assertEquals(List.of(1, 2, 3), humanSteps.stream().map(Expectation::getOrder).toList());
+    List<Expectation> unordered =
+        expectationsField.getAvailableExpectations().stream()
+            .filter(expectation -> expectation.getName() == null)
+            .toList();
+    assertEquals(2, unordered.size());
+    assertTrue(unordered.stream().allMatch(expectation -> expectation.getOrder() == null));
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -1217,10 +1217,10 @@ class InjectExpectationServiceTest {
       // with the max - Hibernate then flushed that on commit, so every poll of the results page
       // grew the row's results JSON (until requests exceeded the Hikari leak threshold and
       // exhausted the pool) and flipped a compromised step back to green in the database.
-      ManualInjectExpectation opened = manualStep("exp-opened", "Email opened", 0.0);
-      ManualInjectExpectation clicked = manualStep("exp-clicked", "Phishing link clicked", 100.0);
+      ManualInjectExpectation opened = manualStep("exp-opened", "Email not opened", 0.0);
+      ManualInjectExpectation clicked = manualStep("exp-clicked", "Link not clicked", 100.0);
       ManualInjectExpectation submitted =
-          manualStep("exp-submitted", "Credentials submitted", 100.0);
+          manualStep("exp-submitted", "Credentials not submitted", 100.0);
       when(injectExpectationRepository.findAllByInjectAndTeam("inject-id", "team-id"))
           .thenReturn(List.of(opened, clicked, submitted));
 

--- a/openaev-framework/src/main/java/io/openaev/model/inject/form/Expectation.java
+++ b/openaev-framework/src/main/java/io/openaev/model/inject/form/Expectation.java
@@ -67,6 +67,16 @@ public class Expectation {
   private boolean predefined;
 
   /**
+   * Optional display order of this expectation within its inject, ascending. Lets a contract
+   * declare the logical sequence of its expectations (e.g. a phishing action orders its human steps
+   * email {@literal ->} link {@literal ->} submission) instead of relying on an incidental
+   * alphabetical sort. {@code null} means unordered - the reader then falls back to name / id, so
+   * every other contract is unaffected.
+   */
+  @JsonProperty("expectation_order")
+  private Integer order;
+
+  /**
    * Security platform types expected to fulfil this expectation.
    *
    * <p>When non-empty, the platform focuses the detection/prevention result on collectors of those

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/TargetResultsDetail.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/TargetResultsDetail.tsx
@@ -71,6 +71,19 @@ const TargetResultsDetail = ({ inject, target, isAgentless, position, total, onS
       .toSorted((a, b) => Object.keys(ExpectationType).indexOf(a as ExpectationResultType) - Object.keys(ExpectationType).indexOf(b as ExpectationResultType))
       .forEach((key) => {
         sortedGroupedResults[key] = groupedByType[key].toSorted((a, b) => {
+          // Contract-declared order first (e.g. phishing: email -> link -> submission);
+          // unordered expectations sort after ordered ones, then by name, then by id.
+          const aOrder = a.inject_expectation_order;
+          const bOrder = b.inject_expectation_order;
+          if (aOrder != null && bOrder != null && aOrder !== bOrder) {
+            return aOrder - bOrder;
+          }
+          if (aOrder != null && bOrder == null) {
+            return -1; // ordered comes before unordered
+          }
+          if (aOrder == null && bOrder != null) {
+            return 1;
+          }
           if (a.inject_expectation_name && b.inject_expectation_name) {
             return a.inject_expectation_name.localeCompare(b.inject_expectation_name);
           }

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/TargetResultsTimeline.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/TargetResultsTimeline.tsx
@@ -89,7 +89,7 @@ const TargetResultsTimeline: FunctionComponent<Props> = ({
         const color = getColor(step.status);
         const completed = isCompleted(step);
         const previous = steps[index - 1];
-        // Prefer the expectation's own name (e.g. "Credentials submitted") over the generic
+        // Prefer the expectation's own name (e.g. "Credentials not submitted") over the generic
         // status label (e.g. "Validation Failed"): the outcome is already conveyed by the node
         // color and detailed in the cards below. Fall back to the status label for the
         // attack start/end steps and for expectations without a name.

--- a/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/targetResultsSteps.ts
+++ b/openaev-front/src/admin/components/atomic_testings/atomic_testing/target_result/targetResultsSteps.ts
@@ -4,7 +4,7 @@ export interface TimelineStep {
   key: string;
   /** Status-derived label (e.g. "Validation Failed") - used as a fallback when the expectation has no name. */
   label: string;
-  /** The expectation's own name (e.g. "Credentials submitted") - preferred over the status label in the timeline. */
+  /** The expectation's own name (e.g. "Credentials not submitted") - preferred over the status label in the timeline. */
   name?: string;
   /** Expectation type (PREVENTION, DETECTION, ...) - undefined for the attack start / end steps. */
   type?: string;

--- a/openaev-front/src/admin/components/common/injects/expectations/Expectation.ts
+++ b/openaev-front/src/admin/components/common/injects/expectations/Expectation.ts
@@ -24,13 +24,19 @@ export interface ExpectationInput {
   // Security platform types expected to fulfil this expectation (empty = any platform).
   expectation_expected_security_platform_types?: string[];
   expectation_is_predefined: boolean;
+  // Display order within the inject, declared by the injector contract (e.g. phishing orders its
+  // steps email -> link -> submission). Not user-editable: carried through edits so the results
+  // timeline keeps its logical order. Null/undefined means unordered.
+  expectation_order?: number | null;
 }
 
 // Derived from the canonical type map so a platform type added server-side
 // (e.g. VULNERABILITY_SCANNER) always shows up in the expectation forms.
 export const SECURITY_PLATFORM_TYPES = Object.keys(SECURITY_PLATFORM_TYPE_LABELS) as SecurityPlatformType[];
 
-export interface ExpectationInputForm extends Omit<ExpectationInput, 'expectation_expiration_time' | 'expectation_is_multi_selectable'> {
+// expectation_order is deliberately not part of the form: it is contract-declared, not
+// user-editable, and ExpectationPopover carries it through on submit.
+export interface ExpectationInputForm extends Omit<ExpectationInput, 'expectation_expiration_time' | 'expectation_is_multi_selectable' | 'expectation_order'> {
   expiration_time_days: number;
   expiration_time_hours: number;
   expiration_time_minutes: number;

--- a/openaev-front/src/admin/components/common/injects/expectations/ExpectationPopover.tsx
+++ b/openaev-front/src/admin/components/common/injects/expectations/ExpectationPopover.tsx
@@ -75,6 +75,9 @@ const ExpectationPopover: FunctionComponent<ExpectationPopoverProps> = ({
       expectation_expiration_time: data.expiration_time_days * 3600 * 24
         + data.expiration_time_hours * 3600
         + data.expiration_time_minutes * 60,
+      // The contract-declared display order is not part of the edit form: carry it through so
+      // editing a predefined expectation (e.g. a phishing step) keeps its place in the chain.
+      expectation_order: expectation.expectation_order,
     };
     handleUpdate(values, index);
     handleCloseEdit();

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -6143,6 +6143,11 @@ export interface InjectExpectationOutput {
   inject_expectation_inject?: string;
   /** Name of the inject expectation */
   inject_expectation_name?: string;
+  /**
+   * Display order of the expectation within its inject, ascending. Declared by the injector contract (e.g. phishing orders its steps email -> link -> submission); null means unordered and readers fall back to name / id.
+   * @format int32
+   */
+  inject_expectation_order?: number;
   /** Results associated with the inject expectation */
   inject_expectation_results?: InjectExpectationResult[];
   /**

--- a/openaev-model/src/main/java/io/openaev/database/model/BaseInjectExpectation.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/BaseInjectExpectation.java
@@ -198,6 +198,18 @@ public class BaseInjectExpectation implements Base, Cloneable {
   private boolean expectationGroup;
 
   /**
+   * Optional display order of this expectation within its inject, ascending. Populated from the
+   * injector contract (see the phishing action, which orders its human steps email {@literal ->}
+   * link {@literal ->} submission) and used by the results UI to sort the chain timeline and the
+   * per-type list deterministically. {@code null} means unordered (every expectation that does not
+   * declare an order), and the UI falls back to name / id.
+   */
+  @Setter
+  @Column(name = "inject_expectation_order")
+  @JsonProperty("inject_expectation_order")
+  private Integer order;
+
+  /**
    * Security platform types expected to fulfil this (technical) expectation. When non-empty, only
    * collectors of those types are pre-seeded as pending results and considered for scoring. Empty
    * or null means "any security platform" (legacy behaviour).


### PR DESCRIPTION
## Summary

Fixes #7463.

Phishing expectations use inverted polarity (pre-scored green as "resisted", flipped red on interaction), but their names described the interaction, so a green "Email opened" meant the email was NOT opened. This PR renames the steps to the resisted outcome and adds a generic, contract-declared display order so the results chain and list render email -> click -> submission deterministically instead of alphabetically.

### 1. Resisted-outcome step names

- `PhishingTrackingService` constants renamed: "Email opened" -> "Email not opened", "Phishing link clicked" -> "Link not clicked", "Credentials submitted" -> "Credentials not submitted". Step descriptions on the landing-page contract updated to match ("Red once the recipient..., green while...").
- These names are the join key between persisted expectation rows and the tracking service, so the migration realigns existing data (see below) - otherwise in-flight injects would stop scoring after the upgrade.

### 2. Generic contract-declared expectation ordering (no UI workaround)

- New optional `expectation_order` / `inject_expectation_order` field across the stack: contract form DTO (`model.inject.form.Expectation`), domain expectation (`Expectation` interface + `ManualExpectation`), persisted entity (`BaseInjectExpectation`, new nullable `inject_expectation_order` column), converter (`InjectExpectationUtils`), output DTO + mapper (`InjectExpectationOutput`, `InjectExpectationMapper`), and generated `api-types.d.ts`.
- The phishing landing-page contract declares order 1/2/3 on its human steps (email -> link -> submission) in `PhishingLandingPageService`.
- The results UI (`TargetResultsDetail`) sorts each type group by contract-declared order first, ordered before unordered, then name, then id. The chain timeline consumes the sorted results, so both the chain and the list follow the declared order. Any other injector contract can declare orders the same way; expectations without an order keep the existing name/id sort.
- The edit form does not expose the order (it is contract-declared, not user-editable); `ExpectationPopover` carries it through on update so editing a step does not lose its place.

### 3. Migration (`V6_20260816120000000`)

- Adds the nullable `inject_expectation_order` column (metadata-only ALTER).
- Renames existing phishing step rows and backfills their order 1/2/3, scoped to injects of the `openaev_phishing` injector so user-defined expectations sharing a name are never touched.
- Rewrites the `expectations` array inside `inject_content` of phishing injects (pending injects re-create rows from that JSON at execution time).
- Deletes `expectation-inject` indexing status rows to force a re-index (names are indexed in ES).
- Injector contract rows are not migrated: `resyncAllContracts()` rebuilds every landing-page contract at startup with the new names and orders.
- Idempotent: IF NOT EXISTS ALTER, renames match only old names, order backfill and JSON rewrite converge on re-run.

## Test plan

- [x] `PhishingLandingPageServiceTest`: new test asserting the synthesized contract declares the three resisted-outcome step names with orders 1/2/3 (and leaves detection/prevention unordered) - 14/14 green.
- [x] `PhishingTrackingServiceTest` (15/15), `PhishingExecutorTest` (1/1): tracking and executor still score by the renamed constants.
- [x] `io.openaev.service.InjectExpectationServiceTest` (49/49) including the same-type display merge tests updated to the new names.
- [x] `io.openaev.rest.inject_expectation.InjectExpectationServiceTest` (5/5).
- [x] Backend compiles (model, framework, api) with Spotless applied.
- [x] Frontend `yarn check-ts` and ESLint on touched files: clean.
