### PR TITLE
fix(ui): align the export and create buttons in list headers (#7711)

### DIFF
--- a/openaev-front/src/components/Theme.ts
+++ b/openaev-front/src/components/Theme.ts
@@ -218,6 +218,12 @@ export const LabelColorDict = {
 
 export const FONT_FAMILY_CODE = 'Consolas, monaco, monospace';
 
+// Shared height of the small inline controls that sit side by side in list
+// headers: toggle button groups and the create button. MUI gives a small
+// ToggleButton and a small contained Button different metrics, so the two only
+// line up if they are pinned to the same value.
+export const INLINE_CONTROL_HEIGHT = 36;
+
 // === Design System Palette Types ===
 
 type MainPalette = {

--- a/openaev-front/src/components/ThemeDark.ts
+++ b/openaev-front/src/components/ThemeDark.ts
@@ -4,7 +4,7 @@ import LogoCollapsed from '../static/images/logo_dark.png';
 import LogoText from '../static/images/logo_text_dark.png';
 import { hexToRGB } from '../utils/Colors';
 import { fileUri } from '../utils/Environment';
-import { FONT_FAMILY_CODE, type LabelColor, LabelColorDict } from './Theme';
+import { FONT_FAMILY_CODE, INLINE_CONTROL_HEIGHT, type LabelColor, LabelColorDict } from './Theme';
 
 // Aligned with OpenCTI's dark theme (opencti-front/src/components/ThemeDark.ts):
 // same default palette, typography, and component overrides, so both platforms
@@ -444,7 +444,7 @@ const ThemeDark = (
       defaultProps: { size: 'small' },
       styleOverrides: {
         root: {
-          'height': 36,
+          'height': INLINE_CONTROL_HEIGHT,
           '& .MuiTouchRipple-root': { display: 'none' },
           '& .MuiToggleButton-root': {
             'border': '1px solid #2B3447',

--- a/openaev-front/src/components/ThemeLight.ts
+++ b/openaev-front/src/components/ThemeLight.ts
@@ -4,7 +4,7 @@ import LogoCollapsed from '../static/images/logo_light.png';
 import LogoText from '../static/images/logo_text_light.png';
 import { hexToRGB } from '../utils/Colors';
 import { fileUri } from '../utils/Environment';
-import { FONT_FAMILY_CODE, type LabelColor, LabelColorDict } from './Theme';
+import { FONT_FAMILY_CODE, INLINE_CONTROL_HEIGHT, type LabelColor, LabelColorDict } from './Theme';
 
 // Aligned with OpenCTI's light theme (opencti-front/src/components/ThemeLight.ts):
 // same default palette, typography, and component overrides, so both platforms
@@ -445,7 +445,7 @@ const ThemeLight = (
       defaultProps: { size: 'small' },
       styleOverrides: {
         root: {
-          'height': 36,
+          'height': INLINE_CONTROL_HEIGHT,
           '& .MuiTouchRipple-root': { display: 'none' },
           '& .MuiToggleButton-root': {
             'border': '1px solid #D2D2D2',

--- a/openaev-front/src/components/common/ButtonCreate.tsx
+++ b/openaev-front/src/components/common/ButtonCreate.tsx
@@ -3,6 +3,7 @@ import { Button, Tooltip } from '@mui/material';
 import { type FunctionComponent } from 'react';
 
 import { useFormatter } from '../i18n';
+import { INLINE_CONTROL_HEIGHT } from '../Theme';
 
 interface Props {
   onClick: () => void;
@@ -33,7 +34,7 @@ const ButtonCreate: FunctionComponent<Props> = ({ onClick, style, label, disable
       sx={{
         whiteSpace: 'nowrap',
         flexShrink: 0,
-        minHeight: 36,
+        minHeight: INLINE_CONTROL_HEIGHT,
       }}
     >
       {label ?? t('Create')}

--- a/openaev-front/src/components/common/ButtonCreate.tsx
+++ b/openaev-front/src/components/common/ButtonCreate.tsx
@@ -33,6 +33,7 @@ const ButtonCreate: FunctionComponent<Props> = ({ onClick, style, label, disable
       sx={{
         whiteSpace: 'nowrap',
         flexShrink: 0,
+        minHeight: 36,
       }}
     >
       {label ?? t('Create')}

--- a/openaev-front/src/components/common/ExportButton.tsx
+++ b/openaev-front/src/components/common/ExportButton.tsx
@@ -49,7 +49,7 @@ const ExportButton = <T extends object>({ totalElements, exportProps, exportCsvM
 
   const exportBtn = (enableOnClick: boolean) => (
     <Tooltip title={t('Export this list')}>
-      <span>
+      <span style={{ display: 'inline-flex' }}>
         <ToggleButton value="export" aria-label="export" size="small" disabled={totalElements === 0} onClick={enableOnClick ? exportCsvMapperAction : undefined}>
           <FileDownloadOutlined
             color={totalElements === 0 ? 'disabled' : 'primary'}


### PR DESCRIPTION
### Proposed changes

The two controls share every list header but not their metrics: a small MUI `ToggleButton` is 36px tall where a small contained `Button` is 30.75px, so the export square overhung the create button by roughly 2px on each side.

* The create button is pinned to the toggle height, rather than shrinking the toggles: on the assets screens the export button is grouped with an import button, and shrinking one of them breaks the pair apart.
* That 36px was already written in the theme, on `MuiToggleButtonGroup`, in both the dark and the light variant — and the button repeated it a third time. It becomes `INLINE_CONTROL_HEIGHT`, exported from `Theme.ts` and used by the two themes and the button, so the controls can no longer drift apart.
* The tooltip wrapper around the export button becomes `inline-flex` — a bare inline span adds the line-height gap of a text box under the control.

`theme.spacing(4.5)` would also have produced 36, but by coincidence: the value comes from the metrics of a small MUI `ToggleButton`, not from the spacing scale, and the link would break silently if the scale factor changed.

### Testing Instructions

1. Open the players or teams list: export and create share the same height and baseline.
2. Open **Assets**, where the export button is grouped with the import button: all three line up.
3. Switch between the light and dark themes: both read the height from the same constant.

### Related issues

* Closes #7711

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation