### PR TITLE
fix(lists): keep the pagination counter in step with the rows (#7710)

### DIFF
--- a/openaev-front/src/admin/components/components/teams/Teams.tsx
+++ b/openaev-front/src/admin/components/components/teams/Teams.tsx
@@ -188,7 +188,13 @@ const Teams = () => {
           <Box display="flex" gap={1} alignItems="center">
             <ExportButton totalElements={queryableHelpers.paginationHelpers.getTotalElements()} exportProps={exportProps} />
             <Can I={ACTIONS.MANAGE} a={SUBJECTS.TEAMS_AND_PLAYERS}>
-              <CreateTeam onCreate={result => setTeams([result, ...teams])} />
+              <CreateTeam onCreate={(result) => {
+                setTeams([result, ...teams]);
+                queryableHelpers.paginationHelpers.handleChangeTotalElements(
+                  queryableHelpers.paginationHelpers.getTotalElements() + 1,
+                );
+              }}
+              />
             </Can>
           </Box>
         )}
@@ -257,7 +263,12 @@ const Teams = () => {
                     team={team}
                     managePlayers={() => setSelectedTeam(team.team_id)}
                     onUpdate={result => onTeamUpdated(result)}
-                    onDelete={result => setTeams(teams.filter(v => (v.team_id !== result)))}
+                    onDelete={(result) => {
+                      setTeams(teams.filter(v => (v.team_id !== result)));
+                      queryableHelpers.paginationHelpers.handleChangeTotalElements(
+                        Math.max(0, queryableHelpers.paginationHelpers.getTotalElements() - 1),
+                      );
+                    }}
                     openEditOnInit={team.team_id === searchId}
                   />
                 )}

--- a/openaev-front/src/admin/components/teams/Players.tsx
+++ b/openaev-front/src/admin/components/teams/Players.tsx
@@ -181,7 +181,12 @@ const Players = () => {
             <ExportButton totalElements={queryableHelpers.paginationHelpers.getTotalElements()} exportProps={exportProps} />
             <Can I={ACTIONS.MANAGE} a={SUBJECTS.TEAMS_AND_PLAYERS}>
               <CreatePlayer
-                onCreate={result => setPlayers([result, ...players])}
+                onCreate={(result) => {
+                  setPlayers([result, ...players]);
+                  queryableHelpers.paginationHelpers.handleChangeTotalElements(
+                    queryableHelpers.paginationHelpers.getTotalElements() + 1,
+                  );
+                }}
               />
             </Can>
           </Box>
@@ -255,7 +260,12 @@ const Players = () => {
                           ...result,
                         }
                       : p)))}
-                    onDelete={result => setPlayers(players.filter(p => (p.user_id !== result)))}
+                    onDelete={(result) => {
+                      setPlayers(players.filter(p => (p.user_id !== result)));
+                      queryableHelpers.paginationHelpers.handleChangeTotalElements(
+                        Math.max(0, queryableHelpers.paginationHelpers.getTotalElements() - 1),
+                      );
+                    }}
                   />
                 )}
               >


### PR DESCRIPTION
### Proposed changes

The `X-Y of Z` counter kept its previous value after a create or a delete, while the row itself appeared or disappeared. Only a reload put it right.

Bulk delete already adjusted the total; the single create and single delete paths did not. Both now call `handleChangeTotalElements` the same way, on the players and the teams lists.

### Testing Instructions

1. Open the players list, note the counter, create a player: the counter now follows.
2. Delete a player from the row menu: same.
3. Repeat on the teams list.

### Related issues

* Closes #7710

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation