### PR TITLE
fix(inject): open tx inside parallelstream for InjectsExecutionJob (#7556)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -519,7 +519,8 @@ public class InjectsExecutionJob implements Job {
                               ? "atomic"
                               : ex.getInjection().getExercise().getId()));
 
-      // Execute injects in parallel for each exercise.
+      // Execute exercise batches in parallel. Each inject execution opens its own tenant scope so
+      // nested parallel workers never share or leak tenant context.
       byExercises.entrySet().parallelStream()
           .forEach(
               entry -> {
@@ -539,33 +540,33 @@ public class InjectsExecutionJob implements Job {
                   return;
                 }
 
-                executeInTenant(
-                    tenantIdForEntry.orElseThrow(),
-                    () -> {
-                      // Execute each inject for the exercise in order.
-                      entry.getValue().parallelStream()
-                          .forEach(
-                              executableInject -> {
-                                Inject inject = executableInject.getInjection().getInject();
-                                try {
-                                  this.executeInject(executableInject);
-                                } catch (RuntimeException e) {
-                                  Throwable cause = e.getCause() != null ? e.getCause() : e;
-                                  log.warn(cause.getMessage(), cause);
-                                  injectStatusService.failInjectStatus(
-                                      inject.getId(), cause.getMessage());
-                                } catch (Exception e) {
-                                  log.warn(e.getMessage(), e);
-                                  injectStatusService.failInjectStatus(
-                                      inject.getId(), e.getMessage());
-                                }
-                              });
+                String tenantId = tenantIdForEntry.orElseThrow();
+                // Execute each inject in parallel under its own scoped transaction/thread-local.
+                entry.getValue().parallelStream()
+                    .forEach(
+                        executableInject ->
+                            executeInTenant(
+                                tenantId,
+                                () -> {
+                                  Inject inject = executableInject.getInjection().getInject();
+                                  try {
+                                    this.executeInject(executableInject);
+                                  } catch (RuntimeException e) {
+                                    Throwable cause = e.getCause() != null ? e.getCause() : e;
+                                    log.warn(cause.getMessage(), cause);
+                                    injectStatusService.failInjectStatus(
+                                        inject.getId(), cause.getMessage());
+                                  } catch (Exception e) {
+                                    log.warn(e.getMessage(), e);
+                                    injectStatusService.failInjectStatus(
+                                        inject.getId(), e.getMessage());
+                                  }
+                                }));
 
-                      // Update the exercise once all injects of the batch are processed.
-                      if (!entry.getKey().equals("atomic")) {
-                        updateExercise(entry.getKey());
-                      }
-                    });
+                // Update the exercise once all injects of the batch are processed.
+                if (!entry.getKey().equals("atomic")) {
+                  executeInTenant(tenantId, () -> updateExercise(entry.getKey()));
+                }
               });
       // Change status of finished simulations.
       handleInjectExpectationCollectStatus();

