### PR TITLE
fix(chaining): ask for the scope instead of ending an unscoped autonomous run (#7684)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
+++ b/openaev-api/src/main/java/io/openaev/service/autonomous/AutonomousRunService.java
@@ -162,6 +162,19 @@ public class AutonomousRunService {
   private static final String ENGAGED_EVENT_DATA = "{\"phase\":\"engaged\"}";
 
   /**
+   * Title of the QUESTION event OpenAEV itself raises when a live run is launched with no perimeter
+   * at all. The run parks in WAITING_INPUT on it and the cockpit renders it as a pending question
+   * with a reply composer, so the operator answers the scope in the chat and the run then starts.
+   */
+  private static final String SCOPE_QUESTION_TITLE = "Which targets are in scope?";
+
+  /** Body of {@link #SCOPE_QUESTION_TITLE}. */
+  private static final String SCOPE_QUESTION_BODY =
+      "This run has no perimeter yet, so nothing can be attacked. Tell me which targets I am"
+          + " authorized to attack - assets, asset groups, teams, persons, IPs or hostnames - and I"
+          + " will start right away. You can also define them in the Scope tab.";
+
+  /**
    * Default OpenAEV-enforced run timeout when the launcher does not specify one: 24 hours.
    * Autonomous runs are long-lived (recon, waiting on human-in-the-loop injects, slow exploitation)
    * so the default is far larger than the 1h chained-scenario workflow timeout.
@@ -890,10 +903,40 @@ public class AutonomousRunService {
           HttpStatus.CONFLICT, "Run cannot be started from status " + run.getStatus());
     }
     boolean planMode = run.isPlanMode();
-    run.setStatus(planMode ? AutonomousRunStatus.PLANNING : AutonomousRunStatus.RUNNING);
+    // A live run launched with NO perimeter at all is parked on the operator instead of being
+    // handed to the orchestrator: OpenAEV asks for the scope in the cockpit chat (a QUESTION event
+    // + WAITING_INPUT) and only engages once the operator answers (see addDirective). Driving an
+    // unscoped run had no target to act on, so its still-empty simulation immediately read FINISHED
+    // and reconcileWithSimulation completed the run seconds after the launch - the reported
+    // "autonomous chaining ends immediately" behaviour. Plan mode designs a path without executing
+    // anything, so it never needs a perimeter up front.
+    boolean awaitingScope = !planMode && !hasLaunchScope(run);
+    run.setStatus(
+        planMode
+            ? AutonomousRunStatus.PLANNING
+            : awaitingScope ? AutonomousRunStatus.WAITING_INPUT : AutonomousRunStatus.RUNNING);
     run.setLastError(null);
     stampDeadline(run);
     AutonomousRun saved = runRepository.save(run);
+    if (awaitingScope) {
+      eventService.append(
+          runId,
+          runTenantId(run),
+          run.getSimulationId(),
+          AutonomousEventType.STATUS,
+          "Waiting for the scope",
+          "No perimeter is defined for this run, so nothing has been engaged yet.",
+          null);
+      eventService.append(
+          runId,
+          runTenantId(run),
+          run.getSimulationId(),
+          AutonomousEventType.QUESTION,
+          SCOPE_QUESTION_TITLE,
+          SCOPE_QUESTION_BODY,
+          null);
+      return saved;
+    }
     eventService.append(
         runId,
         runTenantId(run),
@@ -906,6 +949,21 @@ public class AutonomousRunService {
         ENGAGED_EVENT_DATA);
     engageOrchestratorAfterCommit(saved);
     return saved;
+  }
+
+  /**
+   * Whether the run carries an actual attack perimeter: either an entity target on the run's own
+   * scope projection, or an ALLOWLIST rule on its live simulation workflow (which already carries
+   * both the launch stepper's rules and the scenario's own scope, seeded at creation).
+   */
+  private boolean hasLaunchScope(AutonomousRun run) {
+    if (run.getScope() != null && !run.getScope().isEmpty()) {
+      return true;
+    }
+    if (hasText(run.getScopeAssetGroupId()) || hasText(run.getScopeTeamId())) {
+      return true;
+    }
+    return workflowService.hasAllowlistScopeForSimulation(run.getSimulationId());
   }
 
   /**
@@ -2151,14 +2209,22 @@ public class AutonomousRunService {
     // returns to PLANNING (still authoring), a live run to RUNNING; the
     // orchestrator refines this on its next cycle. Only WAITING_INPUT is
     // touched, so a directive on an already-active run never perturbs it.
-    if (run.getStatus() == AutonomousRunStatus.WAITING_INPUT) {
+    boolean wasWaitingInput = run.getStatus() == AutonomousRunStatus.WAITING_INPUT;
+    if (wasWaitingInput) {
       run.setStatus(run.isPlanMode() ? AutonomousRunStatus.PLANNING : AutonomousRunStatus.RUNNING);
       runRepository.save(run);
     }
-    // Re-arm the orchestrator so it picks up the directive now, not only at its next scheduled
-    // re-check - crucial when the run is parked in WAITING_INPUT after asking the operator a
-    // question. Fired after commit so the orchestrator can never consume before the row is visible.
-    wakeOrchestratorAfterCommit(runId, "operator directive queued");
+    // A live run parked at launch on the "which targets are in scope?" question was never engaged
+    // (no orchestrator session), so the operator's answer is what actually starts it: engage
+    // instead of waking a session that does not exist. Any other case is a running orchestrator
+    // that only needs to be re-armed so it picks the directive up now rather than at its next
+    // scheduled re-check. Both fire after commit so the directive row is visible to the
+    // orchestrator's consume-directives read.
+    if (wasWaitingInput && !run.isPlanMode() && !hasText(run.getXtmSessionId())) {
+      engageOrchestratorAfterCommit(run);
+    } else {
+      wakeOrchestratorAfterCommit(runId, "operator directive queued");
+    }
     return saved;
   }
 
@@ -2207,6 +2273,11 @@ public class AutonomousRunService {
    * Applies a live scope / rate-limit / safe-mode edit to the run's RUN workflow(s) without
    * stopping it. The chaining engine reads the updated scope on its next decision cycle, so a
    * denylist entry added here walls off the matching assets immediately.
+   *
+   * <p>It is also the second way to answer the launch-time "which targets are in scope?" question:
+   * a live run parked on it (never engaged, no perimeter) is started here as soon as the edit gives
+   * it an allow-list, so defining the scope in the Scope tab is equivalent to answering in the
+   * chat.
    */
   @Transactional(rollbackFor = Exception.class)
   public List<Workflow> applyLiveConfiguration(String runId, WorkflowConfigurationInput input) {
@@ -2222,6 +2293,23 @@ public class AutonomousRunService {
         "Live configuration updated",
         "Scope / rate-limit / safe-mode edited on the running workflow.",
         null);
+    boolean parkedOnScope =
+        run.getStatus() == AutonomousRunStatus.WAITING_INPUT
+            && !run.isPlanMode()
+            && !hasText(run.getXtmSessionId());
+    if (parkedOnScope && hasLaunchScope(run)) {
+      run.setStatus(AutonomousRunStatus.RUNNING);
+      AutonomousRun started = runRepository.save(run);
+      eventService.append(
+          runId,
+          runTenantId(run),
+          run.getSimulationId(),
+          AutonomousEventType.STATUS,
+          "Run started",
+          "Scope defined; orchestrator engaged and autonomous execution is now running.",
+          ENGAGED_EVENT_DATA);
+      engageOrchestratorAfterCommit(started);
+    }
     return updated;
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/WorkflowService.java
@@ -370,6 +370,24 @@ public class WorkflowService {
     }
   }
 
+  /**
+   * Whether a simulation's RUN workflow(s) carry at least one ALLOWLIST scope rule, i.e. an actual
+   * attack perimeter. The autonomous launch uses it to detect a run that has no scope at all (the
+   * launch stepper left both lists empty AND the scenario carried none), so it can ask the operator
+   * for one instead of driving an unscoped run.
+   *
+   * @param simulationId the ID of the simulation
+   * @return true when any RUN workflow of the simulation has a non-empty allow-list
+   */
+  @Transactional(readOnly = true)
+  public boolean hasAllowlistScopeForSimulation(String simulationId) {
+    if (!hasText(simulationId)) {
+      return false;
+    }
+    return findWorkflowRunBySimulationId(simulationId).stream()
+        .anyMatch(workflow -> !workflow.getAllowlist().isEmpty());
+  }
+
   private boolean appendScopeRules(Workflow workflow, List<WorkflowScopeRuleInput> ruleInputs) {
     List<WorkflowScopeRule> existing = workflow.getWorkflowScopeRules();
     Set<String> existingKeys =

--- a/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/autonomous/AutonomousRunServiceTest.java
@@ -164,6 +164,9 @@ class AutonomousRunServiceTest {
       run.setStatus(AutonomousRunStatus.CREATED);
       run.setPlanMode(false);
       run.setTenant(new Tenant("tenant-1"));
+      // A live run only engages the orchestrator once it has a perimeter (an unscoped one parks on
+      // the operator instead - see LaunchWithoutScope), so these engagement tests need one.
+      run.setScope(List.of(new AutonomousScopeTarget("ASSETS_GROUPS", "group-1")));
       return run;
     }
 
@@ -852,6 +855,194 @@ class AutonomousRunServiceTest {
     verify(workflowService).provisionSimulationTemplateWorkflow(eq("scenario-1"), any());
     verify(workflowService, never()).startWorkflowByScenarioIdAndSimulation(anyString(), any());
     assertThat(restarted.getStatus()).isEqualTo(AutonomousRunStatus.CREATED);
+  }
+
+  // endregion
+
+  // region start: a live run with no perimeter parks on the operator instead of engaging
+
+  /**
+   * A live autonomous run launched with NO perimeter (empty launch stepper, scenario carrying no
+   * scope) used to be handed to the orchestrator anyway: it had nothing to act on, its still-empty
+   * simulation immediately read FINISHED and the reconcile completed the run seconds after the
+   * launch. It now parks in WAITING_INPUT on a QUESTION event so the cockpit chat asks the operator
+   * for the scope, and only engages once that question is answered.
+   */
+  @Nested
+  @DisplayName("Launching a live run without a scope")
+  class LaunchWithoutScope {
+
+    private AutonomousRun createdRun() {
+      AutonomousRun run = new AutonomousRun();
+      run.setId("run-1");
+      run.setScenarioId("scenario-1");
+      run.setSimulationId("sim-1");
+      run.setStatus(AutonomousRunStatus.CREATED);
+      run.setPlanMode(false);
+      run.setObjective("Reach the domain controller");
+      run.setTenant(new Tenant("tenant-1"));
+      return run;
+    }
+
+    @BeforeEach
+    void stubSave() {
+      lenient()
+          .when(runRepository.save(any(AutonomousRun.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("with no scope at all, the run parks on a scope question and nothing is engaged")
+    void given_unscopedLiveRun_when_started_then_parksAndAsksForTheScope() {
+      // -- PREPARE --
+      AutonomousRun run = createdRun();
+      when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+      when(workflowService.hasAllowlistScopeForSimulation("sim-1")).thenReturn(false);
+
+      // -- EXECUTE --
+      AutonomousRun started = service.start("run-1");
+
+      // -- ASSERT --
+      assertThat(started.getStatus()).isEqualTo(AutonomousRunStatus.WAITING_INPUT);
+      verify(eventService)
+          .append(
+              eq("run-1"),
+              eq("tenant-1"),
+              eq("sim-1"),
+              eq(AutonomousEventType.QUESTION),
+              anyString(),
+              anyString(),
+              isNull());
+      // Never engaged: an unscoped orchestrator run is exactly what completed immediately.
+      verifyNoInteractions(xtmOneClient);
+    }
+
+    @Test
+    @DisplayName("an entity target on the run is scope enough to engage the orchestrator")
+    void given_runWithScopeTargets_when_started_then_engagesTheOrchestrator() {
+      // -- PREPARE --
+      AutonomousRun run = createdRun();
+      run.setScope(List.of(new AutonomousScopeTarget("ASSETS_GROUPS", "group-1")));
+      when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+
+      // -- EXECUTE --
+      AutonomousRun started = service.start("run-1");
+
+      // -- ASSERT --
+      assertThat(started.getStatus()).isEqualTo(AutonomousRunStatus.RUNNING);
+      verify(xtmOneClient)
+          .startAutonomousRun(
+              any(),
+              anyString(),
+              eq("run-1"),
+              eq("sim-1"),
+              eq("scenario-1"),
+              anyBoolean(),
+              any(),
+              any(),
+              anyList(),
+              any(),
+              anyBoolean(),
+              any(),
+              any(),
+              anyList(),
+              anyMap());
+    }
+
+    @Test
+    @DisplayName("an allow-list on the simulation workflow is scope enough to engage")
+    void given_workflowAllowlist_when_started_then_engagesTheOrchestrator() {
+      // -- PREPARE --
+      AutonomousRun run = createdRun();
+      when(runRepository.findById("run-1")).thenReturn(Optional.of(run));
+      when(workflowService.hasAllowlistScopeForSimulation("sim-1")).thenReturn(true);
+
+      // -- EXECUTE --
+      AutonomousRun started = service.start("run-1");
+
+      // -- ASSERT --
+      assertThat(started.getStatus()).isEqualTo(AutonomousRunStatus.RUNNING);
+      verify(eventService, never())
+          .append(
+              anyString(),
+              anyString(),
+              anyString(),
+              eq(AutonomousEventType.QUESTION),
+              anyString(),
+              anyString(),
+              any());
+    }
+
+    @Test
+    @DisplayName("answering the scope question engages the orchestrator that was never started")
+    void given_runParkedOnScope_when_operatorAnswers_then_orchestratorIsEngaged() {
+      // -- PREPARE --
+      AutonomousRun run = createdRun();
+      run.setStatus(AutonomousRunStatus.WAITING_INPUT);
+      when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
+      when(directiveRepository.save(any(AutonomousDirective.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      // -- EXECUTE --
+      service.addDirective("run-1", "Attack the asset group Workstations");
+
+      // -- ASSERT --
+      assertThat(run.getStatus()).isEqualTo(AutonomousRunStatus.RUNNING);
+      // A run that was never engaged has no session to wake: the answer starts it.
+      verify(xtmOneClient)
+          .startAutonomousRun(
+              any(),
+              anyString(),
+              eq("run-1"),
+              eq("sim-1"),
+              eq("scenario-1"),
+              anyBoolean(),
+              any(),
+              any(),
+              anyList(),
+              any(),
+              anyBoolean(),
+              any(),
+              any(),
+              anyList(),
+              anyMap());
+      verify(xtmOneClient, never()).wakeAutonomousRun(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("a directive on an already engaged run still only wakes it")
+    void given_engagedRun_when_operatorAnswers_then_orchestratorIsOnlyWoken() {
+      // -- PREPARE --
+      AutonomousRun run = createdRun();
+      run.setStatus(AutonomousRunStatus.WAITING_INPUT);
+      run.setXtmSessionId("xtm-session-1");
+      when(runRepository.findByIdForUpdate("run-1")).thenReturn(Optional.of(run));
+      when(directiveRepository.save(any(AutonomousDirective.class)))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+
+      // -- EXECUTE --
+      service.addDirective("run-1", "Pivot to the DMZ");
+
+      // -- ASSERT --
+      verify(xtmOneClient).wakeAutonomousRun(eq("run-1"), anyString());
+      verify(xtmOneClient, never())
+          .startAutonomousRun(
+              any(),
+              any(),
+              anyString(),
+              any(),
+              any(),
+              anyBoolean(),
+              any(),
+              any(),
+              anyList(),
+              any(),
+              anyBoolean(),
+              any(),
+              any(),
+              anyList(),
+              anyMap());
+    }
   }
 
   // endregion


### PR DESCRIPTION
## Description

Fixes #7684 — an autonomous attack chaining run ended immediately after launch, without ever asking for a scope.

### Root cause

`AutonomousRunService.doStart` engaged the orchestrator even when the run had no perimeter at all. With nothing to act on, the still-empty simulation read `FINISHED` right away and `reconcileWithSimulation` flipped the run to `COMPLETED` a few seconds after the launch. Guards against that premature `FINISHED -> COMPLETED` sync already existed for plan mode and `WAITING_INPUT`, but not for an unscoped live launch.

### Fix

- **`doStart`** — a live run with no scope (no entity target on the run and no allow-list rule on its simulation workflow) is no longer handed to the orchestrator. It parks in `WAITING_INPUT` and emits a `QUESTION` event, so the cockpit chat asks *"Which targets are in scope?"*. `WAITING_INPUT` is already exempt from the reconcile and from the stall watchdog, so the parked run stays alive instead of completing.
- **`addDirective`** — answering that question engages the orchestrator that was never started (it previously only tried to wake a session that did not exist).
- **`applyLiveConfiguration`** — defining the scope in the Scope tab resumes the parked run the same way, so both surfaces answer the question.
- **`WorkflowService.hasAllowlistScopeForSimulation`** — new read used to detect a run with no perimeter (it covers both the launch stepper's rules and the scenario's own scope, which are seeded onto the simulation workflow at creation).

No frontend change: the reasoning panel already renders a pending `QUESTION` with a reply composer while the run is `WAITING_INPUT`.

## Tests

- New `@Nested` group `Launching a live run without a scope` in `AutonomousRunServiceTest` (5 tests): unscoped launch parks and asks + never engages, a run scope target or a workflow allow-list still engages, answering the question engages, a directive on an already engaged run still only wakes it.
- `AutonomousRunServiceTest`, `AutonomousRunServiceScopeTest`, `AutonomousEventServiceTest`, `AutonomousRunAccessControlTest`, `AutonomousRunReconciliationWriterTest`, `WorkflowServiceTest` all pass; `mvn spotless:apply` clean.

## Checklist

- [x] Linked to an issue (#7684)
- [x] Tests added
- [x] Spotless / compile verified locally
- [ ] Manual validation on main-ff / Demo (launch an autonomous chaining scenario with no scope and check the cockpit asks for it)