### PR TITLE
fix(dashboard): mount home grid once after human response probe resolves (#7599)

### DIFF
--- a/openaev-front/src/__tests__/admin/components/DefaultHomeDashboard.test.tsx
+++ b/openaev-front/src/__tests__/admin/components/DefaultHomeDashboard.test.tsx
@@ -1,0 +1,153 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type EsSeries } from '../../../utils/api-types';
+
+const { mockDispatch, adHocSeriesMock, gridMountSpy } = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  adHocSeriesMock: vi.fn(),
+  gridMountSpy: vi.fn(),
+}));
+
+vi.mock('../../../components/i18n', () => ({
+  useFormatter: () => ({
+    t: (value: string) => value,
+    locale: 'en',
+  }),
+}));
+
+// Plain state instead of persistence: Node's non-functional localStorage
+// global shadows the happy-dom one, breaking the real hook in tests.
+vi.mock('usehooks-ts', () => ({ useLocalStorage: (_key: string, initialValue: unknown) => useState(initialValue) }));
+
+vi.mock('../../../utils/hooks', () => ({ useAppDispatch: () => mockDispatch }));
+
+vi.mock('../../../utils/hooks/useDataLoader', () => ({
+  default: (loader: () => void) => {
+    loader();
+  },
+}));
+
+vi.mock('../../../actions/assets/securityPlatform-actions', () => ({ fetchSecurityPlatforms: () => ({ type: 'fetchSecurityPlatforms' }) }));
+
+vi.mock(import('../../../actions/dashboards/dashboard-action'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    adHocSeries: adHocSeriesMock,
+  };
+});
+
+// Counts MOUNTS (not renders): the #7599 regression was the grid mounting
+// eagerly with 3 gauges and being key-remounted (second mount, full refetch)
+// once the Human Response probe resolved.
+const GridMountProbe = () => {
+  useEffect(() => {
+    gridMountSpy();
+  }, []);
+  return <div data-testid="dashboard-grid" />;
+};
+
+vi.mock('../../../admin/components/workspaces/custom_dashboards/CustomDashboardReactLayout', () => ({ default: () => <GridMountProbe /> }));
+
+import DefaultHomeDashboard from '../../../admin/components/default_dashboard/DefaultHomeDashboard';
+
+const theme = createTheme();
+
+const renderDashboard = () => render(
+  <ThemeProvider theme={theme}>
+    <MemoryRouter>
+      <DefaultHomeDashboard />
+    </MemoryRouter>
+  </ThemeProvider>,
+);
+
+const probeResponse = (value: number): { data: EsSeries[] } => ({
+  data: [{
+    label: '',
+    data: [{
+      key: 'PENDING',
+      value,
+    }],
+  }],
+});
+
+describe('DefaultHomeDashboard first load (#7599)', () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+    adHocSeriesMock.mockReset();
+    gridMountSpy.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('defers the grid until the probe resolves, then mounts it exactly once with human response data', async () => {
+    // Arrange
+    let resolveProbe: (response: { data: EsSeries[] }) => void = () => {};
+    adHocSeriesMock.mockImplementation(() => new Promise((resolve) => {
+      resolveProbe = resolve;
+    }));
+
+    // Act
+    renderDashboard();
+    // Let the concurrency limiter actually start the probe (one microtask hop)
+    await act(async () => {});
+
+    // Assert: probe in flight, the grid must not be mounted yet
+    expect(screen.queryByTestId('dashboard-grid')).toBeNull();
+
+    // Act: the probe finds human-driven expectations in range
+    await act(async () => {
+      resolveProbe(probeResponse(3));
+    });
+
+    // Assert: a single mount, directly with the final gauge geometry
+    expect(await screen.findByTestId('dashboard-grid')).toBeDefined();
+    expect(gridMountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts the grid exactly once when the probe finds no human response data', async () => {
+    // Arrange
+    let resolveProbe: (response: { data: EsSeries[] }) => void = () => {};
+    adHocSeriesMock.mockImplementation(() => new Promise((resolve) => {
+      resolveProbe = resolve;
+    }));
+
+    // Act
+    renderDashboard();
+    await act(async () => {});
+    expect(screen.queryByTestId('dashboard-grid')).toBeNull();
+    await act(async () => {
+      resolveProbe(probeResponse(0));
+    });
+
+    // Assert
+    expect(await screen.findByTestId('dashboard-grid')).toBeDefined();
+    expect(gridMountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still mounts the grid exactly once when the probe fails', async () => {
+    // Arrange
+    let rejectProbe: (error: Error) => void = () => {};
+    adHocSeriesMock.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectProbe = reject;
+    }));
+
+    // Act
+    renderDashboard();
+    await act(async () => {});
+    expect(screen.queryByTestId('dashboard-grid')).toBeNull();
+    await act(async () => {
+      rejectProbe(new Error('engine warming up'));
+    });
+
+    // Assert: the gauge defaults to hidden, the dashboard still renders
+    expect(await screen.findByTestId('dashboard-grid')).toBeDefined();
+    expect(gridMountSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openaev-front/src/admin/components/default_dashboard/DefaultHomeDashboard.tsx
+++ b/openaev-front/src/admin/components/default_dashboard/DefaultHomeDashboard.tsx
@@ -8,6 +8,7 @@ import { useLocalStorage } from 'usehooks-ts';
 import { fetchSecurityPlatforms } from '../../../actions/assets/securityPlatform-actions';
 import { adHocAverage, adHocCount, adHocEntities, adHocEntitiesRuntime, adHocSeries } from '../../../actions/dashboards/dashboard-action';
 import { useFormatter } from '../../../components/i18n';
+import Loader from '../../../components/Loader';
 import { type CustomDashboard, type EsSeries, type Widget, type WidgetToEntitiesInput } from '../../../utils/api-types';
 import { useBulkOperationsFinishedCount } from '../../../utils/bulkOperations';
 import { useAppDispatch } from '../../../utils/hooks';
@@ -55,11 +56,14 @@ const DefaultHomeDashboard = () => {
   // "Human Response" is situational (manual/article/challenge expectations, e.g.
   // phishing), so - like the command center's human node - the gauge is mounted
   // only when there is data in range, never as a sample-only card. Probe the same
-  // config the gauge queries; default hidden so an empty range never flashes it.
-  // The gauge occupies a RESERVED 4th slot (see defaultHomeWidgets GAUGE_WIDTH):
-  // the three core gauges never move whether or not it is present, so it can arrive
-  // late (after this probe resolves) without reflowing them onto a second row.
-  const [humanResponsePresent, setHumanResponsePresent] = useState(false);
+  // config the gauge queries. Tri-state: null = probe in flight, and the grid is
+  // NOT mounted until it resolves. The gauge row is responsive (3 gauges at w=4,
+  // 4 at w=3, see buildDefaultHomeWidgets) and react-grid-layout only reads a
+  // child's data-grid at first mount, so the grid must mount with its FINAL gauge
+  // count: mounting it eagerly with 3 gauges and key-remounting when the probe
+  // resolved re-rendered (blank flash) and refetched the entire dashboard on
+  // every first load of a platform with human response data (#7599).
+  const [humanResponsePresent, setHumanResponsePresent] = useState<boolean | null>(null);
   useEffect(() => {
     let cancelled = false;
     limitWidgetQueries(() => adHocSeries(buildHumanResponseProbeConfig(timeRange)))
@@ -98,7 +102,7 @@ const DefaultHomeDashboard = () => {
   // context value and refetches all ~20 widgets (same rule as DefaultHomeResults).
   // `locale` is the stable signal that t's output actually changed, so a runtime
   // language switch still recomputes the titles (one refetch, but only then).
-  const widgets = useMemo(() => buildDefaultHomeWidgets(timeRange, t, humanResponsePresent), [timeRange, locale, humanResponsePresent]);
+  const widgets = useMemo(() => buildDefaultHomeWidgets(timeRange, t, humanResponsePresent === true), [timeRange, locale, humanResponsePresent]);
 
   const widgetById = useMemo(() => {
     const map = new Map<string, Widget>();
@@ -235,13 +239,26 @@ const DefaultHomeDashboard = () => {
         </Tooltip>
       </div>
       {/*
-        Remount the grid when the gauge count changes. react-grid-layout keeps the
-        internal layout of already-mounted children and ignores width changes, so
-        flipping 3 gauges (w=4) <-> 4 gauges (w=3) in place would leave the core
-        gauges at their old width and strand Human Response on a second row. A fresh
-        mount re-reads every gauge's width, so each state fills the row evenly.
+        Mounted only once the Human Response probe has resolved - with the grid
+        not mounted yet the probe is the only query in the concurrency limiter,
+        so it resolves as fast as the platform can answer one aggregation. The
+        grid then mounts directly with its final geometry (3 gauges at w=4, or 4
+        gauges at w=3 on the SAME line) and every widget fetches exactly once per
+        load (#7599). The key still remounts the grid if the flag flips later
+        (time range switch or refresh changing the probe result): react-grid-layout
+        keeps the internal layout of already-mounted children and ignores width
+        changes, so an in-place flip would leave the core gauges at their old
+        width and strand Human Response on a second row.
       */}
-      <CustomDashboardReactLayout key={`default-grid-hr-${humanResponsePresent}`} readOnly />
+      {humanResponsePresent === null
+        ? (
+            // Fixed height so the inElement loader centers roughly where the
+            // command center hero will mount, instead of hugging the header.
+            <div style={{ height: 420 }}>
+              <Loader variant="inElement" />
+            </div>
+          )
+        : <CustomDashboardReactLayout key={`default-grid-hr-${humanResponsePresent}`} readOnly />}
     </CustomDashboardContext.Provider>
   );
 };

--- a/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
+++ b/openaev-front/src/admin/components/default_dashboard/defaultHomeWidgets.ts
@@ -212,7 +212,9 @@ export const buildHumanResponseProbeConfig = (timeRange: DefaultTimeRange): Widg
  *   remount the grid when this flag flips (see DefaultHomeDashboard) - react-grid-
  *   layout keeps the internal layout of already-mounted children and ignores a
  *   width change, so an in-place flip would leave the core gauges at their old
- *   width and strand Human Response on a second row.
+ *   width and strand Human Response on a second row. To keep every load
+ *   single-mount, the caller defers the FIRST grid mount until the presence
+ *   probe has resolved instead of remounting on the fly (#7599).
  */
 export const buildDefaultHomeWidgets = (
   timeRange: DefaultTimeRange,


### PR DESCRIPTION
## Summary

Fixes the recent regression where the default home dashboard (Adversarial
exposure overview) double-renders and blinks on every first load of a
platform with human-driven expectation data in range (MANUAL / ARTICLE /
CHALLENGE, e.g. phishing), refetching every widget (~20 ad-hoc queries)
twice.

Root cause: c0e6a7e133 (#7343) made the resilience gauge row responsive to
the gauge count and kept the key-based grid remount, but reverted the
deferred first mount introduced by 7b04e5f8fa (#7320). The grid therefore
mounted eagerly with 3 gauges, and when the Human Response presence probe
resolved true (queued behind the ~20 widget queries in the concurrency
limiter, so often seconds later), the React key flipped and the entire grid
unmounted (blank flash), remounted with 4 gauges and refetched everything.

Changes:

- Restore the tri-state probe (null = in flight) and defer the FIRST grid
  mount until it resolves: the grid now always mounts exactly once per load,
  directly with its final gauge geometry. With the grid not mounted yet, the
  probe is the only query in the concurrency limiter, so it resolves as fast
  as the platform can answer one aggregation.
- Show a lightweight centered loader (fixed-height slot) while the probe is
  in flight.
- Keep the key-based remount for the rare later flips (time range switch or
  refresh changing the probe result), still required for react-grid-layout
  to re-read the gauge widths.
- Fix the stale "RESERVED 4th slot / GAUGE_WIDTH" comment describing a
  design that no longer exists, and document the single-mount contract in
  buildDefaultHomeWidgets.
- Add a regression test asserting the grid is deferred until the probe
  resolves and mounts exactly once (data present, data absent, probe
  failure).

## Test plan

- [x] New regression test: openaev-front/src/__tests__/admin/components/DefaultHomeDashboard.test.tsx (3 tests)
- [x] Full folder run: src/__tests__/admin/components/ -> 28 files, 305 tests passed
- [x] yarn check-ts (tsc) clean
- [x] eslint --max-warnings 0 clean on changed files

Closes #7599
