### PR TITLE
feat(audit-logging): UI improvement for capability triad visibility and restrictions (#7199)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/capabilities/CapabilityApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/capabilities/CapabilityApi.java
@@ -1,11 +1,14 @@
 package io.openaev.api.capabilities;
 
 import io.openaev.database.model.CapabilityScope;
+import io.openaev.database.model.User;
 import io.openaev.rest.settings.PreviewFeature;
 import io.openaev.service.PreviewFeatureService;
+import io.openaev.service.UserService;
+import io.openaev.service.account.PrivilegeEscalationValidator;
 import io.swagger.v3.oas.annotations.Operation;
-import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CapabilityApi {
 
   private final PreviewFeatureService previewFeatureService;
+  private final UserService userService;
 
   @Operation(
       summary = "Get the capability tree",
@@ -34,6 +38,40 @@ public class CapabilityApi {
     boolean credentialAssetEnabled =
         previewFeatureService.isFeatureEnabled(PreviewFeature.CREDENTIAL_ASSET);
     List<CapabilityOutput> tree = CapabilityTreeBuilder.buildTree(scope, credentialAssetEnabled);
-    return ResponseEntity.ok().cacheControl(CacheControl.maxAge(Duration.ofDays(1))).body(tree);
+    User currentUser = userService.currentUser();
+    Set<CapabilityScope> effectiveScopes =
+        scope == null ? Set.of(CapabilityScope.PLATFORM, CapabilityScope.TENANT) : Set.of(scope);
+    List<CapabilityOutput> treeWithUserFlags =
+        tree.stream().map(node -> withUserCanHave(node, currentUser, effectiveScopes)).toList();
+    return ResponseEntity.ok().cacheControl(CacheControl.noStore()).body(treeWithUserFlags);
+  }
+
+  private CapabilityOutput withUserCanHave(
+      CapabilityOutput node, User currentUser, Set<CapabilityScope> effectiveScopes) {
+    boolean userCanHave = computeUserCanHave(node, currentUser, effectiveScopes);
+    List<CapabilityOutput> children =
+        node.children().stream()
+            .map(child -> withUserCanHave(child, currentUser, effectiveScopes))
+            .toList();
+    return new CapabilityOutput(
+        node.value(), node.checkable(), userCanHave, node.scopes(), children);
+  }
+
+  private boolean computeUserCanHave(
+      CapabilityOutput node, User currentUser, Set<CapabilityScope> effectiveScopes) {
+    if (!node.checkable()) {
+      return false;
+    }
+    io.openaev.database.model.Capability capability;
+    try {
+      capability = io.openaev.database.model.Capability.valueOf(node.value());
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+    return effectiveScopes.stream()
+        .filter(capability.getScopes()::contains)
+        .anyMatch(
+            scope ->
+                PrivilegeEscalationValidator.canAssignCapability(currentUser, capability, scope));
   }
 }

--- a/openaev-api/src/main/java/io/openaev/api/capabilities/CapabilityMapper.java
+++ b/openaev-api/src/main/java/io/openaev/api/capabilities/CapabilityMapper.java
@@ -13,12 +13,12 @@ public class CapabilityMapper {
 
   public static CapabilityOutput toOutput(Capability capability, List<CapabilityOutput> children) {
     return new CapabilityOutput(
-        capability.name(), capability.isCheckable(), scopeNames(capability), children);
+        capability.name(), capability.isCheckable(), false, scopeNames(capability), children);
   }
 
   public static CapabilityOutput toOutput(
       CapabilityGroup capability, List<Capability> groupRoots, List<CapabilityOutput> children) {
-    return new CapabilityOutput(capability.name(), false, scopeNames(groupRoots), children);
+    return new CapabilityOutput(capability.name(), false, false, scopeNames(groupRoots), children);
   }
 
   private static Set<String> scopeNames(Capability cap) {

--- a/openaev-api/src/main/java/io/openaev/api/capabilities/CapabilityOutput.java
+++ b/openaev-api/src/main/java/io/openaev/api/capabilities/CapabilityOutput.java
@@ -17,6 +17,12 @@ public record CapabilityOutput(
         @Schema(description = "Whether this capability can be assigned to a role")
         @NotNull
         boolean checkable,
+    @JsonProperty("capability_user_can_have")
+        @Schema(
+            description =
+                "Whether the current authenticated user is allowed to grant this capability")
+        @NotNull
+        boolean userCanHave,
     @JsonProperty("capability_scopes")
         @Schema(description = "Scopes where this capability applies (PLATFORM, TENANT)")
         @NotBlank

--- a/openaev-api/src/main/java/io/openaev/service/TenantRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/TenantRoleService.java
@@ -117,8 +117,13 @@ public class TenantRoleService {
       @NotBlank final String roleDescription,
       @NotNull final Set<Capability> capabilities) {
     Set<Capability> scopedCapabilities = Capability.filterForTenantRole(capabilities);
+    Role role = findByIdInTenant(roleId);
+    Set<Capability> currentScopedCapabilities =
+        Capability.filterForTenantRole(role.getCapabilities());
+    Set<Capability> capabilitiesToAuthorize = new HashSet<>(currentScopedCapabilities);
+    capabilitiesToAuthorize.addAll(scopedCapabilities);
     assertCanAssignCapabilities(
-        userService.currentUser(), scopedCapabilities, CapabilityScope.TENANT);
+        userService.currentUser(), capabilitiesToAuthorize, CapabilityScope.TENANT);
     ReservedKeyValidator.validateRoleId(roleId);
     return updateRoleInternal(
         roleId, roleName, roleDescription, scopedCapabilities, TenantContext.getCurrentTenant());

--- a/openaev-api/src/main/java/io/openaev/service/TenantRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/TenantRoleService.java
@@ -117,13 +117,8 @@ public class TenantRoleService {
       @NotBlank final String roleDescription,
       @NotNull final Set<Capability> capabilities) {
     Set<Capability> scopedCapabilities = Capability.filterForTenantRole(capabilities);
-    Role role = findByIdInTenant(roleId);
-    Set<Capability> currentScopedCapabilities =
-        Capability.filterForTenantRole(role.getCapabilities());
-    Set<Capability> capabilitiesToAuthorize = new HashSet<>(currentScopedCapabilities);
-    capabilitiesToAuthorize.addAll(scopedCapabilities);
     assertCanAssignCapabilities(
-        userService.currentUser(), capabilitiesToAuthorize, CapabilityScope.TENANT);
+        userService.currentUser(), scopedCapabilities, CapabilityScope.TENANT);
     ReservedKeyValidator.validateRoleId(roleId);
     return updateRoleInternal(
         roleId, roleName, roleDescription, scopedCapabilities, TenantContext.getCurrentTenant());

--- a/openaev-api/src/main/java/io/openaev/service/account/PrivilegeEscalationValidator.java
+++ b/openaev-api/src/main/java/io/openaev/service/account/PrivilegeEscalationValidator.java
@@ -42,6 +42,16 @@ public final class PrivilegeEscalationValidator {
     }
   }
 
+  public static boolean canAssignCapability(
+      @NotNull final User currentUser,
+      @NotNull final Capability capability,
+      @NotNull final CapabilityScope scope) {
+    if (currentUser.isAdmin() || currentUser.hasBypassIn(scope)) {
+      return true;
+    }
+    return currentUser.getCapabilities(scope).contains(capability);
+  }
+
   // -- GRANT --
 
   private static PrivilegeGrantException unheldGrant(

--- a/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
@@ -108,12 +108,6 @@ public class PlatformRoleService {
       @NotNull final Set<Capability> capabilities) {
     Set<Capability> scopedCapabilities = Capability.filterForPlatformRole(capabilities);
     Role role = findById(roleId);
-    Set<Capability> currentScopedCapabilities =
-        Capability.filterForPlatformRole(role.getCapabilities());
-    Set<Capability> capabilitiesToAuthorize = new HashSet<>(currentScopedCapabilities);
-    capabilitiesToAuthorize.addAll(scopedCapabilities);
-    assertCanAssignCapabilities(
-        userService.currentUser(), capabilitiesToAuthorize, CapabilityScope.PLATFORM);
     role.setName(name);
     role.setDescription(description);
     role.setCapabilities(scopedCapabilities);

--- a/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
+++ b/openaev-api/src/main/java/io/openaev/service/platform/roles/PlatformRoleService.java
@@ -14,6 +14,7 @@ import io.openaev.utils.pagination.SearchPaginationInput;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -106,9 +107,13 @@ public class PlatformRoleService {
       final String description,
       @NotNull final Set<Capability> capabilities) {
     Set<Capability> scopedCapabilities = Capability.filterForPlatformRole(capabilities);
-    assertCanAssignCapabilities(
-        userService.currentUser(), scopedCapabilities, CapabilityScope.PLATFORM);
     Role role = findById(roleId);
+    Set<Capability> currentScopedCapabilities =
+        Capability.filterForPlatformRole(role.getCapabilities());
+    Set<Capability> capabilitiesToAuthorize = new HashSet<>(currentScopedCapabilities);
+    capabilitiesToAuthorize.addAll(scopedCapabilities);
+    assertCanAssignCapabilities(
+        userService.currentUser(), capabilitiesToAuthorize, CapabilityScope.PLATFORM);
     role.setName(name);
     role.setDescription(description);
     role.setCapabilities(scopedCapabilities);

--- a/openaev-api/src/test/java/io/openaev/rest/role/PlatformRoleApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/role/PlatformRoleApiTest.java
@@ -305,7 +305,11 @@ public class PlatformRoleApiTest extends IntegrationTest {
   class Update {
 
     @Test
-    @WithMockUser(withCapabilities = {Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES})
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_PLATFORM_SETTINGS
+        })
     @DisplayName("Given MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES, should update a platform role")
     void given_managePlatform_should_updateRole() throws Exception {
       // -------- Arrange --------
@@ -340,7 +344,11 @@ public class PlatformRoleApiTest extends IntegrationTest {
     }
 
     @Test
-    @WithMockUser(withCapabilities = {Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES})
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_PLATFORM_USERS_GROUPS_AND_ROLES
+        })
     @DisplayName(
         "Given a platform role polluted with a tenant-only capability, update should drop it"
             + " instead of rejecting the payload")
@@ -432,6 +440,48 @@ public class PlatformRoleApiTest extends IntegrationTest {
                   .accept(MediaType.APPLICATION_JSON)
                   .with(csrf()))
           .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_PLATFORM_SETTINGS
+        })
+    @DisplayName(
+        "Given a platform role containing capabilities the caller does not hold, update should reject removing those unheld capabilities")
+    void given_updateRemovingUnheldCapabilities_should_beRejected() throws Exception {
+      // -------- Arrange --------
+      Role role =
+          platformRoleComposer
+              .forPlatformRole(
+                  PlatformRoleFixture.getPlatformRole(
+                      "EscalationGuard",
+                      Set.of(Capability.ACCESS_PLATFORM_SETTINGS, Capability.ACCESS_TENANTS)))
+              .persist()
+              .get();
+
+      PlatformRoleInput input =
+          new PlatformRoleInput(
+              "EscalationGuard", "desc", Set.of(Capability.ACCESS_PLATFORM_SETTINGS));
+
+      // -------- Act --------
+      String response =
+          mvc.perform(
+                  put(PLATFORM_ROLES_URI + "/" + role.getId())
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isBadRequest())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -------- Assert --------
+      assertEquals(UNHELD_CAPABILITIES, JsonPath.read(response, "$.message"));
+      List<String> refused = JsonPath.read(response, "$.errors.children.message.errors");
+      assertTrue(refused.contains(Capability.ACCESS_TENANTS.name()));
     }
   }
 

--- a/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
@@ -445,6 +445,46 @@ public class TenantRoleApiTest extends IntegrationTest {
                   .with(csrf()))
           .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_SETTINGS, Capability.ACCESS_ASSETS})
+    @DisplayName(
+        "Given a role containing capabilities the caller does not hold, update should reject removing those unheld capabilities")
+    void given_updateRemovingUnheldCapabilities_should_beRejected() throws Exception {
+      // -------- Arrange --------
+      Role role =
+          tenantRoleComposer
+              .forRole(
+                  TenantRoleFixture.getRole(
+                      "EscalationGuard",
+                      Set.of(Capability.ACCESS_ASSETS, Capability.ACCESS_CHALLENGES)))
+              .persist()
+              .get();
+
+      RoleInput input =
+          RoleInput.builder()
+              .name("EscalationGuard")
+              .capabilities(Set.of(Capability.ACCESS_ASSETS))
+              .build();
+
+      // -------- Act --------
+      String response =
+          mvc.perform(
+                  put(tenantUri("/api/tenants/{tenantId}/roles/") + role.getId())
+                      .content(asJsonString(input))
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .accept(MediaType.APPLICATION_JSON)
+                      .with(csrf()))
+              .andExpect(status().isBadRequest())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -------- Assert --------
+      assertEquals(UNHELD_CAPABILITIES, JsonPath.read(response, "$.message"));
+      List<String> refused = JsonPath.read(response, "$.errors.children.message.errors");
+      assertTrue(refused.contains(Capability.ACCESS_CHALLENGES.name()));
+    }
   }
 
   @Nested

