### PR TITLE
feat(audit-log): introduce hard delete + insert of tokens when renew and audit (#7491)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -29,10 +29,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -130,17 +128,7 @@ public class MeApi extends RestBehavior {
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   @Transactional(rollbackFor = Exception.class)
   public Token renewToken(@Valid @RequestBody RenewTokenInput input) {
-    User user =
-        userRepository
-            .findById(currentUser().getId())
-            .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
-    Token token =
-        tokenRepository.findById(input.getTokenId()).orElseThrow(ElementNotFoundException::new);
-    if (!user.equals(token.getUser())) {
-      throw new AccessDeniedException("You are not allowed to renew this token");
-    }
-    token.setValue(UUID.randomUUID().toString());
-    return tokenRepository.save(token);
+    return userService.renewUserToken(input.getTokenId());
   }
 
   @GetMapping(ME_URI + "/tenants")

--- a/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
+++ b/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
@@ -62,7 +62,7 @@ public class InitAdminCommandLineRunner implements CommandLineRunner {
     User adminUser = adminUserOptional.map(this::updateUser).orElseGet(this::createUser);
 
     // Handle admin token
-    Optional<Token> adminToken = this.tokenRepository.findById(ADMIN_TOKEN_UUID);
+    Optional<Token> adminToken = this.tokenRepository.findByUserId(adminUser.getId());
     adminToken.ifPresentOrElse(this::updateToken, () -> this.createToken(adminUser));
 
     // Ensure the admin user holds full administrative privileges through well-known groups: a

--- a/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
+++ b/openaev-api/src/main/java/io/openaev/runner/InitAdminCommandLineRunner.java
@@ -62,7 +62,8 @@ public class InitAdminCommandLineRunner implements CommandLineRunner {
     User adminUser = adminUserOptional.map(this::updateUser).orElseGet(this::createUser);
 
     // Handle admin token
-    Optional<Token> adminToken = this.tokenRepository.findByUserId(adminUser.getId());
+    Optional<Token> adminToken =
+        this.tokenRepository.findFirstByUserIdOrderByCreatedAsc(adminUser.getId());
     adminToken.ifPresentOrElse(this::updateToken, () -> this.createToken(adminUser));
 
     // Ensure the admin user holds full administrative privileges through well-known groups: a

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -499,16 +499,9 @@ public class UserService {
     return createdToken;
   }
 
-  /**
-   * Delete an existing API token
-   *
-   * @param user the user to create a token for
-   * @param discreteToken the specific token value to use
-   * @return the created token
-   */
+  /** Delete an existing API token */
   public void deleteUserToken(Token token) {
     tokenRepository.delete(token);
-    ;
     logTokenDeleted(token);
   }
 
@@ -560,7 +553,7 @@ public class UserService {
   }
 
   /**
-   * Emits an audit event for a token creation.
+   * Emits an audit event for a token deleted.
    *
    * @param token the token that was deleted
    */

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -6,6 +6,10 @@ import static io.openaev.utils.pagination.CriteriaBuilderPagination.paginate;
 import static io.openaev.utils.pagination.PaginationUtils.buildPaginationCriteriaBuilder;
 import static java.time.Instant.now;
 
+import io.openaev.aop.audit_log.AuditEvent;
+import io.openaev.aop.audit_log.AuditEventOrigin;
+import io.openaev.aop.audit_log.AuditEventScope;
+import io.openaev.aop.audit_log.AuditLogger;
 import io.openaev.api.users.dto.UserInput;
 import io.openaev.api.users.dto.UserOutput;
 import io.openaev.config.DefaultOpenAEVPrincipal;
@@ -39,14 +43,10 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
@@ -104,6 +104,7 @@ public class UserService {
   private final RandomUtils randomUtils;
   private final TenantMembershipCacheManager tenantMembershipCacheManager;
   private final TenantScopedTransaction tenantTx;
+  private final ObjectProvider<AuditLogger> auditLoggerProvider;
 
   /** Cache for admin users to improve lookup performance. */
   private Cache adminCache;
@@ -492,7 +493,55 @@ public class UserService {
     token.setUser(user);
     token.setCreated(now());
     token.setValue(discreteToken);
-    return tokenRepository.save(token);
+    Token createdToken = tokenRepository.save(token);
+    logTokenCreated(createdToken);
+    return createdToken;
+  }
+
+  public Token renewUserToken(String tokenId) {
+    User user =
+        userRepository
+            .findById(currentUser().getId())
+            .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
+    Token token = tokenRepository.findById(tokenId).orElseThrow(ElementNotFoundException::new);
+    if (!user.equals(token.getUser())) {
+      throw new AccessDeniedException("You are not allowed to renew this token");
+    }
+
+    tokenRepository.delete(token);
+
+    return createUserToken(user, UUID.randomUUID().toString());
+  }
+
+  /**
+   * Emits an audit event for a token creation.
+   *
+   * @param createdToken the token that was created
+   */
+  private void logTokenCreated(Token createdToken) {
+    AuditLogger auditLogger = auditLoggerProvider.getIfAvailable();
+    if (auditLogger == null) {
+      return;
+    }
+    User actor = currentUserOrNull();
+    String tokenUserId = createdToken.getUser() != null ? createdToken.getUser().getId() : null;
+    Map<String, Object> contextData = new LinkedHashMap<>();
+    contextData.put("token_id", createdToken.getId());
+    contextData.put("token_user_id", tokenUserId);
+    contextData.put("actor_user_id", actor != null ? actor.getId() : null);
+    contextData.put("token_created_at", createdToken.getCreated());
+
+    auditLogger.logEvent(
+        AuditEvent.builder()
+            .eventType(EventType.MUTATION)
+            .eventScope(AuditEventScope.CREATE)
+            .eventStatus(EventStatus.SUCCESS)
+            .resourceType(ResourceType.TOKEN)
+            .resourceId(createdToken.getId())
+            .contextData(contextData)
+            .message("User token created")
+            .origin(actor != null ? AuditEventOrigin.REQUEST : AuditEventOrigin.SYSTEM)
+            .build());
   }
 
   public Optional<User> findByTokenAndTenantId(

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -43,6 +43,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
@@ -498,6 +499,19 @@ public class UserService {
     return createdToken;
   }
 
+  /**
+   * Delete an existing API token
+   *
+   * @param user the user to create a token for
+   * @param discreteToken the specific token value to use
+   * @return the created token
+   */
+  public void deleteUserToken(Token token) {
+    tokenRepository.delete(token);
+    ;
+    logTokenDeleted(token);
+  }
+
   public Token renewUserToken(String tokenId) {
     User user =
         userRepository
@@ -509,6 +523,7 @@ public class UserService {
     }
 
     tokenRepository.delete(token);
+    deleteUserToken(token);
 
     return createUserToken(user, UUID.randomUUID().toString());
   }
@@ -540,6 +555,37 @@ public class UserService {
             .resourceId(createdToken.getId())
             .contextData(contextData)
             .message("User token created")
+            .origin(actor != null ? AuditEventOrigin.REQUEST : AuditEventOrigin.SYSTEM)
+            .build());
+  }
+
+  /**
+   * Emits an audit event for a token creation.
+   *
+   * @param token the token that was deleted
+   */
+  private void logTokenDeleted(Token token) {
+    AuditLogger auditLogger = auditLoggerProvider.getIfAvailable();
+    if (auditLogger == null) {
+      return;
+    }
+    User actor = currentUserOrNull();
+    String tokenUserId = token.getUser() != null ? token.getUser().getId() : null;
+    Map<String, Object> contextData = new LinkedHashMap<>();
+    contextData.put("token_id", token.getId());
+    contextData.put("token_user_id", tokenUserId);
+    contextData.put("actor_user_id", actor != null ? actor.getId() : null);
+    contextData.put("token_deleted_at", Instant.now());
+
+    auditLogger.logEvent(
+        AuditEvent.builder()
+            .eventType(EventType.MUTATION)
+            .eventScope(AuditEventScope.DELETE)
+            .eventStatus(EventStatus.SUCCESS)
+            .resourceType(ResourceType.TOKEN)
+            .resourceId(token.getId())
+            .contextData(contextData)
+            .message("User token deleted")
             .origin(actor != null ? AuditEventOrigin.REQUEST : AuditEventOrigin.SYSTEM)
             .build());
   }

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -514,8 +514,6 @@ public class UserService {
     if (!user.equals(token.getUser())) {
       throw new AccessDeniedException("You are not allowed to renew this token");
     }
-
-    tokenRepository.delete(token);
     deleteUserToken(token);
 
     return createUserToken(user, UUID.randomUUID().toString());

--- a/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerTest.java
+++ b/openaev-api/src/test/java/io/openaev/aop/audit_log/AuditLoggerTest.java
@@ -3,6 +3,7 @@ package io.openaev.aop.audit_log;
 import static io.openaev.aop.audit_log.AuditLogTestHelper.setupFileAppender;
 import static io.openaev.aop.audit_log.AuditLogTestHelper.teardownFileAppender;
 import static io.openaev.rest.team.TeamApi.TEAM_URI;
+import static io.openaev.rest.user.MeApi.ME_URI;
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -11,10 +12,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.BannerMessage;
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.Team;
+import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.TeamRepository;
 import io.openaev.database.repository.UserRepository;
@@ -23,9 +26,11 @@ import io.openaev.rest.team.form.TeamUpdateInput;
 import io.openaev.rest.user.form.login.LoginUserInput;
 import io.openaev.service.PlatformSettingsService;
 import io.openaev.service.PreviewFeatureService;
+import io.openaev.service.UserService;
 import io.openaev.utils.fixtures.TeamFixture;
 import io.openaev.utils.fixtures.UserFixture;
 import io.openaev.utils.fixtures.composers.UserComposer;
+import io.openaev.utils.mockUser.TestUserHolder;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,6 +69,8 @@ class AuditLoggerTest extends IntegrationTest {
   @Autowired private UserComposer userComposer;
   @Autowired private TeamRepository teamRepository;
   @Autowired private AuditLogger auditLogger;
+  @Autowired private UserService userService;
+  @Autowired private TestUserHolder testUserHolder;
 
   @MockitoBean private EnterpriseEditionService enterpriseEditionService;
   @MockitoBean private PreviewFeatureService previewFeatureService;
@@ -241,6 +248,50 @@ class AuditLoggerTest extends IntegrationTest {
       throws Exception {
     AuditLogTestHelper.assertAuditLogDoesNotContainNewContent(
         AUDIT_LOG_FILE, sizeBefore, unexpectedSnippet);
+  }
+
+  @Nested
+  @DisplayName("Token renewal endpoint")
+  class TokenRenewalEndpoint {
+
+    @Test
+    @WithMockUser
+    @DisplayName("Given a token renewal should audit both the deletion and the creation")
+    void given_tokenRenewal_should_logDeletionAndCreationEvents() throws Exception {
+      // Arrange — renewing hard-deletes the row and issues a new one, so the rotation must stay
+      // reconstructable from the audit trail alone.
+      Token previousToken =
+          userService.createUserToken(testUserHolder.get(), UUID.randomUUID().toString());
+      String previousTokenId = previousToken.getId();
+      long sizeBefore = Files.exists(AUDIT_LOG_FILE) ? Files.size(AUDIT_LOG_FILE) : 0L;
+
+      // Act
+      String response =
+          mvc.perform(
+                  post(ME_URI + "/token/refresh")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"token_id\":\"" + previousTokenId + "\"}")
+                      .with(csrf()))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // Assert
+      String renewedTokenId = JsonPath.read(response, "$.token_id");
+      assertThat(renewedTokenId).isNotEqualTo(previousTokenId);
+
+      String auditLog =
+          AuditLogTestHelper.assertAuditLogContainsNewContent(
+              AUDIT_LOG_FILE, sizeBefore, "User token deleted", "User token created");
+      assertThat(auditLog).contains("\"event_scope\" : \"delete\"");
+      assertThat(auditLog).contains("\"event_scope\" : \"create\"");
+      // The revoked token is traceable by id...
+      assertThat(auditLog).contains(previousTokenId);
+      assertThat(auditLog).contains(renewedTokenId);
+      // ...but its secret value must never reach the audit trail.
+      assertThat(auditLog).doesNotContain(previousToken.getValue());
+    }
   }
 
   @Nested

--- a/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
@@ -6,7 +6,10 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
+import io.openaev.database.model.Token;
+import io.openaev.database.repository.TokenRepository;
 import jakarta.servlet.http.Cookie;
 import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AppSecurityConfigTest extends IntegrationTest {
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private TokenRepository tokenRepository;
 
   @Value("${openbas.admin.token:${openaev.admin.token:#{null}}}")
   private String adminToken;
@@ -188,5 +192,51 @@ public class AppSecurityConfigTest extends IntegrationTest {
 
     assertThat(result.getResponse().getCookie("JSESSIONID")).isNull();
     assertThat(result.getRequest().getSession(false)).isNull();
+  }
+
+  @Test
+  @DisplayName("given renewed token, should reject old bearer and accept new bearer")
+  void given_renewedToken_should_reject_old_bearer_and_accept_new_bearer() throws Exception {
+    // -- ARRANGE --
+    Token currentAdminToken = tokenRepository.findByValue(adminToken).orElseThrow();
+    String refreshBody =
+        """
+        {
+          "token_id": "%s"
+        }
+        """
+            .formatted(currentAdminToken.getId());
+
+    // -- ACT --
+    MvcResult refreshResult =
+        mockMvc
+            .perform(
+                post("/api/me/token/refresh")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(refreshBody))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String refreshedToken =
+        JsonPath.read(refreshResult.getResponse().getContentAsString(), "$.token_value");
+    assertThat(refreshedToken).isNotBlank().isNotEqualTo(adminToken);
+
+    // -- ASSERT --
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY))
+        .andExpect(status().isUnauthorized());
+
+    mockMvc
+        .perform(
+            post(SCENARIO_SEARCH_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + refreshedToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(SEARCH_BODY))
+        .andExpect(status().isOk());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
+++ b/openaev-api/src/test/java/io/openaev/runner/InitAdminCommandLineRunnerTest.java
@@ -3,6 +3,7 @@ package io.openaev.runner;
 import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
 import static io.openaev.database.model.Token.ADMIN_TOKEN_UUID;
 import static io.openaev.database.model.User.ADMIN_UUID;
+import static io.openaev.database.specification.TokenSpecification.fromUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.openaev.IntegrationTest;
@@ -13,16 +14,22 @@ import io.openaev.database.model.User;
 import io.openaev.database.repository.TokenRepository;
 import io.openaev.database.repository.UserRepository;
 import io.openaev.service.AbstractPrivilegeService;
+import io.openaev.service.UserService;
 import io.openaev.service.account.AdminPrivilegeService;
 import io.openaev.utilstest.RabbitMQTestListener;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @TestExecutionListeners(
@@ -36,6 +43,15 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
   @Autowired private TokenRepository tokenRepository;
 
   @Autowired private AdminPrivilegeService adminPrivilegeService;
+
+  @Autowired private InitAdminCommandLineRunner initAdminCommandLineRunner;
+
+  @Autowired private UserService userService;
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Value("${openbas.admin.token:${openaev.admin.token:#{null}}}")
+  private String configuredAdminToken;
 
   @DisplayName("Test if admin user is created")
   @Test
@@ -116,5 +132,38 @@ public class InitAdminCommandLineRunnerTest extends IntegrationTest {
     assertThat(platformAdminGroup.getRoles())
         .anyMatch(role -> role.getCapabilities().contains(Capability.BYPASS));
     assertThat(adminUser.hasPlatformBypass()).isTrue();
+  }
+
+  @DisplayName("A renewed admin token is reused at bootstrap instead of minting a second one")
+  @Test
+  @Transactional
+  void given_renewedAdminToken_should_reuseItInsteadOfMintingASecondOne() throws Exception {
+    // Arrange — renewUserToken() acts on behalf of the authenticated user, so the admin must own
+    // the security context. Cleared in the finally block: the other tests of this class run
+    // unauthenticated and the context is thread-bound.
+    Token renewedAdminToken;
+    this.userService.createAdminSession();
+    try {
+      renewedAdminToken = this.userService.renewUserToken(ADMIN_TOKEN_UUID);
+    } finally {
+      SecurityContextHolder.clearContext();
+    }
+    this.entityManager.flush();
+
+    // The rotation is a hard delete followed by an insert, so the well-known bootstrap id is gone.
+    assertThat(renewedAdminToken.getId()).isNotEqualTo(ADMIN_TOKEN_UUID);
+
+    // Act
+    this.initAdminCommandLineRunner.run();
+    this.entityManager.flush();
+    this.entityManager.clear();
+
+    // Assert
+    List<Token> adminTokens = this.tokenRepository.findAll(fromUser(ADMIN_UUID));
+    assertThat(adminTokens)
+        .as("the bootstrap must not mint an extra admin token on every restart")
+        .hasSize(1);
+    assertThat(adminTokens.getFirst().getId()).isEqualTo(renewedAdminToken.getId());
+    assertThat(adminTokens.getFirst().getValue()).isEqualTo(this.configuredAdminToken);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/UserServiceTest.java
@@ -7,12 +7,16 @@ import io.openaev.IntegrationTest;
 import io.openaev.api.users.dto.UserInput;
 import io.openaev.database.model.Group;
 import io.openaev.database.model.Tenant;
+import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.GroupRepository;
+import io.openaev.database.repository.TokenRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
 import io.openaev.utils.fixtures.composers.UserComposer;
 import io.openaev.utils.fixtures.tenants.TenantComposer;
 import io.openaev.utils.fixtures.tenants.TenantFixture;
+import io.openaev.utils.mockUser.TestUserHolder;
+import io.openaev.utils.mockUser.WithMockUser;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
@@ -21,6 +25,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -31,6 +36,8 @@ class UserServiceTest extends IntegrationTest {
   @Autowired private UserComposer userComposer;
   @Autowired private TenantComposer tenantComposer;
   @Autowired private GroupRepository groupRepository;
+  @Autowired private TokenRepository tokenRepository;
+  @Autowired private TestUserHolder testUserHolder;
   @PersistenceContext private EntityManager entityManager;
 
   // -- CREATE --
@@ -361,6 +368,61 @@ class UserServiceTest extends IntegrationTest {
 
     // -- ASSERT --
     assertThatThrownBy(() -> userService.user(persisted.getId()))
+        .isInstanceOf(ElementNotFoundException.class);
+  }
+
+  // -- TOKENS --
+
+  @Test
+  @WithMockUser
+  @DisplayName("given_ownToken_should_hardDeleteItAndIssueANewOne")
+  void given_ownToken_should_hardDeleteItAndIssueANewOne() {
+    // -- ARRANGE --
+    User currentUser = testUserHolder.get();
+    Token previousToken = userService.createUserToken(currentUser, UUID.randomUUID().toString());
+    String previousTokenId = previousToken.getId();
+    String previousTokenValue = previousToken.getValue();
+
+    // -- ACT --
+    Token renewedToken = userService.renewUserToken(previousTokenId);
+    entityManager.flush();
+    entityManager.clear();
+
+    // -- ASSERT --
+    assertThat(renewedToken.getId()).isNotNull().isNotEqualTo(previousTokenId);
+    assertThat(renewedToken.getValue()).isNotBlank().isNotEqualTo(previousTokenValue);
+    assertThat(renewedToken.getUser().getId()).isEqualTo(currentUser.getId());
+
+    // The row is deleted, not updated: neither the old id nor the old value resolve anymore.
+    assertThat(tokenRepository.findById(previousTokenId)).isEmpty();
+    assertThat(tokenRepository.findByValue(previousTokenValue)).isEmpty();
+    assertThat(tokenRepository.findByValue(renewedToken.getValue())).isPresent();
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("given_tokenOwnedByAnotherUser_should_throwAccessDenied")
+  void given_tokenOwnedByAnotherUser_should_throwAccessDenied() {
+    // -- ARRANGE --
+    User otherUser =
+        userComposer
+            .forUser(getUser("Other", "Owner", UUID.randomUUID() + "@test.invalid"))
+            .persist()
+            .get();
+    Token foreignToken = userService.createUserToken(otherUser, UUID.randomUUID().toString());
+
+    // -- ACT & ASSERT --
+    assertThatThrownBy(() -> userService.renewUserToken(foreignToken.getId()))
+        .isInstanceOf(AccessDeniedException.class);
+    assertThat(tokenRepository.findById(foreignToken.getId())).isPresent();
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("given_unknownTokenId_should_throwElementNotFound")
+  void given_unknownTokenId_should_throwElementNotFound() {
+    // -- ACT & ASSERT --
+    assertThatThrownBy(() -> userService.renewUserToken(UUID.randomUUID().toString()))
         .isInstanceOf(ElementNotFoundException.class);
   }
 }

--- a/openaev-front/src/actions/users/User.js
+++ b/openaev-front/src/actions/users/User.js
@@ -1,3 +1,4 @@
+import { DATA_DELETE_SUCCESS } from '../../constants/ActionTypes';
 import { delReferential, getReferential, postReferential, putReferential, simpleCall, simplePostCall } from '../../utils/Action';
 import * as schema from '../Schema';
 
@@ -56,5 +57,15 @@ export const updateMeProfile = data => dispatch => putReferential(schema.user, '
 
 export const updateMeInformation = data => dispatch => putReferential(schema.user, '/api/me/information', data)(dispatch);
 
-export const renewToken = tokenId => dispatch => postReferential(schema.token, '/api/me/token/refresh', { token_id: tokenId })(dispatch);
+export const renewToken = tokenId => dispatch => postReferential(schema.token, '/api/me/token/refresh', { token_id: tokenId })(dispatch)
+  .then((data) => {
+    dispatch({
+      type: DATA_DELETE_SUCCESS,
+      payload: {
+        type: 'tokens',
+        id: tokenId,
+      },
+    });
+    return data;
+  });
 // endregion

--- a/openaev-front/src/utils/api-types.d.ts
+++ b/openaev-front/src/utils/api-types.d.ts
@@ -7893,6 +7893,7 @@ export interface NotificationTriggerInput {
     | "STEP"
     | "CONDITION"
     | "SESSION"
+    | "TOKEN"
     | "PLATFORM_SESSION"
     | "SKIP_RBAC";
   /** Digest firing time (UTC): DAY=HH:mm, WEEK=<1-7>-HH:mm, MONTH=<1-31>-HH:mm */
@@ -7998,6 +7999,7 @@ export interface NotificationTriggerOutput {
     | "STEP"
     | "CONDITION"
     | "SESSION"
+    | "TOKEN"
     | "PLATFORM_SESSION"
     | "SKIP_RBAC";
   /** Digest firing time (UTC) */

--- a/openaev-model/src/main/java/io/openaev/database/model/ResourceType.java
+++ b/openaev-model/src/main/java/io/openaev/database/model/ResourceType.java
@@ -67,6 +67,7 @@ public enum ResourceType {
   CONDITION,
   // Auth related
   SESSION,
+  TOKEN,
   PLATFORM_SESSION,
   SKIP_RBAC; // Used to skip RBAC checks.
 

--- a/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
@@ -20,6 +20,8 @@ public interface TokenRepository
 
   Optional<Token> findByValue(String value);
 
+  Optional<Token> findByUserId(String value);
+
   /**
    * Oldest (most stable) API token of a user. Used by the reporting renderer to authenticate the
    * headless browser as the acting user; the token value never leaves the server process.

--- a/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
@@ -20,8 +20,6 @@ public interface TokenRepository
 
   Optional<Token> findByValue(String value);
 
-  Optional<Token> findByUserId(String value);
-
   /**
    * Oldest (most stable) API token of a user. Used by the reporting renderer to authenticate the
    * headless browser as the acting user; the token value never leaves the server process.


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Introducing a hard delete as we're expecting it would be enough for our current need
*

### Testing Instructions

1. Renew a token
2. Check the audit log is logging a delete and a create of the token

### Related issues

* Related #7585 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
