### PR TITLE
chore(deps): let spring-security-crypto follow the Spring Boot BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
         <pyroscope.version>2.9.1</pyroscope.version>
-        <spring-security-crypto.version>6.5.11</spring-security-crypto.version>
         <bouncycastle.version>1.85.2</bouncycastle.version>
         <jackson-bom.version>2.22.2</jackson-bom.version>
         <netty.version>4.2.17.Final</netty.version>
@@ -198,7 +197,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>${spring-security-crypto.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Proposed changes

The dependency is genuinely used but it carried its own version property set to `6.5.11`, which is exactly what the Boot 3.5.16 BOM already manages.