### PR TITLE
fix(api): return actionable message on method-level validation 400 (#7466)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Resource;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springdoc.api.ErrorMessage;
@@ -275,20 +276,48 @@ public class RestBehavior {
                 : error instanceof ObjectError objectError
                     ? objectError.getObjectName()
                     : valueParameterLabel;
-        String label = jsonFieldsMapping.getOrDefault(rawName, rawName);
-        String errorMessage = error.getDefaultMessage();
-        // getDefaultMessage() is nullable and ValidationContent wraps it in List.of(), which
-        // rejects null - degrade to a generic reason instead of a 500, as the sibling handler does.
-        errorsBag.put(
-            label, new ValidationContent(errorMessage == null ? "Invalid value" : errorMessage));
-        summaryParts.add(summaryPart(label, errorMessage));
+        collectValidationError(
+            errorsBag, summaryParts, jsonFieldsMapping.getOrDefault(rawName, rawName), error);
       }
+    }
+    // Method-level cross-parameter constraints (rejecting a combination of arguments) are
+    // reported separately from the per-parameter results; without this they would degrade to
+    // the generic "Validation Failed" fallback with empty children.
+    for (MessageSourceResolvable error : ex.getCrossParameterValidationResults()) {
+      collectValidationError(errorsBag, summaryParts, "parameters", error);
     }
     errors.setChildren(errorsBag);
     bag.setErrors(errors);
     bag.setMessage(summarizeValidationErrors(summaryParts));
     log.debug("HandlerMethodValidationException: {}", bag.getMessage(), ex);
     return bag;
+  }
+
+  // One children entry plus one summary part per violation. Children entries MERGE on a duplicate
+  // label (the same field rejected by two constraints, or two unnamed parameters sharing a
+  // degraded label) so no reason is silently clobbered. getDefaultMessage() is nullable and
+  // ValidationContent wraps it in List.of(), which rejects null - degrade to a generic reason
+  // instead of a 500, as the sibling MethodArgumentNotValidException handler does.
+  private static void collectValidationError(
+      Map<String, ValidationContent> errorsBag,
+      List<String> summaryParts,
+      String label,
+      MessageSourceResolvable error) {
+    String errorMessage = error.getDefaultMessage();
+    ValidationContent content =
+        new ValidationContent(errorMessage == null ? "Invalid value" : errorMessage);
+    errorsBag.merge(label, content, RestBehavior::mergeValidationContents);
+    summaryParts.add(summaryPart(label, errorMessage));
+  }
+
+  private static ValidationContent mergeValidationContents(
+      ValidationContent existing, ValidationContent added) {
+    ValidationContent merged = new ValidationContent();
+    merged.setErrors(
+        Stream.concat(existing.getErrors().stream(), added.getErrors().stream())
+            .distinct()
+            .toList());
+    return merged;
   }
 
   // Best-effort internal-name -> JSON-name mapping for a validated bean argument. Empty when the
@@ -305,17 +334,21 @@ public class RestBehavior {
     }
   }
 
-  // Parameter name for a value-level constraint, degrading to the declaring type when the name is
-  // unavailable (sources not compiled with -parameters); never null so the children key stays valid
-  // (Jackson refuses to serialize a null map key, which would be a 500).
+  // Parameter name for a value-level constraint, degrading to the JDK-style positional argN label
+  // when the name is unavailable (sources not compiled with -parameters): a bare type simple name
+  // could collide across parameters (e.g. two String parameters) and clobber children entries.
+  // Never null so the children key stays valid (Jackson refuses to serialize a null map key, which
+  // would be a 500).
   private static String parameterLabel(ParameterValidationResult result) {
     MethodParameter parameter = result.getMethodParameter();
     String name = parameter.getParameterName();
     if (name != null && !name.isBlank()) {
       return name;
     }
-    Class<?> type = parameter.getParameterType();
-    return type != null ? type.getSimpleName() : "parameter";
+    int index = parameter.getParameterIndex();
+    // Index -1 is the method return value, which has no position to point at - the declared type
+    // is the most useful label left.
+    return index >= 0 ? "arg" + index : parameter.getParameterType().getSimpleName();
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springdoc.api.ErrorMessage;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.core.MethodParameter;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,12 +37,15 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.validation.method.ParameterValidationResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.reactive.function.UnsupportedMediaTypeException;
 
 @RestControllerAdvice
@@ -52,12 +57,21 @@ public class RestBehavior {
   // Build the mapping between json specific name and the actual database field name
   private Map<String, String> buildJsonMappingFields(MethodArgumentNotValidException ex) {
     Class<?> inputClass = Objects.requireNonNull(ex.getBindingResult().getTarget()).getClass();
+    return buildJsonMappingFields(inputClass);
+  }
+
+  // Internal-name -> JSON-name mapping for a bound input class, shared by the two validation
+  // handlers. The merge function keeps a duplicate internal name from failing the collector with an
+  // IllegalStateException inside the handler (which would turn the 400 into a 500).
+  private Map<String, String> buildJsonMappingFields(Class<?> inputClass) {
     JavaType javaType = mapper.getTypeFactory().constructType(inputClass);
     BeanDescription beanDescription = mapper.getSerializationConfig().introspect(javaType);
     return beanDescription.findProperties().stream()
         .collect(
             Collectors.toMap(
-                BeanPropertyDefinition::getInternalName, BeanPropertyDefinition::getName));
+                BeanPropertyDefinition::getInternalName,
+                BeanPropertyDefinition::getName,
+                (existing, ignored) -> existing));
   }
 
   // -- 400 BAD_REQUEST --
