### PR TITLE
fix(rbac): set the tenant scope before the permission check runs

### DIFF
--- a/openaev-api/src/main/java/io/openaev/aop/AccessControlAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/AccessControlAspect.java
@@ -33,7 +33,10 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Aspect
 @Component
-@Order(Ordered.LOWEST_PRECEDENCE) // Inner to audit aspect (LOWEST_PRECEDENCE - 1)
+// Innermost of the chain: inner to the audit aspect (LP-1) and, crucially, to both tenant scoping
+// aspects (LP-3 / LP-2). The permission check below loads entities to resolve a resource's parent,
+// so it must never run before the tenant scope of its own transaction has been written.
+@Order(Ordered.LOWEST_PRECEDENCE)
 @RequiredArgsConstructor
 @Slf4j
 public class AccessControlAspect {

--- a/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/audit_log/AccessControlAuditLogAspect.java
@@ -52,10 +52,11 @@ import org.springframework.web.server.ResponseStatusException;
  * "unauthorized" audit event before being re-thrown.
  *
  * <p>The aspect order is {@code LOWEST_PRECEDENCE - 1} so it runs <b>inside</b> the transaction
- * boundary ({@code LOWEST_PRECEDENCE - 2}) and <b>outside</b> the RBAC aspect ({@code
- * LOWEST_PRECEDENCE}). When halt-on-failure is active and the audit transport fails, the thrown
- * {@link AuditLogFailureException} propagates through the transaction interceptor, which rolls back
- * the mutation.
+ * boundary ({@code LOWEST_PRECEDENCE - 4}) and the tenant scoping aspects ({@code LOWEST_PRECEDENCE
+ * - 3} / {@code - 2}), and <b>outside</b> the RBAC aspect ({@code LOWEST_PRECEDENCE}). When
+ * halt-on-failure is active and the audit transport fails, the thrown {@link
+ * AuditLogFailureException} propagates through the transaction interceptor, which rolls back the
+ * mutation.
  *
  * <p>Phase 1: delegates to {@link io.openaev.service.LogService} for console-only output.
  */

--- a/openaev-api/src/main/java/io/openaev/aop/lock/LockAspect.java
+++ b/openaev-api/src/main/java/io/openaev/aop/lock/LockAspect.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 @Order(
-    Ordered.LOWEST_PRECEDENCE - 3) // Execute before @Transactional (LP-2), so the lock wraps the tx
+    Ordered.LOWEST_PRECEDENCE - 5) // Execute before @Transactional (LP-4), so the lock wraps the tx
 public class LockAspect {
 
   private final ConcurrentHashMap<LockResourceType, Striped<Lock>> lockStripes;

--- a/openaev-api/src/main/java/io/openaev/config/AppConfig.java
+++ b/openaev-api/src/main/java/io/openaev/config/AppConfig.java
@@ -25,9 +25,10 @@ import org.springframework.web.client.RestTemplate;
 @Component
 @EnableAsync
 @EnableScheduling
-// The transaction advisor runs just inside @Lock and just outside the audit aspect,
-// so the chain is lock -> tx -> audit -> scope/rbac.
-@EnableTransactionManagement(order = Ordered.LOWEST_PRECEDENCE - 2)
+// The transaction advisor runs just inside @Lock and just outside the tenant scope aspects,
+// so the chain is lock -> tx -> tenant filter -> tenant scope -> audit -> rbac. The scope must be
+// written before the RBAC check, which reads entities of its own (see AccessControlAspect).
+@EnableTransactionManagement(order = Ordered.LOWEST_PRECEDENCE - 4)
 public class AppConfig {
 
   static {

--- a/openaev-api/src/test/java/io/openaev/config/TenantScopeLockOrderingIntegrationTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantScopeLockOrderingIntegrationTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.openaev.aop.AccessControlAspect;
+import io.openaev.aop.HibernateFilterTransactionAspect;
+import io.openaev.aop.TenantScopeTransactionAspect;
 import io.openaev.aop.audit_log.AccessControlAuditLogAspect;
 import io.openaev.aop.lock.Lock;
 import io.openaev.aop.lock.LockAspect;
@@ -36,9 +38,9 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
- * Proves the precedence chain {@code @Lock -> transaction -> tenant scope} holds for a method that
- * carries all three. Two properties matter and both are checked against a real Spring context and a
- * real database, no mocks:
+ * Proves the precedence chain {@code @Lock -> transaction -> tenant scope -> audit -> RBAC} holds
+ * for a method that carries all three. Two properties matter and both are checked against a real
+ * Spring context and a real database, no mocks:
  *
  * <ul>
  *   <li>the tenant scope is set <b>inside</b> the active transaction even when {@code @Lock} is
@@ -61,13 +63,14 @@ class TenantScopeLockOrderingIntegrationTest {
 
   @Test
   @DisplayName(
-      "the transaction advisor really sits at LOWEST_PRECEDENCE - 2 (the order is effective)")
+      "the transaction advisor really sits at LOWEST_PRECEDENCE - 4 (the order is effective)")
   void transactionAdvisorOrderIsApplied() {
     assertEquals(
-        Ordered.LOWEST_PRECEDENCE - 2,
+        Ordered.LOWEST_PRECEDENCE - 4,
         transactionAdvisor.getOrder(),
         "@EnableTransactionManagement(order=...) must actually move the advisor; otherwise the lock"
-            + " -> tx -> audit -> scope ordering is illusory and still rests on an undefined tie-break");
+            + " -> tx -> scope -> audit -> rbac ordering is illusory and still rests on an undefined"
+            + " tie-break");
   }
 
   @Test
@@ -122,11 +125,14 @@ class TenantScopeLockOrderingIntegrationTest {
   }
 
   @Test
-  @DisplayName("aspect ordering: Lock < Transaction < Audit < RBAC (no ties)")
+  @DisplayName(
+      "aspect ordering: Lock < Transaction < TenantFilter < TenantScope < Audit < RBAC (no ties)")
   void given_allAspects_should_respectStrictRelativeOrdering() {
     // Arrange
     int lockOrder = getOrderValue(LockAspect.class);
     int transactionOrder = transactionAdvisor.getOrder();
+    int tenantFilterOrder = getOrderValue(HibernateFilterTransactionAspect.class);
+    int tenantScopeOrder = getOrderValue(TenantScopeTransactionAspect.class);
     int auditOrder = getOrderValue(AccessControlAuditLogAspect.class);
     int rbacOrder = getOrderValue(AccessControlAspect.class);
 
@@ -135,7 +141,18 @@ class TenantScopeLockOrderingIntegrationTest {
         .as("LockAspect must wrap @Transactional (lower order)")
         .isLessThan(transactionOrder);
     assertThat(transactionOrder)
-        .as("@Transactional must wrap AuditLogAspect (lower order)")
+        .as("@Transactional must wrap the tenant filter aspect (lower order)")
+        .isLessThan(tenantFilterOrder);
+    assertThat(tenantFilterOrder)
+        .as("the v1 tenant filter must be installed before the v2 tenant scope (lower order)")
+        .isLessThan(tenantScopeOrder);
+    assertThat(tenantScopeOrder)
+        .as(
+            "the tenant scope must wrap AuditLogAspect, and through it the RBAC aspect:"
+                + " AccessControlAspect resolves a resource's parent by loading the entity, inside"
+                + " this same transaction. Tied on LOWEST_PRECEDENCE that read could win and"
+                + " hydrate v2-scoped associations as null (fail-closed can_access_tenant) before"
+                + " the scope existed, and the controller would then serve the partial entity.")
         .isLessThan(auditOrder);
     assertThat(auditOrder)
         .as("AuditLogAspect must wrap AccessControlAspect (lower order)")

--- a/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
@@ -1,0 +1,148 @@
+package io.openaev.rest.atomic_testing;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.context.TenantContext;
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
+import io.openaev.database.model.Capability;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.InjectorContract;
+import io.openaev.utils.TenantIsolationTestHelper;
+import io.openaev.utils.fixtures.ExerciseFixture;
+import io.openaev.utils.fixtures.InjectFixture;
+import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.composers.ExerciseComposer;
+import io.openaev.utils.fixtures.composers.InjectComposer;
+import io.openaev.utils.fixtures.composers.InjectorContractComposer;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Behavioural companion of {@link io.openaev.config.TenantScopeLockOrderingIntegrationTest}: that
+ * test pins the aspect order, this one pins what the order is for.
+ *
+ * <p>{@code GET /atomic-testings/{injectId}} serves simulation injects too and carries a {@code
+ * TxCtx}, so the tenant scope IS set for its transaction. The bug was purely one of order: tied on
+ * {@code LOWEST_PRECEDENCE}, {@code AccessControlAspect} could run before the scoping advices of
+ * the same transaction. For an INJECT it resolves the parent simulation by loading the inject
+ * itself, which eagerly walks {@code injectorContract -> injectorLinks -> injector}; with {@code
+ * injectors} v2-activated and no scope yet, {@code can_access_tenant} denied the row (fail-closed),
+ * {@code @NotFound(IGNORE)} hydrated the association as null, and that null stayed cached in the
+ * persistence context. The endpoint then served a 200 with {@code inject_type: null} and the
+ * frontend, which gates the whole "Results by target" panel on that field, rendered an empty
+ * column.
+ *
+ * <p>Two properties of this test are load-bearing:
+ *
+ * <ul>
+ *   <li><b>non-admin</b>: {@code hasPermission} returns at {@code user.isAdmin()} before ever
+ *       resolving the parent, so an admin caller cannot reach the poisoning read;
+ *   <li><b>not {@code @Transactional}</b>: a test-managed transaction would pre-hydrate the seeded
+ *       entities in the shared persistence context, so the endpoint would never issue the read that
+ *       gets poisoned. Seeding commits through the tenant-scoped primitive and is undone in
+ *       {@code @AfterEach}.
+ * </ul>
+ */
+@TestPropertySource(properties = "openaev.tenant.active-tables=injectors")
+@WithMockUser(isAdmin = false)
+@DisplayName("A non-admin reading a simulation inject gets a resolved inject_type")
+class AtomicTestingApiNonAdminTenantScopeTest extends IntegrationTest {
+
+  private static final String DETAIL = "/api/tenants/{tenantId}/atomic-testings/{injectId}";
+  private static final Set<Capability> ACCESS_ASSESSMENT = Set.of(Capability.ACCESS_ASSESSMENT);
+
+  @Autowired private MockMvc mvc;
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private TenantIsolationTestHelper tenantHelper;
+  @Autowired private TenantScopedTransaction tenantTx;
+  @Autowired private ExerciseComposer exerciseComposer;
+  @Autowired private InjectComposer injectComposer;
+  @Autowired private InjectorContractComposer injectorContractComposer;
+
+  private String tenantA;
+  private String injectId;
+  private String injectorId;
+  private String injectorContractId;
+  private String expectedInjectType;
+
+  @BeforeEach
+  void seedSimulationInjectInTenant() throws Exception {
+    tenantA =
+        tenantHelper.createTenantWithCapabilities("at-rbac-scope-a", ACCESS_ASSESSMENT).getId();
+
+    inTenant(
+        tenantA,
+        () -> {
+          InjectorContract contract = InjectorContractFixture.createDefaultInjectorContract();
+          injectorContractId = contract.getId();
+          injectorId = contract.getFirstInjector().getId();
+          expectedInjectType = contract.getFirstInjector().getType();
+
+          Inject inject = InjectFixture.getInjectWithoutContract();
+          exerciseComposer
+              .forExercise(ExerciseFixture.createDefaultExercise())
+              .withInject(
+                  injectComposer
+                      .forInject(inject)
+                      .withInjectorContract(injectorContractComposer.forInjectorContract(contract)))
+              .persist();
+          injectId = inject.getId();
+          return null;
+        });
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (injectId != null) {
+      jdbc.update("DELETE FROM injects WHERE inject_id = ?", injectId);
+    }
+    if (tenantA != null) {
+      jdbc.update("DELETE FROM exercises WHERE tenant_id = ?", tenantA);
+      jdbc.update(
+          "DELETE FROM injectors_injector_contracts WHERE injector_contract_id = ?",
+          injectorContractId);
+      jdbc.update(
+          "DELETE FROM injectors_contracts WHERE injector_contract_id = ?", injectorContractId);
+      jdbc.update("DELETE FROM injectors WHERE injector_id = ?", injectorId);
+      tenantHelper.deleteCommittedTenants(tenantA);
+    }
+    TenantContext.clearCurrentTenant();
+  }
+
+  @Test
+  @DisplayName("inject_type resolves through the v2-scoped injectors table, it is not served null")
+  void nonAdminSimulationInjectReadResolvesInjectType() throws Exception {
+    mvc.perform(get(DETAIL, tenantA, injectId).with(csrf()))
+        .andExpect(status().is2xxSuccessful())
+        .andExpect(jsonPath("$.inject_type").value(expectedInjectType));
+  }
+
+  private <T> T inTenant(String tenantId, Supplier<T> work) {
+    String previousTenant =
+        TenantContext.hasCurrentTenant() ? TenantContext.getCurrentTenant() : null;
+    TenantContext.setCurrentTenant(tenantId);
+    try {
+      return tenantTx.execute(TxCtx.forTenant(tenantId), work);
+    } finally {
+      if (previousTenant == null) {
+        TenantContext.clearCurrentTenant();
+      } else {
+        TenantContext.setCurrentTenant(previousTenant);
+      }
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
@@ -10,12 +10,12 @@ import io.openaev.context.TenantContext;
 import io.openaev.context.TenantScopedTransaction;
 import io.openaev.context.TxCtx;
 import io.openaev.database.model.Capability;
-import io.openaev.database.model.Inject;
-import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.Injector;
 import io.openaev.utils.TenantIsolationTestHelper;
 import io.openaev.utils.fixtures.ExerciseFixture;
 import io.openaev.utils.fixtures.InjectFixture;
 import io.openaev.utils.fixtures.InjectorContractFixture;
+import io.openaev.utils.fixtures.InjectorFixture;
 import io.openaev.utils.fixtures.composers.ExerciseComposer;
 import io.openaev.utils.fixtures.composers.InjectComposer;
 import io.openaev.utils.fixtures.composers.InjectorContractComposer;
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -38,9 +37,9 @@ class AtomicTestingApiNonAdminTenantScopeTest extends IntegrationTest {
 
   private static final String DETAIL = "/api/tenants/{tenantId}/atomic-testings/{injectId}";
   private static final Set<Capability> ACCESS_ASSESSMENT = Set.of(Capability.ACCESS_ASSESSMENT);
+  private static final String INJECTOR_NAME = "at rbac scope injector";
 
   @Autowired private MockMvc mvc;
-  @Autowired private JdbcTemplate jdbc;
   @Autowired private TenantIsolationTestHelper tenantHelper;
   @Autowired private TenantScopedTransaction tenantTx;
   @Autowired private ExerciseComposer exerciseComposer;
@@ -49,9 +48,8 @@ class AtomicTestingApiNonAdminTenantScopeTest extends IntegrationTest {
 
   private String tenantA;
   private String injectId;
-  private String injectorId;
-  private String injectorContractId;
-  private String expectedInjectType;
+  private String injectorType;
+  private ExerciseComposer.Composer simulation;
 
   @BeforeEach
   void seedSimulationInjectInTenant() throws Exception {
@@ -61,39 +59,38 @@ class AtomicTestingApiNonAdminTenantScopeTest extends IntegrationTest {
     inTenant(
         tenantA,
         () -> {
-          InjectorContract contract = InjectorContractFixture.createDefaultInjectorContract();
-          injectorContractId = contract.getId();
-          injectorId = contract.getFirstInjector().getId();
-          expectedInjectType = contract.getFirstInjector().getType();
+          Injector injector = InjectorFixture.createDefaultInjector(INJECTOR_NAME);
+          injectorType = injector.getType();
 
-          Inject inject = InjectFixture.getInjectWithoutContract();
-          exerciseComposer
-              .forExercise(ExerciseFixture.createDefaultExercise())
-              .withInject(
-                  injectComposer
-                      .forInject(inject)
-                      .withInjectorContract(injectorContractComposer.forInjectorContract(contract)))
-              .persist();
-          injectId = inject.getId();
+          InjectComposer.Composer inject =
+              injectComposer
+                  .forInject(InjectFixture.getInjectWithoutContract())
+                  .withInjectorContract(
+                      injectorContractComposer
+                          .forInjectorContract(
+                              InjectorContractFixture.createDefaultInjectorContract())
+                          .withInjector(injector));
+          simulation =
+              exerciseComposer
+                  .forExercise(ExerciseFixture.createDefaultExercise())
+                  .withInject(inject)
+                  .persist();
+          injectId = inject.get().getId();
           return null;
         });
   }
 
   @AfterEach
   void cleanup() {
-    if (injectId != null) {
-      jdbc.update("DELETE FROM injects WHERE inject_id = ?", injectId);
+    if (simulation != null) {
+      inTenant(
+          tenantA,
+          () -> {
+            simulation.delete();
+            return null;
+          });
     }
-    if (tenantA != null) {
-      jdbc.update("DELETE FROM exercises WHERE tenant_id = ?", tenantA);
-      jdbc.update(
-          "DELETE FROM injectors_injector_contracts WHERE injector_contract_id = ?",
-          injectorContractId);
-      jdbc.update(
-          "DELETE FROM injectors_contracts WHERE injector_contract_id = ?", injectorContractId);
-      jdbc.update("DELETE FROM injectors WHERE injector_id = ?", injectorId);
-      tenantHelper.deleteCommittedTenants(tenantA);
-    }
+    tenantHelper.deleteCommittedTenants(tenantA);
     TenantContext.clearCurrentTenant();
   }
 
@@ -102,7 +99,7 @@ class AtomicTestingApiNonAdminTenantScopeTest extends IntegrationTest {
   void nonAdminSimulationInjectReadResolvesInjectType() throws Exception {
     mvc.perform(get(DETAIL, tenantA, injectId).with(csrf()))
         .andExpect(status().is2xxSuccessful())
-        .andExpect(jsonPath("$.inject_type").value(expectedInjectType));
+        .andExpect(jsonPath("$.inject_type").value(injectorType));
   }
 
   private <T> T inTenant(String tenantId, Supplier<T> work) {

--- a/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
@@ -31,14 +31,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
-/**
- * Guards the behaviour whose aspect order {@link
- * io.openaev.config.TenantScopeLockOrderingIntegrationTest} pins: with {@code injectors}
- * v2-activated, a non-admin read of a simulation inject must resolve {@code inject_type} instead of
- * serving it null. Non-admin because {@code hasPermission} returns at {@code isAdmin()} before
- * resolving the inject's parent, and transaction-free because a test-managed transaction
- * pre-hydrates the seeded entities, leaving the endpoint no read to poison.
- */
 @TestPropertySource(properties = "openaev.tenant.active-tables=injectors")
 @WithMockUser(isAdmin = false)
 @DisplayName("A non-admin reading a simulation inject gets a resolved inject_type")

--- a/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/atomic_testing/AtomicTestingApiNonAdminTenantScopeTest.java
@@ -32,30 +32,12 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
- * Behavioural companion of {@link io.openaev.config.TenantScopeLockOrderingIntegrationTest}: that
- * test pins the aspect order, this one pins what the order is for.
- *
- * <p>{@code GET /atomic-testings/{injectId}} serves simulation injects too and carries a {@code
- * TxCtx}, so the tenant scope IS set for its transaction. The bug was purely one of order: tied on
- * {@code LOWEST_PRECEDENCE}, {@code AccessControlAspect} could run before the scoping advices of
- * the same transaction. For an INJECT it resolves the parent simulation by loading the inject
- * itself, which eagerly walks {@code injectorContract -> injectorLinks -> injector}; with {@code
- * injectors} v2-activated and no scope yet, {@code can_access_tenant} denied the row (fail-closed),
- * {@code @NotFound(IGNORE)} hydrated the association as null, and that null stayed cached in the
- * persistence context. The endpoint then served a 200 with {@code inject_type: null} and the
- * frontend, which gates the whole "Results by target" panel on that field, rendered an empty
- * column.
- *
- * <p>Two properties of this test are load-bearing:
- *
- * <ul>
- *   <li><b>non-admin</b>: {@code hasPermission} returns at {@code user.isAdmin()} before ever
- *       resolving the parent, so an admin caller cannot reach the poisoning read;
- *   <li><b>not {@code @Transactional}</b>: a test-managed transaction would pre-hydrate the seeded
- *       entities in the shared persistence context, so the endpoint would never issue the read that
- *       gets poisoned. Seeding commits through the tenant-scoped primitive and is undone in
- *       {@code @AfterEach}.
- * </ul>
+ * Guards the behaviour whose aspect order {@link
+ * io.openaev.config.TenantScopeLockOrderingIntegrationTest} pins: with {@code injectors}
+ * v2-activated, a non-admin read of a simulation inject must resolve {@code inject_type} instead of
+ * serving it null. Non-admin because {@code hasPermission} returns at {@code isAdmin()} before
+ * resolving the inject's parent, and transaction-free because a test-managed transaction
+ * pre-hydrates the seeded entities, leaving the endpoint no read to poison.
  */
 @TestPropertySource(properties = "openaev.tenant.active-tables=injectors")
 @WithMockUser(isAdmin = false)

--- a/openaev-model/src/main/java/io/openaev/aop/HibernateFilterTransactionAspect.java
+++ b/openaev-model/src/main/java/io/openaev/aop/HibernateFilterTransactionAspect.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.hibernate.Session;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,9 +16,14 @@ import org.springframework.stereotype.Component;
  *
  * <p>Native SQL queries must manually include {@code WHERE tenant_id = :tenantId} since the
  * Hibernate filter does not apply to native queries.
+ *
+ * <p>Ordered inside the transaction advisor but <b>outside</b> the RBAC aspect: the permission
+ * check loads entities of its own, so leaving this advice tied with it on {@code LOWEST_PRECEDENCE}
+ * let an unfiltered read win the tie and hydrate the persistence context before the filter existed.
  */
 @Aspect
 @Component
+@Order(Ordered.LOWEST_PRECEDENCE - 3)
 @RequiredArgsConstructor
 public class HibernateFilterTransactionAspect {
 

--- a/openaev-model/src/main/java/io/openaev/aop/TenantScopeTransactionAspect.java
+++ b/openaev-model/src/main/java/io/openaev/aop/TenantScopeTransactionAspect.java
@@ -34,6 +34,15 @@ import org.springframework.stereotype.Component;
  * never reach the method. The integration test pins this down for the propagations the application
  * actually uses (REQUIRED, REQUIRES_NEW, read-only).
  *
+ * <p>It must equally run <em>before</em> the RBAC aspect, which is why the order is explicit rather
+ * than {@code LOWEST_PRECEDENCE}. {@code AccessControlAspect} resolves a resource's parent by
+ * loading the entity itself, inside this same transaction; tied on {@code LOWEST_PRECEDENCE} the
+ * two advices had an undefined relative order, and when RBAC won the tie its read ran with no
+ * scope. Rows of v2-scoped tables then failed {@code can_access_tenant} (fail-closed) and were
+ * hydrated as null into the persistence context, which the controller happily served afterwards -
+ * an authorized user silently reading a partial entity (e.g. {@code inject_type} coming back null
+ * on an atomic testing).
+ *
  * <p>Within one transaction the scope is set once. A nested {@code @Transactional} method that
  * would <em>change</em> an already-set scope is refused (a programming error), while one that
  * repeats the same set of tenants is tolerated. A nested method that needs a different scope must
@@ -42,8 +51,9 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 @RequiredArgsConstructor
-// Innermost of the chain: it runs as a @Before once the transaction advisor has opened the tx.
-@Order(Ordered.LOWEST_PRECEDENCE)
+// Inside the transaction advisor (LP-4) so it runs as a @Before once the tx is open, and outside
+// the RBAC aspect (LP) so the scope exists before the permission check reads anything.
+@Order(Ordered.LOWEST_PRECEDENCE - 2)
 public class TenantScopeTransactionAspect {
 
   private final EntityManager entityManager;


### PR DESCRIPTION
## Facts

A non-admin caller with `ACCESS_ASSESSMENT` reads a simulation inject and gets **200 with `inject_type: null`**. The frontend gates the whole "Results by target" panel on that field, so the column renders empty — no results, no empty state, no error. Same user, same session:

| Endpoint | RBAC path | Result |
|---|---|---|
| `GET /injector_contracts/{id}` | pure mapping, no entity load | 200, `injector_contract_injector_type: "openaev_implant"` |
| `GET /atomic-testings/{injectId}` | `resolveTarget`, **loads the Inject** | 200, `inject_type: null` |

Admins are never affected.

## Cause

The permission check ran before the tenant scope was set.

`resolveTarget` loads the `Inject` to check permissions on it. At that point `app.current_tenants` was still empty, so the tenant filter denied the `injectors` rows (fail-closed). `@NotFound(IGNORE)` turned the missing association into `null`, that `null` stayed in the persistence context, and the controller served it.

The order was undefined: `TenantScopeTransactionAspect` and `AccessControlAspect` were both on `Ordered.LOWEST_PRECEDENCE` (a tie Spring breaks arbitrarily) and `HibernateFilterTransactionAspect` had no `@Order` at all. Admins short-circuit at `user.isAdmin()` before `resolveTarget`, which is why only non-admins hit it.

## Fix

An explicit order for every advice, no ties: lock `LP-5` → transaction `LP-4` → tenant filter `LP-3` → tenant scope `LP-2` → audit `LP-1` → rbac `LP`. `@Lock` still wraps the transaction, audit still wraps RBAC. No production logic changed.

`TenantScopeLockOrderingIntegrationTest` asserted the chain but omitted the two scoping aspects — the tied pair; it now covers all of them.

## Review note

- The transaction boundary moves two slots: anything ordered between `LP-4` and `LP-2` would now sit outside the transaction. Nothing else in the codebase uses that band.
- No functional regression test: I wrote one and it passed with the old `@Order` too. `AtomicTestingApiTenantIsolationTest` is `@Transactional`, so MockMvc requests share one transaction and the create request's scope is still set when the detail request runs. A real guard needs a non-transactional test (one transaction per request) — test-infrastructure work, out of scope here. The existing `detailExposesInjectTypeUnderV2Activation` covers this field but runs `isAdmin = true`, which is why the suite never saw it.
