### PR TITLE
feat(injects): add an execution status filter on inject results

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/inject/utils/InjectFilterUtils.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/utils/InjectFilterUtils.java
@@ -1,0 +1,65 @@
+package io.openaev.rest.inject.utils;
+
+import static java.util.Optional.ofNullable;
+
+import io.openaev.database.model.Filters;
+import io.openaev.database.model.Inject;
+import io.openaev.database.specification.InjectSpecification;
+import io.openaev.utils.pagination.SearchPaginationInput;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import org.springframework.data.jpa.domain.Specification;
+
+/** Inject filters that the generic filter mechanics cannot express on their own. */
+public class InjectFilterUtils {
+
+  public static final String INJECT_STATUS_FILTER = "inject_status";
+
+  private InjectFilterUtils() {}
+
+  /**
+   * Manage the {@code inject_status} filter: an inject never launched has no status row, so the
+   * DRAFT value it is serialized with matches nothing on a plain {@code status.name} comparison,
+   * and a negative filter silently drops those injects. The filter is stripped from the generic
+   * group and re-expressed as a Specification, combined with the group's AND/OR mode.
+   */
+  public static UnaryOperator<Specification<Inject>> handleCustomFilter(
+      @NotNull final SearchPaginationInput searchPaginationInput) {
+    Specification<Inject> customSpecification = executionStatusSpecification(searchPaginationInput);
+    if (customSpecification == null) {
+      return (Specification<Inject> specification) -> specification;
+    }
+    // Combined like any other filter of the group. Anything but an explicit "or" is an AND: the
+    // filter has been stripped from the group, dropping it here would silently widen the search.
+    return Filters.FilterMode.or.equals(searchPaginationInput.getFilterGroup().getMode())
+        ? customSpecification::or
+        : customSpecification::and;
+  }
+
+  /** Strips and maps the {@code inject_status} filter to a Specification (or null). */
+  private static Specification<Inject> executionStatusSpecification(
+      final SearchPaginationInput searchPaginationInput) {
+    Optional<Filters.Filter> filterOpt =
+        ofNullable(searchPaginationInput.getFilterGroup())
+            .flatMap(f -> f.findByKey(INJECT_STATUS_FILTER));
+    if (filterOpt.isEmpty()) {
+      return null;
+    }
+    Filters.Filter filter = filterOpt.get();
+    List<String> values = filter.getValues();
+    Filters.FilterOperator operator =
+        ofNullable(filter.getOperator()).orElse(Filters.FilterOperator.eq);
+    // empty / not_empty keep their generic meaning (with or without a status row at all)
+    boolean handled =
+        Filters.FilterOperator.eq.equals(operator)
+            || Filters.FilterOperator.not_eq.equals(operator);
+    if (!handled || values == null || values.isEmpty()) {
+      return null;
+    }
+    searchPaginationInput.getFilterGroup().removeByKey(INJECT_STATUS_FILTER);
+    return InjectSpecification.hasExecutionStatusNames(
+        values, Filters.FilterOperator.not_eq.equals(operator));
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/AtomicTestingService.java
+++ b/openaev-api/src/main/java/io/openaev/service/AtomicTestingService.java
@@ -3,6 +3,7 @@ package io.openaev.service;
 import static io.openaev.config.SessionHelper.currentUser;
 import static io.openaev.helper.StreamHelper.fromIterable;
 import static io.openaev.helper.StreamHelper.iterableToSet;
+import static io.openaev.rest.inject.utils.InjectFilterUtils.handleCustomFilter;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationCriteriaBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +29,7 @@ import jakarta.persistence.criteria.Join;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.*;
+import java.util.function.UnaryOperator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -343,13 +345,16 @@ public class AtomicTestingService {
                     currentUser.getCapabilities().contains(Capability.ACCESS_ASSESSMENT),
                     Grant.GRANT_TYPE.OBSERVER));
 
+    UnaryOperator<Specification<Inject>> deepFilterSpecification =
+        handleCustomFilter(searchPaginationInput);
+
     return buildPaginationCriteriaBuilder(
         (Specification<Inject> specification,
             Specification<Inject> specificationCount,
             Pageable pageable) ->
             injectSearchService.injectResults(
-                customSpec.and(specification),
-                customSpec.and(specificationCount),
+                customSpec.and(deepFilterSpecification.apply(specification)),
+                customSpec.and(deepFilterSpecification.apply(specificationCount)),
                 pageable,
                 joinMap),
         searchPaginationInput,

--- a/openaev-api/src/main/java/io/openaev/service/InjectSearchService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectSearchService.java
@@ -1,6 +1,7 @@
 package io.openaev.service;
 
 import static io.openaev.database.criteria.GenericCriteria.countQuery;
+import static io.openaev.rest.inject.utils.InjectFilterUtils.handleCustomFilter;
 import static io.openaev.utils.JpaUtils.createJoinArrayAggOnId;
 import static io.openaev.utils.JpaUtils.createJoinArrayAggOnIdForJoin;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationCriteriaBuilder;
@@ -40,6 +41,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.time.Instant;
 import java.util.*;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -309,13 +311,16 @@ public class InjectSearchService {
                   return predicate;
                 });
 
+    UnaryOperator<Specification<Inject>> deepFilterSpecification =
+        handleCustomFilter(searchPaginationInput);
+
     return buildPaginationCriteriaBuilder(
         (Specification<Inject> specification,
             Specification<Inject> specificationCount,
             Pageable pageable) ->
             injectResults(
-                customSpec.and(specification),
-                customSpec.and(specificationCount),
+                customSpec.and(deepFilterSpecification.apply(specification)),
+                customSpec.and(deepFilterSpecification.apply(specificationCount)),
                 pageable,
                 joinMap),
         searchPaginationInput,
@@ -379,13 +384,16 @@ public class InjectSearchService {
                     currentUser.getCapabilities().contains(Capability.ACCESS_ASSESSMENT),
                     Grant.GRANT_TYPE.OBSERVER));
 
+    UnaryOperator<Specification<Inject>> deepFilterSpecification =
+        handleCustomFilter(searchPaginationInput);
+
     return buildPaginationCriteriaBuilder(
         (Specification<Inject> specification,
             Specification<Inject> specificationCount,
             Pageable pageable) ->
             injectResults(
-                customSpec.and(specification),
-                customSpec.and(specificationCount),
+                customSpec.and(deepFilterSpecification.apply(specification)),
+                customSpec.and(deepFilterSpecification.apply(specificationCount)),
                 pageable,
                 joinMap),
         searchPaginationInput,

--- a/openaev-api/src/test/java/io/openaev/rest/inject/InjectExecutionStatusFilterApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/InjectExecutionStatusFilterApiTest.java
@@ -1,0 +1,174 @@
+package io.openaev.rest.inject;
+
+import static io.openaev.rest.atomic_testing.AtomicTestingApi.ATOMIC_TESTING_URI;
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.ExecutionStatus;
+import io.openaev.database.model.Filters;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectStatus;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.InjectStatusFixture;
+import io.openaev.utils.fixtures.PaginationFixture;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectStatusComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import io.openaev.utils.pagination.SearchPaginationInput;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Integration tests for the {@code inject_status} and {@code inject_enabled} filters of the inject
+ * results search. An inject never launched has no status row and is serialized as DRAFT, so those
+ * injects must answer to a DRAFT filter and must not vanish from a negative one.
+ */
+@TestInstance(PER_CLASS)
+@Transactional
+@DisplayName("Inject execution status filter")
+@WithMockUser(isAdmin = true)
+class InjectExecutionStatusFilterApiTest extends IntegrationTest {
+
+  @Autowired private MockMvc mvc;
+  @Autowired private EntityManager entityManager;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectStatusComposer injectStatusComposer;
+
+  private String injectWithoutStatusId;
+  private String draftInjectId;
+  private String executedInjectId;
+  private String disabledInjectId;
+
+  @BeforeEach
+  void setup() {
+    injectComposer.reset();
+    injectStatusComposer.reset();
+
+    injectWithoutStatusId = persistInject(InjectFixture.getDefaultInject(), null);
+    draftInjectId =
+        persistInject(
+            InjectFixture.getDefaultInject(), InjectStatusFixture.createDraftInjectStatus());
+    executedInjectId =
+        persistInject(InjectFixture.getDefaultInject(), InjectStatusFixture.createSuccessStatus());
+
+    Inject disabledInject = InjectFixture.getDefaultInject();
+    disabledInject.setEnabled(false);
+    disabledInjectId = persistInject(disabledInject, null);
+
+    entityManager.flush();
+  }
+
+  private String persistInject(Inject inject, InjectStatus status) {
+    InjectComposer.Composer composer = injectComposer.forInject(inject);
+    if (status != null) {
+      composer = composer.withInjectStatus(injectStatusComposer.forInjectStatus(status));
+    }
+    return composer.persist().get().getId();
+  }
+
+  private SearchPaginationInput searchOn(
+      String key, Filters.FilterOperator operator, String... values) {
+    Filters.Filter filter = new Filters.Filter();
+    filter.setKey(key);
+    filter.setValues(List.of(values));
+    filter.setOperator(operator);
+    Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+    filterGroup.setMode(Filters.FilterMode.and);
+    filterGroup.setFilters(new ArrayList<>(List.of(filter)));
+    return PaginationFixture.getDefault().size(100).filterGroup(filterGroup).build();
+  }
+
+  /** Asserts the search returns the expected injects and none of the unexpected ones. */
+  private void searchAndExpect(
+      SearchPaginationInput input, List<String> expectedIds, List<String> unexpectedIds)
+      throws Exception {
+    ResultActions result =
+        mvc.perform(
+                post(ATOMIC_TESTING_URI + "/search")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(asJsonString(input))
+                    .with(csrf()))
+            .andExpect(status().is2xxSuccessful());
+    for (String expectedId : expectedIds) {
+      result.andExpect(
+          jsonPath("$.content[?(@.inject_id == '%s')]".formatted(expectedId)).exists());
+    }
+    for (String unexpectedId : unexpectedIds) {
+      result.andExpect(
+          jsonPath("$.content[?(@.inject_id == '%s')]".formatted(unexpectedId)).doesNotExist());
+    }
+  }
+
+  @Test
+  @DisplayName("DRAFT matches injects with a draft status and injects with no status row")
+  void given_draftFilter_should_returnInjectsWithoutStatus() throws Exception {
+    searchAndExpect(
+        searchOn("inject_status", Filters.FilterOperator.eq, ExecutionStatus.DRAFT.name()),
+        List.of(injectWithoutStatusId, draftInjectId, disabledInjectId),
+        List.of(executedInjectId));
+  }
+
+  @Test
+  @DisplayName("A real status only matches the injects holding it")
+  void given_executedFilter_should_returnOnlyExecutedInject() throws Exception {
+    searchAndExpect(
+        searchOn("inject_status", Filters.FilterOperator.eq, ExecutionStatus.EXECUTED.name()),
+        List.of(executedInjectId),
+        List.of(injectWithoutStatusId, draftInjectId, disabledInjectId));
+  }
+
+  @Test
+  @DisplayName("Several statuses are OR-combined")
+  void given_multipleStatuses_should_returnAllOfThem() throws Exception {
+    searchAndExpect(
+        searchOn(
+            "inject_status",
+            Filters.FilterOperator.eq,
+            ExecutionStatus.EXECUTED.name(),
+            ExecutionStatus.DRAFT.name()),
+        List.of(executedInjectId, injectWithoutStatusId, draftInjectId),
+        List.of());
+  }
+
+  @Test
+  @DisplayName("A negative filter keeps the injects with no status row")
+  void given_negativeFilter_should_keepInjectsWithoutStatus() throws Exception {
+    searchAndExpect(
+        searchOn("inject_status", Filters.FilterOperator.not_eq, ExecutionStatus.EXECUTED.name()),
+        List.of(injectWithoutStatusId, draftInjectId, disabledInjectId),
+        List.of(executedInjectId));
+  }
+
+  @Test
+  @DisplayName("Negating DRAFT excludes the injects with no status row")
+  void given_negativeDraftFilter_should_excludeInjectsWithoutStatus() throws Exception {
+    searchAndExpect(
+        searchOn("inject_status", Filters.FilterOperator.not_eq, ExecutionStatus.DRAFT.name()),
+        List.of(executedInjectId),
+        List.of(injectWithoutStatusId, draftInjectId, disabledInjectId));
+  }
+
+  @Test
+  @DisplayName("Disabled injects are found on the enabled filter")
+  void given_enabledFilter_should_returnDisabledInject() throws Exception {
+    searchAndExpect(
+        searchOn("inject_enabled", Filters.FilterOperator.eq, "false"),
+        List.of(disabledInjectId),
+        List.of(injectWithoutStatusId, draftInjectId, executedInjectId));
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/inject/utils/InjectFilterUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/utils/InjectFilterUtilsTest.java
@@ -1,0 +1,89 @@
+package io.openaev.rest.inject.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.database.model.Filters;
+import io.openaev.database.model.Inject;
+import io.openaev.utils.pagination.SearchPaginationInput;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+@DisplayName("Inject custom filters")
+class InjectFilterUtilsTest {
+
+  private static SearchPaginationInput inputWith(Filters.Filter... filters) {
+    Filters.FilterGroup filterGroup = new Filters.FilterGroup();
+    filterGroup.setMode(Filters.FilterMode.and);
+    filterGroup.setFilters(new ArrayList<>(List.of(filters)));
+    return SearchPaginationInput.builder().page(0).size(10).filterGroup(filterGroup).build();
+  }
+
+  private static Filters.Filter filter(
+      String key, Filters.FilterOperator operator, String... values) {
+    Filters.Filter filter = new Filters.Filter();
+    filter.setKey(key);
+    filter.setOperator(operator);
+    filter.setValues(List.of(values));
+    return filter;
+  }
+
+  @Test
+  @DisplayName("An inject_status filter is stripped from the group and re-expressed")
+  void given_statusFilter_should_stripItAndReturnSpecification() {
+    SearchPaginationInput input =
+        inputWith(
+            filter("inject_status", Filters.FilterOperator.eq, "DRAFT"),
+            filter("inject_title", Filters.FilterOperator.contains, "test"));
+
+    UnaryOperator<Specification<Inject>> operator = InjectFilterUtils.handleCustomFilter(input);
+
+    assertThat(input.getFilterGroup().findByKey("inject_status")).isEmpty();
+    assertThat(input.getFilterGroup().findByKey("inject_title")).isPresent();
+    Specification<Inject> generic = Specification.unrestricted();
+    assertThat(operator.apply(generic)).isNotSameAs(generic);
+  }
+
+  @Test
+  @DisplayName("Other filters are left to the generic mechanics")
+  void given_noStatusFilter_should_returnIdentity() {
+    SearchPaginationInput input =
+        inputWith(filter("inject_title", Filters.FilterOperator.contains, "test"));
+
+    Specification<Inject> generic = Specification.unrestricted();
+    assertThat(InjectFilterUtils.handleCustomFilter(input).apply(generic)).isSameAs(generic);
+    assertThat(input.getFilterGroup().findByKey("inject_title")).isPresent();
+  }
+
+  @Test
+  @DisplayName("Emptiness operators keep their generic meaning")
+  void given_emptyOperator_should_returnIdentity() {
+    SearchPaginationInput input = inputWith(filter("inject_status", Filters.FilterOperator.empty));
+
+    Specification<Inject> generic = Specification.unrestricted();
+    assertThat(InjectFilterUtils.handleCustomFilter(input).apply(generic)).isSameAs(generic);
+    assertThat(input.getFilterGroup().findByKey("inject_status")).isPresent();
+  }
+
+  @Test
+  @DisplayName("A valueless status filter is left untouched")
+  void given_statusFilterWithoutValue_should_returnIdentity() {
+    SearchPaginationInput input = inputWith(filter("inject_status", Filters.FilterOperator.eq));
+
+    Specification<Inject> generic = Specification.unrestricted();
+    assertThat(InjectFilterUtils.handleCustomFilter(input).apply(generic)).isSameAs(generic);
+    assertThat(input.getFilterGroup().findByKey("inject_status")).isPresent();
+  }
+
+  @Test
+  @DisplayName("No filter group at all is supported")
+  void given_noFilterGroup_should_returnIdentity() {
+    SearchPaginationInput input = SearchPaginationInput.builder().page(0).size(10).build();
+
+    Specification<Inject> generic = Specification.unrestricted();
+    assertThat(InjectFilterUtils.handleCustomFilter(input).apply(generic)).isSameAs(generic);
+  }
+}

--- a/openaev-front/src/admin/components/atomic_testings/InjectResultList.tsx
+++ b/openaev-front/src/admin/components/atomic_testings/InjectResultList.tsx
@@ -59,7 +59,6 @@ interface Props {
   goTo: (injectId: string, inject: InjectResultOutput) => string;
   queryableHelpers: QueryableHelpers;
   searchPaginationInput: SearchPaginationInput;
-  availableFilterNames?: string[];
   contextId?: string;
   // Optional creation button rendered at the top right of the list header
   // (OpenCTI-aligned placement), next to the import action.
@@ -117,6 +116,8 @@ const InjectResultList: FunctionComponent<Props> = ({
     'inject_asset_groups',
     'inject_teams',
     'inject_contract_domains',
+    'inject_status',
+    'inject_enabled',
   ];
   const [injects, setInjects] = useState<InjectResultOutput[]>([]);
 

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "Vermögenswerte",
   "inject_attack_patterns": "Angriffsmuster",
   "inject_contract_domains": "Domains",
+  "inject_enabled": "Aktiviert",
   "inject_expectation_description": "Beschreibung",
   "inject_expectation_expected_score": "Erwartete Punktzahl",
   "inject_expectation_expiration_time": "Verfallszeit",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "Assets",
   "inject_attack_patterns": "Attack pattern",
   "inject_contract_domains": "Domains",
+  "inject_enabled": "Enabled",
   "inject_expectation_description": "Description",
   "inject_expectation_expected_score": "Expected score",
   "inject_expectation_expiration_time": "Expiration time",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "Activos",
   "inject_attack_patterns": "Patrón de ataque",
   "inject_contract_domains": "Dominios",
+  "inject_enabled": "Activado",
   "inject_expectation_description": "Descripción",
   "inject_expectation_expected_score": "Puntuación esperada",
   "inject_expectation_expiration_time": "Tiempo de expiración",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "Actifs",
   "inject_attack_patterns": "Modèle d'attaque",
   "inject_contract_domains": "Domaines",
+  "inject_enabled": "Activé",
   "inject_expectation_description": "Description",
   "inject_expectation_expected_score": "Score attendu",
   "inject_expectation_expiration_time": "Temps d'expiration",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "Attività",
   "inject_attack_patterns": "Schema di attacco",
   "inject_contract_domains": "Domini",
+  "inject_enabled": "Attivo",
   "inject_expectation_description": "Descrizione",
   "inject_expectation_expected_score": "Punteggio previsto",
   "inject_expectation_expiration_time": "Tempo di scadenza",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "資産",
   "inject_attack_patterns": "攻撃パターン",
   "inject_contract_domains": "ドメイン",
+  "inject_enabled": "有効",
   "inject_expectation_description": "説明",
   "inject_expectation_expected_score": "予想スコア",
   "inject_expectation_expiration_time": "有効期限",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "에셋",
   "inject_attack_patterns": "공격 패턴",
   "inject_contract_domains": "도메인",
+  "inject_enabled": "활성화됨",
   "inject_expectation_description": "설명",
   "inject_expectation_expected_score": "예상 점수",
   "inject_expectation_expiration_time": "만료 시간",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "Активы",
   "inject_attack_patterns": "Модель атаки",
   "inject_contract_domains": "Домены",
+  "inject_enabled": "Включено",
   "inject_expectation_description": "Описание",
   "inject_expectation_expected_score": "Ожидаемый результат",
   "inject_expectation_expiration_time": "Срок действия",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -1823,6 +1823,7 @@
   "inject_assets": "资产",
   "inject_attack_patterns": "攻击模式",
   "inject_contract_domains": "领域",
+  "inject_enabled": "已启用",
   "inject_expectation_description": "说明",
   "inject_expectation_expected_score": "预期得分",
   "inject_expectation_expiration_time": "到期时间",

--- a/openaev-model/src/main/java/io/openaev/database/model/Inject.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Inject.java
@@ -91,6 +91,8 @@ public class Inject implements GrantableBase, Injection, TenantBase {
   private String city;
 
   @Getter
+  // Filterable: a disabled inject is never scheduled, so it has no execution status of its own
+  @Queryable(filterable = true)
   @Column(name = "inject_enabled")
   @JsonProperty("inject_enabled")
   private boolean enabled = true;

--- a/openaev-model/src/main/java/io/openaev/database/specification/InjectSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/InjectSpecification.java
@@ -25,8 +25,10 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -150,6 +152,38 @@ public class InjectSpecification {
 
   public static Specification<Inject> hasStatus(List<ExecutionStatus> statuses) {
     return (root, query, cb) -> root.get("status").get("name").in(statuses);
+  }
+
+  /**
+   * Matches injects on their execution status name. An inject never launched has no status row and
+   * is serialized as DRAFT, so DRAFT must also match a missing status. Values are OR-combined ("any
+   * of these") and negations AND-combined ("none of these"), like the generic filter engine.
+   */
+  public static Specification<Inject> hasExecutionStatusNames(
+      @NotNull final List<String> statusNames, final boolean negate) {
+    List<ExecutionStatus> statuses =
+        statusNames.stream()
+            .filter(StringUtils::isNotBlank)
+            .map(name -> EnumUtils.getEnumIgnoreCase(ExecutionStatus.class, name.trim()))
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    boolean includesDraft = statuses.contains(ExecutionStatus.DRAFT);
+
+    return (root, query, cb) -> {
+      if (statuses.isEmpty()) {
+        return negate ? cb.conjunction() : cb.disjunction();
+      }
+      Path<ExecutionStatus> statusName = root.join("status", JoinType.LEFT).get("name");
+      if (negate) {
+        return includesDraft
+            ? cb.and(cb.isNotNull(statusName), cb.not(statusName.in(statuses)))
+            : cb.or(cb.isNull(statusName), cb.not(statusName.in(statuses)));
+      }
+      return includesDraft
+          ? cb.or(cb.isNull(statusName), statusName.in(statuses))
+          : statusName.in(statuses);
+    };
   }
 
   public static Specification<Inject> hasCollectingStatus(List<CollectExecutionStatus> statuses) {


### PR DESCRIPTION
Le statut d'exécution était affiché en colonne dans les listes de résultats d'injects mais pas filtrable.

- front : `inject_status` et `inject_enabled` ajoutés aux filtres de `InjectResultList` (atomic testings, injects d'une simulation, injects joués d'un asset / asset group / team / player / orga)
- back : nouveau `InjectFilterUtils.handleCustomFilter` appliqué aux trois recherches d'inject results, qui retire `inject_status` du groupe générique et le réexprime en Specification
- `Inject.enabled` devient filtrable (picker true/false), un inject désactivé n'ayant pas de statut d'exécution propre

Le point non évident : un inject jamais lancé n'a pas de ligne `injects_statuses`, DRAFT est synthétisé à la sérialisation. Le filtre générique comparait `status.name` sur un LEFT JOIN, donc DRAFT ne remontait rien et un filtre négatif (`≠ EXECUTED`) faisait disparaître ces injects. La Specification traite l'absence de statut comme DRAFT dans les deux sens.

Deux limites assumées : les injects désactivés restent comptés comme DRAFT côté statut (ils n'ont jamais été exécutés) — c'est le filtre `inject_enabled` qui les isole ; et dans une simulation lancée la colonne affiche PENDING pour un inject encore DRAFT en base, ce que le filtre ne reproduit pas.