### PR TITLE
fix(security): align amqp-client version across modules (#7526)

### DIFF
--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <elasticsearch.version>8.19.20</elasticsearch.version>
         <opensearch.version>3.9.0</opensearch.version>
-        <amqp-client.version>5.34.0</amqp-client.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
         <kotlin.version>2.1.21</kotlin.version>
         <opentelemetry.version>1.65.0</opentelemetry.version>
         <amqp-client.version>5.34.0</amqp-client.version>
-        <!-- Spring Boot BOM pulls amqp-client transitively; keep it aligned with the pin above -->
         <rabbit-amqp-client.version>${amqp-client.version}</rabbit-amqp-client.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,9 @@
         <httpclient5.version>5.6.4</httpclient5.version>
         <kotlin.version>2.1.21</kotlin.version>
         <opentelemetry.version>1.65.0</opentelemetry.version>
+        <amqp-client.version>5.34.0</amqp-client.version>
+        <!-- Spring Boot BOM pulls amqp-client transitively; keep it aligned with the pin above -->
+        <rabbit-amqp-client.version>${amqp-client.version}</rabbit-amqp-client.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Closes #7526

Moves `amqp-client.version` to the root pom and overrides the Spring Boot BOM property `rabbit-amqp-client.version` with it, so every module resolves the pinned version instead of the BOM's 5.25.0.

`mvn -pl openaev-api -am dependency:tree -Dincludes=com.rabbitmq:amqp-client`:
- before: model 5.34.0, framework 5.25.0, api **5.25.0**
- after: 5.34.0 everywhere

Renovate keeps bumping `amqp-client.version` as before, now in the root pom.