### PR TITLE
TEST DO NOT MERGE fix(rabbitmq): bound a publish so it cannot hold a transaction open

### DIFF
--- a/openaev-api/src/main/resources/application.properties
+++ b/openaev-api/src/main/resources/application.properties
@@ -130,6 +130,8 @@ openaev.rabbitmq.management-port=15672
 openaev.rabbitmq.queue-type=classic
 # Whether or not the calls to the management plugin of rabbitmq can be insecure
 openaev.rabbitmq.management-insecure=true
+# Hard cap on a single publish, so a broker that stops answering cannot hold a transaction open
+openaev.rabbitmq.publish-timeout-ms=30000
 # if the SSL key is set to true and Insecure Management to false,
 # fill in the following settings to enable access
 openaev.rabbitmq.trust-store-password=<trust-store-password>

--- a/openaev-model/src/main/java/io/openaev/driver/RabbitmqDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/RabbitmqDriver.java
@@ -26,6 +26,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class RabbitmqDriver {
 
+  private static final int CONNECTION_TIMEOUT_MS = 10_000;
+
   private final RabbitmqConfig rabbitmqConfig;
   private final RabbitMQSslConfiguration rabbitMQSslConfiguration;
 
@@ -42,6 +44,7 @@ public class RabbitmqDriver {
     factory.setUsername(rabbitmqConfig.getUser());
     factory.setPassword(rabbitmqConfig.getPass());
     factory.setVirtualHost(rabbitmqConfig.getVhost());
+    factory.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
 
     if (rabbitmqConfig.isSsl()) {
       try {

--- a/openaev-model/src/main/java/io/openaev/service/RabbitmqService.java
+++ b/openaev-model/src/main/java/io/openaev/service/RabbitmqService.java
@@ -11,14 +11,22 @@ import io.openaev.service.queue.BatchQueueService;
 import io.openaev.service.queue.QueueExecution;
 import io.openaev.service.queue.Queueable;
 import io.openaev.service.rabbitmq.RabbitmqManagementClient;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -61,6 +69,15 @@ public class RabbitmqService {
 
   /** Connection timeout for health check probes, so a degraded broker fails fast. */
   private static final int HEALTH_CHECK_CONNECTION_TIMEOUT_MS = 5_000;
+
+  @Value("${openaev.rabbitmq.publish-timeout-ms:30000}")
+  private long publishTimeoutMs;
+
+  /** A publish always holds a database connection, so it cannot outrun the pool. */
+  @Value("${spring.datasource.hikari.maximum-pool-size:20}")
+  private int publishThreads;
+
+  private ExecutorService publishExecutor;
 
   private final RabbitmqConfig rabbitmqConfig;
   private final ConnectionFactory connectionFactory;
@@ -115,6 +132,40 @@ public class RabbitmqService {
       throw new IllegalArgumentException("publishedJson cannot be null or empty");
     }
 
+    Future<Void> pending =
+        publishExecutor.submit(
+            () -> {
+              doPublish(injectType, publishedJson);
+              return null;
+            });
+    try {
+      pending.get(publishTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException ex) {
+      pending.cancel(true);
+      log.error(
+          "Publish to RabbitMQ did not return within {} ms for inject type '{}'; giving up so the"
+              + " caller's transaction is not held open",
+          publishTimeoutMs,
+          injectType);
+      throw ex;
+    } catch (InterruptedException ex) {
+      pending.cancel(true);
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while publishing to RabbitMQ", ex);
+    } catch (ExecutionException ex) {
+      Throwable cause = ex.getCause();
+      if (cause instanceof IOException ioCause) {
+        throw ioCause;
+      }
+      if (cause instanceof TimeoutException timeoutCause) {
+        throw timeoutCause;
+      }
+      throw new IOException("Failed to publish to RabbitMQ", cause);
+    }
+  }
+
+  private void doPublish(String injectType, String publishedJson)
+      throws IOException, TimeoutException {
     try (Connection connection = connectionFactory.newConnection();
         Channel channel = connection.createChannel()) {
       String routingKey = rabbitmqConfig.getPrefix() + ROUTING_KEY + injectType;
@@ -135,6 +186,25 @@ public class RabbitmqService {
     } catch (TimeoutException ex) {
       log.error("Timeout while publishing to RabbitMQ for inject type '{}'", injectType, ex);
       throw ex;
+    }
+  }
+
+  @PostConstruct
+  void initPublishExecutor() {
+    publishExecutor =
+        Executors.newFixedThreadPool(
+            publishThreads,
+            runnable -> {
+              Thread thread = new Thread(runnable, "rabbitmq-publish");
+              thread.setDaemon(true);
+              return thread;
+            });
+  }
+
+  @PreDestroy
+  void shutdownPublishExecutor() {
+    if (publishExecutor != null) {
+      publishExecutor.shutdownNow();
     }
   }
 


### PR DESCRIPTION
Executor.executeExternal publishes inside the inject's transaction. A broker under a memory or disk alarm accepts the connection then stops draining its sockets, so basicPublish blocks - and Java has no write timeout to bound it. The job thread parks, the transaction stays open with its row locks, the Hikari pool drains and the whole platform stops answering, since the session store is in the same database.

Run the publish on an executor and give up after
openaev.rabbitmq.publish-timeout-ms. The worker stays parked - a socket write is not interruptible - but the caller returns, its transaction rolls back and the inject fails instead of the platform. The executor is sized on the database pool, which already bounds how many publishes can run at once.

Also drop the connection timeout from the client default of 60s to 10s: publish opens a connection per call, so an unreachable broker would tie a worker up for a full minute.

<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Related #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
