### PR TITLE
fix(teams): lay out the tag filter with flexbox instead of floats (#5944)

### DIFF
--- a/openaev-front/src/admin/components/common/filters/TagsFilter.tsx
+++ b/openaev-front/src/admin/components/common/filters/TagsFilter.tsx
@@ -31,15 +31,16 @@ const TagsFilter: FunctionComponent<Props> = ({
     label: tag.tag_name,
     color: tag.tag_color,
   });
-  const tagsOptions = tags.map(tagTransform);
+  const tagsOptions = tags
+    .map(tagTransform)
+    .filter((option: Option) => !currentTags.some(currentTag => currentTag.id === option.id));
 
   return (
     <>
       <Autocomplete<Option>
         sx={{
           width: fullWidth ? '100%' : 250,
-          float: 'left',
-          marginRight: '10px',
+          flexShrink: 0,
         }}
         selectOnFocus
         openOnFocus
@@ -90,14 +91,16 @@ const TagsFilter: FunctionComponent<Props> = ({
         <Box
           component="div"
           sx={{
-            float: 'left',
-            mt: 0.5,
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            gap: 1,
+            minWidth: 0,
           }}
         >
           {currentTags.map(currentTag => (
             <Chip
               key={currentTag.id}
-              sx={{ marginRight: '10px' }}
               label={currentTag.label}
               onDelete={() => onRemoveTag?.(currentTag.id)}
             />

--- a/openaev-front/src/admin/components/components/teams/TeamAddPlayers.tsx
+++ b/openaev-front/src/admin/components/components/teams/TeamAddPlayers.tsx
@@ -106,14 +106,14 @@ const TeamAddPlayers: FunctionComponent<Props> = ({ addedUsersIds, teamId }) => 
   return (
     <div>
       <Can I={ACTIONS.MANAGE} a={SUBJECTS.TEAMS_AND_PLAYERS}>
-        <ButtonCreate onClick={() => setOpen(true)} label={t('Add players in this team')} />
+        <ButtonCreate onClick={() => setOpen(true)} label={t('Add players')} />
       </Can>
       {/* Inline dialog: TeamPlayers itself renders in a drawer (never drawer over drawer). */}
       <SelectListPicker<PlayerOutput>
         open={open}
         onClose={handleClose}
         onSubmit={submitAddUsers}
-        title={t('Add players in this team')}
+        title={t('Add players')}
         submitLabel={t('Add')}
         inline
         headerComponent={paginationComponent}

--- a/openaev-front/src/admin/components/components/teams/TeamPlayers.tsx
+++ b/openaev-front/src/admin/components/components/teams/TeamPlayers.tsx
@@ -238,7 +238,9 @@ const TeamPlayers: FunctionComponent<Props> = ({ teamId, handleClose, canManage,
             sx={{
               display: 'flex',
               alignItems: 'center',
+              flexWrap: 'wrap',
               gap: 1.5,
+              minWidth: 0,
             }}
           >
             <SearchFilter
@@ -259,10 +261,16 @@ const TeamPlayers: FunctionComponent<Props> = ({ teamId, handleClose, canManage,
             />
           </Box>
           {canManage && (
-            <TeamAddPlayers
-              teamId={teamId}
-              addedUsersIds={users.filter(u => !!u).map(u => u.user_id)}
-            />
+            <Box sx={{
+              alignSelf: 'flex-start',
+              flexShrink: 0,
+            }}
+            >
+              <TeamAddPlayers
+                teamId={teamId}
+                addedUsersIds={users.filter(u => !!u).map(u => u.user_id)}
+              />
+            </Box>
           )}
         </Box>
         <List classes={{ root: classes.container }}>

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "Fügen Sie den Mediendruck in dieser Injektion hinzu",
   "Add multiple items at once by separating them with commas.": "Fügen Sie mehrere Elemente auf einmal hinzu, indem Sie sie mit Kommas trennen.",
   "Add parent": "Elternteil hinzufugen",
-  "Add players in this team": "Spieler in dieser Mannschaft hinzufügen",
+  "Add players": "Spieler hinzufügen",
   "Add schedule": "Add schedule",
   "Add tags": "Tags hinzufügen",
   "Add tags to this scenario": "Tags zu diesem Szenario hinzufügen",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "Add media pressure in this inject",
   "Add multiple items at once by separating them with commas.": "Add multiple items at once by separating them with commas.",
   "Add parent": "Add parent",
-  "Add players in this team": "Add persons in this team",
+  "Add players": "Add players",
   "Add schedule": "Add schedule",
   "Add tags": "Add tags",
   "Add tags to this scenario": "Add tags to this scenario",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "Añadir medio de prensa en esta inyección",
   "Add multiple items at once by separating them with commas.": "Añada varios elementos a la vez separándolos con comas.",
   "Add parent": "Anadir padre",
-  "Add players in this team": "Añadir jugadores en este equipo",
+  "Add players": "Añadir jugadores",
   "Add schedule": "Add schedule",
   "Add tags": "Añadir etiquetas",
   "Add tags to this scenario": "Añadir etiquetas a este escenario",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "Ajouter de la pression médiatique dans ce stimuli",
   "Add multiple items at once by separating them with commas.": "Ajoutez plusieurs éléments à la fois en les séparant par des virgules.",
   "Add parent": "Ajouter un parent",
-  "Add players in this team": "Ajouter des joueurs dans cette équipe",
+  "Add players": "Ajouter des joueurs",
   "Add schedule": "Ajouter une planification",
   "Add tags": "Ajouter des étiquettes",
   "Add tags to this scenario": "Ajouter des tags à ce scenario",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "Aggiungere la pressione dei media in questo modo",
   "Add multiple items at once by separating them with commas.": "Aggiungete più elementi contemporaneamente separandoli con le virgole.",
   "Add parent": "Aggiungi genitore",
-  "Add players in this team": "Aggiungi giocatori in questa squadra",
+  "Add players": "Aggiungi giocatori",
   "Add schedule": "Add schedule",
   "Add tags": "Aggiungi tag",
   "Add tags to this scenario": "Aggiungi tag a questo scenario",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "このインジェクトにメディアプレッシャーを追加する",
   "Add multiple items at once by separating them with commas.": "カンマ区切りで複数の項目を一度に追加できます。",
   "Add parent": "親を追加",
-  "Add players in this team": "このチームにプレイヤーを追加する",
+  "Add players": "プレイヤーを追加",
   "Add schedule": "Add schedule",
   "Add tags": "タグを追加",
   "Add tags to this scenario": "このシナリオにタグを追加する",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "이 인젝트에 미디어 압력 추가",
   "Add multiple items at once by separating them with commas.": "쉼표로 구분하여 한 번에 여러 항목을 추가합니다.",
   "Add parent": "부모 추가",
-  "Add players in this team": "이 팀에 선수 추가",
+  "Add players": "선수 추가",
   "Add schedule": "Add schedule",
   "Add tags": "태그 추가",
   "Add tags to this scenario": "이 시나리오에 태그 추가",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "Добавьте давление в прессу при этом",
   "Add multiple items at once by separating them with commas.": "Добавляйте сразу несколько элементов, разделяя их запятыми.",
   "Add parent": "Добавить родителя",
-  "Add players in this team": "Добавить игроков в эту команду",
+  "Add players": "Добавить игроков",
   "Add schedule": "Add schedule",
   "Add tags": "Добавить теги",
   "Add tags to this scenario": "Добавить теги к этому сценарию",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -205,7 +205,7 @@
   "Add media pressure in this inject": "在此注入中加入媒体",
   "Add multiple items at once by separating them with commas.": "用逗号分隔，一次添加多个项目。",
   "Add parent": "添加父项",
-  "Add players in this team": "添加选手到这个团队",
+  "Add players": "添加选手",
   "Add schedule": "Add schedule",
   "Add tags": "添加标签",
   "Add tags to this scenario": "添加标记到这个场景",


### PR DESCRIPTION
### Proposed changes

`TagsFilter` laid itself out with `float: left`, inside containers that are already flex — the floats never applied, and nothing handled overflow. From the very first tag the chip list pushes the "add players" button out of the drawer and squeezes the two fields.

* Chip list: wrapping flex row with `gap` and `minWidth: 0`
* Autocomplete: `flexShrink: 0` instead of being the first thing squeezed
* Drawer filter row wraps, add button anchored with `alignSelf: flex-start`
* Manual margins dropped — all five callers already provide a `gap`
* An already selected tag is no longer offered: no caller de-duplicates, so picking one twice added a duplicate chip
* Button and dialog both read "Add players"; `Add players in this team` has no caller left and is removed from the nine locale files

### Testing Instructions

1. Team → ⋮ **Manage players** → select a tag: the button stays inside the drawer, the fields keep their width.
2. Add two more: chips wrap onto their own line instead of stretching the row.
3. Reopen the tag list: the selected tags are no longer offered.

### Related issues

* Closes #5944

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation