### PR TITLE
docs(dev): add macOS development environment guide (#7775)

### DIFF
--- a/docs/docs/development/build-from-source.md
+++ b/docs/docs/development/build-from-source.md
@@ -4,8 +4,8 @@
     platform of choice:
 
     * [Linux (Ubuntu used as example)](environment-ubuntu.md)
+    * [macOS](environment-macos.md)
     * [Windows](environment-windows.md)
-    * macOS — not yet documented; contributions welcome
 
 # Build from source
 
@@ -24,49 +24,43 @@ cd openaev
 ## Backend
 
 ### Configuring
-Development assumes that you are using a development-specific properties file. The file located at
-`./openaev-api/src/main/resources/application.properties` is a version-controlled example file and
-lacks many of the required configuration settings needed for OpenAEV to execute.
+Development uses a `dev` Spring profile. Copy the version-controlled example rather than
+`application.properties` (the latter is incomplete for local development):
 
-It is strongly recommended to make a copy of the sample `application.properties` file to create
-a development-specific profile called `dev`.
-
-Copy and paste the example `application.properties` file into the same directory:
 ```shell
-cp ./openaev-api/src/main/resources/application.properties ./openaev-api/src/main/resources/application-dev.properties
+cp ./openaev-api/src/main/resources/application-dev.properties.example \
+   ./openaev-api/src/main/resources/application-dev.properties
 ```
+
+`application-dev.properties` is gitignored. Generate a UUID for `openaev.admin.token` before the
+first start.
+
+!!! tip
+
+    The example enables optional integrations (SAML, Caldera, IMAP, SMS, and others) that need
+    external credentials. If you do not have those accounts, set the corresponding `*.enable`
+    flags to `false` and set `openaev.listener.smtp.enabled=false`.
 
 #### Required dependencies
 
 **Start the development dependencies docker stack**
 
-Preconfigured containers for all the needed support containers (PostgreSQL, MinIO, RabbitMQ, Elasticsearch...)
-can be found as a docker compose file in `./openaev/openaev-dev`.
+Preconfigured containers for the support services (PostgreSQL, MinIO, RabbitMQ, Elasticsearch)
+live in `./openaev-dev`. Copy the example environment file, then start the four required services:
 
-Create a file a this location: `./openaev/openaev-dev/.env` and populate it with a minimal set of keys:
 ```shell
-POSTGRES_USER=openaev	
-POSTGRES_PASSWORD=openaev
-KEYSTORE_PASSWORD=minioadmin
-MINIO_ROOT_USER=minioadmin
-MINIO_ROOT_PASSWORD=minioadmin
-RABBITMQ_DEFAULT_USER=rbit
-RABBITMQ_DEFAULT_PASS=rbitpass
+cd ./openaev-dev
+cp .env.example .env
+docker compose up -d openaev-dev-pgsql openaev-dev-minio openaev-dev-elasticsearch openaev-dev-rabbitmq
 ```
-Note: these are example values, but will do in a development environment. Available environment variables
-can be examined in `./openaev/openaev-dev/docker-compose.yml`.
 
-Then start the stack:
-```shell
-cd ./openaev/openaev-dev
-docker compose up -d
-```
+The values in `.env.example` work for local development. RabbitMQ uses the image defaults
+(`guest` / `guest`) on ports `5672` and `15672`. See `./openaev-dev/README.md` for optional
+services (pgAdmin, Kibana, OpenSearch).
 
 **Set up the local development configuration for the OpenAEV server**
 
-Edit the `application-dev.properties` file, according to the .env file created earlier,
-and any additional configuration. Make sure the file contains settings for at the very minimum
-the following dependencies:
+Edit `application-dev.properties` so it matches the Compose services. At minimum it must include:
 
 - PostgreSQL
 - MinIO
@@ -81,7 +75,7 @@ Maven is used for package management and building the main server binary.
 OpenAEV is a Spring Boot application and thus can be built and started
 in one fell swoop with
 ```shell
-mvn spring-boot:run -Dspring-boot.run.profiles=dev -Dspring-boot.run.main-class=io.openaev.App
+mvn spring-boot:run -pl openaev-api -DskipTests -Dspring-boot.run.profiles=dev
 ```
 
 !!! tip "IntelliJ IDEA run configuration"
@@ -103,10 +97,14 @@ cd ./openaev-front
 ```
 
 ### Building
-Execute `yarn install` to fetch all dependencies from npmjs.com:
+Enable Corepack (Yarn 4 is pinned in `package.json`), then install dependencies:
 ```shell
+corepack enable
 yarn install
 ```
+
+If `yarn install` fails during the link step with `ENOENT` on a cloned `node_modules` path, run
+it again. The frontend CI job already retries this install once for the same reason.
 
 ### Running
 Execute `yarn start` to start a frontend locally:
@@ -115,7 +113,7 @@ yarn start
 ```
 The banner should come up soon after:
 ```
-  VITE v6.3.4  ready in 168 ms
+  VITE v8.2.2  ready in 168 ms
 
   ➜  Local:   http://localhost:3001/
   ➜  Network: use --host to expose
@@ -130,3 +128,10 @@ to be running otherwise the GUI will not come up in the browser.
     both the frontend. After loading the OpenAEV cloned repository's root
     directory in IDEA, the "Frontend start" run configuration will show up in the Run
     widget in the top right corner.
+
+## What's next?
+
+- [Platform development](platform.md) -- Day-to-day backend and frontend workflow
+- [Prerequisites macOS](environment-macos.md) -- macOS toolchain setup
+- [Prerequisites Ubuntu](environment-ubuntu.md) -- Linux toolchain setup
+- [Prerequisites Windows](environment-windows.md) -- Windows toolchain setup

--- a/docs/docs/development/environment-macos.md
+++ b/docs/docs/development/environment-macos.md
@@ -1,0 +1,173 @@
+# Prerequisites macOS
+
+This page lists the tools and dependencies required to build and run OpenAEV from source on macOS (Intel and Apple Silicon).
+
+## Backend
+
+### Homebrew
+
+Install [Homebrew](https://brew.sh/) if it is not already present:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### Java 21
+
+Install OpenJDK 21 and Maven with Homebrew:
+
+```bash
+brew install openjdk@21 maven
+```
+
+`openjdk@21` is keg-only. Add it to your `PATH` and `JAVA_HOME` (for example in `~/.zshrc`):
+
+```bash
+export PATH="/opt/homebrew/opt/openjdk@21/bin:$PATH"
+export JAVA_HOME="/opt/homebrew/opt/openjdk@21"
+```
+
+On Intel Macs, Homebrew uses `/usr/local/opt/openjdk@21` instead of `/opt/homebrew/opt/openjdk@21`.
+
+Verify the installation:
+
+```bash
+java -version
+mvn -version
+```
+
+Both commands must report Java 21. If `java -version` still prints *Unable to locate a Java Runtime*, the `PATH` / `JAVA_HOME` exports above are missing from the current shell.
+
+### Docker
+
+Development services (PostgreSQL, Elasticsearch, RabbitMQ, MinIO) run in containers. Use either Docker Desktop or Colima.
+
+#### Option A — Docker Desktop
+
+1. Download and install [Docker Desktop for Mac](https://docs.docker.com/desktop/setup/install/mac-install/).
+2. Start Docker Desktop and wait until the engine is running.
+3. Verify the installation:
+
+```bash
+docker --version
+docker compose version
+```
+
+#### Option B — Colima
+
+Colima is a lightweight Docker runtime that works well on Apple Silicon:
+
+```bash
+brew install colima docker docker-compose
+```
+
+Start a VM with enough memory for Elasticsearch (the compose stack sets a 2 GB heap):
+
+```bash
+colima start --cpu 4 --memory 8 --disk 40
+```
+
+If Homebrew installed Compose as a Docker CLI plugin, add this to `~/.docker/config.json` so `docker compose` is discovered:
+
+```json
+{
+  "cliPluginsExtraDirs": [
+    "/opt/homebrew/lib/docker/cli-plugins"
+  ]
+}
+```
+
+Verify the installation:
+
+```bash
+docker --version
+docker compose version
+```
+
+!!! tip
+
+    If `docker compose pull` fails with `docker-credential-desktop: executable file not found`, a leftover Docker Desktop `credsStore` entry is still in `~/.docker/config.json`. Remove the `"credsStore": "desktop"` line, or point `DOCKER_HOST` at Colima (`unix://$HOME/.colima/default/docker.sock`) and use a config file that does not reference that helper.
+
+### Git
+
+macOS includes Git through Xcode Command Line Tools:
+
+```bash
+xcode-select --install
+```
+
+Or install a current Git with Homebrew:
+
+```bash
+brew install git
+```
+
+## Frontend
+
+### Node.js
+
+Install Node.js 24 or later with [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+nvm install 24
+nvm use 24
+nvm alias default 24
+```
+
+Verify:
+
+```bash
+node -v
+```
+
+The frontend `package.json` requires Node.js `>= 24.11.0`.
+
+### Yarn
+
+OpenAEV uses Yarn 4. After installing Node.js, enable Corepack:
+
+```bash
+corepack enable
+```
+
+Yarn is bundled with the repository and is used automatically when you run `yarn` commands inside `openaev-front/`.
+
+## Development services
+
+Copy the Compose environment file, then start the four required services:
+
+```bash
+cd openaev-dev
+cp .env.example .env
+docker compose up -d openaev-dev-pgsql openaev-dev-minio openaev-dev-elasticsearch openaev-dev-rabbitmq
+```
+
+This starts:
+
+| Service | Port | Description |
+|---|---|---|
+| PostgreSQL 17 | 5432 | Database |
+| MinIO | 10000, 10001 | S3-compatible object storage |
+| Elasticsearch 8 | 9200 | Analytics engine |
+| RabbitMQ 4 | 5672, 15672 | Message broker |
+
+!!! warning
+
+    Ensure these ports are not already in use on your machine before starting the services.
+
+!!! note "Apple Silicon"
+
+    The Elasticsearch and OpenSearch services in `openaev-dev/docker-compose.yml` already set `-XX:UseSVE=0` for M-series compatibility. You do not need to change that flag.
+
+Then copy the Spring Boot development profile and start the backend and frontend as described in [Build from source](build-from-source.md).
+
+!!! tip
+
+    The sample `application-dev.properties.example` enables optional integrations (SAML, Caldera, Tanium, CrowdStrike, IMAP, OVH SMS) that need external credentials. If you do not have those accounts, set the corresponding `*.enable` flags to `false` and set `openaev.listener.smtp.enabled=false` so the backend starts without connection warnings every 10 seconds.
+
+## What's next?
+
+- [Platform development](platform.md) -- Build and run OpenAEV from source
+- [Build from source](build-from-source.md) -- Detailed build instructions
+- [Prerequisites Ubuntu](environment-ubuntu.md) -- Linux setup instructions
+- [Prerequisites Windows](environment-windows.md) -- Windows setup instructions

--- a/docs/docs/development/environment-macos.md
+++ b/docs/docs/development/environment-macos.md
@@ -106,7 +106,7 @@ brew install git
 
 ### Node.js
 
-Install Node.js 24 or later with [nvm](https://github.com/nvm-sh/nvm):
+Install Node.js 24.11.0 or later with [nvm](https://github.com/nvm-sh/nvm):
 
 ```bash
 nvm install 24

--- a/docs/docs/development/environment-ubuntu.md
+++ b/docs/docs/development/environment-ubuntu.md
@@ -23,3 +23,10 @@ Then install and set as default Node.js 24 (the version used by the CI and the D
 nvm install 24
 nvm use 24
 ```
+
+## What's next?
+
+- [Platform development](platform.md) -- Build and run OpenAEV from source
+- [Build from source](build-from-source.md) -- Detailed build instructions
+- [Prerequisites macOS](environment-macos.md) -- macOS setup instructions
+- [Prerequisites Windows](environment-windows.md) -- Windows setup instructions

--- a/docs/docs/development/environment-windows.md
+++ b/docs/docs/development/environment-windows.md
@@ -104,3 +104,4 @@ This starts:
 - [Platform development](platform.md) -- Build and run OpenAEV from source
 - [Build from source](build-from-source.md) -- Detailed build instructions
 - [Prerequisites Ubuntu](environment-ubuntu.md) -- Linux setup instructions
+- [Prerequisites macOS](environment-macos.md) -- macOS setup instructions

--- a/docs/docs/development/platform.md
+++ b/docs/docs/development/platform.md
@@ -7,6 +7,7 @@ This page explains how to set up a local development environment for the OpenAEV
 Before starting, install the required tools for your operating system:
 
 - [Prerequisites Ubuntu](environment-ubuntu.md)
+- [Prerequisites macOS](environment-macos.md)
 - [Prerequisites Windows](environment-windows.md)
 
 ## Architecture overview

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -234,6 +234,7 @@ nav:
   - Development:
     - Prerequisites:
       - Ubuntu: development/environment-ubuntu.md
+      - macOS: development/environment-macos.md
       - Windows: development/environment-windows.md
     - Building and running from source: development/build-from-source.md
     - Database migrations: development/database-migrations.md

--- a/openaev-dev/README.md
+++ b/openaev-dev/README.md
@@ -6,10 +6,10 @@ This folder contains configuration files for setting up a local development envi
 
 - Podman with a Compose provider, or Docker with the Compose plugin
 - Java 21+ (for backend development)
-- Node.js 24+ and Yarn (for frontend development)
+- Node.js >= 24.11.0 and Yarn (for frontend development)
 - IntelliJ IDEA (recommended IDE)
 
-On macOS, see the [macOS development guide](../docs/docs/development/environment-macos.md) for Homebrew, Java 21, Node 24, and Docker Desktop or Colima.
+On macOS, see the [macOS development guide](../docs/docs/development/environment-macos.md) for Homebrew, Java 21, Node.js >= 24.11.0, and Docker Desktop or Colima.
 
 ## Quick Start
 

--- a/openaev-dev/README.md
+++ b/openaev-dev/README.md
@@ -6,8 +6,10 @@ This folder contains configuration files for setting up a local development envi
 
 - Podman with a Compose provider, or Docker with the Compose plugin
 - Java 21+ (for backend development)
-- Node.js 20+ and Yarn (for frontend development)
+- Node.js 24+ and Yarn (for frontend development)
 - IntelliJ IDEA (recommended IDE)
+
+On macOS, see the [macOS development guide](../docs/docs/development/environment-macos.md) for Homebrew, Java 21, Node 24, and Docker Desktop or Colima.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- Add a macOS development prerequisites page (Homebrew, Java 21, Node 24, Docker Desktop or Colima) and link it from the docs nav, platform page, and sibling OS guides.
- Replace the "macOS — not yet documented" placeholder in the build-from-source guide.
- Align first-run instructions with the repo: copy `application-dev.properties.example`, use `./openaev-dev`, start the four required Compose services, and require Node 24 / Corepack.

Closes #7775

## Test plan
- [ ] Open the docs preview and confirm **Development > Prerequisites > macOS** renders and is linked from Build from source, Platform, Ubuntu, and Windows pages
- [ ] Follow the macOS page on a clean machine (or mentally walk the commands) through Java 21, Node 24, Compose, and `yarn start`
- [ ] Confirm `openaev-dev/README.md` now lists Node.js 24+ to match `openaev-front/package.json`


Made with [Cursor](https://cursor.com)