### PR TITLE
chore(deps): let the Spring Boot starters inherit the parent version

### DIFF
--- a/openaev-api/pom.xml
+++ b/openaev-api/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>3.5.16</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -80,7 +79,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
-            <version>3.5.16</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### Proposed changes

`spring-boot-starter-security` and `spring-boot-starter-oauth2-client` carried a hard coded `3.5.16` while the parent already manages them. Renovate treats such a declaration as its own dependency and bumps it separately, so the two can drift away from the rest of Spring Boot.