### PR TITLE
fix(autonomous): validate reused event roots at the append and update service boundaries (#7483)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -1730,6 +1730,12 @@ public class WorkflowService {
                 () ->
                     new ElementNotFoundException(
                         "Workflow (TEMPLATE) not found. Simulation ID: " + simulationId));
+    // Defence in depth: the link channel below (stepInput.conditionIds -> findConditionRootById)
+    // only checks root-ness, so enforce the FULL event invariant at this service boundary - each
+    // reused id must be an AND/OR finding-event root on THIS simulation's own workflow - instead of
+    // trusting the caller's earlier validation. A no-op for the validated autonomous caller; it
+    // closes the boundary against a cross-workflow or non-event link from any other caller.
+    assertEventRootsOnWorkflow(simulationTemplate.getId(), existingEventConditionIds);
 
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
@@ -1895,6 +1901,12 @@ public class WorkflowService {
                 () ->
                     new ElementNotFoundException(
                         "Workflow (TEMPLATE) not found. Scenario ID: " + scenarioId));
+    // Defence in depth (same as doAppendChainedStep): validate each reused id is an AND/OR
+    // finding-event root on THIS scenario's own workflow before linking, so the isolated mirror
+    // path - which links a recorded eventMirror twin without re-validating - can never cross-link
+    // workflows on a stale or incorrect entry. A no-op for a valid twin; a stale entry throws and
+    // is swallowed by the best-effort mirror exactly like a missing id already was.
+    assertEventRootsOnWorkflow(scenarioTemplate.getId(), existingEventConditionIds);
 
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
@@ -1967,6 +1979,25 @@ public class WorkflowService {
                     new ChainingException(
                         "Workflow (TEMPLATE) not found. Scenario ID: " + scenarioId));
     assertEventRootOnWorkflow(template.getId(), eventId);
