### PR TITLE
fix(pagination): refuse sorting on collection-valued properties (#7704)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/utils/pagination/InvalidSortPropertyException.java
+++ b/openaev-api/src/main/java/io/openaev/utils/pagination/InvalidSortPropertyException.java
@@ -6,4 +6,8 @@ public class InvalidSortPropertyException extends IllegalArgumentException {
   public InvalidSortPropertyException(String property) {
     super("Unknown sort property '%s', please try an other one".formatted(property));
   }
+
+  public InvalidSortPropertyException(String property, String reason) {
+    super("Cannot sort on property '%s': %s".formatted(property, reason));
+  }
 }

--- a/openaev-api/src/main/java/io/openaev/utils/pagination/SortUtilsJpa.java
+++ b/openaev-api/src/main/java/io/openaev/utils/pagination/SortUtilsJpa.java
@@ -6,6 +6,7 @@ import static org.springframework.util.StringUtils.hasText;
 import io.openaev.schema.PropertySchema;
 import io.openaev.schema.SchemaUtils;
 import jakarta.validation.constraints.NotNull;
+import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.data.domain.Sort;
@@ -42,7 +43,7 @@ public class SortUtilsJpa {
                         propertySchemas.stream()
                             .filter(p -> p.getJsonName().equals(property))
                             .findFirst()
-                            .map(PropertySchema::getName)
+                            .map(SortUtilsJpa::sortablePropertyName)
                             .orElseThrow(() -> new InvalidSortPropertyException(property));
                     Sort.NullHandling nullHandling =
                         field.nullHandling() != null
@@ -54,5 +55,13 @@ public class SortUtilsJpa {
     }
 
     return Sort.by(orders);
+  }
+
+  private static String sortablePropertyName(@NotNull final PropertySchema schema) {
+    if (Collection.class.isAssignableFrom(schema.getType())) {
+      throw new InvalidSortPropertyException(
+          schema.getJsonName(), "it is a to-many association and cannot be used to sort");
+    }
+    return schema.getName();
   }
 }

