### PR TITLE
perf(backend): build the JSON mappers once instead of on every call

### DIFF
--- a/openaev-api/src/main/java/io/openaev/export/WorkflowExportInitializer.java
+++ b/openaev-api/src/main/java/io/openaev/export/WorkflowExportInitializer.java
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
 @Component
 @Slf4j
 public class WorkflowExportInitializer {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private static final String WORKFLOW_STEPS = "workflow_steps";
   private static final String WORKFLOW_SCOPE_RULES = "workflow_scope_rules";
@@ -116,7 +117,6 @@ public class WorkflowExportInitializer {
       return tags;
     }
 
-    ObjectMapper objectMapper = new ObjectMapper();
     for (Step step : workflow.getSteps()) {
       if (!StringUtils.hasText(step.getData())) {
         continue;

--- a/openaev-api/src/main/java/io/openaev/healthcheck/utils/HealthCheckUtils.java
+++ b/openaev-api/src/main/java/io/openaev/healthcheck/utils/HealthCheckUtils.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class HealthCheckUtils {
+  private static final ObjectMapper mapper = new ObjectMapper();
 
   /** Scope allowlist entry types consumed by asset/IP-centric (technical) steps. */
   private static final Set<ScopeRuleValueType> TECHNICAL_SCOPE_TYPES =
@@ -328,7 +329,6 @@ public class HealthCheckUtils {
       return result;
     }
 
-    ObjectMapper mapper = new ObjectMapper();
     ArrayNode injectContractFields;
 
     try {

--- a/openaev-api/src/main/java/io/openaev/opencti/client/mutations/Ping.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/mutations/Ping.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class Ping implements Mutation {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Getter private final ConnectorBase connector;
   @Getter private Boolean withJwks = false;
 
@@ -46,7 +48,6 @@ public class Ping implements Mutation {
 
   @Override
   public JsonNode getVariables() throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
     ObjectNode node = mapper.createObjectNode();
     node.set("id", mapper.valueToTree(connector.getId()));
     node.set("state", null);

--- a/openaev-api/src/main/java/io/openaev/opencti/client/mutations/PushStixBundle.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/mutations/PushStixBundle.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class PushStixBundle implements Mutation {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Getter private final ConnectorBase connector;
   @Getter private final JsonNode bundle;
   @Getter private final String workId = null;
@@ -27,7 +29,6 @@ public class PushStixBundle implements Mutation {
 
   @Override
   public JsonNode getVariables() throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
     ObjectNode node = mapper.createObjectNode();
     node.set("connectorId", mapper.valueToTree(connector.getId()));
     node.set("bundle", mapper.valueToTree(bundle.toString()));

--- a/openaev-api/src/main/java/io/openaev/opencti/client/mutations/QueryTypeFields.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/mutations/QueryTypeFields.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class QueryTypeFields implements Mutation {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Getter private final ConnectorBase connector;
   @Getter private final String typeName;
 
@@ -31,7 +33,6 @@ public class QueryTypeFields implements Mutation {
 
   @Override
   public JsonNode getVariables() throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
     ObjectNode node = mapper.createObjectNode();
     node.set("typeName", mapper.valueToTree(typeName));
     return node;

--- a/openaev-api/src/main/java/io/openaev/opencti/client/mutations/RegisterConnector.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/mutations/RegisterConnector.java
@@ -12,6 +12,8 @@ import lombok.*;
 
 @RequiredArgsConstructor
 public class RegisterConnector implements Mutation {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Getter private final ConnectorBase connector;
   @Getter private Boolean withJwks = false;
 
@@ -54,7 +56,6 @@ public class RegisterConnector implements Mutation {
 
   @Override
   public JsonNode getVariables() throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
     ObjectNode node = mapper.createObjectNode();
     node.set("input", mapper.valueToTree(toInput(connector)));
     return node;

--- a/openaev-api/src/main/java/io/openaev/opencti/client/mutations/WorkToProcessed.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/mutations/WorkToProcessed.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class WorkToProcessed implements Mutation {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Getter private final String workId;
   @Getter private final String message;
   @Getter private final Boolean inError;
@@ -28,7 +30,6 @@ public class WorkToProcessed implements Mutation {
 
   @Override
   public JsonNode getVariables() throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
     ObjectNode node = mapper.createObjectNode();
     node.set("id", mapper.valueToTree(workId));
     node.set("message", mapper.valueToTree(message));

--- a/openaev-api/src/main/java/io/openaev/opencti/client/mutations/WorkToReceived.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/mutations/WorkToReceived.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class WorkToReceived implements Mutation {
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   @Getter private final String workId;
   @Getter private final String message;
 
@@ -27,7 +29,6 @@ public class WorkToReceived implements Mutation {
 
   @Override
   public JsonNode getVariables() throws JsonProcessingException {
-    ObjectMapper mapper = new ObjectMapper();
     ObjectNode node = mapper.createObjectNode();
     node.set("id", mapper.valueToTree(workId));
     node.set("message", mapper.valueToTree(message));

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/StructuredOutputUtils.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/StructuredOutputUtils.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 public class StructuredOutputUtils {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private final OutputProcessorFactory outputProcessorFactory;
   @Resource private final ObjectMapper mapper;
@@ -75,7 +76,6 @@ public class StructuredOutputUtils {
     }
 
     try {
-      ObjectMapper objectMapper = new ObjectMapper();
       JsonNode rootNode = objectMapper.readTree(rawOutput);
 
       if (mode == ParserMode.STDOUT && rootNode.has("stdout")) {

--- a/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
+++ b/openaev-api/src/main/java/io/openaev/service/InjectImportService.java
@@ -59,6 +59,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Slf4j
 public class InjectImportService {
+  private static final ObjectMapper mapper = new ObjectMapper();
 
   private final InjectRepository injectRepository;
   private final ScenarioTeamUserRepository scenarioTeamUserRepository;
@@ -738,7 +739,6 @@ public class InjectImportService {
     }
 
     // Initializing the content with a root node
-    ObjectMapper mapper = new ObjectMapper();
     inject.setContent(mapper.createObjectNode());
 
     // Once it's done, we set the injectorContract

--- a/openaev-api/src/main/java/io/openaev/service/UserMappingService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserMappingService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 @Service
 public class UserMappingService {
+  private static final ObjectMapper mapper = new ObjectMapper();
 
   private final GroupRepository groupRepository;
   private final TenantRepository tenantRepository;
@@ -100,7 +101,6 @@ public class UserMappingService {
     if (json == null || json.isBlank()) {
       return List.of();
     }
-    ObjectMapper mapper = new ObjectMapper();
     try {
       return mapper.readValue(json, new TypeReference<>() {});
     } catch (IOException e) {

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -113,6 +113,7 @@ import org.springframework.validation.annotation.Validated;
 @Slf4j
 @Validated
 public class ScenarioService {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Value("${openaev.mail.imap.enabled}")
   private boolean imapEnabled;
@@ -423,7 +424,6 @@ public class ScenarioService {
   }
 
   public ScenarioOutput getScenarioById(@NotBlank final String scenarioId) {
-    ObjectMapper objectMapper = new ObjectMapper();
     RawScenario rawScenario = this.scenarioRepository.getScenarioByIdAndTenantId(scenarioId);
     if (rawScenario == null) {
       throw new ElementNotFoundException("Scenario not found");

--- a/openaev-model/src/main/java/io/openaev/database/raw/RawAssetGroup.java
+++ b/openaev-model/src/main/java/io/openaev/database/raw/RawAssetGroup.java
@@ -15,6 +15,7 @@ import java.util.List;
  * @see io.openaev.database.model.AssetGroup
  */
 public interface RawAssetGroup {
+  ObjectMapper objectMapper = new ObjectMapper();
 
   /**
    * Parses and returns the dynamic filter configuration for this asset group.
@@ -26,7 +27,6 @@ public interface RawAssetGroup {
    *     or parsing fails
    */
   default Filters.FilterGroup getAssetGroupDynamicFilter() {
-    ObjectMapper objectMapper = new ObjectMapper();
     try {
       return objectMapper.readValue(getAsset_group_dynamic_filter(), Filters.FilterGroup.class);
     } catch (JsonProcessingException | IllegalArgumentException e) {

--- a/openaev-model/src/main/java/io/openaev/database/raw/RawAssetGroupDynamicFilter.java
+++ b/openaev-model/src/main/java/io/openaev/database/raw/RawAssetGroupDynamicFilter.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.database.model.Filters;
 
 public interface RawAssetGroupDynamicFilter {
+  ObjectMapper objectMapper = new ObjectMapper();
 
   default Filters.FilterGroup getAssetGroupDynamicFilter() {
-    ObjectMapper objectMapper = new ObjectMapper();
     try {
       return objectMapper.readValue(getAsset_group_dynamic_filter(), Filters.FilterGroup.class);
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
### Proposed changes

Fourteen call sites built a fresh `ObjectMapper` inside a method, one per invocation, including two JPA projection interfaces walked for every row.

* Hoisted to a constant: no site configures its mapper, so the instances are identical and an unconfigured `ObjectMapper` is thread safe once built
* Left alone: the Flyway migrations, `InjectExecutionStep` which configures its mapper locally, and `InjectorContractContentUtils` whose local mapper shadows an injected bean

In the two interfaces the constant is implicitly `public`; a package-private holder would hide it, at the cost of an extra class.
