### PR TITLE
fix(threats): add in bulk to scenario (#7625)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioApi.java
@@ -146,7 +146,7 @@ public class ScenarioApi extends RestBehavior {
   // commit-time flush - the arsenal selection can create thousands of injects.
   @Transactional(propagation = Propagation.SUPPORTS)
   @AccessControl(actionPerformed = Action.CREATE, resourceType = ResourceType.SCENARIO)
-  public Scenario createScenarioWithInjectorContracts(
+  public ScenarioSimple createScenarioWithInjectorContracts(
       // TxCtx is still declared so the resolver injects the request scope; there is no real
       // transaction here to write the GUC into (SUPPORTS), so it is passed down manually into
       // ScenarioService's own @Transactional method.
@@ -170,7 +170,7 @@ public class ScenarioApi extends RestBehavior {
   // commit-time flush - the arsenal selection can create thousands of injects.
   @Transactional(propagation = Propagation.SUPPORTS)
   @AccessControl(actionPerformed = Action.WRITE, resourceType = ResourceType.SCENARIO)
-  public List<Scenario> updateScenariosWithInjectorContracts(
+  public List<ScenarioSimple> updateScenariosWithInjectorContracts(
       // TxCtx is still declared so the resolver injects the request scope; there is no real
       // transaction here to write the GUC into (SUPPORTS), so it is passed down manually into
       // ScenarioService's own @Transactional method.

--- a/openaev-api/src/main/java/io/openaev/rest/scenario/form/ScenarioSimple.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/form/ScenarioSimple.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Data;
-import org.springframework.beans.BeanUtils;
 
 @Data
 public class ScenarioSimple {
@@ -31,9 +30,17 @@ public class ScenarioSimple {
   @JsonProperty("scenario_tags")
   private Set<Tag> tags = new HashSet<>();
 
+  /**
+   * Builds the DTO from a managed entity. Must be called inside the transaction that loaded the
+   * scenario: the tag set is copied into a detached {@link HashSet} so the DTO carries no lazy
+   * Hibernate collection once serialization happens outside the session.
+   */
   public static ScenarioSimple fromScenario(@NotNull final Scenario scenario) {
     ScenarioSimple simple = new ScenarioSimple();
-    BeanUtils.copyProperties(scenario, simple);
+    simple.setId(scenario.getId());
+    simple.setName(scenario.getName());
+    simple.setSubtitle(scenario.getSubtitle());
+    simple.setTags(new HashSet<>(scenario.getTags()));
     return simple;
   }
 

--- a/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
+++ b/openaev-api/src/main/java/io/openaev/service/scenario/ScenarioService.java
@@ -185,7 +185,7 @@ public class ScenarioService {
   }
 
   @Transactional
-  public Scenario createScenarioWithInjectorContracts(
+  public ScenarioSimple createScenarioWithInjectorContracts(
       // Unused by the method body; TenantScopeTransactionAspect reads it to set the tenant scope
       // for this transaction (the arsenal selection resolves injector contracts and their linked
       // injector, both v2 tenant-scoped through the injectors table).
@@ -198,11 +198,11 @@ public class ScenarioService {
     Scenario scenario = computeAndCreateScenario(preparedScenario);
     this.injectService.createInjectsFromInjectorContractInput(
         null, new ArrayList<>(List.of(scenario)), injectorContractSearchPaginationInput, locale);
-    return scenario;
+    return ScenarioSimple.fromScenario(scenario);
   }
 
   @Transactional
-  public List<Scenario> updateScenariosWithInjectorContracts(
+  public List<ScenarioSimple> updateScenariosWithInjectorContracts(
       // Unused by the method body; TenantScopeTransactionAspect reads it to set the tenant scope
       // for this transaction (same reason as createScenarioWithInjectorContracts above).
       TxCtx ctx,
@@ -212,7 +212,7 @@ public class ScenarioService {
     List<Scenario> scenarios = this.scenarioRepository.findAllById(scenarioIds);
     this.injectService.createInjectsFromInjectorContractInput(
         null, scenarios, injectorContractSearchPaginationInput, locale);
-    return scenarios;
+    return scenarios.stream().map(ScenarioSimple::fromScenario).toList();
   }
 
   public void computeEmails(@NotNull Scenario scenario) {

--- a/openaev-front/src/admin/components/threat_arsenal/bulk/ThreatArsenalScenarioCreationComponent.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/bulk/ThreatArsenalScenarioCreationComponent.tsx
@@ -1,4 +1,5 @@
 import { Slide } from '@mui/material';
+import { type AxiosResponse } from 'axios';
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
 
@@ -11,6 +12,7 @@ import {
   type PlatformSettings,
   type ScenarioAndInjectorContractsInputs,
   type ScenarioInput,
+  type ScenarioSimple,
   type ThreatArsenalAction,
 } from '../../../../utils/api-types';
 import ScenarioForm from '../../scenarios/ScenarioForm';
@@ -41,7 +43,7 @@ const ThreatArsenalScenarioCreationComponent = ({ isExclusionMode, selectedEleme
         injector_contract_ids_to_ignore: isExclusionMode ? Object.keys(deSelectedElements) : [],
       },
     };
-    const result = await addScenarioWithInjectorContracts(inputs);
+    const result: AxiosResponse<ScenarioSimple> = await addScenarioWithInjectorContracts(inputs);
     navigate(`/admin/scenarios/${result.data.scenario_id}/injects`);
   };
 

--- a/openaev-front/src/admin/components/threat_arsenal/bulk/ThreatArsenalScenarioUpdateComponent.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/bulk/ThreatArsenalScenarioUpdateComponent.tsx
@@ -25,8 +25,8 @@ import {
   type InjectorContractSearchPaginationInput,
   type PageRawPaginationScenario,
   type RawPaginationScenario,
-  type Scenario,
   type ScenarioIdsAndInjectorContractsInputs,
+  type ScenarioSimple,
   type ThreatArsenalAction,
 } from '../../../../utils/api-types';
 
@@ -132,7 +132,7 @@ const ThreatArsenalScenarioUpdateComponent = ({
         injector_contract_ids_to_ignore: isExclusionMode ? Object.keys(deSelectedElements) : [],
       },
     };
-    updateScenariosWithInjectorContracts(inputs).then((result: AxiosResponse<Scenario[]>) => {
+    updateScenariosWithInjectorContracts(inputs).then((result: AxiosResponse<ScenarioSimple[]>) => {
       navigate(`/admin/scenarios/${result.data[0].scenario_id}/injects`);
     }).finally(() => setSubmitting(false));
   };

--- a/openaev-front/src/admin/components/threat_arsenal/bulk/ThreatArsenalScenarioUpdateComponent.tsx
+++ b/openaev-front/src/admin/components/threat_arsenal/bulk/ThreatArsenalScenarioUpdateComponent.tsx
@@ -17,6 +17,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { searchScenarios, updateScenariosWithInjectorContracts } from '../../../../actions/scenarios/scenario-actions';
+import { generateFilterId } from '../../../../components/common/queryable/filter/FilterUtils';
 import { buildSearchPagination } from '../../../../components/common/queryable/QueryableUtils';
 import { useFormatter } from '../../../../components/i18n';
 import ItemSeverity from '../../../../components/ItemSeverity';
@@ -29,6 +30,7 @@ import {
   type ScenarioSimple,
   type ThreatArsenalAction,
 } from '../../../../utils/api-types';
+import { SCENARIO_TYPE_TIME_BASED } from '../../scenarios/scenario/ScenarioType';
 
 interface Props {
   isExclusionMode: boolean;
@@ -72,6 +74,16 @@ const ThreatArsenalScenarioUpdateComponent = ({
       page: pageToLoad,
       size: PAGE_SIZE,
       textSearch: search,
+      filterGroup: {
+        mode: 'and',
+        filters: [{
+          id: generateFilterId(),
+          key: 'scenario_type',
+          operator: 'eq',
+          mode: 'or',
+          values: [SCENARIO_TYPE_TIME_BASED],
+        }],
+      },
       sorts: [{
         property: 'scenario_updated_at',
         direction: 'DESC',
@@ -148,6 +160,9 @@ const ThreatArsenalScenarioUpdateComponent = ({
       >
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>
           {t('Select the scenarios that will receive the selected actions')}
+        </Typography>
+        <Typography variant="caption" sx={{ color: 'text.disabled' }}>
+          {t('Chained scenarios are not listed: their injects are driven by their workflow')}
         </Typography>
 
         <TextField

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "Verketten Sie diese Injektion mit anderen: ein Elternteil lauft davor, Kinder danach. Fugen Sie Ausfuhrungsbedingungen hinzu, um je nach Erfolg oder Fehlschlag des Elternteils zu verzweigen.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "Verkettung eines nicht authentifizierten Datei-Uploads zu einer Shell auf dem Zielhost.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "Verkettete Szenarien werden nicht aufgeführt: Ihre Injects werden von ihrem Workflow gesteuert",
   "chaining.chaining-scenario.description": "Führt eine vollautomatische End-to-End-Sequenz aus, bei der jeder Schritt die nächsten möglichen Schritte auslöst.",
   "chaining.chaining-scenario.title": "Verkettetes Szenario",
   "chaining.chaining-simulation.title": "Verkettete Simulation",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "Chained an unauthenticated file upload into a shell on the target host.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "Chained scenarios are not listed: their injects are driven by their workflow",
   "chaining.chaining-scenario.description": "Runs a fully automated, end-to-end sequence where each step triggers the next potential steps.",
   "chaining.chaining-scenario.title": "Chained scenario",
   "chaining.chaining-simulation.title": "Chained simulation",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "Encadene esta inyeccion con otras: un padre se ejecuta antes y los hijos despues. Anada condiciones de ejecucion para ramificar segun si el padre tuvo exito o fallo.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "Se encadeno una carga de archivo no autenticada hasta obtener una shell en el host objetivo.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "Los escenarios encadenados no se muestran: sus inyecciones se controlan mediante su flujo de trabajo",
   "chaining.chaining-scenario.description": "Ejecuta una secuencia totalmente automatizada, de extremo a extremo, donde cada paso desencadena los siguientes pasos potenciales.",
   "chaining.chaining-scenario.title": "Escenario encadenado",
   "chaining.chaining-simulation.title": "Simulación encadenada",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "Chainez cette injection a d'autres : un parent s'execute avant, les enfants apres. Ajoutez des conditions d'execution pour brancher selon la reussite ou l'echec du parent.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "Enchainement d'un televersement de fichier non authentifie vers un shell sur l'hote cible.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "Les scénarios chaînés ne sont pas listés : leurs injections sont pilotées par leur workflow",
   "chaining.chaining-scenario.description": "Exécute une séquence entièrement automatisée, de bout en bout, où chaque étape déclenche les étapes potentielles suivantes.",
   "chaining.chaining-scenario.title": "Scénario chaîné",
   "chaining.chaining-simulation.title": "Simulation chaînée",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "Concatena questa iniezione ad altre: un genitore viene eseguito prima, i figli dopo. Aggiungi condizioni di esecuzione per diramare in base al successo o al fallimento del genitore.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "Concatenato un caricamento di file non autenticato fino a una shell sull'host di destinazione.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "Gli scenari concatenati non sono elencati: le loro injection sono gestite dal loro workflow",
   "chaining.chaining-scenario.description": "Esegue una sequenza end-to-end completamente automatizzata in cui ogni fase innesca le potenziali fasi successive.",
   "chaining.chaining-scenario.title": "Scenario concatenato",
   "chaining.chaining-simulation.title": "Simulazione concatenata",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "このインジェクトを他とチェーンします。親が先に実行され、子が後に実行されます。親の成功または失敗で分岐する実行条件を追加できます。",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "認証不要のファイルアップロードを連鎖させ、標的ホスト上でシェルを取得しました。",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "連鎖シナリオは表示されません。インジェクトはワークフローによって制御されます",
   "chaining.chaining-scenario.description": "完全に自動化されたエンド・ツー・エンドのシーケンスを実行し、各ステップが次の可能性のあるステップをトリガーする。",
   "chaining.chaining-scenario.title": "連鎖のシナリオ",
   "chaining.chaining-simulation.title": "連鎖シミュレーション",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "이 인젝트를 다른 인젝트와 연결합니다. 부모가 먼저 실행되고 자식이 이후에 실행됩니다. 부모의 성공 또는 실패에 따라 분기하도록 실행 조건을 추가하세요.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "인증되지 않은 파일 업로드를 연계하여 대상 호스트에서 셸을 획득했습니다.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "체인 시나리오는 표시되지 않습니다: 인젝트는 워크플로에 의해 제어됩니다",
   "chaining.chaining-scenario.description": "각 단계가 다음 잠재적 단계를 트리거하는 완전 자동화된 엔드투엔드 시퀀스를 실행합니다.",
   "chaining.chaining-scenario.title": "체인 시나리오",
   "chaining.chaining-simulation.title": "체인 시뮬레이션",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "Свяжите эту инъекцию с другими: родитель выполняется до нее, потомки - после. Добавьте условия выполнения для ветвления в зависимости от успеха или неудачи родителя.",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "Связали неаутентифицированную загрузку файла с получением оболочки на целевом узле.",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "Цепочечные сценарии не отображаются: их инжекты управляются рабочим процессом",
   "chaining.chaining-scenario.description": "Запускает полностью автоматизированную сквозную последовательность, где каждый шаг вызывает следующие потенциальные шаги.",
   "chaining.chaining-scenario.title": "Сценарий цепочки",
   "chaining.chaining-simulation.title": "Моделирование цепочек",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -608,6 +608,7 @@
   "Chain this inject to others: a parent runs before it, children run after. Add execution conditions to branch on whether the parent succeeded or failed.": "将此注入与其他注入串联：父项先运行，子项后运行。添加执行条件以根据父项成功或失败进行分支。",
   "Chained": "Chained",
   "Chained an unauthenticated file upload into a shell on the target host.": "将未经身份验证的文件上传串联，在目标主机上获得了 shell。",
+  "Chained scenarios are not listed: their injects are driven by their workflow": "不显示链式场景：其注入由工作流驱动",
   "chaining.chaining-scenario.description": "运行全自动端到端序列，其中每个步骤都会触发下一个潜在步骤。",
   "chaining.chaining-scenario.title": "连锁方案",
   "chaining.chaining-simulation.title": "连锁模拟",


### PR DESCRIPTION
### Proposed changes

* Fix the threat arsenal bulk process, allow the injects to be added to a scenario in bulk

### Testing Instructions

1. Go to the threat arsenal page
2. Select one or more injects
3. Click on "Run a test" on the bulk menu
4. Select "Add to an existing scenario"
5. Select one or more scenario
6. You should be redirected to the scenario, and all the selected injects should be added to the scenario

### Related issues

* Related #7625 

