### PR TITLE
fix(octi): fix redirection link (#7284)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/migration/V6_20260902100000000__Fix_duplicated_slash_in_external_urls.java
+++ b/openaev-api/src/main/java/io/openaev/migration/V6_20260902100000000__Fix_duplicated_slash_in_external_urls.java
@@ -1,0 +1,49 @@
+package io.openaev.migration;
+
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.stereotype.Component;
+
+/**
+ * Data backfill for external URLs containing duplicated slashes.
+ *
+ * <p>When the configured OpenCTI base URL ended with a trailing {@code /}, the concatenation with
+ * the relative path produced URLs such as {@code https://opencti.local//dashboard/id/xxx}. The
+ * concatenation is now normalised in {@code SecurityCoverageService}, but rows persisted before the
+ * fix keep the extra slash.
+ *
+ * <p>This migration rewrites {@code security_coverages.security_coverage_external_url} and {@code
+ * scenarios.scenario_external_url}: the scheme separator ({@code ://}) is preserved as-is and every
+ * remaining sequence of consecutive slashes in the path is collapsed into a single one. Only rows
+ * actually affected are updated, which makes the migration idempotent.
+ */
+@Component
+public class V6_20260902100000000__Fix_duplicated_slash_in_external_urls extends BaseJavaMigration {
+
+  /** Matches the scheme part of an absolute URL, e.g. {@code https://}. */
+  private static final String SCHEME_PATTERN = "^[a-zA-Z][a-zA-Z0-9+.-]*://";
+
+  private static String normalizeUrlStatement(String table, String column) {
+    return """
+        UPDATE %s
+        SET %s = substring(%s from '%s')
+                 || regexp_replace(substring(%s from '%s(.*)$'), '/{2,}', '/', 'g')
+        WHERE %s ~ '%s.*//';
+        """
+        .formatted(
+            table, column, column, SCHEME_PATTERN, column, SCHEME_PATTERN, column, SCHEME_PATTERN);
+  }
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      // 1. Security coverages external URLs (built from the OpenCTI base URL).
+      statement.execute(
+          normalizeUrlStatement("security_coverages", "security_coverage_external_url"));
+
+      // 2. Scenario external URLs (propagated from the same source).
+      statement.execute(normalizeUrlStatement("scenarios", "scenario_external_url"));
+    }
+  }
+}

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -6,6 +6,7 @@ import static io.openaev.helper.UrlHelper.buildFrontSimulationUrl;
 import static io.openaev.rest.payload.service.PayloadService.DYNAMIC_DNS_RESOLUTION_HOSTNAME_KEY;
 import static io.openaev.stix.objects.constants.CommonProperties.MODIFIED;
 import static io.openaev.utils.constants.StixConstants.*;
+import static org.apache.commons.lang3.StringUtils.stripEnd;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -165,10 +166,7 @@ public class SecurityCoverageService {
                     new ConnectorError(
                         "No active OpenCTI connector found for tenant %s".formatted(tenantId)));
 
-    if (openCtiUrl.endsWith("/")) {
-      openCtiUrl = openCtiUrl.substring(0, openCtiUrl.length() - 1);
-    }
-    securityCoverage.setExternalUrl(openCtiUrl + "/dashboard/id/" + coveredRef);
+    securityCoverage.setExternalUrl(stripEnd(openCtiUrl, "/") + "/dashboard/id/" + coveredRef);
 
     // Optional fields
     stixCoverageObj.setIfPresent(STIX_DESCRIPTION, securityCoverage::setDescription);

--- a/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
+++ b/openaev-api/src/main/java/io/openaev/service/stix/SecurityCoverageService.java
@@ -164,6 +164,10 @@ public class SecurityCoverageService {
                 () ->
                     new ConnectorError(
                         "No active OpenCTI connector found for tenant %s".formatted(tenantId)));
+
+    if (openCtiUrl.endsWith("/")) {
+      openCtiUrl = openCtiUrl.substring(0, openCtiUrl.length() - 1);
+    }
     securityCoverage.setExternalUrl(openCtiUrl + "/dashboard/id/" + coveredRef);
 
     // Optional fields


### PR DESCRIPTION
### Proposed changes

* Fix the external links for OCTI

### Testing Instructions

1. Create a scenario on OAEV using the interconnection with OCTI
2. On the OAEV side, on the scenario page click the link who do a redirection to OCTI
3. You should reach the OCTI page, on the report

### Related issues

* Related #7284 
