### PR TITLE
fix(deps): update the Elasticsearch client to 9 and require an Elasticsearch 9 cluster

### DIFF
--- a/docs/docs/deployment/breaking-changes.md
+++ b/docs/docs/deployment/breaking-changes.md
@@ -18,6 +18,7 @@ implemented.
 | [URL access token enforcement](#url-access-token-enforcement) | -             | 2.260622.0 |
 | [Injector contract expectation format](#injector-contract-expectation-format) | -             | \[MigrationVersion\]        |
 | [Tenant users, groups and roles capabilities](#tenant-users-groups-and-roles-capabilities) | -             | \[MigrationVersion\]        |
+| [Elasticsearch 9](#elasticsearch-9)                            | -             | \[MigrationVersion\]        |
 
 ## OpenAEV 2.2.0
 
@@ -124,3 +125,13 @@ For more details, see [this migration guide](breaking-changes/MigrationVersion-i
 Starting with **OpenAEV \[MigrationVersion\]**, managing a tenant's users, groups and roles is governed by its own *Access / Manage / Delete tenant users, groups and roles* capabilities, instead of the *tenant settings* ones which also cover collectors, injectors and tag rules. Existing roles are migrated automatically and keep the access they had.
 
 For more details, see [this migration guide](breaking-changes/MigrationVersion-tenant-users-groups-and-roles-capabilities.md)
+
+<a id="elasticsearch-9"></a>
+
+#### Elasticsearch 9
+
+Starting with **OpenAEV \[MigrationVersion\]**, the platform requires an Elasticsearch 9 cluster. The 9.x client
+tags its requests as `compatible-with=9`, which an 8.x server rejects, so every engine call fails against
+Elasticsearch 8. OpenSearch deployments are unaffected.
+
+For more details, see [this migration guide](breaking-changes/MigrationVersion-elasticsearch-9.md)

--- a/docs/docs/deployment/breaking-changes/MigrationVersion-elasticsearch-9.md
+++ b/docs/docs/deployment/breaking-changes/MigrationVersion-elasticsearch-9.md
@@ -1,0 +1,32 @@
+# Elasticsearch 9
+
+!!! info ""
+
+    * **Introduced in**: `OpenAEV [MigrationVersion]`
+
+## Description of changes
+
+The platform now uses the 9.x Elasticsearch Java client. That client stamps every request with an
+`application/vnd.elasticsearch+json; compatible-with=9` content type, which an 8.x server rejects
+outright:
+
+```json
+{"error":{"type":"media_type_header_exception","reason":"Invalid media-type value on headers [Accept, Content-Type]"},"status":400}
+```
+
+Elasticsearch 8 is therefore no longer usable: every engine call fails, and the platform refuses to
+start. **Upgrade your cluster to Elasticsearch 9 before upgrading OpenAEV.** OpenSearch deployments
+are unaffected.
+
+## Migration
+
+1. Upgrade the Elasticsearch cluster to 9.x, following
+   [Elastic's upgrade documentation](https://www.elastic.co/docs/deploy-manage/upgrade). Elasticsearch 9
+   only reads indices created by 8.x or later, so any index still carrying a 7.x creation version has
+   to be reindexed or removed first — Elastic's Upgrade Assistant reports them.
+2. Upgrade OpenAEV.
+
+The platform owns every index it queries and can rebuild them from PostgreSQL, so an alternative to
+migrating the data is to point OpenAEV at an empty Elasticsearch 9 cluster: the indices, templates and
+lifecycle policy are recreated at startup and reindexed from scratch. Expect the initial reindex to
+take a while on a large dataset, and dashboards to be incomplete until it finishes.

--- a/docs/docs/deployment/breaking-changes/MigrationVersion-elasticsearch-9.md
+++ b/docs/docs/deployment/breaking-changes/MigrationVersion-elasticsearch-9.md
@@ -30,3 +30,11 @@ The platform owns every index it queries and can rebuild them from PostgreSQL, s
 migrating the data is to point OpenAEV at an empty Elasticsearch 9 cluster: the indices, templates and
 lifecycle policy are recreated at startup and reindexed from scratch. Expect the initial reindex to
 take a while on a large dataset, and dashboards to be incomplete until it finishes.
+
+## Clusters served over HTTPS
+
+A cluster whose certificate is signed by an internal CA is now trusted as soon as that CA is dropped
+in `openaev.extra-trusted-certs-dir`, like every other outgoing connection of the platform (see
+[certificate validation](../certificate-validation.md)). The engine client used to read the JVM
+default trust store only, which left `engine.reject-unauthorized=false` — no verification at all — as
+the only way to reach such a cluster. That parameter still works, and is no longer needed here.

--- a/docs/docs/deployment/platform/overview.md
+++ b/docs/docs/deployment/platform/overview.md
@@ -54,12 +54,15 @@ if an inject (execution, emails, etc.) has been detected or prevented and fill t
 | Component     | Recommended version             | CPU     | RAM     | Disk type | Disk space |
 |:--------------|:--------------------------------|:--------|:--------|:----------|:-----------|
 | PostgreSQL    | ≥ 17.0                          | 2 cores | ≥ 8GB   | SSD       | ≥ 16GB     |
-| ElasticSearch | ≥ 8.19                          | 2 cores | ≥ 8GB   | SSD       | ≥ 16GB     |
+| ElasticSearch | ≥ 9.0                           | 2 cores | ≥ 8GB   | SSD       | ≥ 16GB     |
 | RabbitMQ      | >= 4.1                          | 1 core  | ≥ 512MB | Standard  | ≥ 2GB      |
 | S3 / MinIO    | ≥ RELEASE.2025-06-13T11-33-47Z  | 1 core  | ≥ 128MB | SSD       | ≥ 16GB     |
 
 Please note that while the versions of these dependencies are the recommended ones, OpenAEV may still function with
 earlier versions. However, we will not provide support for versions prior to the recommended ones.
+
+Elasticsearch is the exception: the platform's client rejects 8.x servers outright, so 9.0 is a hard
+minimum. See [this migration guide](../breaking-changes/MigrationVersion-elasticsearch-9.md).
 
 ### Platform
 

--- a/docs/docs/development/environment-windows.md
+++ b/docs/docs/development/environment-windows.md
@@ -92,7 +92,7 @@ This starts:
 |---|---|---|
 | PostgreSQL 17 | 5432 | Database |
 | MinIO | 10000, 10001 | S3-compatible object storage |
-| Elasticsearch 8 | 9200 | Analytics engine |
+| Elasticsearch 9 | 9200 | Analytics engine |
 | RabbitMQ 4 | 5672, 15672 | Message broker |
 
 !!! warning

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
         - URL access token enforcement for email links: deployment/breaking-changes/2.260622.0-url-access-token-enforcement.md
         - Injector contract expectation format: deployment/breaking-changes/MigrationVersion-injector-contract-expectation-format.md
         - Tenant users, groups and roles capabilities: deployment/breaking-changes/MigrationVersion-tenant-users-groups-and-roles-capabilities.md
+        - Elasticsearch 9: deployment/breaking-changes/MigrationVersion-elasticsearch-9.md
   - User Guide:
     - Getting started: usage/getting-started.md
     - Foundations:

--- a/openaev-api/pom.xml
+++ b/openaev-api/pom.xml
@@ -20,7 +20,6 @@
         <cron-utils.version>9.2.1</cron-utils.version>
         <apache-poi.version>5.5.1</apache-poi.version>
         <opencsv-version>5.12.0</opencsv-version>
-        <elasticsearch.version>9.5.1</elasticsearch.version>
         <opentelemetry-semconv.version>1.43.0</opentelemetry-semconv.version>
         <!-- Not managed by the Spring Boot BOM; pinned here. Apache-2.0. -->
         <datasource-proxy.version>1.11.0</datasource-proxy.version>
@@ -73,7 +72,6 @@
         <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
-            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>

--- a/openaev-api/pom.xml
+++ b/openaev-api/pom.xml
@@ -20,7 +20,7 @@
         <cron-utils.version>9.2.1</cron-utils.version>
         <apache-poi.version>5.5.1</apache-poi.version>
         <opencsv-version>5.12.0</opencsv-version>
-        <elasticsearch.version>8.19.21</elasticsearch.version>
+        <elasticsearch.version>9.5.1</elasticsearch.version>
         <opentelemetry-semconv.version>1.43.0</opentelemetry-semconv.version>
         <!-- Not managed by the Spring Boot BOM; pinned here. Apache-2.0. -->
         <datasource-proxy.version>1.11.0</datasource-proxy.version>

--- a/openaev-api/src/test/java/io/openaev/utilstest/DatabaseSnapshotManager.java
+++ b/openaev-api/src/test/java/io/openaev/utilstest/DatabaseSnapshotManager.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Component;
 public class DatabaseSnapshotManager {
 
   private final JdbcTemplate jdbcTemplate;
-  private final ElasticsearchClient esClient;
+  private final ObjectProvider<ElasticsearchClient> esClientProvider;
   private final EngineConfig config;
 
   private static final Map<String, List<Map<String, Object>>> startupData = new HashMap<>();
@@ -102,6 +103,7 @@ public class DatabaseSnapshotManager {
 
   /** Delete ES indices */
   private void cleanElasticsearchIndices() {
+    ElasticsearchClient esClient = esClientProvider.getIfAvailable();
     if (esClient == null) {
       return;
     }

--- a/openaev-dev/docker-compose.yml
+++ b/openaev-dev/docker-compose.yml
@@ -61,7 +61,7 @@ services:
   # Development Elasticsearch (persistent storage)
   openaev-dev-elasticsearch:
     container_name: openaev-dev-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.1
     volumes:
       - esdata:/usr/share/elasticsearch/data
       - essnapshots:/usr/share/elasticsearch/snapshots
@@ -161,7 +161,7 @@ services:
   # Test Elasticsearch (ephemeral - no volume for clean test runs)
   openaev-test-elasticsearch:
     container_name: openaev-test-elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.1
     environment:
       - discovery.type=single-node
       - xpack.ml.enabled=false
@@ -202,7 +202,7 @@ services:
   # Kibana - Elasticsearch UI for development
   openaev-dev-kibana:
     container_name: openaev-dev-kibana
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.1
     environment:
       - ELASTICSEARCH_HOSTS=http://openaev-dev-elasticsearch:9200
     restart: unless-stopped
@@ -214,7 +214,7 @@ services:
   # Kibana - Elasticsearch UI for testing
   openaev-test-kibana:
     container_name: openaev-test-kibana
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.1
     environment:
       - ELASTICSEARCH_HOSTS=http://openaev-test-elasticsearch:9200
     restart: unless-stopped

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -13,7 +13,7 @@
     <description>OpenAEV model</description>
 
     <properties>
-        <elasticsearch.version>8.19.21</elasticsearch.version>
+        <elasticsearch.version>9.5.1</elasticsearch.version>
         <opensearch.version>3.9.0</opensearch.version>
         <amqp-client.version>5.35.0</amqp-client.version>
         <azure-core-management.version>1.19.6</azure-core-management.version>

--- a/openaev-model/pom.xml
+++ b/openaev-model/pom.xml
@@ -13,7 +13,6 @@
     <description>OpenAEV model</description>
 
     <properties>
-        <elasticsearch.version>9.5.1</elasticsearch.version>
         <opensearch.version>3.9.0</opensearch.version>
         <amqp-client.version>5.35.0</amqp-client.version>
         <azure-core-management.version>1.19.6</azure-core-management.version>
@@ -112,7 +111,6 @@
         <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
-            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.opensearch.client</groupId>

--- a/openaev-model/src/main/java/io/openaev/authorisation/TlsConfig.java
+++ b/openaev-model/src/main/java/io/openaev/authorisation/TlsConfig.java
@@ -1,7 +1,5 @@
 package io.openaev.authorisation;
 
-import io.openaev.config.OpenAEVConfig;
-import jakarta.annotation.Resource;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -23,6 +21,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 
@@ -31,7 +30,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TlsConfig {
 
-  @Resource private OpenAEVConfig openAEVConfig;
+  // Read from the environment rather than through OpenAEVConfig: that class lives in
+  // openaev-framework, which sits above this module.
+  @Value("${openbas.extra-trusted-certs-dir:${openaev.extra-trusted-certs-dir:#{null}}}")
+  private String extraTrustedCertsDir;
 
   /** Get files paths ".pem" from directory */
   private Set<String> getFilesPaths(String dir) {
@@ -94,7 +96,7 @@ public class TlsConfig {
 
   private Optional<X509TrustManager> getAdditionalTrustManager()
       throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException {
-    Set<String> filesPaths = getFilesPaths(openAEVConfig.getExtraTrustedCertsDir());
+    Set<String> filesPaths = getFilesPaths(extraTrustedCertsDir);
 
     // early return; if there aren't any extra certs
     // don't bother building a trust manager

--- a/openaev-model/src/main/java/io/openaev/driver/ElasticDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/ElasticDriver.java
@@ -13,7 +13,10 @@ import co.elastic.clients.elasticsearch.indices.put_index_template.IndexTemplate
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.transport.TransportUtils;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openaev.config.EngineConfig;
 import io.openaev.database.model.IndexingStatus;
@@ -25,21 +28,18 @@ import io.openaev.engine.model.EsBase;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
-import java.security.cert.X509Certificate;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
-import javax.net.ssl.SSLContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -73,45 +73,56 @@ public class ElasticDriver {
   }
 
   private ElasticsearchClient getElasticClient() {
-    RestClientBuilder restClientBuilder = RestClient.builder(HttpHost.create(config.getUrl()));
+    Rest5ClientBuilder restClientBuilder = Rest5Client.builder(URI.create(config.getUrl()));
     // The library defaults (1s connect / 30s socket timeout, 10 connections per route) are too
     // tight for this platform: during bulk indexing (full reindex after a migration) the async
     // client saturates and cancels pending requests, surfacing as "Request execution cancelled"
     // in dashboard queries and engine jobs. Configure explicit limits instead.
+    Timeout socketTimeout = Timeout.ofMilliseconds(config.getSocketTimeoutMs());
+    restClientBuilder.setConnectionConfigCallback(
+        connectionConfig ->
+            connectionConfig
+                .setConnectTimeout(Timeout.ofMilliseconds(config.getConnectTimeoutMs()))
+                .setSocketTimeout(socketTimeout));
+    // HttpClient 5 splits the single socket timeout of HttpClient 4 in two: the wait for the
+    // response, and the wait for a free connection in the pool. Both default to 30s and both must
+    // be raised, otherwise a saturated pool keeps cancelling requests whatever the socket timeout.
     restClientBuilder.setRequestConfigCallback(
         requestConfig ->
             requestConfig
-                .setConnectTimeout(config.getConnectTimeoutMs())
-                .setSocketTimeout(config.getSocketTimeoutMs()));
-    HttpAsyncClientBuilder clientBuilder = HttpAsyncClientBuilder.create();
-    clientBuilder
-        .setMaxConnTotal(config.getMaxConnections())
-        .setMaxConnPerRoute(config.getMaxConnections());
+                .setResponseTimeout(socketTimeout)
+                .setConnectionRequestTimeout(socketTimeout));
+    restClientBuilder.setConnectionManagerCallback(
+        connectionManager -> {
+          connectionManager
+              .setMaxConnTotal(config.getMaxConnections())
+              .setMaxConnPerRoute(config.getMaxConnections());
+          if (!config.isRejectUnauthorized()) {
+            // Trust any server certificate, and any mismatch between it and the requested host.
+            // The hostname verifier only gets a say under the CLIENT policy: the default policy
+            // delegates verification to the SSLEngine, which ignores it entirely.
+            connectionManager.setTlsStrategy(
+                ClientTlsStrategyBuilder.create()
+                    .setSslContext(TransportUtils.insecureSSLContext())
+                    .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
+                    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    .build());
+          }
+        });
     if (config.getUsername() != null) {
-      BasicCredentialsProvider credsProv = new BasicCredentialsProvider();
-      credsProv.setCredentials(
-          AuthScope.ANY,
-          new UsernamePasswordCredentials(config.getUsername(), config.getPassword()));
-      clientBuilder.setDefaultCredentialsProvider(credsProv);
+      // Preemptive basic auth, as the official Rest5 transport does: the low-level client has no
+      // credentials provider, and a challenge/response round trip per connection buys nothing.
+      String credentials =
+          Base64.getEncoder()
+              .encodeToString(
+                  (config.getUsername() + ":" + config.getPassword())
+                      .getBytes(StandardCharsets.UTF_8));
+      restClientBuilder.setDefaultHeaders(
+          new Header[] {new BasicHeader("Authorization", "Basic " + credentials)});
     }
-    if (!config.isRejectUnauthorized()) {
-      // Create an SSLContext that trusts all certificates
-      try {
-        SSLContext sslContext =
-            SSLContextBuilder.create()
-                .loadTrustMaterial(null, (X509Certificate[] chain, String authType) -> true)
-                .build();
-        clientBuilder
-            .setSSLContext(sslContext)
-            .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-    restClientBuilder.setHttpClientConfigCallback(hc -> clientBuilder);
-    RestClient restClient = restClientBuilder.build();
     JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(engineObjectMapper);
-    ElasticsearchTransport transport = new RestClientTransport(restClient, jsonpMapper);
+    ElasticsearchTransport transport =
+        new Rest5ClientTransport(restClientBuilder.build(), jsonpMapper);
     return new ElasticsearchClient(transport);
   }
 
@@ -151,7 +162,7 @@ public class ElasticDriver {
     coreSettings.name(config.getIndexPrefix() + ES_CORE_SETTINGS);
     coreSettings.create(false);
     coreSettings.template(
-        new IndexState.Builder()
+        new IndexTemplateMapping.Builder()
             .settings(
                 new IndexSettings.Builder()
                     .maxResultWindow(config.getMaxResultWindow())

--- a/openaev-model/src/main/java/io/openaev/driver/ElasticDriver.java
+++ b/openaev-model/src/main/java/io/openaev/driver/ElasticDriver.java
@@ -30,8 +30,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.*;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
@@ -39,6 +43,7 @@ import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -54,6 +59,7 @@ public class ElasticDriver {
   private EngineContext searchEngine;
   private final EngineConfig config;
   private final IndexingStatusRepository indexingStatusRepository;
+  private final X509TrustManager trustManager;
 
   /**
    * Shared ObjectMapper used by the Elasticsearch client for JSON serialization. Exposed via {@link
@@ -70,6 +76,30 @@ public class ElasticDriver {
   @Autowired
   public void setSearchEngine(EngineContext searchEngine) {
     this.searchEngine = searchEngine;
+  }
+
+  /**
+   * Trusts the platform chain: the JVM default store plus the PEM certificates dropped in {@code
+   * extra-trusted-certs-dir}, as every other outgoing client of the platform does.
+   */
+  private TlsStrategy tlsStrategy() {
+    if (!config.isRejectUnauthorized()) {
+      // Trust any server certificate, and any mismatch between it and the requested host.
+      // The hostname verifier only gets a say under the CLIENT policy: the default policy
+      // delegates verification to the SSLEngine, which ignores it entirely.
+      return ClientTlsStrategyBuilder.create()
+          .setSslContext(TransportUtils.insecureSSLContext())
+          .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
+          .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+          .build();
+    }
+    try {
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, new TrustManager[] {trustManager}, null);
+      return ClientTlsStrategyBuilder.create().setSslContext(sslContext).build();
+    } catch (GeneralSecurityException e) {
+      throw new IllegalStateException("Unable to build the engine TLS context", e);
+    }
   }
 
   private ElasticsearchClient getElasticClient() {
@@ -97,17 +127,7 @@ public class ElasticDriver {
           connectionManager
               .setMaxConnTotal(config.getMaxConnections())
               .setMaxConnPerRoute(config.getMaxConnections());
-          if (!config.isRejectUnauthorized()) {
-            // Trust any server certificate, and any mismatch between it and the requested host.
-            // The hostname verifier only gets a say under the CLIENT policy: the default policy
-            // delegates verification to the SSLEngine, which ignores it entirely.
-            connectionManager.setTlsStrategy(
-                ClientTlsStrategyBuilder.create()
-                    .setSslContext(TransportUtils.insecureSSLContext())
-                    .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
-                    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                    .build());
-          }
+          connectionManager.setTlsStrategy(tlsStrategy());
         });
     if (config.getUsername() != null) {
       // Preemptive basic auth, as the official Rest5 transport does: the low-level client has no

--- a/openaev-model/src/main/java/io/openaev/service/ElasticService.java
+++ b/openaev-model/src/main/java/io/openaev/service/ElasticService.java
@@ -555,7 +555,7 @@ public class ElasticService implements EngineService {
               .script(
                   Script.of(
                       s ->
-                          s.source(SIDE_CLEANUP_SCRIPT)
+                          s.source(src -> src.scriptString(SIDE_CLEANUP_SCRIPT))
                               .params("valuesToRemove", JsonData.of(ids))
                               .lang("painless")))
               .refresh(true)
@@ -1214,7 +1214,7 @@ public class ElasticService implements EngineService {
     try {
       Set<String> versions = new HashSet<>();
       mapper
-          .readTree(elasticClient.cluster().state().valueBody().toJson().toString())
+          .readTree(elasticClient.cluster().state().state().toJson().toString())
           .get("nodes")
           .elements()
           .forEachRemaining(jsonNode -> versions.add(jsonNode.get("version").textValue()));
@@ -1223,6 +1223,11 @@ public class ElasticService implements EngineService {
       log.warn("Unable to retrieve engine version", e);
     }
     return null;
+  }
+
+  /** The configured low-level client, for the few components needing raw index access. */
+  public ElasticsearchClient getElasticClient() {
+    return elasticClient;
   }
 
   @Override

--- a/openaev-model/src/main/java/io/openaev/service/EngineComponent.java
+++ b/openaev-model/src/main/java/io/openaev/service/EngineComponent.java
@@ -1,5 +1,6 @@
 package io.openaev.service;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.openaev.config.EngineConfig;
 import io.openaev.database.repository.IndexingStatusRepository;
 import io.openaev.driver.ElasticDriver;
@@ -8,6 +9,7 @@ import io.openaev.engine.EngineContext;
 import io.openaev.engine.EngineService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 
@@ -59,5 +61,20 @@ public class EngineComponent {
           searchEngine, openSearchDriver, indexingStatusRepository, config, commonSearchService);
     }
     throw new IllegalStateException("engine selector not supported");
+  }
+
+  /**
+   * Publishes the Elasticsearch client built from the {@code engine.*} configuration. Spring Boot
+   * used to autoconfigure one from the legacy low-level client, wired from {@code
+   * spring.elasticsearch.*} and therefore pointing somewhere else entirely; the Rest5 transport
+   * carries no such autoconfiguration, and this platform has a single engine endpoint anyway.
+   */
+  @Bean
+  @ConditionalOnProperty(
+      name = "engine.engine-selector",
+      havingValue = "elk",
+      matchIfMissing = true)
+  public ElasticsearchClient elasticsearchClient(EngineService engine) {
+    return ((ElasticService) engine).getElasticClient();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <commons-validator.version>1.11.0</commons-validator.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
+        <elasticsearch.version>9.5.1</elasticsearch.version>
         <jjwt.version>0.13.0</jjwt.version>
         <postgresql.version>42.7.13</postgresql.version>
         <pyroscope.version>2.9.1</pyroscope.version>
@@ -98,6 +99,11 @@
     </repositories>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>co.elastic.clients</groupId>
+                <artifactId>elasticsearch-java</artifactId>
+                <version>${elasticsearch.version}</version>
+            </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-api</artifactId>


### PR DESCRIPTION
### Proposed changes

**After this change OpenAEV can no longer run against an Elasticsearch 8 cluster.** The 9.x Java client sends a content type the 8.x server refuses, so every engine call fails and the platform does not start. Existing deployments have to upgrade their cluster to Elasticsearch 9 first — the added migration page walks through it.

* Client 8.19 -> 9.5.1, dev and test images with it
* `ElasticDriver` moves to `Rest5Client`: the 9.x client drops the HttpClient 4 transport, so auth, the trust-all SSL context and preemptive basic auth are rebuilt on HttpClient 5
* OpenSearch deployments are unaffected

### No data migration

Elasticsearch holds nothing PostgreSQL does not — all 13 `Handler` implementations read through a JPA repository, and the full rebuild path is already exercised by migrations like `V4_16__Force_es_reindex_injects`.

An empty 9.x cluster is therefore a valid target: indices, templates and the lifecycle policy are recreated at startup and reindexed. That also sidesteps the 7.x-created indices the Upgrade Assistant flags. The cost is reindex time, not risk.

None of the Elasticsearch 9 breaking changes apply to us.
