### PR TITLE
fix(dockerfile): fixed the base image to use the noble version of eclipse-temurin (#7572)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,7 +86,7 @@ See the domain-specific instruction files in `.github/instructions/` for detaile
 
 Before creating a pull request, validate locally:
 
-1. **Formatting**: `mvn spotless:check` (or via Docker: `docker run --rm -v $(pwd):/app -w /app maven:3.9-eclipse-temurin-21 mvn spotless:check`)
+1. **Formatting**: `mvn spotless:check` (or via Docker: `docker run --rm -v $(pwd):/app -w /app maven:3.9-eclipse-temurin-21-noble mvn spotless:check`)
 2. **PR title**: Must match `type(scope?): description (#issue)` — no `[context]` prefix. The `openaev-pr-checks` GitHub App validates this pattern; titles with extra prefixes (e.g. `[backend]`) will be rejected.
 3. **Compile**: `mvn compile -DskipTests` (or via Docker)
 4. **Frontend** (if changed): `cd openaev-front && yarn check-ts && yarn lint`

--- a/.github/skills/add-contract-output-type/SKILL.md
+++ b/.github/skills/add-contract-output-type/SKILL.md
@@ -137,7 +137,7 @@ single-token substring fallback.
 
 ```bash
 # backend
-docker run --rm -v "$PWD":/src -v "$HOME/.m2":/root/.m2 -w /src maven:3.9-eclipse-temurin-21 \
+docker run --rm -v "$PWD":/src -v "$HOME/.m2":/root/.m2 -w /src maven:3.9-eclipse-temurin-21-noble \
   mvn -q -pl openaev-model,openaev-api -am test -Dtest='*OutputProcessor*,*ChainingType*'
 # frontend
 cd openaev-front && yarn eslint src && yarn tsc --noEmit

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn install
 COPY openaev-front /opt/openaev-build/openaev-front
 RUN yarn build
 
-FROM maven:3.9.16-eclipse-temurin-21 AS api-builder
+FROM maven:3.9.16-eclipse-temurin-21-noble AS api-builder
 
 WORKDIR /opt/openaev-build/openaev
 COPY openaev-annotation-processor ./openaev-annotation-processor
@@ -22,7 +22,7 @@ COPY pom.xml ./pom.xml
 COPY --from=front-builder /opt/openaev-build/openaev-front/builder/prod/build ./openaev-front/builder/prod/build
 RUN mvn install -DskipTests -Pdev
 
-FROM eclipse-temurin:21.0.11_10-jre AS app
+FROM eclipse-temurin:21.0.11_10-jre-noble AS app
 
 # Fixed world-readable browser path so any runtime UID finds the Chromium bundle (reporting)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY pom.xml ./pom.xml
 COPY --from=front-builder /opt/openaev-build/openaev-front/builder/prod/build ./openaev-front/builder/prod/build
 RUN mvn install -DskipTests -Pdev
 
-FROM eclipse-temurin:21.0.11_10-jre-noble AS app
+FROM eclipse-temurin:21.0.12_8-jre-noble AS app
 
 # Fixed world-readable browser path so any runtime UID finds the Chromium bundle (reporting)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright

--- a/Dockerfile_ga_deprecated
+++ b/Dockerfile_ga_deprecated
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.11_10-jre-noble AS app
+FROM eclipse-temurin:21.0.12_8-jre-noble AS app
 
 # Fixed world-readable browser path so any runtime UID finds the Chromium bundle (reporting)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright

--- a/Dockerfile_ga_deprecated
+++ b/Dockerfile_ga_deprecated
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.11_10-jre AS app
+FROM eclipse-temurin:21.0.11_10-jre-noble AS app
 
 # Fixed world-readable browser path so any runtime UID finds the Chromium bundle (reporting)
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright


### PR DESCRIPTION
Due to the non noble version of the image we use still having CVE's in their base image from the go/pebble stack, we are changing to use the noble version which uses an ubuntu 24.04 instead of 26.04 but which doesn't have thoses CVEs.

Non regression tests should be performed to make sure no regression are possible, notably in terms of cryptography and in terms of communication and deployment of external components, like collectors and executors.

### Proposed changes

* changed from eclipse-temurin.21.0.11_10-jre to eclipse-temurin.21.0.11_10-jre-noble
* same for the maven layer

### Testing Instructions

Tests must be done using the docker image, not the intellij deployment feature.
1. build an image for the current release version (or retrieve it from docker hub)
2. build an image from this branch and add it to your local docker repo.

Then - mimic an upgrade to the new image : 
1. First, run the current stack, with the release image, and fill the database, in order to have enough data
2. Then, dhutsown the openaev container only, keep the DB, minio, etc. and deploy a container with the new image
3. Check that everything still works, including communication with collectors and external executors, as well as external injectors (nmap, netexec, etc.)

Then - mimic a brand new installation, no upgrade :
Do the same, but starting with a fully empty database

### Related issues

* Closes #7572

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

