### PR TITLE
fix(chaining): rebuild imported action TTPs from the target injector contract (#7577)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
+++ b/openaev-api/src/main/java/io/openaev/importer/V1_DataImporter.java
@@ -1926,7 +1926,12 @@ public class V1_DataImporter implements Importer {
     if (result.injectorContract() != null) {
       return result.injectorContract();
     } else {
-      log.warn("An error has occurred when importing the payload: {}", result.payload().getName());
+      log.warn(
+          "Payload '{}' (id={}) was created but no injector contract could be synchronised for it:"
+              + " no payload-capable injector is registered in tenant {}",
+          result.payload().getName(),
+          result.payload().getId(),
+          TenantContext.getCurrentTenant());
       InjectorContract injectorContract = new InjectorContract();
       injectorContract.setPayload(result.payload());
       return injectorContract;
@@ -3172,6 +3177,13 @@ public class V1_DataImporter implements Importer {
     // target, so surface it as a missing step (same type/name convention as
     // evaluateChainingStepResolvability) instead of persisting a step pointing to a broken id.
     if (resolvedStepContract != null) {
+      log.warn(
+          "Payload recreation for missing injector contract {} returned a transient contract"
+              + " (payload='{}'): the step cannot reference it and is skipped",
+          injectorContractId,
+          resolvedStepContract.getPayload() != null
+              ? resolvedStepContract.getPayload().getName()
+              : null);
       return StepDataResolution.failed(
           missingContractSkip(dataJson, injectContractNode, injectorContractId));
     }
@@ -3336,6 +3348,7 @@ public class V1_DataImporter implements Importer {
       rewriteInjectorContractDomains(injectContractObject, baseIds);
       rewriteInjectorContractAttackPatterns(injectContractObject, baseIds);
     }
+    buildStepTtpFromInjectorContract(dataObject);
     if (workflow.getSimulation() != null) {
       dataObject.put("inject_exercise", workflow.getSimulation().getId());
       dataObject.putNull("inject_scenario");
@@ -3543,6 +3556,43 @@ public class V1_DataImporter implements Importer {
     if (payloadNode instanceof ObjectNode payloadObject) {
       rewriteAttackPatternArray(payloadObject, "payload_", baseIds);
     }
+  }
+
+  /**
+   * Rebuilds {@code inject_attack_patterns} and {@code inject_kill_chain_phases} of a step_data
+   * from the target injector contract, which owns these fields at run time (#7577).
+   */
+  private void buildStepTtpFromInjectorContract(ObjectNode dataObject) {
+    String injectorContractId =
+        extractInjectorContractId(dataObject.get("inject_injector_contract"));
+    InjectorContract contract =
+        hasText(injectorContractId)
+            ? injectorContractRepository
+                .findByContractIdAndTenant(injectorContractId, TenantContext.getCurrentTenant())
+                .orElse(null)
+            : null;
+    if (contract == null) {
+      return;
+    }
+
+    ArrayNode attackPatternsNode = mapper.createArrayNode();
+    ArrayNode killChainPhasesNode = mapper.createArrayNode();
+    Set<String> seenKillChainPhaseIds = new LinkedHashSet<>();
+    for (AttackPattern attackPattern : contract.getAttackPatterns()) {
+      if (attackPattern == null || attackPattern.getId() == null) {
+        continue;
+      }
+      attackPatternsNode.add(mapper.valueToTree(attackPattern));
+      for (KillChainPhase killChainPhase : attackPattern.getKillChainPhases()) {
+        if (killChainPhase != null
+            && killChainPhase.getId() != null
+            && seenKillChainPhaseIds.add(killChainPhase.getId())) {
+          killChainPhasesNode.add(mapper.valueToTree(killChainPhase));
+        }
+      }
+    }
+    dataObject.set("inject_attack_patterns", attackPatternsNode);
+    dataObject.set("inject_kill_chain_phases", killChainPhasesNode);
   }
 
   private void rewriteAttackPatternArray(

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -100,13 +100,24 @@ public class PayloadService {
     // the injector links, otherwise the contract (stamped on the payload's tenant) could reference
     // another tenant's injector or fail on the injectors_injector_contracts FK.
     String payloadTenantId = payload.getTenant().getId();
+    List<Injector> allPayloadInjectors = this.injectorRepository.findAllByPayloads(true);
     List<Injector> injectors =
-        this.injectorRepository.findAllByPayloads(true).stream()
+        allPayloadInjectors.stream()
             .filter(injector -> payloadTenantId.equals(injector.getTenantId()))
             .toList();
 
     Injector referenceInjector = injectors.isEmpty() ? null : injectors.getFirst();
     if (referenceInjector == null) {
+      log.warn(
+          "No injector contract can be synchronised for payload '{}' (id={}, tenant={}): no"
+              + " payload-capable injector found in that tenant (visible payload-capable injectors:"
+              + " {})",
+          payload.getName(),
+          payload.getId(),
+          payloadTenantId,
+          allPayloadInjectors.stream()
+              .map(injector -> injector.getName() + "@" + injector.getTenantId())
+              .toList());
       return null;
     }
 

--- a/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/payload/service/PayloadService.java
@@ -100,24 +100,13 @@ public class PayloadService {
     // the injector links, otherwise the contract (stamped on the payload's tenant) could reference
     // another tenant's injector or fail on the injectors_injector_contracts FK.
     String payloadTenantId = payload.getTenant().getId();
-    List<Injector> allPayloadInjectors = this.injectorRepository.findAllByPayloads(true);
     List<Injector> injectors =
-        allPayloadInjectors.stream()
+        this.injectorRepository.findAllByPayloads(true).stream()
             .filter(injector -> payloadTenantId.equals(injector.getTenantId()))
             .toList();
 
     Injector referenceInjector = injectors.isEmpty() ? null : injectors.getFirst();
     if (referenceInjector == null) {
-      log.warn(
-          "No injector contract can be synchronised for payload '{}' (id={}, tenant={}): no"
-              + " payload-capable injector found in that tenant (visible payload-capable injectors:"
-              + " {})",
-          payload.getName(),
-          payload.getId(),
-          payloadTenantId,
-          allPayloadInjectors.stream()
-              .map(injector -> injector.getName() + "@" + injector.getTenantId())
-              .toList());
       return null;
     }
 

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -2112,52 +2112,6 @@ class V1_DataImporterTest extends IntegrationTest {
   @Test
   @Transactional
   @WithMockUser
-  void
-      given_stepDataInjectAttackPatternsWithUnresolvableContract_when_resolving_should_leaveSnapshotUntouched() {
-    // -- Arrange --
-    // Nothing can be rebuilt from a contract absent from the target tenant: the rewrite must be a
-    // no-op (such a step is already discarded upfront by evaluateChainingStepResolvability) and
-    // must never crash the sanitization of the rest of the step_data.
-    String missingContractId = UUID.randomUUID().toString();
-    assertTrue(injectorContractRepository.findById(missingContractId).isEmpty());
-    ObjectMapper om = new ObjectMapper();
-    ObjectNode stepData = om.createObjectNode();
-    stepData.put("inject_title", "stale ttp snapshot");
-    stepData.put("inject_injector_contract", missingContractId);
-    String sourceAttackPatternId = UUID.randomUUID().toString();
-    stepData.set(
-        "inject_attack_patterns",
-        attackPatternObjectArray(om, sourceAttackPatternId, "T1059.001", "Command"));
-    stepData.set("inject_kill_chain_phases", om.createArrayNode());
-    ObjectNode stepNode = om.createObjectNode();
-    stepNode.set("step_data", stepData);
-
-    Scenario scenario = new Scenario();
-    scenario.setId(UUID.randomUUID().toString());
-    Workflow workflow = Workflow.builder().scenario(scenario).build();
-
-    // -- Act --
-    V1_DataImporter.StepDataResolution resolution =
-        ReflectionTestUtils.invokeMethod(
-            importer,
-            "resolveStepData",
-            stepNode,
-            new HashMap<String, String>(),
-            new HashMap<String, Base>(),
-            workflow);
-    JsonNode json = assertDoesNotThrow(() -> new ObjectMapper().readTree(resolution.stepData()));
-
-    // -- Assert --
-    assertEquals(
-        sourceAttackPatternId,
-        json.get("inject_attack_patterns").get(0).get("attack_pattern_id").asText(),
-        "an unresolvable contract must leave the exported snapshot untouched");
-    assertEquals(scenario.getId(), json.get("inject_scenario").asText());
-  }
-
-  @Test
-  @Transactional
-  @WithMockUser
   void given_stepDataTextualContractMissingFromDb_when_resolving_should_logAndSanitize() {
     // -- Arrange --
     // A textual contract id that does not exist on the target and cannot be recreated (textual form

--- a/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
+++ b/openaev-api/src/test/java/io/openaev/importer/V1_DataImporterTest.java
@@ -25,6 +25,7 @@ import io.openaev.service.ImportEntry;
 import io.openaev.utils.constants.Constants;
 import io.openaev.utils.fixtures.DocumentFixture;
 import io.openaev.utils.fixtures.InjectorFixture;
+import io.openaev.utils.fixtures.KillChainPhaseFixture;
 import io.openaev.utils.fixtures.PayloadFixture;
 import io.openaev.utils.fixtures.files.AttackPatternFixture;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
@@ -2039,6 +2040,118 @@ class V1_DataImporterTest extends IntegrationTest {
     // -- Assert --
     // The contract object is preserved (no id to resolve) and the step is bound to the scenario.
     assertTrue(json.get("inject_injector_contract").isObject());
+    assertEquals(scenario.getId(), json.get("inject_scenario").asText());
+  }
+
+  @Test
+  @Transactional
+  @WithMockUser
+  void given_stepDataWithSourceInjectAttackPatterns_when_importing_should_rebuildTtpFromContract()
+      throws Exception {
+    // -- Arrange --
+    // The exported step_data carries the SOURCE instance TTP snapshot (inject_attack_patterns /
+    // inject_kill_chain_phases). The target contract is the authoritative source of both fields,
+    // so the import must recompute them from it, otherwise the imported action is displayed
+    // TTP-less ("Other" tactic) by the chaining UI (#7577).
+    KillChainPhase targetPhase =
+        killChainPhaseRepository.save(KillChainPhaseFixture.getKillChainPhase("execution", 2L));
+    AttackPattern targetAttackPattern =
+        AttackPatternFixture.createAttackPatternsWithExternalId("T1059.001");
+    targetAttackPattern.setKillChainPhases(new ArrayList<>(List.of(targetPhase)));
+    targetAttackPattern = attackPatternRepository.save(targetAttackPattern);
+
+    ObjectMapper om = new ObjectMapper();
+    String scenarioName = "wf inject ttp " + UUID.randomUUID();
+    ObjectNode importData =
+        buildScenarioWorkflowWithStepTags(
+            om, scenarioName, om.createArrayNode(), om.createArrayNode(), om.createArrayNode());
+    ObjectNode stepData =
+        (ObjectNode)
+            importData.get("scenario_workflow").get("workflow_steps").get(0).get("step_data");
+    String contractId =
+        stepData.get("inject_injector_contract").get("injector_contract_id").asText();
+    InjectorContract targetContract = injectorContractRepository.findById(contractId).orElseThrow();
+    targetContract.setAttackPatterns(new ArrayList<>(List.of(targetAttackPattern)));
+    injectorContractRepository.save(targetContract);
+
+    String sourceAttackPatternId = UUID.randomUUID().toString();
+    String sourcePhaseId = UUID.randomUUID().toString();
+    ArrayNode sourceAttackPatterns =
+        attackPatternObjectArray(om, sourceAttackPatternId, "T1059.001", "Command and Scripting");
+    ((ArrayNode) sourceAttackPatterns.get(0).get("attack_pattern_kill_chain_phases"))
+        .add(sourcePhaseId);
+    stepData.set("inject_attack_patterns", sourceAttackPatterns);
+    ObjectNode sourcePhase = om.createObjectNode();
+    sourcePhase.put("phase_id", sourcePhaseId);
+    sourcePhase.put("phase_name", "execution");
+    stepData.set("inject_kill_chain_phases", om.createArrayNode().add(sourcePhase));
+
+    // -- Act --
+    this.importer.importData(
+        importData, Map.of(), null, null, null, null, Constants.IMPORTED_OBJECT_NAME_SUFFIX);
+
+    // -- Assert --
+    JsonNode storedData = readStoredStepData(scenarioName, om);
+    JsonNode storedAttackPatterns = storedData.get("inject_attack_patterns");
+    assertEquals(1, storedAttackPatterns.size());
+    assertEquals(
+        targetAttackPattern.getId(),
+        storedAttackPatterns.get(0).get("attack_pattern_id").asText(),
+        "inject_attack_patterns must be rebuilt from the resolved target contract");
+    assertEquals(
+        List.of(targetPhase.getId()),
+        tagIdList(storedAttackPatterns.get(0).get("attack_pattern_kill_chain_phases")),
+        "the nested kill chain phase ids must point to the target instance");
+    assertEquals(
+        targetPhase.getId(),
+        storedData.get("inject_kill_chain_phases").get(0).get("phase_id").asText(),
+        "inject_kill_chain_phases must be rebuilt from the resolved target contract");
+    assertDoesNotThrow(() -> deserializeStepDataAsRun(storedData.toString()));
+  }
+
+  @Test
+  @Transactional
+  @WithMockUser
+  void
+      given_stepDataInjectAttackPatternsWithUnresolvableContract_when_resolving_should_leaveSnapshotUntouched() {
+    // -- Arrange --
+    // Nothing can be rebuilt from a contract absent from the target tenant: the rewrite must be a
+    // no-op (such a step is already discarded upfront by evaluateChainingStepResolvability) and
+    // must never crash the sanitization of the rest of the step_data.
+    String missingContractId = UUID.randomUUID().toString();
+    assertTrue(injectorContractRepository.findById(missingContractId).isEmpty());
+    ObjectMapper om = new ObjectMapper();
+    ObjectNode stepData = om.createObjectNode();
+    stepData.put("inject_title", "stale ttp snapshot");
+    stepData.put("inject_injector_contract", missingContractId);
+    String sourceAttackPatternId = UUID.randomUUID().toString();
+    stepData.set(
+        "inject_attack_patterns",
+        attackPatternObjectArray(om, sourceAttackPatternId, "T1059.001", "Command"));
+    stepData.set("inject_kill_chain_phases", om.createArrayNode());
+    ObjectNode stepNode = om.createObjectNode();
+    stepNode.set("step_data", stepData);
+
+    Scenario scenario = new Scenario();
+    scenario.setId(UUID.randomUUID().toString());
+    Workflow workflow = Workflow.builder().scenario(scenario).build();
+
+    // -- Act --
+    V1_DataImporter.StepDataResolution resolution =
+        ReflectionTestUtils.invokeMethod(
+            importer,
+            "resolveStepData",
+            stepNode,
+            new HashMap<String, String>(),
+            new HashMap<String, Base>(),
+            workflow);
+    JsonNode json = assertDoesNotThrow(() -> new ObjectMapper().readTree(resolution.stepData()));
+
+    // -- Assert --
+    assertEquals(
+        sourceAttackPatternId,
+        json.get("inject_attack_patterns").get(0).get("attack_pattern_id").asText(),
+        "an unresolvable contract must leave the exported snapshot untouched");
     assertEquals(scenario.getId(), json.get("inject_scenario").asText());
   }
 


### PR DESCRIPTION
Fixes #7577

## Problem

After exporting a chaining scenario and importing it (on another instance), every action was displayed as TTP-less and grouped under the "Other" tactic.

## Fix

`V1_DataImporter.sanitizateStepData()` now rebuilds both fields from the injector contract so the step is imported with the correct ttp

A contract that cannot be resolved on the target tenant is a no-op: such a step is already discarded upfront by `evaluateChainingStepResolvability`.

## How to Tests

- Export a scenario from one main with different ttp 
- Import it locally -> if you go to the logic page it should be organise by TTP and not have all the actions in 'Other'
-  You can use the folowing scenario for test
[test hedi ttp _2026-08-24T15_20_05.521363936Z_(no_variable_values & no_scope_definition).zip](https://github.com/user-attachments/files/31382604/test.hedi.ttp._2026-08-24T15_20_05.521363936Z_.no_variable_values.no_scope_definition.zip)
