### PR TITLE
fix(ci): point the design-system deploy at the renamed Dockerfile

### DIFF
--- a/.github/workflows/deploy-design-system.yml
+++ b/.github/workflows/deploy-design-system.yml
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./Dockerfile_ga
+          file: ./Dockerfile_ga_deprecated
           push: true
           pull: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
`deploy-design-system.yml` still built `./Dockerfile_ga`, which was renamed to `Dockerfile_ga_deprecated` on `main` by #6396 and reached this branch through the 2026-08-09 merge. The workflow has failed on every push since (2026-08-09, 08-13, 08-19); the AWX restart job was skipped each time, so the design-system staging instance is still serving the 2026-08-07 image.

One line, no other change: the same file the workflow already builds, under its current name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)