### PR TITLE
fix(scenario): reload injects list after bulk modification (#6650)

### DIFF
--- a/openaev-front/src/admin/components/common/injects/Injects.tsx
+++ b/openaev-front/src/admin/components/common/injects/Injects.tsx
@@ -434,7 +434,6 @@ const Injects: FunctionComponent<Props> = ({
       simulation_or_scenario_id: contextId,
       update_operations: operationsToPerform,
     });
-    handleClearSelectedElements();
     setReloadInjectCount(prev => prev + 1);
   };
 

--- a/openaev-front/src/admin/components/common/injects/Injects.tsx
+++ b/openaev-front/src/admin/components/common/injects/Injects.tsx
@@ -296,12 +296,6 @@ const Injects: FunctionComponent<Props> = ({
     }
   };
 
-  const onBulkUpdate = (updatedResults: Inject[]) => {
-    setInjects(injects.map((originalInject) => {
-      return updatedResults.find(updatedInject => updatedInject.inject_id === originalInject.inject_id) as unknown as InjectOutputType || originalInject;
-    }));
-  };
-
   const onDelete = (result: string) => {
     if (result) {
       setInjects(injects.filter(i => (i.inject_id !== result)));
@@ -439,10 +433,9 @@ const Injects: FunctionComponent<Props> = ({
       inject_ids_to_ignore: injectIdsToIgnore(selectAll),
       simulation_or_scenario_id: contextId,
       update_operations: operationsToPerform,
-    })
-      .then((result) => {
-        if (result) onBulkUpdate(result);
-      });
+    });
+    handleClearSelectedElements();
+    setReloadInjectCount(prev => prev + 1);
   };
 
   const bulkDeleteInjects = () => {


### PR DESCRIPTION
### Proposed changes

* Fix the injects status after a modification in bulk, made the list reload once the bulk is validated

### Testing Instructions

1. On a scenario modify one or more injects with the bulk process
2. The list should reload and refresh the injects status

### Related issues

* Related #6650