### PR TITLE
fix(channels): keep the live preview alive while a color is typed (#7771)

### DIFF
--- a/openaev-front/src/admin/components/components/channels/ChannelPreview.tsx
+++ b/openaev-front/src/admin/components/components/channels/ChannelPreview.tsx
@@ -4,6 +4,7 @@ import { alpha } from '@mui/material/styles';
 import { type FunctionComponent, type ReactNode } from 'react';
 
 import { type Document } from '../../../../utils/api-types';
+import { colorOrFallback } from '../../../../utils/Colors';
 import { buildTenantApiPath } from '../../../../utils/url-helper';
 
 // The preview renders the channel exactly as readers will see it, in the
@@ -93,8 +94,8 @@ const MockCard = ({ surface, children }: {
 
 const ChannelPreview: FunctionComponent<Props> = ({ channel, mode }) => {
   const surface = SURFACES[mode];
-  const primary = (mode === 'dark' ? channel.channel_primary_color_dark : channel.channel_primary_color_light) || surface.text;
-  const secondary = (mode === 'dark' ? channel.channel_secondary_color_dark : channel.channel_secondary_color_light) || surface.muted;
+  const primary = colorOrFallback(mode === 'dark' ? channel.channel_primary_color_dark : channel.channel_primary_color_light, surface.text);
+  const secondary = colorOrFallback(mode === 'dark' ? channel.channel_secondary_color_dark : channel.channel_secondary_color_light, surface.muted);
   const logo = mode === 'dark' ? channel.logoDark : channel.logoLight;
   const showLogo = channel.channel_mode !== 'title' && !!logo;
   const showTitle = channel.channel_mode !== 'logo' || !logo;

--- a/openaev-front/src/utils/Colors.ts
+++ b/openaev-front/src/utils/Colors.ts
@@ -74,3 +74,8 @@ export const getSeverityAndColor = (score: number | string | null | undefined): 
     color: '#607d8b',
   };
 };
+
+const HEX_COLOR = /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+export const colorOrFallback = (color: string | null | undefined, fallback: string): string =>
+  color?.trim().match(HEX_COLOR)?.[0] ?? fallback;


### PR DESCRIPTION
Closes #7771.

Channel > Configuration, typing #ff5722 character by character: on the very first # the live preview throws inside MUI's alpha(), the error boundary unmounts the whole panel and a reload is needed. The native color picker is unaffected, since it only ever emits complete values.

ChannelParametersForm streams every keystroke to the preview through watch(), so ChannelPreview sees half-typed values and passed them straight to alpha(): alpha('#') resolves to decomposeColor('') and throws, and the existing || surface.text guard never fired because '#' is truthy.

colorOrFallback(color, fallback) in utils/Colors.ts now takes a complete hex (3/4/6/8 digits) as is, runs other notations through decomposeColor() under try/catch, and rejects truncated ones such as rgb(255, 87) on their missing or NaN channels — MUI does not throw on those, but they render as broken CSS. ChannelPreview runs both colors through it and falls back to the surface default until the value is complete. Unit tests on the helper, plus a ChannelPreview render test over the whole # to #ff5722 keystroke sequence, verified failing on main.

Review note: #ff5 and #ff57 are valid CSS hex colors, so the preview briefly shows a yellow-green while #ff5722 is being typed — that is the input being complete but not finished, not a fallback.
