### PR TITLE
chore(deps): stop reaching into Apache HttpClient 4 for constants

### DIFF
--- a/openaev-api/src/main/java/io/openaev/opencti/client/OpenCTIClient.java
+++ b/openaev-api/src/main/java/io/openaev/opencti/client/OpenCTIClient.java
@@ -22,9 +22,9 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/openaev-api/src/test/java/io/openaev/rest/injector_contract/InjectorContractApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/injector_contract/InjectorContractApiTest.java
@@ -46,12 +46,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.javacrumbs.jsonunit.core.Option;
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
@@ -1419,7 +1419,7 @@ public class InjectorContractApiTest extends IntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .with(csrf()))
               .andDo(print())
-              .andExpect(status().is(HttpStatus.SC_OK));
+              .andExpect(status().is(HttpStatus.OK.value()));
 
       // Verify the response based on user permissions
       if (shouldSeeAllContracts) {
@@ -1461,7 +1461,7 @@ public class InjectorContractApiTest extends IntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content(asJsonString(searchPaginationInput))
                       .with(csrf()))
-              .andExpect(status().is(HttpStatus.SC_OK));
+              .andExpect(status().is(HttpStatus.OK.value()));
 
       // Verify pagination response
       result.andExpect(jsonPath("$.totalElements").exists());
@@ -1508,7 +1508,7 @@ public class InjectorContractApiTest extends IntegrationTest {
                       .contentType(MediaType.APPLICATION_JSON)
                       .content(asJsonString(searchPaginationInput))
                       .with(csrf()))
-              .andExpect(status().is(HttpStatus.SC_OK));
+              .andExpect(status().is(HttpStatus.OK.value()));
 
       // Verify pagination response with full details
       result.andExpect(jsonPath("$.totalElements").exists());


### PR DESCRIPTION
### Proposed changes

Two files imported HttpClient 4 only to name constants, while nothing declares that library: it arrives transitively through the Elasticsearch rest client. The day that transitive moves, the compile errors appear far from their cause.