### PR TITLE
docs(usage): document notification triggers and asset-scoped filters (#6937)

### DIFF
--- a/docs/docs/usage/evaluate/findings/findings.md
+++ b/docs/docs/usage/evaluate/findings/findings.md
@@ -8,7 +8,7 @@ Findings transform raw execution output into searchable, categorized technical i
 
 - **Identify exposure**: see which CVEs, open ports, and credentials were discovered across your infrastructure
 - **Track remediation**: monitor whether previously detected issues reappear in subsequent Simulations
-- **Correlate with Assets**: understand which endpoints are affected by each Finding
+- **Correlate with Assets**: understand which assets are affected by each Finding, across every inventory category except security platforms
 - **Prioritize action**: CVE-type Findings include CVSS scores and enrichment data from [Taxonomies](../../../administration/taxonomies.md)
 
 ## How Findings are created
@@ -16,6 +16,10 @@ Findings transform raw execution output into searchable, categorized technical i
 Findings are created automatically during Inject execution. When an Inject produces structured output (e.g., a port scan result, a CVE detection, or extracted credentials), OpenAEV parses the output and creates one Finding per discovered indicator.
 
 Each Finding is deduplicated by its combination of value, type, and field. If the same Finding is detected again in a later execution, the existing record is updated with a new "last seen" timestamp rather than creating a duplicate.
+
+## Assets on a Finding
+
+A Finding can attach to any asset in the inventory: hosts, containers, cloud resources, web applications, network and mobile devices, identities, SaaS applications, AI targets, and generic assets. Security platforms are not offered in Finding asset filters (including notification trigger criteria on Findings). The overview labels this count **Impacted assets**.
 
 ## Finding types
 
@@ -43,8 +47,8 @@ Each row displays:
 |---|---|
 | Type | The Finding category (CVE, Port, Credentials, etc.) |
 | Value | The technical value (monospace display) |
-| Assets | Endpoints where the Finding was detected |
-| Asset groups | Asset groups containing affected endpoints |
+| Assets | Assets where the Finding was detected (hosts, cloud resources, web applications, and other categories; not security platforms) |
+| Asset groups | Asset groups containing affected assets |
 | First seen | When the Finding was first detected |
 | Last seen | When the Finding was most recently detected (default sort) |
 
@@ -56,7 +60,7 @@ Use the search bar and filters to narrow results by type, date range, Assets, or
 
 Click on a Finding to open its detail view. The **Overview** presents the Finding at a glance:
 
-- **Finding type and value** with occurrence count and impacted Asset count
+- **Finding type and value** with occurrence count and **Impacted assets** count
 - **Information**: type, value, field, first seen, last seen, tags
 - **Occurrences**: every Inject execution that produced this Finding, shown both as a list and as a timeline, with links to the parent Simulation and Scenario
 - **Vulnerability panel**: for CVE-type Findings, a summary of the vulnerability enrichment surfaced directly in the Overview
@@ -87,7 +91,7 @@ Findings are accessible from multiple locations in the platform:
 | **Simulation detail** | Findings produced by Injects in that Simulation |
 | **Scenario detail** | Findings aggregated across all Simulations of the Scenario |
 | **Inject execution results** | Findings produced by a specific Inject |
-| **Endpoint detail** | All Findings linked to a specific Asset |
+| **Asset detail** | All Findings linked to a specific Asset |
 
 ## What's next?
 

--- a/docs/docs/usage/notifications.md
+++ b/docs/docs/usage/notifications.md
@@ -1,33 +1,94 @@
 # Notifications
 
-Notifications alert you when important events occur on the platform. OpenAEV currently supports one notification type: Scenario score degradation.
+Notifications alert you when important events occur on the platform. You configure them as **triggers** (what to watch) and **notifiers** (how you are told).
+
+The older Scenario score-degradation email is still available: it is now a live trigger on the Scenario resource with the Score degradation event.
 
 ## Why use Notifications?
 
-- Detect regressions in your security posture automatically without manually comparing Simulation runs.
-- Receive email alerts when a Scenario's score drops, so you can investigate and remediate quickly.
+- React as soon as a Finding, Simulation, or other resource is created, updated, or deleted.
+- Receive a periodic digest instead of a notification for every event.
+- Keep the Scenario score-degradation alert, and attach it to UI, email, or webhook notifiers.
 
-## Scenario score degradation
+## Triggers
 
-This notification sends an email when a Simulation's score drops below the score of the previous run for the same Scenario. It helps track regressions in your security posture over time.
+Open **Profile > Triggers**. Create a **live trigger** or a **regular digest**.
 
-### How to enable
+### Live triggers
 
-1. Open the Scenario page.
-2. Click the notification icon in the Scenario header.
-3. Edit the email subject in the popup. The **Trigger** (score degradation) and **Notifier** (email) are fixed.
-4. Confirm. The alert is sent to the email address of the user who activates it.
+A live trigger fires one notification for each matching event, as it happens.
 
-### How to disable
+1. Click **Create Live trigger**.
+2. Name the trigger.
+3. Choose the **resource type** to watch.
+4. Select one or more **event types**.
+5. Optionally add **filters** so only matching entities notify you. Leave the filters empty to match every entity of that type.
+6. Choose one or more **notifiers**.
+7. Save.
 
-1. Open the Scenario page.
-2. Click the notification icon.
-3. Select **Delete** in the popup.
+### Digests
 
-## In-app notifications
+A digest collects matching events and sends them together on a schedule.
 
-OpenAEV also provides an in-app notification center accessible from the top navigation bar. Notifications appear as unread items and can be:
+1. Click **Create Regular digest**.
+2. Name the digest.
+3. Choose the aggregation **period**: hour, day, week, or month. Weekly and monthly digests also take a weekday and time.
+4. Attach the **live triggers** whose events should be included.
+5. Choose one or more **notifiers**.
+6. Save.
 
+### Resource types
+
+A trigger watches one of these resource types:
+
+| Resource | Notes |
+|---|---|
+| Scenario | Includes the Score degradation event (see below) |
+| Simulation | |
+| Inject | |
+| Finding | Asset filters cover every asset category except security platforms |
+| Asset | Hosts, cloud resources, web applications, AI targets, and the other inventory categories |
+| Asset group | |
+| Team | |
+| Player | |
+| Payload | |
+| Vulnerability | |
+| Security platform | |
+| Document | |
+| Challenge | |
+
+### Event types
+
+| Event | When it fires |
+|---|---|
+| Creation | A new entity of the selected type is created |
+| Modification | An existing entity is updated |
+| Deletion | An entity is deleted |
+| Score degradation | Only for **Scenario**. A Simulation score drops below the previous run of the same Scenario (the former notification-rule trigger) |
+
+### Filters
+
+Filters restrict a live trigger to entities you care about. Empty filters match everything of that type.
+
+For Findings (and other asset-scoped criteria), the asset picker lists the **unified inventory**: hosts, containers, cloud resources, web applications, network and mobile devices, identities, SaaS and AI targets, and generic assets. **Security platforms are excluded** from that picker.
+
+## Notifiers
+
+Notifiers are the delivery channels a trigger can use.
+
+| Channel | Where it is configured |
+|---|---|
+| UI | Built in. Notifications appear in the in-app center |
+| Email | **Settings > Customization > Notifiers**. Optional subject and template |
+| Webhook | **Settings > Customization > Notifiers**. HTTP URL (http/https), verb, optional template and headers |
+
+You can create email and webhook notifiers there, then select them on a trigger. The UI notifier does not need to be created.
+
+## In-app notification center
+
+Open **Profile > Notifications**, or the bell in the top navigation bar. Notifications appear as unread items and can be:
+
+- Opened (live notifications jump to the entity when it still exists; digests open a grouped detail)
 - Marked as read individually or in bulk
 - Deleted in bulk
 - Searched and filtered
@@ -36,3 +97,5 @@ OpenAEV also provides an in-app notification center accessible from the top navi
 
 - [Scenario](build/scenario/scenario.md) -- Create and manage Scenarios
 - [Simulation](evaluate/simulation/simulation.md) -- Run Simulations and track results
+- [Findings](evaluate/findings/findings.md) -- Review extracted security insights
+- [Assets](build/assets.md) -- Manage the asset inventory


### PR DESCRIPTION
### Proposed changes

* Rewrote the notifications usage guide for live and digest triggers, resource types, event types (including Scenario score degradation), filters, and UI / email / webhook notifiers.
* Updated the findings guide so assets are every inventory category except security platforms, and the overview uses Impacted assets.

### Testing Instructions

1. Open the docs preview for `docs/docs/usage/notifications.md` and `docs/docs/usage/evaluate/findings/findings.md`.
2. Check the trigger and notifier steps against Profile > Triggers and Settings > Customization > Notifiers.

### Related issues

* Closes #6937

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
