### PR TITLE
chore(deps): drop the springdoc and swagger pins, their conditions are met

### DIFF
--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations-jakarta</artifactId>
-            <version>2.2.43</version>
+            <version>2.2.54</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/renovate.json5
+++ b/renovate.json5
@@ -105,32 +105,6 @@
                 '/^io\\.openaev:/',
             ],
         },
-        // swagger-annotations-jakarta must stay aligned with swagger-core embedded in springdoc-openapi 2.6.0.
-        // Versions > 2.2.43 cause /api-docs to return invalid schema. Requires Spring Boot 3.4+ and springdoc 2.7+ upgrade first.
-        {
-            description: 'Pin swagger-annotations-jakarta until springdoc 2.7+ upgrade',
-            matchDatasources: [
-                'maven'
-            ],
-            matchPackageNames: [
-                'io.swagger.core.v3:swagger-annotations-jakarta'
-            ],
-            allowedVersions: '<=2.2.43',
-            enabled: true,
-        },
-        // springdoc-openapi 2.7+ requires Spring Boot 3.4+ (uses LiteWebJarsResourceResolver from Spring Framework 6.2).
-        // Blocked until Spring Boot is upgraded from 3.3.7.
-        {
-            description: 'Pin springdoc-openapi until Spring Boot 3.4+ upgrade',
-            matchDatasources: [
-                'maven'
-            ],
-            matchPackageNames: [
-                '/^org\\.springdoc:/'
-            ],
-            allowedVersions: '<=2.6.0',
-            enabled: true,
-        },
         {
             description: 'apexcharts >= 5 uses a commercial license (not MIT). Block major updates.',
             matchDepNames: [


### PR DESCRIPTION
### Proposed changes

Both Renovate rules block updates on a condition satisfied months ago, so neither family has been proposed an update since — security patches included.
