### PR TITLE
feat(multi-tenancy): differentiate tenant-scoped user creation (#7613)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/api/platform/users/PlatformUserApi.java
+++ b/openaev-api/src/main/java/io/openaev/api/platform/users/PlatformUserApi.java
@@ -8,6 +8,7 @@ import io.openaev.api.users.dto.UserMapper;
 import io.openaev.api.users.dto.UserOutput;
 import io.openaev.database.model.Action;
 import io.openaev.database.model.ResourceType;
+import io.openaev.service.UserCreationScope;
 import io.openaev.service.UserService;
 import io.openaev.utils.pagination.SearchPaginationInput;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,7 +39,7 @@ public class PlatformUserApi {
   @ResponseStatus(HttpStatus.CREATED)
   @Transactional
   public UserOutput create(@Valid @RequestBody UserInput input) {
-    return toPlatformOutput(userService.createUser(input));
+    return toPlatformOutput(userService.createUser(input, UserCreationScope.PLATFORM));
   }
 
   // -- READ --

--- a/openaev-api/src/main/java/io/openaev/config/security/SecurityService.java
+++ b/openaev-api/src/main/java/io/openaev/config/security/SecurityService.java
@@ -69,7 +69,9 @@ public class SecurityService {
                 String.class,
                 "");
         userMappingService.mapCurrentUserWithGroup(groupsManagementObject, user, groups);
-        attachTenant(registrationId, user);
+        attachTenant(registrationId, user)
+            .ifPresent(
+                tenantId -> userService.assignAutoAssignGroups(user.getId(), List.of(tenantId)));
         return this.userService.saveUser(user);
       } else {
         // If user exists, update it
@@ -86,7 +88,10 @@ public class SecurityService {
                 String.class,
                 "");
         userMappingService.mapCurrentUserWithGroup(groupsManagementObject, currentUser, groups);
-        attachTenant(registrationId, currentUser);
+        attachTenant(registrationId, currentUser)
+            .ifPresent(
+                tenantId ->
+                    userService.assignAutoAssignGroups(currentUser.getId(), List.of(tenantId)));
         return this.userService.saveUser(currentUser);
       }
     }
