### PR TITLE
fix(opencti): log the STIX bundle received from OpenCTI

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/stix_process/StixApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/stix_process/StixApi.java
@@ -62,18 +62,19 @@ public class StixApi extends RestBehavior {
   public ResponseEntity<?> processBundle(@RequestBody @Validated CTIEvent ctiEvent, TxCtx ctx)
       throws ParsingException, ConnectorError, IOException {
     String tenantId = writeScopeResolver.tenantForWrite(ctx, null);
+    String workId = ctiEvent.getInternal().getWorkId();
+    String stixBundle = ctiEvent.getEvent().getStixObjects();
+
+    log.debug("STIX bundle received from OpenCTI (workId={}). bundle={}", workId, stixBundle);
 
     try {
       openCTIService.acknowledgeReceivedOfCoverage(
-          ctiEvent.getInternal().getWorkId(), "OpenAEV ready to process the operation", tenantId);
+          workId, "OpenAEV ready to process the operation", tenantId);
 
-      Scenario scenario = stixService.processBundle(ctiEvent.getEvent().getStixObjects(), tenantId);
+      Scenario scenario = stixService.processBundle(stixBundle, tenantId);
 
       openCTIService.acknowledgeProcessedOfCoverage(
-          ctiEvent.getInternal().getWorkId(),
-          "Coverage successfully created or updated",
-          false,
-          tenantId);
+          workId, "Coverage successfully created or updated", false, tenantId);
       return ResponseEntity.ok(
           new BundleImportReport(
               scenario.getId(), stixService.generateBundleImportReport(scenario)));
@@ -85,12 +86,12 @@ public class StixApi extends RestBehavior {
       // we will signal the failure with a log in the OAEV process and an "isError" ack
       // for OpenCTI
       log.error(
-          "OpenAEV did not process this STIX bundle due to processing rules (workId={}). ctiEvent={}",
-          ctiEvent.getInternal().getWorkId(),
-          ctiEvent,
+          "OpenAEV did not process this STIX bundle due to processing rules (workId={}). bundle={}",
+          workId,
+          stixBundle,
           e);
       openCTIService.acknowledgeProcessedOfCoverage(
-          ctiEvent.getInternal().getWorkId(),
+          workId,
           "OpenAEV did not process this STIX bundle due to processing rules: %s"
               .formatted(e.getMessage()),
           true,
@@ -100,12 +101,12 @@ public class StixApi extends RestBehavior {
       return ResponseEntity.status(HttpStatus.OK).build();
     } catch (Exception e) {
       log.error(
-          "An error occurred while processing STIX bundle (workId={}). ctiEvent={}",
-          ctiEvent.getInternal().getWorkId(),
-          ctiEvent,
+          "An error occurred while processing STIX bundle (workId={}). bundle={}",
+          workId,
+          stixBundle,
           e);
       openCTIService.acknowledgeProcessedOfCoverage(
-          ctiEvent.getInternal().getWorkId(),
+          workId,
           "An error occurred while processing STIX bundle: %s".formatted(e.getMessage()),
           true,
           tenantId);


### PR DESCRIPTION
### Proposed changes

* Fix the two error logs of `/stix/process-bundle`: they interpolated the `CTIEvent` object, which has no `toString()`, so the logs showed `ctiEvent=io.openaev.opencti.dto.CTIEvent@3f2a1b7c` instead of the bundle. They now log the bundle payload.
* Add a debug log on every bundle received, to trace the reception itself.

### Testing Instructions

1. Send a security coverage from OpenCTI, and check the logs of a failed processing: the bundle is now there.
2. `LOGGING_LEVEL_IO_OPENAEV=DEBUG` to also see the bundles received on the nominal path.

### Related issues

* None — request from the OpenCTI side to be able to debug an OpenCTI/OpenAEV interaction from the logs.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