--- a/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
+++ b/openaev-api/src/main/java/io/openaev/scheduler/jobs/InjectsExecutionJob.java
@@ -81,6 +81,8 @@ public class InjectsExecutionJob implements Job {
   // Thread-safe and expensive to instantiate; never recreate per dependency evaluation
   private static final ExpressionParser SPEL_PARSER = new SpelExpressionParser();
 
+  private static final String ATOMIC_BATCH_KEY = "atomic";
+
   @Value("${openaev.notification.simulation-completed-delay-seconds:3600}")
   private long delayForSimulationCompletedEvent;
 
@@ -494,6 +496,18 @@ public class InjectsExecutionJob implements Job {
       Map<String, List<ExecutableInject>> byExercises =
           injects.stream()
               .filter(
+                  executableInject -> {
+                    Inject inject = executableInject.getInjection().getInject();
+                    if (inject.getTenant() != null) {
+                      return true;
+                    }
+                    String message =
+                        "Inject " + inject.getId() + " has no tenant, cannot be executed";
+                    log.warn(message);
+                    injectStatusService.failInjectStatus(inject.getId(), message);
+                    return false;
+                  })
+              .filter(
                   executableInject ->
                       // If we got dependencies, we check that the parents are not part of the
                       // current batch of injects running. If so, we're filtering them out and
@@ -516,56 +530,49 @@ public class InjectsExecutionJob implements Job {
                   groupingBy(
                       ex ->
                           ex.getInjection().getExercise() == null
-                              ? "atomic"
+                              // Atomic injects have no exercise to group by.
+                              ? ATOMIC_BATCH_KEY
                               : ex.getInjection().getExercise().getId()));
 
-      // Execute exercise batches in parallel. Each inject execution opens its own tenant scope so
-      // nested parallel workers never share or leak tenant context.
+      // Execute exercise batches in parallel. Each inject execution resolves and opens its own
+      // tenant scope - a plain field lookup, not a DB call - so nested parallel workers never
+      // share or leak tenant context, and the correctness of the scope no longer depends on a
+      // batch being single-tenant.
       byExercises.entrySet().parallelStream()
           .forEach(
               entry -> {
-                // Atomic testing don't belong to an exercise, so it's safer to retrieve
-                // tenant from inject itself
-                Optional<String> tenantIdForEntry =
-                    entry.getValue().stream()
-                        .map(executableInject -> executableInject.getInjection().getInject())
-                        .map(Inject::getTenant)
-                        .map(Tenant::getId)
-                        .filter(Objects::nonNull)
-                        .findFirst();
-                if (tenantIdForEntry.isEmpty()) {
-                  log.warn(
-                      "Skipping inject batch for {} because tenant could not be resolved",
-                      entry.getKey());
-                  return;
-                }
-
-                String tenantId = tenantIdForEntry.orElseThrow();
-                // Execute each inject in parallel under its own scoped transaction/thread-local.
                 entry.getValue().parallelStream()
                     .forEach(
-                        executableInject ->
-                            executeInTenant(
-                                tenantId,
-                                () -> {
-                                  Inject inject = executableInject.getInjection().getInject();
-                                  try {
-                                    this.executeInject(executableInject);
-                                  } catch (RuntimeException e) {
-                                    Throwable cause = e.getCause() != null ? e.getCause() : e;
-                                    log.warn(cause.getMessage(), cause);
-                                    injectStatusService.failInjectStatus(
-                                        inject.getId(), cause.getMessage());
-                                  } catch (Exception e) {
-                                    log.warn(e.getMessage(), e);
-                                    injectStatusService.failInjectStatus(
-                                        inject.getId(), e.getMessage());
-                                  }
-                                }));
+                        executableInject -> {
+                          Inject inject = executableInject.getInjection().getInject();
+                          executeInTenant(
+                              inject.getTenant().getId(),
+                              () -> {
+                                try {
+                                  this.executeInject(executableInject);
+                                } catch (RuntimeException e) {
+                                  Throwable cause = e.getCause() != null ? e.getCause() : e;
+                                  log.warn(cause.getMessage(), cause);
+                                  injectStatusService.failInjectStatus(
+                                      inject.getId(), cause.getMessage());
+                                } catch (Exception e) {
+                                  log.warn(e.getMessage(), e);
+                                  injectStatusService.failInjectStatus(
+                                      inject.getId(), e.getMessage());
+                                }
+                              });
+                        });
 
                 // Update the exercise once all injects of the batch are processed.
-                if (!entry.getKey().equals("atomic")) {
-                  executeInTenant(tenantId, () -> updateExercise(entry.getKey()));
+                if (!entry.getKey().equals(ATOMIC_BATCH_KEY)) {
+                  entry.getValue().stream()
+                      .findFirst()
+                      .map(
+                          executableInject ->
+                              executableInject.getInjection().getInject().getTenant().getId())
+                      .ifPresent(
+                          tenantId ->
+                              executeInTenant(tenantId, () -> updateExercise(entry.getKey())));
                 }
               });
       // Change status of finished simulations.

--- a/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/scheduler/jobs/InjectsExecutionJobTenantScopeTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
 import io.openaev.context.TxCtx;
+import io.openaev.database.model.Exercise;
 import io.openaev.database.model.Inject;
 import io.openaev.database.model.Injection;
 import io.openaev.database.model.Tenant;
@@ -31,8 +32,10 @@ import io.openaev.service.chaining.WorkflowService;
 import io.openaev.telemetry.metric_collectors.ActionMetricCollector;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hibernate.Session;
 import org.junit.jupiter.api.AfterEach;
@@ -145,6 +148,14 @@ class InjectsExecutionJobTenantScopeTest {
 
   /** An atomic inject (no exercise) so the run needs no dependency or exercise bookkeeping. */
   private static ExecutableInject atomicInjectOfTenant(String tenantId) {
+    return injectOfTenant(tenantId, null);
+  }
+
+  /**
+   * An inject of the given tenant, optionally attached to an exercise. When {@code exercise} is
+   * null the inject is atomic (no exercise bookkeeping needed).
+   */
+  private static ExecutableInject injectOfTenant(String tenantId, Exercise exercise) {
     Inject inject = new Inject();
     inject.setId(UUID.randomUUID().toString());
     inject.setTitle("Nuclei - CVE scan");
@@ -153,11 +164,15 @@ class InjectsExecutionJobTenantScopeTest {
     Injection injection = mock(Injection.class);
     when(injection.getInject()).thenReturn(inject);
     when(injection.getId()).thenReturn(inject.getId());
-    when(injection.getExercise()).thenReturn(null);
+    when(injection.getExercise()).thenReturn(exercise);
 
     ExecutableInject executableInject = mock(ExecutableInject.class);
     when(executableInject.getInjection()).thenReturn(injection);
-    when(executableInject.getExerciseId()).thenReturn(null);
+    // Computed before the when(): calling exercise.getId() (itself a mock) inside a when(...)
+    // argument nests a stub inside another's finishing call and trips Mockito's unfinished-
+    // stubbing detection.
+    String exerciseId = exercise == null ? null : exercise.getId();
+    when(executableInject.getExerciseId()).thenReturn(exerciseId);
     return executableInject;
   }
 
@@ -218,5 +233,54 @@ class InjectsExecutionJobTenantScopeTest {
 
     verify(injectStatusService).failInjectStatus(anyString(), anyString());
     assertThat(tenantDuringFailStatus.get()).isEqualTo(INJECT_TENANT);
+  }
+
+  @Test
+  @DisplayName(
+      "an exercise inject and two atomic injects of different tenants in the same sweep each"
+          + " execute under their own tenant, never a sibling's")
+  void mixedBatchExecutesEachInjectUnderItsOwnTenant() throws Exception {
+    // Regression for the "atomic" constant batch key: before the fix, every exercise-less inject
+    // shared one synthetic batch key regardless of tenant, so the batch's tenant was resolved
+    // once (from whichever inject happened to be first) and reused for every atomic inject in it
+    // - a customer's atomic inject could silently execute (and resolve its injector) under
+    // another tenant's scope.
+    String exerciseTenant = "22222222-2222-2222-2222-222222222222";
+    String atomicTenantA = "33333333-3333-3333-3333-333333333333";
+    String atomicTenantB = "44444444-4444-4444-4444-444444444444";
+
+    Exercise exercise = mock(Exercise.class);
+    when(exercise.getId()).thenReturn("exercise-1");
+
+    ExecutableInject exerciseInject = injectOfTenant(exerciseTenant, exercise);
+    ExecutableInject atomicInjectA = injectOfTenant(atomicTenantA, null);
+    ExecutableInject atomicInjectB = injectOfTenant(atomicTenantB, null);
+
+    when(injectHelper.getInjectsToRun())
+        .thenReturn(List.of(exerciseInject, atomicInjectA, atomicInjectB));
+
+    // Exercise batch bookkeeping (updateExercise), reached only for the exercise-linked inject.
+    when(exerciseRepository.findById(exercise.getId())).thenReturn(Optional.of(exercise));
+    when(exerciseRepository.save(any(Exercise.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    // Record the tenant scope actually active while each inject executes, keyed by inject id.
+    Map<String, String> tenantSeenPerInject = new ConcurrentHashMap<>();
+    when(executor.execute(any(ExecutableInject.class), any()))
+        .thenAnswer(
+            invocation -> {
+              ExecutableInject arg = invocation.getArgument(0);
+              String injectId = arg.getInjection().getInject().getId();
+              tenantSeenPerInject.put(injectId, TenantContext.getCurrentTenant());
+              return null;
+            });
+
+    job.execute(null);
+
+    assertThat(tenantSeenPerInject)
+        .as("each inject must resolve/execute under its own tenant scope, never a sibling's")
+        .containsEntry(exerciseInject.getInjection().getInject().getId(), exerciseTenant)
+        .containsEntry(atomicInjectA.getInjection().getInject().getId(), atomicTenantA)
+        .containsEntry(atomicInjectB.getInjection().getInject().getId(), atomicTenantB);
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes: Multi-tenancy race in `InjectsExecutionJob` (`parallelStream`)

Root cause: tenant scoping is thread-bound.  
`executeInTenant(...)` scopes the current thread, but inner `parallelStream()` runs injects on other ForkJoin threads, so tenant scope may be missing/stale there.

### Fix option 1 — keep inner parallelism (implemented)
- Keep `entry.getValue().parallelStream()`
- Wrap **each inject execution** in `executeInTenant(tenantId, () -> executeInject(...))`
- Also scope `updateExercise(...)` in tenant context

✅ Preserves parallelism inside one exercise  
✅ Correct tenant scope per worker thread (v1 + v2)  
⚠️ More transaction/scope setup overhead (one scoped tx per inject)

### Fix option 2 — remove inner parallelism
- Keep outer `byExercises.entrySet().parallelStream()`
- Replace inner `entry.getValue().parallelStream()` with sequential `stream()`
- Execute whole batch inside one `executeInTenant(...)`

✅ Simple and robust  
✅ Lower per-inject transaction overhead  
⚠️ Injects within a single exercise run sequentially (less intra-batch parallelism)


### Testing Instructions

1. Reproduced the issue in `main-ff` with this simulation [here](https://main-ff.oaev.staging.filigran.io/2cffad3a-0001-4078-b0e2-ef74274022c3/admin/simulations/5bedf9f0-3654-43f6-939d-cbabb7a1dc18/execution/timeline)

Locally fixed it
<img width="1541" height="1667" alt="Screenshot 2026-08-24 at 12 15 19" src="https://github.com/user-attachments/assets/6321ef10-9629-47ad-9c10-5834ee8108a5" />



### Related issues

* related [7556](https://github.com/OpenAEV-Platform/openaev/issues/7556)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
