### PR TITLE
fix(multi-tenancy): implement tenant auto-assign groups for user creation and updates (#7548)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -40,6 +40,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -172,7 +173,8 @@ public class UserService {
     if (StringUtils.hasLength(password)) {
       user.setPassword(this.encodeUserPassword(password));
     }
-    syncAutoAssignGroups(user);
+    // Creation enters every scope at once: platform, plus each tenant attached in the input.
+    assignAutoAssignGroups(user, user.getTenants().stream().map(Tenant::getId).toList(), true);
     User savedUser = userRepository.save(user);
     this.createUserToken(savedUser, token);
     return savedUser;
@@ -241,7 +243,14 @@ public class UserService {
         new ArrayList<>(
             referenceResolver.resolve(
                 input.tenantIds(), Tenant.class, tenantRepository::countByIdIn)));
-    syncAutoAssignGroups(existing);
+    // Only tenants the user just joined trigger auto-assignment: re-applying it to tenants he
+    // already belonged to would restore groups deliberately removed from within those tenants.
+    List<String> attachedTenantIds =
+        existing.getTenants().stream()
+            .map(Tenant::getId)
+            .filter(tenantId -> !oldTenantIds.contains(tenantId))
+            .toList();
+    assignAutoAssignGroups(existing, attachedTenantIds, false);
     User savedUser = userRepository.save(existing);
     // Evict cache for old tenants (removed memberships) and new tenants (added memberships)
     List<String> newTenantIds = input.tenantIds() != null ? input.tenantIds() : List.of();
@@ -550,14 +559,37 @@ public class UserService {
   }
 
   /**
-   * Ensures the user holds every default-assign group applicable to their current scope:
-   * platform-scoped auto-assign groups, plus the auto-assign groups of each tenant they are
-   * attached to. Never removes an existing group membership.
+   * Grants the auto-assign groups of the given tenants to an already persisted user. Used when a
+   * user joins a tenant outside of the create/update flows, i.e. when attached from a tenant
+   * screen.
    */
-  private void syncAutoAssignGroups(User user) {
-    Specification<Group> spec = GroupSpecification.defaultUserAssignablePlatform();
-    for (Tenant tenant : user.getTenants()) {
-      spec = spec.or(GroupSpecification.defaultUserAssignableTenant(tenant.getId()));
+  @Transactional(rollbackFor = Exception.class)
+  public void assignAutoAssignGroups(
+      @NotBlank final String userId, @NotNull final Collection<String> tenantIds) {
+    if (tenantIds.isEmpty()) {
+      return;
+    }
+    User user = user(userId);
+    assignAutoAssignGroups(user, tenantIds, false);
+    userRepository.save(user);
+  }
+
+  /**
+   * Grants the default-assign groups of the scopes the user just entered: the platform scope at
+   * creation, plus every tenant freshly attached. Scopes the user already belonged to are skipped,
+   * so a group deliberately removed from a user is never re-granted by a later update. Never
+   * removes an existing group membership.
+   */
+  private void assignAutoAssignGroups(
+      User user, Collection<String> tenantIds, boolean includePlatformScope) {
+    if (!includePlatformScope && tenantIds.isEmpty()) {
+      return;
+    }
+    Specification<Group> spec =
+        includePlatformScope ? GroupSpecification.defaultUserAssignablePlatform() : null;
+    for (String tenantId : tenantIds) {
+      Specification<Group> tenantSpec = GroupSpecification.defaultUserAssignableTenant(tenantId);
+      spec = spec == null ? tenantSpec : spec.or(tenantSpec);
     }
     List<Group> applicableGroups = groupRepository.findAll(spec);
     if (applicableGroups.isEmpty()) {

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -53,6 +53,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
@@ -171,9 +172,7 @@ public class UserService {
     if (StringUtils.hasLength(password)) {
       user.setPassword(this.encodeUserPassword(password));
     }
-    List<Group> assignableGroups =
-        groupRepository.findAll(GroupSpecification.defaultUserAssignablePlatform());
-    user.setGroups(assignableGroups);
+    syncAutoAssignGroups(user);
     User savedUser = userRepository.save(user);
     this.createUserToken(savedUser, token);
     return savedUser;
@@ -242,6 +241,7 @@ public class UserService {
         new ArrayList<>(
             referenceResolver.resolve(
                 input.tenantIds(), Tenant.class, tenantRepository::countByIdIn)));
+    syncAutoAssignGroups(existing);
     User savedUser = userRepository.save(existing);
     // Evict cache for old tenants (removed memberships) and new tenants (added memberships)
     List<String> newTenantIds = input.tenantIds() != null ? input.tenantIds() : List.of();
@@ -547,5 +547,28 @@ public class UserService {
 
   public Optional<User> findByEmailIgnoreCase(String email) {
     return userRepository.findByEmailIgnoreCase(email);
+  }
+
+  /**
+   * Ensures the user holds every default-assign group applicable to their current scope:
+   * platform-scoped auto-assign groups, plus the auto-assign groups of each tenant they are
+   * attached to. Never removes an existing group membership.
+   */
+  private void syncAutoAssignGroups(User user) {
+    Specification<Group> spec = GroupSpecification.defaultUserAssignablePlatform();
+    for (Tenant tenant : user.getTenants()) {
+      spec = spec.or(GroupSpecification.defaultUserAssignableTenant(tenant.getId()));
+    }
+    List<Group> applicableGroups = groupRepository.findAll(spec);
+    if (applicableGroups.isEmpty()) {
+      return;
+    }
+    List<Group> current = new ArrayList<>(user.getUnscopedGroups());
+    for (Group group : applicableGroups) {
+      if (!current.contains(group)) {
+        current.add(group);
+      }
+    }
+    user.setGroups(current);
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
@@ -11,14 +11,11 @@ import io.openaev.api.users.dto.UserMapper;
 import io.openaev.api.users.dto.UserOutput;
 import io.openaev.config.cache.TenantMembershipCacheManager;
 import io.openaev.context.TenantContext;
-import io.openaev.database.model.Group;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.User;
 import io.openaev.database.raw.RawUser;
-import io.openaev.database.repository.GroupRepository;
 import io.openaev.database.repository.TenantRepository;
 import io.openaev.database.repository.UserRepository;
-import io.openaev.database.specification.GroupSpecification;
 import io.openaev.database.specification.UserSpecification;
 import io.openaev.multitenancy.DependenciesManager;
 import io.openaev.rest.exception.ElementNotFoundException;
@@ -46,7 +43,6 @@ public class TenantUserService implements DependenciesManager {
   private final UserService userService;
   private final UserRepository userRepository;
   private final TenantRepository tenantRepository;
-  private final GroupRepository groupRepository;
   private final TenantMembershipCacheManager tenantMembershipCacheManager;
   @PersistenceContext private EntityManager entityManager;
 
@@ -61,14 +57,14 @@ public class TenantUserService implements DependenciesManager {
     if (existingUser.isPresent()) {
       String userId = existingUser.get().getId();
       attachToTenant(userId, tenantId);
-      assignDefaultTenantGroups(userId, tenantId);
+      userService.assignAutoAssignGroups(userId, List.of(tenantId));
       // Reload user after @Modifying queries cleared the persistence context
       User reloaded = userRepository.findById(userId).orElseThrow();
       return UserMapper.toOutput(reloaded);
     }
     User user = userService.createUser(input);
     attachToTenant(user.getId(), tenantId);
-    assignDefaultTenantGroups(user.getId(), tenantId);
+    userService.assignAutoAssignGroups(user.getId(), List.of(tenantId));
     // Reload user after @Modifying queries cleared the persistence context
     User reloaded = userRepository.findById(user.getId()).orElseThrow();
     return UserMapper.toOutput(reloaded);
@@ -179,23 +175,5 @@ public class TenantUserService implements DependenciesManager {
       throw new IllegalStateException("TenantUserService requires a tenant context");
     }
     return tenantId;
-  }
-
-  private void assignDefaultTenantGroups(String userId, String tenantId) {
-    List<Group> defaultGroups =
-        groupRepository.findAll(GroupSpecification.defaultUserAssignableTenant(tenantId));
-    if (defaultGroups.isEmpty()) {
-      return;
-    }
-    User user =
-        userRepository
-            .findById(userId)
-            .orElseThrow(() -> new ElementNotFoundException("User not found with id: " + userId));
-    for (Group group : defaultGroups) {
-      if (!group.getUsers().contains(user)) {
-        group.getUsers().add(user);
-        groupRepository.save(group);
-      }
-    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/api/platform/users/PlatformUserApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/platform/users/PlatformUserApiTest.java
@@ -1,0 +1,109 @@
+package io.openaev.api.platform.users;
+
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import io.openaev.IntegrationTest;
+import io.openaev.api.users.dto.UserInput;
+import io.openaev.database.model.Capability;
+import io.openaev.database.model.Group;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.model.User;
+import io.openaev.database.repository.GroupRepository;
+import io.openaev.ee.EnterpriseEditionService;
+import io.openaev.service.UserService;
+import io.openaev.utils.fixtures.tenants.TenantComposer;
+import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.WithMockUser;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@DisplayName("Platform User API")
+class PlatformUserApiTest extends IntegrationTest {
+
+  private static final String PLATFORM_USERS_URI = "/api/platform-users";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private TenantComposer tenantComposer;
+  @Autowired private GroupRepository groupRepository;
+  @Autowired private UserService userService;
+  @PersistenceContext private EntityManager entityManager;
+
+  @MockitoBean private EnterpriseEditionService enterpriseEditionService;
+
+  @BeforeEach
+  void setup() {
+    when(enterpriseEditionService.isEnterpriseLicenseInactive(any())).thenReturn(false);
+  }
+
+  @Test
+  @WithMockUser(withCapabilities = {Capability.MANAGE_PLATFORM_USERS_GROUPS_AND_ROLES})
+  @DisplayName("given_creationWithTenants_should_assignPlatformAndTenantAutoAssignGroups")
+  void given_creationWithTenants_should_assignAutoAssignGroups() throws Exception {
+    // -- ARRANGE --
+    Tenant tenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("api-auto-assign")).persist().get();
+    Group platformGroup = autoAssignGroup("api-platform-auto-assign", null);
+    Group tenantGroup = autoAssignGroup("api-tenant-auto-assign", tenant);
+    UserInput input =
+        new UserInput(
+            "api-auto-assign-" + UUID.randomUUID() + "@filigran.io",
+            "Auto",
+            "Assign",
+            "secureP@ss1",
+            null,
+            null,
+            null,
+            null,
+            List.of(),
+            false,
+            List.of(tenant.getId()));
+
+    // -- ACT --
+    String response =
+        mvc.perform(
+                post(PLATFORM_USERS_URI)
+                    .content(asJsonString(input))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .with(csrf()))
+            .andExpect(status().is2xxSuccessful())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    // -- ASSERT --
+    String userId = JsonPath.read(response, "$.user_id");
+    entityManager.flush();
+    entityManager.clear();
+    User created = userService.user(userId);
+    assertThat(created.getUnscopedGroups())
+        .extracting(Group::getId)
+        .contains(platformGroup.getId(), tenantGroup.getId());
+  }
+
+  private Group autoAssignGroup(String name, Tenant tenant) {
+    Group group = new Group();
+    group.setName(name);
+    group.setDefaultUserAssignation(true);
+    group.setTenant(tenant);
+    return groupRepository.save(group);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
@@ -134,6 +134,40 @@ class UserServiceTest extends IntegrationTest {
     assertThat(reloaded.getUnscopedGroups()).extracting(Group::getId).contains(tenantGroup.getId());
   }
 
+  @Test
+  @DisplayName("given_groupRemovedInTenant_should_notReassignItOnPlatformUpdate")
+  void given_groupRemovedInTenant_should_notReassignItOnPlatformUpdate() {
+    // -- ARRANGE --
+    Tenant tenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("auto-assign-removed")).persist().get();
+    Group tenantGroup = autoAssignGroup("tenant-auto-assign-removed", tenant);
+    UserInput input =
+        getUserInputWithTenants(
+            "auto-assign-removed@test.invalid",
+            "Auto",
+            "Removed",
+            "secureP@ss1",
+            List.of(tenant.getId()));
+    User created = userService.createUser(input);
+    // The tenant admin removes the auto-assign group from the user, from within the tenant.
+    created.getUnscopedGroups().remove(tenantGroup);
+    userService.saveUser(created);
+    entityManager.flush();
+    entityManager.clear();
+
+    // -- ACT --
+    // A later update from the platform screen keeps the very same tenants attached.
+    userService.updateUser(created.getId(), input);
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(created.getId());
+    assertThat(reloaded.getUnscopedGroups())
+        .extracting(Group::getId)
+        .doesNotContain(tenantGroup.getId());
+  }
+
   private Group autoAssignGroup(String name, Tenant tenant) {
     Group group = new Group();
     group.setName(name);

--- a/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
@@ -168,6 +168,38 @@ class UserServiceTest extends IntegrationTest {
         .doesNotContain(tenantGroup.getId());
   }
 
+  @Test
+  @DisplayName("given_alreadyAttachedTenant_should_notAssignAutoAssignGroupsOnUpdate")
+  void given_alreadyAttachedTenant_should_notAssignAutoAssignGroupsOnUpdate() {
+    // -- ARRANGE --
+    Tenant tenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("auto-assign-unchanged")).persist().get();
+    UserInput input =
+        getUserInputWithTenants(
+            "auto-assign-unchanged@test.invalid",
+            "Auto",
+            "Unchanged",
+            "secureP@ss1",
+            List.of(tenant.getId()));
+    User created = userService.createUser(input);
+    entityManager.flush();
+    entityManager.clear();
+    // The auto-assign group only appears after the user already belongs to the tenant.
+    Group lateGroup = autoAssignGroup("tenant-auto-assign-late", tenant);
+
+    // -- ACT --
+    // Updating the user without changing his tenants must not trigger any auto-assignment.
+    userService.updateUser(created.getId(), input);
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(created.getId());
+    assertThat(reloaded.getUnscopedGroups())
+        .extracting(Group::getId)
+        .doesNotContain(lateGroup.getId());
+  }
+
   private Group autoAssignGroup(String name, Tenant tenant) {
     Group group = new Group();
     group.setName(name);

--- a/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
@@ -5,12 +5,16 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.openaev.IntegrationTest;
 import io.openaev.api.users.dto.UserInput;
+import io.openaev.database.model.Group;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.User;
+import io.openaev.database.repository.GroupRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.utils.fixtures.composers.UserComposer;
 import io.openaev.utils.fixtures.tenants.TenantComposer;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +29,8 @@ class UserServiceTest extends IntegrationTest {
   @Autowired private UserService userService;
   @Autowired private UserComposer userComposer;
   @Autowired private TenantComposer tenantComposer;
+  @Autowired private GroupRepository groupRepository;
+  @PersistenceContext private EntityManager entityManager;
 
   // -- CREATE --
 
@@ -68,6 +74,72 @@ class UserServiceTest extends IntegrationTest {
     // -- ASSERT --
     assertThat(created.getId()).isNotNull();
     assertThat(created.getTenants()).extracting(Tenant::getId).containsExactly(tenant.getId());
+  }
+
+  @Test
+  @DisplayName("given_platformCreationWithTenants_should_assignPlatformAndTenantAutoAssignGroups")
+  void given_platformCreationWithTenants_should_assignAutoAssignGroups() {
+    // -- ARRANGE --
+    Tenant tenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("auto-assign-create")).persist().get();
+    Group platformGroup = autoAssignGroup("platform-auto-assign-create", null);
+    Group tenantGroup = autoAssignGroup("tenant-auto-assign-create", tenant);
+
+    // -- ACT --
+    User created =
+        userService.createUser(
+            getUserInputWithTenants(
+                "auto-assign-create@test.invalid",
+                "Auto",
+                "Assign",
+                "secureP@ss1",
+                List.of(tenant.getId())));
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(created.getId());
+    assertThat(reloaded.getUnscopedGroups())
+        .extracting(Group::getId)
+        .contains(platformGroup.getId(), tenantGroup.getId());
+  }
+
+  @Test
+  @DisplayName("given_platformUpdateAttachingTenant_should_assignTenantAutoAssignGroups")
+  void given_platformUpdateAttachingTenant_should_assignAutoAssignGroups() {
+    // -- ARRANGE --
+    Tenant tenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("auto-assign-update")).persist().get();
+    Group tenantGroup = autoAssignGroup("tenant-auto-assign-update", tenant);
+    User persisted =
+        userComposer
+            .forUser(getUser("Auto", "Update", "auto-assign-update@test.invalid"))
+            .persist()
+            .get();
+
+    // -- ACT --
+    userService.updateUser(
+        persisted.getId(),
+        getUserInputWithTenants(
+            "auto-assign-update@test.invalid",
+            "Auto",
+            "Update",
+            "secureP@ss1",
+            List.of(tenant.getId())));
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(persisted.getId());
+    assertThat(reloaded.getUnscopedGroups()).extracting(Group::getId).contains(tenantGroup.getId());
+  }
+
+  private Group autoAssignGroup(String name, Tenant tenant) {
+    Group group = new Group();
+    group.setName(name);
+    group.setDefaultUserAssignation(true);
+    group.setTenant(tenant);
+    return groupRepository.save(group);
   }
 
   // -- READ --


### PR DESCRIPTION
This pull request enhances the user group assignment logic in the `UserService` to ensure that users are automatically assigned to all applicable platform and tenant-scoped auto-assign groups both on creation and update. It also adds comprehensive integration and unit tests to verify this behavior.

**User group auto-assignment improvements:**

* Refactored group assignment logic by introducing a private `syncAutoAssignGroups` method in `UserService`, which ensures that a user is assigned to all relevant platform and tenant auto-assign groups without removing existing group memberships. This method is now called during both user creation and update

### Testing Instructions

1. In tenant T, Settings > Security > Groups: create a group with "Auto assign" enabled (tenant-scoped group).
2. Settings > Security > Users inside tenant T: create user `A` → `A` is a member of the auto-assign group. OK.
3. Platform > Users: create user `B` and select tenant T in the "Tenants" field → `B` must have the group that was auto-assigned.
4. Same result when attaching T afterwards by editing `B` from the platform screen.

## Expected output
Creation (and tenant attachment) from the platform screen assigns platform-scoped auto-assign
groups plus the auto-assign groups of every attached tenant.

### Related issues

* Closes #7548 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] For bug fix -> I implemented a test that covers the bug


