### PR TITLE
fix(ai): modify target ai types to endpoints (#7624)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260729120000000__Restore_demoted_endpoint_assets.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260729120000000__Restore_demoted_endpoint_assets.java
@@ -22,10 +22,11 @@ import org.springframework.stereotype.Component;
  *
  * <ol>
  *   <li>Re-promote base {@code Asset} rows of the seven demoted categories back to {@code
- *       Endpoint}. AI targets are untouched: they are the only rows legitimately persisted with the
- *       base type (via {@code /api/ai_targets}) and always carry {@code asset_category =
- *       'AI_TARGET'}, which is not part of the list. Once re-promoted, the second run matches
- *       nothing.
+ *       Endpoint}. AI targets are untouched here: at the time this migration was written they were
+ *       the only rows legitimately persisted with the base type (via {@code /api/ai_targets}) and
+ *       always carry {@code asset_category = 'AI_TARGET'}, which is not part of the list. They are
+ *       promoted separately by {@code V6_20260831100000000__Promote_ai_targets_to_endpoints}. Once
+ *       re-promoted, the second run matches nothing.
  *   <li>Reset the indexing status of the asset-derived ES indexes so documents indexed with the
  *       demoted type are rebuilt.
  * </ol>

--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260831100000000__Promote_ai_targets_to_endpoints.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260831100000000__Promote_ai_targets_to_endpoints.java
@@ -1,0 +1,62 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Promotes AI targets ({@code asset_category = 'AI_TARGET'}) from the base {@code Asset} type to
+ * {@code Endpoint}.
+ *
+ * <p>AI targets were the last category persisted with the base discriminator (via {@code
+ * /api/ai_targets}). Every {@code Endpoint}-typed surface therefore ignored them: they never showed
+ * up in {@code POST /api/endpoints/search}, could not be resolved by {@code GET/PUT
+ * /api/endpoints/{id}}, and were missing from the atomic-testing target picker. They are now
+ * created as agentless {@code Endpoint} rows, exactly like the other non-host categories restored
+ * by {@code V6_20260729120000000__Restore_demoted_endpoint_assets}; this migration re-discriminates
+ * the rows created before that change.
+ *
+ * <p>Idempotent and targeted (no table rewrite):
+ *
+ * <ol>
+ *   <li>Backfill the host-only columns that are NOT NULL or read as primitives on the {@code
+ *       Endpoint} entity ({@code endpoint_arch}, {@code endpoint_platform}, {@code
+ *       endpoint_is_eol}) for the rows about to be promoted. {@code Unknown} is the same default
+ *       {@code Endpoint#applyEndpointDefaults()} applies at runtime for agentless endpoints.
+ *   <li>Re-discriminate the rows to {@code Endpoint}. The category is left untouched, so the {@code
+ *       /api/ai_targets} facade keeps resolving exactly the same rows. Once promoted, a second run
+ *       matches nothing.
+ *   <li>Reset the indexing status of the asset-derived ES indexes so documents indexed with the
+ *       base type are rebuilt.
+ * </ol>
+ */
+@Component
+public class V6_20260831100000000__Promote_ai_targets_to_endpoints extends BaseJavaMigration {
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // -- 1. Backfill the host-only columns before the promotion --
+      statement.execute(
+          "UPDATE assets SET "
+              + "endpoint_platform = COALESCE(endpoint_platform, 'Unknown'), "
+              + "endpoint_arch = COALESCE(endpoint_arch, 'Unknown'), "
+              + "endpoint_is_eol = COALESCE(endpoint_is_eol, FALSE) "
+              + "WHERE asset_type = 'Asset' AND asset_category = 'AI_TARGET';");
+
+      // -- 2. Promote AI targets to Endpoint --
+      statement.execute(
+          "UPDATE assets SET asset_type = 'Endpoint' "
+              + "WHERE asset_type = 'Asset' AND asset_category = 'AI_TARGET';");
+
+      // -- 3. Rebuild the asset-derived ES indexes --
+      // The promotion is an UPDATE, so the incremental indexer would leave documents carrying the
+      // base type behind. Dropping the indexing status makes the engine recreate and fully reindex
+      // these indexes at startup. Idempotent by nature.
+      statement.execute(
+          "DELETE FROM indexing_status "
+              + "WHERE indexing_status_type IN ('asset', 'vulnerable-endpoint');");
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/rest/asset/ai_targets/AiTargetApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/asset/ai_targets/AiTargetApi.java
@@ -6,8 +6,8 @@ import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 
 import io.openaev.aop.AccessControl;
 import io.openaev.database.model.Action;
-import io.openaev.database.model.Asset;
 import io.openaev.database.model.AssetCategory;
+import io.openaev.database.model.Endpoint;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.repository.AiTargetRepository;
 import io.openaev.database.repository.TagRepository;
@@ -26,9 +26,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * CRUD facade for AI targets. AI targets are {@link Asset} rows with {@code category = AI_TARGET} -
- * this controller keeps the dedicated {@code /api/ai_targets} surface (menu / marketing) while
- * persisting through the unified asset model.
+ * CRUD facade for AI targets. AI targets are {@link Endpoint} rows with {@code category =
+ * AI_TARGET} - this controller keeps the dedicated {@code /api/ai_targets} surface (menu /
+ * marketing) while persisting through the unified asset model.
+ *
+ * <p>They are persisted with the {@code Endpoint} discriminator (and no agent) so they remain
+ * reachable from the {@code Endpoint}-typed surfaces: {@code /api/endpoints/search}, {@code GET/PUT
+ * /api/endpoints/{id}} and the atomic-testing target picker.
  */
 @RequiredArgsConstructor
 @RestController
@@ -41,11 +45,11 @@ public class AiTargetApi {
   private final TagRepository tagRepository;
 
   /** Restricts any search to AI target assets, on top of the caller-provided specification. */
-  private Specification<Asset> aiTargetCategory() {
+  private Specification<Endpoint> aiTargetCategory() {
     return (root, query, cb) -> cb.equal(root.get("category"), AssetCategory.AI_TARGET);
   }
 
-  private Asset prepareAiTarget(Asset aiTarget, AiTargetInput input) {
+  private Endpoint prepareAiTarget(Endpoint aiTarget, AiTargetInput input) {
     aiTarget.setUpdateAttributes(input);
     aiTarget.setCategory(AssetCategory.AI_TARGET);
     aiTarget.setTags(iterableToSet(this.tagRepository.findAllById(input.getTagIds())));
@@ -55,21 +59,21 @@ public class AiTargetApi {
   @GetMapping({AI_TARGET_URI, TENANT_AI_TARGET_URI})
   @Transactional
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.ASSET)
-  public Iterable<Asset> aiTargets() {
+  public Iterable<Endpoint> aiTargets() {
     return aiTargetRepository.findAllAiTargets();
   }
 
   @PostMapping({AI_TARGET_URI, TENANT_AI_TARGET_URI})
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.ASSET)
   @Transactional(rollbackFor = Exception.class)
-  public Asset createAiTarget(@Valid @RequestBody final AiTargetInput input) {
-    return this.aiTargetRepository.save(prepareAiTarget(new Asset(), input));
+  public Endpoint createAiTarget(@Valid @RequestBody final AiTargetInput input) {
+    return this.aiTargetRepository.save(prepareAiTarget(new Endpoint(), input));
   }
 
   @GetMapping({AI_TARGET_URI + "/{aiTargetId}", TENANT_AI_TARGET_URI + "/{aiTargetId}"})
   @Transactional
   @AccessControl(actionPerformed = Action.READ, resourceType = ResourceType.ASSET)
-  public Asset aiTarget(@PathVariable @NotBlank final String aiTargetId) {
+  public Endpoint aiTarget(@PathVariable @NotBlank final String aiTargetId) {
     return this.aiTargetRepository
         .findAiTargetById(aiTargetId)
         .orElseThrow(ElementNotFoundException::new);
@@ -78,21 +82,21 @@ public class AiTargetApi {
   @PostMapping({AI_TARGET_URI + "/search", TENANT_AI_TARGET_URI + "/search"})
   @Transactional
   @AccessControl(actionPerformed = Action.SEARCH, resourceType = ResourceType.ASSET)
-  public Page<Asset> aiTargets(@RequestBody @Valid SearchPaginationInput searchPaginationInput) {
+  public Page<Endpoint> aiTargets(@RequestBody @Valid SearchPaginationInput searchPaginationInput) {
     return buildPaginationJPA(
-        (Specification<Asset> spec, org.springframework.data.domain.Pageable pageable) ->
+        (Specification<Endpoint> spec, org.springframework.data.domain.Pageable pageable) ->
             this.aiTargetRepository.findAll(aiTargetCategory().and(spec), pageable),
         searchPaginationInput,
-        Asset.class);
+        Endpoint.class);
   }
 
   @PutMapping({AI_TARGET_URI + "/{aiTargetId}", TENANT_AI_TARGET_URI + "/{aiTargetId}"})
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.ASSET)
   @Transactional(rollbackFor = Exception.class)
-  public Asset updateAiTarget(
+  public Endpoint updateAiTarget(
       @PathVariable @NotBlank final String aiTargetId,
       @Valid @RequestBody final AiTargetInput input) {
-    Asset aiTarget =
+    Endpoint aiTarget =
         this.aiTargetRepository
             .findAiTargetById(aiTargetId)
             .orElseThrow(ElementNotFoundException::new);
@@ -105,7 +109,7 @@ public class AiTargetApi {
   public void deleteAiTarget(@PathVariable @NotBlank final String aiTargetId) {
     // Resolve through the tenant-filtered, category-scoped lookup first: a raw deleteById would
     // bypass the Hibernate tenant filter (em.find) and could delete any asset type by id.
-    Asset aiTarget =
+    Endpoint aiTarget =
         this.aiTargetRepository
             .findAiTargetById(aiTargetId)
             .orElseThrow(ElementNotFoundException::new);

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -436,7 +436,7 @@ public class InjectService {
    */
   private Optional<Asset> resolveContentAiTarget(Inject inject) {
     return InjectContentUtils.contentAiTargetId(inject.getContent())
-        .<Asset>flatMap(aiTargetRepository::findAiTargetById);
+        .flatMap(id -> aiTargetRepository.findAiTargetById(id).map(Asset.class::cast));
   }
 
   public void cleanInjectsDocExercise(String exerciseId, String documentId) {

--- a/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/inject/service/InjectService.java
@@ -436,7 +436,7 @@ public class InjectService {
    */
   private Optional<Asset> resolveContentAiTarget(Inject inject) {
     return InjectContentUtils.contentAiTargetId(inject.getContent())
-        .flatMap(aiTargetRepository::findAiTargetById);
+        .<Asset>flatMap(aiTargetRepository::findAiTargetById);
   }
 
   public void cleanInjectsDocExercise(String exerciseId, String documentId) {

--- a/openaev-api/src/main/java/io/openaev/service/targets/search/AiTargetSearchAdaptor.java
+++ b/openaev-api/src/main/java/io/openaev/service/targets/search/AiTargetSearchAdaptor.java
@@ -43,7 +43,7 @@ public class AiTargetSearchAdaptor extends SearchAdaptorBase {
   private Optional<Asset> contentAiTarget(Inject scopedInject) {
     // Key parsing shared with InjectService.resolveContentAiTarget via InjectContentUtils.
     return InjectContentUtils.contentAiTargetId(scopedInject.getContent())
-        .<Asset>flatMap(aiTargetRepository::findAiTargetById);
+        .flatMap(id -> aiTargetRepository.findAiTargetById(id).map(Asset.class::cast));
   }
 
   /**

--- a/openaev-api/src/main/java/io/openaev/service/targets/search/AiTargetSearchAdaptor.java
+++ b/openaev-api/src/main/java/io/openaev/service/targets/search/AiTargetSearchAdaptor.java
@@ -43,7 +43,7 @@ public class AiTargetSearchAdaptor extends SearchAdaptorBase {
   private Optional<Asset> contentAiTarget(Inject scopedInject) {
     // Key parsing shared with InjectService.resolveContentAiTarget via InjectContentUtils.
     return InjectContentUtils.contentAiTargetId(scopedInject.getContent())
-        .flatMap(aiTargetRepository::findAiTargetById);
+        .<Asset>flatMap(aiTargetRepository::findAiTargetById);
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/rest/AiTargetApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/AiTargetApiTest.java
@@ -1,6 +1,7 @@
 package io.openaev.rest;
 
 import static io.openaev.rest.asset.ai_targets.AiTargetApi.AI_TARGET_URI;
+import static io.openaev.rest.asset.endpoint.EndpointApi.ENDPOINT_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,6 +21,7 @@ import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.persistence.EntityManager;
 import org.json.JSONArray;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -175,5 +177,60 @@ class AiTargetApiTest extends IntegrationTest {
             .getContentAsString();
 
     assertEquals(1, new JSONArray(response).length());
+  }
+
+  @Nested
+  @DisplayName("AI targets are Endpoint-typed assets")
+  class AiTargetIsAnEndpoint {
+
+    @DisplayName("Given an AI target creation, should persist it with the Endpoint discriminator")
+    @Test
+    @WithMockUser(isAdmin = true)
+    void given_an_ai_target_creation_should_persist_it_as_an_endpoint() throws Exception {
+      // -- ACT --
+      String id = createAiTarget("Endpoint-Typed-1");
+
+      // -- ASSERT --
+      assertThat(aiTargetRepository.findAiTargetById(id)).isPresent();
+      assertEquals(
+          "Endpoint",
+          entityManager
+              .createNativeQuery("SELECT asset_type FROM assets WHERE asset_id = :id")
+              .setParameter("id", id)
+              .getSingleResult());
+    }
+
+    @DisplayName("Given an AI target, should be returned by the endpoint search")
+    @Test
+    @WithMockUser(isAdmin = true)
+    void given_an_ai_target_should_be_returned_by_the_endpoint_search() throws Exception {
+      // -- PREPARE --
+      createAiTarget("Endpoint-Searchable-AI");
+
+      // -- ACT & ASSERT --
+      mvc.perform(
+              post(ENDPOINT_URI + "/search")
+                  .content(
+                      asJsonString(PaginationFixture.simpleTextSearch("Endpoint-Searchable-AI")))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .with(csrf()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.numberOfElements").value(1))
+          .andExpect(jsonPath("$.content.[0].asset_name").value("Endpoint-Searchable-AI"));
+    }
+
+    @DisplayName("Given an AI target, should be resolvable through the endpoint edit flow")
+    @Test
+    @WithMockUser(isAdmin = true)
+    void given_an_ai_target_should_be_resolvable_as_an_endpoint() throws Exception {
+      // -- PREPARE --
+      String id = createAiTarget("Endpoint-Editable-AI");
+
+      // -- ACT & ASSERT --
+      mvc.perform(get(ENDPOINT_URI + "/" + id).accept(MediaType.APPLICATION_JSON).with(csrf()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.asset_id").value(id));
+    }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/AiTargetApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/AiTargetApiTest.java
@@ -223,7 +223,7 @@ class AiTargetApiTest extends IntegrationTest {
     @DisplayName("Given an AI target, should be resolvable through the endpoint edit flow")
     @Test
     @WithMockUser(isAdmin = true)
-    void given_an_ai_target_should_be_resolvable_as_an_endpoint() throws Exception {
+    void given_anAiTarget_should_beResolvableAsAnEndpoint() throws Exception {
       // -- PREPARE --
       String id = createAiTarget("Endpoint-Editable-AI");
 

--- a/openaev-front/src/actions/assets/aiTarget-actions.ts
+++ b/openaev-front/src/actions/assets/aiTarget-actions.ts
@@ -8,7 +8,7 @@ import {
   simpleCall,
   simplePostCall,
 } from '../../utils/Action';
-import { type AiTargetInput, type Asset, type SearchPaginationInput } from '../../utils/api-types';
+import { type AiTargetInput, type Endpoint, type SearchPaginationInput } from '../../utils/api-types';
 import { aiTarget, arrayOfAiTargets } from './asset-schema';
 
 const AI_TARGET_URI = '/api/ai_targets';
@@ -18,14 +18,14 @@ export const addAiTarget = (data: AiTargetInput) => (dispatch: Dispatch) => {
 };
 
 export const updateAiTarget = (
-  assetId: Asset['asset_id'],
+  assetId: Endpoint['asset_id'],
   data: AiTargetInput,
 ) => (dispatch: Dispatch) => {
   const uri = `${AI_TARGET_URI}/${assetId}`;
   return putReferential(aiTarget, uri, data)(dispatch);
 };
 
-export const deleteAiTarget = (assetId: Asset['asset_id']) => (dispatch: Dispatch) => {
+export const deleteAiTarget = (assetId: Endpoint['asset_id']) => (dispatch: Dispatch) => {
   const uri = `${AI_TARGET_URI}/${assetId}`;
   return delReferential(uri, aiTarget.key, assetId)(dispatch);
 };

--- a/openaev-front/src/admin/components/assets/endpoints/EndpointCreation.tsx
+++ b/openaev-front/src/admin/components/assets/endpoints/EndpointCreation.tsx
@@ -52,14 +52,23 @@ const EndpointCreation: FunctionComponent<Props> = ({
   };
 
   const onSubmitAiTarget = (data: AiTargetInput) => {
-    // AI targets are base Assets, not Endpoints, so they are not prepended to the
-    // (endpoint-shaped) onCreate list here; they surface in the unified asset inventory.
-    dispatch(addAiTarget(data)).then((result: { entities?: unknown }) => {
-      if (result.entities) {
-        handleClose();
-      }
-      return result;
-    });
+    // AI targets are Endpoint-typed assets: the created row belongs to the endpoint list, so it is
+    // prepended like any other creation. It is normalized under its own `aitargets` schema key,
+    // hence the dedicated lookup.
+    dispatch(addAiTarget(data)).then(
+      (result: {
+        result: string;
+        entities?: { aitargets: Record<string, Endpoint> };
+      }) => {
+        if (result.entities) {
+          if (onCreate) {
+            onCreate(result.entities.aitargets[result.result]);
+          }
+          handleClose();
+        }
+        return result;
+      },
+    );
   };
 
   const renderStepContent = () => {

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -500,155 +500,6 @@ export interface ArticleUpdateInput {
   article_shares?: number;
 }
 
-export interface Asset {
-  ai_target_configuration?: Record<string, any>;
-  ai_target_endpoint?: string;
-  ai_target_modality?: "TEXT" | "VISION" | "AUDIO" | "MULTIMODAL";
-  ai_target_model?: string;
-  ai_target_provider?:
-    | "OPENAI_COMPATIBLE"
-    | "ANTHROPIC"
-    | "AZURE_OPENAI"
-    | "AWS_BEDROCK"
-    | "GOOGLE_VERTEX"
-    | "HUGGINGFACE"
-    | "OLLAMA"
-    | "CUSTOM_HTTP"
-    | "MCP_SERVER"
-    | "AGENT_HTTP"
-    | "XTM_ONE";
-  ai_target_system_prompt?: string;
-  ai_target_token?: string;
-  asset_category?:
-    | "HOST"
-    | "CONTAINER_WORKLOAD"
-    | "CLOUD_RESOURCE"
-    | "WEB_APPLICATION"
-    | "NETWORK_DEVICE"
-    | "MOBILE_DEVICE"
-    | "IOT_OT_DEVICE"
-    | "IDENTITY"
-    | "SAAS_APPLICATION"
-    | "AI_TARGET"
-    | "SECURITY_PLATFORM"
-    | "GENERIC_ASSET";
-  asset_cloud_native_type?: string;
-  asset_cloud_provider?:
-    | "AWS"
-    | "AZURE"
-    | "GCP"
-    | "OCI"
-    | "ALIBABA"
-    | "KUBERNETES"
-    | "OTHER";
-  asset_cloud_region?: string;
-  /** @format date-time */
-  asset_created_at: string;
-  asset_criticality?: "VERY_HIGH" | "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN";
-  asset_description?: string;
-  asset_external_reference?: string;
-  asset_hostname?: string;
-  /** @minLength 1 */
-  asset_id: string;
-  asset_internet_facing?: boolean;
-  asset_ips?: string[];
-  asset_linked_person?: string;
-  asset_mac_addresses?: string[];
-  asset_metadata?: Record<string, any>;
-  /** @minLength 1 */
-  asset_name: string;
-  asset_seen_ip?: string;
-  /** Activity status derived from agents (ACTIVE / INACTIVE / AGENTLESS) */
-  asset_status?: "ACTIVE" | "INACTIVE" | "AGENTLESS";
-  asset_subcategory?:
-    | "SERVER"
-    | "WORKSTATION"
-    | "LAPTOP"
-    | "VIRTUAL_MACHINE"
-    | "HYPERVISOR"
-    | "MAINFRAME"
-    | "THIN_CLIENT"
-    | "CONTAINER"
-    | "CONTAINER_IMAGE"
-    | "KUBERNETES_POD"
-    | "KUBERNETES_CLUSTER"
-    | "KUBERNETES_NODE"
-    | "SERVERLESS_FUNCTION"
-    | "COMPUTE"
-    | "STORAGE"
-    | "DATABASE"
-    | "NETWORKING"
-    | "SERVERLESS"
-    | "CONTAINER_REGISTRY"
-    | "KUBERNETES"
-    | "IAM_PRINCIPAL"
-    | "SECRETS_KEY_MGMT"
-    | "MESSAGING_QUEUE"
-    | "ANALYTICS_DATA"
-    | "AI_ML_SERVICE"
-    | "IAC_TEMPLATE"
-    | "CLOUD_OTHER"
-    | "WEBSITE"
-    | "WEB_API"
-    | "SINGLE_PAGE_APP"
-    | "GRAPHQL_API"
-    | "WEB_SERVICE"
-    | "MICROSERVICE"
-    | "ROUTER"
-    | "SWITCH"
-    | "FIREWALL"
-    | "LOAD_BALANCER"
-    | "VPN_GATEWAY"
-    | "WIRELESS_AP"
-    | "PROXY"
-    | "DNS_SERVER"
-    | "DHCP_SERVER"
-    | "SAN_NAS"
-    | "NETWORK_OTHER"
-    | "SMARTPHONE"
-    | "TABLET"
-    | "IOT_SENSOR"
-    | "IP_CAMERA"
-    | "GATEWAY"
-    | "POINT_OF_SALE"
-    | "MEDIA_DEVICE"
-    | "PLC"
-    | "RTU"
-    | "HMI"
-    | "SCADA_HISTORIAN"
-    | "MEDICAL_DEVICE"
-    | "PRINTER_PERIPHERAL"
-    | "BUILDING_MGMT"
-    | "USER_ACCOUNT"
-    | "SERVICE_ACCOUNT"
-    | "GROUP"
-    | "ROLE"
-    | "SHARED_MAILBOX"
-    | "NON_HUMAN_IDENTITY"
-    | "SAAS_APP"
-    | "SAAS_TENANT"
-    | "LLM_MODEL"
-    | "AI_AGENT"
-    | "MCP_SERVER"
-    | "RAG_PIPELINE"
-    | "EDR"
-    | "XDR"
-    | "SIEM"
-    | "SOAR"
-    | "NDR"
-    | "ISPM"
-    | "EMAIL_SECURITY"
-    | "LLM_FIREWALL"
-    | "AI_GATEWAY"
-    | "VULNERABILITY_SCANNER";
-  asset_tags?: string[];
-  asset_type?: string;
-  /** @format date-time */
-  asset_updated_at: string;
-  asset_url?: string;
-  listened?: boolean;
-}
-
 export interface AssetAgentJob {
   asset_agent_agent?: string;
   /** @deprecated */
@@ -8163,25 +8014,6 @@ export interface PageAggregatedFindingOutput {
   totalPages?: number;
 }
 
-export interface PageAsset {
-  content?: Asset[];
-  empty?: boolean;
-  first?: boolean;
-  last?: boolean;
-  /** @format int32 */
-  number?: number;
-  /** @format int32 */
-  numberOfElements?: number;
-  pageable?: PageableObject;
-  /** @format int32 */
-  size?: number;
-  sort?: SortObject[];
-  /** @format int64 */
-  totalElements?: number;
-  /** @format int32 */
-  totalPages?: number;
-}
-
 export interface PageAssetGroupOutput {
   content?: AssetGroupOutput[];
   empty?: boolean;
@@ -8298,6 +8130,25 @@ export interface PageCustomDashboard {
 
 export interface PageCustomDomain {
   content?: CustomDomain[];
+  empty?: boolean;
+  first?: boolean;
+  last?: boolean;
+  /** @format int32 */
+  number?: number;
+  /** @format int32 */
+  numberOfElements?: number;
+  pageable?: PageableObject;
+  /** @format int32 */
+  size?: number;
+  sort?: SortObject[];
+  /** @format int64 */
+  totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
+}
+
+export interface PageEndpoint {
+  content?: Endpoint[];
   empty?: boolean;
   first?: boolean;
   last?: boolean;

--- a/openaev-model/src/main/java/io/openaev/database/repository/AiTargetRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/AiTargetRepository.java
@@ -1,6 +1,6 @@
 package io.openaev.database.repository;
 
-import io.openaev.database.model.Asset;
+import io.openaev.database.model.Endpoint;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -9,9 +9,14 @@ import org.springframework.stereotype.Repository;
 
 /**
  * Category-scoped view over the {@code assets} table for AI targets ({@code category = AI_TARGET}).
- * AI targets are no longer a distinct entity type - they are {@link Asset} rows discriminated by
+ * AI targets are no longer a distinct entity type - they are {@link Endpoint} rows discriminated by
  * category - so every query here is filtered on {@code asset_category = 'AI_TARGET'} to keep the
  * {@code /api/ai_targets} facade behaving as a dedicated AI target surface.
+ *
+ * <p>The entity type is {@link Endpoint}, not the base {@code Asset}: AI targets must be visible
+ * through the {@code Endpoint}-typed surfaces ({@code /api/endpoints/search}, {@code
+ * /api/endpoints/{id}}, the atomic-testing target picker). They stay agentless (empty {@code
+ * agents}) - the endpoint discriminator only makes them addressable as targets.
  *
  * <p>Deliberately extends the marker {@link org.springframework.data.repository.Repository} rather
  * than {@code CrudRepository}: inherited generic methods ({@code findAll()}, {@code findById()},
@@ -22,41 +27,41 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface AiTargetRepository
-    extends org.springframework.data.repository.Repository<Asset, String>,
-        JpaSpecificationExecutor<Asset> {
+    extends org.springframework.data.repository.Repository<Endpoint, String>,
+        JpaSpecificationExecutor<Endpoint> {
 
   // -- Write operations (used after a category-scoped lookup / preparation) --
 
-  Asset save(Asset asset);
+  Endpoint save(Endpoint asset);
 
-  void delete(Asset asset);
+  void delete(Endpoint asset);
 
   // -- Category-scoped queries --
 
   @Query(
-      "SELECT DISTINCT a FROM Asset a WHERE a.category = io.openaev.database.model.AssetCategory.AI_TARGET")
-  List<Asset> findAllAiTargets();
+      "SELECT DISTINCT a FROM Endpoint a WHERE a.category = io.openaev.database.model.AssetCategory.AI_TARGET")
+  List<Endpoint> findAllAiTargets();
 
   @Query(
-      "SELECT DISTINCT a FROM Asset a "
+      "SELECT DISTINCT a FROM Endpoint a "
           + "WHERE a.category = io.openaev.database.model.AssetCategory.AI_TARGET AND "
           + "(:name IS NULL OR lower(a.name) LIKE lower(concat('%', cast(coalesce(:name, '') as string), '%')))")
-  List<Asset> findAllByName(String name);
+  List<Endpoint> findAllByName(String name);
 
   @Query(
-      "SELECT a FROM Asset a "
+      "SELECT a FROM Endpoint a "
           + "WHERE a.id = :id AND a.category = io.openaev.database.model.AssetCategory.AI_TARGET")
-  Optional<Asset> findAiTargetById(String id);
+  Optional<Endpoint> findAiTargetById(String id);
 
   /** AI target assets among the given ids (non-AI assets are filtered out by the query). */
   @Query(
-      "SELECT a FROM Asset a "
+      "SELECT a FROM Endpoint a "
           + "WHERE a.id IN :ids AND a.category = io.openaev.database.model.AssetCategory.AI_TARGET")
-  List<Asset> findAiTargetsByIds(List<String> ids);
+  List<Endpoint> findAiTargetsByIds(List<String> ids);
 
   /** AI target assets that statically belong to any of the given asset groups. */
   @Query(
-      "SELECT DISTINCT a FROM Asset a JOIN a.assetGroups g "
+      "SELECT DISTINCT a FROM Endpoint a JOIN a.assetGroups g "
           + "WHERE g.id IN :assetGroupIds AND a.category = io.openaev.database.model.AssetCategory.AI_TARGET")
-  List<Asset> findAllByAssetGroupIds(List<String> assetGroupIds);
+  List<Endpoint> findAllByAssetGroupIds(List<String> assetGroupIds);
 }


### PR DESCRIPTION
### Proposed changes

* Consider "Target AI" assets as Endpoints to allow them to be used in AI injects for time based and chaining process.

### Testing Instructions

1. Every "Target AI" should be endpoints now, you can check for the search response on the assets page
2. "Target AI" Endpoints should be displayed on the assets selection for time based and chaining scenarios

### Related issues

* Related #7624