### PR TITLE
fix(multi-tenancy): revoke tenant-scoped groups when a user leaves the tenant

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -245,12 +245,14 @@ public class UserService {
                 input.tenantIds(), Tenant.class, tenantRepository::countByIdIn)));
     // Only tenants the user just joined trigger auto-assignment: re-applying it to tenants he
     // already belonged to would restore groups deliberately removed from within those tenants.
+    List<String> currentTenantIds = existing.getTenants().stream().map(Tenant::getId).toList();
     List<String> attachedTenantIds =
-        existing.getTenants().stream()
-            .map(Tenant::getId)
-            .filter(tenantId -> !oldTenantIds.contains(tenantId))
-            .toList();
+        currentTenantIds.stream().filter(tenantId -> !oldTenantIds.contains(tenantId)).toList();
     assignAutoAssignGroups(existing, attachedTenantIds, false);
+    // Symmetrically, a membership must not outlive the tenant attachment that granted it.
+    List<String> detachedTenantIds =
+        oldTenantIds.stream().filter(tenantId -> !currentTenantIds.contains(tenantId)).toList();
+    revokeTenantGroups(existing, detachedTenantIds);
     User savedUser = userRepository.save(existing);
     // Evict cache for old tenants (removed memberships) and new tenants (added memberships)
     List<String> newTenantIds = input.tenantIds() != null ? input.tenantIds() : List.of();
@@ -602,5 +604,34 @@ public class UserService {
       }
     }
     user.setGroups(current);
+  }
+
+  /**
+   * Revokes the groups of the given tenants from an already persisted user. Used when a user leaves
+   * a tenant outside of the update flow, i.e. when detached from a tenant screen.
+   */
+  @Transactional(rollbackFor = Exception.class)
+  public void revokeTenantGroups(
+      @NotBlank final String userId, @NotNull final Collection<String> tenantIds) {
+    if (tenantIds.isEmpty()) {
+      return;
+    }
+    User user = user(userId);
+    revokeTenantGroups(user, tenantIds);
+    userRepository.save(user);
+  }
+
+  /**
+   * Drops every group scoped to a tenant the user just left: a group grants capabilities inside its
+   * own tenant only, so keeping it would leave access to a tenant the user no longer belongs to.
+   * Platform groups and the groups of the remaining tenants are untouched.
+   */
+  private void revokeTenantGroups(User user, Collection<String> tenantIds) {
+    if (tenantIds.isEmpty()) {
+      return;
+    }
+    user.getUnscopedGroups()
+        .removeIf(
+            group -> group.getTenant() != null && tenantIds.contains(group.getTenant().getId()));
   }
 }

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -618,7 +618,8 @@ public class UserService {
     }
     User user = user(userId);
     revokeTenantGroups(user, tenantIds);
