### PR TITLE
feat(autonomous): allow authoring an attack-path step onto an existing event (#7481)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/autonomous/dto/AutonomousAttackPathStepState.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/dto/AutonomousAttackPathStepState.java
@@ -41,6 +41,16 @@ public class AutonomousAttackPathStepState {
               + "ordering fallback, not the primary wiring.")
   private String parentStepTemplateId;
 
+  @JsonProperty("event_id")
+  @Schema(
+      description =
+          "Stable id of the finding EVENT this step fires on (the trigger root), or null for a "
+              + "seed / standalone / pure DEPEND_ON step that has no event. Pass it back as a "
+              + "trigger's event_id when authoring another step to attach that step to the SAME "
+              + "event instead of duplicating it - this is how several actions share one event "
+              + "(e.g. one \"SMB service exposed\" event feeding many follow-on actions).")
+  private String eventId;
+
   @JsonProperty("event_name")
   @Schema(
       description =

--- a/openaev-api/src/main/java/io/openaev/api/autonomous/dto/AutonomousStepTrigger.java
+++ b/openaev-api/src/main/java/io/openaev/api/autonomous/dto/AutonomousStepTrigger.java
@@ -23,6 +23,21 @@ import lombok.Setter;
 @Schema(description = "A finding-driven trigger: react to findings and consume their values")
 public class AutonomousStepTrigger {
 
+  @JsonProperty("event_id")
+  @Schema(
+      description =
+          "OPTIONAL. Id of an EXISTING event (a finding-trigger root already on this run's"
+              + " workflow) to attach this step to, instead of minting a new event. Read it from"
+              + " another step's event_id in the attack-path state, then pass it here so several"
+              + " actions fire off the SAME event (e.g. one \"SMB service exposed\" event feeding"
+              + " many follow-on actions) rather than duplicating it. When set, event_name / match /"
+              + " filters are IGNORED (the event already exists and is not re-described); only"
+              + " mappings still apply, binding this step's inject inputs from that event's finding"
+              + " values. Leave it null to create a new event from the filters, or omit the whole"
+              + " trigger entirely for an event-less seed or standalone action. It is never"
+              + " required: linking to an existing event is a choice, not an obligation.")
+  private String eventId;
+
   @JsonProperty("event_name")
   @Schema(
       description =

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260817120000000__Add_autonomous_event_mirror.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260817120000000__Add_autonomous_event_mirror.java
@@ -1,0 +1,33 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds the {@code autonomous_run_event_mirror} JSONB column to {@code autonomous_runs}.
+ *
+ * <p>An autonomous run authors its finding EVENTS on the SIMULATION workflow, and the same steps
+ * are mirrored onto the run's SCENARIO workflow so the scenario carries an exportable attack path.
+ * When the orchestrator REUSES an existing event (attaching several actions to one event instead of
+ * duplicating it), the mirror must reattach the scenario twin to the SAME scenario event. This
+ * column stores the mapping from each simulation event root id to its scenario twin ({@code {"<sim
+ * event id>": "<scenario event id>"}}) so the exported scenario shares events exactly like the
+ * executing simulation side. It is the event-level counterpart of {@code
+ * autonomous_run_step_mirror}. Internal bookkeeping only; never exposed on the API.
+ *
+ * <p>Additive, idempotent, and lock-light: a nullable {@code ADD COLUMN} is metadata-only on
+ * PostgreSQL 11+ (no table rewrite), and {@code IF NOT EXISTS} makes re-running a no-op.
+ */
+@Component
+public class V6_20260817120000000__Add_autonomous_event_mirror extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      statement.execute(
+          "ALTER TABLE autonomous_runs ADD COLUMN IF NOT EXISTS autonomous_run_event_mirror jsonb;");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -3111,18 +3111,23 @@ public class AutonomousRunService {
               scenarioConditions,
               scenarioExistingEventIds);
       stepMirror.put(simStepId, scenarioStepId);
-      // Record the sim->scenario EVENT twin for a NEWLY created event (not a reuse), so a later
-      // step
-      // reusing this same sim event mirrors onto the SAME scenario event above. Best-effort: a
-      // lookup miss just leaves the mapping unrecorded and the fallback copy path handles the rare
-      // un-mirrored reuse.
-      if (!hasText(reusedSimEventId)) {
-        String simEventId = workflowService.findStepTriggerEventRootId(simStepId);
-        if (hasText(simEventId)) {
-          String scenarioEventId = workflowService.findStepTriggerEventRootId(scenarioStepId);
-          if (hasText(scenarioEventId)) {
-            eventMirror.put(simEventId, scenarioEventId);
-          }
+      // Record the sim->scenario EVENT twin so a later step reusing this sim event mirrors onto the
+      // SAME scenario event instead of duplicating it. This must happen not only when the event was
+      // authored fresh, but ALSO when a reuse took the fallback COPY path above (no twin was
+      // recorded yet): otherwise every later reuse would take the fallback again and mint another
+      // scenario event, re-introducing the duplication this feature removes. A reuse that instead
+      // LINKED an already-recorded twin just re-records the same mapping (a harmless no-op). For a
+      // reuse the sim event id is exactly reusedSimEventId; for a fresh author it is read back from
+      // the newly authored step. Best-effort: a lookup miss leaves the mapping unrecorded and the
+      // fallback path still keeps the twin non-event-less.
+      String simEventId =
+          hasText(reusedSimEventId)
+              ? reusedSimEventId
+              : workflowService.findStepTriggerEventRootId(simStepId);
+      if (hasText(simEventId)) {
+        String scenarioEventId = workflowService.findStepTriggerEventRootId(scenarioStepId);
+        if (hasText(scenarioEventId)) {
+          eventMirror.put(simEventId, scenarioEventId);
         }
       }
       run.setStepMirror(stepMirror);
@@ -3182,14 +3187,21 @@ public class AutonomousRunService {
     try {
       workflowService.updateChainedStepIsolated(
           scenarioStepId, injectInput, scenarioConditions, scenarioExistingEventIds);
-      // A fresh-trigger update rebuilt a NEW event on both the sim step and its scenario twin;
-      // re-record the sim->scenario event twin so a later step reusing the rebuilt event mirrors
-      // onto the SAME scenario event. Reuse and data-only updates create no event, so skip them.
-      if (!hasText(reusedSimEventId) && triggerConditions != null) {
-        String simEventId = workflowService.findStepTriggerEventRootId(simStepId);
+      // Record the sim->scenario event twin whenever the trigger was (re)built - a fresh event OR a
+      // reuse that took the fallback COPY path - so a later step reusing this sim event shares the
+      // SAME scenario event instead of triggering the fallback again and duplicating it. A
+      // data-only update (triggerConditions == null) changes no event, so there is nothing to
+      // record; a reuse that linked an already-recorded twin re-records the same mapping, so only
+      // persist when it actually changed. For a reuse the sim event id is reusedSimEventId; for a
+      // fresh update it is read back from the rebuilt step.
+      if (triggerConditions != null) {
+        String simEventId =
+            hasText(reusedSimEventId)
+                ? reusedSimEventId
+                : workflowService.findStepTriggerEventRootId(simStepId);
         if (hasText(simEventId)) {
           String scenarioEventId = workflowService.findStepTriggerEventRootId(scenarioStepId);
-          if (hasText(scenarioEventId)) {
+          if (hasText(scenarioEventId) && !scenarioEventId.equals(eventMirror.get(simEventId))) {
             eventMirror.put(simEventId, scenarioEventId);
             run.setEventMirror(eventMirror);
             runRepository.save(run);

--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -2503,7 +2503,15 @@ public class AutonomousRunService {
     // updateStatus / restart.
     AutonomousRun run = requireForUpdate(runId);
     assertRunAcceptsAuthoring(run);
-    List<ConditionCreateInput> triggerConditions = toTriggerConditions(trigger);
+    // A trigger MAY reuse an existing event by id instead of minting a new one. When it does, the
+    // trigger contributes MAPPERS ONLY (the event's filter tree already exists on the workflow and
+    // is linked by id below); otherwise it builds a fresh event tree + mappers as before. event_id
+    // is always OPTIONAL - a null/absent trigger is an event-less seed or standalone action, which
+    // is a perfectly valid step, so nothing here forces an event to exist.
+    String requestedEventId = trigger != null ? trigger.getEventId() : null;
+    boolean reuseEvent = hasText(requestedEventId);
+    List<ConditionCreateInput> triggerConditions =
+        reuseEvent ? toMapperConditions(trigger) : toTriggerConditions(trigger);
     // Bridge the run's own tenant as the v1 TenantContext around the WHOLE authoring body (the
     // primary executing/scenario step AND the secondary projections). This callback arrives on the
     // legacy non-prefixed /api/autonomous-runs route where the v1 TenantContext is never set and
@@ -2533,18 +2541,32 @@ public class AutonomousRunService {
               HttpStatus.CONFLICT,
               "The autonomous run has neither a live simulation nor a scenario to build steps on");
         }
+        // Validate a reused event id up front so a bad/foreign id is a precise 400, never a silent
+        // mislink. In author-scenario mode the event lives on the scenario's own workflow.
+        if (reuseEvent) {
+          try {
+            workflowService.assertEventRootOnScenarioWorkflow(
+                run.getScenarioId(), requestedEventId);
+          } catch (ChainingException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+          }
+        }
         String scenarioStepId;
         try {
           scenarioStepId =
               workflowService.appendChainedStepToScenario(
-                  run.getScenarioId(), injectInput, parentStepTemplateId, triggerConditions);
+                  run.getScenarioId(),
+                  injectInput,
+                  parentStepTemplateId,
+                  triggerConditions,
+                  reuseEvent ? List.of(requestedEventId) : List.of());
         } catch (ChainingException e) {
           throw new ResponseStatusException(
               HttpStatus.BAD_REQUEST,
               "Failed to author the attack-path step onto the scenario: " + e.getMessage(),
               e);
         }
-        boolean findingDrivenPlan = !triggerConditions.isEmpty();
+        boolean findingDrivenPlan = reuseEvent || !triggerConditions.isEmpty();
         eventService.append(
             runId,
             runTenantId(run),
@@ -2560,11 +2582,26 @@ public class AutonomousRunService {
             null);
         return scenarioStepId;
       }
+      // Validate a reused event id up front so a bad/foreign id is a precise 400, never a silent
+      // mislink. In live mode the event lives on the simulation's own workflow (the state read
+      // surfaces simulation event ids, so this is what the orchestrator passes back).
+      if (reuseEvent) {
+        try {
+          workflowService.assertEventRootOnSimulationWorkflow(
+              run.getSimulationId(), requestedEventId);
+        } catch (ChainingException e) {
+          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+        }
+      }
       String stepTemplateId;
       try {
         stepTemplateId =
             workflowService.appendChainedStep(
-                run.getSimulationId(), injectInput, parentStepTemplateId, triggerConditions);
+                run.getSimulationId(),
+                injectInput,
+                parentStepTemplateId,
+                triggerConditions,
+                reuseEvent ? List.of(requestedEventId) : List.of());
       } catch (ChainingException e) {
         throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST, "Failed to author the attack-path step: " + e.getMessage(), e);
@@ -2583,8 +2620,13 @@ public class AutonomousRunService {
       //    lives on the simulation; this twin never runs).
       enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
       mirrorStepOntoScenario(
-          run, injectInput, parentStepTemplateId, stepTemplateId, triggerConditions);
-      boolean findingDriven = !triggerConditions.isEmpty();
+          run,
+          injectInput,
+          parentStepTemplateId,
+          stepTemplateId,
+          triggerConditions,
+          requestedEventId);
+      boolean findingDriven = reuseEvent || !triggerConditions.isEmpty();
       eventService.append(
           runId,
           runTenantId(run),
@@ -2680,6 +2722,25 @@ public class AutonomousRunService {
     }
 
     // MAPPER conditions bind finding values into this step's inject inputs (default GLOBAL pool).
+    conditions.addAll(toMapperConditions(mappings));
+    return conditions;
+  }
+
+  /**
+   * Builds ONLY the {@code MAPPER} conditions of a trigger - the finding-value input bindings, with
+   * NO event root and NO filter leaves. Used when a step REUSES an existing event (its filter tree
+   * already exists on the workflow and is linked by id): the step still needs its own mappers to
+   * consume that event's finding values into its inject inputs, but must never mint a duplicate
+   * event tree. Returns an empty list for a {@code null}/mapping-less trigger (the step then simply
+   * fires on the shared event with no value binding).
+   */
+  private List<ConditionCreateInput> toMapperConditions(AutonomousStepTrigger trigger) {
+    return toMapperConditions(
+        trigger == null || trigger.getMappings() == null ? List.of() : trigger.getMappings());
+  }
+
+  private List<ConditionCreateInput> toMapperConditions(List<AutonomousInputMapping> mappings) {
+    List<ConditionCreateInput> conditions = new ArrayList<>();
     for (AutonomousInputMapping mapping : mappings) {
       if (mapping == null || mapping.getKeyType() == null || !hasText(mapping.getInputKey())) {
         continue;
@@ -2787,12 +2848,23 @@ public class AutonomousRunService {
   @Transactional(rollbackFor = Exception.class)
   public String updateAttackPathStep(
       String runId, String stepTemplateId, InjectInput injectInput, AutonomousStepTrigger trigger) {
-    AutonomousRun run = require(runId);
+    // Row-locked read: a fresh-trigger update re-records the run's sim->scenario EVENT twin
+    // (eventMirror) with a full-entity write on a version-less row, so it must serialise with every
+    // other run writer exactly like doAppendAttackPathStep / deleteAttackPathStep.
+    AutonomousRun run = requireForUpdate(runId);
     assertRunAcceptsAuthoring(run);
     // A supplied trigger is translated to the engine's condition vocabulary once and used to
-    // rebuild the step (and its mirror twin); null means "leave the conditions as they are".
+    // rebuild
+    // the step (and its mirror twin); null means "leave the conditions as they are" (data-only,
+    // which also preserves any existing event link). When the trigger REUSES an event by id it
+    // contributes MAPPERS ONLY (the event is linked by id, not rebuilt); event_id stays OPTIONAL,
+    // so correcting a step never requires an event.
+    String requestedEventId = trigger != null ? trigger.getEventId() : null;
+    boolean reuseEvent = hasText(requestedEventId);
     List<ConditionCreateInput> triggerConditions =
-        trigger != null ? toTriggerConditions(trigger) : null;
+        trigger == null
+            ? null
+            : (reuseEvent ? toMapperConditions(trigger) : toTriggerConditions(trigger));
     // Bridge the run's own tenant as the v1 TenantContext around the WHOLE update body (the primary
     // in-place step update AND the secondary projections), for the same reason as
     // doAppendAttackPathStep: on the legacy non-prefixed callback route the v1 TenantContext falls
@@ -2818,8 +2890,22 @@ public class AutonomousRunService {
               HttpStatus.CONFLICT,
               "The autonomous run has neither a live simulation nor a scenario to update steps on");
         }
+        // Validate a reused event id up front so a bad/foreign id is a precise 400. In
+        // author-scenario mode the event lives on the scenario's own workflow.
+        if (reuseEvent) {
+          try {
+            workflowService.assertEventRootOnScenarioWorkflow(
+                run.getScenarioId(), requestedEventId);
+          } catch (ChainingException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+          }
+        }
         try {
-          workflowService.updateChainedStep(stepTemplateId, injectInput, triggerConditions);
+          workflowService.updateChainedStep(
+              stepTemplateId,
+              injectInput,
+              triggerConditions,
+              reuseEvent ? List.of(requestedEventId) : List.of());
         } catch (ChainingException e) {
           throw new ResponseStatusException(
               HttpStatus.BAD_REQUEST,
@@ -2836,30 +2922,35 @@ public class AutonomousRunService {
             null);
         return stepTemplateId;
       }
+      // Validate a reused event id up front so a bad/foreign id is a precise 400. In live mode the
+      // event lives on the simulation's own workflow (the state read surfaces simulation event
+      // ids).
+      if (reuseEvent) {
+        try {
+          workflowService.assertEventRootOnSimulationWorkflow(
+              run.getSimulationId(), requestedEventId);
+        } catch (ChainingException e) {
+          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+        }
+      }
       try {
-        workflowService.updateChainedStep(stepTemplateId, injectInput, triggerConditions);
+        workflowService.updateChainedStep(
+            stepTemplateId,
+            injectInput,
+            triggerConditions,
+            reuseEvent ? List.of(requestedEventId) : List.of());
       } catch (ChainingException e) {
         throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST, "Failed to update the attack-path step: " + e.getMessage(), e);
       }
       // The executing simulation step is updated above. Keeping the scenario mirror twin in
-      // lock-step and re-enabling any newly targeted team's members are SECONDARY projections that
-      // must never fail (500) this callback: each runs in its OWN REQUIRES_NEW transaction so a
-      // failure rolls back only itself and can never mark this update transaction rollback-only.
-      // Mirrors doAppendAttackPathStep / setRunScope.
-      Map<String, String> mirror = run.getStepMirror();
-      String scenarioStepId = mirror == null ? null : mirror.get(stepTemplateId);
-      if (hasText(scenarioStepId)) {
-        try {
-          workflowService.updateChainedStepIsolated(scenarioStepId, injectInput, triggerConditions);
-        } catch (Exception e) {
-          log.warn(
-              "[Autonomous] Failed to update scenario mirror step {} for run {}: {}",
-              scenarioStepId,
-              runId,
-              e.getMessage());
-        }
-      }
+      // lock-step (with the same event sharing) and re-enabling any newly targeted team's members
+      // are SECONDARY projections that must never fail (500) this callback: the twin update runs in
+      // its OWN REQUIRES_NEW transaction so a failure rolls back only itself and can never mark
+      // this
+      // update transaction rollback-only. Mirrors doAppendAttackPathStep / setRunScope.
+      mirrorStepUpdateOntoScenario(
+          run, stepTemplateId, injectInput, triggerConditions, requestedEventId);
       enableTargetedTeamMembersBestEffort(run.getSimulationId(), injectInput.getTeams());
       eventService.append(
           runId,
@@ -2967,33 +3058,148 @@ public class AutonomousRunService {
       InjectInput injectInput,
       String parentSimStepId,
       String simStepId,
-      List<ConditionCreateInput> triggerConditions) {
+      List<ConditionCreateInput> triggerConditions,
+      String reusedSimEventId) {
     String scenarioId = run.getScenarioId();
     if (!hasText(scenarioId)) {
       return;
     }
-    Map<String, String> mirror =
+    Map<String, String> stepMirror =
         run.getStepMirror() == null ? new HashMap<>() : new HashMap<>(run.getStepMirror());
-    String parentScenarioStepId = hasText(parentSimStepId) ? mirror.get(parentSimStepId) : null;
+    Map<String, String> eventMirror =
+        run.getEventMirror() == null ? new HashMap<>() : new HashMap<>(run.getEventMirror());
+    String parentScenarioStepId = hasText(parentSimStepId) ? stepMirror.get(parentSimStepId) : null;
+
+    // Resolve the scenario-side event linkage for a step that REUSED an existing simulation event,
+    // so the exported scenario SHARES one event across those steps exactly like the executing
+    // simulation does, instead of duplicating it per step:
+    //   - normal case: the scenario twin of the reused sim event was recorded in eventMirror when
+    //     that event was first authored (below), so link the twin by id and add no fresh event tree
+    //     (triggerConditions here are mappers-only).
+    //   - fallback: no twin recorded (the source event pre-dates event-mirror tracking, or its own
+    //     mirror failed), so re-create a faithful COPY of the event on the scenario from the sim
+    //     event's subtree plus this step's mappers, so the twin is never left event-less. That copy
+    //     is not shared - a graceful degradation of the export's display fidelity only, since the
+    //     scenario twin never executes.
+    List<ConditionCreateInput> scenarioConditions = triggerConditions;
+    List<String> scenarioExistingEventIds = List.of();
+    if (hasText(reusedSimEventId)) {
+      String scenarioEventId = eventMirror.get(reusedSimEventId);
+      if (hasText(scenarioEventId)) {
+        scenarioExistingEventIds = List.of(scenarioEventId);
+      } else {
+        List<ConditionCreateInput> recreated =
+            new ArrayList<>(workflowService.resolveEventRootAsInputs(reusedSimEventId));
+        recreated.addAll(triggerConditions);
+        scenarioConditions = recreated;
+      }
+    }
     try {
       // Append the scenario twin in its OWN transaction (REQUIRES_NEW): a mirror-side persistence
       // failure (scenario template invisible under this thread's tenant, an action-target
       // realignment error, a concurrent author racing the same scenario workflow) then rolls back
       // only the twin and can never mark the caller's authoring transaction rollback-only - which
       // previously turned a swallowed mirror error into a failed commit that lost the executing
-      // step. The stepMirror map update + run save below deliberately stay in the OUTER transaction
+      // step. The mirror map updates + run save below deliberately stay in the OUTER transaction
       // so they commit atomically with the executing step and never race a REQUIRES_NEW twin over
       // the same managed AutonomousRun row.
       String scenarioStepId =
           workflowService.appendChainedStepToScenarioIsolated(
-              scenarioId, injectInput, parentScenarioStepId, triggerConditions);
-      mirror.put(simStepId, scenarioStepId);
-      run.setStepMirror(mirror);
+              scenarioId,
+              injectInput,
+              parentScenarioStepId,
+              scenarioConditions,
+              scenarioExistingEventIds);
+      stepMirror.put(simStepId, scenarioStepId);
+      // Record the sim->scenario EVENT twin for a NEWLY created event (not a reuse), so a later
+      // step
+      // reusing this same sim event mirrors onto the SAME scenario event above. Best-effort: a
+      // lookup miss just leaves the mapping unrecorded and the fallback copy path handles the rare
+      // un-mirrored reuse.
+      if (!hasText(reusedSimEventId)) {
+        String simEventId = workflowService.findStepTriggerEventRootId(simStepId);
+        if (hasText(simEventId)) {
+          String scenarioEventId = workflowService.findStepTriggerEventRootId(scenarioStepId);
+          if (hasText(scenarioEventId)) {
+            eventMirror.put(simEventId, scenarioEventId);
+          }
+        }
+      }
+      run.setStepMirror(stepMirror);
+      run.setEventMirror(eventMirror);
       runRepository.save(run);
     } catch (Exception e) {
       log.warn(
           "[Autonomous] Failed to mirror attack-path step onto scenario {} for run {}: {}",
           scenarioId,
+          run.getId(),
+          e.getMessage());
+    }
+  }
+
+  /**
+   * Update-side twin of {@link #mirrorStepOntoScenario}: keeps the scenario mirror step in
+   * lock-step when the orchestrator updates a simulation step, PRESERVING event sharing on the
+   * scenario. A reused event links its recorded scenario twin (fallback: re-create a faithful copy
+   * from the sim event subtree so the twin is never event-less); a fresh trigger copies verbatim
+   * and re-records the sim-&gt;scenario event twin so a later step reusing the rebuilt event still
+   * mirrors onto the SAME scenario event; a data-only update ({@code triggerConditions == null})
+   * leaves the twin's conditions untouched. Best-effort: the executing simulation step is already
+   * updated, so a twin failure is logged and swallowed, never propagated (it runs in its OWN
+   * REQUIRES_NEW transaction).
+   */
+  private void mirrorStepUpdateOntoScenario(
+      AutonomousRun run,
+      String simStepId,
+      InjectInput injectInput,
+      List<ConditionCreateInput> triggerConditions,
+      String reusedSimEventId) {
+    Map<String, String> stepMirror = run.getStepMirror();
+    String scenarioStepId = stepMirror == null ? null : stepMirror.get(simStepId);
+    if (!hasText(scenarioStepId)) {
+      return;
+    }
+    Map<String, String> eventMirror =
+        run.getEventMirror() == null ? new HashMap<>() : new HashMap<>(run.getEventMirror());
+    // Resolve the scenario-side event linkage exactly like the append mirror: a reused event links
+    // its recorded scenario twin (fallback: recreate a copy); a fresh/absent trigger copies
+    // verbatim.
+    List<ConditionCreateInput> scenarioConditions = triggerConditions;
+    List<String> scenarioExistingEventIds = List.of();
+    if (hasText(reusedSimEventId)) {
+      String scenarioEventId = eventMirror.get(reusedSimEventId);
+      if (hasText(scenarioEventId)) {
+        scenarioExistingEventIds = List.of(scenarioEventId);
+      } else {
+        List<ConditionCreateInput> recreated =
+            new ArrayList<>(workflowService.resolveEventRootAsInputs(reusedSimEventId));
+        if (triggerConditions != null) {
+          recreated.addAll(triggerConditions);
+        }
+        scenarioConditions = recreated;
+      }
+    }
+    try {
+      workflowService.updateChainedStepIsolated(
+          scenarioStepId, injectInput, scenarioConditions, scenarioExistingEventIds);
+      // A fresh-trigger update rebuilt a NEW event on both the sim step and its scenario twin;
+      // re-record the sim->scenario event twin so a later step reusing the rebuilt event mirrors
+      // onto the SAME scenario event. Reuse and data-only updates create no event, so skip them.
+      if (!hasText(reusedSimEventId) && triggerConditions != null) {
+        String simEventId = workflowService.findStepTriggerEventRootId(simStepId);
+        if (hasText(simEventId)) {
+          String scenarioEventId = workflowService.findStepTriggerEventRootId(scenarioStepId);
+          if (hasText(scenarioEventId)) {
+            eventMirror.put(simEventId, scenarioEventId);
+            run.setEventMirror(eventMirror);
+            runRepository.save(run);
+          }
+        }
+      }
+    } catch (Exception e) {
+      log.warn(
+          "[Autonomous] Failed to update scenario mirror step {} for run {}: {}",
+          scenarioStepId,
           run.getId(),
           e.getMessage());
     }
@@ -3148,11 +3354,13 @@ public class AutonomousRunService {
     }
     String injectId = injects.isEmpty() ? "" : injects.get(injects.size() - 1).getId();
     // Argument order MUST match the DTO field declaration order (its @AllArgsConstructor):
-    // stepTemplateId, parentStepTemplateId, event_name, trigger_filters, trigger_mappings,
+    // stepTemplateId, parentStepTemplateId, event_id, event_name, trigger_filters,
+    // trigger_mappings,
     // inject_id, title, type, injector_contract_id, target, status, traces.
     return new AutonomousAttackPathStepState(
         authored.stepTemplateId(),
         authored.parentStepTemplateId(),
+        authored.eventId(),
         authored.eventName(),
         authored.triggerFilters(),
         authored.triggerMappings(),

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -327,6 +327,22 @@ public class ConditionService {
   }
 
   /**
+   * Finds a condition by id without throwing when it is missing or is not a root. Used by callers
+   * that need to VALIDATE an untrusted, caller-supplied condition id (e.g. an autonomous step's
+   * {@code event_id}) and produce their own precise error, rather than a generic not-found.
+   *
+   * @param conditionId the condition id to look up
+   * @return the condition, or {@code null} when no condition has that id
+   */
+  @Transactional(readOnly = true)
+  public Condition findConditionByIdOrNull(String conditionId) {
+    if (conditionId == null || conditionId.isBlank()) {
+      return null;
+    }
+    return conditionRepository.findById(conditionId).orElse(null);
+  }
+
+  /**
    * Returns all condition tree roots for a given workflow (conditions with no parent).
    *
    * @param workflowId the workflow identifier

--- a/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/ConditionService.java
@@ -327,12 +327,16 @@ public class ConditionService {
   }
 
   /**
-   * Finds a condition by id without throwing when it is missing or is not a root. Used by callers
-   * that need to VALIDATE an untrusted, caller-supplied condition id (e.g. an autonomous step's
-   * {@code event_id}) and produce their own precise error, rather than a generic not-found.
+   * Finds a condition by id, returning {@code null} instead of throwing when no condition has that
+   * id (unlike {@link #findConditionRootById}, which throws). It returns whatever condition carries
+   * the id REGARDLESS of its position in the tree - a root or a child leaf alike - and never
+   * inspects root-ness; deciding whether the condition is acceptable (a root, an AND/OR event, on
+   * the right workflow, ...) is left entirely to the caller. Used by callers that VALIDATE an
+   * untrusted, caller-supplied condition id (e.g. an autonomous step's {@code event_id}) and
+   * produce their own precise error rather than a generic not-found.
    *
    * @param conditionId the condition id to look up
-   * @return the condition, or {@code null} when no condition has that id
+   * @return the condition (root or child), or {@code null} when no condition has that id
    */
   @Transactional(readOnly = true)
   public Condition findConditionByIdOrNull(String conditionId) {

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -114,12 +114,28 @@ public class StepService {
 
     String candidateData = candidate.getData();
     String normalizedParent = normalizeDependOnParent(dependOnParentTemplateId);
+    // The EVENT linkage is part of the idempotency identity. When this author REUSES an existing
+    // event by id (stepInput.conditionIds), only a pending twin ALREADY linked to exactly that
+    // event may collapse this call: otherwise a same-inject / same-parent step authored under a
+    // DIFFERENT event (or none) would swallow the call, silently drop the requested event_id, and
+    // mislead the scenario mirror into twinning the wrong event. A fresh-event / no-event author
+    // (empty conditionIds) keeps the historical data + parent identity, so the duplicate-storm
+    // guard for replayed identical authors is unchanged.
+    Set<String> requestedEventIds =
+        stepInput.getConditionIds() == null
+            ? Set.of()
+            : stepInput.getConditionIds().stream()
+                .filter(id -> id != null && !id.isBlank())
+                .collect(Collectors.toSet());
     Optional<Step> existing =
         findAllStepTemplateByWorkflow(workflow.getId()).stream()
             .filter(s -> StepActionClass.INJECT_EXECUTION.equals(s.getStepAction()))
             .filter(s -> Objects.equals(s.getData(), candidateData))
             .filter(
                 s -> Objects.equals(normalizeDependOnParent(dependOnParentOf(s)), normalizedParent))
+            // Same inject + same parent but a DIFFERENT reused event is NOT the same step.
+            .filter(
+                s -> requestedEventIds.isEmpty() || linkedEventRootIds(s).equals(requestedEventIds))
             // Collapse a duplicate ONLY while the twin is still pending (no run step yet). A twin
             // that already executed means this author is a deliberate re-run and must create a new
             // template - never block the try -> tweak -> re-fire loop.
@@ -163,6 +179,24 @@ public class StepService {
         .filter(v -> v != null && !v.isBlank())
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * The set of AND/OR finding-event ROOT condition ids linked to a step template. Part of the
+   * idempotency identity in {@link #createInjectStepTemplateIdempotent}: reusing a DIFFERENT event
+   * by id must never collapse onto a same-inject / same-parent twin authored under another event.
+   * Filters on root-ness (no parent) so a linked event leaf or a nested AND/OR group is never
+   * mistaken for the event root.
+   *
+   * @param step the step template to inspect
+   * @return the linked event root ids (empty when the step has no finding event)
+   */
+  private Set<String> linkedEventRootIds(Step step) {
+    return conditionService.findAllConditionsByStepId(step.getId()).stream()
+        .filter(c -> c.getConditionParent() == null)
+        .filter(c -> c.getType() == ConditionType.AND || c.getType() == ConditionType.OR)
+        .map(Condition::getId)
+        .collect(Collectors.toSet());
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/StepService.java
@@ -215,10 +215,18 @@ public class StepService {
    * non-preserved conditions, clear the step-side links, recreate from input, re-link the preserved
    * DEPEND_ON root.
    *
+   * <p>When {@code stepInput.getConditionIds()} names EXISTING event roots to reuse (the
+   * event-sharing path: a step corrected to fire on an event that already exists), those roots and
+   * their whole subtree are PRESERVED across the delete (never unlinked, so a shared event other
+   * steps depend on is never dropped) and then linked to this step, exactly the {@code
+   * condition_ids} channel {@link #createInjectStepTemplateIdempotent} uses. The link is
+   * idempotent, so re-passing an already-linked event is a no-op.
+   *
    * @param stepTemplateId the id of the step template to update
-   * @param stepInput the new inject step input (data)
+   * @param stepInput the new inject step input (data); its {@code conditionIds} name existing event
+   *     roots to reuse
    * @param triggerConditions the finding-trigger + mapper conditions to install (an empty list
-   *     clears the trigger while keeping DEPEND_ON)
+   *     clears the trigger while keeping DEPEND_ON and any reused event links)
    * @return the updated step template
    */
   @Transactional(rollbackFor = Exception.class)
@@ -250,12 +258,27 @@ public class StepService {
             .filter(condition -> condition.getType() == ConditionType.DEPEND_ON)
             .map(Condition::getId)
             .toList();
-    conditionService.deleteAllConditionsByStepId(stepTemplateId, preservedDependOnIds);
+    // Existing event roots the caller asked to reuse are preserved across the delete alongside the
+    // DEPEND_ON parent, so rebuilding this step's trigger never unlinks - let alone deletes - a
+    // shared event that other steps still fire on. deleteAllConditionsByStepId preserves the whole
+    // subtree of every excluded root, so the event's leaves survive too.
+    List<String> reusedEventIds =
+        stepInput.getConditionIds() == null
+            ? List.of()
+            : stepInput.getConditionIds().stream()
+                .filter(id -> id != null && !id.isBlank())
+                .toList();
+    List<String> preserved = new ArrayList<>(preservedDependOnIds);
+    preserved.addAll(reusedEventIds);
+    conditionService.deleteAllConditionsByStepId(stepTemplateId, preserved);
     if (existing.getConditionSteps() != null) {
       existing.getConditionSteps().clear();
     }
     stepConditionTemplate(triggerConditions, existing.getWorkflow().getId(), existing);
     conditionService.linkExistingConditionsToStep(existing, preservedDependOnIds);
+    // Link the reused event roots (idempotent: a re-passed, still-linked event is a no-op; a newly
+    // chosen event is linked fresh). This is how an updated step attaches to a SHARED event.
+    conditionService.linkExistingConditionsToStep(existing, reusedEventIds);
     return saveStep(existing);
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -2192,9 +2192,17 @@ public class WorkflowService {
         .orElse(null);
   }
 
-  /** The finding-trigger event root (an AND / OR root) among a step's linked roots, or null. */
+  /**
+   * The finding-trigger event ROOT (an AND / OR node with no parent) among a step's linked
+   * conditions, or null. Filters on root-ness (conditionParent == null) as well as the AND/OR type:
+   * a step links its event's leaf children too, and an event may nest AND/OR groups, so a type-only
+   * match could return a nested child group. This value is surfaced to the orchestrator as {@code
+   * event_id} and passed back to reuse the event, where {@link #assertEventRootOnWorkflow} rejects
+   * anything that is not a true root - so it must be the root here.
+   */
   private static Condition triggerRoot(List<Condition> roots) {
     return roots.stream()
+        .filter(condition -> condition.getConditionParent() == null)
         .filter(
             condition ->
                 condition.getType() == ConditionType.AND || condition.getType() == ConditionType.OR)

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -1658,7 +1658,8 @@ public class WorkflowService {
   public String appendChainedStep(
       String simulationId, InjectInput injectInput, String parentStepTemplateId)
       throws ChainingException {
-    return doAppendChainedStep(simulationId, injectInput, parentStepTemplateId, List.of());
+    return doAppendChainedStep(
+        simulationId, injectInput, parentStepTemplateId, List.of(), List.of());
   }
 
   /**
@@ -1679,10 +1680,39 @@ public class WorkflowService {
       String parentStepTemplateId,
       List<ConditionCreateInput> triggerConditions)
       throws ChainingException {
-    return doAppendChainedStep(simulationId, injectInput, parentStepTemplateId, triggerConditions);
+    return doAppendChainedStep(
+        simulationId, injectInput, parentStepTemplateId, triggerConditions, List.of());
   }
 
-  // Shared body for both appendChainedStep overloads. Private and non-transactional on purpose: the
+  /**
+   * Existing-event overload of {@link #appendChainedStep(String, InjectInput, String, List)}. In
+   * addition to any inline {@code triggerConditions} (typically just MAPPER bindings), the step is
+   * LINKED to one or more EXISTING event roots by id ({@code existingEventConditionIds}) instead of
+   * minting a fresh finding-trigger tree - so several actions can fire off the SAME event rather
+   * than each duplicating it. The engine's step-create already re-links existing condition roots
+   * via {@code condition_ids}, exactly like the manual UI does. An empty list behaves like the
+   * plain finding-driven overload.
+   *
+   * @param existingEventConditionIds ids of existing event roots (finding-trigger roots) to attach
+   *     this step to; empty to create a new event from {@code triggerConditions}
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public String appendChainedStep(
+      String simulationId,
+      InjectInput injectInput,
+      String parentStepTemplateId,
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
+      throws ChainingException {
+    return doAppendChainedStep(
+        simulationId,
+        injectInput,
+        parentStepTemplateId,
+        triggerConditions,
+        existingEventConditionIds);
+  }
+
+  // Shared body for the appendChainedStep overloads. Private and non-transactional on purpose: the
   // public overloads are the @Transactional entry points, and each simply widens its arguments and
   // delegates here. Delegating to a plain helper (instead of one overload self-invoking the other)
   // keeps the transactional boundary on the proxied public method - an intra-class call to a
@@ -1691,7 +1721,8 @@ public class WorkflowService {
       String simulationId,
       InjectInput injectInput,
       String parentStepTemplateId,
-      List<ConditionCreateInput> triggerConditions)
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
       throws ChainingException {
     Workflow simulationTemplate =
         findWorkflowTemplateBySimulationId(simulationId)
@@ -1715,6 +1746,12 @@ public class WorkflowService {
     }
     if (!conditions.isEmpty()) {
       stepInput.setConditions(conditions);
+    }
+    // Link EXISTING event roots (finding-trigger roots the orchestrator chose to reuse) by id, the
+    // same condition_ids channel the manual UI uses, so multiple actions share one event instead of
+    // duplicating it. Never a fresh event tree - that is what triggerConditions above is for.
+    if (existingEventConditionIds != null && !existingEventConditionIds.isEmpty()) {
+      stepInput.setConditionIds(existingEventConditionIds);
     }
 
     // Idempotent authoring: a retried/replayed orchestrator call for the SAME inject + same parent
@@ -1748,7 +1785,7 @@ public class WorkflowService {
       String scenarioId, InjectInput injectInput, String parentScenarioStepTemplateId)
       throws ChainingException {
     return doAppendChainedStepToScenario(
-        scenarioId, injectInput, parentScenarioStepTemplateId, List.of());
+        scenarioId, injectInput, parentScenarioStepTemplateId, List.of(), List.of());
   }
 
   /**
@@ -1768,7 +1805,30 @@ public class WorkflowService {
       List<ConditionCreateInput> triggerConditions)
       throws ChainingException {
     return doAppendChainedStepToScenario(
-        scenarioId, injectInput, parentScenarioStepTemplateId, triggerConditions);
+        scenarioId, injectInput, parentScenarioStepTemplateId, triggerConditions, List.of());
+  }
+
+  /**
+   * Existing-event overload of {@link #appendChainedStepToScenario(String, InjectInput, String,
+   * List)}: links the scenario step to EXISTING scenario event roots by id instead of minting a new
+   * event tree, the scenario-side twin of {@link #appendChainedStep(String, InjectInput, String,
+   * List, List)}. Used when the orchestrator authors a step directly onto the scenario (no
+   * simulation) and reuses an event it already authored there.
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public String appendChainedStepToScenario(
+      String scenarioId,
+      InjectInput injectInput,
+      String parentScenarioStepTemplateId,
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
+      throws ChainingException {
+    return doAppendChainedStepToScenario(
+        scenarioId,
+        injectInput,
+        parentScenarioStepTemplateId,
+        triggerConditions,
+        existingEventConditionIds);
   }
 
   /**
@@ -1794,17 +1854,40 @@ public class WorkflowService {
       List<ConditionCreateInput> triggerConditions)
       throws ChainingException {
     return doAppendChainedStepToScenario(
-        scenarioId, injectInput, parentScenarioStepTemplateId, triggerConditions);
+        scenarioId, injectInput, parentScenarioStepTemplateId, triggerConditions, List.of());
   }
 
-  // Shared body for both appendChainedStepToScenario overloads. See doAppendChainedStep for why
-  // this
+  /**
+   * Existing-event variant of {@link #appendChainedStepToScenarioIsolated(String, InjectInput,
+   * String, List)}: links the mirrored scenario twin to an EXISTING scenario event root by id
+   * (resolved by the caller from its sim-&gt;scenario event mapping) so the exported scenario
+   * shares one event across the actions that reuse it, exactly like the executing simulation side.
+   * Still REQUIRES_NEW and best-effort - the mirror must never fail the author callback.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public String appendChainedStepToScenarioIsolated(
+      String scenarioId,
+      InjectInput injectInput,
+      String parentScenarioStepTemplateId,
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
+      throws ChainingException {
+    return doAppendChainedStepToScenario(
+        scenarioId,
+        injectInput,
+        parentScenarioStepTemplateId,
+        triggerConditions,
+        existingEventConditionIds);
+  }
+
+  // Shared body for the appendChainedStepToScenario overloads. See doAppendChainedStep for why this
   // is a private, non-transactional helper the public @Transactional overloads delegate to.
   private String doAppendChainedStepToScenario(
       String scenarioId,
       InjectInput injectInput,
       String parentScenarioStepTemplateId,
-      List<ConditionCreateInput> triggerConditions)
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
       throws ChainingException {
     Workflow scenarioTemplate =
         findWorkflowTemplateByScenarioId(scenarioId)
@@ -1829,6 +1912,12 @@ public class WorkflowService {
     if (!conditions.isEmpty()) {
       stepInput.setConditions(conditions);
     }
+    // Link an EXISTING scenario event root by id (the scenario twin of a reused simulation event)
+    // so the exported scenario shares the event instead of duplicating it, mirroring the executing
+    // simulation side. Empty means a fresh event copy, the historical mirror behaviour.
+    if (existingEventConditionIds != null && !existingEventConditionIds.isEmpty()) {
+      stepInput.setConditionIds(existingEventConditionIds);
+    }
 
     // Idempotent mirror: keep the scenario twin in lock-step with the (now idempotent) simulation
     // side so a replayed author call never doubles the exported attack path either.
@@ -1836,6 +1925,147 @@ public class WorkflowService {
         stepService.createInjectStepTemplateIdempotent(
             scenarioTemplate, stepInput, parentScenarioStepTemplateId);
     return created.getId();
+  }
+
+  /** The event-root condition types: an AND / OR node is a finding EVENT the engine fires on. */
+  private static final Set<ConditionType> EVENT_ROOT_TYPES =
+      EnumSet.of(ConditionType.AND, ConditionType.OR);
+
+  /**
+   * Validates that a caller-supplied {@code eventId} is an EXISTING finding-event root on the
+   * simulation's template workflow, so a step can be linked to it instead of minting a duplicate
+   * event. Throws {@link ChainingException} (surfaced as a 400) with a precise reason when the id
+   * is unknown, is a child condition rather than a root, is not an AND/OR event, or belongs to a
+   * different workflow - never a silent mislink.
+   *
+   * @param simulationId the run's live simulation
+   * @param eventId the event root id the orchestrator asked to reuse
+   */
+  @Transactional(readOnly = true)
+  public void assertEventRootOnSimulationWorkflow(String simulationId, String eventId)
+      throws ChainingException {
+    Workflow template =
+        findWorkflowTemplateBySimulationId(simulationId)
+            .orElseThrow(
+                () ->
+                    new ChainingException(
+                        "Workflow (TEMPLATE) not found. Simulation ID: " + simulationId));
+    assertEventRootOnWorkflow(template.getId(), eventId);
+  }
+
+  /**
+   * Scenario-side twin of {@link #assertEventRootOnSimulationWorkflow}: validates {@code eventId}
+   * is an existing finding-event root on the scenario's template workflow (author-scenario mode).
+   */
+  @Transactional(readOnly = true)
+  public void assertEventRootOnScenarioWorkflow(String scenarioId, String eventId)
+      throws ChainingException {
+    Workflow template =
+        findWorkflowTemplateByScenarioId(scenarioId)
+            .orElseThrow(
+                () ->
+                    new ChainingException(
+                        "Workflow (TEMPLATE) not found. Scenario ID: " + scenarioId));
+    assertEventRootOnWorkflow(template.getId(), eventId);
+  }
+
+  private void assertEventRootOnWorkflow(String workflowId, String eventId)
+      throws ChainingException {
+    Condition condition = conditionService.findConditionByIdOrNull(eventId);
+    if (condition == null) {
+      throw new ChainingException(
+          "event_id '"
+              + eventId
+              + "' does not exist. Read a step's event_id from the attack-path state and pass"
+              + " exactly that, or omit event_id to create a new event.");
+    }
+    if (condition.getConditionParent() != null) {
+      throw new ChainingException(
+          "event_id '"
+              + eventId
+              + "' is not an event root (it is a child condition). Pass the event's root id from a"
+              + " step's event_id.");
+    }
+    if (!EVENT_ROOT_TYPES.contains(condition.getType())) {
+      throw new ChainingException(
+          "event_id '"
+              + eventId
+              + "' is not a finding EVENT (type "
+              + condition.getType()
+              + ", expected AND/OR). Only finding events can be shared across steps.");
+    }
+    if (!Objects.equals(condition.getWorkflowId(), workflowId)) {
+      throw new ChainingException(
+          "event_id '"
+              + eventId
+              + "' belongs to a different workflow. An event can only be reused within the same"
+              + " run's attack path.");
+    }
+  }
+
+  /**
+   * The AND/OR finding-event root id currently linked to a step template, or {@code null} when the
+   * step has no finding event (a seed, standalone, or pure DEPEND_ON step). This is the id the
+   * attack-path state surfaces as {@code event_id} and the caller records in the run's sim-&gt;
+   * scenario event mapping so a reused event mirrors to the same scenario event.
+   *
+   * @param stepTemplateId the step template to inspect
+   * @return the linked event root id, or {@code null}
+   */
+  @Transactional(readOnly = true)
+  public String findStepTriggerEventRootId(String stepTemplateId) {
+    return conditionService.findAllConditionsByStepId(stepTemplateId).stream()
+        .filter(condition -> EVENT_ROOT_TYPES.contains(condition.getType()))
+        .map(Condition::getId)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * Resolves an existing finding-event root into a fresh set of {@link ConditionCreateInput}s (the
+   * AND/OR root plus its non-MAPPER leaf filters) so a faithful COPY of the event can be created on
+   * another workflow. Used by the scenario mirror as a fallback: when the run has no recorded
+   * sim-&gt;scenario twin for a reused simulation event, the mirror re-creates the event on the
+   * scenario so the exported step is never left event-less. MAPPER children are excluded - the
+   * caller supplies the step's own mappers. Returns an empty list when {@code eventId} is not a
+   * resolvable event root.
+   *
+   * @param eventId the existing event root id to copy
+   * @return the root + leaf inputs, or an empty list
+   */
+  @Transactional(readOnly = true)
+  public List<ConditionCreateInput> resolveEventRootAsInputs(String eventId) {
+    Condition root = conditionService.findConditionByIdOrNull(eventId);
+    if (root == null
+        || root.getConditionParent() != null
+        || !EVENT_ROOT_TYPES.contains(root.getType())) {
+      return List.of();
+    }
+    String tmpRootId = UUID.randomUUID().toString();
+    List<ConditionCreateInput> inputs = new ArrayList<>();
+    inputs.add(
+        ConditionCreateInput.builder()
+            .temporaryId(tmpRootId)
+            .type(root.getType())
+            .name(root.getName())
+            .build());
+    conditionService.findAllNonMapperConditionsByWorkflowId(root.getWorkflowId()).stream()
+        .filter(
+            leaf ->
+                leaf.getConditionParent() != null
+                    && Objects.equals(leaf.getConditionParent().getId(), eventId))
+        .forEach(
+            leaf ->
+                inputs.add(
+                    ConditionCreateInput.builder()
+                        .temporaryId(UUID.randomUUID().toString())
+                        .temporaryIdConditionParent(tmpRootId)
+                        .type(leaf.getType())
+                        .keyTypes(leaf.getKeyTypes())
+                        .value(leaf.getValue())
+                        .caseSensitive(leaf.isCaseSensitive())
+                        .build()));
+    return inputs;
   }
 
   /**
@@ -1911,6 +2141,7 @@ public class WorkflowService {
               dependOnParentFromRoots(roots),
               step.getData(),
               runInjectIds,
+              triggerRootId(roots),
               triggerEventName(roots),
               triggerFilters(roots, filterLeavesByParentId),
               triggerMappings(roots)));
@@ -1936,6 +2167,16 @@ public class WorkflowService {
                 condition.getType() == ConditionType.AND || condition.getType() == ConditionType.OR)
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * Stable id of the step's finding EVENT (the trigger root), or null when it has none. This is the
+   * handle the orchestrator passes back as a trigger's {@code event_id} to attach another step to
+   * the SAME event instead of duplicating it.
+   */
+  private static String triggerRootId(List<Condition> roots) {
+    Condition root = triggerRoot(roots);
+    return root != null ? root.getId() : null;
   }
 
   /** Human name of the step's finding EVENT (the trigger root's name), or null when it has none. */
@@ -2040,6 +2281,26 @@ public class WorkflowService {
   }
 
   /**
+   * Existing-event overload of {@link #updateChainedStep(String, InjectInput, List)}: rebuilds the
+   * step's finding trigger from {@code triggerConditions} (typically MAPPERs only) AND links it to
+   * EXISTING event roots by id, so the orchestrator can CORRECT a step to fire on an event that
+   * already exists instead of minting a duplicate. Preserves the DEPEND_ON ordering parent and the
+   * reused event subtree across the rebuild.
+   *
+   * @param existingEventConditionIds ids of existing event roots to attach this step to (empty to
+   *     rebuild a fresh trigger with no reuse)
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void updateChainedStep(
+      String stepTemplateId,
+      InjectInput injectInput,
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
+      throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput, triggerConditions, existingEventConditionIds);
+  }
+
+  /**
    * Transaction-isolated variant of {@link #updateChainedStep} for the autonomous orchestrator's
    * step-update callback, used to keep the scenario mirror twin in lock-step. Runs in its OWN
    * transaction ({@link Propagation#REQUIRES_NEW}) so a twin-update failure rolls back only itself
@@ -2071,6 +2332,21 @@ public class WorkflowService {
   }
 
   /**
+   * Existing-event, transaction-isolated variant used to keep the scenario mirror twin's event
+   * linkage in lock-step when the corrected simulation step reuses an existing event. Same {@link
+   * Propagation#REQUIRES_NEW} best-effort isolation as the other isolated update overloads.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = Exception.class)
+  public void updateChainedStepIsolated(
+      String stepTemplateId,
+      InjectInput injectInput,
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
+      throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput, triggerConditions, existingEventConditionIds);
+  }
+
+  /**
    * Deletes a chained step template (and its conditions) on behalf of the autonomous orchestrator,
    * so it can PRUNE a mis-authored finding-driven step. Bypasses the manual editability guard for
    * the same reason the author path does (the orchestrator owns the run's workflow).
@@ -2099,8 +2375,25 @@ public class WorkflowService {
   private void doUpdateChainedStep(
       String stepTemplateId, InjectInput injectInput, List<ConditionCreateInput> triggerConditions)
       throws ChainingException {
+    doUpdateChainedStep(stepTemplateId, injectInput, triggerConditions, List.of());
+  }
+
+  // Existing-event variant of the update body: in addition to rebuilding the trigger it can LINK
+  // the step to EXISTING event roots by id ({@code existingEventConditionIds}), so a corrected step
+  // attaches to an event that already exists instead of duplicating it - the update-side twin of
+  // doAppendChainedStep's condition_ids channel. The step service preserves those roots (subtree
+  // included) across the condition rebuild so a shared event is never dropped, then links them.
+  private void doUpdateChainedStep(
+      String stepTemplateId,
+      InjectInput injectInput,
+      List<ConditionCreateInput> triggerConditions,
+      List<String> existingEventConditionIds)
+      throws ChainingException {
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
+    if (existingEventConditionIds != null && !existingEventConditionIds.isEmpty()) {
+      stepInput.setConditionIds(existingEventConditionIds);
+    }
     Step updated =
         triggerConditions == null
             ? stepService.updateInjectStepTemplateData(stepTemplateId, stepInput)
@@ -2143,6 +2436,7 @@ public class WorkflowService {
       String parentStepTemplateId,
       String injectDataJson,
       List<String> runInjectIds,
+      String eventId,
       String eventName,
       List<String> triggerFilters,
       List<String> triggerMappings) {}

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -2004,10 +2004,18 @@ public class WorkflowService {
   }
 
   /**
-   * The AND/OR finding-event root id currently linked to a step template, or {@code null} when the
+   * The AND/OR finding-event ROOT id currently linked to a step template, or {@code null} when the
    * step has no finding event (a seed, standalone, or pure DEPEND_ON step). This is the id the
    * attack-path state surfaces as {@code event_id} and the caller records in the run's sim-&gt;
    * scenario event mapping so a reused event mirrors to the same scenario event.
+   *
+   * <p>Filters on both the AND/OR type AND root-ness ({@code conditionParent == null}): a step's
+   * linked conditions include an event's leaf children (they carry the step link too), and a
+   * manually authored event MAY nest AND/OR groups, so a type-only match could return a nested
+   * child group instead of the root. The returned id must be a true root because {@link
+   * #assertEventRootOnWorkflow} rejects non-roots when the caller reuses it, and the sim-&gt;
+   * scenario event mirror is keyed on root ids. Autonomous events are flat (one AND/OR root + leaf
+   * filters), so this only hardens the read against manually edited or future nested trees.
    *
    * @param stepTemplateId the step template to inspect
    * @return the linked event root id, or {@code null}
@@ -2015,6 +2023,7 @@ public class WorkflowService {
   @Transactional(readOnly = true)
   public String findStepTriggerEventRootId(String stepTemplateId) {
     return conditionService.findAllConditionsByStepId(stepTemplateId).stream()
+        .filter(condition -> condition.getConditionParent() == null)
         .filter(condition -> EVENT_ROOT_TYPES.contains(condition.getType()))
         .map(Condition::getId)
         .findFirst()
@@ -2023,15 +2032,22 @@ public class WorkflowService {
 
   /**
    * Resolves an existing finding-event root into a fresh set of {@link ConditionCreateInput}s (the
-   * AND/OR root plus its non-MAPPER leaf filters) so a faithful COPY of the event can be created on
-   * another workflow. Used by the scenario mirror as a fallback: when the run has no recorded
+   * AND/OR root plus its WHOLE non-MAPPER subtree) so a faithful COPY of the event can be created
+   * on another workflow. Used by the scenario mirror as a fallback: when the run has no recorded
    * sim-&gt;scenario twin for a reused simulation event, the mirror re-creates the event on the
    * scenario so the exported step is never left event-less. MAPPER children are excluded - the
    * caller supplies the step's own mappers. Returns an empty list when {@code eventId} is not a
    * resolvable event root.
    *
+   * <p>Copies the subtree to FULL depth (not just the root's direct children): an event authored in
+   * the manual logic map MAY nest AND/OR condition groups, and a shallow copy would silently drop
+   * grandchildren, mirroring a structurally incorrect / partial event onto the scenario. The walk
+   * mirrors {@link StepService#copyStepConditionTemplate} - group children by parent id, then BFS
+   * from the root re-parenting each copied node by temporary id. Autonomous events are flat, so
+   * this only hardens the fallback against manually edited or future nested trees.
+   *
    * @param eventId the existing event root id to copy
-   * @return the root + leaf inputs, or an empty list
+   * @return the root + full-subtree inputs, or an empty list
    */
   @Transactional(readOnly = true)
   public List<ConditionCreateInput> resolveEventRootAsInputs(String eventId) {
@@ -2041,30 +2057,47 @@ public class WorkflowService {
         || !EVENT_ROOT_TYPES.contains(root.getType())) {
       return List.of();
     }
-    String tmpRootId = UUID.randomUUID().toString();
+    // Index the event's whole subtree by parent id so nested groups are copied to full depth.
+    Map<String, List<Condition>> childrenByParentId =
+        conditionService.findAllNonMapperConditionsByWorkflowId(root.getWorkflowId()).stream()
+            .filter(condition -> condition.getConditionParent() != null)
+            .collect(Collectors.groupingBy(condition -> condition.getConditionParent().getId()));
+
     List<ConditionCreateInput> inputs = new ArrayList<>();
+    String rootTmpId = UUID.randomUUID().toString();
     inputs.add(
         ConditionCreateInput.builder()
-            .temporaryId(tmpRootId)
+            .temporaryId(rootTmpId)
             .type(root.getType())
             .name(root.getName())
             .build());
-    conditionService.findAllNonMapperConditionsByWorkflowId(root.getWorkflowId()).stream()
-        .filter(
-            leaf ->
-                leaf.getConditionParent() != null
-                    && Objects.equals(leaf.getConditionParent().getId(), eventId))
-        .forEach(
-            leaf ->
-                inputs.add(
-                    ConditionCreateInput.builder()
-                        .temporaryId(UUID.randomUUID().toString())
-                        .temporaryIdConditionParent(tmpRootId)
-                        .type(leaf.getType())
-                        .keyTypes(leaf.getKeyTypes())
-                        .value(leaf.getValue())
-                        .caseSensitive(leaf.isCaseSensitive())
-                        .build()));
+    // BFS from the root carrying each source node's assigned temporary id so children re-parent
+    // onto their copied parent. The visited set guards against a corrupted parent chain cycling
+    // (same guard as ConditionService#isPreserved).
+    Set<String> visited = new HashSet<>();
+    visited.add(root.getId());
+    Queue<Map.Entry<String, String>> queue = new LinkedList<>();
+    queue.add(Map.entry(root.getId(), rootTmpId));
+    while (!queue.isEmpty()) {
+      Map.Entry<String, String> current = queue.poll();
+      for (Condition child : childrenByParentId.getOrDefault(current.getKey(), List.of())) {
+        if (child.getId() == null || !visited.add(child.getId())) {
+          continue;
+        }
+        String childTmpId = UUID.randomUUID().toString();
+        inputs.add(
+            ConditionCreateInput.builder()
+                .temporaryId(childTmpId)
+                .temporaryIdConditionParent(current.getValue())
+                .type(child.getType())
+                .keyTypes(child.getKeyTypes())
+                .value(child.getValue())
+                .caseSensitive(child.isCaseSensitive())
+                .name(child.getName())
+                .build());
+        queue.add(Map.entry(child.getId(), childTmpId));
+      }
+    }
     return inputs;
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
@@ -430,6 +430,42 @@ class AutonomousRunServiceScopeTest {
 
   @Test
   @DisplayName(
+      "Reusing an event with NO recorded scenario twin recreates it as a fallback AND records the"
+          + " fresh twin, so later reuses share it instead of duplicating")
+  void given_aReusedEventWithoutAMirror_when_appendingLive_then_theFallbackTwinIsRecorded()
+      throws Exception {
+    // eventMirror is EMPTY: the reused sim event has no scenario twin yet (it pre-dates mirror
+    // tracking, or its first mirror failed), so the mirror RECREATES the event on the scenario as a
+    // fallback. It must also RECORD that fresh twin - otherwise every later step reusing the same
+    // sim event takes the fallback again and mints yet another scenario event, re-introducing the
+    // duplication this feature removes.
+    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList(), anyList()))
+        .thenReturn("sim-step-2");
+    when(workflowService.resolveEventRootAsInputs("sim-evt-smb"))
+        .thenReturn(List.of(ConditionCreateInput.builder().type(ConditionType.AND).build()));
+    when(workflowService.appendChainedStepToScenarioIsolated(
+            anyString(), any(), any(), anyList(), scenarioEventIdsCaptor.capture()))
+        .thenReturn("scenario-step-copy");
+    when(workflowService.findStepTriggerEventRootId("scenario-step-copy"))
+        .thenReturn("scenario-evt-copy");
+
+    AutonomousStepTrigger trigger = new AutonomousStepTrigger();
+    trigger.setEventId("sim-evt-smb");
+    AutonomousInputMapping mapping = new AutonomousInputMapping();
+    mapping.setInputKey("host");
+    mapping.setKeyType(PrimitiveType.Host);
+    trigger.setMappings(List.of(mapping));
+
+    runService.appendAttackPathStep(RUN_ID, new InjectInput(), null, trigger);
+
+    // Fallback: no existing scenario event is LINKED (it is recreated, not shared yet)...
+    assertThat(scenarioEventIdsCaptor.getValue()).isEmpty();
+    // ...and the recreated scenario event twin is now recorded, so the NEXT reuse shares it.
+    assertThat(run.getEventMirror()).containsEntry("sim-evt-smb", "scenario-evt-copy");
+  }
+
+  @Test
+  @DisplayName(
       "Authoring WITHOUT event_id mints a fresh event and neither validates nor links an existing"
           + " one - event_id is optional")
   void given_noEventId_when_appendingLive_then_noReuseAndNoValidation() throws Exception {

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceScopeTest.java
@@ -2,6 +2,7 @@ package io.openaev.service.autonomous;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -18,11 +19,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.api.autonomous.dto.AutonomousInputMapping;
+import io.openaev.api.autonomous.dto.AutonomousStepTrigger;
+import io.openaev.api.autonomous.dto.AutonomousTriggerFilter;
+import io.openaev.api.chaining.dto.ConditionCreateInput;
 import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.config.TenantWriteScopeResolver;
 import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
+import io.openaev.database.model.ConditionType;
+import io.openaev.database.model.PrimitiveType;
 import io.openaev.database.model.ScopeRuleSelectedMode;
 import io.openaev.database.model.ScopeRuleSource;
 import io.openaev.database.model.Tenant;
@@ -39,6 +46,7 @@ import io.openaev.database.repository.TeamRepository;
 import io.openaev.database.repository.UserRepository;
 import io.openaev.database.repository.autonomous.AutonomousDirectiveRepository;
 import io.openaev.database.repository.autonomous.AutonomousRunRepository;
+import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exercise.service.ExerciseService;
 import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.service.EndpointService;
@@ -47,7 +55,9 @@ import io.openaev.service.chaining.WorkflowService;
 import io.openaev.service.scenario.ScenarioService;
 import io.openaev.xtmone.XtmOneClient;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +70,8 @@ import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Unit tests for the orchestrator scope + attack-path authoring callbacks ({@link
@@ -109,6 +121,9 @@ class AutonomousRunServiceScopeTest {
   @InjectMocks private AutonomousRunService runService;
 
   @Captor private ArgumentCaptor<List<WorkflowScopeRuleInput>> rulesCaptor;
+  @Captor private ArgumentCaptor<List<String>> existingEventIdsCaptor;
+  @Captor private ArgumentCaptor<List<String>> scenarioEventIdsCaptor;
+  @Captor private ArgumentCaptor<List<ConditionCreateInput>> triggerConditionsCaptor;
 
   private AutonomousRun run;
 
@@ -269,7 +284,7 @@ class AutonomousRunServiceScopeTest {
   @Test
   @DisplayName("Appending a step loads the run FOR UPDATE (row lock), never the unlocked read")
   void given_anAuthorCallback_when_appendingAStep_then_theRunIsLoadedForUpdate() throws Exception {
-    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList()))
+    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList(), anyList()))
         .thenReturn("sim-step-1");
 
     runService.appendAttackPathStep(RUN_ID, new InjectInput(), null);
@@ -288,7 +303,7 @@ class AutonomousRunServiceScopeTest {
     // Reproduce the legacy non-prefixed route's no-tenant thread (see the scope projections test).
     TenantContext.clearCurrentTenant();
     List<String> seenTenants = new ArrayList<>();
-    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList()))
+    when(workflowService.appendChainedStep(anyString(), any(), any(), anyList(), anyList()))
         .thenAnswer(
             inv -> {
               seenTenants.add(TenantContext.getCurrentTenant());
@@ -312,7 +327,8 @@ class AutonomousRunServiceScopeTest {
     run.setSimulationId(null);
     TenantContext.clearCurrentTenant();
     List<String> seenTenants = new ArrayList<>();
-    when(workflowService.appendChainedStepToScenario(anyString(), any(), any(), anyList()))
+    when(workflowService.appendChainedStepToScenario(
+            anyString(), any(), any(), anyList(), anyList()))
         .thenAnswer(
             inv -> {
               seenTenants.add(TenantContext.getCurrentTenant());
@@ -330,23 +346,183 @@ class AutonomousRunServiceScopeTest {
       "The PRIMARY in-place step update runs under the run's v1 tenant, cleared afterwards")
   void given_theLegacyCallbackRoute_when_updatingAStep_then_thePrimaryRunsUnderTheRunTenant()
       throws Exception {
-    // updateAttackPathStep never saves the run, so it keeps the plain read (stubbed here).
-    when(runRepository.findById(RUN_ID)).thenReturn(Optional.of(run));
+    // updateAttackPathStep now loads the run FOR UPDATE (row lock) too: a fresh-trigger update
+    // re-records the sim->scenario event twin (eventMirror) with a version-less full-entity write,
+    // so it must serialise with the other run writers. The lock read is lenient-stubbed in setUp.
     TenantContext.clearCurrentTenant();
     List<String> seenTenants = new ArrayList<>();
-    // A null trigger routes through the three-argument updateChainedStep (data-only), so the tenant
-    // probe is stubbed on that overload.
+    // A null trigger routes through the four-argument updateChainedStep with an EMPTY
+    // existing-event
+    // id list (data-only: conditions untouched, no event minted or reused), so the tenant probe is
+    // stubbed on that overload.
     doAnswer(
             inv -> {
               seenTenants.add(TenantContext.getCurrentTenant());
               return null;
             })
         .when(workflowService)
-        .updateChainedStep(eq("sim-step-1"), any(), any());
+        .updateChainedStep(eq("sim-step-1"), any(), any(), anyList());
 
     runService.updateAttackPathStep(RUN_ID, "sim-step-1", new InjectInput(), null);
 
     assertThat(seenTenants).containsExactly("tenant-1");
     assertThat(TenantContext.hasCurrentTenant()).isFalse();
+  }
+
+  // ------------------------------------------------------------------------- //
+  // Event REUSE: attach a step to an EXISTING event by id instead of minting a  //
+  // duplicate. event_id is always OPTIONAL - an absent trigger/event is a valid //
+  // event-less seed or standalone action and nothing here forces an event.      //
+  // ------------------------------------------------------------------------- //
+
+  @Test
+  @DisplayName(
+      "Authoring with trigger.event_id links the EXISTING sim event (mappers-only) and the mirror"
+          + " shares its recorded scenario twin instead of duplicating it")
+  void given_aTriggerReusingAnEvent_when_appendingLive_then_theEventIsLinkedAndMirrorShares()
+      throws Exception {
+    // The run already knows this sim event's scenario twin (recorded when the event was first
+    // authored), so the exported scenario shares ONE event across the reusing steps - exactly like
+    // the executing simulation - rather than duplicating it per step.
+    run.setEventMirror(new HashMap<>(Map.of("sim-evt-smb", "scenario-evt-smb")));
+    when(workflowService.appendChainedStep(
+            anyString(),
+            any(),
+            any(),
+            triggerConditionsCaptor.capture(),
+            existingEventIdsCaptor.capture()))
+        .thenReturn("sim-step-2");
+    when(workflowService.appendChainedStepToScenarioIsolated(
+            anyString(), any(), any(), anyList(), scenarioEventIdsCaptor.capture()))
+        .thenReturn("scenario-step-2");
+
+    AutonomousStepTrigger trigger = new AutonomousStepTrigger();
+    trigger.setEventId("sim-evt-smb");
+    // event_name / filters are provided but MUST be ignored when reusing (the event already
+    // exists);
+    // only the mappers survive so this step still consumes the shared event's finding values.
+    trigger.setEventName("ignored when reusing");
+    AutonomousTriggerFilter filter = new AutonomousTriggerFilter();
+    filter.setKeyType(PrimitiveType.Port);
+    filter.setOperator(ConditionType.EQ);
+    filter.setValue("445");
+    trigger.setFilters(List.of(filter));
+    AutonomousInputMapping mapping = new AutonomousInputMapping();
+    mapping.setInputKey("host");
+    mapping.setKeyType(PrimitiveType.Host);
+    trigger.setMappings(List.of(mapping));
+
+    String stepId = runService.appendAttackPathStep(RUN_ID, new InjectInput(), null, trigger);
+
+    assertThat(stepId).isEqualTo("sim-step-2");
+    // The reused id is validated on the SIMULATION workflow (the state read surfaces sim event
+    // ids).
+    verify(workflowService).assertEventRootOnSimulationWorkflow(SIMULATION_ID, "sim-evt-smb");
+    // Linked by id (never re-minted): the reused id is threaded to the workflow append.
+    assertThat(existingEventIdsCaptor.getValue()).containsExactly("sim-evt-smb");
+    // MAPPERS ONLY: no event root / filter leaves are rebuilt - just the single value binding.
+    assertThat(triggerConditionsCaptor.getValue()).hasSize(1);
+    assertThat(triggerConditionsCaptor.getValue())
+        .allSatisfy(c -> assertThat(c.getType()).isEqualTo(ConditionType.MAPPER));
+    // The scenario twin SHARES the recorded scenario event (from eventMirror), not a duplicate.
+    assertThat(scenarioEventIdsCaptor.getValue()).containsExactly("scenario-evt-smb");
+  }
+
+  @Test
+  @DisplayName(
+      "Authoring WITHOUT event_id mints a fresh event and neither validates nor links an existing"
+          + " one - event_id is optional")
+  void given_noEventId_when_appendingLive_then_noReuseAndNoValidation() throws Exception {
+    when(workflowService.appendChainedStep(
+            anyString(), any(), any(), anyList(), existingEventIdsCaptor.capture()))
+        .thenReturn("sim-step-1");
+
+    AutonomousStepTrigger trigger = new AutonomousStepTrigger();
+    trigger.setEventName("SMB service exposed");
+    AutonomousTriggerFilter filter = new AutonomousTriggerFilter();
+    filter.setKeyType(PrimitiveType.Port);
+    filter.setOperator(ConditionType.EQ);
+    filter.setValue("445");
+    trigger.setFilters(List.of(filter));
+
+    runService.appendAttackPathStep(RUN_ID, new InjectInput(), null, trigger);
+
+    // No reuse -> the existing-event id list is EMPTY (a fresh event is minted from the filters).
+    assertThat(existingEventIdsCaptor.getValue()).isEmpty();
+    // Nothing to validate -> the reuse validation is never invoked.
+    verify(workflowService, never()).assertEventRootOnSimulationWorkflow(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName(
+      "Author-scenario mode reuses an event by validating it on the SCENARIO workflow and linking"
+          + " it by id (never the live-mode validation)")
+  void given_aPlanRunReusingAnEvent_when_appending_then_theScenarioEventIsValidatedAndLinked()
+      throws Exception {
+    run.setSimulationId(null);
+    when(workflowService.appendChainedStepToScenario(
+            anyString(), any(), any(), anyList(), existingEventIdsCaptor.capture()))
+        .thenReturn("scenario-step-2");
+
+    AutonomousStepTrigger trigger = new AutonomousStepTrigger();
+    trigger.setEventId("scenario-evt-web");
+
+    String stepId = runService.appendAttackPathStep(RUN_ID, new InjectInput(), null, trigger);
+
+    assertThat(stepId).isEqualTo("scenario-step-2");
+    verify(workflowService).assertEventRootOnScenarioWorkflow(SCENARIO_ID, "scenario-evt-web");
+    assertThat(existingEventIdsCaptor.getValue()).containsExactly("scenario-evt-web");
+    verify(workflowService, never()).assertEventRootOnSimulationWorkflow(anyString(), anyString());
+  }
+
+  @Test
+  @DisplayName(
+      "Updating with trigger.event_id re-points the step onto the EXISTING event (mappers-only) and"
+          + " links it by id")
+  void given_aTriggerReusingAnEvent_when_updatingLive_then_theEventIsValidatedAndLinked()
+      throws Exception {
+    AutonomousStepTrigger trigger = new AutonomousStepTrigger();
+    trigger.setEventId("sim-evt-smb");
+    AutonomousInputMapping mapping = new AutonomousInputMapping();
+    mapping.setInputKey("host");
+    mapping.setKeyType(PrimitiveType.Host);
+    trigger.setMappings(List.of(mapping));
+
+    runService.updateAttackPathStep(RUN_ID, "sim-step-9", new InjectInput(), trigger);
+
+    verify(workflowService).assertEventRootOnSimulationWorkflow(SIMULATION_ID, "sim-evt-smb");
+    // updateChainedStep is void: capture its args after the fact to assert the reused link + shape.
+    verify(workflowService)
+        .updateChainedStep(
+            eq("sim-step-9"),
+            any(),
+            triggerConditionsCaptor.capture(),
+            existingEventIdsCaptor.capture());
+    assertThat(existingEventIdsCaptor.getValue()).containsExactly("sim-evt-smb");
+    assertThat(triggerConditionsCaptor.getValue())
+        .allSatisfy(c -> assertThat(c.getType()).isEqualTo(ConditionType.MAPPER));
+  }
+
+  @Test
+  @DisplayName("A bad/foreign event_id is a precise 400 and no step is authored (never a mislink)")
+  void given_anInvalidEventId_when_appendingLive_then_itIs400_andNoStepAuthored() throws Exception {
+    doThrow(new ChainingException("No such event root on this workflow"))
+        .when(workflowService)
+        .assertEventRootOnSimulationWorkflow(SIMULATION_ID, "nope");
+
+    AutonomousStepTrigger trigger = new AutonomousStepTrigger();
+    trigger.setEventId("nope");
+
+    assertThatThrownBy(
+            () -> runService.appendAttackPathStep(RUN_ID, new InjectInput(), null, trigger))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            e ->
+                assertThat(((ResponseStatusException) e).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+
+    // Rejected up front: nothing is authored, so no duplicate or mislinked step ever lands.
+    verify(workflowService, never())
+        .appendChainedStep(anyString(), any(), any(), anyList(), anyList());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceIntegrationTest.java
@@ -290,6 +290,15 @@ class StepServiceIntegrationTest extends IntegrationTest {
     Condition survivingRoot = conditionRepository.findById(rootId).orElse(null);
     assertNotNull(survivingRoot, "the preserved event survives");
     assertEquals(1, survivingRoot.getConditionChildren().size(), "and keeps its child");
+    // The step->root JOIN must survive too, not just the condition rows: the unconditional
+    // step-side conditionSteps.clear() must never orphan-delete the link the caller asked to
+    // preserve via conditionIds, or the updated step would be silently event-less. This is the
+    // exact clear() + linkExistingConditionsToStep(preserved) mechanism the autonomous
+    // updateInjectStepTemplateDataAndTrigger reuses to preserve a shared event on update (#7482).
+    List<Condition> stillLinked = conditionService.findAllConditionsByStepId(updated.getId());
+    assertTrue(
+        stillLinked.stream().anyMatch(c -> rootId.equals(c.getId())),
+        "the step stays linked to its preserved event root");
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/StepServiceTest.java
@@ -1113,6 +1113,79 @@ class StepServiceTest {
     }
 
     @Test
+    @DisplayName(
+        "Idempotent author reusing a DIFFERENT event does not collapse onto a same-inject /"
+            + " same-parent pending twin - it mints a new step linked to the requested event")
+    void given_sameInjectDifferentEvent_should_notCollapse_andLinkRequestedEvent()
+        throws ChainingException {
+      // Arrange - a pending twin (same inject data, no DEPEND_ON parent) already gated by event A.
+      Workflow wf = mock(Workflow.class);
+      when(wf.getId()).thenReturn("wf-1");
+      Step existing = mock(Step.class);
+      when(existing.getId()).thenReturn("existing-1");
+      when(existing.getStepAction()).thenReturn(StepActionClass.INJECT_EXECUTION);
+      when(existing.getData()).thenReturn("DATA");
+      // existing-1 is linked to event root A and has no DEPEND_ON parent.
+      Condition eventA = Condition.builder().id("evt-A").type(ConditionType.AND).build();
+      when(conditionService.findAllConditionsByStepId("existing-1")).thenReturn(List.of(eventA));
+      doReturn(List.of(existing)).when(stepService).findAllStepTemplateByWorkflow("wf-1");
+
+      // This author reuses a DIFFERENT event, B, for the same inject + parent.
+      StepsCreateInput.StepInput stepInput = mock(StepsCreateInput.StepInput.class);
+      when(stepInput.getStepAction()).thenReturn(StepActionClass.INJECT_EXECUTION);
+      when(stepInput.getConditions()).thenReturn(Collections.emptyList());
+      when(stepInput.getConditionIds()).thenReturn(List.of("evt-B"));
+      Step candidate = mock(Step.class);
+      when(candidate.getData()).thenReturn("DATA");
+      doReturn(actionStep).when(stepService).factoryAction(StepActionClass.INJECT_EXECUTION, null);
+      when(actionStep.create(stepInput, wf)).thenReturn(Optional.of(candidate));
+      when(stepRepository.save(candidate)).thenReturn(candidate);
+
+      // Act
+      Step result = stepService.createInjectStepTemplateIdempotent(wf, stepInput, null);
+
+      // Assert - a NEW step is minted (not the event-A twin) and linked to the requested event B.
+      assertSame(candidate, result);
+      assertNotSame(existing, result);
+      verify(stepRepository).save(candidate);
+      verify(conditionService).linkExistingConditionsToStep(candidate, List.of("evt-B"));
+    }
+
+    @Test
+    @DisplayName(
+        "Idempotent author reusing the SAME event still collapses onto the pending twin (the storm"
+            + " guard is unchanged for a genuine replay)")
+    void given_sameInjectSameEvent_should_collapseOntoPendingTwin() throws ChainingException {
+      Workflow wf = mock(Workflow.class);
+      when(wf.getId()).thenReturn("wf-1");
+      Step existing = mock(Step.class);
+      when(existing.getId()).thenReturn("existing-1");
+      when(existing.getStepAction()).thenReturn(StepActionClass.INJECT_EXECUTION);
+      when(existing.getData()).thenReturn("DATA");
+      Condition eventA = Condition.builder().id("evt-A").type(ConditionType.AND).build();
+      when(conditionService.findAllConditionsByStepId("existing-1")).thenReturn(List.of(eventA));
+      doReturn(List.of(existing)).when(stepService).findAllStepTemplateByWorkflow("wf-1");
+      // Still pending (no run step yet), so the storm guard may collapse.
+      when(stepRepository.existsByStepTemplateId("existing-1")).thenReturn(false);
+
+      StepsCreateInput.StepInput stepInput = mock(StepsCreateInput.StepInput.class);
+      when(stepInput.getStepAction()).thenReturn(StepActionClass.INJECT_EXECUTION);
+      when(stepInput.getConditionIds()).thenReturn(List.of("evt-A"));
+      Step candidate = mock(Step.class);
+      when(candidate.getData()).thenReturn("DATA");
+      doReturn(actionStep).when(stepService).factoryAction(StepActionClass.INJECT_EXECUTION, null);
+      when(actionStep.create(stepInput, wf)).thenReturn(Optional.of(candidate));
+
+      // Act
+      Step result = stepService.createInjectStepTemplateIdempotent(wf, stepInput, null);
+
+      // Assert - same inject + same parent + SAME event + still pending -> reuse the pending twin.
+      assertSame(existing, result);
+      verify(stepRepository, never()).save(candidate);
+      verify(conditionService, never()).linkExistingConditionsToStep(eq(candidate), any());
+    }
+
+    @Test
     void given_existingStep_should_updateStepTemplate_andRebuildConditions()
         throws ChainingException {
       // Arrange

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import io.openaev.api.chaining.dto.ConditionCreateInput;
 import io.openaev.api.chaining.dto.ScopeVariableInput;
 import io.openaev.api.chaining.dto.WorkflowConfigurationInput;
 import io.openaev.api.chaining.dto.WorkflowScopeRuleInput;
@@ -13,6 +14,7 @@ import io.openaev.database.model.*;
 import io.openaev.database.repository.ScopeVariableRepository;
 import io.openaev.database.repository.WorkflowRepository;
 import io.openaev.database.repository.WorkflowScopeRuleRepository;
+import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.exception.WorkflowNotEditableException;
 import io.openaev.telemetry.metric_collectors.ChainingSafetyPolicyMetricCollector;
@@ -2337,6 +2339,230 @@ class WorkflowServiceTest {
 
       // Assert
       verifyNoInteractions(workflowRepository);
+    }
+  }
+
+  // ========================================================================
+  // Event reuse: validate / resolve an existing event root (#7481)
+  // ========================================================================
+  @Nested
+  @DisplayName("event reuse - validation, root resolution, subtree copy")
+  class EventReuseTests {
+
+    private static final String SIMULATION_ID = "sim-1";
+    private static final String SCENARIO_ID = "scenario-1";
+    private static final String RUN_WORKFLOW_ID = "wf-run";
+
+    private Condition condition(
+        String id, ConditionType type, Condition parent, String workflowId) {
+      return Condition.builder()
+          .id(id)
+          .type(type)
+          .conditionParent(parent)
+          .workflowId(workflowId)
+          .build();
+    }
+
+    private void stubSimulationTemplate() {
+      Workflow template =
+          Workflow.builder().id(RUN_WORKFLOW_ID).status(WorkflowStatus.TEMPLATE).build();
+      when(workflowRepository.findBySimulation_IdAndStatus(SIMULATION_ID, WorkflowStatus.TEMPLATE))
+          .thenReturn(template);
+    }
+
+    @Test
+    @DisplayName("accepts an AND/OR event root that lives on the run's own simulation workflow")
+    void given_anEventRootOnTheRunWorkflow_when_validating_then_itPasses() {
+      stubSimulationTemplate();
+      when(conditionService.findConditionByIdOrNull("evt"))
+          .thenReturn(condition("evt", ConditionType.AND, null, RUN_WORKFLOW_ID));
+
+      assertDoesNotThrow(
+          () -> workflowService.assertEventRootOnSimulationWorkflow(SIMULATION_ID, "evt"));
+    }
+
+    @Test
+    @DisplayName("rejects an unknown event_id with a precise 'does not exist' message")
+    void given_anUnknownEventId_when_validating_then_itThrows() {
+      stubSimulationTemplate();
+      when(conditionService.findConditionByIdOrNull("nope")).thenReturn(null);
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () -> workflowService.assertEventRootOnSimulationWorkflow(SIMULATION_ID, "nope"));
+      assertTrue(ex.getMessage().contains("does not exist"));
+    }
+
+    @Test
+    @DisplayName("rejects a child condition id (not a root) with a precise message")
+    void given_aChildConditionId_when_validating_then_itThrows() {
+      stubSimulationTemplate();
+      Condition root = condition("evt", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      when(conditionService.findConditionByIdOrNull("leaf"))
+          .thenReturn(condition("leaf", ConditionType.EQ, root, RUN_WORKFLOW_ID));
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () -> workflowService.assertEventRootOnSimulationWorkflow(SIMULATION_ID, "leaf"));
+      assertTrue(ex.getMessage().contains("not an event root"));
+    }
+
+    @Test
+    @DisplayName("rejects a non-AND/OR root (e.g. a DEPEND_ON) as not a finding EVENT")
+    void given_aNonEventRoot_when_validating_then_itThrows() {
+      stubSimulationTemplate();
+      when(conditionService.findConditionByIdOrNull("dep"))
+          .thenReturn(condition("dep", ConditionType.DEPEND_ON, null, RUN_WORKFLOW_ID));
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () -> workflowService.assertEventRootOnSimulationWorkflow(SIMULATION_ID, "dep"));
+      assertTrue(ex.getMessage().contains("not a finding EVENT"));
+    }
+
+    @Test
+    @DisplayName(
+        "rejects an event root that belongs to a DIFFERENT workflow (cross-workflow / cross-run"
+            + " isolation)")
+    void given_anEventRootOnAnotherWorkflow_when_validating_then_itThrows() {
+      stubSimulationTemplate();
+      // A real AND/OR root, but authored on some other run's workflow - reuse must be pinned to the
+      // caller's own workflow, never leak across runs/tenants.
+      when(conditionService.findConditionByIdOrNull("foreign-evt"))
+          .thenReturn(condition("foreign-evt", ConditionType.AND, null, "wf-some-other-run"));
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () ->
+                  workflowService.assertEventRootOnSimulationWorkflow(
+                      SIMULATION_ID, "foreign-evt"));
+      assertTrue(ex.getMessage().contains("belongs to a different workflow"));
+    }
+
+    @Test
+    @DisplayName("rejects reuse when the run has no simulation template workflow")
+    void given_noSimulationTemplate_when_validating_then_itThrows() {
+      when(workflowRepository.findBySimulation_IdAndStatus(SIMULATION_ID, WorkflowStatus.TEMPLATE))
+          .thenReturn(null);
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () -> workflowService.assertEventRootOnSimulationWorkflow(SIMULATION_ID, "evt"));
+      assertTrue(ex.getMessage().contains("Workflow (TEMPLATE) not found"));
+    }
+
+    @Test
+    @DisplayName("author-scenario mode validates the event root on the SCENARIO workflow")
+    void given_anEventRootOnTheScenarioWorkflow_when_validating_then_itPasses() {
+      Workflow template =
+          Workflow.builder().id(RUN_WORKFLOW_ID).status(WorkflowStatus.TEMPLATE).build();
+      when(workflowRepository.findByScenario_IdAndStatus(SCENARIO_ID, WorkflowStatus.TEMPLATE))
+          .thenReturn(List.of(template));
+      when(conditionService.findConditionByIdOrNull("evt"))
+          .thenReturn(condition("evt", ConditionType.OR, null, RUN_WORKFLOW_ID));
+
+      assertDoesNotThrow(
+          () -> workflowService.assertEventRootOnScenarioWorkflow(SCENARIO_ID, "evt"));
+    }
+
+    @Test
+    @DisplayName(
+        "author-scenario mode rejects an event root from a different workflow (cross-workflow"
+            + " isolation)")
+    void given_aForeignEventRoot_when_validatingScenario_then_itThrows() {
+      Workflow template =
+          Workflow.builder().id(RUN_WORKFLOW_ID).status(WorkflowStatus.TEMPLATE).build();
+      when(workflowRepository.findByScenario_IdAndStatus(SCENARIO_ID, WorkflowStatus.TEMPLATE))
+          .thenReturn(List.of(template));
+      when(conditionService.findConditionByIdOrNull("foreign-evt"))
+          .thenReturn(condition("foreign-evt", ConditionType.AND, null, "wf-some-other-run"));
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () -> workflowService.assertEventRootOnScenarioWorkflow(SCENARIO_ID, "foreign-evt"));
+      assertTrue(ex.getMessage().contains("belongs to a different workflow"));
+    }
+
+    @Test
+    @DisplayName("findStepTriggerEventRootId returns the AND/OR ROOT, never a nested child group")
+    void given_aNestedEventTree_when_findingTheRootId_then_theRootWins() {
+      Condition root = condition("evt-root", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      Condition nestedGroup = condition("grp-child", ConditionType.OR, root, RUN_WORKFLOW_ID);
+      Condition leaf = condition("leaf", ConditionType.EQ, nestedGroup, RUN_WORKFLOW_ID);
+      // Deliberately return the nested group FIRST so a type-only filter would pick the wrong id.
+      when(conditionService.findAllConditionsByStepId("step"))
+          .thenReturn(List.of(nestedGroup, root, leaf));
+
+      assertEquals("evt-root", workflowService.findStepTriggerEventRootId("step"));
+    }
+
+    @Test
+    @DisplayName("findStepTriggerEventRootId returns null when the step has no finding event")
+    void given_aStepWithoutAnEvent_when_findingTheRootId_then_itIsNull() {
+      Condition dependOn = condition("dep", ConditionType.DEPEND_ON, null, RUN_WORKFLOW_ID);
+      Condition mapper = condition("map", ConditionType.MAPPER, null, RUN_WORKFLOW_ID);
+      when(conditionService.findAllConditionsByStepId("step"))
+          .thenReturn(List.of(dependOn, mapper));
+
+      assertNull(workflowService.findStepTriggerEventRootId("step"));
+    }
+
+    @Test
+    @DisplayName("resolveEventRootAsInputs copies the FULL subtree including nested groups")
+    void given_aNestedEvent_when_resolvingInputs_then_grandchildrenArePreserved() {
+      Condition root = condition("r", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      root.setName("SMB service exposed");
+      Condition directLeaf = condition("d", ConditionType.IS_NOT_NULL, root, RUN_WORKFLOW_ID);
+      directLeaf.setKeyTypes(List.of(PrimitiveType.Host));
+      Condition nestedGroup = condition("c", ConditionType.OR, root, RUN_WORKFLOW_ID);
+      Condition grandLeaf = condition("g", ConditionType.EQ, nestedGroup, RUN_WORKFLOW_ID);
+      grandLeaf.setKeyTypes(List.of(PrimitiveType.Port));
+      grandLeaf.setValue("445");
+
+      when(conditionService.findConditionByIdOrNull("r")).thenReturn(root);
+      when(conditionService.findAllNonMapperConditionsByWorkflowId(RUN_WORKFLOW_ID))
+          .thenReturn(List.of(root, directLeaf, nestedGroup, grandLeaf));
+
+      List<ConditionCreateInput> inputs = workflowService.resolveEventRootAsInputs("r");
+
+      // root + direct leaf + nested group + grandchild leaf = 4 nodes, none dropped.
+      assertEquals(4, inputs.size());
+
+      ConditionCreateInput rootInput =
+          inputs.stream()
+              .filter(i -> i.getTemporaryIdConditionParent() == null)
+              .findFirst()
+              .orElseThrow();
+      assertEquals(ConditionType.AND, rootInput.getType());
+      assertEquals("SMB service exposed", rootInput.getName());
+
+      // The nested OR group re-parents onto the copied root...
+      ConditionCreateInput groupInput =
+          inputs.stream().filter(i -> i.getType() == ConditionType.OR).findFirst().orElseThrow();
+      assertEquals(rootInput.getTemporaryId(), groupInput.getTemporaryIdConditionParent());
+
+      // ...and the grandchild leaf re-parents onto the copied group (depth > 1 preserved).
+      ConditionCreateInput grandInput =
+          inputs.stream().filter(i -> i.getType() == ConditionType.EQ).findFirst().orElseThrow();
+      assertEquals(groupInput.getTemporaryId(), grandInput.getTemporaryIdConditionParent());
+      assertEquals(List.of(PrimitiveType.Port), grandInput.getKeyTypes());
+      assertEquals("445", grandInput.getValue());
+    }
+
+    @Test
+    @DisplayName("resolveEventRootAsInputs returns empty when the id is not a resolvable root")
+    void given_aNonRoot_when_resolvingInputs_then_itIsEmpty() {
+      Condition root = condition("r", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      when(conditionService.findConditionByIdOrNull("leaf"))
+          .thenReturn(condition("leaf", ConditionType.EQ, root, RUN_WORKFLOW_ID));
+
+      assertTrue(workflowService.resolveEventRootAsInputs("leaf").isEmpty());
     }
   }
 }

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -1293,6 +1293,8 @@ export interface AutonomousAttackPathStepResult {
 
 /** Live state of one authored attack-path step */
 export interface AutonomousAttackPathStepState {
+  /** Stable id of the finding EVENT this step fires on (the trigger root), or null for a seed / standalone / pure DEPEND_ON step that has no event. Pass it back as a trigger's event_id when authoring another step to attach that step to the SAME event instead of duplicating it - this is how several actions share one event (e.g. one "SMB service exposed" event feeding many follow-on actions). */
+  event_id?: string;
   /** Human-readable name of the finding EVENT this step reacts to (the trigger root's name, e.g. "SMB service exposed"), or null when the step has no finding trigger (a seed or a pure DEPEND_ON step). Mirror of the trigger's event_name on the write side. */
   event_name?: string;
   /** Id of the inject backing this step (empty until the step has executed) */
@@ -1691,6 +1693,8 @@ export interface AutonomousStatusUpdateInput {
 
 /** A finding-driven trigger: react to findings and consume their values */
 export interface AutonomousStepTrigger {
+  /** OPTIONAL. Id of an EXISTING event (a finding-trigger root already on this run's workflow) to attach this step to, instead of minting a new event. Read it from another step's event_id in the attack-path state, then pass it here so several actions fire off the SAME event (e.g. one "SMB service exposed" event feeding many follow-on actions) rather than duplicating it. When set, event_name / match / filters are IGNORED (the event already exists and is not re-described); only mappings still apply, binding this step's inject inputs from that event's finding values. Leave it null to create a new event from the filters, or omit the whole trigger entirely for an event-less seed or standalone action. It is never required: linking to an existing event is a choice, not an obligation. */
+  event_id?: string;
   /** Short, human-readable name for the EVENT this trigger represents - the discovery it fires on, phrased as an operator would read it (e.g. "SMB service exposed", "Valid credentials found", "Open web port discovered"). It becomes the event node's title in the Logic graph. When omitted, a readable name is derived from the filters so the event is never shown as "Untitled event". */
   event_name?: string;
   /** The predicates that make this step fire. Empty means: fire as soon as any of the mapped key_types is present in the finding pool. */

--- a/openaev-model/src/main/java/io/openaev/database/model/autonomous/AutonomousRun.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/autonomous/AutonomousRun.java
@@ -150,6 +150,18 @@ public class AutonomousRun implements TenantBase {
   @Column(name = "autonomous_run_step_mirror")
   private Map<String, String> stepMirror = new HashMap<>();
 
+  // Internal bookkeeping: maps each finding-EVENT root condition id authored on the SIMULATION
+  // workflow to its twin event root id mirrored onto the SCENARIO workflow. The orchestrator only
+  // ever knows simulation event ids (those are what the attack-path state surfaces as event_id), so
+  // when it authors a step that REUSES an existing simulation event, this lets the mirror reattach
+  // the scenario twin to the SAME scenario event - keeping the exported scenario's events shared
+  // instead of duplicated, exactly like the live simulation side. Never exposed to the API or the
+  // orchestrator.
+  @JsonIgnore
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "autonomous_run_event_mirror")
+  private Map<String, String> eventMirror = new HashMap<>();
+
   @Column(name = "autonomous_run_xtm_session_id")
   @JsonProperty("autonomous_run_xtm_session_id")
   @Schema(description = "XTM One orchestrator session id for streaming reconnection")


### PR DESCRIPTION
## Summary

- Adds an OPTIONAL `event_id` to the autonomous attack-path step trigger so a step can attach to an EXISTING finding-event root on the run's workflow instead of always minting a new event. This is what caused duplicate events when several actions fired on the same finding. No automatic backend de-duplication - reuse is opt-in and manual duplication stays a valid choice.
- Exposes each step's `event_id` on the attack-path state output so the orchestrator can discover and reuse existing events.
- `WorkflowService` append/update overloads link a step to an existing event condition root, validated to belong to the run's own workflow and to be a real AND/OR event root (400 otherwise), plus helpers to resolve an event subtree for mirroring.
- Live mode: a new sim -> scenario event mirror map on `AutonomousRun` (jsonb column, migration `V6_20260817120000000`) keeps a reused event shared on the exported scenario twin instead of duplicating it.
- `StepService` preserves reused event roots (and their whole subtree) when rebuilding a step's conditions on update.
- `event_id` is always optional: omit it for a fresh event, or omit the trigger entirely for an event-less seed / standalone action.

## Review fixes (this PR)

- Regenerated `openaev-front/src/utils/api-types.d.ts` for the two new `event_id` fields - the API Types Check was red because the DTO change was not reflected in the generated types.
- Hardened both event-root resolvers - `triggerRoot` (the state read that surfaces `event_id`) and `findStepTriggerEventRootId` (the mirror) - to filter on root-ness (`conditionParent == null`), not just the AND/OR type, so a linked leaf or a nested AND/OR group can never be exposed as `event_id` and then rejected on reuse.
- Made `resolveEventRootAsInputs` copy the WHOLE event subtree (breadth-first, re-parenting by temporary id) instead of only the root's direct children, so a nested condition group is never dropped from the scenario mirror fallback. Mirrors the existing `copyStepConditionTemplate` walk.
- Fixed the scenario mirror to record the sim -> scenario event twin even when a reuse takes the fallback COPY path (both the append and update mirrors), so a later step reusing an un-mirrored event links the one recreated twin instead of duplicating it again.
- Folded the reused-event linkage into the step idempotency identity: `createInjectStepTemplateIdempotent` now only collapses a reuse call onto a pending twin already linked to exactly that event, so authoring the same inject/parent under a DIFFERENT event no longer silently ignores the requested `event_id` (nor mis-twins the mirror). A fresh-event / no-event author keeps the historical data + parent identity, so the duplicate-storm guard is unchanged.
- Corrected the `findConditionByIdOrNull` javadoc to match its behavior (returns the condition regardless of position in the tree; null only when missing).

## Behavioral notes

- Subtree depth: autonomous events built by `toTriggerConditions` are flat (one AND/OR root + leaf filters); the recursive copy and the root-ness guards harden the reuse and mirror paths against manually authored or future nested trees.
- Cross-workflow / tenant isolation: a reused `event_id` is pinned to the run's OWN simulation (live) or scenario (plan) template workflow by comparing workflow ids, so an event from another run or tenant is rejected with a precise 400 - now covered by tests.
- Shared-root lifecycle: reusing a step links only the event ROOT, so deleting a reusing step never removes the shared root (it survives while any step still links it), and the update rebuild preserves the reused root and its whole subtree.

## Test plan

- [x] `AutonomousRunServiceScopeTest` - 16 tests (live reuse + mirror sharing, no-event-id fresh mint, plan-run scenario reuse, live update reuse, invalid event_id -> 400, and reuse-with-no-mirror recreates the scenario event once AND records the fallback twin so later reuses share it).
- [x] `WorkflowServiceTest` - new event-reuse suite: validation (missing / child / wrong-type / cross-workflow rejection, valid simulation and scenario roots), the `findStepTriggerEventRootId` root-ness guard, and the recursive `resolveEventRootAsInputs` subtree copy.
- [x] `StepServiceIntegrationTest` - the preserved-condition update now also asserts the step stays LINKED to its preserved event root, proving the reuse / DEPEND_ON preservation never orphans the link.
- [x] `StepServiceTest` - reusing a DIFFERENT event mints a new step linked to the requested event (no collapse); reusing the SAME event still collapses onto the pending twin (storm guard unchanged).
- [x] `spotless:apply` + targeted `mvn -pl openaev-api test` - BUILD SUCCESS
- [x] CI green

Paired with the XTM-One orchestrator change (XTM-One #2939) that teaches the tooling and persona to use `event_id`.

Closes #7481
