### PR TITLE
fix(backend): use the configured JSON mapper in InjectorContractContentUtils

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractContentUtils.java
+++ b/openaev-api/src/main/java/io/openaev/utils/injector_contract/InjectorContractContentUtils.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.openaev.database.model.*;
 import io.openaev.injector_contract.fields.ContractFieldType;
 import io.openaev.injector_contract.outputs.InjectorContractContentOutputElement;
-import jakarta.annotation.Resource;
 import jakarta.validation.constraints.NotNull;
 import java.util.*;
 import java.util.stream.StreamSupport;
@@ -24,7 +23,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class InjectorContractContentUtils {
 
-  @Resource protected ObjectMapper mapper;
+  private final ObjectMapper mapper;
 
   public static final String OUTPUTS = "outputs";
   public static final String FIELDS = "fields";
@@ -109,7 +108,7 @@ public class InjectorContractContentUtils {
     if (convertedContent.has(FIELDS) && convertedContent.get(FIELDS).isArray()) {
       ArrayNode fieldsArray = (ArrayNode) convertedContent.get(FIELDS);
       ArrayNode fieldsNode = fieldsArray.deepCopy();
-      ObjectNode injectContent = new ObjectMapper().createObjectNode();
+      ObjectNode injectContent = mapper.createObjectNode();
 
       for (JsonNode field : fieldsNode) {
         String key = field.get(CONTRACT_ELEMENT_CONTENT_KEY).asText();
@@ -257,7 +256,6 @@ public class InjectorContractContentUtils {
     }
 
     try {
-      ObjectMapper mapper = new ObjectMapper();
       ObjectNode objectNode = (ObjectNode) mapper.readTree(injectorContract.getContent());
 
       return objectNode.get("fields") != null

--- a/openaev-api/src/test/java/io/openaev/api/expectations/ExpectationsDriftServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/api/expectations/ExpectationsDriftServiceTest.java
@@ -23,6 +23,7 @@ import io.openaev.database.model.Scenario;
 import io.openaev.database.repository.ExerciseRepository;
 import io.openaev.database.repository.InjectRepository;
 import io.openaev.database.repository.ScenarioRepository;
+import io.openaev.helper.ObjectMapperHelper;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.service.utils.BulkDeleteChunkRunner;
 import io.openaev.service.utils.BulkOperationMonitor;
@@ -62,7 +63,7 @@ class ExpectationsDriftServiceTest {
             injectRepository,
             scenarioRepository,
             exerciseRepository,
-            new InjectorContractContentUtils(),
+            new InjectorContractContentUtils(ObjectMapperHelper.openAEVJsonMapper()),
             bulkOperationMonitor,
             chunkRunner,
             MAPPER);

--- a/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/service/InjectServiceTest.java
@@ -18,6 +18,7 @@ import io.openaev.executors.utils.ExecutorUtils;
 import io.openaev.healthcheck.dto.HealthCheck;
 import io.openaev.healthcheck.enums.ExternalServiceDependency;
 import io.openaev.healthcheck.utils.HealthCheckUtils;
+import io.openaev.helper.ObjectMapperHelper;
 import io.openaev.injectors.email.service.ImapService;
 import io.openaev.injectors.email.service.SmtpService;
 import io.openaev.rest.collector.service.CollectorService;
@@ -136,7 +137,9 @@ class InjectServiceTest {
 
   @Mock private ConditionService conditionService;
 
-  @Spy private InjectorContractContentUtils injectorContractContentUtils;
+  @Spy
+  private InjectorContractContentUtils injectorContractContentUtils =
+      new InjectorContractContentUtils(ObjectMapperHelper.openAEVJsonMapper());
 
   @Mock private ApplicationEventPublisher eventPublisher;
 

--- a/openaev-api/src/test/java/io/openaev/utils/mapper/ThreatArsenalMapperTest.java
+++ b/openaev-api/src/test/java/io/openaev/utils/mapper/ThreatArsenalMapperTest.java
@@ -15,6 +15,7 @@ import io.openaev.api.threat_arsenal.dto.ThreatArsenalActionFullOutput;
 import io.openaev.api.threat_arsenal.dto.ThreatArsenalExpectationDetail;
 import io.openaev.database.model.BaseInjectExpectation;
 import io.openaev.database.model.InjectorContract;
+import io.openaev.helper.ObjectMapperHelper;
 import io.openaev.utils.injector_contract.InjectorContractContentUtils;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -38,7 +39,9 @@ class ThreatArsenalMapperTest {
     // Real content utils: the predefined-expectation readers only walk the contract's
     // converted content, so no Spring context is needed.
     return new ThreatArsenalMapper(
-        payloadMapper, new InjectorContractContentUtils(), entityManager);
+        payloadMapper,
+        new InjectorContractContentUtils(ObjectMapperHelper.openAEVJsonMapper()),
+        entityManager);
   }
 
   /** One predefined expectation node as the contract content serializes it. */


### PR DESCRIPTION
### Proposed changes

The component injected the platform `ObjectMapper` and then ignored it: one method built a throwaway mapper to create a node, another declared a local of the same name that shadowed the field.

* Both now use the injected mapper
* The dependency moves from `@Resource` field injection to the constructor Lombok already generates

Field injection is what hid the problem: two tests built the component with `new` and got a half initialised object that still worked, since the methods carried their own mapper. They now have to supply one, and a missing mapper fails at construction rather than at the first `readTree`.
