### PR TITLE
chore(deps): move HikariCP and Micrometer to their Spring Boot 4 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,12 @@
         <log4j2.version>2.25.5</log4j2.version>
         <httpclient5.version>5.6.4</httpclient5.version>
         <kotlin.version>2.1.21</kotlin.version>
+        <hikaricp.version>7.0.2</hikaricp.version>
         <opentelemetry.version>1.65.0</opentelemetry.version>
         <amqp-client.version>5.35.0</amqp-client.version>
         <rabbit-amqp-client.version>${amqp-client.version}</rabbit-amqp-client.version>
-        <micrometer.version>1.16.7</micrometer.version>
-        <micrometer-tracing.version>1.6.7</micrometer-tracing.version>
+        <micrometer.version>1.17.1</micrometer.version>
+        <micrometer-tracing.version>1.7.1</micrometer-tracing.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
### Proposed changes

Spring Boot 4 will bring HikariCP 7 and Micrometer 1.17 in one go with a dozen other libraries. Both run on 3.5.16, so they can move now and leave the upgrade with less to validate at once.

* HikariCP 6.3.3 -> 7.0.2 (new override): metric registry fix, credentials provider, clean bail out of the pool filling loop on interrupt, two `ConcurrentBag` tuning changes. No API break
* Micrometer 1.16.7 -> 1.17.1 and tracing 1.6.7 -> 1.7.1, advancing overrides we already carry

Netty 4.2 is left out on purpose: it switches the default buffer allocator, and deserves its own load test.

### Checks done

The platform starts on this branch, `db` and `elasticsearch` UP, and `PoolExhaustionWatchdogTest` passes. That watchdog is the only real coupling: it calls four `HikariPoolMXBean` methods, all unchanged in 7.0.2, and matches stack frames on `com.zaxxer.hikari.pool.Proxy*` class names, which are identical between the two jars. Not verified locally: `/actuator/prometheus` is not exposed in the dev profile, so the pool metrics touched by the metric registry fix are worth a look on a deployed environment.