--- a/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/role/TenantRoleApiTest.java
@@ -46,7 +46,11 @@ public class TenantRoleApiTest extends IntegrationTest {
   class Create {
 
     @Test
-    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES})
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_ASSETS
+        })
     @DisplayName("Given MANAGE_TENANT_USERS_GROUPS_AND_ROLES, should create a tenant role")
     void given_manageTenantUsersGroupsAndRoles_should_createRole() throws Exception {
       // -------- Arrange --------
@@ -84,7 +88,7 @@ public class TenantRoleApiTest extends IntegrationTest {
       RoleInput input =
           RoleInput.builder()
               .name("Forbidden")
-              .capabilities(Set.of(Capability.ACCESS_ASSETS))
+              .capabilities(Set.of(Capability.ACCESS_ASSETS, Capability.ACCESS_CHALLENGES))
               .build();
 
       // -------- Act & Assert --------
@@ -311,7 +315,11 @@ public class TenantRoleApiTest extends IntegrationTest {
   class Update {
 
     @Test
-    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES})
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_ASSETS
+        })
     @DisplayName("Given MANAGE_TENANT_USERS_GROUPS_AND_ROLES, should update a tenant role")
     void given_manageTenantUsersGroupsAndRoles_should_updateRole() throws Exception {
       // -------- Arrange --------
@@ -324,6 +332,7 @@ public class TenantRoleApiTest extends IntegrationTest {
       RoleInput input =
           RoleInput.builder()
               .name("NewName")
+              .description("updated")
               .capabilities(Set.of(Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES))
               .build();
 
@@ -345,7 +354,11 @@ public class TenantRoleApiTest extends IntegrationTest {
     }
 
     @Test
-    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES})
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_ASSETS
+        })
     @DisplayName(
         "Given a tenant role polluted with a platform-only capability, update should drop it"
             + " instead of rejecting the payload")
