### PR TITLE
chore(deps): prepare the Spring Boot 4 migration

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ProvidingFilterSpecificationBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/service/threat_arsenal/ProvidingFilterSpecificationBuilder.java
@@ -34,7 +34,7 @@ public class ProvidingFilterSpecificationBuilder {
   public ProvidingFilterContext extractProvidingFilter(SearchPaginationInput searchInput) {
     if (searchInput.getFilterGroup() == null || searchInput.getFilterGroup().getFilters() == null) {
       return new ProvidingFilterContext(
-          searchInput, Specification.where(null), Filters.FilterMode.and, false, false);
+          searchInput, Specification.unrestricted(), Filters.FilterMode.and, false, false);
     }
 
     List<Filters.Filter> allFilters = searchInput.getFilterGroup().getFilters();
@@ -44,7 +44,7 @@ public class ProvidingFilterSpecificationBuilder {
     if (providingFilters.isEmpty()) {
       return new ProvidingFilterContext(
           searchInput,
-          Specification.where(null),
+          Specification.unrestricted(),
           Filters.FilterMode.and,
           false,
           !allFilters.isEmpty());
@@ -87,7 +87,7 @@ public class ProvidingFilterSpecificationBuilder {
 
     Set<ContractOutputType> expectedOutputTypes = resolveContractOutputTypes(filter.getValues());
     if (expectedOutputTypes.isEmpty()) {
-      return Specification.where(null);
+      return Specification.unrestricted();
     }
 
     Specification<InjectorContract> hasProviding =

--- a/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/ConnectorInstanceApiTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -215,7 +216,7 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
       when(xtmComposerEncryptionService.encrypt(any())).thenReturn("fake-encrypted-value");
       Token token = new Token();
       token.setValue("fake-token-value");
-      when(tokenRepository.findAll(any())).thenReturn(List.of(token));
+      when(tokenRepository.findAll(any(Specification.class))).thenReturn(List.of(token));
 
       CatalogConnectorConfiguration confDef1 =
           createCatalogConfiguration(
@@ -288,7 +289,7 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
       when(xtmComposerEncryptionService.encrypt(any())).thenReturn("fake-encrypted-value");
       Token token = new Token();
       token.setValue("fake-token-value");
-      when(tokenRepository.findAll(any())).thenReturn(List.of(token));
+      when(tokenRepository.findAll(any(Specification.class))).thenReturn(List.of(token));
 
       CatalogConnectorConfiguration confDef1 =
           createCatalogConfiguration(
@@ -426,7 +427,7 @@ public class ConnectorInstanceApiTest extends IntegrationTest {
       when(xtmComposerEncryptionService.encrypt(any())).thenReturn("fake-encrypted-value");
       Token token = new Token();
       token.setValue("fake-token-value");
-      when(tokenRepository.findAll(any())).thenReturn(List.of(token));
+      when(tokenRepository.findAll(any(Specification.class))).thenReturn(List.of(token));
 
       Set<String> enumList = Set.of("info", "debug", "warn");
       CatalogConnectorConfiguration confDef1 =

--- a/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseLessonsApiTenantIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/exercise/ExerciseLessonsApiTenantIsolationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -57,7 +58,8 @@ class ExerciseLessonsApiTenantIsolationTest extends IntegrationTest {
     when(exerciseRepository.findByIdAndTenantId(anyString(), anyString()))
         .thenReturn(Optional.of(new Exercise()));
     when(lessonsCategoryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-    when(lessonsCategoryRepository.findAll(any())).thenReturn(List.<LessonsCategory>of());
+    when(lessonsCategoryRepository.findAll(any(Specification.class)))
+        .thenReturn(List.<LessonsCategory>of());
     when(lessonsQuestionRepository.saveAll(any())).thenReturn(List.of());
   }
 

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioLessonsApiTenantIsolationTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioLessonsApiTenantIsolationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -57,7 +58,8 @@ class ScenarioLessonsApiTenantIsolationTest extends IntegrationTest {
     when(scenarioRepository.findByIdAndTenantId(anyString(), anyString()))
         .thenReturn(Optional.of(new Scenario()));
     when(lessonsCategoryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
-    when(lessonsCategoryRepository.findAll(any())).thenReturn(List.<LessonsCategory>of());
+    when(lessonsCategoryRepository.findAll(any(Specification.class)))
+        .thenReturn(List.<LessonsCategory>of());
     when(lessonsQuestionRepository.saveAll(any())).thenReturn(List.of());
   }
 

--- a/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/InjectExpectationServiceTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -533,7 +534,7 @@ class InjectExpectationServiceTest {
         InjectExpectationFixture.createPreventionInjectExpectation(inject, null);
     BaseInjectExpectation expectation2 =
         InjectExpectationFixture.createPreventionInjectExpectation(inject, null);
-    when(injectExpectationRepository.findAll(any()))
+    when(injectExpectationRepository.findAll(any(Specification.class)))
         .thenReturn(List.of(expectation1, expectation2));
 
     List<BaseInjectExpectation> result =
@@ -552,7 +553,7 @@ class InjectExpectationServiceTest {
         InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
     BaseInjectExpectation expectation2 =
         InjectExpectationFixture.createDetectionInjectExpectation(inject, null);
-    when(injectExpectationRepository.findAll(any()))
+    when(injectExpectationRepository.findAll(any(Specification.class)))
         .thenReturn(List.of(expectation1, expectation2));
 
     List<BaseInjectExpectation> result =
@@ -571,7 +572,7 @@ class InjectExpectationServiceTest {
         InjectExpectationFixture.createManualInjectExpectation(null, inject);
     BaseInjectExpectation expectation2 =
         InjectExpectationFixture.createManualInjectExpectation(null, inject);
-    when(injectExpectationRepository.findAll(any()))
+    when(injectExpectationRepository.findAll(any(Specification.class)))
         .thenReturn(List.of(expectation1, expectation2));
 
     List<BaseInjectExpectation> result =

--- a/openaev-api/src/test/java/io/openaev/service/MapperServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/MapperServiceTest.java
@@ -54,6 +54,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestExecutionListeners;
 
@@ -520,7 +521,8 @@ public class MapperServiceTest extends IntegrationTest {
     org.springframework.mock.web.MockHttpServletResponse response =
         new org.springframework.mock.web.MockHttpServletResponse();
 
-    when(injectorContractRepository.findAll(any())).thenReturn(List.of(injectorContract));
+    when(injectorContractRepository.findAll(any(Specification.class)))
+        .thenReturn(List.of(injectorContract));
 
     // Act
     mapperService.exportMappersCsv(CsvType.INJECTOR_CONTRACTS, input, response);
@@ -570,7 +572,8 @@ public class MapperServiceTest extends IntegrationTest {
     org.springframework.mock.web.MockHttpServletResponse response =
         new org.springframework.mock.web.MockHttpServletResponse();
 
-    when(injectorContractRepository.findAll(any())).thenReturn(List.of(injectorContract));
+    when(injectorContractRepository.findAll(any(Specification.class)))
+        .thenReturn(List.of(injectorContract));
 
     // Act
     mapperService.exportMappersCsv(CsvType.INJECTOR_CONTRACTS, input, response);
@@ -602,7 +605,7 @@ public class MapperServiceTest extends IntegrationTest {
     SearchPaginationInput input = new SearchPaginationInput();
     org.springframework.mock.web.MockHttpServletResponse response =
         new org.springframework.mock.web.MockHttpServletResponse();
-    when(endpointRepository.findAll(any())).thenReturn(List.of());
+    when(endpointRepository.findAll(any(Specification.class))).thenReturn(List.of());
 
     // Act
     mapperService.exportMappersCsv(CsvType.ENDPOINTS, input, response);
@@ -621,7 +624,8 @@ public class MapperServiceTest extends IntegrationTest {
         new org.springframework.mock.web.MockHttpServletResponse();
     RuntimeException repositoryException = new RuntimeException("boom");
 
-    when(injectorContractRepository.findAll(any())).thenThrow(repositoryException);
+    when(injectorContractRepository.findAll(any(Specification.class)))
+        .thenThrow(repositoryException);
 
     // Act
     RuntimeException thrown =

--- a/openaev-api/src/test/java/io/openaev/service/TeamServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/TeamServiceTest.java
@@ -331,7 +331,7 @@ class TeamServiceTest {
     private Specification<Team> createSpecification(Predicate predicate) {
       Specification<Team> spec = mock(Specification.class);
       Specification<Team> combined = mock(Specification.class);
-      when(spec.and(any())).thenReturn(combined);
+      when(spec.and(any(Specification.class))).thenReturn(combined);
       when(combined.toPredicate(any(), any(), any())).thenReturn(predicate);
       return spec;
     }

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -48,10 +48,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate6</artifactId>
         </dependency>

--- a/openaev-model/src/main/java/io/openaev/database/model/Scenario.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Scenario.java
@@ -23,6 +23,8 @@ import io.openaev.helper.MultiModelSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedEntityGraphs;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;


### PR DESCRIPTION
### Proposed changes

Spring Boot 3.5 no longer gets open-source releases (3.5.16, 25/06/2026, is the last one on Central). This lands the part of the Boot 4 migration that already compiles on 3.5.16, to keep the upgrade PR to what is genuinely coupled.

* `Specification.where(null)` -> `Specification.unrestricted()`: the `PredicateSpecification` overload added in Spring Data JPA 4 makes `where(null)` ambiguous
* `findAll(any())` -> `findAll(any(Specification.class))` in tests: same ambiguity
* Explicit `jakarta.persistence` imports in `Scenario`: Hibernate 7 adds `org.hibernate.annotations.NamedEntityGraph(s)`, which collides with the `jakarta.persistence.*` wildcard import
* Drop `spring-retry`: no usage in the codebase, and no longer managed by the Boot 4 BOM
