### PR TITLE
fix(teams): match the hero stat labels to their count (#7715)

### DIFF
--- a/openaev-front/src/admin/components/teams/teams/TeamDetail.tsx
+++ b/openaev-front/src/admin/components/teams/teams/TeamDetail.tsx
@@ -64,6 +64,7 @@ const withFilter = (input: SearchPaginationInput, key: string, values: string[])
 // the findings linked to the team. Compact and grid-based.
 const TeamDetail = () => {
   const { t, fldt } = useFormatter();
+  const countLabel = (count: number, singular: string, plural: string) => t(count === 1 ? singular : plural);
   const bodyItemsStyles = useBodyItemsStyles();
   const theme = useTheme();
   const navigate = useNavigate();
@@ -237,11 +238,11 @@ const TeamDetail = () => {
           )}
           stats={(
             <>
-              <HeroStat icon={PersonOutlined} label={t('Players')} value={team.team_users_number ?? players.length} color={theme.palette.success.main} />
-              <HeroStat icon={HubOutlined} label={t('Simulations')} value={team.team_exercises?.length ?? 0} color={theme.palette.primary.main} />
-              <HeroStat icon={AssignmentOutlined} label={t('Scenarios')} value={team.team_scenarios?.length ?? 0} color={theme.palette.secondary.main} />
-              <HeroStat icon={TrackChangesOutlined} label={t('Simulation injects')} value={team.team_exercise_injects_number ?? 0} color={theme.palette.warning.main} />
-              <HeroStat icon={TrackChangesOutlined} label={t('Expectations')} value={team.team_injects_expectations_number ?? 0} />
+              <HeroStat icon={PersonOutlined} label={countLabel(team.team_users_number ?? players.length, 'Player', 'Players')} value={team.team_users_number ?? players.length} color={theme.palette.success.main} />
+              <HeroStat icon={HubOutlined} label={countLabel(team.team_exercises?.length ?? 0, 'Simulation', 'Simulations')} value={team.team_exercises?.length ?? 0} color={theme.palette.primary.main} />
+              <HeroStat icon={AssignmentOutlined} label={countLabel(team.team_scenarios?.length ?? 0, 'Scenario', 'Scenarios')} value={team.team_scenarios?.length ?? 0} color={theme.palette.secondary.main} />
+              <HeroStat icon={TrackChangesOutlined} label={countLabel(team.team_exercise_injects_number ?? 0, 'Simulation inject', 'Simulation injects')} value={team.team_exercise_injects_number ?? 0} color={theme.palette.warning.main} />
+              <HeroStat icon={TrackChangesOutlined} label={countLabel(team.team_injects_expectations_number ?? 0, 'Expectation', 'Expectations')} value={team.team_injects_expectations_number ?? 0} />
               <HeroStat icon={TrackChangesOutlined} label={t('Score')} value={scoreLabel} />
             </>
           )}

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "FUSSZEILE DER SIMULATION",
   "SIMULATION HEADER": "SIMULATION KOPFZEILE",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "Die Simulation ist derzeit nicht verfügbar oder Sie haben keine ausreichenden Berechtigungen, um darauf zuzugreifen.",
   "Simulation logs": "Protokolle der Simulation",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "SIMULATION FOOTER",
   "SIMULATION HEADER": "SIMULATION HEADER",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "Simulation is currently unavailable or you do not have sufficient permissions to access it.",
   "Simulation logs": "Simulation logs",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "PIE DE SIMULACIÓN",
   "SIMULATION HEADER": "ENCABEZADO DE LA SIMULACIÓN",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "La simulación no está disponible actualmente o no dispone de permisos suficientes para acceder a ella.",
   "Simulation logs": "Registros de simulación",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "PIED DE PAGE DE SIMULATION",
   "SIMULATION HEADER": "EN-TÊTE DE SIMULATION",
   "Simulation id": "Id de simulation",
+  "Simulation inject": "Injection de simulation",
   "Simulation injects": "Injections de simulation",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "La simulation est actuellement indisponible ou vous n'avez pas les autorisations nécessaires pour y accéder.",
   "Simulation logs": "Journal de la simulation",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "PIÈ DI PAGINA DELLA SIMULAZIONE",
   "SIMULATION HEADER": "INTESTAZIONE DELLA SIMULAZIONE",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "La simulazione non è attualmente disponibile o non si dispone di permessi sufficienti per accedervi.",
   "Simulation logs": "Registri della simulazione",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "シミュレーションフッター",
   "SIMULATION HEADER": "シミュレーション・ヘッダー",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "シミュレーションは現在利用できません。",
   "Simulation logs": "シミュレーションログ",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "시뮬레이션 바닥글",
   "SIMULATION HEADER": "시뮬레이션 헤더",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "현재 시뮬레이션을 사용할 수 없거나 액세스할 수 있는 권한이 충분하지 않습니다.",
   "Simulation logs": "시뮬레이션 로그",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "НИЖНИЙ КОЛОНТИТУЛ СИМУЛЯЦИИ",
   "SIMULATION HEADER": "ВЕРХНИЙ КОЛОНТИТУЛ СИМУЛЯЦИИ",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "Симуляция в настоящее время недоступна или у вас нет достаточных прав для доступа к ней.",
   "Simulation logs": "Журналы симуляции",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -3357,6 +3357,7 @@
   "SIMULATION FOOTER": "模拟页脚",
   "SIMULATION HEADER": "模拟标头",
   "Simulation id": "Simulation id",
+  "Simulation inject": "Simulation inject",
   "Simulation injects": "Simulation injects",
   "Simulation is currently unavailable or you do not have sufficient permissions to access it.": "模拟当前不可用，或您没有足够的权限进行访问。",
   "Simulation logs": "模拟日志",


### PR DESCRIPTION
### Proposed changes

The stat labels on a team page were hardcoded plural, so a team with a single member read "1 PLAYERS". The five counters now pick the singular below two.

`Simulation inject` had no singular key and is added to the nine locale files.

### Testing Instructions

1. Open a team with exactly one member: the header reads "1 player".
2. Add a second: it reads "2 players".

### Related issues

* Closes #7715

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation