### PR TITLE
chore(deps): declare httpclient5 and commons-io where they are actually used

### DIFF
--- a/openaev-framework/pom.xml
+++ b/openaev-framework/pom.xml
@@ -22,16 +22,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-freemarker</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${httpclient5.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-        </dependency>
         <!-- TEST -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -21,6 +21,12 @@
 
     <dependencyManagement>
         <dependencies>
+        <!-- Used directly by OpenSearchDriver; only reached us through the OpenSearch client. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
+        </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>


### PR DESCRIPTION
### Proposed changes

`openaev-framework` declares both libraries and imports neither — 0 occurrences, imports and qualified names, main and test. `openaev-model` imports HttpClient 5 in `OpenSearchDriver` and declares nothing, so it only compiles because the OpenSearch client happens to drag the library along.