@@ -363,6 +376,7 @@ public class TenantRoleApiTest extends IntegrationTest {
       RoleInput input =
           RoleInput.builder()
               .name("Healed")
+              .description("healed")
               .capabilities(
                   Set.of(
                       Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES,
@@ -404,6 +418,7 @@ public class TenantRoleApiTest extends IntegrationTest {
       RoleInput input =
           RoleInput.builder()
               .name("Forbidden")
+              .description("forbidden")
               .capabilities(Set.of(Capability.ACCESS_CHALLENGES))
               .build();
 
@@ -433,6 +448,7 @@ public class TenantRoleApiTest extends IntegrationTest {
       RoleInput input =
           RoleInput.builder()
               .name("Forbidden")
+              .description("forbidden")
               .capabilities(Set.of(Capability.ACCESS_ASSETS))
               .build();
 
@@ -447,7 +463,11 @@ public class TenantRoleApiTest extends IntegrationTest {
     }
 
     @Test
-    @WithMockUser(withCapabilities = {Capability.MANAGE_TENANT_SETTINGS, Capability.ACCESS_ASSETS})
+    @WithMockUser(
+        withCapabilities = {
+          Capability.MANAGE_TENANT_USERS_GROUPS_AND_ROLES,
+          Capability.ACCESS_ASSETS
+        })
     @DisplayName(
         "Given a role containing capabilities the caller does not hold, update should reject removing those unheld capabilities")
     void given_updateRemovingUnheldCapabilities_should_beRejected() throws Exception {
@@ -464,6 +484,7 @@ public class TenantRoleApiTest extends IntegrationTest {
       RoleInput input =
           RoleInput.builder()
               .name("EscalationGuard")
+              .description("desc")
               .capabilities(Set.of(Capability.ACCESS_ASSETS))
               .build();
 

--- a/openaev-front/src/admin/components/settings/roles/CapabilitiesTab.tsx
+++ b/openaev-front/src/admin/components/settings/roles/CapabilitiesTab.tsx
@@ -1,5 +1,5 @@
-import { LocalPoliceOutlined } from '@mui/icons-material';
-import { Box, Checkbox, Divider } from '@mui/material';
+import { LocalPoliceOutlined, LockOutlined } from '@mui/icons-material';
+import { Box, Checkbox, Divider, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Controller, type FieldValues, type Path, useFormContext, useWatch } from 'react-hook-form';
 
@@ -119,6 +119,17 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
         >
           <LocalPoliceOutlined sx={{ opacity: isCapabilityDisabled ? 0.5 : 1 }} />
           {t(capability.capability_value)}
+          {isCapabilityDisabled && (
+            <Tooltip title={t('the user can not assign or revoke the capability')}>
+              <LockOutlined
+                sx={{
+                  ml: 0.5,
+                  fontSize: 16,
+                  color: 'text.disabled',
+                }}
+              />
+            </Tooltip>
+          )}
         </Box>
         {capability.capability_checkable && capability.capability_value
           && (

--- a/openaev-front/src/admin/components/settings/roles/CapabilitiesTab.tsx
+++ b/openaev-front/src/admin/components/settings/roles/CapabilitiesTab.tsx
@@ -2,7 +2,6 @@ import { LocalPoliceOutlined } from '@mui/icons-material';
 import { Box, Checkbox, Divider } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Controller, type FieldValues, type Path, useFormContext, useWatch } from 'react-hook-form';
-import { makeStyles } from 'tss-react/mui';
 
 import { useFormatter } from '../../../../components/i18n';
 import { type CapabilityOutput } from '../../../../utils/api-types';
@@ -18,27 +17,20 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
   const { t } = useFormatter();
   const theme = useTheme();
 
-  const { classes } = makeStyles()(() => ({
-    capability_name: {
-      display: 'flex',
-      alignItems: 'center',
-      gap: 4,
-      margin: theme.spacing(1),
-    },
-  }))();
-
   const { control } = useFormContext<T>();
   const selected = (useWatch({
     control,
     name: fieldName,
   }) ?? []) as string[];
 
+  const canAssignCapability = (cap: CapabilityOutput): boolean => cap.capability_user_can_have !== false;
+
   // Get all children's capabilities
   const getAllChildren = (cap: CapabilityOutput): string[] => {
     const children: string[] = [];
 
     const collectCheckableValues = (c: CapabilityOutput) => {
-      if (c.capability_checkable && c.capability_value) {
+      if (c.capability_checkable && c.capability_value && canAssignCapability(c)) {
         children.push(c.capability_value);
       }
       c.capability_children?.forEach(child => collectCheckableValues(child));
@@ -53,13 +45,13 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
     for (const cap of caps) {
       if (cap.capability_children) {
         const directChild = cap.capability_children.find(child => child.capability_value === targetValue);
-        if (directChild && cap.capability_checkable && cap.capability_value) {
+        if (directChild && cap.capability_checkable && cap.capability_value && canAssignCapability(cap)) {
           return [...parents, cap.capability_value];
         }
 
         const foundParents = getAllParents(targetValue, cap.capability_children,
-          cap.capability_checkable && cap.capability_value ? [...parents, cap.capability_value] : parents);
-        if (foundParents.length > (cap.capability_checkable && cap.capability_value ? parents.length + 1 : parents.length)) {
+          cap.capability_checkable && cap.capability_value && canAssignCapability(cap) ? [...parents, cap.capability_value] : parents);
+        if (foundParents.length > (cap.capability_checkable && cap.capability_value && canAssignCapability(cap) ? parents.length + 1 : parents.length)) {
           return foundParents;
         }
       }
@@ -68,6 +60,10 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
   };
 
   const toggle = (checked: boolean, cap: CapabilityOutput, allCapabilities: CapabilityOutput[]) => {
+    if (!cap.capability_value || !canAssignCapability(cap)) {
+      return selected;
+    }
+
     let newSelected = [...selected];
 
     if (checked) {
@@ -91,6 +87,10 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
     return newSelected;
   };
 
+  const isAssignable = canAssignCapability(capability);
+  const isCapabilityDisabled = capability.capability_checkable && !isAssignable;
+  const isSelected = capability.capability_value ? selected.includes(capability.capability_value) : false;
+
   return (
     <>
       <Box
@@ -100,16 +100,26 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
         justifyContent="space-between"
         width="100%"
         sx={{
-          backgroundColor: selected.includes(capability.capability_value)
+          backgroundColor: isSelected
             ? 'action.selected'
             : 'transparent',
           paddingRight: theme.spacing(2),
+          opacity: isCapabilityDisabled ? 0.5 : 1,
         }}
       >
-        <div className={classes.capability_name}>
-          <LocalPoliceOutlined sx={{ opacity: capability.capability_checkable ? 1 : 0.5 }} />
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            margin: theme.spacing(1),
+            color: isCapabilityDisabled ? theme.palette.text.disabled : undefined,
+          }}
+          title={isCapabilityDisabled ? t('You cannot assign this capability') : undefined}
+        >
+          <LocalPoliceOutlined sx={{ opacity: isCapabilityDisabled ? 0.5 : 1 }} />
           {t(capability.capability_value)}
-        </div>
+        </Box>
         {capability.capability_checkable && capability.capability_value
           && (
             <Controller
@@ -121,7 +131,8 @@ function CapabilitiesTab<T extends FieldValues>({ capabilities, capability, fiel
                     m: 0,
                     p: 0,
                   }}
-                  checked={selected.includes(capability.capability_value)}
+                  checked={isSelected}
+                  disabled={!isAssignable}
                   onChange={e => field.onChange(toggle(e.target.checked, capability, capabilities))}
                 />
               )}

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -2094,6 +2094,8 @@ export interface CapabilityOutput {
    * @uniqueItems true
    */
   capability_scopes: string[];
+  /** Whether the current authenticated user is allowed to grant this capability */
+  capability_user_can_have: boolean;
   /**
    * Enum key of the capability or group
    * @minLength 1


### PR DESCRIPTION

### Proposed changes

Show through UI what capabilitiesa user can assign/remove to a role.

### Testing Instructions

1. Create a user with a set of capabilities, including **tenant settings**
2. Log in as that user
3. When trying to create or update a role, the user must have access  to the capas he holds only