@@ -103,21 +108,27 @@ public class SecurityService {
   // -- PRIVATE --
 
   /** Attaches the user to the tenant configured for the given SSO provider registration. */
-  private void attachTenant(String registrationId, User user) {
+  /**
+   * Attaches the user to the tenant configured for this identity provider, and returns that tenant
+   * ID when the user just entered it. Returns empty when nothing was attached, so a group
+   * deliberately removed from the user is never re-granted on a later login.
+   */
+  private Optional<String> attachTenant(String registrationId, User user) {
     String configuredTenantId =
         env.getProperty(
             OPENAEV_PROVIDER_PATH_PREFIX + registrationId + TENANT_ID_SUFFIX, String.class, "");
     String tenantId = hasText(configuredTenantId) ? configuredTenantId : Tenant.DEFAULT_TENANT_UUID;
     boolean alreadyAttached = user.getTenants().stream().anyMatch(t -> t.getId().equals(tenantId));
     if (alreadyAttached) {
-      return;
+      return Optional.empty();
     }
     if (!tenantRepository.existsById(tenantId)) {
       log.warn("SSO tenant ID '{}' configured but not found in database", tenantId);
-      return;
+      return Optional.empty();
     }
     Tenant tenant = tenantRepository.getReferenceById(tenantId);
     user.getTenants().add(tenant);
+    return Optional.of(tenantId);
   }
 
   private List<String> getAdminRoles(@NotBlank final String registrationId) {

--- a/openaev-api/src/main/java/io/openaev/service/UserCreationScope.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserCreationScope.java
@@ -1,0 +1,20 @@
+package io.openaev.service;
+
+/**
+ * Scope a user is created from. It decides which auto-assign groups the new user inherits: the
+ * creator can only hand out groups it has authority over.
+ */
+public enum UserCreationScope {
+  /**
+   * Creation from the platform: the platform administrator has authority over every tenant, so the
+   * platform auto-assign groups are granted, plus those of each tenant carried by the input.
+   */
+  PLATFORM,
+
+  /**
+   * Creation from within a tenant: the creator has no authority over the platform, so no
+   * platform-wide group is ever granted and the tenants carried by the input are ignored. The
+   * caller attaches the user to its own tenant, then grants that tenant's auto-assign groups.
+   */
+  TENANT
+}

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -131,7 +131,6 @@ public class UserService {
     return createUser(input, input.tenantIds(), true);
   }
 
-
   @Transactional(rollbackFor = Exception.class)
   public User createTenantUser(UserInput input) {
     return createUser(input, List.of(), false);

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -128,6 +128,16 @@ public class UserService {
 
   @Transactional(rollbackFor = Exception.class)
   public User createUser(UserInput input) {
+    return createUser(input, input.tenantIds(), true);
+  }
+
+
+  @Transactional(rollbackFor = Exception.class)
+  public User createTenantUser(UserInput input) {
+    return createUser(input, List.of(), false);
+  }
+
+  private User createUser(UserInput input, List<String> tenantIds, boolean includePlatformScope) {
     if (!StringUtils.hasLength(input.plainPassword())) {
       throw new IllegalArgumentException("Password is required when creating a user");
     }
@@ -143,13 +153,13 @@ public class UserService {
     user.setOrganization(referenceResolver.resolve(input.organizationId(), Organization.class));
     user.setTenants(
         new ArrayList<>(
-            referenceResolver.resolve(
-                input.tenantIds(), Tenant.class, tenantRepository::countByIdIn)));
+            referenceResolver.resolve(tenantIds, Tenant.class, tenantRepository::countByIdIn)));
     // The user's id is generated on save (UUID generator), not before: evict only after
     // persisting, using the saved user's id, or evictForUser is called with a null key.
-    User createdUser = createUser(user, input.plainPassword(), UUID.randomUUID().toString());
-    if (!CollectionUtils.isEmpty(input.tenantIds())) {
-      tenantMembershipCacheManager.evictForUser(createdUser.getId(), input.tenantIds());
+    User createdUser =
+        createUser(user, input.plainPassword(), UUID.randomUUID().toString(), includePlatformScope);
+    if (!CollectionUtils.isEmpty(tenantIds)) {
+      tenantMembershipCacheManager.evictForUser(createdUser.getId(), tenantIds);
     }
     return createdUser;
   }
@@ -166,15 +176,17 @@ public class UserService {
     user.setFirstname(firstname);
     user.setLastname(lastname);
     user.setAdmin(isAdmin);
-    return createUser(user, null, token);
+    return createUser(user, null, token, true);
   }
 
-  private User createUser(User user, String password, String token) {
+  private User createUser(User user, String password, String token, boolean includePlatformScope) {
     if (StringUtils.hasLength(password)) {
       user.setPassword(this.encodeUserPassword(password));
     }
-    // Creation enters every scope at once: platform, plus each tenant attached in the input.
-    assignAutoAssignGroups(user, user.getTenants().stream().map(Tenant::getId).toList(), true);
+    // Creation enters every scope at once: the platform when created from the platform screen,
+    // plus each tenant attached in the input.
+    assignAutoAssignGroups(
+        user, user.getTenants().stream().map(Tenant::getId).toList(), includePlatformScope);
     User savedUser = userRepository.save(user);
     this.createUserToken(savedUser, token);
     return savedUser;

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -126,17 +126,12 @@ public class UserService {
 
   // -- CREATE --
 
+  /**
+   * Creates a user. The {@link UserCreationScope} decides which auto-assign groups are granted, and
+   * whether the tenants carried by the input are honoured.
+   */
   @Transactional(rollbackFor = Exception.class)
-  public User createUser(UserInput input) {
-    return createUser(input, input.tenantIds(), true);
-  }
-
-  @Transactional(rollbackFor = Exception.class)
-  public User createTenantUser(UserInput input) {
-    return createUser(input, List.of(), false);
-  }
-
-  private User createUser(UserInput input, List<String> tenantIds, boolean includePlatformScope) {
+  public User createUser(UserInput input, UserCreationScope scope) {
     if (!StringUtils.hasLength(input.plainPassword())) {
       throw new IllegalArgumentException("Password is required when creating a user");
     }
@@ -146,6 +141,9 @@ public class UserService {
           "User with email " + input.email() + " already exists");
     }
     PrivilegeEscalationValidator.assertAdminFlagUnchanged(input.admin(), false);
+    // A tenant creator has no authority over other tenants: it never attaches any, the caller
+    // attaches its own right after.
+    List<String> tenantIds = scope == UserCreationScope.PLATFORM ? input.tenantIds() : List.of();
     User user = new User();
     user.setUpdateAttributes(input);
     user.setTags(referenceResolver.resolve(input.tagIds(), Tag.class, tagRepository::countByIdIn));
@@ -155,15 +153,20 @@ public class UserService {
             referenceResolver.resolve(tenantIds, Tenant.class, tenantRepository::countByIdIn)));
     // The user's id is generated on save (UUID generator), not before: evict only after
     // persisting, using the saved user's id, or evictForUser is called with a null key.
-    User createdUser =
-        createUser(user, input.plainPassword(), UUID.randomUUID().toString(), includePlatformScope);
+    User createdUser = createUser(user, input.plainPassword(), UUID.randomUUID().toString(), scope);
     if (!CollectionUtils.isEmpty(tenantIds)) {
       tenantMembershipCacheManager.evictForUser(createdUser.getId(), tenantIds);
     }
     return createdUser;
   }
 
-  /** Creates a user for internal/technical purposes (SSO login, connector provisioning). */
+  /**
+   * Creates a user for internal/technical purposes (SSO login, connector provisioning, service
+   * accounts). Such a user always lands in a tenant, attached by the caller right after: the
+   * platform auto-assign groups are therefore never granted. Callers own the group assignment —
+   * either explicitly (technical accounts) or through {@link #assignAutoAssignGroups(String,
+   * Collection)} once the tenant is attached (SSO).
+   */
   @Transactional(rollbackFor = Exception.class)
   public User createInternalUser(
       String email, String firstname, String lastname, boolean isAdmin, String token) {
@@ -175,17 +178,19 @@ public class UserService {
     user.setFirstname(firstname);
     user.setLastname(lastname);
     user.setAdmin(isAdmin);
-    return createUser(user, null, token, true);
+    return createUser(user, null, token, UserCreationScope.TENANT);
   }
 
-  private User createUser(User user, String password, String token, boolean includePlatformScope) {
+  private User createUser(User user, String password, String token, UserCreationScope scope) {
     if (StringUtils.hasLength(password)) {
       user.setPassword(this.encodeUserPassword(password));
     }
     // Creation enters every scope at once: the platform when created from the platform screen,
     // plus each tenant attached in the input.
     assignAutoAssignGroups(
-        user, user.getTenants().stream().map(Tenant::getId).toList(), includePlatformScope);
+        user,
+        user.getTenants().stream().map(Tenant::getId).toList(),
+        scope == UserCreationScope.PLATFORM);
     User savedUser = userRepository.save(user);
     this.createUserToken(savedUser, token);
     return savedUser;

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
@@ -62,7 +62,7 @@ public class TenantUserService implements DependenciesManager {
       User reloaded = userRepository.findById(userId).orElseThrow();
       return UserMapper.toOutput(reloaded);
     }
-    User user = userService.createUser(input);
+    User user = userService.createTenantUser(input);
     attachToTenant(user.getId(), tenantId);
     userService.assignAutoAssignGroups(user.getId(), List.of(tenantId));
     // Reload user after @Modifying queries cleared the persistence context

--- a/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/tenants/TenantUserService.java
@@ -19,6 +19,7 @@ import io.openaev.database.repository.UserRepository;
 import io.openaev.database.specification.UserSpecification;
 import io.openaev.multitenancy.DependenciesManager;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.service.UserCreationScope;
 import io.openaev.service.UserService;
 import io.openaev.service.account.PrivilegeEscalationValidator;
 import io.openaev.service.account.ReservedKeyValidator;
@@ -62,7 +63,7 @@ public class TenantUserService implements DependenciesManager {
       User reloaded = userRepository.findById(userId).orElseThrow();
       return UserMapper.toOutput(reloaded);
     }
-    User user = userService.createTenantUser(input);
+    User user = userService.createUser(input, UserCreationScope.TENANT);
     attachToTenant(user.getId(), tenantId);
     userService.assignAutoAssignGroups(user.getId(), List.of(tenantId));
     // Reload user after @Modifying queries cleared the persistence context

--- a/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import io.openaev.utils.fixtures.tenants.TenantFixture;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -40,7 +41,7 @@ class UserServiceTest extends IntegrationTest {
     UserInput input =
         getUserInputWithPasswordAndPhone(
             "create@test.invalid", "John", "Doe", "secureP@ss1", "+33612345678");
-    User created = userService.createUser(input);
+    User created = userService.createUser(input, UserCreationScope.PLATFORM);
 
     // -- ASSERT --
     assertThat(created.getId()).isNotNull();
@@ -69,7 +70,7 @@ class UserServiceTest extends IntegrationTest {
             List.of(tenant.getId()));
 
     // -- ACT --
-    User created = userService.createUser(input);
+    User created = userService.createUser(input, UserCreationScope.PLATFORM);
 
     // -- ASSERT --
     assertThat(created.getId()).isNotNull();
@@ -93,7 +94,8 @@ class UserServiceTest extends IntegrationTest {
                 "Auto",
                 "Assign",
                 "secureP@ss1",
-                List.of(tenant.getId())));
+                List.of(tenant.getId())),
+            UserCreationScope.PLATFORM);
 
     // -- ASSERT --
     entityManager.flush();
@@ -102,6 +104,32 @@ class UserServiceTest extends IntegrationTest {
     assertThat(reloaded.getUnscopedGroups())
         .extracting(Group::getId)
         .contains(platformGroup.getId(), tenantGroup.getId());
+  }
+
+  @Test
+  @DisplayName("given_internalUserCreation_should_notAssignPlatformAutoAssignGroups")
+  void given_internalUserCreation_should_notAssignPlatformAutoAssignGroups() {
+    // -- ARRANGE --
+    // Internal accounts (SSO, connectors, service accounts) always land in a tenant attached by
+    // the caller: they must never inherit the platform-wide auto-assign groups.
+    Group platformGroup = autoAssignGroup("platform-auto-assign-internal", null);
+
+    // -- ACT --
+    User created =
+        userService.createInternalUser(
+            "internal-auto-assign@test.invalid",
+            "Internal",
+            "Account",
+            false,
+            UUID.randomUUID().toString());
+
+    // -- ASSERT --
+    entityManager.flush();
+    entityManager.clear();
+    User reloaded = userService.user(created.getId());
+    assertThat(reloaded.getUnscopedGroups())
+        .extracting(Group::getId)
+        .doesNotContain(platformGroup.getId());
   }
 
   @Test
@@ -148,7 +176,7 @@ class UserServiceTest extends IntegrationTest {
             "Removed",
             "secureP@ss1",
             List.of(tenant.getId()));
-    User created = userService.createUser(input);
+    User created = userService.createUser(input, UserCreationScope.PLATFORM);
     // The tenant admin removes the auto-assign group from the user, from within the tenant.
     created.getUnscopedGroups().remove(tenantGroup);
     userService.saveUser(created);
@@ -181,7 +209,7 @@ class UserServiceTest extends IntegrationTest {
             "Unchanged",
             "secureP@ss1",
             List.of(tenant.getId()));
-    User created = userService.createUser(input);
+    User created = userService.createUser(input, UserCreationScope.PLATFORM);
     entityManager.flush();
     entityManager.clear();
     // The auto-assign group only appears after the user already belongs to the tenant.
@@ -216,7 +244,8 @@ class UserServiceTest extends IntegrationTest {
                 "Detach",
                 "Tenant",
                 "secureP@ss1",
-                List.of(kept.getId(), left.getId())));
+                List.of(kept.getId(), left.getId())),
+            UserCreationScope.PLATFORM);
     entityManager.flush();
     entityManager.clear();
 
@@ -256,7 +285,8 @@ class UserServiceTest extends IntegrationTest {
                 "Revoke",
                 "Scoped",
                 "secureP@ss1",
-                List.of(tenant.getId())));
+                List.of(tenant.getId())),
+            UserCreationScope.PLATFORM);
     entityManager.flush();
     entityManager.clear();
 

--- a/openaev-api/src/test/java/io/openaev/service/tenants/TenantUserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/tenants/TenantUserServiceTest.java
@@ -16,11 +16,14 @@ import io.openaev.database.model.User;
 import io.openaev.database.raw.RawUser;
 import io.openaev.database.repository.GroupRepository;
 import io.openaev.database.repository.TenantRepository;
+import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.utils.fixtures.PaginationFixture;
 import io.openaev.utils.fixtures.TenantGroupFixture;
 import io.openaev.utils.fixtures.composers.TenantGroupComposer;
 import io.openaev.utils.fixtures.composers.UserComposer;
+import io.openaev.utils.fixtures.platform.PlatformGroupComposer;
+import io.openaev.utils.fixtures.platform.PlatformGroupFixture;
 import io.openaev.utils.fixtures.tenants.TenantComposer;
 import io.openaev.utils.mockUser.WithMockUser;
 import io.openaev.utils.pagination.SearchPaginationInput;
@@ -45,7 +48,9 @@ class TenantUserServiceTest extends IntegrationTest {
   @Autowired private UserComposer userComposer;
   @Autowired private TenantComposer tenantComposer;
   @Autowired private TenantGroupComposer tenantGroupComposer;
+  @Autowired private PlatformGroupComposer platformGroupComposer;
   @Autowired private GroupRepository groupRepository;
+  @Autowired private UserRepository userRepository;
   @Autowired private EntityManager entityManager;
 
   private Tenant tenant;
@@ -347,6 +352,66 @@ class TenantUserServiceTest extends IntegrationTest {
       entityManager.clear();
       Group reloaded = groupRepository.findById(autoGroup.getId()).orElseThrow();
       assertThat(reloaded.getUsers()).extracting(User::getId).contains(existingUser.getId());
+    }
+
+    @Test
+    @DisplayName("Given a platform auto-assign group, should not assign a user created in a tenant")
+    void given_platformAutoAssignGroup_should_notAssignTenantCreatedUser() {
+      // -- ARRANGE --
+      Group platformAutoGroup = PlatformGroupFixture.getPlatformGroup("AutoAssignPlatform");
+      platformAutoGroup.setDefaultUserAssignation(true);
+      platformGroupComposer.forPlatformGroup(platformAutoGroup).persist();
+      Group tenantAutoGroup = TenantGroupFixture.getGroup("AutoAssignTenantScoped");
+      tenantAutoGroup.setDefaultUserAssignation(true);
+      tenantGroupComposer.forGroup(tenantAutoGroup).persist();
+      entityManager.flush();
+
+      UserInput input = getUserInput("tenant-scoped@test.invalid", "Tenant", "Scoped");
+
+      // -- ACT --
+      UserOutput result = tenantUserService.createOrAttach(input);
+
+      // -- ASSERT --
+      entityManager.flush();
+      entityManager.clear();
+      Group reloadedPlatform = groupRepository.findById(platformAutoGroup.getId()).orElseThrow();
+      assertThat(reloadedPlatform.getUsers()).extracting(User::getId).doesNotContain(result.id());
+      Group reloadedTenant = groupRepository.findById(tenantAutoGroup.getId()).orElseThrow();
+      assertThat(reloadedTenant.getUsers()).extracting(User::getId).contains(result.id());
+    }
+
+    @Test
+    @DisplayName("Given tenants in the input, should ignore them when creating from a tenant")
+    void given_tenantIdsInInput_should_ignoreThem() {
+      // -- ARRANGE --
+      Tenant otherTenant = tenantComposer.forTenant(getTenant("Other tenant")).persist().get();
+      entityManager.flush();
+      UserInput base = getUserInput("cross-tenant@test.invalid", "Cross", "Tenant");
+      UserInput input =
+          new UserInput(
+              base.email(),
+              base.firstname(),
+              base.lastname(),
+              base.plainPassword(),
+              base.pgpKey(),
+              base.phone(),
+              base.phone2(),
+              base.organizationId(),
+              base.tagIds(),
+              base.admin(),
+              List.of(otherTenant.getId()));
+
+      // -- ACT --
+      UserOutput result = tenantUserService.createOrAttach(input);
+
+      // -- ASSERT --
+      entityManager.flush();
+      entityManager.clear();
+      User reloaded = userRepository.findById(result.id()).orElseThrow();
+      assertThat(reloaded.getTenants())
+          .extracting(Tenant::getId)
+          .containsExactly(tenant.getId())
+          .doesNotContain(otherTenant.getId());
     }
   }
 }