+  }
+
+  /**
+   * Validates every non-blank id in {@code eventConditionIds} is an AND/OR finding-event root on
+   * {@code workflowId}. The service-boundary guard for the reused-event link channel (which itself
+   * only checks root-ness): callers pass the reused ids straight to {@code
+   * stepInput.setConditionIds}, so this is what keeps a cross-workflow or non-event id from being
+   * linked. No-op for a null/empty list.
+   */
+  private void assertEventRootsOnWorkflow(String workflowId, List<String> eventConditionIds)
+      throws ChainingException {
+    if (eventConditionIds == null) {
+      return;
+    }
+    for (String eventConditionId : eventConditionIds) {
+      if (hasText(eventConditionId)) {
+        assertEventRootOnWorkflow(workflowId, eventConditionId);
+      }
+    }
   }
 
   private void assertEventRootOnWorkflow(String workflowId, String eventId)

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -2453,14 +2453,27 @@ public class WorkflowService {
   // Existing-event variant of the update body: in addition to rebuilding the trigger it can LINK
   // the step to EXISTING event roots by id ({@code existingEventConditionIds}), so a corrected step
   // attaches to an event that already exists instead of duplicating it - the update-side twin of
-  // doAppendChainedStep's condition_ids channel. The step service preserves those roots (subtree
-  // included) across the condition rebuild so a shared event is never dropped, then links them.
+  // doAppendChainedStep's condition_ids channel. Reused ids are validated at this service boundary
+  // exactly like the append paths. The step service preserves those roots (subtree included)
+  // across the condition rebuild so a shared event is never dropped, then links them.
   private void doUpdateChainedStep(
       String stepTemplateId,
       InjectInput injectInput,
       List<ConditionCreateInput> triggerConditions,
       List<String> existingEventConditionIds)
       throws ChainingException {
+    // Defence in depth (same boundary as the append paths): the link channel below only checks
+    // root-ness, so validate every reused id is an AND/OR finding-event root on the step's OWN
+    // workflow before the rebuild links it. Resolved lazily - the step lookup only happens when a
+    // reused id is actually present, so the common no-reuse update pays nothing. A no-op for the
+    // validated autonomous caller; a stale scenario-mirror twin id throws and is swallowed by the
+    // best-effort mirror exactly like on the append side.
+    if (existingEventConditionIds != null
+        && existingEventConditionIds.stream().anyMatch(id -> hasText(id))) {
+      Workflow stepWorkflow = stepService.findStepTemplateById(stepTemplateId).getWorkflow();
+      assertEventRootsOnWorkflow(
+          stepWorkflow == null ? null : stepWorkflow.getId(), existingEventConditionIds);
+    }
     StepsCreateInput.StepInput stepInput =
         InjectExecutionStep.getInjectAsStepsCreateInput(injectInput);
     if (existingEventConditionIds != null && !existingEventConditionIds.isEmpty()) {

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -2588,5 +2588,74 @@ class WorkflowServiceTest {
       // Rejected at the boundary: the step-service link is never reached.
       verifyNoInteractions(stepService);
     }
+
+    @Test
+    @DisplayName(
+        "appendChainedStep rejects a reused event root from a DIFFERENT workflow at the service"
+            + " boundary, before any step is linked")
+    void given_aForeignReusedRoot_when_appending_then_itThrowsBeforeLinking() {
+      stubSimulationTemplate();
+      // A real AND/OR event root, but authored on some other run's workflow - the boundary must
+      // pin reuse to the caller's own workflow, never allow a silent cross-run link.
+      when(conditionService.findConditionByIdOrNull("foreign-evt"))
+          .thenReturn(condition("foreign-evt", ConditionType.AND, null, "wf-some-other-run"));
+
+      ChainingException ex =
+          assertThrows(
+              ChainingException.class,
+              () ->
+                  workflowService.appendChainedStep(
+                      SIMULATION_ID, new InjectInput(), null, List.of(), List.of("foreign-evt")));
+      assertTrue(ex.getMessage().contains("belongs to a different workflow"));
+      verifyNoInteractions(stepService);
+    }
+
+    @Test
+    @DisplayName(
+        "appendChainedStepToScenarioIsolated rejects a reused id that is not an event root on the"
+            + " scenario workflow at the service boundary, before any step is linked")
+    void given_aNonRootReusedId_when_appendingToScenarioIsolated_then_itThrowsBeforeLinking() {
+      Workflow template =
+          Workflow.builder().id(RUN_WORKFLOW_ID).status(WorkflowStatus.TEMPLATE).build();
+      when(workflowRepository.findByScenario_IdAndStatus(SCENARIO_ID, WorkflowStatus.TEMPLATE))
+          .thenReturn(List.of(template));
+      // The mirror-recorded twin id resolves to a CHILD condition (a leaf), not an event root.
+      Condition root = condition("evt", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      when(conditionService.findConditionByIdOrNull("leaf"))
+          .thenReturn(condition("leaf", ConditionType.EQ, root, RUN_WORKFLOW_ID));
+
+      assertThrows(
+          ChainingException.class,
+          () ->
+              workflowService.appendChainedStepToScenarioIsolated(
+                  SCENARIO_ID, new InjectInput(), null, List.of(), List.of("leaf")));
+      // Rejected at the boundary: the scenario mirror's step-service link is never reached.
+      verifyNoInteractions(stepService);
+    }
+
+    @Test
+    @DisplayName(
+        "updateChainedStep rejects a reused id that is not an event root on the step's own"
+            + " workflow at the service boundary, before the step is rebuilt")
+    void given_aNonRootReusedId_when_updating_then_itThrowsBeforeRebuilding()
+        throws ChainingException {
+      Workflow template =
+          Workflow.builder().id(RUN_WORKFLOW_ID).status(WorkflowStatus.TEMPLATE).build();
+      when(stepService.findStepTemplateById("step-1"))
+          .thenReturn(Step.builder().id("step-1").workflow(template).build());
+      Condition root = condition("evt", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      when(conditionService.findConditionByIdOrNull("leaf"))
+          .thenReturn(condition("leaf", ConditionType.EQ, root, RUN_WORKFLOW_ID));
+
+      assertThrows(
+          ChainingException.class,
+          () ->
+              workflowService.updateChainedStep(
+                  "step-1", new InjectInput(), List.of(), List.of("leaf")));
+      // Rejected at the boundary: neither update flavour is ever reached (the isolated overload
+      // shares this exact body).
+      verify(stepService, never()).updateInjectStepTemplateData(any(), any());
+      verify(stepService, never()).updateInjectStepTemplateDataAndTrigger(any(), any(), any());
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/WorkflowServiceTest.java
@@ -17,6 +17,7 @@ import io.openaev.database.repository.WorkflowScopeRuleRepository;
 import io.openaev.rest.exception.ChainingException;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.rest.exception.WorkflowNotEditableException;
+import io.openaev.rest.inject.form.InjectInput;
 import io.openaev.telemetry.metric_collectors.ChainingSafetyPolicyMetricCollector;
 import io.openaev.telemetry.metric_collectors.ResultsMetricCollector;
 import io.openaev.telemetry.metric_collectors.ScopeMetricCollector;
@@ -2563,6 +2564,29 @@ class WorkflowServiceTest {
           .thenReturn(condition("leaf", ConditionType.EQ, root, RUN_WORKFLOW_ID));
 
       assertTrue(workflowService.resolveEventRootAsInputs("leaf").isEmpty());
+    }
+
+    @Test
+    @DisplayName(
+        "appendChainedStep rejects a reused id that is not an event root on the sim workflow at the"
+            + " service boundary, before any step is linked")
+    void given_aNonRootReusedId_when_appending_then_itThrowsBeforeLinking() {
+      Workflow template =
+          Workflow.builder().id(RUN_WORKFLOW_ID).status(WorkflowStatus.TEMPLATE).build();
+      when(workflowRepository.findBySimulation_IdAndStatus(SIMULATION_ID, WorkflowStatus.TEMPLATE))
+          .thenReturn(template);
+      // The caller-supplied reused id resolves to a CHILD condition (a leaf), not an event root.
+      Condition root = condition("evt", ConditionType.AND, null, RUN_WORKFLOW_ID);
+      when(conditionService.findConditionByIdOrNull("leaf"))
+          .thenReturn(condition("leaf", ConditionType.EQ, root, RUN_WORKFLOW_ID));
+
+      assertThrows(
+          ChainingException.class,
+          () ->
+              workflowService.appendChainedStep(
+                  SIMULATION_ID, new InjectInput(), null, List.of(), List.of("leaf")));
+      // Rejected at the boundary: the step-service link is never reached.
+      verifyNoInteractions(stepService);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Recovers a hardening commit that was pushed to the #7481 / #7482 PR branch (`feat/autonomous-event-reuse`, `a7c3ecf46`) AFTER its squash-merge and therefore never landed on `main`, and extends it to the update channel found during review.
- `WorkflowService`: before linking reused event condition ids (`stepInput.conditionIds`), assert every non-blank id is an AND/OR finding-event root on the step's own workflow - on the simulation append path (`doAppendChainedStep`), the scenario append path (`doAppendChainedStepToScenario`, shared by the author-scenario overloads and the isolated REQUIRES_NEW mirror variants), and - added in review - the update path (`doUpdateChainedStep`), which linked reused ids through the same root-ness-only link channel (`linkExistingConditionsToStep` -> `findConditionRootById`). The link channel only checks existence + root-ness, so this enforces the full event invariant (root-ness AND AND/OR type AND same-workflow) at the service boundary.
- New `assertEventRootsOnWorkflow(workflowId, ids)` helper (no-op for null/empty). On the update side the step lookup is lazy - it only happens when a reused id is actually present, so the common no-reuse update pays nothing.
- Defence in depth only, no behaviour change for existing flows. Caller inventory: `AutonomousRunService` is the ONLY production caller reaching these boundaries with non-empty ids (no REST controller, importer, or copy flow does), and every site either pre-validates upstream (`assertEventRootOnSimulationWorkflow` / `assertEventRootOnScenarioWorkflow`) or passes mirror-recorded twin ids, where a stale entry now throws and is swallowed by the best-effort mirror exactly like a missing id already was. The manual UI's `condition_ids` channel goes through `StepApi` -> `StepService` directly and is a generic condition-root linking channel (not event reuse), so it is intentionally untouched.

Closes #7483

## Test plan

- [x] `WorkflowServiceTest` - 92 tests green, incl. 4 boundary tests: the simulation append path rejects a non-root reused id, the simulation append path rejects a cross-workflow event root, the isolated scenario-mirror append path rejects a non-root reused id, and the update path rejects a non-root reused id before any rebuild (missing-id and non-event-type rejections were already covered via the singular assert tests from #7482)
- [x] `spotless:check` clean
- [x] CI green