-    userRepository.save(user);
+    User savedUser = userRepository.save(user);
+    sessionManager.refreshUserSessions(savedUser);
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
@@ -150,6 +150,8 @@ public class TenantUserService implements DependenciesManager {
   public void detach(String userId) {
     User user = userService.user(userId);
     ReservedKeyValidator.validateUserEmailPattern(user.getEmail());
+    // Before the membership row goes away, so the groups it granted go with it.
+    userService.revokeTenantGroups(userId, List.of(tenantId()));
     tenantRepository.removeUserFromTenant(userId, tenantId());
     tenantMembershipCacheManager.evict(userId, tenantId());
   }

--- a/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
@@ -200,6 +200,79 @@ class UserServiceTest extends IntegrationTest {
         .doesNotContain(lateGroup.getId());
   }
 
+  @Test
+  @DisplayName("given_platformUpdateDetachingTenant_should_revokeThatTenantGroups")
+  void given_platformUpdateDetachingTenant_should_revokeTenantGroups() {
+    // -- ARRANGE --
+    Tenant kept = tenantComposer.forTenant(TenantFixture.getTenant("detach-kept")).persist().get();
+    Tenant left = tenantComposer.forTenant(TenantFixture.getTenant("detach-left")).persist().get();
+    Group keptGroup = autoAssignGroup("tenant-auto-assign-kept", kept);
+    Group leftGroup = autoAssignGroup("tenant-auto-assign-left", left);
+    Group platformGroup = autoAssignGroup("platform-auto-assign-detach", null);
+    User created =
+        userService.createUser(
+            getUserInputWithTenants(
+                "detach-tenant@test.invalid",
+                "Detach",
+                "Tenant",
+                "secureP@ss1",
+                List.of(kept.getId(), left.getId())));
+    entityManager.flush();
+    entityManager.clear();
+
+    // -- ACT --
+    // The platform screen drops one of the two tenants.
+    userService.updateUser(
+        created.getId(),
+        getUserInputWithTenants(
+            "detach-tenant@test.invalid",
+            "Detach",
+            "Tenant",
+            "secureP@ss1",
+            List.of(kept.getId())));
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(created.getId());
+    assertThat(reloaded.getUnscopedGroups())
+        .extracting(Group::getId)
+        .doesNotContain(leftGroup.getId())
+        .contains(keptGroup.getId(), platformGroup.getId());
+  }
+
+  @Test
+  @DisplayName("given_detachedTenant_should_keepGroupsOfTheOtherScopes")
+  void given_revokeTenantGroups_should_onlyDropTheGivenTenantGroups() {
+    // -- ARRANGE --
+    Tenant tenant =
+        tenantComposer.forTenant(TenantFixture.getTenant("revoke-scoped")).persist().get();
+    Group tenantGroup = autoAssignGroup("tenant-auto-assign-revoke", tenant);
+    Group platformGroup = autoAssignGroup("platform-auto-assign-revoke", null);
+    User created =
+        userService.createUser(
+            getUserInputWithTenants(
+                "revoke-scoped@test.invalid",
+                "Revoke",
+                "Scoped",
+                "secureP@ss1",
+                List.of(tenant.getId())));
+    entityManager.flush();
+    entityManager.clear();
+
+    // -- ACT --
+    userService.revokeTenantGroups(created.getId(), List.of(tenant.getId()));
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(created.getId());
+    assertThat(reloaded.getUnscopedGroups())
+        .extracting(Group::getId)
+        .doesNotContain(tenantGroup.getId())
+        .contains(platformGroup.getId());
+  }
+
   private Group autoAssignGroup(String name, Tenant tenant) {
     Group group = new Group();
     group.setName(name);

--- a/openaev-api/src/test/java/io/openaev/service/tenants/TenantUserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/tenants/TenantUserServiceTest.java
@@ -247,6 +247,33 @@ class TenantUserServiceTest extends IntegrationTest {
       assertThatThrownBy(() -> tenantUserService.user(user.getId()))
           .isInstanceOf(ElementNotFoundException.class);
     }
+
+    @Test
+    @DisplayName("Given a detached user should lose the groups of that tenant")
+    void given_detachedUser_should_loseTenantGroups() {
+      // -- ARRANGE --
+      Group autoGroup = TenantGroupFixture.getGroup("AutoAssignDetach");
+      autoGroup.setDefaultUserAssignation(true);
+      tenantGroupComposer.forGroup(autoGroup).persist();
+      entityManager.flush();
+      UserOutput created =
+          tenantUserService.createOrAttach(
+              getUserInput("tenant-detach@test.invalid", "Detach", "Tenant"));
+      entityManager.flush();
+      entityManager.clear();
+      assertThat(groupRepository.findById(autoGroup.getId()).orElseThrow().getUsers())
+          .extracting(User::getId)
+          .contains(created.id());
+
+      // -- ACT --
+      tenantUserService.detach(created.id());
+
+      // -- ASSERT --
+      entityManager.flush();
+      entityManager.clear();
+      Group reloaded = groupRepository.findById(autoGroup.getId()).orElseThrow();
+      assertThat(reloaded.getUsers()).extracting(User::getId).doesNotContain(created.id());
+    }
   }
 
   @Nested


### PR DESCRIPTION
### Proposed changes

* Detaching a user from a tenant now drops that tenant's group memberships, on both paths: the tenant screen (`TenantUserService.detach`) and the platform screen (`UserService.updateUser`, when the input removes a tenant). Platform groups and the groups of the remaining tenants are untouched.
* Symmetric counterpart of the auto-assign work merged in #7548: a group grants capabilities inside its own tenant only, so a membership that outlives the attachment leaves access to a tenant the user no longer belongs to — and re-attaching later silently restored groups that had been removed on purpose.

### Testing Instructions

1. In tenant T, create a group with "Auto assign" enabled, then create user A from the tenant screen — A joins the group.
2. Detach A from T (tenant screen) → A is no longer a member of that group.
3. Platform > Users: create B with T attached, then edit B and remove T → same result, while B keeps its platform groups.

### Related issues

* Related to #7248 — with RBAC resolved from the real tenant list rather than the ambient `TenantContext`, an orphan group would no longer grant anything; this keeps the data consistent in the meantime.
* Follow-up of #7548.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- Both new tests were checked to fail with the two call sites disabled. -->
