### PR TITLE
chore(deps): let Renovate see the Spring Boot BOM overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,17 +31,17 @@
         <pyroscope.version>2.9.1</pyroscope.version>
         <spring-security-crypto.version>6.5.11</spring-security-crypto.version>
         <bouncycastle.version>1.85.2</bouncycastle.version>
-        <jackson-bom.version>2.21.5</jackson-bom.version>
+        <jackson-bom.version>2.22.2</jackson-bom.version>
         <netty.version>4.2.17.Final</netty.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <tools-jackson-core.version>3.2.2</tools-jackson-core.version>
-        <tomcat.version>10.1.56</tomcat.version>
+        <tomcat.version>10.1.59</tomcat.version>
         <!-- Override Spring Boot BOM: httpcore5-h2 HTTP/2 HPACK DoS CVE-2026-54428 -->
         <httpcore5.version>5.4.3</httpcore5.version>
         <velocity-engine-core.version>2.4.1</velocity-engine-core.version>
         <opensaml.version>5.2.3</opensaml.version>
         <logback.version>1.6.3</logback.version>
-        <log4j2.version>2.25.5</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <httpclient5.version>5.6.4</httpclient5.version>
         <kotlin.version>2.1.21</kotlin.version>
         <hikaricp.version>7.0.2</hikaricp.version>

--- a/renovate.json5
+++ b/renovate.json5
@@ -35,6 +35,7 @@
             matchStrings: ['<jackson-bom\.version>(?<currentValue>.*?)</jackson-bom\.version>'],
             depNameTemplate: 'com.fasterxml.jackson:jackson-bom',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -42,6 +43,7 @@
             matchStrings: ['<tomcat\.version>(?<currentValue>.*?)</tomcat\.version>'],
             depNameTemplate: 'org.apache.tomcat.embed:tomcat-embed-core',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -49,6 +51,7 @@
             matchStrings: ['<log4j2\.version>(?<currentValue>.*?)</log4j2\.version>'],
             depNameTemplate: 'org.apache.logging.log4j:log4j-bom',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -56,6 +59,7 @@
             matchStrings: ['<logback\.version>(?<currentValue>.*?)</logback\.version>'],
             depNameTemplate: 'ch.qos.logback:logback-classic',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -63,6 +67,7 @@
             matchStrings: ['<httpcore5\.version>(?<currentValue>.*?)</httpcore5\.version>'],
             depNameTemplate: 'org.apache.httpcomponents.core5:httpcore5',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -70,6 +75,7 @@
             matchStrings: ['<hikaricp\.version>(?<currentValue>.*?)</hikaricp\.version>'],
             depNameTemplate: 'com.zaxxer:HikariCP',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -77,6 +83,7 @@
             matchStrings: ['<micrometer\.version>(?<currentValue>.*?)</micrometer\.version>'],
             depNameTemplate: 'io.micrometer:micrometer-bom',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
         {
             customType: 'regex',
@@ -84,6 +91,7 @@
             matchStrings: ['<micrometer-tracing\.version>(?<currentValue>.*?)</micrometer-tracing\.version>'],
             depNameTemplate: 'io.micrometer:micrometer-tracing-bom',
             datasourceTemplate: 'maven',
+            versioningTemplate: 'maven',
         },
     ],
     packageRules: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,6 +25,67 @@
         // vulnerabilityAlerts is disabled since it can cause problems by skipping minimumReleaseAge, schedule and others constraints
         enabled: false,
     },
+    // These properties only override the Spring Boot BOM: no dependency declares the artifacts,
+    // so the maven manager has nothing to track and the pins rot silently. They were all added by
+    // hand for CVEs, which makes them the ones that must not drift.
+    customManagers: [
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<jackson-bom\.version>(?<currentValue>.*?)</jackson-bom\.version>'],
+            depNameTemplate: 'com.fasterxml.jackson:jackson-bom',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<tomcat\.version>(?<currentValue>.*?)</tomcat\.version>'],
+            depNameTemplate: 'org.apache.tomcat.embed:tomcat-embed-core',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<log4j2\.version>(?<currentValue>.*?)</log4j2\.version>'],
+            depNameTemplate: 'org.apache.logging.log4j:log4j-bom',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<logback\.version>(?<currentValue>.*?)</logback\.version>'],
+            depNameTemplate: 'ch.qos.logback:logback-classic',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<httpcore5\.version>(?<currentValue>.*?)</httpcore5\.version>'],
+            depNameTemplate: 'org.apache.httpcomponents.core5:httpcore5',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<hikaricp\.version>(?<currentValue>.*?)</hikaricp\.version>'],
+            depNameTemplate: 'com.zaxxer:HikariCP',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<micrometer\.version>(?<currentValue>.*?)</micrometer\.version>'],
+            depNameTemplate: 'io.micrometer:micrometer-bom',
+            datasourceTemplate: 'maven',
+        },
+        {
+            customType: 'regex',
+            managerFilePatterns: ['/^pom\.xml$/'],
+            matchStrings: ['<micrometer-tracing\.version>(?<currentValue>.*?)</micrometer-tracing\.version>'],
+            depNameTemplate: 'io.micrometer:micrometer-tracing-bom',
+            datasourceTemplate: 'maven',
+        },
+    ],
     packageRules: [
         {
             description: 'Disable updates of internal packages',


### PR DESCRIPTION
### Proposed changes

Nine of our version properties only override the Spring Boot BOM. No dependency declares those artifacts, so the maven manager has nothing to track and Renovate never proposes an update.