### PR TITLE
fix(backend): write the formatted message in JSON logs

### DIFF
--- a/openaev-api/src/main/java/io/openaev/logging/StackDepthLimitingJsonEncoder.java
+++ b/openaev-api/src/main/java/io/openaev/logging/StackDepthLimitingJsonEncoder.java
@@ -14,15 +14,11 @@ import org.slf4j.Marker;
 import org.slf4j.event.KeyValuePair;
 
 /**
- * Extends the built-in Logback {@link JsonEncoder} to write the <b>formatted</b> message in the
- * {@code message} field, and to limit the depth of stack traces and cause chains in JSON log
- * output.
+ * Extends the built-in Logback {@link JsonEncoder} to resolve message placeholders and to limit the
+ * depth of stack traces and cause chains in JSON log output.
  *
- * <p>{@link JsonEncoder} writes the raw SLF4J pattern in {@code message} and the values in a
- * separate {@code arguments} array, so log aggregators reading {@code message} display {@code
- * "Indexing ({}) in progress for {}"} instead of the actual values. This encoder resolves the
- * placeholders up front; pair it with {@code <withArguments>false</withArguments>} so the values
- * are not also duplicated in {@code arguments}.
+ * <p>{@link JsonEncoder} puts the raw SLF4J pattern in {@code message} and the values in {@code
+ * arguments}; this encoder resolves the placeholders so {@code message} reads as is.
  *
  * <p>Deep stack traces (e.g. from Spring proxy chains or Hibernate cascades) can produce JSON log
  * lines that exceed Loki's {@code max_line_size}, causing silent mid-JSON truncation and {@code
@@ -196,8 +192,7 @@ public class StackDepthLimitingJsonEncoder extends JsonEncoder {
 
   /**
    * Delegates all {@link ILoggingEvent} methods to the original event, except {@link #getMessage()}
-   * which returns the formatted message, and {@link #getThrowableProxy()} which returns the
-   * truncated proxy.
+   * (formatted message) and {@link #getThrowableProxy()} (truncated proxy).
    */
   static class FormattedMessageEvent implements ILoggingEvent {
     private final ILoggingEvent delegate;
@@ -223,9 +218,6 @@ public class StackDepthLimitingJsonEncoder extends JsonEncoder {
       return delegate.getLevel();
     }
 
-    /**
-     * Resolves the {@code {}} placeholders so the JSON {@code message} field carries the values.
-     */
     @Override
     public String getMessage() {
       return delegate.getFormattedMessage();

--- a/openaev-api/src/main/java/io/openaev/logging/StackDepthLimitingJsonEncoder.java
+++ b/openaev-api/src/main/java/io/openaev/logging/StackDepthLimitingJsonEncoder.java
@@ -14,8 +14,15 @@ import org.slf4j.Marker;
 import org.slf4j.event.KeyValuePair;
 
 /**
- * Extends the built-in Logback {@link JsonEncoder} to limit the depth of stack traces and cause
- * chains in JSON log output.
+ * Extends the built-in Logback {@link JsonEncoder} to write the <b>formatted</b> message in the
+ * {@code message} field, and to limit the depth of stack traces and cause chains in JSON log
+ * output.
+ *
+ * <p>{@link JsonEncoder} writes the raw SLF4J pattern in {@code message} and the values in a
+ * separate {@code arguments} array, so log aggregators reading {@code message} display {@code
+ * "Indexing ({}) in progress for {}"} instead of the actual values. This encoder resolves the
+ * placeholders up front; pair it with {@code <withArguments>false</withArguments>} so the values
+ * are not also duplicated in {@code arguments}.
  *
  * <p>Deep stack traces (e.g. from Spring proxy chains or Hibernate cascades) can produce JSON log
  * lines that exceed Loki's {@code max_line_size}, causing silent mid-JSON truncation and {@code
@@ -30,6 +37,7 @@ import org.slf4j.event.KeyValuePair;
  *
  * <pre>{@code
  * <encoder class="io.openaev.logging.StackDepthLimitingJsonEncoder">
+ *     <withArguments>false</withArguments>
  *     <withThrowable>true</withThrowable>
  *     <maxStackDepth>80</maxStackDepth>
  * </encoder>
@@ -48,12 +56,10 @@ public class StackDepthLimitingJsonEncoder extends JsonEncoder {
 
   @Override
   public byte[] encode(ILoggingEvent event) {
-    if (event.getThrowableProxy() == null) {
-      return super.encode(event);
-    }
+    IThrowableProxy throwableProxy = event.getThrowableProxy();
     IThrowableProxy truncated =
-        new TruncatedThrowableProxy(event.getThrowableProxy(), maxStackDepth);
-    return super.encode(new TruncatedThrowableEvent(event, truncated));
+        throwableProxy == null ? null : new TruncatedThrowableProxy(throwableProxy, maxStackDepth);
+    return super.encode(new FormattedMessageEvent(event, truncated));
   }
 
   /**
@@ -189,14 +195,15 @@ public class StackDepthLimitingJsonEncoder extends JsonEncoder {
   }
 
   /**
-   * Delegates all {@link ILoggingEvent} methods to the original event, except {@link
-   * #getThrowableProxy()} which returns the truncated proxy.
+   * Delegates all {@link ILoggingEvent} methods to the original event, except {@link #getMessage()}
+   * which returns the formatted message, and {@link #getThrowableProxy()} which returns the
+   * truncated proxy.
    */
-  static class TruncatedThrowableEvent implements ILoggingEvent {
+  static class FormattedMessageEvent implements ILoggingEvent {
     private final ILoggingEvent delegate;
     private final IThrowableProxy throwableProxy;
 
-    TruncatedThrowableEvent(ILoggingEvent delegate, IThrowableProxy throwableProxy) {
+    FormattedMessageEvent(ILoggingEvent delegate, IThrowableProxy throwableProxy) {
       this.delegate = delegate;
       this.throwableProxy = throwableProxy;
     }
@@ -216,9 +223,12 @@ public class StackDepthLimitingJsonEncoder extends JsonEncoder {
       return delegate.getLevel();
     }
 
+    /**
+     * Resolves the {@code {}} placeholders so the JSON {@code message} field carries the values.
+     */
     @Override
     public String getMessage() {
-      return delegate.getMessage();
+      return delegate.getFormattedMessage();
     }
 
     @Override

--- a/openaev-api/src/main/resources/logback-spring.xml
+++ b/openaev-api/src/main/resources/logback-spring.xml
@@ -37,6 +37,8 @@
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <appender name="jsonEncoder" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="io.openaev.logging.StackDepthLimitingJsonEncoder">
+                <!-- placeholders are resolved into "message", so "arguments" would only duplicate them -->
+                <withArguments>false</withArguments>
                 <withThrowable>true</withThrowable>
                 <maxStackDepth>80</maxStackDepth>
             </encoder>
@@ -51,6 +53,8 @@
                 <totalSizeCap>1GB</totalSizeCap>
             </rollingPolicy>
             <encoder class="io.openaev.logging.StackDepthLimitingJsonEncoder">
+                <!-- placeholders are resolved into "message", so "arguments" would only duplicate them -->
+                <withArguments>false</withArguments>
                 <withThrowable>true</withThrowable>
                 <maxStackDepth>80</maxStackDepth>
             </encoder>

--- a/openaev-api/src/main/resources/logback-spring.xml
+++ b/openaev-api/src/main/resources/logback-spring.xml
@@ -37,7 +37,7 @@
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <appender name="jsonEncoder" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="io.openaev.logging.StackDepthLimitingJsonEncoder">
-                <!-- placeholders are resolved into "message", so "arguments" would only duplicate them -->
+                <!-- values are already resolved into "message" -->
                 <withArguments>false</withArguments>
                 <withThrowable>true</withThrowable>
                 <maxStackDepth>80</maxStackDepth>
@@ -53,7 +53,7 @@
                 <totalSizeCap>1GB</totalSizeCap>
             </rollingPolicy>
             <encoder class="io.openaev.logging.StackDepthLimitingJsonEncoder">
-                <!-- placeholders are resolved into "message", so "arguments" would only duplicate them -->
+                <!-- values are already resolved into "message" -->
                 <withArguments>false</withArguments>
                 <withThrowable>true</withThrowable>
                 <maxStackDepth>80</maxStackDepth>

--- a/openaev-api/src/test/java/io/openaev/logging/StackDepthLimitingJsonEncoderTest.java
+++ b/openaev-api/src/test/java/io/openaev/logging/StackDepthLimitingJsonEncoderTest.java
@@ -39,45 +39,6 @@ class StackDepthLimitingJsonEncoderTest {
   }
 
   @Test
-  @DisplayName("message field should carry the resolved placeholders, not the raw pattern")
-  void testMessageIsFormatted() throws Exception {
-    encoder.setWithArguments(false);
-
-    LoggingEvent event = new LoggingEvent();
-    event.setLoggerContext(loggerContext);
-    event.setLoggerName("io.openaev.logging.Test");
-    event.setLevel(ch.qos.logback.classic.Level.INFO);
-    event.setMessage("Indexing ({}) in progress for {}");
-    event.setArgumentArray(new Object[] {500, "expectation-inject"});
-    event.setTimeStamp(System.currentTimeMillis());
-
-    JsonNode node = MAPPER.readTree(new String(encoder.encode(event)));
-
-    assertEquals("Indexing (500) in progress for expectation-inject", node.get("message").asText());
-    assertNull(node.get("arguments"), "arguments must not duplicate the resolved values");
-  }
-
-  @Test
-  @DisplayName("Formatted message and truncated stack trace should combine on the same event")
-  void testFormattedMessageWithThrowable() throws Exception {
-    encoder.setMaxStackDepth(1);
-
-    LoggingEvent event = new LoggingEvent();
-    event.setLoggerContext(loggerContext);
-    event.setLoggerName("io.openaev.logging.Test");
-    event.setLevel(ch.qos.logback.classic.Level.ERROR);
-    event.setMessage("Indexing failed for {}");
-    event.setArgumentArray(new Object[] {"expectation-inject"});
-    event.setThrowableProxy(new ThrowableProxy(new RuntimeException("boom")));
-    event.setTimeStamp(System.currentTimeMillis());
-
-    JsonNode node = MAPPER.readTree(new String(encoder.encode(event)));
-
-    assertEquals("Indexing failed for expectation-inject", node.get("message").asText());
-    assertTrue(node.has("throwable"), "throwable must still be serialized");
-  }
-
-  @Test
   @DisplayName("maxStackDepth=1 should produce valid JSON with truncation marker")
   void testMaxStackDepth1() throws Exception {
     encoder.setMaxStackDepth(1);

--- a/openaev-api/src/test/java/io/openaev/logging/StackDepthLimitingJsonEncoderTest.java
+++ b/openaev-api/src/test/java/io/openaev/logging/StackDepthLimitingJsonEncoderTest.java
@@ -39,6 +39,45 @@ class StackDepthLimitingJsonEncoderTest {
   }
 
   @Test
+  @DisplayName("message field should carry the resolved placeholders, not the raw pattern")
+  void testMessageIsFormatted() throws Exception {
+    encoder.setWithArguments(false);
+
+    LoggingEvent event = new LoggingEvent();
+    event.setLoggerContext(loggerContext);
+    event.setLoggerName("io.openaev.logging.Test");
+    event.setLevel(ch.qos.logback.classic.Level.INFO);
+    event.setMessage("Indexing ({}) in progress for {}");
+    event.setArgumentArray(new Object[] {500, "expectation-inject"});
+    event.setTimeStamp(System.currentTimeMillis());
+
+    JsonNode node = MAPPER.readTree(new String(encoder.encode(event)));
+
+    assertEquals("Indexing (500) in progress for expectation-inject", node.get("message").asText());
+    assertNull(node.get("arguments"), "arguments must not duplicate the resolved values");
+  }
+
+  @Test
+  @DisplayName("Formatted message and truncated stack trace should combine on the same event")
+  void testFormattedMessageWithThrowable() throws Exception {
+    encoder.setMaxStackDepth(1);
+
+    LoggingEvent event = new LoggingEvent();
+    event.setLoggerContext(loggerContext);
+    event.setLoggerName("io.openaev.logging.Test");
+    event.setLevel(ch.qos.logback.classic.Level.ERROR);
+    event.setMessage("Indexing failed for {}");
+    event.setArgumentArray(new Object[] {"expectation-inject"});
+    event.setThrowableProxy(new ThrowableProxy(new RuntimeException("boom")));
+    event.setTimeStamp(System.currentTimeMillis());
+
+    JsonNode node = MAPPER.readTree(new String(encoder.encode(event)));
+
+    assertEquals("Indexing failed for expectation-inject", node.get("message").asText());
+    assertTrue(node.has("throwable"), "throwable must still be serialized");
+  }
+
+  @Test
   @DisplayName("maxStackDepth=1 should produce valid JSON with truncation marker")
   void testMaxStackDepth1() throws Exception {
     encoder.setMaxStackDepth(1);


### PR DESCRIPTION
### Proposed changes

* Logback's `JsonEncoder` writes the raw SLF4J pattern in `message` and the values in a separate `arguments` array, so Grafana showed `Indexing ({}) in progress for {}`. `StackDepthLimitingJsonEncoder` now resolves the placeholders into `message`, and `arguments` is turned off.
