### PR TITLE
fix(autonomous): prevent phantom-flush StaleStateException on autonomous run reads (#7476)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -78,6 +78,8 @@ import io.openaev.service.chaining.WorkflowService;
 import io.openaev.service.scenario.ScenarioService;
 import io.openaev.utils.IpAddressUtils;
 import io.openaev.xtmone.XtmOneClient;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -236,6 +238,12 @@ public class AutonomousRunService {
   // name),
   // so every operator-facing read/mutation gates in-service through this component.
   private final AutonomousRunAccessControl accessControl;
+
+  // Field-injected (not constructor) so it stays out of @RequiredArgsConstructor and null in the
+  // Mockito @InjectMocks unit tests, where detachForResponse() below no-ops. Used only to evict a
+  // returned run from the persistence context on the READ paths, so the open-in-view session's
+  // Spring-Session save at response commit can never flush it - see detachForResponse().
+  @PersistenceContext private EntityManager entityManager;
 
   private static String runTenantId(AutonomousRun run) {
     return run.getTenant().getId();
@@ -3625,13 +3633,33 @@ public class AutonomousRunService {
 
   // region reads
 
+  /**
+   * Evicts a run returned by a READ endpoint from the persistence context so it can never be
+   * flushed after the request transaction ends. {@code autonomous_runs} is served open-in-view, so
+   * the Hibernate session outlives the read-only request transaction and is flushed once more
+   * during the Spring Session {@code save} at response commit - OUTSIDE the request's tenant scope.
+   * Any run still managed and dirty at that point emits a phantom {@code UPDATE} whose tenant
+   * predicate matches nothing (or whose row was superseded by a concurrent relaunch), which blows
+   * up as a {@code StaleStateException} 500 (issue seen on {@code by-scenario}). The primary
+   * defence is that a clean entity is never flushed (see {@link AutonomousScopeTarget}'s value
+   * equality); detaching is belt-and-suspenders that also neutralises the in-memory status set by
+   * {@link #reconcileWithSimulation}'s best-effort fallback. Null-safe: the field is unset in the
+   * Mockito unit tests, where there is no open-in-view session to worry about.
+   */
+  private AutonomousRun detachForResponse(AutonomousRun run) {
+    if (run != null && entityManager != null && entityManager.contains(run)) {
+      entityManager.detach(run);
+    }
+    return run;
+  }
+
   // Not read-only: reconcileWithSimulation may need to persist a status sync so a run whose
   // simulation died out-of-band settles itself instead of dangling active forever.
   @Transactional(rollbackFor = Exception.class)
   public AutonomousRun get(String runId) {
     AutonomousRun run = require(runId);
     accessControl.assertCanRead(run);
-    return reconcileWithSimulation(run);
+    return detachForResponse(reconcileWithSimulation(run));
   }
 
   @Transactional(readOnly = true)
@@ -3640,8 +3668,12 @@ public class AutonomousRunService {
     // and status leaked to any Enterprise-Edition user regardless of their simulation/scenario
     // access. Bound the DB read at MAX_RUNS_LISTED (newest first) so the table is never loaded
     // whole just to filter it down in memory.
-    return accessControl.retainReadable(
-        runRepository.findRecent(PageRequest.of(0, MAX_RUNS_LISTED)));
+    List<AutonomousRun> runs =
+        accessControl.retainReadable(runRepository.findRecent(PageRequest.of(0, MAX_RUNS_LISTED)));
+    // Detach every listed run for the same open-in-view reason as detachForResponse: a listed run
+    // left managed is flushed at the Spring Session save and can 500 the whole list.
+    runs.forEach(this::detachForResponse);
+    return runs;
   }
 
   /**
@@ -3660,7 +3692,7 @@ public class AutonomousRunService {
                     new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "No autonomous run drives this simulation"));
     accessControl.assertCanRead(run);
-    return reconcileWithSimulation(run);
+    return detachForResponse(reconcileWithSimulation(run));
   }
 
   /**
@@ -3680,7 +3712,7 @@ public class AutonomousRunService {
                     new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "No autonomous run drives this scenario"));
     accessControl.assertCanRead(run);
-    return reconcileWithSimulation(run);
+    return detachForResponse(reconcileWithSimulation(run));
   }
 
   /**

--- a/openaev-model/src/main/java/io/openaev/database/model/autonomous/AutonomousScopeTarget.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/autonomous/AutonomousScopeTarget.java
@@ -2,6 +2,7 @@ package io.openaev.database.model.autonomous;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,10 +13,23 @@ import lombok.Setter;
  * an OpenAEV inject can target. {@code type} uses the {@code io.openaev.utils.TargetType}
  * vocabulary ({@code ASSETS}, {@code ASSETS_GROUPS}, {@code TEAMS}, {@code PLAYERS}); {@code id} is
  * the entity id of that kind (asset id / asset-group id / team id / user id).
+ *
+ * <p>Value-based {@link #equals}/{@link #hashCode} (on {@code type} + {@code id}) are REQUIRED, not
+ * cosmetic: this type is an element of {@link AutonomousRun#getScope()}, a {@code
+ * List<AutonomousScopeTarget>} mapped as a JSON column via {@code @JdbcTypeCode(SqlTypes.JSON)}.
+ * Hibernate dirty-checks such a JSON attribute by comparing the current list to a deep-copied
+ * load-time snapshot with {@code List.equals}, i.e. element-wise {@code equals}. With only identity
+ * equality the snapshot's (freshly deserialized) elements never equal the current ones, so the
+ * whole run is flagged dirty on EVERY flush and a phantom {@code UPDATE autonomous_runs} is emitted
+ * even on pure reads. Under open-in-view that UPDATE is replayed during the Spring Session save at
+ * response commit - outside the request's tenant scope - where it matches zero rows and blows up as
+ * a {@code StaleStateException} 500 (the by-scenario read 500 and the orchestrator scope/step-write
+ * 500s). Value equality keeps the list clean when nothing changed, so no phantom flush occurs.
  */
 @Getter
 @Setter
 @NoArgsConstructor
+@EqualsAndHashCode
 @Schema(description = "One targetable entity in an autonomous run's scope")
 public class AutonomousScopeTarget {
 


### PR DESCRIPTION
## Summary

Fixes the intermittent HTTP 500 (`StaleStateException` / optimistic-lock failure)
when reading an autonomous AI scenario. Follow-up to #7472 / #7473, which fixed
several cockpit symptoms but left a phantom-flush `StaleStateException` on plain
autonomous-run reads.

Root cause: `AutonomousRun.scope` is a JSON-mapped `List<AutonomousScopeTarget>`,
and `AutonomousScopeTarget` had no value-based `equals()` / `hashCode()`.
Hibernate therefore marked `scope` dirty on every load and, under Open Session In
View, flushed a spurious `UPDATE autonomous_runs ...` at request commit. Racing a
concurrent orchestrator write (or a moved version), that phantom UPDATE matched
zero rows -> `StaleStateException` -> 500.

## Changes

- `AutonomousScopeTarget`: add `@EqualsAndHashCode` (value equality) so an
  unchanged scope list is no longer seen as dirty.
- `AutonomousRunService`: detach the `AutonomousRun` returned by the read paths
  (`get`, `list`, `getBySimulation`, `getByScenario`) via `EntityManager.detach`,
  so the OSIV end-of-request flush cannot emit an UPDATE for a read-only response.

## Test plan

- [x] `mvn -pl openaev-model,openaev-api compile` + `spotless:apply`
- [x] Targeted autonomous-run service/API tests green (83 tests)
- [ ] Manually open an AI scenario cockpit and poll it under a concurrent run;
      confirm no 500 and no `UPDATE autonomous_runs` emitted on read

Closes #7476