--- a/openaev-front/src/admin/components/common/challenges/ChallengesPreviewDocumentsList.tsx
+++ b/openaev-front/src/admin/components/common/challenges/ChallengesPreviewDocumentsList.tsx
@@ -94,7 +94,7 @@ const ChallengesPreviewDocumentsList: FunctionComponent<Props> = ({ currentChall
     {
       field: 'document_tags',
       label: 'Tags',
-      isSortable: true,
+      isSortable: false,
       value: (document: Document) => {
         return (
           <ItemTags

--- a/openaev-front/src/admin/components/settings/tag_rules/TagRules.tsx
+++ b/openaev-front/src/admin/components/settings/tag_rules/TagRules.tsx
@@ -53,7 +53,7 @@ const TagRules = () => {
     {
       field: 'tag_rule_asset_groups',
       label: 'Asset Groups',
-      isSortable: true,
+      isSortable: false,
       value: (tagRule: TagRuleOutput) => (
         <ItemTargets targets={Object.entries(tagRule.asset_groups ?? []).map(([target_id, target_name]) => ({
           target_id,

--- a/openaev-front/src/admin/components/teams/Players.tsx
+++ b/openaev-front/src/admin/components/teams/Players.tsx
@@ -94,7 +94,7 @@ const Players = () => {
     {
       field: 'user_tags',
       label: 'Tags',
-      isSortable: true,
+      isSortable: false,
       value: (player: PlayerOutput) => <ItemTags variant="list" tags={player.user_tags} />,
     },
   ], [organizationsMap]);

--- a/openaev-model/src/main/java/io/openaev/database/model/AssetGroup.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/AssetGroup.java
@@ -105,7 +105,7 @@ public class AssetGroup implements TenantBase {
       inverseJoinColumns = @JoinColumn(name = "tag_id"))
   @JsonSerialize(using = MultiIdSetSerializer.class)
   @JsonProperty("asset_group_tags")
-  @Queryable(filterable = true, sortable = true, dynamicValues = true, path = "tags.id")
+  @Queryable(filterable = true, dynamicValues = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
   // -- INJECT --

--- a/openaev-model/src/main/java/io/openaev/database/model/Document.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/Document.java
@@ -72,7 +72,7 @@ public class Document implements TenantBase {
       inverseJoinColumns = @JoinColumn(name = "tag_id"))
   @JsonSerialize(using = MultiIdSetSerializer.class)
   @JsonProperty("document_tags")
-  @Queryable(filterable = true, sortable = true, dynamicValues = true, path = "tags.id")
+  @Queryable(filterable = true, dynamicValues = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
   @Schema(implementation = String[].class)

--- a/openaev-model/src/main/java/io/openaev/database/model/TagRule.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/TagRule.java
@@ -56,7 +56,7 @@ public class TagRule implements TenantBase {
       name = "tag_rule_asset_groups",
       joinColumns = @JoinColumn(name = "tag_rule_id"),
       inverseJoinColumns = @JoinColumn(name = "asset_group_id"))
-  @Queryable(filterable = true, sortable = true, path = "assetGroups.name")
+  @Queryable(filterable = true, path = "assetGroups.name")
   @JsonProperty("tag_rule_asset_groups")
   private List<AssetGroup> assetGroups = new ArrayList<>();
 

--- a/openaev-model/src/main/java/io/openaev/database/model/User.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/User.java
@@ -242,7 +242,7 @@ public class User implements Base {
       inverseJoinColumns = @JoinColumn(name = "team_id"))
   @JsonSerialize(using = MultiIdListSerializer.class)
   @JsonProperty("user_teams")
-  @Queryable(dynamicValues = true, filterable = true, sortable = true, path = "teams.id")
+  @Queryable(dynamicValues = true, filterable = true, path = "teams.id")
   private List<Team> teams = new ArrayList<>();
 
   @ArraySchema(schema = @Schema(description = "Tag IDs of the user", implementation = String.class))
@@ -254,7 +254,7 @@ public class User implements Base {
       inverseJoinColumns = @JoinColumn(name = "tag_id"))
   @JsonSerialize(using = MultiIdSetSerializer.class)
   @JsonProperty("user_tags")
-  @Queryable(dynamicValues = true, filterable = true, sortable = true, path = "tags.id")
+  @Queryable(dynamicValues = true, filterable = true, path = "tags.id")
   private Set<Tag> tags = new HashSet<>();
 
   @ArraySchema(


### PR DESCRIPTION
### Proposed changes

* **Model** — collections are no longer advertised as sortable: `User.tags`, `User.teams`, `AssetGroup.tags`, `Document.tags`, `TagRule.assetGroups`. An `ORDER BY` on a to-many association cannot be rendered by Hibernate, so these flags could only ever produce a 500.
* **Guard** — `SortUtilsJpa` now refuses any `Collection`-typed property and raises `InvalidSortPropertyException`, which is already mapped to a **400** naming the offending property. This is the part that keeps the bug from coming back the next time a sortable column is added.
* **Frontend** — the three columns that offered the impossible sort no longer do: players `user_tags`, challenge documents `document_tags`, tag rules `tag_rule_asset_groups`.

Two deliberate exclusions:

* `InjectTarget.tags` and `PlayerTarget.teams` keep their flag. They are not JPA entities and their sort goes through `SearchAdaptorBase`, not `toSortJpa`, so clearing it would disable a sort that works.
* The guard targets `Collection` rather than everything the schema flags as `multiple`. `Scenario.dependencies` is a `text[]` column declared sortable, and it does fail — but for an unrelated reason (`for SELECT DISTINCT, ORDER BY expressions must appear in select list`). Catching it here would have reported a misleading cause and masked a separate defect. Its behaviour is unchanged from `main`; worth its own issue.

### Testing Instructions

1. Go to the players list and click the **Tags** column header. Before: an "Internal error" toast, then an empty list on the next visit. After: the column is no longer sortable.
2. Same on challenge documents (**Tags**) and on tag rules (**Asset Groups**).
3. Check the API refuses the sort cleanly instead of failing:

```
POST /api/players/search
{"page":0,"size":20,"sorts":[{"property":"user_tags","direction":"ASC"}]}

-> 400  {"message":"Unknown sort property 'user_tags', please try an other one"}
```

Before this change the same request returned a 500 with an `UnsupportedOperationException` and no usable message.

4. Sanity check that ordinary sorts are untouched: same endpoint with `user_email` still returns 200.

### Related issues

* Closes #7704

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (no user-facing behaviour is documented for column sorting)