@@ -229,6 +243,79 @@ public class RestBehavior {
     return joined.length() <= MAX_VALIDATION_SUMMARY_LENGTH
         ? joined
         : joined.substring(0, MAX_VALIDATION_SUMMARY_LENGTH - 3) + "...";
+  }
+
+  // Spring 6.2 routes controller method validation through HandlerMethodValidationException, NOT
+  // MethodArgumentNotValidException, whenever a handler mixes a method-level constraint with a
+  // cascaded body - e.g. updateAction's `@NotBlank @PathVariable actionId` alongside a
+  // `@Valid @RequestBody`. RestBehavior does not extend ResponseEntityExceptionHandler, so with no
+  // handler for this class the class-level default applies and the body's "message" is empty
+  // (unless server.error.include-message=always, which this codebase deliberately does not set) -
+  // the opaque "Bad request" a plain API caller or an AI agent's tool wrapper cannot self-correct
+  // from (the exact "why did the arsenal fork bad-request" pain). Mirror the
+  // MethodArgumentNotValidException handler: per-field children plus a concise summarized message.
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(HandlerMethodValidationException.class)
+  public ValidationErrorBag handleHandlerMethodValidationException(
+      HandlerMethodValidationException ex) {
+    ValidationErrorBag bag = new ValidationErrorBag();
+    ValidationError errors = new ValidationError();
+    Map<String, ValidationContent> errorsBag = new HashMap<>();
+    List<String> summaryParts = new ArrayList<>();
+    for (ParameterValidationResult result : ex.getParameterValidationResults()) {
+      // A cascaded @Valid bean argument reports FieldError/ObjectError, whose label needs the JSON
+      // property name; a direct value constraint (@PathVariable / @RequestParam) reports a plain
+      // resolvable, whose best label is the parameter name.
+      Map<String, String> jsonFieldsMapping = jsonMappingForArgument(result.getArgument());
+      String valueParameterLabel = parameterLabel(result);
+      for (MessageSourceResolvable error : result.getResolvableErrors()) {
+        String rawName =
+            error instanceof FieldError fieldError
+                ? fieldError.getField()
+                : error instanceof ObjectError objectError
+                    ? objectError.getObjectName()
+                    : valueParameterLabel;
+        String label = jsonFieldsMapping.getOrDefault(rawName, rawName);
+        String errorMessage = error.getDefaultMessage();
+        // getDefaultMessage() is nullable and ValidationContent wraps it in List.of(), which
+        // rejects null - degrade to a generic reason instead of a 500, as the sibling handler does.
+        errorsBag.put(
+            label, new ValidationContent(errorMessage == null ? "Invalid value" : errorMessage));
+        summaryParts.add(summaryPart(label, errorMessage));
+      }
+    }
+    errors.setChildren(errorsBag);
+    bag.setErrors(errors);
+    bag.setMessage(summarizeValidationErrors(summaryParts));
+    log.debug("HandlerMethodValidationException: {}", bag.getMessage(), ex);
+    return bag;
+  }
+
+  // Best-effort internal-name -> JSON-name mapping for a validated bean argument. Empty when the
+  // argument is null (a direct value constraint) or introspection fails, so labeling degrades to
+  // the raw field/parameter name instead of throwing a second time inside the handler.
+  private Map<String, String> jsonMappingForArgument(Object argument) {
+    if (argument == null) {
+      return Map.of();
+    }
+    try {
+      return buildJsonMappingFields(argument.getClass());
+    } catch (RuntimeException ignored) {
+      return Map.of();
+    }
+  }
+
+  // Parameter name for a value-level constraint, degrading to the declaring type when the name is
+  // unavailable (sources not compiled with -parameters); never null so the children key stays valid
+  // (Jackson refuses to serialize a null map key, which would be a 500).
+  private static String parameterLabel(ParameterValidationResult result) {
+    MethodParameter parameter = result.getMethodParameter();
+    String name = parameter.getParameterName();
+    if (name != null && !name.isBlank()) {
+      return name;
+    }
+    Class<?> type = parameter.getParameterType();
+    return type != null ? type.getSimpleName() : "parameter";
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
+++ b/openaev-api/src/main/java/io/openaev/rest/helper/RestBehavior.java
@@ -255,11 +255,14 @@ public class RestBehavior {
   // the opaque "Bad request" a plain API caller or an AI agent's tool wrapper cannot self-correct
   // from (the exact "why did the arsenal fork bad-request" pain). Mirror the
   // MethodArgumentNotValidException handler: per-field children plus a concise summarized message.
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  // The exception's own status is preserved rather than hard-coding 400: Spring supplies 500 when
+  // the failure is a controller RETURN VALUE constraint (a broken server-side contract, not a
+  // client mistake), and that must not be downgraded to a client error.
   @ExceptionHandler(HandlerMethodValidationException.class)
-  public ValidationErrorBag handleHandlerMethodValidationException(
+  public ResponseEntity<ValidationErrorBag> handleHandlerMethodValidationException(
       HandlerMethodValidationException ex) {
     ValidationErrorBag bag = new ValidationErrorBag();
+    bag.setCode(ex.getStatusCode().value());
     ValidationError errors = new ValidationError();
     Map<String, ValidationContent> errorsBag = new HashMap<>();
     List<String> summaryParts = new ArrayList<>();
@@ -289,8 +292,13 @@ public class RestBehavior {
     errors.setChildren(errorsBag);
     bag.setErrors(errors);
     bag.setMessage(summarizeValidationErrors(summaryParts));
-    log.debug("HandlerMethodValidationException: {}", bag.getMessage(), ex);
-    return bag;
+    if (ex.getStatusCode().is5xxServerError()) {
+      // A rejected return value is a server-side bug: keep it visible in production logs.
+      log.error("HandlerMethodValidationException (return value): {}", bag.getMessage(), ex);
+    } else {
+      log.debug("HandlerMethodValidationException: {}", bag.getMessage(), ex);
+    }
+    return new ResponseEntity<>(bag, ex.getStatusCode());
   }
 
   // One children entry plus one summary part per violation. Children entries MERGE on a duplicate

--- a/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
@@ -24,6 +24,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springdoc.api.ErrorMessage;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,8 +34,11 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
+import org.springframework.validation.method.MethodValidationResult;
+import org.springframework.validation.method.ParameterValidationResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @DisplayName("RestBehavior exception mapping")
 class RestBehaviorTest {
@@ -522,6 +528,133 @@ class RestBehaviorTest {
 
       // THEN
       assertEquals("sample_name: must not be blank", bag.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("HandlerMethodValidationException handling (Spring 6.2 method validation 400)")
+  class HandlerMethodValidationHandling {
+
+    /** Input shape exercising the internal-name -> JSON-name mapping, as the arsenal DTOs do. */
+    static class SampleValidationInput {
+      @JsonProperty("sample_name")
+      public String name;
+
+      @JsonProperty("output_parsers")
+      public List<String> outputParsers;
+    }
+
+    // A handler mixing a method-level path-var constraint with a cascaded @Valid body - the exact
+    // updateAction shape that makes Spring 6.2 raise HandlerMethodValidationException.
+    @SuppressWarnings("unused")
+    private void updateActionLike(String actionId, SampleValidationInput input) {}
+
+    private RestBehavior behavior() {
+      RestBehavior behavior = new RestBehavior();
+      behavior.mapper = ObjectMapperHelper.openAEVJsonMapper();
+      return behavior;
+    }
+
+    private Method updateActionLikeMethod() throws NoSuchMethodException {
+      return HandlerMethodValidationHandling.class.getDeclaredMethod(
+          "updateActionLike", String.class, SampleValidationInput.class);
+    }
+
+    private HandlerMethodValidationException bodyValidationException(FieldError... fieldErrors)
+        throws NoSuchMethodException {
+      Method method = updateActionLikeMethod();
+      MethodParameter bodyParameter = new MethodParameter(method, 1);
+      ParameterValidationResult result =
+          new ParameterValidationResult(
+              bodyParameter, new SampleValidationInput(), List.of(fieldErrors));
+      MethodValidationResult validation =
+          MethodValidationResult.create(this, method, List.of(result));
+      return new HandlerMethodValidationException(validation);
+    }
+
+    @Test
+    @DisplayName("the handler is registered and resolved for HandlerMethodValidationException")
+    void given_handlerMethodValidationException_should_resolveCorrectHandler()
+        throws NoSuchMethodException {
+      // GIVEN
+      ExceptionHandlerMethodResolver resolver =
+          new ExceptionHandlerMethodResolver(RestBehavior.class);
+
+      // WHEN - any non-empty method-validation failure (ParameterValidationResult rejects an
+      // empty resolvable-errors list, so a representative field error is required)
+      Method resolved =
+          resolver.resolveMethodByThrowable(
+              bodyValidationException(new FieldError("input", "name", "must not be blank")));
+
+      // THEN - without this the class falls to Spring's default /error (empty message)
+      assertNotNull(resolved);
+      assertEquals("handleHandlerMethodValidationException", resolved.getName());
+    }
+
+    @Test
+    @DisplayName(
+        "a cascaded @Valid body failure carries a non-empty message with JSON field names "
+            + "(the arsenal fork 400 is now self-correcting)")
+    void given_bodyValidationErrors_should_carryNonEmptySummaryWithJsonNames()
+        throws NoSuchMethodException {
+      // GIVEN - the arsenal shape: name @NotBlank and outputParsers @NotNull both rejected
+      HandlerMethodValidationException ex =
+          bodyValidationException(
+              new FieldError("input", "name", "must not be blank"),
+              new FieldError("input", "outputParsers", "must not be null"));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN - non-empty, actionable, and NOT the opaque default the frontend showed before
+      assertFalse(bag.getMessage() == null || bag.getMessage().isBlank());
+      assertFalse("Validation Failed".equals(bag.getMessage()));
+      assertEquals(
+          "output_parsers: must not be null; sample_name: must not be blank", bag.getMessage());
+      assertTrue(bag.getErrors().getChildren().containsKey("sample_name"));
+      assertTrue(bag.getErrors().getChildren().containsKey("output_parsers"));
+    }
+
+    @Test
+    @DisplayName("a direct value constraint (path variable) still yields a non-empty message")
+    void given_valueConstraintFailure_should_carryNonEmptyMessage() throws NoSuchMethodException {
+      // GIVEN - a method-level @NotBlank @PathVariable actionId reports a plain resolvable, not a
+      // FieldError; the label degrades to the parameter name but the reason must still surface
+      Method method = updateActionLikeMethod();
+      MethodParameter pathParameter = new MethodParameter(method, 0);
+      pathParameter.initParameterNameDiscovery(new DefaultParameterNameDiscoverer());
+      MessageSourceResolvable resolvable =
+          new DefaultMessageSourceResolvable(new String[] {"NotBlank"}, "must not be blank");
+      ParameterValidationResult result =
+          new ParameterValidationResult(pathParameter, "", List.of(resolvable));
+      HandlerMethodValidationException ex =
+          new HandlerMethodValidationException(
+              MethodValidationResult.create(this, method, List.of(result)));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN
+      assertFalse(bag.getMessage() == null || bag.getMessage().isBlank());
+      assertFalse("Validation Failed".equals(bag.getMessage()));
+      assertTrue(bag.getMessage().contains("must not be blank"));
+    }
+
+    @Test
+    @DisplayName("a constraint without a default message never renders a null children key")
+    void given_nullDefaultMessage_should_degradeWithoutNullKey() throws NoSuchMethodException {
+      // GIVEN
+      HandlerMethodValidationException ex =
+          bodyValidationException(new FieldError("input", "name", null));
+
+      // WHEN - must not throw (ValidationContent wraps the message in List.of, which rejects null)
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN
+      assertEquals("sample_name", bag.getMessage());
+      assertFalse(bag.getErrors().getChildren().containsKey(null));
+      assertEquals(
+          List.of("Invalid value"), bag.getErrors().getChildren().get("sample_name").getErrors());
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
@@ -554,6 +554,13 @@ class RestBehaviorTest {
     @SuppressWarnings("unused")
     private void linkActionsLike(String actionId, String parentId) {}
 
+    // A String-returning handler for the return-value regression: parameter index -1 targets the
+    // method return type.
+    @SuppressWarnings("unused")
+    private String renderActionLike() {
+      return "";
+    }
+
     private RestBehavior behavior() {
       RestBehavior behavior = new RestBehavior();
       behavior.mapper = ObjectMapperHelper.openAEVJsonMapper();
@@ -609,9 +616,14 @@ class RestBehaviorTest {
               new FieldError("input", "outputParsers", "must not be null"));
 
       // WHEN
-      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+      ResponseEntity<ValidationErrorBag> response =
+          behavior().handleHandlerMethodValidationException(ex);
 
       // THEN - non-empty, actionable, and NOT the opaque default the frontend showed before
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      ValidationErrorBag bag = response.getBody();
+      assertNotNull(bag);
+      assertEquals(400, bag.getCode());
       assertFalse(bag.getMessage() == null || bag.getMessage().isBlank());
       assertFalse("Validation Failed".equals(bag.getMessage()));
       assertEquals(
@@ -637,9 +649,13 @@ class RestBehaviorTest {
               MethodValidationResult.create(this, method, List.of(result)));
 
       // WHEN
-      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+      ResponseEntity<ValidationErrorBag> response =
+          behavior().handleHandlerMethodValidationException(ex);
 
       // THEN
+      assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+      ValidationErrorBag bag = response.getBody();
+      assertNotNull(bag);
       assertFalse(bag.getMessage() == null || bag.getMessage().isBlank());
       assertFalse("Validation Failed".equals(bag.getMessage()));
       assertTrue(bag.getMessage().contains("must not be blank"));
@@ -653,9 +669,10 @@ class RestBehaviorTest {
           bodyValidationException(new FieldError("input", "name", null));
 
       // WHEN - must not throw (ValidationContent wraps the message in List.of, which rejects null)
-      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex).getBody();
 
       // THEN
+      assertNotNull(bag);
       assertEquals("sample_name", bag.getMessage());
       assertFalse(bag.getErrors().getChildren().containsKey(null));
       assertEquals(
@@ -692,9 +709,10 @@ class RestBehaviorTest {
               MethodValidationResult.create(this, method, List.of(first, second)));
 
       // WHEN
-      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex).getBody();
 
       // THEN - both violations survive under deterministic, distinct labels
+      assertNotNull(bag);
       assertEquals(
           "arg0: must not be blank; arg1: size must be between 36 and 36", bag.getMessage());
       assertTrue(bag.getErrors().getChildren().containsKey("arg0"));
@@ -712,9 +730,10 @@ class RestBehaviorTest {
               new FieldError("input", "name", "must match \"[a-z]+\""));
 
       // WHEN
-      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex).getBody();
 
       // THEN - the children entry merges instead of keeping only the last reason
+      assertNotNull(bag);
       assertEquals(
           List.of("must not be blank", "must match \"[a-z]+\""),
           bag.getErrors().getChildren().get("sample_name").getErrors());
@@ -741,13 +760,45 @@ class RestBehaviorTest {
                           "action and parent identifiers must differ"))));
 
       // WHEN
-      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex).getBody();
 
       // THEN - actionable, not the "Validation Failed" fallback with empty children
+      assertNotNull(bag);
       assertEquals("parameters: action and parent identifiers must differ", bag.getMessage());
       assertEquals(
           List.of("action and parent identifiers must differ"),
           bag.getErrors().getChildren().get("parameters").getErrors());
+    }
+
+    @Test
+    @DisplayName("a return-value validation failure keeps Spring's 500 status (server contract)")
+    void given_returnValueValidationFailure_should_preserve500Status()
+        throws NoSuchMethodException {
+      // GIVEN - a constraint rejecting what the controller RETURNED: Spring marks the result as
+      // for-return-value (parameter index -1) and supplies INTERNAL_SERVER_ERROR, because a
+      // broken response contract is a server bug, not a client mistake
+      Method method = HandlerMethodValidationHandling.class.getDeclaredMethod("renderActionLike");
+      ParameterValidationResult result =
+          new ParameterValidationResult(
+              new MethodParameter(method, -1),
+              "",
+              List.of(
+                  new DefaultMessageSourceResolvable(
+                      new String[] {"NotBlank"}, "must not be blank")));
+      HandlerMethodValidationException ex =
+          new HandlerMethodValidationException(
+              MethodValidationResult.create(this, method, List.of(result)));
+
+      // WHEN
+      ResponseEntity<ValidationErrorBag> response =
+          behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN - the 500 must not be downgraded to a 400
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+      ValidationErrorBag bag = response.getBody();
+      assertNotNull(bag);
+      assertEquals(500, bag.getCode());
+      assertTrue(bag.getMessage().contains("must not be blank"));
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/helper/RestBehaviorTest.java
@@ -549,6 +549,11 @@ class RestBehaviorTest {
     @SuppressWarnings("unused")
     private void updateActionLike(String actionId, SampleValidationInput input) {}
 
+    // Two same-typed parameters: without -parameters both would degrade to the same "String"
+    // label, so this shape proves the positional fallback keeps them apart.
+    @SuppressWarnings("unused")
+    private void linkActionsLike(String actionId, String parentId) {}
+
     private RestBehavior behavior() {
       RestBehavior behavior = new RestBehavior();
       behavior.mapper = ObjectMapperHelper.openAEVJsonMapper();
@@ -655,6 +660,94 @@ class RestBehaviorTest {
       assertFalse(bag.getErrors().getChildren().containsKey(null));
       assertEquals(
           List.of("Invalid value"), bag.getErrors().getChildren().get("sample_name").getErrors());
+    }
+
+    @Test
+    @DisplayName(
+        "unnamed same-typed parameters get distinct positional labels instead of colliding")
+    void given_unnamedParameters_should_labelPositionallyWithoutCollision()
+        throws NoSuchMethodException {
+      // GIVEN - two String parameters whose names are unavailable (no discoverer initialized,
+      // as when sources are not compiled with -parameters): a type-based fallback would label
+      // both "String" and clobber one children entry
+      Method method =
+          HandlerMethodValidationHandling.class.getDeclaredMethod(
+              "linkActionsLike", String.class, String.class);
+      ParameterValidationResult first =
+          new ParameterValidationResult(
+              new MethodParameter(method, 0),
+              "",
+              List.of(
+                  new DefaultMessageSourceResolvable(
+                      new String[] {"NotBlank"}, "must not be blank")));
+      ParameterValidationResult second =
+          new ParameterValidationResult(
+              new MethodParameter(method, 1),
+              "x",
+              List.of(
+                  new DefaultMessageSourceResolvable(
+                      new String[] {"Size"}, "size must be between 36 and 36")));
+      HandlerMethodValidationException ex =
+          new HandlerMethodValidationException(
+              MethodValidationResult.create(this, method, List.of(first, second)));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN - both violations survive under deterministic, distinct labels
+      assertEquals(
+          "arg0: must not be blank; arg1: size must be between 36 and 36", bag.getMessage());
+      assertTrue(bag.getErrors().getChildren().containsKey("arg0"));
+      assertTrue(bag.getErrors().getChildren().containsKey("arg1"));
+    }
+
+    @Test
+    @DisplayName("a field rejected by two constraints keeps both reasons in its children entry")
+    void given_sameFieldRejectedTwice_should_mergeReasonsInsteadOfClobbering()
+        throws NoSuchMethodException {
+      // GIVEN - e.g. @NotBlank and @Pattern both rejecting the same field with different reasons
+      HandlerMethodValidationException ex =
+          bodyValidationException(
+              new FieldError("input", "name", "must not be blank"),
+              new FieldError("input", "name", "must match \"[a-z]+\""));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN - the children entry merges instead of keeping only the last reason
+      assertEquals(
+          List.of("must not be blank", "must match \"[a-z]+\""),
+          bag.getErrors().getChildren().get("sample_name").getErrors());
+      assertTrue(bag.getMessage().contains("must not be blank"));
+      assertTrue(bag.getMessage().contains("must match"));
+    }
+
+    @Test
+    @DisplayName(
+        "a cross-parameter constraint failure surfaces its reason instead of the generic fallback")
+    void given_crossParameterConstraint_should_surfaceReason() throws NoSuchMethodException {
+      // GIVEN - a method-level constraint rejecting a combination of arguments, reported by
+      // Spring 6.2 separately from the per-parameter results
+      Method method = updateActionLikeMethod();
+      HandlerMethodValidationException ex =
+          new HandlerMethodValidationException(
+              MethodValidationResult.create(
+                  this,
+                  method,
+                  List.of(),
+                  List.of(
+                      new DefaultMessageSourceResolvable(
+                          new String[] {"ConsistentIds"},
+                          "action and parent identifiers must differ"))));
+
+      // WHEN
+      ValidationErrorBag bag = behavior().handleHandlerMethodValidationException(ex);
+
+      // THEN - actionable, not the "Validation Failed" fallback with empty children
+      assertEquals("parameters: action and parent identifiers must differ", bag.getMessage());
+      assertEquals(
+          List.of("action and parent identifiers must differ"),
+          bag.getErrors().getChildren().get("parameters").getErrors());
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #7466.

`PUT /api/threat_arsenals/{actionId}` and any handler that mixes a method-level parameter constraint (e.g. `@NotBlank @PathVariable`) with a cascaded `@Valid @RequestBody` could return an opaque `400 Bad Request` with an empty `message`. Spring 6.2 routes those body validation failures through `HandlerMethodValidationException` instead of `MethodArgumentNotValidException`, and `RestBehavior` handled only the latter (and does not extend `ResponseEntityExceptionHandler`), so the failure fell through to Spring's default `/error` path with no actionable detail.

This is the last opaque-400 class on the threat-arsenal update path. It was hit repeatedly by the XTM One orchestrator's fork finalize `PUT`, which got back a bare "Bad Request" it could not self-correct from.

## Changes

- Add `@ExceptionHandler(HandlerMethodValidationException.class)` to `RestBehavior.java`, mirroring the existing `MethodArgumentNotValidException` handler: iterate the `ParameterValidationResult` entries, map internal field names to their JSON property names, and build the same summarized `ValidationErrorBag` (non-empty summary plus per-field children errors) that the frontend already parses.
- Cover all three failure shapes: cascaded `@Valid` body failures (labeled with JSON property names), direct value-level constraint failures on `@PathVariable` / `@RequestParam` (labeled with the parameter name), and Spring 6.2 cross-parameter constraint failures (folded in under a stable `parameters` label instead of degrading to the generic "Validation Failed").
- Robust labeling without data loss: unnamed parameters (sources compiled without `-parameters`) degrade to deterministic positional `argN` labels instead of colliding type names, duplicate children labels merge their reasons instead of clobbering earlier ones, and a null constraint message degrades to "Invalid value" without ever creating a null map key (which Jackson would turn into a 500).
- Preserve the exception's own status instead of hard-coding 400: Spring supplies `INTERNAL_SERVER_ERROR` when the rejected constraint is on a controller return value (a broken server-side contract), so the handler mirrors `ex.getStatusCode()` in both the response and the bag's `code`, and logs that server-side case at error level.
- Refactor `buildJsonMappingFields` into a reusable overload shared by both validation handlers; the added `toMap` merge function also keeps a duplicate internal bean property name from turning the 400 into a 500.

## Test plan

- [x] `RestBehaviorTest`: `HandlerMethodValidationHandling` suite (8 tests) asserting handler resolution, a non-empty 400 summary with JSON field names for cascaded body failures, a non-empty message for value-level constraint failures, distinct positional labels for unnamed same-typed parameters, merged reasons for a field rejected by two constraints, cross-parameter constraint reasons, null-message degradation without null keys, and the preserved 500 for a return-value validation failure.
- [x] `mvn -pl openaev-api -am test -Dtest=RestBehaviorTest` green (33 tests).
- [x] `mvn -pl openaev-api spotless:check` clean.