### PR DESCRIPTION
### Proposed changes

* Introduced tenant-aware user creation flow so that user provisioning behavior is explicitly scoped to the current tenant context.
* Differentiated user creation logic between tenant-scoped and non-tenant/global contexts to avoid ambiguous ownership and cross-tenant side effects.
* Updated related service/controller handling to consistently propagate and enforce tenant scope during user creation operations.

### Testing Instructions

1. Prepare at least two tenants in a test environment (e.g., `tenant-a` and `tenant-b`) with appropriate admin/operator roles.
2. From `tenant-a` context, create a new user and verify:
   - user is created successfully,
   - user is attached only to `tenant-a`,
   - no visibility/association appears in `tenant-b`.
3. From `tenant-b` context, create a new user and verify equivalent tenant isolation behavior.
4. (If supported) Execute user creation in a non-tenant/global context and verify expected fallback behavior is preserved.
5. Validate error cases:
   - missing/invalid tenant scope,
   - unauthorized actor attempting tenant-scoped creation,
   - duplicate/conflicting identity in same tenant rules.
6. Run automated tests covering user creation and tenancy boundaries; ensure no regressions in existing user provisioning flows.

### Related issues

* Closes #7613
* Related to multi-tenancy user management hardening

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

This change focuses on making tenant boundaries explicit at user creation time to reduce accidental cross-tenant coupling and improve predictability in multi-tenant environments.  
The implementation favors explicit scope propagation and validation over implicit inference, which makes the behavior easier to reason about and safer for future extensions.
