### PR TITLE
fix(challenges): serve the scenario challenge reads on the tenant path (#7770)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/scenario/ScenarioChallengesApi.java
@@ -1,5 +1,6 @@
 package io.openaev.rest.scenario;
 
+import static io.openaev.config.TenantUriUtils.TENANT_PREFIX;
 import static io.openaev.helper.StreamHelper.fromIterable;
 
 import io.openaev.aop.AccessControl;
@@ -40,7 +41,10 @@ public class ScenarioChallengesApi extends RestBehavior {
     return documentService.getPlayerDocuments(articles, injects);
   }
 
-  @GetMapping("/api/player/scenarios/{scenarioId}/documents")
+  @GetMapping({
+    "/api/player/scenarios/{scenarioId}/documents",
+    TENANT_PREFIX + "/player/scenarios/{scenarioId}/documents"
+  })
   @Transactional
   @AccessControl(skipRBAC = true)
   @UrlAccessControl(userId = "#userId")
@@ -61,7 +65,10 @@ public class ScenarioChallengesApi extends RestBehavior {
     }
   }
 
-  @GetMapping("/api/observer/scenarios/{scenarioId}/challenges")
+  @GetMapping({
+    "/api/observer/scenarios/{scenarioId}/challenges",
+    TENANT_PREFIX + "/observer/scenarios/{scenarioId}/challenges"
+  })
   @Transactional
   @AccessControl(
       resourceId = "#scenarioId",

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioChallengesApiTenantPathTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/ScenarioChallengesApiTenantPathTest.java
@@ -1,0 +1,64 @@
+package io.openaev.rest.scenario;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.openaev.IntegrationTest;
+import io.openaev.database.model.Scenario;
+import io.openaev.database.repository.ScenarioRepository;
+import io.openaev.utils.TenantIsolationTestHelper;
+import io.openaev.utils.mockUser.WithMockUser;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The frontend rewrites every /api/ call to /api/tenants/{tenantId}/..., so an endpoint that only
+ * declares the legacy path answers 404 and the screen calling it never loads.
+ */
+@Transactional
+@WithMockUser(isAdmin = true)
+@DisplayName("ScenarioChallengesApi serves the player and observer reads on the tenant path")
+class ScenarioChallengesApiTenantPathTest extends IntegrationTest {
+
+  private static final String OBSERVER_CHALLENGES =
+      "/api/tenants/{tenantId}/observer/scenarios/{scenarioId}/challenges";
+  private static final String PLAYER_DOCUMENTS =
+      "/api/tenants/{tenantId}/player/scenarios/{scenarioId}/documents";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private TenantIsolationTestHelper tenantHelper;
+
+  @MockitoBean private ScenarioRepository scenarioRepository;
+
+  private String tenantId;
+
+  @BeforeEach
+  void seedTenantAndScenario() throws Exception {
+    tenantId = tenantHelper.createTenantWithCurrentUser("scenario-challenges-tenant").getId();
+    when(scenarioRepository.findByIdAndTenantId(anyString(), anyString()))
+        .thenReturn(Optional.of(new Scenario()));
+  }
+
+  @Test
+  @DisplayName("the observer challenges of a scenario are readable under the tenant path")
+  void observerChallengesUnderTenantPath() throws Exception {
+    mvc.perform(get(OBSERVER_CHALLENGES, tenantId, UUID.randomUUID().toString()))
+        .andExpect(status().is2xxSuccessful());
+  }
+
+  @Test
+  @DisplayName("the player documents of a scenario are readable under the tenant path")
+  void playerDocumentsUnderTenantPath() throws Exception {
+    mvc.perform(get(PLAYER_DOCUMENTS, tenantId, UUID.randomUUID().toString()))
+        .andExpect(status().is2xxSuccessful());
+  }
+}


### PR DESCRIPTION
Closes #7770.

Scenario > Challenges (the preview reached from the injects screen) never loads: the page stays on its spinner. Two calls answer 404, GET /api/tenants/{tenantId}/observer/scenarios/{id}/challenges and GET /api/tenants/{tenantId}/player/scenarios/{id}/documents. The same preview on a simulation works.

ScenarioChallengesApi declares those two endpoints on the legacy /api/ path only, while the frontend rewrites every /api/ call to /api/tenants/{tenantId}/... through buildTenantApiPath. Every other challenge endpoint already declares both variants, these two were missed.

Both mappings now carry the TENANT_PREFIX variant, and two MockMvc tests read them under the tenant path. No TxCtx is added: like the simulation siblings, these are plain reads and do not touch a v2 tenant-scoped table.
