### PR TITLE
fix(endpoints): stabilize search total across pages (#3208)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/service/EndpointService.java
+++ b/openaev-api/src/main/java/io/openaev/service/EndpointService.java
@@ -11,7 +11,6 @@ import static io.openaev.integration.impl.executors.paloaltocortex.PaloAltoCorte
 import static io.openaev.utils.ArchitectureFilterUtils.handleEndpointFilter;
 import static io.openaev.utils.FilterUtilsJpa.computeFilterGroupJpa;
 import static io.openaev.utils.SecurityUtils.validateJFrogUri;
-import static io.openaev.utils.pagination.PaginationUtils.buildPageable;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationJPA;
 import static java.time.Instant.now;
 import static java.util.Optional.ofNullable;
@@ -332,46 +331,23 @@ public class EndpointService implements AuditLoggedService {
             .findById(assetGroupId)
             .orElseThrow(() -> new IllegalArgumentException("Asset group not found"));
 
-    Specification<Endpoint> specificationStatic =
-        findEndpointsForAssetGroup(assetGroupId)
-            .and(findEndpointsForInjectionOrAgentlessEndpoints());
+    Specification<Endpoint> membership = findEndpointsForAssetGroup(assetGroupId);
 
     if (!isEmptyFilterGroup(assetGroup.getDynamicFilter())) {
-      Specification<Endpoint> specificationDynamic =
-          computeFilterGroupJpa(assetGroup.getDynamicFilter());
-      Specification<Endpoint> specificationDynamicWithInjection =
-          specificationDynamic.and(findEndpointsForInjectionOrAgentlessEndpoints());
-
-      Page<Endpoint> dynamicResult =
-          buildPaginationJPA(
-              (Specification<Endpoint> specification, Pageable pageable) ->
-                  this.endpointRepository.findAll(
-                      specificationDynamicWithInjection.and(specification), pageable),
-              handleEndpointFilter(searchPaginationInput),
-              Endpoint.class);
-      Page<Endpoint> staticResult =
-          buildPaginationJPA(
-              (Specification<Endpoint> specification, Pageable pageable) ->
-                  this.endpointRepository.findAll(specificationStatic.and(specification), pageable),
-              handleEndpointFilter(searchPaginationInput),
-              Endpoint.class);
-      List<Endpoint> mergedContent =
-          Stream.concat(dynamicResult.getContent().stream(), staticResult.getContent().stream())
-              .distinct()
-              .limit(searchPaginationInput.getSize())
-              .collect(toList());
-
-      long total = dynamicResult.getTotalElements() + staticResult.getTotalElements();
-
-      Pageable pageable = buildPageable(searchPaginationInput, Endpoint.class);
-      return new PageImpl<>(mergedContent, pageable, total);
-    } else {
-      return buildPaginationJPA(
-          (Specification<Endpoint> specification, Pageable pageable) ->
-              this.endpointRepository.findAll(specificationStatic.and(specification), pageable),
-          handleEndpointFilter(searchPaginationInput),
-          Endpoint.class);
+      // Static members OR dynamic members, resolved in a SINGLE paginated query. Running two
+      // separate queries and concatenating their pages double-counted the endpoints belonging to
+      // both sets (the total was a plain sum) and broke sorting/pagination past the first page.
+      membership = membership.or(computeFilterGroupJpa(assetGroup.getDynamicFilter()));
     }
+
+    Specification<Endpoint> finalSpec =
+        membership.and(findEndpointsForInjectionOrAgentlessEndpoints());
+
+    return buildPaginationJPA(
+        (Specification<Endpoint> specification, Pageable pageable) ->
+            this.endpointRepository.findAll(finalSpec.and(specification), pageable),
+        handleEndpointFilter(searchPaginationInput),
+        Endpoint.class);
   }
 
   public Endpoint updateEndpoint(

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointSearchTotalTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointSearchTotalTest.java
@@ -1,0 +1,173 @@
+package io.openaev.service.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Agent;
+import io.openaev.database.model.AssetGroup;
+import io.openaev.database.model.Endpoint;
+import io.openaev.database.model.Filters;
+import io.openaev.database.model.Tenant;
+import io.openaev.database.repository.TenantRepository;
+import io.openaev.service.EndpointService;
+import io.openaev.utils.fixtures.AgentFixture;
+import io.openaev.utils.fixtures.AssetGroupFixture;
+import io.openaev.utils.fixtures.EndpointFixture;
+import io.openaev.utils.fixtures.ExecutorFixture;
+import io.openaev.utils.fixtures.PaginationFixture;
+import io.openaev.utils.fixtures.composers.AgentComposer;
+import io.openaev.utils.fixtures.composers.AssetGroupComposer;
+import io.openaev.utils.fixtures.composers.EndpointComposer;
+import io.openaev.utils.fixtures.composers.ExecutorComposer;
+import io.openaev.utils.mockUser.TestUserHolder;
+import io.openaev.utils.mockUser.WithMockUser;
+import io.openaev.utils.pagination.SearchPaginationInput;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Non-regression tests for the endpoint search totals.
+ *
+ * <p>The endpoint specifications used to join on agents and deduplicate with a {@code GROUP BY}.
+ * Spring Data applies the specification to the count query too and cannot handle a grouped count:
+ * it sums the returned rows, so the total counted agents instead of endpoints. The bug was only
+ * visible on pages that are full (Spring short-circuits the count with {@code offset + size} on a
+ * partial page), hence a total that changed from one page to another.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+class EndpointSearchTotalTest extends IntegrationTest {
+
+  private static final String NAME_PREFIX = "search-total-";
+
+  @Autowired private EndpointService endpointService;
+  @Autowired private EndpointComposer endpointComposer;
+  @Autowired private AgentComposer agentComposer;
+  @Autowired private AssetGroupComposer assetGroupComposer;
+  @Autowired private ExecutorComposer executorComposer;
+  @Autowired private ExecutorFixture executorFixture;
+  @Autowired private TenantRepository tenantRepository;
+  @Autowired private TestUserHolder testUserHolder;
+  @Autowired private EntityManager entityManager;
+
+  @BeforeEach
+  void setUp() {
+    executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
+    if (testUserHolder.get() != null) {
+      tenantRepository.addUserToTenant(testUserHolder.get().getId(), Tenant.DEFAULT_TENANT_UUID);
+    }
+  }
+
+  /** Persists an endpoint carrying {@code agentCount} injectable agents (no parent, no inject). */
+  private EndpointComposer.Composer persistEndpointWithAgents(String name, int agentCount) {
+    Endpoint endpoint = EndpointFixture.createEndpoint(NAME_PREFIX + name);
+    EndpointComposer.Composer composer = endpointComposer.forEndpoint(endpoint);
+    for (int i = 0; i < agentCount; i++) {
+      Agent agent = AgentFixture.createDefaultAgentService();
+      // Distinct executedByUser keeps each agent a separate row on the same endpoint
+      agent.setExecutedByUser(name + "-user-" + i);
+      composer.withAgent(
+          agentComposer
+              .forAgent(agent)
+              .withExecutor(executorComposer.forExecutor(executorFixture.getDefaultExecutor())));
+    }
+    return composer.persist();
+  }
+
+  private SearchPaginationInput searchPage(int page, int size) {
+    return PaginationFixture.getDefault().textSearch(NAME_PREFIX).page(page).size(size).build();
+  }
+
+  @Nested
+  @DisplayName("Endpoint search total")
+  class EndpointSearchTotal {
+
+    @Test
+    @DisplayName("Given endpoints with several agents, should count endpoints and not agents")
+    void given_endpointsWithSeveralAgents_should_countEndpointsAndNotAgents() {
+      // -- PREPARE --
+      persistEndpointWithAgents("multi", 3); // would have counted 3 before the fix
+      persistEndpointWithAgents("single", 1);
+      persistEndpointWithAgents("agentless", 0);
+      entityManager.flush();
+      entityManager.clear();
+
+      // -- EXECUTE --
+      Page<Endpoint> page = endpointService.searchEndpoints(searchPage(0, 100));
+
+      // -- ASSERT --
+      assertThat(page.getTotalElements()).isEqualTo(3);
+      assertThat(page.getContent()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Given a full first page, should advertise the same total on every page")
+    void given_fullFirstPage_should_advertiseSameTotalOnEveryPage() {
+      // -- PREPARE --
+      // A full page forces Spring Data to run the real count query (it does not short-circuit
+      // with offset + content size), which is where the inflated total used to show up.
+      persistEndpointWithAgents("multi", 3);
+      persistEndpointWithAgents("single", 1);
+      persistEndpointWithAgents("agentless", 0);
+      entityManager.flush();
+      entityManager.clear();
+
+      // -- EXECUTE --
+      Page<Endpoint> firstPage = endpointService.searchEndpoints(searchPage(0, 2));
+      Page<Endpoint> secondPage = endpointService.searchEndpoints(searchPage(1, 2));
+
+      // -- ASSERT --
+      assertThat(firstPage.getTotalElements()).isEqualTo(3);
+      assertThat(secondPage.getTotalElements()).isEqualTo(firstPage.getTotalElements());
+      assertThat(firstPage.getContent()).hasSize(2);
+      assertThat(secondPage.getContent()).hasSize(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("Endpoint search total by asset group")
+  class EndpointSearchTotalByAssetGroup {
+
+    @Test
+    @DisplayName("Given an endpoint both static and dynamic member, should not count it twice")
+    void given_endpointBothStaticAndDynamicMember_should_notCountItTwice() {
+      // -- PREPARE --
+      EndpointComposer.Composer staticMember = persistEndpointWithAgents("static-member", 2);
+      EndpointComposer.Composer dynamicMember = persistEndpointWithAgents("dynamic-member", 1);
+
+      // The dynamic filter matches BOTH endpoints, one of which is also a static member
+      Filters.Filter filter = new Filters.Filter();
+      filter.setKey("asset_name");
+      filter.setOperator(Filters.FilterOperator.contains);
+      filter.setValues(List.of(NAME_PREFIX));
+      Filters.FilterGroup dynamicFilter = new Filters.FilterGroup();
+      dynamicFilter.setMode(Filters.FilterMode.and);
+      dynamicFilter.setFilters(new ArrayList<>(List.of(filter)));
+
+      AssetGroup assetGroup =
+          AssetGroupFixture.createAssetGroupWithDynamicFilter(NAME_PREFIX + "group", dynamicFilter);
+      assetGroupComposer.forAssetGroup(assetGroup).withAsset(staticMember).persist();
+      entityManager.flush();
+      entityManager.clear();
+
+      // -- EXECUTE --
+      Page<Endpoint> page =
+          endpointService.searchManagedEndpointsByAssetGroup(
+              assetGroup.getId(), searchPage(0, 100));
+
+      // -- ASSERT --
+      assertThat(page.getTotalElements()).isEqualTo(2);
+      assertThat(page.getContent())
+          .extracting(Endpoint::getId)
+          .containsExactlyInAnyOrder(staticMember.get().getId(), dynamicMember.get().getId());
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointSearchTotalTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/endpoint/EndpointSearchTotalTest.java
@@ -3,18 +3,10 @@ package io.openaev.service.endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openaev.IntegrationTest;
-import io.openaev.database.model.Agent;
-import io.openaev.database.model.AssetGroup;
-import io.openaev.database.model.Endpoint;
-import io.openaev.database.model.Filters;
-import io.openaev.database.model.Tenant;
+import io.openaev.database.model.*;
 import io.openaev.database.repository.TenantRepository;
 import io.openaev.service.EndpointService;
-import io.openaev.utils.fixtures.AgentFixture;
-import io.openaev.utils.fixtures.AssetGroupFixture;
-import io.openaev.utils.fixtures.EndpointFixture;
-import io.openaev.utils.fixtures.ExecutorFixture;
-import io.openaev.utils.fixtures.PaginationFixture;
+import io.openaev.utils.fixtures.*;
 import io.openaev.utils.fixtures.composers.AgentComposer;
 import io.openaev.utils.fixtures.composers.AssetGroupComposer;
 import io.openaev.utils.fixtures.composers.EndpointComposer;
@@ -60,6 +52,11 @@ class EndpointSearchTotalTest extends IntegrationTest {
 
   @BeforeEach
   void setUp() {
+    endpointComposer.reset();
+    agentComposer.reset();
+    assetGroupComposer.reset();
+    executorComposer.reset();
+
     executorComposer.forExecutor(executorFixture.getDefaultExecutor()).persist();
     if (testUserHolder.get() != null) {
       tenantRepository.addUserToTenant(testUserHolder.get().getId(), Tenant.DEFAULT_TENANT_UUID);

--- a/openaev-model/src/main/java/io/openaev/database/specification/EndpointSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/EndpointSpecification.java
@@ -1,11 +1,13 @@
 package io.openaev.database.specification;
 
 import io.openaev.database.model.Agent;
+import io.openaev.database.model.Asset;
 import io.openaev.database.model.AssetGroup;
 import io.openaev.database.model.Endpoint;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.data.jpa.domain.Specification;
@@ -15,33 +17,72 @@ public class EndpointSpecification {
   private EndpointSpecification() {}
 
   public static Specification<Endpoint> findEndpointsForInjectionOrAgentlessEndpoints() {
-    return findAgentlessEndpoints().or(findEndpointsForInjection());
+    return distinctEndpoints().and(findAgentlessEndpoints().or(findEndpointsForInjection()));
   }
 
+  /**
+   * Marks the query as distinct. The specifications below never duplicate rows on their own (they
+   * rely on EXISTS), but user filters resolved by {@code FilterUtilsJpa} can traverse to-many paths
+   * (e.g. {@code assetGroups.id}) and produce an implicit duplicating join. {@code DISTINCT} keeps
+   * both the page content and the count correct: Spring Data reads {@code query.isDistinct()} to
+   * emit {@code count(distinct endpoint)} instead of {@code count(endpoint)}.
+   *
+   * <p>Do NOT replace this with a {@code GROUP BY}: Spring Data cannot handle a grouped count query
+   * (it sums the returned rows), which is exactly what made the endpoint total unstable across
+   * pages (see spring-projects/spring-data-jpa#2376).
+   */
+  private static Specification<Endpoint> distinctEndpoints() {
+    return (root, query, criteriaBuilder) -> {
+      query.distinct(true);
+      return criteriaBuilder.conjunction();
+    };
+  }
+
+  /**
+   * Endpoints having at least one "injectable" agent (no parent, not bound to an inject).
+   *
+   * <p>Implemented with an {@code EXISTS} subquery on purpose: a {@code JOIN} would duplicate rows
+   * and require a {@code GROUP BY} to deduplicate them. Spring Data applies the specification to
+   * the count query as well, and it cannot handle a {@code GROUP BY} there: the count returns one
+   * row per group and Spring sums them, so the total ends up counting agents instead of endpoints
+   * (see spring-projects/spring-data-jpa#2376). {@code EXISTS} produces no duplicates, so no
+   * grouping is needed and the count stays correct on every page.
+   */
   public static Specification<Endpoint> findEndpointsForInjection() {
     return (root, query, criteriaBuilder) -> {
-      Join<Endpoint, Agent> agentsJoin = root.join("agents", JoinType.LEFT);
-      query.groupBy(root.get("id"));
-      return criteriaBuilder.and(
-          criteriaBuilder.isNull(agentsJoin.get("parent")),
-          criteriaBuilder.isNull(agentsJoin.get("inject")));
+      Subquery<String> subquery = query.subquery(String.class);
+      Root<Agent> agent = subquery.from(Agent.class);
+      subquery
+          .select(agent.get("id"))
+          .where(
+              criteriaBuilder.equal(agent.get("asset"), root),
+              criteriaBuilder.isNull(agent.get("parent")),
+              criteriaBuilder.isNull(agent.get("inject")));
+      return criteriaBuilder.exists(subquery);
     };
   }
 
   public static Specification<Endpoint> findAgentlessEndpoints() {
-    return (root, query, criteriaBuilder) -> {
-      query.groupBy(root.get("id"));
-      return criteriaBuilder.and(criteriaBuilder.isEmpty(root.get("agents")));
-    };
+    // No join here: isEmpty() already compiles to a NOT EXISTS, so no grouping is required.
+    return (root, query, criteriaBuilder) -> criteriaBuilder.isEmpty(root.get("agents"));
   }
 
+  /**
+   * Endpoints statically attached to the given asset group. Uses an {@code EXISTS} subquery for the
+   * same reason as {@link #findEndpointsForInjection()}.
+   */
   public static Specification<Endpoint> findEndpointsForAssetGroup(
       @NotNull final String assetGroupId) {
     return (root, query, criteriaBuilder) -> {
-      Join<Endpoint, AssetGroup> assetGroupJoin = root.join("assetGroups", JoinType.LEFT);
-      query.groupBy(root.get("id"));
-      query.distinct(true);
-      return criteriaBuilder.and(criteriaBuilder.equal(assetGroupJoin.get("id"), assetGroupId));
+      Subquery<String> subquery = query.subquery(String.class);
+      Root<AssetGroup> assetGroup = subquery.from(AssetGroup.class);
+      Join<AssetGroup, Asset> assets = assetGroup.join("assets");
+      subquery
+          .select(assetGroup.get("id"))
+          .where(
+              criteriaBuilder.equal(assetGroup.get("id"), assetGroupId),
+              criteriaBuilder.equal(assets, root));
+      return criteriaBuilder.exists(subquery);
     };
   }
 


### PR DESCRIPTION
### Proposed changes

* The count on the endpoints lists was inconsistent, it change to reflect the real amount of endpoints.

### Testing Instructions

1. Go to a list of endpoints (on a technical inject for example)
2. The displayed amount of elements should represent the real amount of endpoints on the platform

### Related issues

* Related #3208 