### PR TITLE
fix(autonomous): keep AI scenario cockpit reliable - tooltip, reload, scope 500 (#7472)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/AutonomousRunApi.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -470,8 +471,10 @@ public class AutonomousRunApi extends RestBehavior {
           "Edits a step the orchestrator already authored - payload / target / injector contract /"
               + " title - by its step template id (from the attack-path state read), preserving the"
               + " step's id and its DEPEND_ON kill-chain parent. This is how the AI changes"
-              + " existing logic instead of re-authoring a duplicate. The parent in the body is"
-              + " ignored; the existing dependency is kept.")
+              + " existing logic instead of re-authoring a duplicate. When a 'trigger' is supplied,"
+              + " the step's finding trigger is rebuilt too, so a mis-wired finding-driven step can"
+              + " be corrected in place; omit it to leave the conditions untouched. The parent in"
+              + " the body is ignored; the existing dependency is kept.")
   @PutMapping("/{runId}/attack-path/steps/{stepTemplateId}")
   @Transactional
   @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
@@ -481,8 +484,25 @@ public class AutonomousRunApi extends RestBehavior {
       @PathVariable String stepTemplateId,
       @Valid @RequestBody AutonomousAttackPathStepInput input) {
     String updatedId =
-        autonomousRunService.updateAttackPathStep(runId, stepTemplateId, input.getInject());
+        autonomousRunService.updateAttackPathStep(
+            runId, stepTemplateId, input.getInject(), input.getTrigger());
     return new AutonomousAttackPathStepResult(updatedId);
+  }
+
+  @Operation(
+      summary = "Orchestrator: delete an authored chained step",
+      description =
+          "Removes a step the orchestrator authored, by its step template id (from the attack-path"
+              + " state read) - the pruning counterpart of appending / updating a step, so a"
+              + " mis-wired finding-driven step can be corrected by deletion instead of left"
+              + " dangling. The scenario mirror twin is pruned in lock-step. Executed run steps stay"
+              + " as history; only the reusable template is removed.")
+  @DeleteMapping("/{runId}/attack-path/steps/{stepTemplateId}")
+  @Transactional
+  @AccessControl(skipRBAC = true, isEnterpriseEdition = true)
+  public void deleteAttackPathStep(
+      @RunTenantScope TxCtx ctx, @PathVariable String runId, @PathVariable String stepTemplateId) {
+    autonomousRunService.deleteAttackPathStep(runId, stepTemplateId);
   }
 
   @Operation(

--- a/openaev-api/src/main/java/io/openaev/api/autonomous/dto/AutonomousAttackPathStepState.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/dto/AutonomousAttackPathStepState.java
@@ -7,13 +7,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * A live snapshot of one step already authored on an autonomous attack path: its stable authoring
- * handle (the step template id), its kill-chain parent (the DEPEND_ON step it runs after), its
- * resolved target, its backing inject, its current execution status, and its execution traces. The
- * orchestrator reads the full list every decision cycle so it can reconstruct the exact chain it
- * has ALREADY built - by {@code step_template_id} and {@code parent_step_template_id}, not by
- * guesswork - and therefore chain onto or UPDATE an existing step instead of re-authoring a
- * duplicate, and see what each step actually did (its traces) before deciding the next move.
+ * A live snapshot of one step already authored on an autonomous attack path. Every attack path is a
+ * finding-driven graph, not a linear chain: a step fires either when an upstream finding matches
+ * its {@code trigger} (the preferred wiring - {@code event_name} + {@code trigger_filters} + {@code
+ * trigger_mappings}) or, only for pure ordering, when its {@code parent_step_template_id}
+ * (DEPEND_ON) step has run. The snapshot carries both so a reader can reconstruct the EXACT wiring
+ * it has already built - which findings each step reacts to and which values it consumes, plus the
+ * kill-chain parent when one exists - and therefore chain onto, correct, or prune an existing step
+ * (by its stable {@code step_template_id}) instead of re-authoring a duplicate or rebuilding the
+ * path as a flat DEPEND_ON list. It also carries each step's backing inject, live execution status
+ * and execution traces so the reader can see what a step actually did before deciding the next
+ * move.
  */
 @Getter
 @AllArgsConstructor
@@ -31,9 +35,37 @@ public class AutonomousAttackPathStepState {
   @JsonProperty("parent_step_template_id")
   @Schema(
       description =
-          "The step template id this step runs AFTER (its DEPEND_ON parent), or null for a root "
-              + "step. Together with step_template_id this reconstructs the attack-path graph.")
+          "Pure-ordering parent: the step template id this step runs AFTER (its DEPEND_ON parent), "
+              + "or null when the step is a seed or is wired finding-driven via its trigger. Prefer "
+              + "reading the trigger fields below to understand WHY a step fires; this is only the "
+              + "ordering fallback, not the primary wiring.")
   private String parentStepTemplateId;
+
+  @JsonProperty("event_name")
+  @Schema(
+      description =
+          "Human-readable name of the finding EVENT this step reacts to (the trigger root's name, "
+              + "e.g. \"SMB service exposed\"), or null when the step has no finding trigger (a seed "
+              + "or a pure DEPEND_ON step). Mirror of the trigger's event_name on the write side.")
+  private String eventName;
+
+  @JsonProperty("trigger_filters")
+  @Schema(
+      description =
+          "The finding predicates that make this step fire, each rendered as "
+              + "\"<key> <operator> <value>\" (e.g. \"port EQ 445\", \"service IS_NOT_NULL\"). Empty "
+              + "when the step is a seed or a pure DEPEND_ON step. This is the read-back of the "
+              + "trigger's filters, so a reader can see - and correct - exactly what the step "
+              + "listens for instead of inferring a linear chain.")
+  private List<String> triggerFilters;
+
+  @JsonProperty("trigger_mappings")
+  @Schema(
+      description =
+          "The finding values this step binds into its inject inputs, each rendered as "
+              + "\"<key> -> <input>\" (e.g. \"ipv4 -> target_host\"). Empty when the step consumes no "
+              + "finding values. This is the read-back of the trigger's mappings.")
+  private List<String> triggerMappings;
 
   @JsonProperty("inject_id")
   @Schema(description = "Id of the inject backing this step (empty until the step has executed)")

--- a/openaev-api/src/main/java/io/openaev/config/MvcConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/MvcConfig.java
@@ -30,11 +30,20 @@ public class MvcConfig implements WebMvcConfigurer {
 
   @Resource private ObjectMapper objectMapper;
   @Resource private TenantInterceptor tenantInterceptor;
+  @Resource private OrchestratorRunTenantInterceptor orchestratorRunTenantInterceptor;
   @Resource private TxCtxArgumentResolver txCtxArgumentResolver;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(tenantInterceptor).addPathPatterns("/api/tenants/**");
+    // Bridges the legacy v1 TenantContext for the orchestrator callbacks on the non-prefixed
+    // autonomous route (the prefixed route names its tenant and is caller-scoped). Without it, the
+    // 8 callbacks that read/write v1 @Filter entities (Exercise, Team, Finding, Inject, Endpoint)
+    // silently hit the DEFAULT tenant for a run owned by a non-default tenant. See
+    // OrchestratorRunTenantInterceptor for why v1 must be established at request entry.
+    registry
+        .addInterceptor(orchestratorRunTenantInterceptor)
+        .addPathPatterns("/api/autonomous-runs/**");
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/config/OrchestratorRunTenantInterceptor.java
+++ b/openaev-api/src/main/java/io/openaev/config/OrchestratorRunTenantInterceptor.java
@@ -1,0 +1,110 @@
+package io.openaev.config;
+
+import io.openaev.context.TenantContext;
+import io.openaev.security.token.XtmJwksExtractor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.AsyncHandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Establishes the legacy v1 {@link TenantContext} for the orchestrator CALLBACK route, so the
+ * entities those callbacks still reach through the v1 Hibernate {@code tenantFilter} (workflows,
+ * injects, exercises, teams, assets, findings - scoped by {@link
+ * io.openaev.aop.HibernateFilterTransactionAspect}, which reads this ThreadLocal) are filtered to
+ * the run's own tenant. It is the v1 counterpart of what {@link
+ * TxCtxArgumentResolver#runTenantScope} does for the v2 {@code app.current_tenants} GUC.
+ *
+ * <p>Why an interceptor and not per-method: the callbacks ride the legacy NON-prefixed route
+ * ({@code /api/autonomous-runs/**}), which {@link TenantInterceptor} (registered only for {@code
+ * /api/tenants/**}) never covers, so on that route the v1 ThreadLocal is unset and {@code
+ * HibernateFilterTransactionAspect} falls back to {@link
+ * io.openaev.database.model.Tenant#DEFAULT_TENANT_UUID}. A run owned by a non-default tenant would
+ * then record its v2 state correctly (its {@code TxCtx} is run-derived) yet silently read/write
+ * NOTHING through the v1 filter: an empty attack-path state read (so the orchestrator re-authors
+ * duplicates), no workflow scope mirror, no team enablement, dropped finding-to-asset promotions.
+ * The v1 filter is enabled at transaction START, so the scope has to be set BEFORE the handler's
+ * {@code @Transactional} opens - {@code preHandle} is that point, and it also covers the {@code
+ * REQUIRES_NEW} sessions the service opens on the same thread.
+ *
+ * <p>The gating mirrors {@link TxCtxArgumentResolver} EXACTLY so v1 and v2 can never derive
+ * different tenants for the same request: only the VERIFIED XTM One cross-platform service identity
+ * ({@link XtmJwksExtractor#CROSS_PLATFORM_ATTRIBUTE}, a server-side attribute a client cannot
+ * forge), only on the non-prefixed route (no {@code {tenantId}} path variable - the prefixed
+ * operator route is already scoped by {@link TenantInterceptor}), and only when a {@code {runId}}
+ * names the run. Every other caller is left with the default v1 scope exactly as today, so knowing
+ * a run id never turns into cross-tenant v1 reach; the tenant is read from the run's own immutable
+ * {@code tenant_id} by primary key ({@link AutonomousRunTenantLocator}), and an unknown or
+ * soft-deleted run resolves empty and sets nothing (fail-closed), matching the v2 derivation.
+ *
+ * <p>{@link AsyncHandlerInterceptor}: the ThreadLocal is cleared in BOTH {@code afterCompletion}
+ * and {@code afterConcurrentHandlingStarted} - the latter is the exit path for an async dispatch
+ * (e.g. a streaming callback) - so a pooled thread never carries the run's tenant into an unrelated
+ * request, the same lifecycle {@link TenantInterceptor} uses. Clearing is unconditional and safe:
+ * nothing else sets the v1 ThreadLocal on the non-prefixed route this interceptor is registered
+ * for.
+ */
+@Component
+@RequiredArgsConstructor
+public class OrchestratorRunTenantInterceptor implements AsyncHandlerInterceptor {
+
+  private final AutonomousRunTenantLocator runTenantLocator;
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (!isCrossPlatformServiceCaller(request)) {
+      return true;
+    }
+    Map<String, String> pathVariables = pathVariables(request);
+    if (pathVariables == null) {
+      return true;
+    }
+    // The prefixed operator route names its tenant in the URL and is scoped by TenantInterceptor;
+    // this interceptor only ever acts on the non-prefixed callback route.
+    if (hasText(pathVariables.get(TxCtxArgumentResolver.TENANT_ID_PATH_VARIABLE))) {
+      return true;
+    }
+    String runId = pathVariables.get(TxCtxArgumentResolver.RUN_ID_PATH_VARIABLE);
+    if (!hasText(runId)) {
+      return true;
+    }
+    runTenantLocator.findRunTenant(runId.trim()).ifPresent(TenantContext::setCurrentTenant);
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    TenantContext.clearCurrentTenant();
+  }
+
+  @Override
+  public void afterConcurrentHandlingStarted(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    TenantContext.clearCurrentTenant();
+  }
+
+  /**
+   * Whether this request authenticated as the XTM One cross-platform service identity. The marker
+   * is a server-side request attribute set exclusively by {@link XtmJwksExtractor} after full JWT
+   * validation (trusted issuer, JWKS signature, expected audience); it cannot be supplied by a
+   * client.
+   */
+  private static boolean isCrossPlatformServiceCaller(HttpServletRequest request) {
+    return Boolean.TRUE.equals(request.getAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> pathVariables(HttpServletRequest request) {
+    return (Map<String, String>)
+        request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -93,6 +93,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -1262,6 +1263,23 @@ public class ExerciseService {
    * @param teamIds the ids of the teams targeted by a chained/authored step
    */
   public void enableTargetedTeamMembers(String simulationId, List<String> teamIds) {
+    this.exerciseTeamUserService.enableTargetedTeamMembers(simulationId, teamIds);
+  }
+
+  /**
+   * Transaction-isolated variant of {@link #enableTargetedTeamMembers} for the autonomous
+   * orchestrator's scope callback. Runs in its OWN transaction ({@link Propagation#REQUIRES_NEW})
+   * so that a repository-level failure while enabling players (e.g. the check-then-insert on {@code
+   * exercise_teams_users} racing a concurrent callback, or a team deleted mid-flight) rolls back
+   * only this enablement and can NEVER mark the caller's transaction rollback-only - a poisoned
+   * callback transaction would fail its commit and lose the run's recorded scope, which is exactly
+   * the failure class the scope callback must not have. Only for callers whose simulation already
+   * exists in committed state (the callback path); creation flows must keep using {@link
+   * #enableTargetedTeamMembers}, which joins the surrounding transaction and therefore sees a
+   * simulation created in it. See {@code AutonomousRunService#setRunScope}.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void enableTargetedTeamMembersIsolated(String simulationId, List<String> teamIds) {
     this.exerciseTeamUserService.enableTargetedTeamMembers(simulationId, teamIds);
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/ExerciseTeamUserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/ExerciseTeamUserService.java
@@ -115,12 +115,12 @@ public class ExerciseTeamUserService {
         teamRepository.save(team);
       }
       for (User member : members) {
-        boolean alreadyLinked =
-            exerciseTeamUserRepository.existsByExerciseIdAndTeamIdAndUserId(
-                simulationId, teamId, member.getId());
-        if (!alreadyLinked) {
-          createExerciseTeamUser(simulation, team, member);
-        }
+        // DB-atomic idempotent insert (ON CONFLICT DO NOTHING) instead of exists-then-create: the
+        // autonomous orchestrator authors steps in parallel (asyncio.gather), so two callbacks in
+        // one cycle could both pass an exists check, then both insert and violate the composite PK
+        // - poisoning the enclosing transaction and losing the step just authored. Let the DB
+        // serialise the enablement.
+        exerciseTeamUserRepository.insertIfAbsent(simulationId, teamId, member.getId());
       }
     }
   }

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -23,6 +23,7 @@ import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
 import io.openaev.api.xtmone.dto.ChatbotAgentOutput;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.TenantWriteScopeResolver;
+import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.AssetGroup;
@@ -2229,39 +2230,59 @@ public class AutonomousRunService {
     run.setScopeAssetGroupId(firstScopeIdOfType(scope, "ASSETS_GROUPS"));
     run.setScopeTeamId(firstScopeIdOfType(scope, "TEAMS"));
     AutonomousRun saved = runRepository.save(run);
-    // Best-effort, transaction-isolated: mirror the allowlist onto the scenario template + live
-    // simulation workflow(s). REQUIRES_NEW so a mirror failure (e.g. an action-target realignment
-    // error) rolls back only the mirror and cannot mark this callback's transaction rollback-only.
+    // Both projections below read v1-filtered entities (the scenario's template workflow through
+    // its scenario join, the simulation, its teams), and this callback arrives on the legacy
+    // non-prefixed route where the v1 TenantContext is never set and falls back to the DEFAULT
+    // tenant. Establish the run's own tenant for their isolated transactions - the same
+    // run-authoritative scope @RunTenantScope already gives the v2 GUC - so a run owned by another
+    // tenant mirrors its scope instead of silently matching nothing. Restored in finally: the
+    // operator (tenant-prefixed) route carries the caller's tenant in this thread-local and must
+    // get it back, and a pooled request thread must never leak the run tenant onward.
+    boolean hadTenant = TenantContext.hasCurrentTenant();
+    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(runTenantId(run));
     try {
-      workflowService.writeAllowlistScopeIsolated(
-          run.getScenarioId(), run.getSimulationId(), toAllowlistScopeInputs(scope), true);
-    } catch (Exception e) {
-      log.warn(
-          "[Autonomous] Scope recorded on run {} but the workflow mirror failed (best-effort)",
-          runId,
-          e);
-    }
-    // Best-effort and transaction-isolated like the mirror above: enable in-scope team members on
-    // the simulation so human-targeted steps are deliverable (skipped for plan/author-scenario
-    // runs, which have no simulation). REQUIRES_NEW because a repository-level failure (e.g. the
-    // check-then-insert on exercise_teams_users racing a concurrent callback) would otherwise mark
-    // this callback's transaction rollback-only - a poisoning the catch below could not undo, so
-    // the commit would still fail and lose the scope just recorded on the run.
-    try {
-      if (hasText(run.getSimulationId())) {
-        exerciseService.enableTargetedTeamMembersIsolated(
-            run.getSimulationId(),
-            scope.stream()
-                .filter(t -> "TEAMS".equals(t.getType()))
-                .map(AutonomousScopeTarget::getId)
-                .toList());
+      // Best-effort, transaction-isolated: mirror the allowlist onto the scenario template + live
+      // simulation workflow(s). REQUIRES_NEW so a mirror failure (e.g. an action-target
+      // realignment error) rolls back only the mirror and cannot mark this callback's transaction
+      // rollback-only.
+      try {
+        workflowService.writeAllowlistScopeIsolated(
+            run.getScenarioId(), run.getSimulationId(), toAllowlistScopeInputs(scope), true);
+      } catch (Exception e) {
+        log.warn(
+            "[Autonomous] Scope recorded on run {} but the workflow mirror failed (best-effort)",
+            runId,
+            e);
       }
-    } catch (Exception e) {
-      log.warn(
-          "[Autonomous] Scope recorded on run {} but enabling targeted team members failed"
-              + " (best-effort)",
-          runId,
-          e);
+      // Best-effort and transaction-isolated like the mirror above: enable in-scope team members
+      // on the simulation so human-targeted steps are deliverable (skipped for plan/author-scenario
+      // runs, which have no simulation). REQUIRES_NEW because a repository-level failure (e.g. the
+      // check-then-insert on exercise_teams_users racing a concurrent callback) would otherwise
+      // mark this callback's transaction rollback-only - a poisoning the catch below could not
+      // undo, so the commit would still fail and lose the scope just recorded on the run.
+      try {
+        if (hasText(run.getSimulationId())) {
+          exerciseService.enableTargetedTeamMembersIsolated(
+              run.getSimulationId(),
+              scope.stream()
+                  .filter(t -> "TEAMS".equals(t.getType()))
+                  .map(AutonomousScopeTarget::getId)
+                  .toList());
+        }
+      } catch (Exception e) {
+        log.warn(
+            "[Autonomous] Scope recorded on run {} but enabling targeted team members failed"
+                + " (best-effort)",
+            runId,
+            e);
+      }
+    } finally {
+      if (hadTenant) {
+        TenantContext.setCurrentTenant(previousTenant);
+      } else {
+        TenantContext.clearCurrentTenant();
+      }
     }
     eventService.append(
         runId,

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -68,6 +68,7 @@ import io.openaev.database.repository.autonomous.AutonomousDirectiveRepository;
 import io.openaev.database.repository.autonomous.AutonomousRunRepository;
 import io.openaev.rest.asset.endpoint.form.EndpointInput;
 import io.openaev.rest.exception.ChainingException;
+import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.service.EndpointService;
@@ -94,6 +95,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -118,6 +120,13 @@ public class AutonomousRunService {
 
   /** Temporary-id anchor for the synthetic AND/OR root of a finding-driven trigger tree. */
   private static final String TRIGGER_ROOT_TMP_ID = "trigger-root";
+
+  /**
+   * Cap on the newest-first run list read: the result is filtered to readable runs in memory, so
+   * reading the whole tenant-wide table (unbounded over a deployment's life) is wasteful. The
+   * cockpit list is a newest-first view, so the cap never hides a run an operator is looking for.
+   */
+  private static final int MAX_RUNS_LISTED = 500;
 
   /**
    * Slug of the license-independent built-in specialist (payload creator) the orchestrator consults
@@ -2754,19 +2763,28 @@ public class AutonomousRunService {
   /**
    * Updates an existing chained step's inject definition IN PLACE - same step template id, same
    * DEPEND_ON parent - so the orchestrator edits a step it already authored (payload / target /
-   * injector contract / title) instead of minting a duplicate. The scenario mirror twin is updated
+   * injector contract / title) instead of minting a duplicate. When {@code trigger} is non-null the
+   * step's finding trigger is rebuilt too, so the orchestrator can CORRECT a mis-wired
+   * finding-driven step (change what it fires on / consumes); a null {@code trigger} leaves the
+   * conditions untouched (data-only), the historical behaviour. The scenario mirror twin is updated
    * in lock-step so the exported attack path stays faithful, and any newly targeted team's members
    * are re-enabled so a re-targeted human step stays deliverable.
    *
    * @param runId the autonomous run
    * @param stepTemplateId the step template to update (from the attack-path state read)
    * @param injectInput the new inject definition
+   * @param trigger the finding trigger to rebuild the step conditions from, or null to keep them
    * @return the (unchanged) step template id
    */
   @Transactional(rollbackFor = Exception.class)
-  public String updateAttackPathStep(String runId, String stepTemplateId, InjectInput injectInput) {
+  public String updateAttackPathStep(
+      String runId, String stepTemplateId, InjectInput injectInput, AutonomousStepTrigger trigger) {
     AutonomousRun run = require(runId);
     assertRunAcceptsAuthoring(run);
+    // A supplied trigger is translated to the engine's condition vocabulary once and used to
+    // rebuild the step (and its mirror twin); null means "leave the conditions as they are".
+    List<ConditionCreateInput> triggerConditions =
+        trigger != null ? toTriggerConditions(trigger) : null;
     // Bridge the run's own tenant as the v1 TenantContext around the WHOLE update body (the primary
     // in-place step update AND the secondary projections), for the same reason as
     // doAppendAttackPathStep: on the legacy non-prefixed callback route the v1 TenantContext falls
@@ -2793,7 +2811,7 @@ public class AutonomousRunService {
               "The autonomous run has neither a live simulation nor a scenario to update steps on");
         }
         try {
-          workflowService.updateChainedStep(stepTemplateId, injectInput);
+          workflowService.updateChainedStep(stepTemplateId, injectInput, triggerConditions);
         } catch (ChainingException e) {
           throw new ResponseStatusException(
               HttpStatus.BAD_REQUEST,
@@ -2811,7 +2829,7 @@ public class AutonomousRunService {
         return stepTemplateId;
       }
       try {
-        workflowService.updateChainedStep(stepTemplateId, injectInput);
+        workflowService.updateChainedStep(stepTemplateId, injectInput, triggerConditions);
       } catch (ChainingException e) {
         throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST, "Failed to update the attack-path step: " + e.getMessage(), e);
@@ -2825,7 +2843,7 @@ public class AutonomousRunService {
       String scenarioStepId = mirror == null ? null : mirror.get(stepTemplateId);
       if (hasText(scenarioStepId)) {
         try {
-          workflowService.updateChainedStepIsolated(scenarioStepId, injectInput);
+          workflowService.updateChainedStepIsolated(scenarioStepId, injectInput, triggerConditions);
         } catch (Exception e) {
           log.warn(
               "[Autonomous] Failed to update scenario mirror step {} for run {}: {}",
@@ -2844,6 +2862,80 @@ public class AutonomousRunService {
           "An existing chained step was updated in place (no new step created).",
           null);
       return stepTemplateId;
+    } finally {
+      if (hadTenant) {
+        TenantContext.setCurrentTenant(previousTenant);
+      } else {
+        TenantContext.clearCurrentTenant();
+      }
+    }
+  }
+
+  /**
+   * Removes a chained step the orchestrator previously authored - the pruning counterpart of {@link
+   * #appendAttackPathStep} / {@link #updateAttackPathStep} - so a mis-wired finding-driven step can
+   * be corrected by deletion instead of left dangling. The scenario mirror twin is pruned in
+   * lock-step and the sim-&gt;scenario mapping entry is dropped so the exported attack path stays
+   * faithful. Executed run steps stay as history (the on-delete policy nulls their template
+   * reference), so pruning a template never rewrites what already ran.
+   *
+   * @param runId the autonomous run
+   * @param stepTemplateId the step template to delete (from the attack-path state read)
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void deleteAttackPathStep(String runId, String stepTemplateId) {
+    // Row-locked read: this callback drops the pruned step's sim->scenario mapping entry and saves
+    // the run (a full-entity write on a version-less row), so it must serialise with every other
+    // run writer exactly like setRunScope / doAppendAttackPathStep, or a racing terminal settle
+    // committing between this read and the save would be resurrected. Mirrors updateStatus.
+    AutonomousRun run = requireForUpdate(runId);
+    assertRunAcceptsAuthoring(run);
+    // Bridge the run's own tenant as the v1 TenantContext around the whole delete body, for the
+    // same reason as updateAttackPathStep: the legacy non-prefixed callback route leaves the v1
+    // TenantContext on the DEFAULT tenant, but the step template and its conditions live under the
+    // run's own tenant filter. Restored in finally so a pooled request thread never leaks it.
+    boolean hadTenant = TenantContext.hasCurrentTenant();
+    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(runTenantId(run));
+    try {
+      try {
+        workflowService.deleteChainedStep(stepTemplateId);
+      } catch (ChainingException e) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Failed to delete the attack-path step: " + e.getMessage(), e);
+      }
+      // Prune the scenario mirror twin and drop the mapping entry - both SECONDARY projections that
+      // must never fail (500) this callback (the primary step is already gone). The twin delete
+      // runs in its OWN REQUIRES_NEW transaction so a failure rolls back only itself.
+      Map<String, String> mirror = run.getStepMirror();
+      String scenarioStepId = mirror == null ? null : mirror.get(stepTemplateId);
+      if (hasText(scenarioStepId)) {
+        try {
+          workflowService.deleteChainedStepIsolated(scenarioStepId);
+        } catch (Exception e) {
+          log.warn(
+              "[Autonomous] Deleted step {} but pruning its scenario mirror twin {} failed"
+                  + " (best-effort) for run {}",
+              stepTemplateId,
+              scenarioStepId,
+              runId,
+              e);
+        }
+      }
+      if (mirror != null && mirror.containsKey(stepTemplateId)) {
+        Map<String, String> updatedMirror = new HashMap<>(mirror);
+        updatedMirror.remove(stepTemplateId);
+        run.setStepMirror(updatedMirror);
+        runRepository.save(run);
+      }
+      eventService.append(
+          runId,
+          runTenantId(run),
+          run.getSimulationId(),
+          AutonomousEventType.TOOL_ACTION,
+          "Attack-path step removed",
+          "A chained step was removed from the attack path.",
+          null);
     } finally {
       if (hadTenant) {
         TenantContext.setCurrentTenant(previousTenant);
@@ -2994,31 +3086,43 @@ public class AutonomousRunService {
   @Transactional(readOnly = true)
   public List<AutonomousAttackPathStepState> attackPathState(String runId) {
     AutonomousRun run = require(runId);
+    List<WorkflowService.AuthoredAttackStep> authoredSteps;
     // Author-scenario mode: read the steps authored onto the scenario workflow (no simulation).
     if (!hasText(run.getSimulationId())) {
       if (!hasText(run.getScenarioId())) {
         return List.of();
       }
-      return workflowService.readAuthoredAttackPathForScenario(run.getScenarioId()).stream()
-          .map(this::toStepState)
-          .toList();
+      authoredSteps = workflowService.readAuthoredAttackPathForScenario(run.getScenarioId());
+    } else {
+      // Build the snapshot from the simulation TEMPLATE workflow's steps (the STABLE authoring
+      // handles the orchestrator built) rather than from materialized injects, so the read returns
+      // each step's step_template_id + parent + trigger + target - the finding-driven wiring the
+      // orchestrator needs to chain onto, correct, or UPDATE an existing step instead of
+      // re-authoring a duplicate.
+      authoredSteps = workflowService.readAuthoredAttackPath(run.getSimulationId());
     }
-    // Build the snapshot from the simulation TEMPLATE workflow's steps (the STABLE authoring
-    // handles the orchestrator built) rather than from materialized injects, so the read returns
-    // each step's step_template_id + DEPEND_ON parent + target - the graph the orchestrator needs
-    // to chain onto or UPDATE an existing step instead of re-authoring a duplicate.
-    return workflowService.readAuthoredAttackPath(run.getSimulationId()).stream()
-        .map(this::toStepState)
-        .toList();
+    // Batch the backing-inject lookup: one findAllById for every run-inject id across all steps,
+    // instead of one findById per id per step. The orchestrator polls this read every decision
+    // cycle, so an N+1 over the whole authored path is exactly the hot path to keep flat.
+    List<String> injectIds =
+        authoredSteps.stream()
+            .flatMap(step -> step.runInjectIds().stream())
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    Map<String, Inject> injectsById =
+        injectIds.isEmpty()
+            ? Map.of()
+            : injectRepository.findAllById(injectIds).stream()
+                .collect(Collectors.toMap(Inject::getId, inject -> inject));
+    return authoredSteps.stream().map(step -> toStepState(step, injectsById)).toList();
   }
 
-  private AutonomousAttackPathStepState toStepState(WorkflowService.AuthoredAttackStep authored) {
+  private AutonomousAttackPathStepState toStepState(
+      WorkflowService.AuthoredAttackStep authored, Map<String, Inject> injectsById) {
     JsonNode data = parseInjectData(authored.injectDataJson());
     List<Inject> injects =
-        authored.runInjectIds().stream()
-            .map(id -> injectRepository.findById(id).orElse(null))
-            .filter(Objects::nonNull)
-            .toList();
+        authored.runInjectIds().stream().map(injectsById::get).filter(Objects::nonNull).toList();
     String title = jsonText(data, "inject_title");
     String type = jsonText(data, "inject_type");
     String contractId = injectContractId(data);
@@ -3044,7 +3148,10 @@ public class AutonomousRunService {
         contractId,
         targetSummary(data),
         aggregateStatus(injects),
-        aggregateTraces(injects));
+        aggregateTraces(injects),
+        authored.eventName(),
+        authored.triggerFilters(),
+        authored.triggerMappings());
   }
 
   private JsonNode parseInjectData(String json) {
@@ -3528,8 +3635,10 @@ public class AutonomousRunService {
   public List<AutonomousRun> list() {
     // Filter the tenant-wide list to runs the caller can READ: without this, every run's objective
     // and status leaked to any Enterprise-Edition user regardless of their simulation/scenario
-    // access.
-    return accessControl.retainReadable(runRepository.findAllByOrderByCreatedAtDesc());
+    // access. Bound the DB read at MAX_RUNS_LISTED (newest first) so the table is never loaded
+    // whole just to filter it down in memory.
+    return accessControl.retainReadable(
+        runRepository.findRecent(PageRequest.of(0, MAX_RUNS_LISTED)));
   }
 
   /**
@@ -4011,9 +4120,17 @@ public class AutonomousRunService {
     if (!active) {
       return run;
     }
-    ExerciseStatus simStatus = loadSimulationStatusOrNull(run.getSimulationId());
+    SimulationStatusProbe probe = probeSimulationStatus(run.getSimulationId());
+    if (probe.unreadable()) {
+      // Defense in depth on top of OrchestratorRunTenantInterceptor: an UNREADABLE simulation read
+      // (a scope miss, a DB blip, any non-not-found error) must never be mistaken for a deletion
+      // and cancel a healthy run. Leave the status untouched; the next read/poll re-probes. Only a
+      // genuine not-found (deleted) settles the run below.
+      return run;
+    }
+    ExerciseStatus simStatus = probe.status();
     AutonomousRunStatus target;
-    if (simStatus == null) {
+    if (probe.deleted()) {
       // Simulation deleted out-of-band: there is nothing left to drive, settle the run.
       target = AutonomousRunStatus.CANCELED;
     } else if (simStatus == ExerciseStatus.CANCELED) {
@@ -4063,7 +4180,7 @@ public class AutonomousRunService {
     // truthful and never 500s.
     String detail =
         "Synced from the underlying simulation ("
-            + (simStatus == null ? "deleted" : simStatus.name())
+            + (probe.deleted() ? "deleted" : simStatus.name())
             + "): an autonomous run and its simulation are always kept in lockstep.";
     try {
       AutonomousRun settled =
@@ -4090,12 +4207,42 @@ public class AutonomousRunService {
     return run;
   }
 
-  /** Reads the simulation's status, or {@code null} when it no longer exists / is unreadable. */
-  private ExerciseStatus loadSimulationStatusOrNull(String simulationId) {
+  /**
+   * Probes the simulation's status, distinguishing the three outcomes reconcile must treat
+   * differently: READABLE (its {@link ExerciseStatus}), DELETED (a genuine not-found, so nothing is
+   * left to drive), and UNREADABLE (any other error - a scope miss, a DB blip). Only DELETED may
+   * settle a run; an UNREADABLE probe must leave the run untouched so a transient miss can never be
+   * mistaken for a deletion and cancel a healthy run.
+   */
+  private SimulationStatusProbe probeSimulationStatus(String simulationId) {
     try {
-      return exerciseService.exercise(simulationId).getStatus();
+      return SimulationStatusProbe.readable(exerciseService.exercise(simulationId).getStatus());
+    } catch (ElementNotFoundException e) {
+      return SimulationStatusProbe.deleted();
     } catch (Exception e) {
-      return null;
+      log.warn(
+          "[Autonomous] Simulation {} status unreadable during reconcile; leaving the run status"
+              + " untouched (not treated as a deletion)",
+          simulationId,
+          e);
+      return SimulationStatusProbe.unreadable();
+    }
+  }
+
+  /**
+   * Outcome of {@link #probeSimulationStatus}: readable status, a deletion, or an unreadable read.
+   */
+  private record SimulationStatusProbe(ExerciseStatus status, boolean deleted, boolean unreadable) {
+    static SimulationStatusProbe readable(ExerciseStatus status) {
+      return new SimulationStatusProbe(status, false, false);
+    }
+
+    static SimulationStatusProbe deleted() {
+      return new SimulationStatusProbe(null, true, false);
+    }
+
+    static SimulationStatusProbe unreadable() {
+      return new SimulationStatusProbe(null, false, true);
     }
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -2221,18 +2221,42 @@ public class AutonomousRunService {
     AutonomousRun run = require(runId);
     assertRunAcceptsAuthoring(run);
     List<AutonomousScopeTarget> scope = targets != null ? new ArrayList<>(targets) : List.of();
-    workflowService.writeAllowlistScope(
-        run.getScenarioId(), run.getSimulationId(), toAllowlistScopeInputs(scope), true);
+    // Record the resolved scope on the run AUTHORITATIVELY first. This is the callback's primary
+    // job and the source the cockpit, a restart and the read-path reconcile all read back. The
+    // workflow mirror and team enablement below are secondary projections and must never fail (500)
+    // this callback - a failure there previously propagated out and stalled the run.
     run.setScope(scope);
     run.setScopeAssetGroupId(firstScopeIdOfType(scope, "ASSETS_GROUPS"));
     run.setScopeTeamId(firstScopeIdOfType(scope, "TEAMS"));
     AutonomousRun saved = runRepository.save(run);
-    enableTargetedTeamMembers(
-        run.getSimulationId(),
-        scope.stream()
-            .filter(t -> "TEAMS".equals(t.getType()))
-            .map(AutonomousScopeTarget::getId)
-            .toList());
+    // Best-effort, transaction-isolated: mirror the allowlist onto the scenario template + live
+    // simulation workflow(s). REQUIRES_NEW so a mirror failure (e.g. an action-target realignment
+    // error) rolls back only the mirror and cannot mark this callback's transaction rollback-only.
+    try {
+      workflowService.writeAllowlistScopeIsolated(
+          run.getScenarioId(), run.getSimulationId(), toAllowlistScopeInputs(scope), true);
+    } catch (Exception e) {
+      log.warn(
+          "[Autonomous] Scope recorded on run {} but the workflow mirror failed (best-effort): {}",
+          runId,
+          e.getMessage());
+    }
+    // Best-effort: enable in-scope team members on the simulation so human-targeted steps are
+    // deliverable (a no-op for plan/author-scenario runs, which have no simulation).
+    try {
+      enableTargetedTeamMembers(
+          run.getSimulationId(),
+          scope.stream()
+              .filter(t -> "TEAMS".equals(t.getType()))
+              .map(AutonomousScopeTarget::getId)
+              .toList());
+    } catch (Exception e) {
+      log.warn(
+          "[Autonomous] Scope recorded on run {} but enabling targeted team members failed"
+              + " (best-effort): {}",
+          runId,
+          e.getMessage());
+    }
     eventService.append(
         runId,
         runTenantId(run),

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -2219,7 +2219,17 @@ public class AutonomousRunService {
    */
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun setRunScope(String runId, List<AutonomousScopeTarget> targets) {
-    AutonomousRun run = require(runId);
+    // Row-locked read: this callback records the resolved scope with a full-entity save on a run
+    // row
+    // that carries NO optimistic version, so the check-then-save must serialise with every other
+    // run
+    // writer - updateStatus / pause / resume take the same lock, and the reconcile / timeout
+    // watchdog settle via row-locking conditional UPDATEs. The orchestrator fires scope and author
+    // callbacks in parallel (asyncio.gather), so without the lock a concurrent author's run save
+    // (its step mirror) and this scope save last-write-wins each other's fields, and a racing
+    // terminal settle committing between this read and the save would be silently resurrected.
+    // Mirrors updateStatus / restart.
+    AutonomousRun run = requireForUpdate(runId);
     assertRunAcceptsAuthoring(run);
     List<AutonomousScopeTarget> scope = targets != null ? new ArrayList<>(targets) : List.of();
     // Record the resolved scope on the run AUTHORITATIVELY first. This is the callback's primary
@@ -2467,79 +2477,111 @@ public class AutonomousRunService {
       InjectInput injectInput,
       String parentStepTemplateId,
       AutonomousStepTrigger trigger) {
-    AutonomousRun run = require(runId);
+    // Row-locked read: the author callback saves the run (its step mirror) with a full-entity write
+    // on a row that carries NO optimistic version, and the orchestrator fires author callbacks in
+    // parallel (asyncio.gather). Without the lock, two parallel authors last-write-wins the step
+    // mirror map - dropping a sim->scenario mapping, which then reattaches a later scenario twin as
+    // a root and breaks the exported attack path's kill-chain edges - and a reconcile / watchdog
+    // terminal settle committing between this read and the save would be resurrected. Mirrors
+    // updateStatus / restart.
+    AutonomousRun run = requireForUpdate(runId);
     assertRunAcceptsAuthoring(run);
     List<ConditionCreateInput> triggerConditions = toTriggerConditions(trigger);
-    // Author-scenario (AI planning) mode: no simulation exists, so the orchestrator authors the
-    // step directly onto the scenario's workflow TEMPLATE. Nothing executes; there is no mirror
-    // (the scenario IS the authored artifact) and the returned id is the scenario step id the
-    // orchestrator chains the next step onto.
-    if (!hasText(run.getSimulationId())) {
-      if (!hasText(run.getScenarioId())) {
-        throw new ResponseStatusException(
-            HttpStatus.CONFLICT,
-            "The autonomous run has neither a live simulation nor a scenario to build steps on");
+    // Bridge the run's own tenant as the v1 TenantContext around the WHOLE authoring body (the
+    // primary executing/scenario step AND the secondary projections). This callback arrives on the
+    // legacy non-prefixed /api/autonomous-runs route where the v1 TenantContext is never set and
+    // falls back to the DEFAULT tenant, yet baking a step reads v1-filtered entities: it resolves
+    // the injector contract under an EXPLICIT TenantContext.getCurrentTenant() existence check (a
+    // custom threat-arsenal contract lives in the run's own tenant, not DEFAULT, and shares its id
+    // across tenants) and resolves the step's targeted teams/assets under the v1 filter. The
+    // PRIMARY step must therefore see the run's tenant exactly like the scenario mirror twin does -
+    // otherwise an AI-authored custom payload 404s ("Injector contract not found") for any run not
+    // in the default tenant, and human targets resolve empty. @RunTenantScope already gives the
+    // matching v2 GUC; this adds the v1 scope. Restored in finally so the operator
+    // (tenant-prefixed)
+    // route keeps its caller tenant and a pooled request thread never leaks the run tenant onward.
+    // A no-op when the run already is the default tenant.
+    boolean hadTenant = TenantContext.hasCurrentTenant();
+    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(runTenantId(run));
+    try {
+      // Author-scenario (AI planning) mode: no simulation exists, so the orchestrator authors the
+      // step directly onto the scenario's workflow TEMPLATE. Nothing executes; there is no mirror
+      // (the scenario IS the authored artifact) and the returned id is the scenario step id the
+      // orchestrator chains the next step onto. No secondary projection to isolate here - a real
+      // author failure SHOULD surface (400) since the scenario is the primary artifact.
+      if (!hasText(run.getSimulationId())) {
+        if (!hasText(run.getScenarioId())) {
+          throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              "The autonomous run has neither a live simulation nor a scenario to build steps on");
+        }
+        String scenarioStepId;
+        try {
+          scenarioStepId =
+              workflowService.appendChainedStepToScenario(
+                  run.getScenarioId(), injectInput, parentStepTemplateId, triggerConditions);
+        } catch (ChainingException e) {
+          throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              "Failed to author the attack-path step onto the scenario: " + e.getMessage(),
+              e);
+        }
+        boolean findingDrivenPlan = !triggerConditions.isEmpty();
+        eventService.append(
+            runId,
+            runTenantId(run),
+            null,
+            AutonomousEventType.TOOL_ACTION,
+            "Attack-path step authored",
+            "A chained step was added to the scenario's attack path"
+                + (findingDrivenPlan
+                    ? " (fires on a finding and consumes its values)."
+                    : hasText(parentStepTemplateId)
+                        ? " (depends on a previous step)."
+                        : " (seed step - readies immediately against the scope)."),
+            null);
+        return scenarioStepId;
       }
-      String scenarioStepId;
+      String stepTemplateId;
       try {
-        scenarioStepId =
-            workflowService.appendChainedStepToScenario(
-                run.getScenarioId(), injectInput, parentStepTemplateId, triggerConditions);
+        stepTemplateId =
+            workflowService.appendChainedStep(
+                run.getSimulationId(), injectInput, parentStepTemplateId, triggerConditions);
       } catch (ChainingException e) {
         throw new ResponseStatusException(
-            HttpStatus.BAD_REQUEST,
-            "Failed to author the attack-path step onto the scenario: " + e.getMessage(),
-            e);
+            HttpStatus.BAD_REQUEST, "Failed to author the attack-path step: " + e.getMessage(), e);
       }
-      boolean findingDrivenPlan = !triggerConditions.isEmpty();
+      // The executing simulation step authored above is this callback's primary job. Both
+      // projections below are SECONDARY and must NEVER fail (500) this callback: a failure there
+      // previously marked the authoring transaction rollback-only, so a step that already succeeded
+      // was lost at commit and the orchestrator retried it in a loop. Each runs in its OWN
+      // REQUIRES_NEW transaction (see the *Isolated / *BestEffort methods) so a failure rolls back
+      // only itself.
+      //  - Team enablement: a human-in-the-loop inject (email, SMS, ...) delivers only to the
+      //    players ENABLED on the simulation, not merely to team members; a directly targeted team
+      //    whose members were never enabled would otherwise ERROR with "Email needs at least one
+      //    user".
+      //  - Scenario mirror: the exportable/reproducible twin of the attack path (the executing copy
+      //    lives on the simulation; this twin never runs).
+      enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
+      mirrorStepOntoScenario(
+          run, injectInput, parentStepTemplateId, stepTemplateId, triggerConditions);
+      boolean findingDriven = !triggerConditions.isEmpty();
       eventService.append(
           runId,
           runTenantId(run),
-          null,
+          run.getSimulationId(),
           AutonomousEventType.TOOL_ACTION,
           "Attack-path step authored",
-          "A chained step was added to the scenario's attack path"
-              + (findingDrivenPlan
+          "A chained step was added to the live attack path"
+              + (findingDriven
                   ? " (fires on a finding and consumes its values)."
                   : hasText(parentStepTemplateId)
                       ? " (depends on a previous step)."
                       : " (seed step - readies immediately against the scope)."),
           null);
-      return scenarioStepId;
-    }
-    String stepTemplateId;
-    try {
-      stepTemplateId =
-          workflowService.appendChainedStep(
-              run.getSimulationId(), injectInput, parentStepTemplateId, triggerConditions);
-    } catch (ChainingException e) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Failed to author the attack-path step: " + e.getMessage(), e);
-    }
-    // The executing simulation step authored above is this callback's primary job. Both projections
-    // below are SECONDARY and must NEVER fail (500) this callback: a failure there previously
-    // marked
-    // the authoring transaction rollback-only, so a step that already succeeded was lost at commit
-    // and the orchestrator retried it in a loop. They read/write v1-filtered entities (the
-    // simulation's teams via exercise_teams_users; the scenario template workflow) and this
-    // callback
-    // arrives on the legacy non-prefixed /api/autonomous-runs route where the v1 TenantContext is
-    // unset (DEFAULT tenant), so bridge the run's own tenant - the same run-authoritative tenant
-    // @RunTenantScope already gives the v2 GUC - and restore it in finally so a pooled request
-    // thread never leaks it. Each projection runs in its OWN REQUIRES_NEW transaction (see the
-    // *Isolated / *BestEffort methods) so a failure rolls back only itself. Mirrors setRunScope.
-    //  - Team enablement: a human-in-the-loop inject (email, SMS, ...) delivers only to the players
-    //    ENABLED on the simulation, not merely to team members; a directly targeted team whose
-    //    members were never enabled would otherwise ERROR with "Email needs at least one user".
-    //  - Scenario mirror: the exportable/reproducible twin of the attack path (the executing copy
-    //    lives on the simulation; this twin never runs).
-    boolean hadTenant = TenantContext.hasCurrentTenant();
-    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
-    TenantContext.setCurrentTenant(runTenantId(run));
-    try {
-      enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
-      mirrorStepOntoScenario(
-          run, injectInput, parentStepTemplateId, stepTemplateId, triggerConditions);
+      return stepTemplateId;
     } finally {
       if (hadTenant) {
         TenantContext.setCurrentTenant(previousTenant);
@@ -2547,21 +2589,6 @@ public class AutonomousRunService {
         TenantContext.clearCurrentTenant();
       }
     }
-    boolean findingDriven = !triggerConditions.isEmpty();
-    eventService.append(
-        runId,
-        runTenantId(run),
-        run.getSimulationId(),
-        AutonomousEventType.TOOL_ACTION,
-        "Attack-path step authored",
-        "A chained step was added to the live attack path"
-            + (findingDriven
-                ? " (fires on a finding and consumes its values)."
-                : hasText(parentStepTemplateId)
-                    ? " (depends on a previous step)."
-                    : " (seed step - readies immediately against the scope)."),
-        null);
-    return stepTemplateId;
   }
 
   /**
@@ -2740,52 +2767,62 @@ public class AutonomousRunService {
   public String updateAttackPathStep(String runId, String stepTemplateId, InjectInput injectInput) {
     AutonomousRun run = require(runId);
     assertRunAcceptsAuthoring(run);
-    // Author-scenario mode: the step id IS a scenario step template id; update it in place on the
-    // scenario workflow (no simulation, no mirror twin).
-    if (!hasText(run.getSimulationId())) {
-      if (!hasText(run.getScenarioId())) {
-        throw new ResponseStatusException(
-            HttpStatus.CONFLICT,
-            "The autonomous run has neither a live simulation nor a scenario to update steps on");
+    // Bridge the run's own tenant as the v1 TenantContext around the WHOLE update body (the primary
+    // in-place step update AND the secondary projections), for the same reason as
+    // doAppendAttackPathStep: on the legacy non-prefixed callback route the v1 TenantContext falls
+    // back to DEFAULT, but rebuilding the step data resolves the injector contract under an
+    // EXPLICIT
+    // TenantContext.getCurrentTenant() existence check (a custom threat-arsenal contract lives in
+    // the run's own tenant, not DEFAULT) and resolves its targeted teams/assets under the v1
+    // filter.
+    // Without this the primary in-place update of a custom-payload step 404s ("Injector contract
+    // not found") for any run not in the default tenant. @RunTenantScope already gives the matching
+    // v2 GUC; this adds the v1 scope. Restored in finally so a pooled request thread never leaks
+    // the
+    // run tenant onward. A no-op when the run already is the default tenant.
+    boolean hadTenant = TenantContext.hasCurrentTenant();
+    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(runTenantId(run));
+    try {
+      // Author-scenario mode: the step id IS a scenario step template id; update it in place on the
+      // scenario workflow (no simulation, no mirror twin).
+      if (!hasText(run.getSimulationId())) {
+        if (!hasText(run.getScenarioId())) {
+          throw new ResponseStatusException(
+              HttpStatus.CONFLICT,
+              "The autonomous run has neither a live simulation nor a scenario to update steps on");
+        }
+        try {
+          workflowService.updateChainedStep(stepTemplateId, injectInput);
+        } catch (ChainingException e) {
+          throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST,
+              "Failed to update the scenario attack-path step: " + e.getMessage(),
+              e);
+        }
+        eventService.append(
+            runId,
+            runTenantId(run),
+            null,
+            AutonomousEventType.TOOL_ACTION,
+            "Attack-path step updated",
+            "An existing chained step was updated in place on the scenario (no new step created).",
+            null);
+        return stepTemplateId;
       }
       try {
         workflowService.updateChainedStep(stepTemplateId, injectInput);
       } catch (ChainingException e) {
         throw new ResponseStatusException(
-            HttpStatus.BAD_REQUEST,
-            "Failed to update the scenario attack-path step: " + e.getMessage(),
-            e);
+            HttpStatus.BAD_REQUEST, "Failed to update the attack-path step: " + e.getMessage(), e);
       }
-      eventService.append(
-          runId,
-          runTenantId(run),
-          null,
-          AutonomousEventType.TOOL_ACTION,
-          "Attack-path step updated",
-          "An existing chained step was updated in place on the scenario (no new step created).",
-          null);
-      return stepTemplateId;
-    }
-    try {
-      workflowService.updateChainedStep(stepTemplateId, injectInput);
-    } catch (ChainingException e) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST, "Failed to update the attack-path step: " + e.getMessage(), e);
-    }
-    // The executing simulation step is updated above. Keeping the scenario mirror twin in lock-step
-    // and re-enabling any newly targeted team's members are SECONDARY projections that must never
-    // fail (500) this callback. They read/write v1-filtered entities on the legacy non-prefixed
-    // /api/autonomous-runs route (v1 TenantContext unset -> DEFAULT tenant), so bridge the run's
-    // own
-    // tenant (restored in finally) and run each in its OWN REQUIRES_NEW transaction so a failure
-    // rolls back only itself and can never mark this update transaction rollback-only. Mirrors
-    // doAppendAttackPathStep / setRunScope.
-    Map<String, String> mirror = run.getStepMirror();
-    String scenarioStepId = mirror == null ? null : mirror.get(stepTemplateId);
-    boolean hadTenant = TenantContext.hasCurrentTenant();
-    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
-    TenantContext.setCurrentTenant(runTenantId(run));
-    try {
+      // The executing simulation step is updated above. Keeping the scenario mirror twin in
+      // lock-step and re-enabling any newly targeted team's members are SECONDARY projections that
+      // must never fail (500) this callback: each runs in its OWN REQUIRES_NEW transaction so a
+      // failure rolls back only itself and can never mark this update transaction rollback-only.
+      // Mirrors doAppendAttackPathStep / setRunScope.
+      Map<String, String> mirror = run.getStepMirror();
+      String scenarioStepId = mirror == null ? null : mirror.get(stepTemplateId);
       if (hasText(scenarioStepId)) {
         try {
           workflowService.updateChainedStepIsolated(scenarioStepId, injectInput);
@@ -2798,6 +2835,15 @@ public class AutonomousRunService {
         }
       }
       enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
+      eventService.append(
+          runId,
+          runTenantId(run),
+          run.getSimulationId(),
+          AutonomousEventType.TOOL_ACTION,
+          "Attack-path step updated",
+          "An existing chained step was updated in place (no new step created).",
+          null);
+      return stepTemplateId;
     } finally {
       if (hadTenant) {
         TenantContext.setCurrentTenant(previousTenant);
@@ -2805,15 +2851,6 @@ public class AutonomousRunService {
         TenantContext.clearCurrentTenant();
       }
     }
-    eventService.append(
-        runId,
-        runTenantId(run),
-        run.getSimulationId(),
-        AutonomousEventType.TOOL_ACTION,
-        "Attack-path step updated",
-        "An existing chained step was updated in place (no new step created).",
-        null);
-    return stepTemplateId;
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -3139,19 +3139,22 @@ public class AutonomousRunService {
       }
     }
     String injectId = injects.isEmpty() ? "" : injects.get(injects.size() - 1).getId();
+    // Argument order MUST match the DTO field declaration order (its @AllArgsConstructor):
+    // stepTemplateId, parentStepTemplateId, event_name, trigger_filters, trigger_mappings,
+    // inject_id, title, type, injector_contract_id, target, status, traces.
     return new AutonomousAttackPathStepState(
         authored.stepTemplateId(),
         authored.parentStepTemplateId(),
+        authored.eventName(),
+        authored.triggerFilters(),
+        authored.triggerMappings(),
         injectId,
         title,
         type,
         contractId,
         targetSummary(data),
         aggregateStatus(injects),
-        aggregateTraces(injects),
-        authored.eventName(),
-        authored.triggerFilters(),
-        authored.triggerMappings());
+        aggregateTraces(injects));
   }
 
   private JsonNode parseInjectData(String json) {
@@ -4216,32 +4219,34 @@ public class AutonomousRunService {
    */
   private SimulationStatusProbe probeSimulationStatus(String simulationId) {
     try {
-      return SimulationStatusProbe.readable(exerciseService.exercise(simulationId).getStatus());
+      return SimulationStatusProbe.ofReadable(exerciseService.exercise(simulationId).getStatus());
     } catch (ElementNotFoundException e) {
-      return SimulationStatusProbe.deleted();
+      return SimulationStatusProbe.ofDeleted();
     } catch (Exception e) {
       log.warn(
           "[Autonomous] Simulation {} status unreadable during reconcile; leaving the run status"
               + " untouched (not treated as a deletion)",
           simulationId,
           e);
-      return SimulationStatusProbe.unreadable();
+      return SimulationStatusProbe.ofUnreadable();
     }
   }
 
   /**
    * Outcome of {@link #probeSimulationStatus}: readable status, a deletion, or an unreadable read.
+   * The factories are named {@code of*} so they do not collide with the record's {@code deleted()}
+   * / {@code unreadable()} component accessors (which the callers use as boolean predicates).
    */
   private record SimulationStatusProbe(ExerciseStatus status, boolean deleted, boolean unreadable) {
-    static SimulationStatusProbe readable(ExerciseStatus status) {
+    static SimulationStatusProbe ofReadable(ExerciseStatus status) {
       return new SimulationStatusProbe(status, false, false);
     }
 
-    static SimulationStatusProbe deleted() {
+    static SimulationStatusProbe ofDeleted() {
       return new SimulationStatusProbe(null, true, false);
     }
 
-    static SimulationStatusProbe unreadable() {
+    static SimulationStatusProbe ofUnreadable() {
       return new SimulationStatusProbe(null, false, true);
     }
   }

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -2237,25 +2237,31 @@ public class AutonomousRunService {
           run.getScenarioId(), run.getSimulationId(), toAllowlistScopeInputs(scope), true);
     } catch (Exception e) {
       log.warn(
-          "[Autonomous] Scope recorded on run {} but the workflow mirror failed (best-effort): {}",
+          "[Autonomous] Scope recorded on run {} but the workflow mirror failed (best-effort)",
           runId,
-          e.getMessage());
+          e);
     }
-    // Best-effort: enable in-scope team members on the simulation so human-targeted steps are
-    // deliverable (a no-op for plan/author-scenario runs, which have no simulation).
+    // Best-effort and transaction-isolated like the mirror above: enable in-scope team members on
+    // the simulation so human-targeted steps are deliverable (skipped for plan/author-scenario
+    // runs, which have no simulation). REQUIRES_NEW because a repository-level failure (e.g. the
+    // check-then-insert on exercise_teams_users racing a concurrent callback) would otherwise mark
+    // this callback's transaction rollback-only - a poisoning the catch below could not undo, so
+    // the commit would still fail and lose the scope just recorded on the run.
     try {
-      enableTargetedTeamMembers(
-          run.getSimulationId(),
-          scope.stream()
-              .filter(t -> "TEAMS".equals(t.getType()))
-              .map(AutonomousScopeTarget::getId)
-              .toList());
+      if (hasText(run.getSimulationId())) {
+        exerciseService.enableTargetedTeamMembersIsolated(
+            run.getSimulationId(),
+            scope.stream()
+                .filter(t -> "TEAMS".equals(t.getType()))
+                .map(AutonomousScopeTarget::getId)
+                .toList());
+      }
     } catch (Exception e) {
       log.warn(
           "[Autonomous] Scope recorded on run {} but enabling targeted team members failed"
-              + " (best-effort): {}",
+              + " (best-effort)",
           runId,
-          e.getMessage());
+          e);
     }
     eventService.append(
         runId,

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -2516,18 +2516,37 @@ public class AutonomousRunService {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Failed to author the attack-path step: " + e.getMessage(), e);
     }
-    // A human-in-the-loop inject (email, SMS, ...) delivers only to the players ENABLED on the
-    // simulation (exercise_teams_users), not merely to team members. The orchestrator can
-    // legitimately
-    // target a team directly - an operator-pre-selected audience, or one it built - without routing
-    // through ensure_openaev_target_team, and that team's members are then NOT enabled on this
-    // simulation, so the step ERRORs with "Email needs at least one user". Enable every targeted
-    // team's members here so any team-targeted step is deliverable regardless of how it was wired.
-    enableTargetedTeamMembers(run.getSimulationId(), injectInput.getTeams());
-    // Mirror the step onto the run's SCENARIO so the scenario carries the attack path and can be
-    // exported/reproduced (the executing copy lives on the simulation; this twin never runs).
-    mirrorStepOntoScenario(
-        run, injectInput, parentStepTemplateId, stepTemplateId, triggerConditions);
+    // The executing simulation step authored above is this callback's primary job. Both projections
+    // below are SECONDARY and must NEVER fail (500) this callback: a failure there previously
+    // marked
+    // the authoring transaction rollback-only, so a step that already succeeded was lost at commit
+    // and the orchestrator retried it in a loop. They read/write v1-filtered entities (the
+    // simulation's teams via exercise_teams_users; the scenario template workflow) and this
+    // callback
+    // arrives on the legacy non-prefixed /api/autonomous-runs route where the v1 TenantContext is
+    // unset (DEFAULT tenant), so bridge the run's own tenant - the same run-authoritative tenant
+    // @RunTenantScope already gives the v2 GUC - and restore it in finally so a pooled request
+    // thread never leaks it. Each projection runs in its OWN REQUIRES_NEW transaction (see the
+    // *Isolated / *BestEffort methods) so a failure rolls back only itself. Mirrors setRunScope.
+    //  - Team enablement: a human-in-the-loop inject (email, SMS, ...) delivers only to the players
+    //    ENABLED on the simulation, not merely to team members; a directly targeted team whose
+    //    members were never enabled would otherwise ERROR with "Email needs at least one user".
+    //  - Scenario mirror: the exportable/reproducible twin of the attack path (the executing copy
+    //    lives on the simulation; this twin never runs).
+    boolean hadTenant = TenantContext.hasCurrentTenant();
+    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(runTenantId(run));
+    try {
+      enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
+      mirrorStepOntoScenario(
+          run, injectInput, parentStepTemplateId, stepTemplateId, triggerConditions);
+    } finally {
+      if (hadTenant) {
+        TenantContext.setCurrentTenant(previousTenant);
+      } else {
+        TenantContext.clearCurrentTenant();
+      }
+    }
     boolean findingDriven = !triggerConditions.isEmpty();
     eventService.append(
         runId,
@@ -2753,21 +2772,39 @@ public class AutonomousRunService {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Failed to update the attack-path step: " + e.getMessage(), e);
     }
-    // Keep the scenario mirror twin in lock-step so the exported attack path reflects the edit.
+    // The executing simulation step is updated above. Keeping the scenario mirror twin in lock-step
+    // and re-enabling any newly targeted team's members are SECONDARY projections that must never
+    // fail (500) this callback. They read/write v1-filtered entities on the legacy non-prefixed
+    // /api/autonomous-runs route (v1 TenantContext unset -> DEFAULT tenant), so bridge the run's
+    // own
+    // tenant (restored in finally) and run each in its OWN REQUIRES_NEW transaction so a failure
+    // rolls back only itself and can never mark this update transaction rollback-only. Mirrors
+    // doAppendAttackPathStep / setRunScope.
     Map<String, String> mirror = run.getStepMirror();
     String scenarioStepId = mirror == null ? null : mirror.get(stepTemplateId);
-    if (hasText(scenarioStepId)) {
-      try {
-        workflowService.updateChainedStep(scenarioStepId, injectInput);
-      } catch (Exception e) {
-        log.warn(
-            "[Autonomous] Failed to update scenario mirror step {} for run {}: {}",
-            scenarioStepId,
-            runId,
-            e.getMessage());
+    boolean hadTenant = TenantContext.hasCurrentTenant();
+    String previousTenant = hadTenant ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(runTenantId(run));
+    try {
+      if (hasText(scenarioStepId)) {
+        try {
+          workflowService.updateChainedStepIsolated(scenarioStepId, injectInput);
+        } catch (Exception e) {
+          log.warn(
+              "[Autonomous] Failed to update scenario mirror step {} for run {}: {}",
+              scenarioStepId,
+              runId,
+              e.getMessage());
+        }
+      }
+      enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
+    } finally {
+      if (hadTenant) {
+        TenantContext.setCurrentTenant(previousTenant);
+      } else {
+        TenantContext.clearCurrentTenant();
       }
     }
-    enableTargetedTeamMembers(run.getSimulationId(), injectInput.getTeams());
     eventService.append(
         runId,
         runTenantId(run),
@@ -2802,8 +2839,16 @@ public class AutonomousRunService {
         run.getStepMirror() == null ? new HashMap<>() : new HashMap<>(run.getStepMirror());
     String parentScenarioStepId = hasText(parentSimStepId) ? mirror.get(parentSimStepId) : null;
     try {
+      // Append the scenario twin in its OWN transaction (REQUIRES_NEW): a mirror-side persistence
+      // failure (scenario template invisible under this thread's tenant, an action-target
+      // realignment error, a concurrent author racing the same scenario workflow) then rolls back
+      // only the twin and can never mark the caller's authoring transaction rollback-only - which
+      // previously turned a swallowed mirror error into a failed commit that lost the executing
+      // step. The stepMirror map update + run save below deliberately stay in the OUTER transaction
+      // so they commit atomically with the executing step and never race a REQUIRES_NEW twin over
+      // the same managed AutonomousRun row.
       String scenarioStepId =
-          workflowService.appendChainedStepToScenario(
+          workflowService.appendChainedStepToScenarioIsolated(
               scenarioId, injectInput, parentScenarioStepId, triggerConditions);
       mirror.put(simStepId, scenarioStepId);
       run.setStepMirror(mirror);
@@ -2838,6 +2883,35 @@ public class AutonomousRunService {
     // truth (idempotent: attaches each team to the simulation if missing, then enables its
     // players).
     exerciseService.enableTargetedTeamMembers(simulationId, teamIds);
+  }
+
+  /**
+   * Transaction-isolated, best-effort variant of {@link #enableTargetedTeamMembers} for the
+   * orchestrator's step author/update callbacks. Delegates to {@link
+   * ExerciseService#enableTargetedTeamMembersIsolated} ({@link
+   * org.springframework.transaction.annotation.Propagation#REQUIRES_NEW}) and swallows any failure
+   * so enabling players can never fail (500) the callback: the check-then-insert on {@code
+   * exercise_teams_users} can race a concurrent callback (the agent authors steps in parallel), and
+   * such a failure would otherwise mark the callback's transaction rollback-only and lose the
+   * executing step just authored. The caller is responsible for establishing the run's v1 {@link
+   * TenantContext} (the legacy non-prefixed callback route leaves it on the DEFAULT tenant). Unlike
+   * {@link #enableTargetedTeamMembers}, do NOT use this on the creation flow, whose simulation is
+   * not yet committed and must join the caller's transaction.
+   */
+  private void enableTargetedTeamMembersBestEffort(String simulationId, List<String> teamIds) {
+    // Author-scenario (AI planning) runs have no simulation to enable players on - nothing is
+    // delivered while planning, so this is a no-op.
+    if (!hasText(simulationId)) {
+      return;
+    }
+    try {
+      exerciseService.enableTargetedTeamMembersIsolated(simulationId, teamIds);
+    } catch (Exception e) {
+      log.warn(
+          "[Autonomous] Failed to enable targeted team members on simulation {} (best-effort): {}",
+          simulationId,
+          e.getMessage());
+    }
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -202,6 +202,91 @@ public class StepService {
   }
 
   /**
+   * Trigger-aware sibling of {@link #updateInjectStepTemplateData(String,
+   * StepsCreateInput.StepInput)}: updates the baked inject data AND replaces the step's
+   * finding-trigger conditions (event root + leaf filters + MAPPER bindings), while PRESERVING any
+   * DEPEND_ON ordering parent so the kill-chain edge stays intact. This is how the AI orchestrator
+   * CORRECTS a mis-wired finding-driven step (change what it fires on / consumes) in place, instead
+   * of re-authoring a duplicate or moving it in the chain.
+   *
+   * <p>Deliberately does NOT assert {@link WorkflowEditability}: the orchestrator is the author of
+   * an autonomous run's workflow, exactly like {@link #createInjectStepTemplateIdempotent}. The
+   * condition swap mirrors the manual full-replace strategy in {@code updateStep} - delete the
+   * non-preserved conditions, clear the step-side links, recreate from input, re-link the preserved
+   * DEPEND_ON root.
+   *
+   * @param stepTemplateId the id of the step template to update
+   * @param stepInput the new inject step input (data)
+   * @param triggerConditions the finding-trigger + mapper conditions to install (an empty list
+   *     clears the trigger while keeping DEPEND_ON)
+   * @return the updated step template
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public Step updateInjectStepTemplateDataAndTrigger(
+      String stepTemplateId,
+      StepsCreateInput.StepInput stepInput,
+      List<ConditionCreateInput> triggerConditions)
+      throws ChainingException {
+    Step existing =
+        stepRepository
+            .findById(stepTemplateId)
+            .orElseThrow(
+                () ->
+                    new ElementNotFoundException(
+                        "Step template not found. Step template ID: " + stepTemplateId));
+    if (!StepActionClass.INJECT_EXECUTION.equals(existing.getStepAction())) {
+      throw new ChainingException(
+          "Step template " + stepTemplateId + " is not an inject-execution step");
+    }
+    ActionStep actionStep = factoryAction(stepInput.getStepAction(), null);
+    Step candidate =
+        actionStep
+            .create(stepInput, existing.getWorkflow())
+            .orElseThrow(() -> new ChainingException("Failed to rebuild step data (TEMPLATE)"));
+    existing.setData(candidate.getData());
+
+    List<String> preservedDependOnIds =
+        conditionService.findAllConditionsByStepId(stepTemplateId).stream()
+            .filter(condition -> condition.getType() == ConditionType.DEPEND_ON)
+            .map(Condition::getId)
+            .toList();
+    conditionService.deleteAllConditionsByStepId(stepTemplateId, preservedDependOnIds);
+    if (existing.getConditionSteps() != null) {
+      existing.getConditionSteps().clear();
+    }
+    stepConditionTemplate(triggerConditions, existing.getWorkflow().getId(), existing);
+    conditionService.linkExistingConditionsToStep(existing, preservedDependOnIds);
+    return saveStep(existing);
+  }
+
+  /**
+   * Deletes an INJECT_EXECUTION step template and its conditions on behalf of the AI orchestrator,
+   * WITHOUT the manual {@link WorkflowEditability} guard (the orchestrator is the author of an
+   * autonomous run's workflow, exactly like {@link #createInjectStepTemplateIdempotent}). Used to
+   * PRUNE a mis-authored finding-driven step. Executed run steps stay as history (their {@code
+   * stepTemplate} reference is nulled by the on-delete policy), so pruning a template never
+   * rewrites what already ran.
+   *
+   * @param stepTemplateId the id of the step template to delete
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void deleteInjectStepTemplate(String stepTemplateId) throws ChainingException {
+    Step existing =
+        stepRepository
+            .findById(stepTemplateId)
+            .orElseThrow(
+                () ->
+                    new ElementNotFoundException(
+                        "Step template not found. Step template ID: " + stepTemplateId));
+    if (!StepActionClass.INJECT_EXECUTION.equals(existing.getStepAction())) {
+      throw new ChainingException(
+          "Step template " + stepTemplateId + " is not an inject-execution step");
+    }
+    conditionService.deleteAllConditionsByStepId(stepTemplateId);
+    stepRepository.delete(existing);
+  }
+
+  /**
    * Create step templates.
    *
    * @param workflow workflow linked to the step templates

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -1519,10 +1519,15 @@ public class WorkflowService {
     }
     String workflowTemplateId = workflowRun.getWorkflowTemplate().getId();
 
-    // Guard: ignore if workflow run has already ended (e.g. timeout).
+    // Guard: ignore if workflow run has already ended (e.g. timeout). The early return is load-
+    // bearing: without it an ended workflow still fell through to
+    // createReadySteps/enqueueReadySteps
+    // below, re-readying and re-enqueuing steps on a terminated run (churn, and a possible re-fire
+    // after a timeout settle).
     if (this.isWorkflowEnded(workflowRun.getId())) {
       log.info(
           "[Chaining] Ignoring evaluation because workflow run {} has ended.", workflowRun.getId());
+      return workflowRun;
     }
 
     // Get all step template
@@ -1868,13 +1873,29 @@ public class WorkflowService {
     if (template.isEmpty()) {
       return List.of();
     }
+    Workflow workflow = template.get();
     List<Step> steps =
-        stepService.findAllStepTemplateByWorkflow(template.get().getId()).stream()
+        stepService.findAllStepTemplateByWorkflow(workflow.getId()).stream()
             .filter(s -> StepActionClass.INJECT_EXECUTION.equals(s.getStepAction()))
             .sorted(
                 Comparator.comparing(
                     Step::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
             .toList();
+    if (steps.isEmpty()) {
+      return List.of();
+    }
+    // Batch every step's LINKED root conditions in one query - a step links only its condition
+    // ROOTS (the DEPEND_ON parent, the finding-trigger event root, and any MAPPER roots) - and the
+    // workflow's leaf filter conditions once, grouped by parent id. This replaces a per-step
+    // condition read (the old dependOnParentTemplateId call) plus a per-step trigger walk with two
+    // batched reads, so the orchestrator's per-cycle attack-path poll stays flat instead of N+1 in
+    // the step count.
+    Set<String> stepIds = steps.stream().map(Step::getId).collect(Collectors.toSet());
+    Map<String, List<Condition>> rootsByStep = conditionService.findAllConditionsByStepIds(stepIds);
+    Map<String, List<Condition>> filterLeavesByParentId =
+        conditionService.findAllNonMapperConditionsByWorkflowId(workflow.getId()).stream()
+            .filter(condition -> condition.getConditionParent() != null)
+            .collect(Collectors.groupingBy(condition -> condition.getConditionParent().getId()));
     List<AuthoredAttackStep> authored = new ArrayList<>();
     for (Step step : steps) {
       List<String> runInjectIds =
@@ -1883,14 +1904,106 @@ public class WorkflowService {
               .filter(id -> id != null && !id.isBlank())
               .distinct()
               .toList();
+      List<Condition> roots = rootsByStep.getOrDefault(step.getId(), List.of());
       authored.add(
           new AuthoredAttackStep(
               step.getId(),
-              stepService.dependOnParentTemplateId(step.getId()),
+              dependOnParentFromRoots(roots),
               step.getData(),
-              runInjectIds));
+              runInjectIds,
+              triggerEventName(roots),
+              triggerFilters(roots, filterLeavesByParentId),
+              triggerMappings(roots)));
     }
     return authored;
+  }
+
+  /** The DEPEND_ON parent step template id among a step's linked root conditions, or null. */
+  private static String dependOnParentFromRoots(List<Condition> roots) {
+    return roots.stream()
+        .filter(condition -> condition.getType() == ConditionType.DEPEND_ON)
+        .map(Condition::getValue)
+        .filter(value -> value != null && !value.isBlank())
+        .findFirst()
+        .orElse(null);
+  }
+
+  /** The finding-trigger event root (an AND / OR root) among a step's linked roots, or null. */
+  private static Condition triggerRoot(List<Condition> roots) {
+    return roots.stream()
+        .filter(
+            condition ->
+                condition.getType() == ConditionType.AND || condition.getType() == ConditionType.OR)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /** Human name of the step's finding EVENT (the trigger root's name), or null when it has none. */
+  private static String triggerEventName(List<Condition> roots) {
+    Condition root = triggerRoot(roots);
+    return root != null && hasText(root.getName()) ? root.getName().trim() : null;
+  }
+
+  /**
+   * The step's finding predicates rendered as "&lt;key&gt; &lt;operator&gt; &lt;value&gt;" (value
+   * omitted for a valueless operator such as IS_NOT_NULL), read back from the trigger root's leaf
+   * children so the caller sees exactly what the step fires on - the finding-driven wiring, not an
+   * inferred linear chain.
+   */
+  private static List<String> triggerFilters(
+      List<Condition> roots, Map<String, List<Condition>> filterLeavesByParentId) {
+    Condition root = triggerRoot(roots);
+    if (root == null) {
+      return List.of();
+    }
+    return filterLeavesByParentId.getOrDefault(root.getId(), List.of()).stream()
+        .map(WorkflowService::formatTriggerFilter)
+        .filter(Objects::nonNull)
+        .toList();
+  }
+
+  /**
+   * The step's finding-value bindings rendered as "&lt;key&gt; -&gt; &lt;input&gt;", from MAPPERs.
+   */
+  private static List<String> triggerMappings(List<Condition> roots) {
+    return roots.stream()
+        .filter(condition -> condition.getType() == ConditionType.MAPPER)
+        .map(WorkflowService::formatTriggerMapping)
+        .filter(Objects::nonNull)
+        .toList();
+  }
+
+  private static String formatTriggerFilter(Condition condition) {
+    String key = keyTypeLabels(condition.getKeyTypes());
+    if (key == null) {
+      return null;
+    }
+    String operator = condition.getType() != null ? condition.getType().name() : "";
+    String value = condition.getValue();
+    String base = hasText(operator) ? key + " " + operator : key;
+    return hasText(value) ? base + " " + value.trim() : base;
+  }
+
+  private static String formatTriggerMapping(Condition condition) {
+    String key = keyTypeLabels(condition.getKeyTypes());
+    String input = condition.getKey();
+    if (key == null || !hasText(input)) {
+      return null;
+    }
+    return key + " -> " + input.trim();
+  }
+
+  /** Joins a condition's key types by their primitive label (e.g. "port", "ipv4"), or null. */
+  private static String keyTypeLabels(List<PrimitiveType> keyTypes) {
+    if (keyTypes == null || keyTypes.isEmpty()) {
+      return null;
+    }
+    String joined =
+        keyTypes.stream()
+            .filter(Objects::nonNull)
+            .map(keyType -> keyType.label)
+            .collect(Collectors.joining("/"));
+    return hasText(joined) ? joined : null;
   }
 
   /**
@@ -1905,7 +2018,25 @@ public class WorkflowService {
   @Transactional(rollbackFor = Exception.class)
   public void updateChainedStep(String stepTemplateId, InjectInput injectInput)
       throws ChainingException {
-    doUpdateChainedStep(stepTemplateId, injectInput);
+    doUpdateChainedStep(stepTemplateId, injectInput, null);
+  }
+
+  /**
+   * Trigger-aware overload of {@link #updateChainedStep(String, InjectInput)}: in addition to the
+   * inject data, it replaces the step's finding-trigger conditions with {@code triggerConditions}
+   * (preserving any DEPEND_ON ordering parent), so the orchestrator can CORRECT a mis-wired
+   * finding-driven step in place. A {@code null} {@code triggerConditions} keeps the existing
+   * conditions untouched (data-only), exactly like the two-argument overload; an empty list clears
+   * the trigger while keeping the DEPEND_ON parent.
+   *
+   * @param triggerConditions the finding-trigger + mapper conditions to install, or {@code null} to
+   *     leave the step's conditions untouched
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void updateChainedStep(
+      String stepTemplateId, InjectInput injectInput, List<ConditionCreateInput> triggerConditions)
+      throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput, triggerConditions);
   }
 
   /**
@@ -1924,14 +2055,57 @@ public class WorkflowService {
   @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
   public void updateChainedStepIsolated(String stepTemplateId, InjectInput injectInput)
       throws ChainingException {
-    doUpdateChainedStep(stepTemplateId, injectInput);
+    doUpdateChainedStep(stepTemplateId, injectInput, null);
   }
 
-  private void doUpdateChainedStep(String stepTemplateId, InjectInput injectInput)
+  /**
+   * Trigger-aware, transaction-isolated variant of {@link #updateChainedStepIsolated(String,
+   * InjectInput)} used to keep the scenario mirror twin's finding trigger in lock-step with the
+   * corrected simulation step. Same {@link Propagation#REQUIRES_NEW} best-effort isolation.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void updateChainedStepIsolated(
+      String stepTemplateId, InjectInput injectInput, List<ConditionCreateInput> triggerConditions)
+      throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput, triggerConditions);
+  }
+
+  /**
+   * Deletes a chained step template (and its conditions) on behalf of the autonomous orchestrator,
+   * so it can PRUNE a mis-authored finding-driven step. Bypasses the manual editability guard for
+   * the same reason the author path does (the orchestrator owns the run's workflow).
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void deleteChainedStep(String stepTemplateId) throws ChainingException {
+    stepService.deleteInjectStepTemplate(stepTemplateId);
+  }
+
+  /**
+   * Transaction-isolated variant of {@link #deleteChainedStep} for pruning the scenario mirror twin
+   * in lock-step. Runs in its OWN transaction ({@link Propagation#REQUIRES_NEW}) so a twin-delete
+   * failure rolls back only itself and can NEVER mark the caller's delete transaction
+   * rollback-only.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void deleteChainedStepIsolated(String stepTemplateId) throws ChainingException {
+    stepService.deleteInjectStepTemplate(stepTemplateId);
+  }
+
+  // Shared body for the update overloads. Private and non-transactional: the public overloads are
+  // the @Transactional proxy entry points and each delegates here (an intra-class call to a
+  // @Transactional sibling would bypass the proxy). A null triggerConditions means "data-only,
+  // keep the existing conditions"; a non-null list rebuilds the finding trigger while preserving
+  // the DEPEND_ON ordering parent.
+  private void doUpdateChainedStep(
+      String stepTemplateId, InjectInput injectInput, List<ConditionCreateInput> triggerConditions)
       throws ChainingException {
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
-    Step updated = stepService.updateInjectStepTemplateData(stepTemplateId, stepInput);
+    Step updated =
+        triggerConditions == null
+            ? stepService.updateInjectStepTemplateData(stepTemplateId, stepInput)
+            : stepService.updateInjectStepTemplateDataAndTrigger(
+                stepTemplateId, stepInput, triggerConditions);
     rearmStepForReExecution(updated);
   }
 
@@ -1958,12 +2132,18 @@ public class WorkflowService {
   }
 
   /**
-   * One authored attack-path step: its stable template id, its DEPEND_ON parent (null for a root),
-   * the baked inject JSON ({@code step_data}), and the inject ids of every run step it has spawned.
+   * One authored attack-path step: its stable template id, its DEPEND_ON ordering parent (null when
+   * it is a seed or wired finding-driven), the baked inject JSON ({@code step_data}), the inject
+   * ids of every run step it has spawned, and the read-back of its finding TRIGGER - the event
+   * name, the filter predicates it fires on, and the finding-value input bindings it consumes - so
+   * a reader reconstructs the finding-driven wiring rather than inferring a linear DEPEND_ON chain.
    */
   public record AuthoredAttackStep(
       String stepTemplateId,
       String parentStepTemplateId,
       String injectDataJson,
-      List<String> runInjectIds) {}
+      List<String> runInjectIds,
+      String eventName,
+      List<String> triggerFilters,
+      List<String> triggerMappings) {}
 }

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -33,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
@@ -272,6 +273,24 @@ public class WorkflowService {
       findWorkflowRunBySimulationId(simulationId)
           .forEach(w -> writeAllowlistRules(w, rules, replaceExisting));
     }
+  }
+
+  /**
+   * Transaction-isolated variant of {@link #writeAllowlistScope} for the autonomous orchestrator's
+   * scope callback. Runs in its OWN transaction ({@link Propagation#REQUIRES_NEW}) so that a
+   * failure while mirroring the resolved scope onto the scenario template / live simulation
+   * workflow(s) rolls back only this mirror and can NEVER mark the caller's transaction
+   * rollback-only. The caller records the resolved scope on the run authoritatively first and
+   * treats this workflow mirror as a secondary projection - a mirror failure must not fail (500)
+   * the callback and stall the run. See {@code AutonomousRunService#setRunScope}.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void writeAllowlistScopeIsolated(
+      String scenarioId,
+      String simulationId,
+      List<WorkflowScopeRuleInput> allowlistRules,
+      boolean replaceExisting) {
+    writeAllowlistScope(scenarioId, simulationId, allowlistRules, replaceExisting);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -251,6 +251,36 @@ public class WorkflowService {
       String simulationId,
       List<WorkflowScopeRuleInput> allowlistRules,
       boolean replaceExisting) {
+    doWriteAllowlistScope(scenarioId, simulationId, allowlistRules, replaceExisting);
+  }
+
+  /**
+   * Transaction-isolated variant of {@link #writeAllowlistScope} for the autonomous orchestrator's
+   * scope callback. Runs in its OWN transaction ({@link Propagation#REQUIRES_NEW}) so that a
+   * failure while mirroring the resolved scope onto the scenario template / live simulation
+   * workflow(s) rolls back only this mirror and can NEVER mark the caller's transaction
+   * rollback-only. The caller records the resolved scope on the run authoritatively first and
+   * treats this workflow mirror as a secondary projection - a mirror failure must not fail (500)
+   * the callback and stall the run. See {@code AutonomousRunService#setRunScope}.
+   *
+   * <p>Both public entry points delegate to the same private, non-transactional body: a same-class
+   * call to the {@code @Transactional} sibling would bypass the Spring proxy (see {@code
+   * TenantBackgroundTransactionArchTest#no_transactional_self_invocation}).
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void writeAllowlistScopeIsolated(
+      String scenarioId,
+      String simulationId,
+      List<WorkflowScopeRuleInput> allowlistRules,
+      boolean replaceExisting) {
+    doWriteAllowlistScope(scenarioId, simulationId, allowlistRules, replaceExisting);
+  }
+
+  private void doWriteAllowlistScope(
+      String scenarioId,
+      String simulationId,
+      List<WorkflowScopeRuleInput> allowlistRules,
+      boolean replaceExisting) {
     if (!replaceExisting && (allowlistRules == null || allowlistRules.isEmpty())) {
       return;
     }
@@ -273,24 +303,6 @@ public class WorkflowService {
       findWorkflowRunBySimulationId(simulationId)
           .forEach(w -> writeAllowlistRules(w, rules, replaceExisting));
     }
-  }
-
-  /**
-   * Transaction-isolated variant of {@link #writeAllowlistScope} for the autonomous orchestrator's
-   * scope callback. Runs in its OWN transaction ({@link Propagation#REQUIRES_NEW}) so that a
-   * failure while mirroring the resolved scope onto the scenario template / live simulation
-   * workflow(s) rolls back only this mirror and can NEVER mark the caller's transaction
-   * rollback-only. The caller records the resolved scope on the run authoritatively first and
-   * treats this workflow mirror as a secondary projection - a mirror failure must not fail (500)
-   * the callback and stall the run. See {@code AutonomousRunService#setRunScope}.
-   */
-  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
-  public void writeAllowlistScopeIsolated(
-      String scenarioId,
-      String simulationId,
-      List<WorkflowScopeRuleInput> allowlistRules,
-      boolean replaceExisting) {
-    writeAllowlistScope(scenarioId, simulationId, allowlistRules, replaceExisting);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -1766,6 +1766,32 @@ public class WorkflowService {
         scenarioId, injectInput, parentScenarioStepTemplateId, triggerConditions);
   }
 
+  /**
+   * Transaction-isolated variant of {@link #appendChainedStepToScenario(String, InjectInput,
+   * String, List)} for the autonomous orchestrator's step-authoring callback. Runs in its OWN
+   * transaction ({@link Propagation#REQUIRES_NEW}) so a scenario-mirror failure (the scenario
+   * template invisible under the callback thread's tenant, or a concurrent author racing the same
+   * scenario workflow) rolls back only this twin and can NEVER mark the caller's authoring
+   * transaction rollback-only. The executing simulation step is authored authoritatively first and
+   * this scenario mirror is a secondary projection - a mirror failure must not fail (500) the
+   * author callback and lose the executing step at commit. See {@code
+   * AutonomousRunService#mirrorStepOntoScenario}.
+   *
+   * <p>Both public entry points delegate to the same private, non-transactional body: a same-class
+   * call to a {@code @Transactional} sibling would bypass the Spring proxy (see {@code
+   * TenantBackgroundTransactionArchTest#no_transactional_self_invocation}).
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public String appendChainedStepToScenarioIsolated(
+      String scenarioId,
+      InjectInput injectInput,
+      String parentScenarioStepTemplateId,
+      List<ConditionCreateInput> triggerConditions)
+      throws ChainingException {
+    return doAppendChainedStepToScenario(
+        scenarioId, injectInput, parentScenarioStepTemplateId, triggerConditions);
+  }
+
   // Shared body for both appendChainedStepToScenario overloads. See doAppendChainedStep for why
   // this
   // is a private, non-transactional helper the public @Transactional overloads delegate to.
@@ -1878,6 +1904,30 @@ public class WorkflowService {
    */
   @Transactional(rollbackFor = Exception.class)
   public void updateChainedStep(String stepTemplateId, InjectInput injectInput)
+      throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput);
+  }
+
+  /**
+   * Transaction-isolated variant of {@link #updateChainedStep} for the autonomous orchestrator's
+   * step-update callback, used to keep the scenario mirror twin in lock-step. Runs in its OWN
+   * transaction ({@link Propagation#REQUIRES_NEW}) so a twin-update failure rolls back only itself
+   * and can NEVER mark the caller's update transaction rollback-only. The executing simulation step
+   * is updated authoritatively first; the scenario mirror is a secondary projection - a twin
+   * failure must not fail (500) the update callback. See {@code
+   * AutonomousRunService#updateAttackPathStep}.
+   *
+   * <p>Delegates to the same private, non-transactional body as {@link #updateChainedStep}: a
+   * same-class call to a {@code @Transactional} sibling would bypass the Spring proxy (see {@code
+   * TenantBackgroundTransactionArchTest#no_transactional_self_invocation}).
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void updateChainedStepIsolated(String stepTemplateId, InjectInput injectInput)
+      throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput);
+  }
+
+  private void doUpdateChainedStep(String stepTemplateId, InjectInput injectInput)
       throws ChainingException {
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);

--- a/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/autonomous/AutonomousRunApiRunTenantScopeTest.java
@@ -25,14 +25,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * TenantScopedEntrypointsTxCtxArchTest} already forces every handler reaching the tenant-active
  * {@code autonomous_*} tables to carry a {@code TxCtx}; this test forces the NEXT decision - every
  * {@code TxCtx} handler on this controller must be explicitly classified as an orchestrator
- * callback (run-scoped) or an operator endpoint (caller-scoped), so a twelfth callback added later
- * fails here instead of silently defaulting to a scope nobody chose.
+ * callback (run-scoped) or an operator endpoint (caller-scoped), so a thirteenth callback added
+ * later fails here instead of silently defaulting to a scope nobody chose.
  *
  * <p>Each run-scoped handler must also name its run through the {@code {runId}} path variable: the
  * resolver derives the scope from exactly that variable and fails closed (404) when it is absent,
  * so a renamed variable would brick the callback silently in production but loudly here.
  */
-@DisplayName("@RunTenantScope stays pinned to the eleven orchestrator callbacks")
+@DisplayName("@RunTenantScope stays pinned to the twelve orchestrator callbacks")
 class AutonomousRunApiRunTenantScopeTest {
 
   /** The orchestrator callbacks: scoped from the parent run on the legacy non-prefixed route. */
@@ -45,6 +45,7 @@ class AutonomousRunApiRunTenantScopeTest {
           "consumeDirectives",
           "appendAttackPathStep",
           "updateAttackPathStep",
+          "deleteAttackPathStep",
           "attackPathState",
           "evaluateAttackPath",
           "promoteFindingToAsset",

--- a/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/TenantScopedEntrypointsTxCtxArchTest.java
@@ -203,6 +203,7 @@ class TenantScopedEntrypointsTxCtxArchTest {
           "io.openaev.api.autonomous.AutonomousRunApi#consumeDirectives",
           "io.openaev.api.autonomous.AutonomousRunApi#appendAttackPathStep",
           "io.openaev.api.autonomous.AutonomousRunApi#updateAttackPathStep",
+          "io.openaev.api.autonomous.AutonomousRunApi#deleteAttackPathStep",
           "io.openaev.api.autonomous.AutonomousRunApi#attackPathState",
           "io.openaev.api.autonomous.AutonomousRunApi#evaluateAttackPath",
           "io.openaev.api.autonomous.AutonomousRunApi#promoteFindingToAsset",

--- a/openaev-api/src/test/java/io/openaev/config/OrchestratorRunTenantInterceptorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/OrchestratorRunTenantInterceptorTest.java
@@ -1,0 +1,131 @@
+package io.openaev.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TenantContext;
+import io.openaev.security.token.XtmJwksExtractor;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Pins the v1 {@link TenantContext} bridge for the orchestrator callback route. The callbacks reach
+ * still-v1-filtered tables (workflows, injects, exercises, teams, assets, findings) on the legacy
+ * non-prefixed route that {@code TenantInterceptor} never covers, so without this bridge a run
+ * owned by a non-default tenant silently reads/writes NOTHING through the v1 filter (empty
+ * attack-path state, no workflow mirror, no team enablement). The gating must match {@link
+ * TxCtxArgumentResolver} exactly (verified cross-platform service identity, non-prefixed route,
+ * {@code runId} present) or v1 and v2 could derive different tenants; and the ThreadLocal must be
+ * cleared on every exit path or a pooled thread leaks one run's tenant into an unrelated request.
+ */
+@DisplayName("OrchestratorRunTenantInterceptor bridges the v1 TenantContext for run callbacks")
+class OrchestratorRunTenantInterceptorTest {
+
+  private static final String RUN_ID = "run-123";
+  private static final String RUN_TENANT = "tenant-non-default";
+
+  private final AutonomousRunTenantLocator locator = mock(AutonomousRunTenantLocator.class);
+  private final OrchestratorRunTenantInterceptor interceptor =
+      new OrchestratorRunTenantInterceptor(locator);
+
+  @BeforeEach
+  @AfterEach
+  void resetContext() {
+    // Isolate from any tenant a sibling test left on this (pooled) thread, both before and after.
+    TenantContext.clearCurrentTenant();
+  }
+
+  private static MockHttpServletRequest request(boolean crossPlatform, Map<String, String> vars) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    if (crossPlatform) {
+      request.setAttribute(XtmJwksExtractor.CROSS_PLATFORM_ATTRIBUTE, Boolean.TRUE);
+    }
+    request.setAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, vars);
+    return request;
+  }
+
+  @Test
+  @DisplayName("service caller on the non-prefixed route with a runId gets the run's v1 tenant")
+  void setsRunTenantForServiceCallerOnNonPrefixedRoute() {
+    when(locator.findRunTenant(RUN_ID)).thenReturn(Optional.of(RUN_TENANT));
+
+    interceptor.preHandle(
+        request(true, Map.of("runId", RUN_ID)), new MockHttpServletResponse(), new Object());
+
+    assertThat(TenantContext.hasCurrentTenant()).isTrue();
+    assertThat(TenantContext.getCurrentTenant()).isEqualTo(RUN_TENANT);
+  }
+
+  @Test
+  @DisplayName("afterCompletion clears the ThreadLocal so a pooled thread never carries the tenant")
+  void afterCompletionClears() {
+    TenantContext.setCurrentTenant(RUN_TENANT);
+
+    interceptor.afterCompletion(
+        new MockHttpServletRequest(), new MockHttpServletResponse(), new Object(), null);
+
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("afterConcurrentHandlingStarted clears too (the async dispatch exit path)")
+  void afterConcurrentHandlingStartedClears() {
+    TenantContext.setCurrentTenant(RUN_TENANT);
+
+    interceptor.afterConcurrentHandlingStarted(
+        new MockHttpServletRequest(), new MockHttpServletResponse(), new Object());
+
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("a non-service caller is never given the run's tenant (no cross-tenant reach)")
+  void ignoresNonServiceCaller() {
+    interceptor.preHandle(
+        request(false, Map.of("runId", RUN_ID)), new MockHttpServletResponse(), new Object());
+
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+    verifyNoInteractions(locator);
+  }
+
+  @Test
+  @DisplayName("the prefixed operator route (tenantId present) is left to TenantInterceptor")
+  void ignoresPrefixedRoute() {
+    interceptor.preHandle(
+        request(true, Map.of("tenantId", "tenant-x", "runId", RUN_ID)),
+        new MockHttpServletResponse(),
+        new Object());
+
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+    verifyNoInteractions(locator);
+  }
+
+  @Test
+  @DisplayName("a callback without a runId path variable sets nothing (fail-safe)")
+  void ignoresMissingRunId() {
+    interceptor.preHandle(request(true, Map.of()), new MockHttpServletResponse(), new Object());
+
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+    verifyNoInteractions(locator);
+  }
+
+  @Test
+  @DisplayName("an unknown / soft-deleted run resolves empty and sets nothing (fail-closed)")
+  void ignoresUnknownRun() {
+    when(locator.findRunTenant(RUN_ID)).thenReturn(Optional.empty());
+
+    interceptor.preHandle(
+        request(true, Map.of("runId", RUN_ID)), new MockHttpServletResponse(), new Object());
+
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/ExerciseTeamUserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/ExerciseTeamUserServiceTest.java
@@ -5,6 +5,7 @@ import static io.openaev.utils.fixtures.ExerciseTeamUserFixture.createExerciseTe
 import static io.openaev.utils.fixtures.TeamFixture.getDefaultTeam;
 import static io.openaev.utils.fixtures.UserFixture.getUser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -107,8 +108,10 @@ class ExerciseTeamUserServiceTest extends IntegrationTest {
     exerciseTeamUserService.enableTargetedTeamMembers(
         "sim-1", List.of("team-1"), Set.of("user-denied"));
 
-    // -- ASSERT: only the kept member gains an exercise_teams_users link --
-    verify(exerciseTeamUserRepository).save(teamUserCaptor.capture());
-    assertEquals(kept, teamUserCaptor.getValue().getUser());
+    // -- ASSERT: only the kept member gains an exercise_teams_users link; the denied user never
+    // does. Enablement now goes through the DB-atomic idempotent insert (ON CONFLICT DO NOTHING)
+    // instead of a check-then-save, so the link is verified by the insertIfAbsent call.
+    verify(exerciseTeamUserRepository).insertIfAbsent("sim-1", "team-1", "user-kept");
+    verify(exerciseTeamUserRepository, never()).insertIfAbsent("sim-1", "team-1", "user-denied");
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
@@ -334,15 +334,17 @@ class AutonomousRunServiceScopeTest {
     when(runRepository.findById(RUN_ID)).thenReturn(Optional.of(run));
     TenantContext.clearCurrentTenant();
     List<String> seenTenants = new ArrayList<>();
+    // A null trigger routes through the three-argument updateChainedStep (data-only), so the tenant
+    // probe is stubbed on that overload.
     doAnswer(
             inv -> {
               seenTenants.add(TenantContext.getCurrentTenant());
               return null;
             })
         .when(workflowService)
-        .updateChainedStep(eq("sim-step-1"), any());
+        .updateChainedStep(eq("sim-step-1"), any(), any());
 
-    runService.updateAttackPathStep(RUN_ID, "sim-step-1", new InjectInput());
+    runService.updateAttackPathStep(RUN_ID, "sim-step-1", new InjectInput(), null);
 
     assertThat(seenTenants).containsExactly("tenant-1");
     assertThat(TenantContext.hasCurrentTenant()).isFalse();

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
@@ -1,0 +1,205 @@
+package io.openaev.service.autonomous;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
+import io.openaev.config.OpenAEVConfig;
+import io.openaev.config.TenantWriteScopeResolver;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.database.model.ScopeRuleSelectedMode;
+import io.openaev.database.model.ScopeRuleSource;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.autonomous.AutonomousEventType;
+import io.openaev.database.model.autonomous.AutonomousRun;
+import io.openaev.database.model.autonomous.AutonomousScopeTarget;
+import io.openaev.database.repository.AssetGroupRepository;
+import io.openaev.database.repository.ExerciseRepository;
+import io.openaev.database.repository.FindingRepository;
+import io.openaev.database.repository.InjectExpectationRepository;
+import io.openaev.database.repository.InjectRepository;
+import io.openaev.database.repository.SettingRepository;
+import io.openaev.database.repository.TeamRepository;
+import io.openaev.database.repository.UserRepository;
+import io.openaev.database.repository.autonomous.AutonomousDirectiveRepository;
+import io.openaev.database.repository.autonomous.AutonomousRunRepository;
+import io.openaev.rest.exercise.service.ExerciseService;
+import io.openaev.service.EndpointService;
+import io.openaev.service.ScenarioToExerciseService;
+import io.openaev.service.chaining.WorkflowService;
+import io.openaev.service.scenario.ScenarioService;
+import io.openaev.xtmone.XtmOneClient;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the orchestrator scope callback ({@link AutonomousRunService#setRunScope}): the
+ * resolved scope must be recorded on the run AUTHORITATIVELY (saved before any projection), and the
+ * two secondary projections - the workflow allowlist mirror and the targeted-team enablement - must
+ * be genuinely best-effort AND independent of each other. A projection failure previously
+ * propagated out of the callback as a 500 and stalled the run (issue #7472).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AutonomousRunService scope callback")
+class AutonomousRunServiceScopeTest {
+
+  private static final String RUN_ID = "run-1";
+  private static final String SCENARIO_ID = "scenario-1";
+  private static final String SIMULATION_ID = "sim-1";
+
+  @Mock private AutonomousRunRepository runRepository;
+  @Mock private AutonomousDirectiveRepository directiveRepository;
+  @Mock private AutonomousEventService eventService;
+  @Mock private AutonomousObjectiveTemplateService templateService;
+  @Mock private ScenarioService scenarioService;
+  @Mock private ScenarioToExerciseService scenarioToExerciseService;
+  @Mock private WorkflowService workflowService;
+  @Mock private ExerciseService exerciseService;
+  @Mock private XtmOneClient xtmOneClient;
+  @Mock private OpenAEVConfig openAEVConfig;
+  @Mock private ObjectMapper objectMapper;
+  @Mock private InjectRepository injectRepository;
+  @Mock private InjectExpectationRepository injectExpectationRepository;
+  @Mock private FindingRepository findingRepository;
+  @Mock private EndpointService endpointService;
+  @Mock private TeamRepository teamRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private AssetGroupRepository assetGroupRepository;
+  @Mock private ExerciseRepository exerciseRepository;
+  @Mock private SettingRepository settingRepository;
+  @Mock private AutonomousRunReconciliationWriter reconciliationWriter;
+  @Mock private TenantWriteScopeResolver writeScopeResolver;
+  @Mock private TenantScopedTransaction tenantTx;
+  @Mock private AutonomousRunAccessControl accessControl;
+
+  @InjectMocks private AutonomousRunService runService;
+
+  @Captor private ArgumentCaptor<List<WorkflowScopeRuleInput>> rulesCaptor;
+
+  private AutonomousRun run;
+
+  @BeforeEach
+  void setUp() {
+    run = new AutonomousRun();
+    run.setTenant(new Tenant("tenant-1"));
+    run.setScenarioId(SCENARIO_ID);
+    run.setSimulationId(SIMULATION_ID);
+    when(runRepository.findById(RUN_ID)).thenReturn(Optional.of(run));
+    when(runRepository.save(any(AutonomousRun.class))).thenAnswer(inv -> inv.getArgument(0));
+  }
+
+  @Test
+  @DisplayName("The run's scope is saved BEFORE the workflow mirror, with the mapped projections")
+  void given_aResolvedScope_when_settingIt_then_runIsSavedBeforeTheMirror() {
+    List<AutonomousScopeTarget> scope =
+        List.of(
+            new AutonomousScopeTarget("ASSETS_GROUPS", "group-1"),
+            new AutonomousScopeTarget("TEAMS", "team-1"));
+
+    AutonomousRun saved = runService.setRunScope(RUN_ID, scope);
+
+    // The run row is the authoritative record: saved first, projections filled from the scope.
+    InOrder inOrder = inOrder(runRepository, workflowService);
+    inOrder.verify(runRepository).save(run);
+    inOrder
+        .verify(workflowService)
+        .writeAllowlistScopeIsolated(eq(SCENARIO_ID), eq(SIMULATION_ID), anyList(), eq(true));
+    assertThat(saved.getScope()).hasSize(2);
+    assertThat(saved.getScopeAssetGroupId()).isEqualTo("group-1");
+    assertThat(saved.getScopeTeamId()).isEqualTo("team-1");
+
+    // The mirror receives the scope translated to ALLOWLIST rules (unknown kinds dropped).
+    verify(workflowService)
+        .writeAllowlistScopeIsolated(
+            eq(SCENARIO_ID), eq(SIMULATION_ID), rulesCaptor.capture(), eq(true));
+    assertThat(rulesCaptor.getValue())
+        .extracting(
+            WorkflowScopeRuleInput::getSelectedMode,
+            WorkflowScopeRuleInput::getRuleSource,
+            WorkflowScopeRuleInput::getRuleValue)
+        .containsExactly(
+            tuple(ScopeRuleSelectedMode.ALLOWLIST, ScopeRuleSource.ASSET_GROUP, "group-1"),
+            tuple(ScopeRuleSelectedMode.ALLOWLIST, ScopeRuleSource.TEAM, "team-1"));
+  }
+
+  @Test
+  @DisplayName("A workflow-mirror failure neither fails the callback nor skips team enablement")
+  void given_theMirrorThrows_when_settingScope_then_scopeIsRecordedAndTeamsStillEnabled() {
+    doThrow(new IllegalStateException("action-target realignment failed"))
+        .when(workflowService)
+        .writeAllowlistScopeIsolated(anyString(), anyString(), anyList(), anyBoolean());
+    List<AutonomousScopeTarget> scope = List.of(new AutonomousScopeTarget("TEAMS", "team-1"));
+
+    assertThatCode(() -> runService.setRunScope(RUN_ID, scope)).doesNotThrowAnyException();
+
+    // The scope stays recorded, the OTHER best-effort projection still ran, and the DECISION
+    // timeline entry is still appended - the mirror failure is contained to its own step.
+    verify(runRepository).save(run);
+    verify(exerciseService).enableTargetedTeamMembersIsolated(SIMULATION_ID, List.of("team-1"));
+    verify(eventService)
+        .append(
+            eq(RUN_ID),
+            eq("tenant-1"),
+            eq(SIMULATION_ID),
+            eq(AutonomousEventType.DECISION),
+            eq("Scope set"),
+            anyString(),
+            isNull());
+  }
+
+  @Test
+  @DisplayName("A team-enablement failure does not fail the callback either")
+  void given_teamEnablementThrows_when_settingScope_then_callbackStillSucceeds() {
+    doThrow(new IllegalStateException("exercise_teams_users insert race"))
+        .when(exerciseService)
+        .enableTargetedTeamMembersIsolated(anyString(), anyList());
+    List<AutonomousScopeTarget> scope = List.of(new AutonomousScopeTarget("TEAMS", "team-1"));
+
+    AutonomousRun saved = runService.setRunScope(RUN_ID, scope);
+
+    assertThat(saved.getScopeTeamId()).isEqualTo("team-1");
+    verify(eventService)
+        .append(
+            eq(RUN_ID),
+            eq("tenant-1"),
+            eq(SIMULATION_ID),
+            eq(AutonomousEventType.DECISION),
+            eq("Scope set"),
+            anyString(),
+            isNull());
+  }
+
+  @Test
+  @DisplayName("A plan/author-scenario run (no simulation) skips team enablement entirely")
+  void given_aRunWithoutSimulation_when_settingScope_then_teamEnablementIsSkipped() {
+    run.setSimulationId(null);
+    List<AutonomousScopeTarget> scope = List.of(new AutonomousScopeTarget("TEAMS", "team-1"));
+
+    runService.setRunScope(RUN_ID, scope);
+
+    verify(exerciseService, never()).enableTargetedTeamMembersIsolated(anyString(), anyList());
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +40,7 @@ import io.openaev.database.repository.UserRepository;
 import io.openaev.database.repository.autonomous.AutonomousDirectiveRepository;
 import io.openaev.database.repository.autonomous.AutonomousRunRepository;
 import io.openaev.rest.exercise.service.ExerciseService;
+import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.service.EndpointService;
 import io.openaev.service.ScenarioToExerciseService;
 import io.openaev.service.chaining.WorkflowService;
@@ -60,14 +62,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * Unit tests for the orchestrator scope callback ({@link AutonomousRunService#setRunScope}): the
- * resolved scope must be recorded on the run AUTHORITATIVELY (saved before any projection), and the
- * two secondary projections - the workflow allowlist mirror and the targeted-team enablement - must
- * be genuinely best-effort AND independent of each other. A projection failure previously
- * propagated out of the callback as a 500 and stalled the run (issue #7472).
+ * Unit tests for the orchestrator scope + attack-path authoring callbacks ({@link
+ * AutonomousRunService#setRunScope}, {@link AutonomousRunService#appendAttackPathStep}, {@link
+ * AutonomousRunService#updateAttackPathStep}): the resolved scope must be recorded on the run
+ * AUTHORITATIVELY (saved before any projection), the two secondary projections - the workflow
+ * allowlist mirror and the targeted-team enablement - must be genuinely best-effort AND independent
+ * of each other (a projection failure previously propagated out of the callback as a 500 and
+ * stalled the run, issue #7472), the run-saving callbacks must take the row lock so parallel
+ * callbacks cannot last-write-wins the run, and the PRIMARY step author/update - not just the
+ * secondary projections - must run under the run's own v1 tenant so a custom threat-arsenal
+ * injector contract (which lives in the run's tenant, not the callback route's DEFAULT) resolves.
  */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("AutonomousRunService scope callback")
+@DisplayName("AutonomousRunService scope + attack-path authoring callbacks")
 class AutonomousRunServiceScopeTest {
 
   private static final String RUN_ID = "run-1";
@@ -111,8 +118,14 @@ class AutonomousRunServiceScopeTest {
     run.setTenant(new Tenant("tenant-1"));
     run.setScenarioId(SCENARIO_ID);
     run.setSimulationId(SIMULATION_ID);
-    when(runRepository.findById(RUN_ID)).thenReturn(Optional.of(run));
-    when(runRepository.save(any(AutonomousRun.class))).thenAnswer(inv -> inv.getArgument(0));
+    // setRunScope / appendAttackPathStep load the run FOR UPDATE (row lock); updateAttackPathStep
+    // keeps the plain read since it never saves the run. Lenient so a per-method test that
+    // exercises
+    // only one lookup does not trip strict-stub checks on the other.
+    lenient().when(runRepository.findByIdForUpdate(RUN_ID)).thenReturn(Optional.of(run));
+    lenient()
+        .when(runRepository.save(any(AutonomousRun.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
   }
 
   @AfterEach
@@ -251,5 +264,87 @@ class AutonomousRunServiceScopeTest {
     runService.setRunScope(RUN_ID, List.of(new AutonomousScopeTarget("TEAMS", "team-1")));
 
     assertThat(TenantContext.getCurrentTenant()).isEqualTo("caller-tenant");
+  }
+
+  @Test
+  @DisplayName("Appending a step loads the run FOR UPDATE (row lock), never the unlocked read")
+  void given_anAuthorCallback_when_appendingAStep_then_theRunIsLoadedForUpdate() throws Exception {
+    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList()))
+        .thenReturn("sim-step-1");
+
+    runService.appendAttackPathStep(RUN_ID, new InjectInput(), null);
+
+    // The author callback saves the run's step mirror with a full-entity write on a version-less
+    // row, so it must serialise with the parallel author/scope callbacks via the row lock rather
+    // than last-write-wins them through the plain read.
+    verify(runRepository).findByIdForUpdate(RUN_ID);
+    verify(runRepository, never()).findById(anyString());
+  }
+
+  @Test
+  @DisplayName("The PRIMARY step author runs under the run's v1 tenant, cleared again afterwards")
+  void given_theLegacyCallbackRoute_when_appendingAStep_then_thePrimaryRunsUnderTheRunTenant()
+      throws Exception {
+    // Reproduce the legacy non-prefixed route's no-tenant thread (see the scope projections test).
+    TenantContext.clearCurrentTenant();
+    List<String> seenTenants = new ArrayList<>();
+    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList()))
+        .thenAnswer(
+            inv -> {
+              seenTenants.add(TenantContext.getCurrentTenant());
+              return "sim-step-1";
+            });
+
+    runService.appendAttackPathStep(RUN_ID, new InjectInput(), null);
+
+    // The executing step is baked under the run's OWN tenant - not the callback route's DEFAULT -
+    // so the explicit injector-contract existence check (stepData -> assertInjectorContractExists)
+    // resolves a custom threat-arsenal contract that lives in the run's tenant. The thread carried
+    // no tenant before the callback, so it must carry none after it.
+    assertThat(seenTenants).containsExactly("tenant-1");
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("A plan run (no simulation) authors onto the scenario under the run's v1 tenant")
+  void given_aPlanRun_when_appendingAStep_then_theScenarioAuthorRunsUnderTheRunTenant()
+      throws Exception {
+    run.setSimulationId(null);
+    TenantContext.clearCurrentTenant();
+    List<String> seenTenants = new ArrayList<>();
+    when(workflowService.appendChainedStepToScenario(anyString(), any(), any(), anyList()))
+        .thenAnswer(
+            inv -> {
+              seenTenants.add(TenantContext.getCurrentTenant());
+              return "scenario-step-1";
+            });
+
+    runService.appendAttackPathStep(RUN_ID, new InjectInput(), null);
+
+    assertThat(seenTenants).containsExactly("tenant-1");
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName(
+      "The PRIMARY in-place step update runs under the run's v1 tenant, cleared afterwards")
+  void given_theLegacyCallbackRoute_when_updatingAStep_then_thePrimaryRunsUnderTheRunTenant()
+      throws Exception {
+    // updateAttackPathStep never saves the run, so it keeps the plain read (stubbed here).
+    when(runRepository.findById(RUN_ID)).thenReturn(Optional.of(run));
+    TenantContext.clearCurrentTenant();
+    List<String> seenTenants = new ArrayList<>();
+    doAnswer(
+            inv -> {
+              seenTenants.add(TenantContext.getCurrentTenant());
+              return null;
+            })
+        .when(workflowService)
+        .updateChainedStep(eq("sim-step-1"), any());
+
+    runService.updateAttackPathStep(RUN_ID, "sim-step-1", new InjectInput());
+
+    assertThat(seenTenants).containsExactly("tenant-1");
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.TenantWriteScopeResolver;
+import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
 import io.openaev.database.model.ScopeRuleSelectedMode;
 import io.openaev.database.model.ScopeRuleSource;
@@ -42,8 +44,10 @@ import io.openaev.service.ScenarioToExerciseService;
 import io.openaev.service.chaining.WorkflowService;
 import io.openaev.service.scenario.ScenarioService;
 import io.openaev.xtmone.XtmOneClient;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -109,6 +113,11 @@ class AutonomousRunServiceScopeTest {
     run.setSimulationId(SIMULATION_ID);
     when(runRepository.findById(RUN_ID)).thenReturn(Optional.of(run));
     when(runRepository.save(any(AutonomousRun.class))).thenAnswer(inv -> inv.getArgument(0));
+  }
+
+  @AfterEach
+  void cleanUpTenantContext() {
+    TenantContext.clearCurrentTenant();
   }
 
   @Test
@@ -201,5 +210,46 @@ class AutonomousRunServiceScopeTest {
     runService.setRunScope(RUN_ID, scope);
 
     verify(exerciseService, never()).enableTargetedTeamMembersIsolated(anyString(), anyList());
+  }
+
+  @Test
+  @DisplayName("Projections run under the run's v1 tenant scope, cleared again afterwards")
+  void given_theLegacyCallbackRoute_when_settingScope_then_projectionsRunUnderTheRunTenant() {
+    // The legacy non-prefixed orchestrator route never sets the v1 TenantContext, so the
+    // v1-filtered projection reads would otherwise fall back to the default tenant and silently
+    // match nothing for a run owned by another tenant. Clear the context the auto-registered
+    // DefaultTenantExtension seeds for every test to reproduce that route's no-tenant thread.
+    TenantContext.clearCurrentTenant();
+    List<String> seenTenants = new ArrayList<>();
+    doAnswer(
+            inv -> {
+              seenTenants.add(TenantContext.getCurrentTenant());
+              return null;
+            })
+        .when(workflowService)
+        .writeAllowlistScopeIsolated(anyString(), anyString(), anyList(), anyBoolean());
+    doAnswer(
+            inv -> {
+              seenTenants.add(TenantContext.getCurrentTenant());
+              return null;
+            })
+        .when(exerciseService)
+        .enableTargetedTeamMembersIsolated(anyString(), anyList());
+
+    runService.setRunScope(RUN_ID, List.of(new AutonomousScopeTarget("TEAMS", "team-1")));
+
+    assertThat(seenTenants).containsExactly("tenant-1", "tenant-1");
+    // The thread carried no tenant before the callback - it must not keep one after it.
+    assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+
+  @Test
+  @DisplayName("The operator route's caller tenant is restored after the projections")
+  void given_aCallerTenantOnTheThread_when_settingScope_then_itIsRestored() {
+    TenantContext.setCurrentTenant("caller-tenant");
+
+    runService.setRunScope(RUN_ID, List.of(new AutonomousScopeTarget("TEAMS", "team-1")));
+
+    assertThat(TenantContext.getCurrentTenant()).isEqualTo("caller-tenant");
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -2037,6 +2037,35 @@ class WorkflowServiceTest {
     }
 
     @Test
+    @DisplayName("given the workflow run already ended should return early without readying steps")
+    void given_endedWorkflowRun_should_returnEarlyWithoutReadyingSteps() throws Exception {
+      // Arrange - a run that a timeout settle already ENDed. The isWorkflowEnded guard must
+      // short-circuit; without the early return the evaluation fell through and re-readied /
+      // re-enqueued steps on a terminated run (churn, and a possible re-fire after the settle).
+      String workflowRunId = UUID.randomUUID().toString();
+      String workflowTemplateId = UUID.randomUUID().toString();
+      Workflow workflowTemplate = Workflow.builder().id(workflowTemplateId).build();
+      Workflow workflowRun =
+          Workflow.builder()
+              .id(workflowRunId)
+              .status(WorkflowStatus.RUN)
+              .workflowTemplate(workflowTemplate)
+              .build();
+      stubReload(workflowRunId, workflowRun);
+      when(workflowRepository.existsByIdAndStatus(workflowRunId, WorkflowStatus.END))
+          .thenReturn(true);
+
+      // Act
+      Workflow result = workflowService.evaluateWorkflowProgress(workflowRun);
+
+      // Assert - returned untouched, and no step ever readied / enqueued on the ended run.
+      assertSame(workflowRun, result);
+      verify(stepService, never()).findAllStepTemplateByWorkflow(any());
+      verify(stepService, never()).createReadySteps(any(), any(), any(), anyInt());
+      verify(stepService, never()).enqueueReadySteps(any(), any());
+    }
+
+    @Test
     @DisplayName("given workflow run has no template should return early without evaluating steps")
     void given_nullWorkflowTemplate_should_returnEarlyWithoutEvaluatingSteps() throws Exception {
       // Arrange - run with no template (e.g. corrupted state)

--- a/openaev-front/src/__tests__/admin/components/autonomous/useAutonomousRunForSimulation.test.ts
+++ b/openaev-front/src/__tests__/admin/components/autonomous/useAutonomousRunForSimulation.test.ts
@@ -46,11 +46,15 @@ const tickTimes = async (times: number, ms: number) => {
 describe('useAutonomousRunForSimulation (404-streak run detection)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // The session-sticky "detected autonomous" hint lives in sessionStorage, which persists across
+    // tests in jsdom - clear it so a run detected in one test never leaks into the next.
+    sessionStorage.clear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    sessionStorage.clear();
   });
 
   it('given_aTransient404OnReload_should_keepProbingAndReattachTheRun', async () => {
@@ -162,5 +166,56 @@ describe('useAutonomousRunForSimulation (404-streak run detection)', () => {
     expect(mocks.fetchAutonomousRunByScenario).toHaveBeenCalledTimes(MAX_DISCOVERY_NOT_FOUND);
     await tick(DISCOVERY_POLL_MS * 3);
     expect(mocks.fetchAutonomousRunByScenario).toHaveBeenCalledTimes(MAX_DISCOVERY_NOT_FOUND);
+  });
+
+  it('given_aStickyAutonomousEntityWithoutAMarker_should_stayPendingAcrossATransient404', async () => {
+    // Arrange: a first mount detects a run for a LEGACY simulation (no exercise_autonomous marker),
+    // which marks the id sticky for the session. A reload (fresh mount, still no marker) then hits
+    // the post-reload transient 404 before the run is queryable again.
+    mocks.fetchAutonomousRunBySimulation
+      .mockResolvedValueOnce({ data: RUN })
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValue({ data: RUN });
+
+    // Act: first mount detects the run and records the sticky hint, then unmounts (reload).
+    const first = renderHook(() => useAutonomousRunForSimulation('sim-legacy'));
+    await flush();
+    expect(first.result.current.run).toEqual(RUN);
+    first.unmount();
+
+    const { result } = renderHook(() => useAutonomousRunForSimulation('sim-legacy'));
+    await flush();
+
+    // Assert: the sticky hint keeps the reload PENDING (no manual flash) despite the falsy marker
+    // and the transient 404, and the FAST retry re-attaches before the discovery poll would have.
+    expect(result.current.resolved).toBe(false);
+    expect(result.current.run).toBeNull();
+    await tick(DISCOVERY_RETRY_MS);
+    expect(result.current.run).toEqual(RUN);
+  });
+
+  it('given_aStickyEntityStrandedByALongBlip_should_selfHealWithoutAReload', async () => {
+    // Arrange: a first mount detects the run (sticky), then a blip long enough to exhaust the
+    // not-found streak (which latches manual), and finally the run is queryable again.
+    mocks.fetchAutonomousRunBySimulation
+      .mockResolvedValueOnce({ data: RUN })
+      .mockRejectedValue(notFound());
+
+    const first = renderHook(() => useAutonomousRunForSimulation('sim-sticky'));
+    await flush();
+    expect(first.result.current.run).toEqual(RUN);
+    first.unmount();
+
+    // Reload straight into the blip: every probe 404s past the fast streak, so manual latches.
+    const { result } = renderHook(() => useAutonomousRunForSimulation('sim-sticky'));
+    await flush();
+    await tickTimes(MAX_DISCOVERY_NOT_FOUND, DISCOVERY_RETRY_MS);
+    expect(result.current.run).toBeNull();
+
+    // The blip clears: a sticky entity keeps re-probing on the discovery cadence even after the
+    // manual latch, so the cockpit self-heals without a full reload.
+    mocks.fetchAutonomousRunBySimulation.mockResolvedValue({ data: RUN });
+    await tick(DISCOVERY_POLL_MS * 2);
+    expect(result.current.run).toEqual(RUN);
   });
 });

--- a/openaev-front/src/__tests__/admin/components/autonomous/useAutonomousRunForSimulation.test.ts
+++ b/openaev-front/src/__tests__/admin/components/autonomous/useAutonomousRunForSimulation.test.ts
@@ -1,0 +1,166 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import useAutonomousRunForSimulation, { DISCOVERY_POLL_MS, DISCOVERY_RETRY_MS, MAX_DISCOVERY_NOT_FOUND, useAutonomousRunForScenario } from '../../../../admin/components/autonomous/useAutonomousRunForSimulation';
+
+const mocks = vi.hoisted(() => ({
+  fetchAutonomousRunBySimulation: vi.fn(),
+  fetchAutonomousRunByScenario: vi.fn(),
+}));
+
+vi.mock('../../../../actions/autonomous/autonomous-actions', () => ({
+  fetchAutonomousRunBySimulation: mocks.fetchAutonomousRunBySimulation,
+  fetchAutonomousRunByScenario: mocks.fetchAutonomousRunByScenario,
+}));
+
+// Detection is EE- and XTM-One-gated; the streak logic under test only runs when eligible.
+vi.mock('../../../../utils/hooks/useAuth', () => ({ default: () => ({ settings: { platform_xtm_one_configured: true } }) }));
+
+vi.mock('../../../../utils/hooks/useEnterpriseEdition', () => ({ default: () => ({ isValidated: true }) }));
+
+const RUN = { autonomous_run_id: 'run-1' };
+const notFound = () => ({ response: { status: 404 } });
+const serverError = () => ({ response: { status: 500 } });
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+const tick = async (ms = DISCOVERY_POLL_MS) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+};
+// Sequential probe/settle cycles: each tick must fully flush (probe fired, rejection handled,
+// state committed) before the next timer advance, so the ticks cannot be collapsed or parallel.
+const tickTimes = async (times: number, ms: number) => {
+  for (let i = 0; i < times; i += 1) {
+    // eslint-disable-next-line no-await-in-loop -- ordered cycles, see above
+    await tick(ms);
+  }
+};
+
+describe('useAutonomousRunForSimulation (404-streak run detection)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('given_aTransient404OnReload_should_keepProbingAndReattachTheRun', async () => {
+    // Arrange: the post-reload reconcile window answers 404 once, then the run is queryable again.
+    mocks.fetchAutonomousRunBySimulation
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValue({ data: RUN });
+
+    // Act: first probe misses.
+    const { result } = renderHook(() => useAutonomousRunForSimulation('sim-1'));
+    await flush();
+
+    // Assert: one transient miss must NOT latch manual - detection is resolved (no loader churn)
+    // but the discovery poll stays alive and the next probe re-attaches the cockpit.
+    expect(result.current.resolved).toBe(true);
+    expect(result.current.run).toBeNull();
+    await tick();
+    expect(result.current.run).toEqual(RUN);
+  });
+
+  it('given_anUnbrokenStreakOf404s_should_concludeManualAndStopProbing', async () => {
+    // Arrange: a genuinely manual simulation answers 404 forever.
+    mocks.fetchAutonomousRunBySimulation.mockRejectedValue(notFound());
+
+    // Act: the mount probe plus poll re-probes until the streak threshold is reached.
+    const { result } = renderHook(() => useAutonomousRunForSimulation('sim-1'));
+    await flush();
+    await tickTimes(MAX_DISCOVERY_NOT_FOUND - 1, DISCOVERY_POLL_MS);
+
+    // Assert: the manual verdict is latched after exactly the streak threshold...
+    expect(result.current.run).toBeNull();
+    expect(mocks.fetchAutonomousRunBySimulation).toHaveBeenCalledTimes(MAX_DISCOVERY_NOT_FOUND);
+
+    // ...and the discovery poll STOPS - a manual entity is never re-probed forever.
+    await tick(DISCOVERY_POLL_MS * 3);
+    expect(mocks.fetchAutonomousRunBySimulation).toHaveBeenCalledTimes(MAX_DISCOVERY_NOT_FOUND);
+  });
+
+  it('given_aStreakBrokenByATransientError_should_notConcludeManualAndStillRecover', async () => {
+    // Arrange: two misses, a 5xx blip (which must RESET the streak), two more misses - never an
+    // unbroken streak of MAX_DISCOVERY_NOT_FOUND - and then the run becomes queryable.
+    mocks.fetchAutonomousRunBySimulation
+      .mockRejectedValueOnce(notFound())
+      .mockRejectedValueOnce(notFound())
+      .mockRejectedValueOnce(serverError())
+      .mockRejectedValueOnce(notFound())
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValue({ data: RUN });
+
+    // Act
+    const { result } = renderHook(() => useAutonomousRunForSimulation('sim-1'));
+    await flush();
+    await tickTimes(5, DISCOVERY_POLL_MS);
+
+    // Assert: mixed transient errors never accumulated into a false manual verdict - the poll was
+    // still alive on the sixth probe and the cockpit attached.
+    expect(mocks.fetchAutonomousRunBySimulation).toHaveBeenCalledTimes(6);
+    expect(result.current.run).toEqual(RUN);
+  });
+
+  it('given_aDetectedRun_should_stopTheDiscoveryPoll', async () => {
+    // Arrange
+    mocks.fetchAutonomousRunBySimulation.mockResolvedValue({ data: RUN });
+
+    // Act
+    const { result } = renderHook(() => useAutonomousRunForSimulation('sim-1'));
+    await flush();
+
+    // Assert: once detected, the header/panel keep the run fresh - discovery never re-probes.
+    expect(result.current.run).toEqual(RUN);
+    await tick(DISCOVERY_POLL_MS * 3);
+    expect(mocks.fetchAutonomousRunBySimulation).toHaveBeenCalledTimes(1);
+  });
+
+  it('given_aDeclaredAutonomousEntity_should_stayPendingAcrossATransient404AndFastRetry', async () => {
+    // Arrange: the scenario carries the scenario_autonomous marker; the reload race answers 404
+    // once, then the run is queryable again.
+    mocks.fetchAutonomousRunByScenario
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValue({ data: RUN });
+
+    // Act: first probe misses.
+    const { result } = renderHook(() => useAutonomousRunForScenario('scenario-1', true));
+    await flush();
+
+    // Assert: a declared-autonomous entity must NOT resolve to the manual view on a transient miss
+    // - it stays pending (Loader, never a manual flash) and the FAST retry attaches the cockpit
+    // well before the discovery poll would have.
+    expect(result.current.resolved).toBe(false);
+    expect(result.current.run).toBeNull();
+    await tick(DISCOVERY_RETRY_MS);
+    expect(result.current.run).toEqual(RUN);
+    expect(result.current.resolved).toBe(true);
+  });
+
+  it('given_aDeclaredAutonomousEntityWithATornDownRun_should_settleManualAfterTheFastStreak', async () => {
+    // Arrange: the durable marker outlives the run row, so every probe answers 404.
+    mocks.fetchAutonomousRunByScenario.mockRejectedValue(notFound());
+
+    // Act: mount probe + fast retries until the streak threshold.
+    const { result } = renderHook(() => useAutonomousRunForScenario('scenario-1', true));
+    await flush();
+    await tickTimes(MAX_DISCOVERY_NOT_FOUND - 1, DISCOVERY_RETRY_MS);
+
+    // Assert: the pending window is bounded - the full streak latches manual, detection resolves,
+    // and probing stops for good.
+    expect(result.current.resolved).toBe(true);
+    expect(result.current.run).toBeNull();
+    expect(mocks.fetchAutonomousRunByScenario).toHaveBeenCalledTimes(MAX_DISCOVERY_NOT_FOUND);
+    await tick(DISCOVERY_POLL_MS * 3);
+    expect(mocks.fetchAutonomousRunByScenario).toHaveBeenCalledTimes(MAX_DISCOVERY_NOT_FOUND);
+  });
+});

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/GraphCardTooltip.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/GraphCardTooltip.test.tsx
@@ -76,4 +76,18 @@ describe('GraphCardTooltip force-close paths', () => {
     // Assert
     expect(screen.getByText(TOOLTIP_BODY)).toBeTruthy();
   });
+
+  it('given_anOpenTooltip_should_closeOnWheelZoom', async () => {
+    // Arrange
+    render(card('sig-1'), { wrapper });
+    expect(await openTooltip()).toBeTruthy();
+
+    // Act: the operator zooms the pan/zoom canvas. The canvas is overflow:hidden and preventDefaults
+    // the wheel, so Popper never repositions - the capture-phase wheel listener must force-close the
+    // card instead of letting it detach and float over the graph.
+    fireEvent.wheel(window, { deltaY: -120 });
+
+    // Assert
+    await waitFor(() => expect(screen.queryByText(TOOLTIP_BODY)).toBeNull());
+  });
 });

--- a/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/GraphCardTooltip.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/chaining/logic/logic-graph/GraphCardTooltip.test.tsx
@@ -1,0 +1,79 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import GraphCardTooltip from '../../../../../../admin/components/chaining/logic/logic-graph/GraphCardTooltip';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider theme={createTheme()}>{children}</ThemeProvider>
+);
+
+const TOOLTIP_BODY = 'Rich tooltip body';
+const CARD_BODY = 'Card body';
+const MENU = 'menu';
+
+// The nested button mirrors the cards' row-menu / connect-handle children, which stopPropagation
+// on pointerdown in the BUBBLE phase to avoid starting a node drag: the wrapper's capture-phase
+// dismiss must fire anyway.
+const card = (dismissKey?: unknown) => (
+  <GraphCardTooltip title={<div>{TOOLTIP_BODY}</div>} dismissKey={dismissKey}>
+    <div>
+      {CARD_BODY}
+      <button type="button" onPointerDown={e => e.stopPropagation()}>{MENU}</button>
+    </div>
+  </GraphCardTooltip>
+);
+
+// The tooltip opens after its enterDelay; findByText waits for it.
+const openTooltip = async () => {
+  fireEvent.mouseOver(screen.getByText(CARD_BODY));
+  return screen.findByText(TOOLTIP_BODY);
+};
+
+// These pin the two force-close paths that fix the reported "tooltip stays open" defect: an
+// uncontrolled tooltip inside the pan/zoom canvas was routinely robbed of its mouseleave/blur
+// close by presses (drawer/menu opening) and by structural relayouts sliding the card out from
+// under a stationary cursor.
+describe('GraphCardTooltip force-close paths', () => {
+  afterEach(cleanup);
+
+  it('given_anOpenTooltip_should_closeOnAPointerPressEvenFromAStopPropagationChild', async () => {
+    // Arrange
+    render(card('sig-1'), { wrapper });
+    expect(await openTooltip()).toBeTruthy();
+
+    // Act: press the nested control whose bubble-phase handler stops propagation - the dismiss
+    // runs in the CAPTURE phase, so it must fire regardless.
+    fireEvent.pointerDown(screen.getByText(MENU));
+
+    // Assert
+    await waitFor(() => expect(screen.queryByText(TOOLTIP_BODY)).toBeNull());
+  });
+
+  it('given_anOpenTooltip_should_closeWhenTheDismissKeyChanges', async () => {
+    // Arrange: the graph passes its layout fitSignature as the dismissKey.
+    const { rerender } = render(card('sig-1'), { wrapper });
+    expect(await openTooltip()).toBeTruthy();
+
+    // Act: a structural relayout changes the signature (a poll authored/removed a step).
+    rerender(card('sig-2'));
+
+    // Assert
+    await waitFor(() => expect(screen.queryByText(TOOLTIP_BODY)).toBeNull());
+  });
+
+  it('given_anOpenTooltip_should_stayOpenAcrossAPollRerenderWithTheSameDismissKey', async () => {
+    // Arrange
+    const { rerender } = render(card('sig-1'), { wrapper });
+    expect(await openTooltip()).toBeTruthy();
+
+    // Act: the autonomous poll re-renders the canvas every few seconds WITHOUT changing the
+    // layout signature - the tooltip must not blink shut under a hovering cursor.
+    rerender(card('sig-1'));
+    await new Promise(resolve => setTimeout(resolve, 250));
+
+    // Assert
+    expect(screen.getByText(TOOLTIP_BODY)).toBeTruthy();
+  });
+});

--- a/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousOutcome.tsx
@@ -1,5 +1,5 @@
 import { AutoAwesome, BoltOutlined, DownloadOutlined, ErrorOutline, VerifiedOutlined, WarningAmberOutlined } from '@mui/icons-material';
-import { Alert, Box, Button, Chip, Divider, Paper, Stack, Tooltip, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, Divider, Paper, Stack, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import * as R from 'ramda';
 import { type FunctionComponent, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -8,6 +8,7 @@ import { fetchAutonomousTimeline } from '../../../actions/autonomous/autonomous-
 import { type AutonomousEvent, type AutonomousRun, type AutonomousRunStatus } from '../../../actions/autonomous/autonomous-types';
 import { HeroStat, HeroStats, SectionBlock } from '../../../components/common/detail/EntityDetailCommon';
 import { useFormatter } from '../../../components/i18n';
+import GraphCardTooltip from '../chaining/logic/logic-graph/GraphCardTooltip';
 import SamplePreview from '../workspaces/custom_dashboards/widgets/viz/sample/SamplePreview';
 import { eventAccent, eventIcon, EventMarkdown, eventTypeLabel, isHeartbeatEvent, isLiveActivityEvent, sanitizeEventText, stripMarkdown } from './autonomousEventVisuals';
 import AutonomousOutcomeDialog, { type OutcomeKind } from './AutonomousOutcomeDialog';
@@ -261,6 +262,10 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
   // inspect earlier decisions (see the scroll handler + effect below).
   const timelineScrollRef = useRef<HTMLDivElement | null>(null);
   const timelinePinnedRef = useRef(true);
+  // Bumped on every timeline scroll and chained into the tooltip dismiss key: the timeline
+  // auto-scrolls under the live poll (tail-follow), which slides a node out from under a stationary
+  // cursor with no mouseleave - the exact stuck-tooltip trap the graph cards already guard against.
+  const [timelineScrollNonce, setTimelineScrollNonce] = useState(0);
 
   const usesSharedTimeline = sharedEvents !== undefined;
   useEffect(() => {
@@ -299,6 +304,8 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
     }
     const distanceFromRight = node.scrollWidth - node.clientWidth - node.scrollLeft;
     timelinePinnedRef.current = distanceFromRight < 48;
+    // Dismiss any open node tooltip: the card just moved under the cursor.
+    setTimelineScrollNonce(nonce => nonce + 1);
   }, []);
 
   const proofEvents = useMemo(() => events.filter(e => e.autonomous_event_type === 'PROOF'), [events]);
@@ -730,8 +737,14 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
                 );
                 const tipTags = renderTags(tipTechniques, tipCves);
                 return (
-                  <Tooltip
+                  <GraphCardTooltip
                     key={event.autonomous_event_id}
+                    // Controlled tooltip shared with the causal graph: it force-closes on press, on
+                    // wheel-zoom, and whenever the dismiss key changes. The key folds the timeline
+                    // length (a poll appended/removed a node) and a scroll nonce (the auto-scroll
+                    // slid the node under the cursor), so the rich card can never stick open over the
+                    // live-polling timeline the way the old uncontrolled Tooltip did.
+                    dismissKey={`${timelineEvents.length}:${timelineScrollNonce}`}
                     // Render the tooltip as a proper card (matches the panel/dialog surface) rather
                     // than the cramped default: header with the event-type chip + timestamp, a
                     // right-sized title, MITRE/CVE tags, then the reasoning body clamped so a long
@@ -750,7 +763,6 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
                       },
                       arrow: { sx: { color: theme.palette.background.paper } },
                     }}
-                    arrow
                     title={(
                       <Box>
                         <Stack sx={{
@@ -868,7 +880,7 @@ const AutonomousOutcome: FunctionComponent<AutonomousOutcomeProps> = ({ run, liv
                         </Typography>
                       )}
                     </Stack>
-                  </Tooltip>
+                  </GraphCardTooltip>
                 );
               })}
             </Box>

--- a/openaev-front/src/admin/components/autonomous/AutonomousOverview.tsx
+++ b/openaev-front/src/admin/components/autonomous/AutonomousOverview.tsx
@@ -3,7 +3,7 @@ import * as R from 'ramda';
 import { type FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
-import { type AutonomousRun, type AutonomousRunStatus } from '../../../actions/autonomous/autonomous-types';
+import { type AutonomousEvent, type AutonomousRun, type AutonomousRunStatus } from '../../../actions/autonomous/autonomous-types';
 import { fetchExerciseExpectationResult, fetchExerciseInjectExpectationResults } from '../../../actions/exercises/exercise-action';
 import { SectionBlock } from '../../../components/common/detail/EntityDetailCommon';
 import PostureGauges from '../../../components/common/detail/PostureGauges';
@@ -19,7 +19,13 @@ import AutonomousOutcome from './AutonomousOutcome';
 const ACTIVE_STATUSES: AutonomousRunStatus[] = ['PLANNING', 'RUNNING', 'WAITING_INPUT'];
 const POLL_INTERVAL_MS = 5000;
 
-interface AutonomousOverviewProps { run: AutonomousRun }
+interface AutonomousOverviewProps {
+  run: AutonomousRun;
+  // The timeline already polled by the always-open reasoning panel. When provided, the outcome
+  // layer reuses it (via AutonomousOutcome's sharedEvents) instead of starting a SECOND
+  // full-from-cursor-0 poll of the same endpoint - the simulation-side double-poll fix (#7472).
+  sharedEvents?: AutonomousEvent[];
+}
 
 /**
  * Overview tab of an autonomous (AI-driven) run. It renders the durable, exportable
@@ -31,7 +37,7 @@ interface AutonomousOverviewProps { run: AutonomousRun }
  * Plan mode is non-executing (no injects run), so the posture / kill-chain sections are dropped:
  * there are no results to show and the outcome's proofs column is dropped for the same reason.
  */
-const AutonomousOverview: FunctionComponent<AutonomousOverviewProps> = ({ run }) => {
+const AutonomousOverview: FunctionComponent<AutonomousOverviewProps> = ({ run, sharedEvents }) => {
   const { t } = useFormatter();
   const navigate = useNavigate();
   const location = useLocation();
@@ -100,7 +106,7 @@ const AutonomousOverview: FunctionComponent<AutonomousOverviewProps> = ({ run })
 
   return (
     <Stack sx={{ gap: 2 }}>
-      <AutonomousOutcome run={run} />
+      <AutonomousOutcome run={run} sharedEvents={sharedEvents} />
 
       {/* Run posture: the single simulation's prevention / detection / vulnerability / human-response
           gauges. A plan never executes, so it produces no results - the section is dropped in plan

--- a/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
+++ b/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
@@ -7,6 +7,15 @@ import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 
 /** How often to re-probe for an autonomous run until we find one (transient error / late creation). */
 const DISCOVERY_POLL_MS = 10000;
+/**
+ * Consecutive 404s required before concluding a scenario/simulation is manual (non-AI). A single
+ * 404 can be transient right after a page reload - the run row is briefly unqueryable during the
+ * post-start reconcile window - and latching to manual on the FIRST miss permanently stranded the
+ * live AI cockpit until a full reload (the reported "reload and I lost the AI overview, the run is
+ * still going" bug). Requiring a short streak lets a transient miss recover on the next discovery
+ * poll, while a genuinely manual entity still stops quickly (bounded - never re-probes forever).
+ */
+const MAX_DISCOVERY_NOT_FOUND = 3;
 
 interface AutonomousRunDetection {
   /** The run driving this entity, or null when it is a manual (non-AI) scenario/simulation. */
@@ -50,11 +59,12 @@ const useAutonomousRunDetection = (
   const [resolved, setResolved] = useState(false);
   // A run bumps this to force a re-probe (discovery poll below); it is NOT a status poll.
   const [attempt, setAttempt] = useState(0);
-  // Authoritative "this is a manual (non-AI) entity" verdict from a 404. Once set we STOP probing:
-  // a manual scenario/simulation never becomes autonomous (an autonomous run provisions its OWN
-  // scenario), so re-polling it forever only spams an expected 404 and churns state - which, via the
-  // caller's `!resolved` full-page Loader, forced a whole-page remount + refetch every poll. Only a
-  // TRANSIENT error (5xx / network) keeps the discovery poll alive.
+  // Authoritative "this is a manual (non-AI) entity" verdict from a STREAK of consecutive 404s (see
+  // MAX_DISCOVERY_NOT_FOUND). Once set we STOP probing: a manual scenario/simulation never becomes
+  // autonomous (an autonomous run provisions its OWN scenario), so re-polling it forever only spams
+  // an expected 404 and churns state - which, via the caller's `!resolved` full-page Loader, forced
+  // a whole-page remount + refetch every poll. A single transient 404 (5xx / network too) keeps the
+  // discovery poll alive so a post-reload miss on a live AI run still recovers.
   const [manual, setManual] = useState(false);
   // Once we have confirmed this entity is autonomous, it STAYS autonomous for the life of the
   // mount. An eligibility blip (XTM One health / settings refresh flipping platform_xtm_one_configured)
@@ -66,9 +76,13 @@ const useAutonomousRunDetection = (
   // transient-error retry) must NOT flip `resolved` back to false, otherwise the caller's Loader
   // unmounts and remounts the entire page on every poll.
   const resolvedOnceRef = useRef(false);
+  // Consecutive 404 count for the discovery probe (see MAX_DISCOVERY_NOT_FOUND). Reset on any
+  // success and whenever the id changes, so only an UNBROKEN streak of misses concludes "manual".
+  const notFoundStreakRef = useRef(0);
 
   const pushRun = useCallback((next: AutonomousRun) => {
     detectedRef.current = true;
+    notFoundStreakRef.current = 0;
     setManual(false);
     setRun(next);
   }, []);
@@ -89,6 +103,7 @@ const useAutonomousRunDetection = (
       prevIdRef.current = id;
       resolvedOnceRef.current = false;
       detectedRef.current = false;
+      notFoundStreakRef.current = 0;
       setManual(false);
     }
     if (!id) {
@@ -112,20 +127,31 @@ const useAutonomousRunDetection = (
       .then((res) => {
         if (stale) return;
         detectedRef.current = true;
+        notFoundStreakRef.current = 0;
         setManual(false);
         setRun(res.data);
       })
       .catch((err: unknown) => {
         if (stale) return;
         const status = (err as { response?: { status?: number } })?.response?.status;
-        // A 404 is the authoritative "this is a manual (non-AI) entity" signal - only then do we
-        // clear AND stop probing. Any other error (403 / 5xx / network / a transient reconcile)
-        // must leave a previously-detected run intact so a blip can't strand the manual UI, and
-        // keeps the discovery poll alive so a transient first-load failure still recovers.
+        // A 404 is the "this is a manual (non-AI) entity" signal - but a SINGLE 404 can be a
+        // transient post-reload reconcile race on an entity that IS autonomous, so only conclude
+        // manual (clear AND stop probing) after a streak of consecutive 404s. Until the streak is
+        // reached we leave any previously-detected run intact and let the discovery poll retry, so
+        // a reload no longer strands a live AI cockpit on one transient miss.
         if (status === 404) {
-          detectedRef.current = false;
-          setManual(true);
-          setRun(null);
+          notFoundStreakRef.current += 1;
+          if (notFoundStreakRef.current >= MAX_DISCOVERY_NOT_FOUND) {
+            detectedRef.current = false;
+            setManual(true);
+            setRun(null);
+          }
+        } else {
+          // Any other error (403 / 5xx / network / a transient reconcile) must leave a previously-
+          // detected run intact so a blip can't strand the UI, and keeps the discovery poll alive
+          // so a transient first-load failure still recovers. Reset the not-found streak so a mix
+          // of transient errors never accumulates into a false manual verdict.
+          notFoundStreakRef.current = 0;
         }
       })
       .finally(() => {

--- a/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
+++ b/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
@@ -6,7 +6,7 @@ import useAuth from '../../../utils/hooks/useAuth';
 import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 
 /** How often to re-probe for an autonomous run until we find one (transient error / late creation). */
-const DISCOVERY_POLL_MS = 10000;
+export const DISCOVERY_POLL_MS = 10000;
 /**
  * Consecutive 404s required before concluding a scenario/simulation is manual (non-AI). A single
  * 404 can be transient right after a page reload - the run row is briefly unqueryable during the
@@ -15,7 +15,16 @@ const DISCOVERY_POLL_MS = 10000;
  * still going" bug). Requiring a short streak lets a transient miss recover on the next discovery
  * poll, while a genuinely manual entity still stops quickly (bounded - never re-probes forever).
  */
-const MAX_DISCOVERY_NOT_FOUND = 3;
+export const MAX_DISCOVERY_NOT_FOUND = 3;
+/**
+ * Fast re-probe delay used while a DECLARED-autonomous entity (knownAutonomous === true) is
+ * pending on a below-threshold 404 streak. Such an entity keeps the caller's Loader up instead of
+ * rendering the (affirmatively wrong) manual UI, so the streak must settle in seconds, not in
+ * {@link DISCOVERY_POLL_MS} steps: a transient reload miss re-attaches the cockpit after ~one
+ * retry, and the rare torn-down-run edge (marker outlives the run row) settles to manual after
+ * MAX_DISCOVERY_NOT_FOUND fast probes.
+ */
+export const DISCOVERY_RETRY_MS = 2000;
 
 interface AutonomousRunDetection {
   /** The run driving this entity, or null when it is a manual (non-AI) scenario/simulation. */
@@ -54,6 +63,13 @@ const useAutonomousRunDetection = (
   // nothing to look up regardless of EE / feature / XTM One state.
   const knownManual = knownAutonomous === false;
   const eligible = isEnterpriseEdition && xtmOneReady && !knownManual;
+  // A positive "this entity IS autonomous" hint (scenario_autonomous / exercise_autonomous). For a
+  // declared-autonomous entity the manual UI is affirmatively wrong, so while its run has not been
+  // found (and manual has not been latched by a full 404 streak) detection reports UNRESOLVED -
+  // the caller keeps its Loader up instead of flashing the manual page for a discovery-poll period
+  // after a transient reload miss - and misses re-probe on the fast retry cadence instead of the
+  // discovery poll so the pending window stays short.
+  const declaredAutonomous = knownAutonomous === true;
 
   const [run, setRun] = useState<AutonomousRun | null>(null);
   const [resolved, setResolved] = useState(false);
@@ -79,6 +95,10 @@ const useAutonomousRunDetection = (
   // Consecutive 404 count for the discovery probe (see MAX_DISCOVERY_NOT_FOUND). Reset on any
   // success and whenever the id changes, so only an UNBROKEN streak of misses concludes "manual".
   const notFoundStreakRef = useRef(0);
+  // One-shot fast re-probe (see DISCOVERY_RETRY_MS) scheduled after a below-threshold 404 on a
+  // declared-autonomous entity, so its pending window settles in seconds instead of waiting for
+  // the next discovery-poll tick. Cleared on every probe teardown (id change / unmount / re-run).
+  const fastRetryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const pushRun = useCallback((next: AutonomousRun) => {
     detectedRef.current = true;
@@ -145,6 +165,12 @@ const useAutonomousRunDetection = (
             detectedRef.current = false;
             setManual(true);
             setRun(null);
+          } else if (declaredAutonomous) {
+            // A declared-autonomous entity is PENDING (Loader up) while its streak settles, so
+            // re-probe on the fast cadence instead of leaving the operator on a spinner for a
+            // whole discovery-poll period.
+            if (fastRetryRef.current) clearTimeout(fastRetryRef.current);
+            fastRetryRef.current = setTimeout(() => setAttempt(a => a + 1), DISCOVERY_RETRY_MS);
           }
         } else {
           // Any other error (403 / 5xx / network / a transient reconcile) must leave a previously-
@@ -161,8 +187,15 @@ const useAutonomousRunDetection = (
       });
     return () => {
       stale = true;
+      if (fastRetryRef.current) {
+        clearTimeout(fastRetryRef.current);
+        fastRetryRef.current = null;
+      }
     };
-  }, [id, eligible, fetcher, attempt]);
+    // declaredAutonomous is a dependency on purpose: the hint often arrives AFTER the first probe
+    // (the scenario/simulation document lands later), and its arrival must re-probe immediately -
+    // the miss that just resolved may have been the transient reload race on a live AI run.
+  }, [id, eligible, fetcher, attempt, declaredAutonomous]);
 
   // Keep probing until we discover a run, then stop (the header/panel keep it fresh via setRun).
   // This recovers from a transient first-load failure and picks up a run created while the page is
@@ -174,9 +207,16 @@ const useAutonomousRunDetection = (
     return () => clearInterval(timer);
   }, [eligible, id, run, manual]);
 
+  // A DECLARED-autonomous entity with neither a run nor a latched manual verdict reports
+  // unresolved even after a probe answered: rendering the manual page for it would be affirmatively
+  // wrong, and this is what turned a single transient post-reload 404 into "the AI cockpit dropped
+  // to the manual scenario for a whole discovery-poll period". Derived synchronously (not via
+  // effects) so the manual UI cannot even flash for one frame; bounded because a full 404 streak
+  // latches `manual` (torn-down-run edge) and misses re-probe on the fast retry cadence.
+  const pendingDeclaredAutonomous = Boolean(id) && eligible && declaredAutonomous && !run && !manual;
   return {
     run,
-    resolved,
+    resolved: resolved && !pendingDeclaredAutonomous,
     setRun: pushRun,
     clearRun,
   };
@@ -186,9 +226,19 @@ const useAutonomousRunDetection = (
  * Detects whether a simulation is an autonomous (AI-driven) attack-path run, so the simulation
  * detail page can render the AI cockpit (reasoning panel + gated tabs) instead of the manual
  * chaining editor.
+ *
+ * <p>Pass {@code true} for {@code knownAutonomous} when the loaded simulation carries the durable
+ * {@code exercise_autonomous} marker: detection then stays pending (Loader) across a transient
+ * post-reload 404 instead of flashing the manual editor, and misses re-probe on the fast retry
+ * cadence. Leave it {@code undefined} otherwise - a {@code false} marker must NOT be forwarded as
+ * a manual hint, since simulations provisioned before the marker existed carry {@code false} while
+ * still being autonomous.
  */
-const useAutonomousRunForSimulation = (simulationId: string | undefined): AutonomousRunDetection =>
-  useAutonomousRunDetection(simulationId, fetchAutonomousRunBySimulation);
+const useAutonomousRunForSimulation = (
+  simulationId: string | undefined,
+  knownAutonomous?: boolean,
+): AutonomousRunDetection =>
+  useAutonomousRunDetection(simulationId, fetchAutonomousRunBySimulation, knownAutonomous);
 
 /**
  * Scenario-side twin: detects the CURRENT autonomous run of a scenario so the scenario detail page

--- a/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
+++ b/openaev-front/src/admin/components/autonomous/useAutonomousRunForSimulation.ts
@@ -26,6 +26,53 @@ export const MAX_DISCOVERY_NOT_FOUND = 3;
  */
 export const DISCOVERY_RETRY_MS = 2000;
 
+/**
+ * sessionStorage key prefix for the "this entity was detected autonomous THIS session" sticky hint.
+ * Once a run is discovered for an id, that id is remembered for the tab session so a later reload -
+ * before the fresh probe resolves - treats it as declared-autonomous even when the loaded
+ * scenario/simulation carries a falsy marker (legacy entities provisioned before the durable marker
+ * existed read exercise_autonomous=false while still being autonomous). This is what stops those
+ * legacy entities from flashing the manual UI across a reload.
+ */
+const STICKY_AUTONOMOUS_PREFIX = 'openaev.autonomous.detected.';
+
+/** Whether this id was detected autonomous earlier in the tab session (best-effort). */
+const readStickyAutonomous = (id: string | undefined): boolean => {
+  if (!id) {
+    return false;
+  }
+  try {
+    return sessionStorage.getItem(`${STICKY_AUTONOMOUS_PREFIX}${id}`) === '1';
+  } catch {
+    // sessionStorage unavailable (private mode / disabled): degrade to marker-only behaviour.
+    return false;
+  }
+};
+
+/** Remember that this id is autonomous for the tab session (survives a reload, not a new tab). */
+const markStickyAutonomous = (id: string | undefined): void => {
+  if (!id) {
+    return;
+  }
+  try {
+    sessionStorage.setItem(`${STICKY_AUTONOMOUS_PREFIX}${id}`, '1');
+  } catch {
+    // Best-effort UX aid only; silently degrade when sessionStorage is unavailable.
+  }
+};
+
+/** Forget the sticky hint - the run was torn down server-side (operator converted to manual). */
+const clearStickyAutonomous = (id: string | undefined): void => {
+  if (!id) {
+    return;
+  }
+  try {
+    sessionStorage.removeItem(`${STICKY_AUTONOMOUS_PREFIX}${id}`);
+  } catch {
+    // Best-effort; ignore.
+  }
+};
+
 interface AutonomousRunDetection {
   /** The run driving this entity, or null when it is a manual (non-AI) scenario/simulation. */
   run: AutonomousRun | null;
@@ -69,7 +116,19 @@ const useAutonomousRunDetection = (
   // the caller keeps its Loader up instead of flashing the manual page for a discovery-poll period
   // after a transient reload miss - and misses re-probe on the fast retry cadence instead of the
   // discovery poll so the pending window stays short.
-  const declaredAutonomous = knownAutonomous === true;
+  // The marker-declared signal (scenario_autonomous / exercise_autonomous). This is the ONLY part of
+  // the declared-autonomous signal the probe effect depends on: the marker can arrive AFTER the
+  // first probe (the entity document lands later) and its arrival must re-probe, whereas the sticky
+  // hint below flips as a SIDE EFFECT of a successful detection and must NEVER re-fire a probe.
+  const declaredByMarker = knownAutonomous === true;
+  // A session-sticky "this id is autonomous" hint set once a run has been detected. OR-ed into the
+  // declared-autonomous signal so a legacy entity (falsy marker but actually autonomous) still keeps
+  // the Loader up across a reload and re-probes fast, instead of flashing the manual UI. Read in the
+  // probe effect through a ref (never a dependency) so setting it on detection cannot re-probe.
+  const [stickyAutonomous, setStickyAutonomous] = useState<boolean>(() => readStickyAutonomous(id));
+  const stickyAutonomousRef = useRef(stickyAutonomous);
+  stickyAutonomousRef.current = stickyAutonomous;
+  const declaredAutonomous = declaredByMarker || stickyAutonomous;
 
   const [run, setRun] = useState<AutonomousRun | null>(null);
   const [resolved, setResolved] = useState(false);
@@ -103,9 +162,11 @@ const useAutonomousRunDetection = (
   const pushRun = useCallback((next: AutonomousRun) => {
     detectedRef.current = true;
     notFoundStreakRef.current = 0;
+    markStickyAutonomous(id);
+    setStickyAutonomous(true);
     setManual(false);
     setRun(next);
-  }, []);
+  }, [id]);
 
   // Drop the detected run and pin the entity to manual so the discovery poll does NOT immediately
   // re-detect it (the run was just torn down server-side, so a probe would 404 and land on manual
@@ -113,9 +174,11 @@ const useAutonomousRunDetection = (
   // run (a fresh AI build / launch) clears this again through pushRun.
   const clearRun = useCallback(() => {
     detectedRef.current = false;
+    clearStickyAutonomous(id);
+    setStickyAutonomous(false);
     setManual(true);
     setRun(null);
-  }, []);
+  }, [id]);
 
   useEffect(() => {
     // Fresh entity: reset the per-id detection latches so a new scenario/simulation is probed anew.
@@ -125,6 +188,9 @@ const useAutonomousRunDetection = (
       detectedRef.current = false;
       notFoundStreakRef.current = 0;
       setManual(false);
+      // Re-read the new id's session sticky hint so a reload of a legacy autonomous entity keeps
+      // the Loader up instead of flashing manual before the fresh probe resolves.
+      setStickyAutonomous(readStickyAutonomous(id));
     }
     if (!id) {
       setRun(null);
@@ -148,6 +214,8 @@ const useAutonomousRunDetection = (
         if (stale) return;
         detectedRef.current = true;
         notFoundStreakRef.current = 0;
+        markStickyAutonomous(id);
+        setStickyAutonomous(true);
         setManual(false);
         setRun(res.data);
       })
@@ -165,7 +233,7 @@ const useAutonomousRunDetection = (
             detectedRef.current = false;
             setManual(true);
             setRun(null);
-          } else if (declaredAutonomous) {
+          } else if (declaredByMarker || stickyAutonomousRef.current) {
             // A declared-autonomous entity is PENDING (Loader up) while its streak settles, so
             // re-probe on the fast cadence instead of leaving the operator on a spinner for a
             // whole discovery-poll period.
@@ -192,20 +260,27 @@ const useAutonomousRunDetection = (
         fastRetryRef.current = null;
       }
     };
-    // declaredAutonomous is a dependency on purpose: the hint often arrives AFTER the first probe
+    // declaredByMarker is a dependency on purpose: the MARKER often arrives AFTER the first probe
     // (the scenario/simulation document lands later), and its arrival must re-probe immediately -
-    // the miss that just resolved may have been the transient reload race on a live AI run.
-  }, [id, eligible, fetcher, attempt, declaredAutonomous]);
+    // the miss that just resolved may have been the transient reload race on a live AI run. The
+    // STICKY hint is deliberately NOT a dependency (read via ref above): it flips as a side effect
+    // of a successful detection, and depending on it would fire a spurious extra probe right after
+    // every detection.
+  }, [id, eligible, fetcher, attempt, declaredByMarker]);
 
   // Keep probing until we discover a run, then stop (the header/panel keep it fresh via setRun).
   // This recovers from a transient first-load failure and picks up a run created while the page is
   // already open, without adding a permanent poll once the cockpit is live. A confirmed-manual
   // entity (404) stops the poll entirely, so a normal chained scenario never re-probes.
   useEffect(() => {
-    if (!eligible || !id || run || manual) return () => {};
+    // A sticky-autonomous entity keeps re-probing even after a manual latch, so a transient blip
+    // that exhausted the not-found streak self-heals on the discovery cadence instead of stranding
+    // the live cockpit on the manual UI until a full reload. A genuinely manual entity (never
+    // sticky) still stops on the latch, so a normal chained scenario never re-probes.
+    if (!eligible || !id || run || (manual && !stickyAutonomous)) return () => {};
     const timer = setInterval(() => setAttempt(a => a + 1), DISCOVERY_POLL_MS);
     return () => clearInterval(timer);
-  }, [eligible, id, run, manual]);
+  }, [eligible, id, run, manual, stickyAutonomous]);
 
   // A DECLARED-autonomous entity with neither a run nor a latched manual verdict reports
   // unresolved even after a probe answered: rendering the manual page for it would be affirmatively

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphActionCard.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphActionCard.tsx
@@ -1,5 +1,5 @@
 import { BoltOutlined, GpsFixedOutlined, MoreVert, OutputOutlined } from '@mui/icons-material';
-import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import { Box, IconButton, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { type MouseEvent, type ReactNode, useState } from 'react';
 
@@ -8,7 +8,7 @@ import ActionTypeIcon from '../ActionTypeIcon';
 import NodePopover from '../chaining_flow/nodes/NodePopover';
 import LogicNodeTooltip, { type TooltipRow } from '../chaining_flow/NodeTooltip';
 import { formatConditionKeyLabel } from '../events/event-types';
-import graphTooltipSlotProps from './graphTooltipSlotProps';
+import GraphCardTooltip from './GraphCardTooltip';
 
 export interface GraphActionCardProps {
   id: string;
@@ -33,6 +33,8 @@ export interface GraphActionCardProps {
   /** 1-based badge index in the selected trigger's data-flow path. */
   pathIndex?: number;
   readOnly?: boolean;
+  /** Force-closes the rich tooltip when it changes (graph structural relayout). */
+  tooltipDismissKey?: unknown;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
 }
@@ -79,6 +81,7 @@ const GraphActionCard = ({
   dimmed = false,
   pathIndex,
   readOnly = false,
+  tooltipDismissKey,
   onEdit,
   onDelete,
 }: GraphActionCardProps) => {
@@ -131,7 +134,7 @@ const GraphActionCard = ({
   );
 
   return (
-    <Tooltip title={tooltip} placement="top" arrow disableInteractive enterDelay={300} slotProps={graphTooltipSlotProps}>
+    <GraphCardTooltip title={tooltip} dismissKey={tooltipDismissKey}>
       <Box
         sx={{
           'position': 'relative',
@@ -325,7 +328,7 @@ const GraphActionCard = ({
           />
         )}
       </Box>
-    </Tooltip>
+    </GraphCardTooltip>
   );
 };
 

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphCardTooltip.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphCardTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from '@mui/material';
+import { Tooltip, type TooltipProps } from '@mui/material';
 import { cloneElement, type PointerEvent as ReactPointerEvent, type ReactElement, type ReactNode, useCallback, useEffect, useState } from 'react';
 
 import graphTooltipSlotProps from './graphTooltipSlotProps';
@@ -13,6 +13,12 @@ interface GraphCardTooltipProps {
    * would otherwise stay pinned over the graph at the card's old position.
    */
   dismissKey?: unknown;
+  /**
+   * Tooltip slot overrides. Defaults to the shared graph slot props (z-index capped below the
+   * drawer). A caller rendering a rich card body outside the graph canvas (the decision timeline)
+   * passes its own surface styling here while still reusing the controlled dismiss behaviour.
+   */
+  slotProps?: TooltipProps['slotProps'];
   /** The card element the tooltip is anchored to. */
   children: ReactElement<{ onPointerDownCapture?: (event: ReactPointerEvent) => void }>;
 }
@@ -30,7 +36,7 @@ interface GraphCardTooltipProps {
  * body, the row menu, the connect handle - even though those children {@code stopPropagation} in the
  * bubble phase to avoid starting a node drag.
  */
-const GraphCardTooltip = ({ title, dismissKey, children }: GraphCardTooltipProps) => {
+const GraphCardTooltip = ({ title, dismissKey, slotProps, children }: GraphCardTooltipProps) => {
   const [open, setOpen] = useState(false);
   const close = useCallback(() => setOpen(false), []);
 
@@ -44,6 +50,23 @@ const GraphCardTooltip = ({ title, dismissKey, children }: GraphCardTooltipProps
     close();
   }, [dismissKey, close]);
 
+  // Force the popover shut on any wheel while it is open. The cards live in a pan/zoom canvas that
+  // is overflow:hidden and whose own wheel handler preventDefaults the browser zoom, so Popper
+  // never sees a scroll to reposition against: an open card would otherwise detach from its anchor
+  // and float over the graph while the operator zooms. A capture-phase passive listener catches the
+  // wheel before the canvas swallows it, without blocking the zoom itself.
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    const closeOnWheel = () => close();
+    window.addEventListener('wheel', closeOnWheel, {
+      capture: true,
+      passive: true,
+    });
+    return () => window.removeEventListener('wheel', closeOnWheel, { capture: true });
+  }, [open, close]);
+
   return (
     <Tooltip
       title={title}
@@ -54,7 +77,7 @@ const GraphCardTooltip = ({ title, dismissKey, children }: GraphCardTooltipProps
       open={open}
       onOpen={() => setOpen(true)}
       onClose={close}
-      slotProps={graphTooltipSlotProps}
+      slotProps={slotProps ?? graphTooltipSlotProps}
     >
       {cloneElement(children, { onPointerDownCapture: handlePointerDownCapture })}
     </Tooltip>

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphCardTooltip.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphCardTooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip } from '@mui/material';
+import { cloneElement, type PointerEvent as ReactPointerEvent, type ReactElement, type ReactNode, useCallback, useEffect, useState } from 'react';
+
+import graphTooltipSlotProps from './graphTooltipSlotProps';
+
+interface GraphCardTooltipProps {
+  /** Rich tooltip body (see {@link LogicNodeTooltip}). */
+  title: ReactNode;
+  /**
+   * When this value changes the tooltip force-closes. The graph passes its structural layout
+   * signature here: a live poll that authors or removes a step re-lays-out the canvas and can slide
+   * the hovered card out from under a stationary cursor - which fires no mouseleave - so the popover
+   * would otherwise stay pinned over the graph at the card's old position.
+   */
+  dismissKey?: unknown;
+  /** The card element the tooltip is anchored to. */
+  children: ReactElement<{ onPointerDownCapture?: (event: ReactPointerEvent) => void }>;
+}
+
+/**
+ * Controlled MUI Tooltip wrapper shared by the causal-graph cards. The cards live in a pan/zoom
+ * canvas that re-renders on every autonomous poll and opens a drawer or row menu on press - both of
+ * which routinely robbed an UNCONTROLLED tooltip of its mouseleave/blur close and left the rich
+ * popover stuck open over the canvas (the reported "tooltip stays open" bug). Controlling `open`
+ * lets us force it shut the instant the card is pressed (any press = select / drag / open drawer)
+ * and whenever the graph structurally re-lays-out ({@link dismissKey}); neither is something the
+ * hover-only close path can guarantee inside this canvas.
+ *
+ * The dismiss handler runs in the CAPTURE phase so it fires for every press inside the card - the
+ * body, the row menu, the connect handle - even though those children {@code stopPropagation} in the
+ * bubble phase to avoid starting a node drag.
+ */
+const GraphCardTooltip = ({ title, dismissKey, children }: GraphCardTooltipProps) => {
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+
+  const handlePointerDownCapture = useCallback((event: ReactPointerEvent) => {
+    close();
+    children.props.onPointerDownCapture?.(event);
+  }, [children, close]);
+
+  // Force the popover shut when the graph re-lays-out under the cursor (see dismissKey).
+  useEffect(() => {
+    close();
+  }, [dismissKey, close]);
+
+  return (
+    <Tooltip
+      title={title}
+      placement="top"
+      arrow
+      disableInteractive
+      enterDelay={300}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={close}
+      slotProps={graphTooltipSlotProps}
+    >
+      {cloneElement(children, { onPointerDownCapture: handlePointerDownCapture })}
+    </Tooltip>
+  );
+};
+
+export default GraphCardTooltip;

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphTriggerCard.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphTriggerCard.tsx
@@ -78,16 +78,24 @@ const GraphTriggerCard = ({
   };
 
   // This card is the EVENT node (kind 'trigger' internally), so its title must read as the event's
-  // name — never the trigger's technical condition-field keys, which made an unnamed event look like
-  // a trigger. The listened-on fields still appear in the tooltip's "Listens on" row below.
+  // name. When the event is unnamed, fall back to the human condition line (e.g.
+  // `Hostname contains "dc01"`) so the node is self-describing, and only then to the generic
+  // placeholder — never to the raw listened-on condition-FIELD keys, which made an unnamed event
+  // look like a trigger. The listened-on fields still appear in the tooltip's "Listens on" row.
   const trimmedName = (name ?? '').trim();
-  const title = trimmedName || t('Untitled event');
+  const firstConditionLine = conditionLines.find(line => !!line && !!line.trim())?.trim();
+  const title = trimmedName || firstConditionLine || t('Untitled event');
 
   let summaryLine: ReactNode = t('Waits for a matching finding');
   if (conditionLines.length === 1) {
     summaryLine = conditionLines[0];
   } else if (conditionLines.length > 1) {
     summaryLine = `${conditionLines[0]} (+${conditionLines.length - 1})`;
+  }
+  // An unnamed event promotes its condition line to the title; drop it from the subtitle so the
+  // card never prints the same line twice.
+  if (title === summaryLine) {
+    summaryLine = t('Waits for a matching finding');
   }
 
   const tooltipRows: TooltipRow[] = [];

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphTriggerCard.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/GraphTriggerCard.tsx
@@ -7,6 +7,7 @@ import { useFormatter } from '../../../../../components/i18n';
 import NodePopover from '../chaining_flow/nodes/NodePopover';
 import LogicNodeTooltip, { type TooltipRow } from '../chaining_flow/NodeTooltip';
 import { formatConditionKeyLabel } from '../events/event-types';
+import GraphCardTooltip from './GraphCardTooltip';
 import graphTooltipSlotProps from './graphTooltipSlotProps';
 
 export interface GraphTriggerCardProps {
@@ -24,6 +25,8 @@ export interface GraphTriggerCardProps {
   dimmed?: boolean;
   pathIndex?: number;
   readOnly?: boolean;
+  /** Force-closes the rich tooltip when it changes (graph structural relayout). */
+  tooltipDismissKey?: unknown;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
   /** Inline "+": add an action gated by this trigger (continue the chain). */
@@ -50,6 +53,7 @@ const GraphTriggerCard = ({
   dimmed = false,
   pathIndex,
   readOnly = false,
+  tooltipDismissKey,
   onEdit,
   onDelete,
   onAddAction,
@@ -114,7 +118,7 @@ const GraphTriggerCard = ({
   const active = selected || highlighted;
 
   return (
-    <Tooltip title={tooltip} placement="top" arrow disableInteractive enterDelay={300} slotProps={graphTooltipSlotProps}>
+    <GraphCardTooltip title={tooltip} dismissKey={tooltipDismissKey}>
       <Box
         sx={{
           'position': 'relative',
@@ -304,7 +308,7 @@ const GraphTriggerCard = ({
           />
         )}
       </Box>
-    </Tooltip>
+    </GraphCardTooltip>
   );
 };
 

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
@@ -582,6 +582,7 @@ const LogicGraph = ({
                   dimmed={dimmed}
                   pathIndex={flow.pathIndex[node.id]}
                   readOnly={readOnly}
+                  tooltipDismissKey={fitSignature}
                   onEdit={handleEditAction}
                   onDelete={setPendingDeleteNodeId}
                 />
@@ -631,6 +632,7 @@ const LogicGraph = ({
                 dimmed={dimmed}
                 pathIndex={flow.pathIndex[node.id]}
                 readOnly={readOnly}
+                tooltipDismissKey={fitSignature}
                 onEdit={handleEditTrigger}
                 onDelete={setPendingDeleteNodeId}
                 onAddAction={onAddActionToEvent}

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/LogicGraph.tsx
@@ -257,12 +257,21 @@ const LogicGraph = ({
     };
   }, [positionedNodes, layout.bbox]);
 
-  // Stable fingerprint of the graph structure so PanZoom only re-fits on real changes (not on
-  // selection, dragging, or polling re-renders that keep the same nodes). `refitNonce` forces a
-  // re-fit after "Auto-organize" restores the auto positions.
+  // Structural fingerprint of the graph (bbox + node id SET). Drives PanZoom's ONE-TIME fit: a live
+  // run authoring steps changes this, but PanZoom fits only on first content and re-fits only on an
+  // explicit `refitNonce` bump, so authoring a step never yanks the operator's manual pan/zoom.
+  // Deliberately omits node positions and the nonce (both handled elsewhere).
   const fitSignature = useMemo(
-    () => `${Math.round(layout.bbox.width)}x${Math.round(layout.bbox.height)}|${layout.nodes.map(n => n.id).join(',')}|${refitNonce}`,
-    [layout, refitNonce],
+    () => `${Math.round(layout.bbox.width)}x${Math.round(layout.bbox.height)}|${layout.nodes.map(n => n.id).join(',')}`,
+    [layout],
+  );
+  // Tooltip dismiss key: the structural signature PLUS each node's rounded position. A pure relayout
+  // that keeps the same node-id set leaves `fitSignature` unchanged yet still slides a card out from
+  // under a stationary cursor, which would strand a rich tooltip; folding positions in force-closes
+  // it. Kept separate from `fitSignature` so a drag/relayout dismisses tooltips without re-fitting.
+  const tooltipDismissKey = useMemo(
+    () => `${fitSignature}|${positionedNodes.map(n => `${n.id}:${Math.round(n.x)},${Math.round(n.y)}`).join(';')}`,
+    [fitSignature, positionedNodes],
   );
 
   // Data-flow spotlight for the selected node (action or trigger). `flow` resolves one representative
@@ -475,6 +484,7 @@ const LogicGraph = ({
         contentWidth={contentSize.width}
         contentHeight={contentSize.height}
         fitSignature={fitSignature}
+        refitNonce={refitNonce}
         onBackgroundClick={() => setSelectedNodeId(null)}
         onZoomChange={(zoom) => { zoomRef.current = zoom; }}
         onAutoLayout={readOnly ? undefined : handleAutoLayout}
@@ -582,7 +592,7 @@ const LogicGraph = ({
                   dimmed={dimmed}
                   pathIndex={flow.pathIndex[node.id]}
                   readOnly={readOnly}
-                  tooltipDismissKey={fitSignature}
+                  tooltipDismissKey={tooltipDismissKey}
                   onEdit={handleEditAction}
                   onDelete={setPendingDeleteNodeId}
                 />
@@ -632,7 +642,7 @@ const LogicGraph = ({
                 dimmed={dimmed}
                 pathIndex={flow.pathIndex[node.id]}
                 readOnly={readOnly}
-                tooltipDismissKey={fitSignature}
+                tooltipDismissKey={tooltipDismissKey}
                 onEdit={handleEditTrigger}
                 onDelete={setPendingDeleteNodeId}
                 onAddAction={onAddActionToEvent}

--- a/openaev-front/src/admin/components/chaining/logic/logic-graph/PanZoom.tsx
+++ b/openaev-front/src/admin/components/chaining/logic/logic-graph/PanZoom.tsx
@@ -17,8 +17,15 @@ interface PanZoomProps {
   /** Logical content size (bounding box of the laid-out graph). */
   contentWidth: number;
   contentHeight: number;
-  /** Changes whenever the graph structure changes; triggers an auto re-fit. */
+  /**
+   * Structural fingerprint of the graph. Triggers the FIRST fit when content becomes fittable, then
+   * never auto-fits again: a live run that authors steps changes this, and re-fitting there would
+   * yank the operator's manual pan/zoom on every new step. Explicit re-fit stays available via the
+   * Fit button and {@link refitNonce}.
+   */
   fitSignature: string;
+  /** Bumped by the parent (Fit / Auto-organize) to force an explicit re-fit. */
+  refitNonce?: number;
   minZoom?: number;
   maxZoom?: number;
   /** Called on a click on the empty canvas (no drag) - used to clear the selection. */
@@ -54,6 +61,7 @@ const PanZoom = ({
   contentWidth,
   contentHeight,
   fitSignature,
+  refitNonce,
   minZoom = 0.3,
   maxZoom = 2.5,
   onBackgroundClick,
@@ -117,11 +125,33 @@ const PanZoom = ({
     hasFitted.current = true;
   }, [contentWidth, contentHeight, clampZoom]);
 
-  // Re-fit whenever the graph structure changes.
+  // Fit ONCE, when the graph first becomes fittable. Later structural changes (a live run authoring
+  // steps) must NOT re-fit - that yanked the operator's manual pan/zoom on every new step. `fit()`
+  // early-returns while the content/container has no size, leaving `hasFitted` false, so the first
+  // real fit still lands when the first node appears.
   useLayoutEffect(() => {
-    hasFitted.current = false;
-    fit();
+    if (!hasFitted.current) {
+      fit();
+    }
   }, [fitSignature, fit]);
+
+  // Always call the latest `fit` from the explicit re-fit effect without listing it as a dependency:
+  // `fit` changes identity whenever the content size changes (a new step), and depending on it would
+  // turn the explicit-refit effect into an auto-refit-on-every-step - the exact yank #14 removes.
+  const fitRef = useRef(fit);
+  fitRef.current = fit;
+
+  // Explicit re-fit path (Fit button / Auto-organize bump the nonce). Skips the initial mount so it
+  // does not double-fit with the structural effect above; a bump resets `hasFitted` and re-centers.
+  const refitInitialized = useRef(false);
+  useLayoutEffect(() => {
+    if (!refitInitialized.current) {
+      refitInitialized.current = true;
+      return;
+    }
+    hasFitted.current = false;
+    fitRef.current();
+  }, [refitNonce]);
 
   // Fit once the container gets a real size (initial mount / late layout). Never re-fits after the
   // first successful fit, so window/tab resizes preserve the user's manual zoom.

--- a/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
+++ b/openaev-front/src/admin/components/scenarios/scenario/Index.tsx
@@ -357,10 +357,14 @@ const Index = () => {
   // 404). While the scenario is still loading we leave it undefined to probe as before.
   const isChained = !!scenario?.scenario_workflow_id;
   // undefined = still probing (scenario loading, or a chained scenario that may carry a run);
-  // false = known manual (a loaded time-based scenario), which skips the lookup and its 404.
+  // false = known manual (a loaded time-based scenario), which skips the lookup and its 404;
+  // true = declared autonomous (scenario_autonomous marker), so detection stays PENDING across a
+  // transient post-reload 404 instead of flashing this page's manual view, and re-probes fast.
   let knownAutonomous: boolean | undefined;
   if (scenario && !isChained) {
     knownAutonomous = false;
+  } else if (scenario?.scenario_autonomous === true) {
+    knownAutonomous = true;
   }
   const { run: autonomousRun, resolved: autonomousResolved, setRun: setAutonomousRun, clearRun: clearAutonomousRun } = useAutonomousRunForScenario(
     scenarioId,

--- a/openaev-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/Index.tsx
@@ -168,8 +168,15 @@ const Index = () => {
   const { exerciseId } = useParams() as { exerciseId: ExerciseType['exercise_id'] };
   const { exercise } = useHelper((helper: ExercisesHelper) => ({ exercise: helper.getExercise(exerciseId) }));
   // Detect whether this simulation is an autonomous (AI-driven) run, so we can render the AI
-  // cockpit (reasoning panel + gated tabs) instead of the manual chaining editor.
-  const { run: autonomousRun, resolved: autonomousResolved, setRun: setAutonomousRun } = useAutonomousRunForSimulation(exerciseId);
+  // cockpit (reasoning panel + gated tabs) instead of the manual chaining editor. Forward the
+  // durable exercise_autonomous marker as a POSITIVE hint only: a marked simulation keeps the
+  // Loader up across a transient post-reload 404 (no manual-editor flash) and re-probes fast,
+  // while an unmarked one probes as before - `false` is deliberately NOT forwarded, because
+  // simulations provisioned before the marker existed carry false while still being autonomous.
+  const { run: autonomousRun, resolved: autonomousResolved, setRun: setAutonomousRun } = useAutonomousRunForSimulation(
+    exerciseId,
+    exercise?.exercise_autonomous === true ? true : undefined,
+  );
   useDataLoader(() => {
     setLoading(true);
     dispatch(fetchExercise(exerciseId)).finally(() => {

--- a/openaev-front/src/admin/components/simulations/simulation/Index.tsx
+++ b/openaev-front/src/admin/components/simulations/simulation/Index.tsx
@@ -2,7 +2,7 @@ import { Alert, AlertTitle } from '@mui/material';
 import { type FunctionComponent, lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 
-import { type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
+import { type AutonomousEvent, type AutonomousRun } from '../../../../actions/autonomous/autonomous-types';
 import { fetchExercise } from '../../../../actions/Exercise';
 import { fetchScenarioFromSimulation } from '../../../../actions/exercises/exercise-action';
 import { type ExercisesHelper } from '../../../../actions/exercises/exercise-helper';
@@ -19,6 +19,7 @@ import useSimulationPermissions from '../../../../utils/permissions/useSimulatio
 import { AutonomousContext } from '../../autonomous/AutonomousContext';
 import AutonomousOverview from '../../autonomous/AutonomousOverview';
 import AutonomousReasoningPanel from '../../autonomous/AutonomousReasoningPanel';
+import { isAutonomousRunActive } from '../../autonomous/autonomousStatus';
 import useAutonomousPanelWidth from '../../autonomous/useAutonomousPanelWidth';
 import useAutonomousRunForSimulation from '../../autonomous/useAutonomousRunForSimulation';
 import { DocumentContext, type DocumentContextType, InjectContext, PermissionsContext, type PermissionsContextType } from '../../common/Context';
@@ -56,6 +57,35 @@ const IndexComponent: FunctionComponent<{
   const location = useLocation();
   const permissions = useSimulationPermissions(exercise.exercise_id, exercise);
   const isAutonomous = !!autonomousRun;
+  // The AI cockpit polls the run's decision timeline in the always-open reasoning panel. Lift that
+  // stream here and share it with the overview outcome layer so the overview does NOT start a
+  // SECOND full-from-cursor-0 poll of the same endpoint while the run is active (the simulation-side
+  // double-poll fix, #7472 - mirrors the scenario cockpit).
+  const cockpitActive = isAutonomousRunActive(autonomousRun);
+  const [cockpitTimeline, setCockpitTimeline] = useState<AutonomousEvent[]>([]);
+  // Same identity-change rule as AutonomousReasoningPanel / the scenario cockpit: clear only on a
+  // real run / simulation switch. A transient payload that momentarily lost its simulation id on
+  // the SAME run must not blank the overview layer (it would receive sharedEvents=[] and not poll).
+  const cockpitStreamKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const runId = autonomousRun?.autonomous_run_id;
+    const simulationId = autonomousRun?.autonomous_run_simulation_id;
+    if (!runId) {
+      cockpitStreamKeyRef.current = null;
+      setCockpitTimeline([]);
+      return;
+    }
+    const nextKey = `${runId}::${simulationId ?? ''}`;
+    if (cockpitStreamKeyRef.current === nextKey) {
+      return;
+    }
+    const previousRunId = cockpitStreamKeyRef.current?.split('::')[0];
+    if (cockpitStreamKeyRef.current !== null && previousRunId === runId && !simulationId) {
+      return;
+    }
+    cockpitStreamKeyRef.current = nextKey;
+    setCockpitTimeline([]);
+  }, [autonomousRun?.autonomous_run_id, autonomousRun?.autonomous_run_simulation_id]);
   // Resizable reasoning-panel width, shared with the content padding so the two stay in lockstep.
   const [panelWidth, setPanelWidth] = useAutonomousPanelWidth();
   // Attack path only exists for chained simulations (workflow-backed), never
@@ -100,7 +130,7 @@ const IndexComponent: FunctionComponent<{
               <Suspense fallback={<Loader />}>
                 <Routes>
                   {/* Overview swaps to the AI cockpit for autonomous runs. */}
-                  <Route path="" element={isAutonomous ? <AutonomousOverview run={autonomousRun} /> : errorWrapper(Simulation)()} />
+                  <Route path="" element={isAutonomous ? <AutonomousOverview run={autonomousRun} sharedEvents={cockpitActive ? cockpitTimeline : undefined} /> : errorWrapper(Simulation)()} />
                   {/* Definition merged into the Injects authoring tab; redirect old links. */}
                   <Route path="definition" element={<Navigate to={`/admin/simulations/${exercise.exercise_id}/injects`} replace={true} />} />
                   <Route path="injects" element={errorWrapper(Injects)()} />
@@ -147,6 +177,7 @@ const IndexComponent: FunctionComponent<{
             <AutonomousReasoningPanel
               run={autonomousRun}
               onRunUpdate={onAutonomousRunUpdate}
+              onTimelineEvents={setCockpitTimeline}
               width={panelWidth}
               onWidthChange={setPanelWidth}
               readOnly

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1293,11 +1293,13 @@ export interface AutonomousAttackPathStepResult {
 
 /** Live state of one authored attack-path step */
 export interface AutonomousAttackPathStepState {
+  /** Human-readable name of the finding EVENT this step reacts to (the trigger root's name, e.g. "SMB service exposed"), or null when the step has no finding trigger (a seed or a pure DEPEND_ON step). Mirror of the trigger's event_name on the write side. */
+  event_name?: string;
   /** Id of the inject backing this step (empty until the step has executed) */
   inject_id?: string;
   /** Id of the injector contract the step runs, when resolvable */
   injector_contract_id?: string;
-  /** The step template id this step runs AFTER (its DEPEND_ON parent), or null for a root step. Together with step_template_id this reconstructs the attack-path graph. */
+  /** Pure-ordering parent: the step template id this step runs AFTER (its DEPEND_ON parent), or null when the step is a seed or is wired finding-driven via its trigger. Prefer reading the trigger fields below to understand WHY a step fires; this is only the ordering fallback, not the primary wiring. */
   parent_step_template_id?: string;
   /** Execution status: PENDING when never started, otherwise the live ExecutionStatus (QUEUING, EXECUTING, SUCCESS, ERROR, ...) */
   status?: string;
@@ -1309,6 +1311,10 @@ export interface AutonomousAttackPathStepState {
   title?: string;
   /** Execution traces (action/status: message) captured while the step ran */
   traces?: string[];
+  /** The finding predicates that make this step fire, each rendered as "<key> <operator> <value>" (e.g. "port EQ 445", "service IS_NOT_NULL"). Empty when the step is a seed or a pure DEPEND_ON step. This is the read-back of the trigger's filters, so a reader can see - and correct - exactly what the step listens for instead of inferring a linear chain. */
+  trigger_filters?: string[];
+  /** The finding values this step binds into its inject inputs, each rendered as "<key> -> <input>" (e.g. "ipv4 -> target_host"). Empty when the step consumes no finding values. This is the read-back of the trigger's mappings. */
+  trigger_mappings?: string[];
   /** Inject type (injector) of the step */
   type?: string;
 }

--- a/openaev-model/src/main/java/io/openaev/database/repository/ExerciseTeamUserRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/ExerciseTeamUserRepository.java
@@ -43,6 +43,25 @@ public interface ExerciseTeamUserRepository
       @Param("teamId") String teamId,
       @Param("userId") String userId);
 
+  /**
+   * Idempotent, DB-atomic variant of {@link #addExerciseTeamUser}: inserts the composite link only
+   * when it does not already exist, relying on the table's (exercise_id, team_id, user_id) primary
+   * key to no-op the conflict. This replaces the check-then-insert (exists...then create) pattern,
+   * which two concurrent callbacks in one autonomous decision cycle could both pass, then
+   * double-insert and violate the PK - poisoning the enclosing transaction. {@code ON CONFLICT DO
+   * NOTHING} makes the enablement safe to run in parallel.
+   */
+  @Modifying
+  @Query(
+      value =
+          "insert into exercises_teams_users (exercise_id, team_id, user_id) "
+              + "values (:exerciseId, :teamId, :userId) on conflict do nothing",
+      nativeQuery = true)
+  void insertIfAbsent(
+      @Param("exerciseId") String exerciseId,
+      @Param("teamId") String teamId,
+      @Param("userId") String userId);
+
   @Query(
       value = "SELECT * FROM exercises_teams_users WHERE exercise_id IN :ids ;",
       nativeQuery = true)

--- a/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/autonomous/AutonomousRunRepository.java
@@ -6,6 +6,7 @@ import jakarta.persistence.LockModeType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -29,6 +30,14 @@ public interface AutonomousRunRepository extends JpaRepository<AutonomousRun, St
   boolean existsBySimulationId(String simulationId);
 
   List<AutonomousRun> findAllByOrderByCreatedAtDesc();
+
+  /**
+   * Newest-first page of runs, so the list read can be bounded by a cap instead of loading the
+   * whole tenant-wide table (which grows without limit over a deployment's life) and filtering it
+   * in memory. Used by the cockpit list, which is a newest-first view.
+   */
+  @Query("SELECT r FROM AutonomousRun r ORDER BY r.createdAt DESC")
+  List<AutonomousRun> findRecent(Pageable pageable);
 
   /**
    * Tenant-scoped primary-key lookup. Hibernate tenant {@code @Filter}s do not apply to {@code


### PR DESCRIPTION
## Summary

Reliability fixes for the autonomous AI scenario cockpit, grouped in one PR (they share the same feature surface - the live causal graph and the autonomous run lifecycle). Closes #7472.

- **Graph tooltip stuck open (frontend).** The action/trigger cards on the causal graph used an uncontrolled MUI Tooltip inside a pan/zoom canvas that re-renders on every autonomous poll and opens drawers on press, routinely robbing the tooltip of its mouseleave/blur close so it stayed pinned over the canvas. Added a controlled `GraphCardTooltip` shared by both cards that force-closes on any pointer press (capture phase, so stopPropagation children still dismiss) and whenever the graph structurally re-lays-out (dismissKey = the graph fit signature, which only changes on real relayouts - never on polls).

- **Cockpit lost on reload (frontend).** Reloading the scenario page while an autonomous run was still computing dropped the AI cockpit and rendered the scenario as manual. The run-detection hook latched to "manual" on the FIRST 404, but a single 404 can be a transient post-reload reconcile race on an entity that IS autonomous. Detection now requires a streak of consecutive 404s before concluding manual (a genuinely manual entity still stops probing, bounded), and a DECLARED-autonomous entity (`scenario_autonomous` / `exercise_autonomous` marker, now forwarded by both detail pages) stays PENDING behind the Loader across the streak instead of flashing the manual page, re-probing on a fast 2s cadence so the pending window settles in seconds. The `false` marker is deliberately never forwarded for simulations: those provisioned before the marker existed carry `false` while still being autonomous.

- **PUT /autonomous-runs/{id}/scope 500 (backend).** The scope callback mirrored the resolved scope onto the workflow(s) BEFORE recording it on the run, and a failure in that secondary mirror (only `ChainingException` was caught, only on the scenario branch) propagated out as a 500 and stalled the run. The callback now records the resolved scope on the run authoritatively first, then runs the workflow mirror AND the team enablement as genuinely best-effort, transaction-isolated steps: each goes through its own separately proxied `REQUIRES_NEW` boundary (`WorkflowService.writeAllowlistScopeIsolated`, `ExerciseService.enableTargetedTeamMembersIsolated`) so neither a thrown projection nor a repository-level failure can mark the callback transaction rollback-only and lose the recorded scope. Both projections run under the run's own v1 tenant scope (the legacy non-prefixed orchestrator route never sets `TenantContext`, so their v1-filtered lookups would otherwise fall back to the default tenant), restored in `finally`. The isolated wrapper delegates to a private non-transactional body, keeping the frozen `no_transactional_self_invocation` ArchUnit rule green.

## Changes

- `openaev-front/.../logic-graph/GraphCardTooltip.tsx` (new): controlled tooltip wrapper with pointerdown-capture dismiss + dismissKey force-close.
- `openaev-front/.../logic-graph/GraphActionCard.tsx`, `GraphTriggerCard.tsx`: switch the rich card tooltip to `GraphCardTooltip`, accept `tooltipDismissKey`.
- `openaev-front/.../logic-graph/LogicGraph.tsx`: pass `fitSignature` down as the dismiss key.
- `openaev-front/.../autonomous/useAutonomousRunForSimulation.ts`: consecutive-404 streak before the manual verdict, declared-autonomous pending state (derived synchronously - no manual flash frame) + fast retry, positive-hint parameter for the simulation variant.
- `openaev-front/.../scenarios/scenario/Index.tsx`, `simulations/simulation/Index.tsx`: forward the `scenario_autonomous` / `exercise_autonomous` positive hints.
- `openaev-api/.../chaining/WorkflowService.java`: `writeAllowlistScopeIsolated()` (`REQUIRES_NEW`) delegating to a private shared body (no transactional self-invocation).
- `openaev-api/.../exercise/service/ExerciseService.java`: `enableTargetedTeamMembersIsolated()` (`REQUIRES_NEW`) for the callback path only.
- `openaev-api/.../autonomous/AutonomousRunService.java`: record scope first; best-effort isolated projections under the run's v1 tenant scope; full-throwable warn logs.
- Tests: `AutonomousRunServiceScopeTest` (ordering, best-effort independence, tenant scoping/restoration), `useAutonomousRunForSimulation.test.ts` (streak semantics, declared-autonomous pending + fast retry, poll stop), `GraphCardTooltip.test.tsx` (both force-close paths + poll-rerender stability).

## Test plan

- [x] Backend: `mvn -pl openaev-api spotless:check` and `-am test-compile` pass locally (JDK 21).
- [x] Backend: `AutonomousRunServiceScopeTest`, `WorkflowServiceTest`, `ExerciseServiceUnitTest`, `TenantBackgroundTransactionArchTest` pass locally (106 tests).
- [x] Frontend: `yarn lint`, `yarn check-ts` pass; new vitest files pass (`useAutonomousRunForSimulation.test.ts`, `GraphCardTooltip.test.tsx`, plus existing `GraphTriggerCard.test.tsx`).
- [ ] Manual: hover an action/trigger card, then click/drag or let the graph re-fit -> tooltip closes (no stuck tooltip).
- [ ] Manual: start an AI scenario build, reload the page mid-run -> the AI cockpit re-attaches behind the loader (no flash of the manual page).
- [ ] Manual: drive an autonomous run through a scope resolution where the workflow mirror would previously throw -> `PUT /{id}/scope` returns 200, the run's scope is recorded, and the mirror failure is logged with its stack trace (not fatal).

## Notes

Backend was compiled and unit-tested locally for this PR (google-java-format via spotless on JDK 21, `test-compile` across `openaev-model`/`openaev-framework`/`openaev-api`, targeted surefire runs listed above); the initial "no local mvn" caveat from the first push no longer applies. The two API-test failures on the first CI run were an infra artifact-download flake (shard 1) and the `no_transactional_self_invocation` ArchUnit violation (shard 6), fixed in 6201c822.


## Update: attack-path step author/update 500 fix

The step **author** (`POST /api/autonomous-runs/{id}/attack-path/steps`) and
**update** (`PUT /api/autonomous-runs/{id}/attack-path/steps/{stepId}`)
callbacks had the SAME transaction-poisoning shape as the scope callback above.
Each authors/updates the executing simulation step authoritatively, then runs
two secondary projections in the SAME transaction: enabling the targeted teams
members and mirroring the step onto the scenario template. A failure in either
projection (a scenario template invisible under the callback thread default
tenant, a concurrent author racing the same scenario workflow, or a transient
repository error) marked the whole callback transaction rollback-only and
surfaced as a 500 - so the orchestrator could not author/update steps and spun
retrying (observed in production worker logs against a build that predates this
PR).

Both callbacks now run their secondary projections best-effort and
transaction-isolated: `ExerciseService.enableTargetedTeamMembersIsolated` and
the new `WorkflowService.appendChainedStepToScenarioIsolated` /
`updateChainedStepIsolated` twins each go through their own `REQUIRES_NEW`
boundary under the run own v1 tenant scope (restored in `finally`), wrapped in
catch-and-log. The authoritative step write and the `run.stepMirror` save stay
in the OUTER transaction so nothing is lost. The isolated twins delegate to
shared private non-transactional bodies, keeping the frozen
`no_transactional_self_invocation` ArchUnit rule green. Plan-mode authoring (a
run with no simulation) has no secondary projection to isolate and still fails
loudly if its primary scenario append fails.

Additional changed files:
- `openaev-api/.../chaining/WorkflowService.java`: `appendChainedStepToScenarioIsolated()` / `updateChainedStepIsolated()` (`REQUIRES_NEW`) delegating to shared private bodies.
- `openaev-api/.../autonomous/AutonomousRunService.java`: `doAppendAttackPathStep` / `updateAttackPathStep` isolate team-enable + scenario-mirror projections best-effort under the run v1 tenant scope; new `enableTargetedTeamMembersBestEffort` helper.



## Update: systemic v1 tenant interceptor, finding-driven step enablers, and cockpit completeness

This batch supersedes the per-method v1 tenant bridges above with a systemic
request-entry fix, adds the cross-repo enablers XTM One needs to review and
correct a finding-driven attack path, and closes the remaining cockpit
reliability gaps found in a full audit.

Backend:
- Systemic v1 tenant on the callback route. New `OrchestratorRunTenantInterceptor`
  (registered in `MvcConfig` for `/api/autonomous-runs/**`) sets the v1
  `TenantContext` from the run's own tenant, gated EXACTLY like
  `TxCtxArgumentResolver`: only for the verified XTM One cross-platform identity,
  only on the non-prefixed route (no `{tenantId}`), only when a `{runId}` is
  present; cleared in both `afterCompletion` and `afterConcurrentHandlingStarted`.
  This fixes ALL 8 callbacks that read/write v1 `@Filter` entities (Exercise,
  Team, Finding, Inject, Endpoint) at once, not just scope/author - e.g.
  `evaluateAttackPath` no longer cancels a healthy non-default-tenant run,
  `promoteFindingToAsset` no longer 404s or writes to the default tenant, and
  `attackPathState` reads the run's real steps. Passes the frozen ArchUnit rules
  (`AutonomousRunApiRunTenantScopeTest`, `TenantScopedEntrypointsTxCtxArchTest`,
  no raw JDBC outside the allowlist).
- Lost-update / run resurrection. The run-saving callbacks (`setRunScope`,
  `appendAttackPathStep`, and the new delete) load the run FOR UPDATE
  (`requireForUpdate`) so a concurrent terminal settle can no longer be
  overwritten by a full-entity save on a version-less row.
- Cross-repo enablers for XTM One (ship inert-safe on this side):
  - `AutonomousAttackPathStepState` now carries `event_name`, `trigger_filters`
    (e.g. `port EQ 445`) and `trigger_mappings` (e.g. `ipv4 -> target_host`), read
    back from the step's conditions; its Javadoc drops the linear DEPEND_ON
    framing. This lets the state read surface the finding-driven wiring instead of
    inferring a linear chain.
  - `PUT .../attack-path/steps/{id}` now honors a supplied `trigger` (rebuilds the
    step conditions, preserving the DEPEND_ON parent; unchanged when omitted), and
    a new `DELETE .../attack-path/steps/{id}` prunes a mis-wired step. Both keep
    the scenario mirror twin in lock-step.
- Reliability:
  - `ExerciseTeamUserRepository.insertIfAbsent` (`ON CONFLICT DO NOTHING`)
    replaces the check-then-insert on `exercise_teams_users` that two parallel
    callbacks could both pass and then double-insert.
  - `WorkflowService.evaluateWorkflowProgress` returns early when the run has
    already ended instead of re-readying / enqueuing steps on a terminated run.
  - `attackPathState` no longer N+1s: one `findAllById` for every backing inject
    plus two batched condition reads, instead of a per-step lookup + trigger walk.
  - `list()` reads a capped newest-first page instead of the whole runs table.
  - `reconcileWithSimulation` distinguishes an UNREADABLE simulation from a DELETED
    one, so a scope miss can never be mistaken for a deletion and cancel a run
    (defense in depth on top of the interceptor).

Frontend (cockpit completeness):
- The decision-timeline tooltip in `AutonomousOutcome` reuses the controlled
  `GraphCardTooltip` (same stuck-tooltip fix as the graph cards), with a dismiss
  key folding the timeline length and a scroll nonce - it can no longer stick open
  while the timeline auto-scrolls under the live poll.
- `GraphCardTooltip` also force-closes on wheel-zoom (a capture-phase passive
  listener), so an open card cannot detach and float when the operator zooms the
  overflow-hidden canvas.
- `LogicGraph` splits the structural fit signature (PanZoom fit) from a
  position-inclusive tooltip dismiss key, so a pure relayout that keeps the same
  node-id set still dismisses a stranded tooltip.
- `PanZoom` fits once on first content and re-fits only on an explicit refit
  (Fit / Auto-organize), so authoring a step during a live run no longer yanks the
  operator's manual pan/zoom.
- `GraphTriggerCard` falls back to the human condition line before "Untitled
  event" when an event is unnamed.
- The simulation cockpit lifts a shared timeline and passes it to the overview, so
  the reasoning panel and the outcome stop double-polling the same endpoint
  (mirrors the scenario side).
- `useAutonomousRunForSimulation` adds a sessionStorage sticky-autonomous hint so a
  legacy entity (falsy marker but actually autonomous) does not flash the manual
  UI across a reload, and self-heals after a long blip instead of stranding the
  cockpit until a reload.

Tests added: interceptor per-path tenant behavior, `isWorkflowEnded` early return,
`GraphCardTooltip` wheel-dismiss, and the sticky-hint pending / self-heal detection
cases.

Local verification for this batch: frontend `yarn check-ts`, `yarn lint`, and the
affected vitest suites pass. No local Maven toolchain was available for this batch,
so the Java changes were formatted with google-java-format (JDK 21) and otherwise
rely on CI (Backend Compile / Spotless / API Tests). A few LOW-priority frontend
polish items from the audit (graph-node keyboard focus, a couple of i18n
string-concatenations, reasoning-panel resize-listener cleanup on unmount mid-drag)
are intentionally left as follow-ups.
