### PR TITLE
feat(audit-log): prevent renew of admin token (#7491)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -17,6 +17,7 @@ import io.openaev.database.repository.OrganizationRepository;
 import io.openaev.database.repository.TokenRepository;
 import io.openaev.database.repository.UserRepository;
 import io.openaev.rest.exception.ElementNotFoundException;
+import io.openaev.rest.exception.ForbiddenException;
 import io.openaev.rest.exception.InputValidationException;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.user.form.me.UpdateMePasswordInput;
@@ -78,7 +79,7 @@ public class MeApi extends RestBehavior {
             .findById(currentUser().getId())
             .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
     if (user.isExternal() && !input.getEmail().equals(user.getEmail())) {
-      throw new IllegalStateException(
+      throw new ForbiddenException(
           "The admin email cannot be changed using the API. Please change it in the configuration.");
     }
     user.setUpdateAttributes(input);
@@ -116,7 +117,7 @@ public class MeApi extends RestBehavior {
             .findById(currentUser().getId())
             .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
     if (user.isExternal()) {
-      throw new IllegalStateException(
+      throw new ForbiddenException(
           "The admin password cannot be changed using the API. Please change it in the configuration.");
     }
     if (userService.isUserPasswordValid(user, input.getCurrentPassword())) {
@@ -141,7 +142,7 @@ public class MeApi extends RestBehavior {
             .findById(currentUser().getId())
             .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
     if (user.isExternal()) {
-      throw new IllegalStateException(
+      throw new ForbiddenException(
           "The admin token cannot be renewed using the API. Please change it in the configuration.");
     }
     return userService.renewUserToken(user, input.getTokenId());

--- a/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/user/MeApi.java
@@ -77,6 +77,10 @@ public class MeApi extends RestBehavior {
         userRepository
             .findById(currentUser().getId())
             .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
+    if (user.isExternal() && !input.getEmail().equals(user.getEmail())) {
+      throw new IllegalStateException(
+          "The admin email cannot be changed using the API. Please change it in the configuration.");
+    }
     user.setUpdateAttributes(input);
     user.setOrganization(
         updateRelation(input.getOrganizationId(), user.getOrganization(), organizationRepository));
@@ -111,6 +115,10 @@ public class MeApi extends RestBehavior {
         userRepository
             .findById(currentUser().getId())
             .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
+    if (user.isExternal()) {
+      throw new IllegalStateException(
+          "The admin password cannot be changed using the API. Please change it in the configuration.");
+    }
     if (userService.isUserPasswordValid(user, input.getCurrentPassword())) {
       user.setPassword(userService.encodeUserPassword(input.getPassword()));
       User savedUser = userRepository.save(user);
@@ -128,7 +136,15 @@ public class MeApi extends RestBehavior {
   @AccessControl(skipRBAC = true, actionPerformed = Action.WRITE, resourceType = ResourceType.USER)
   @Transactional(rollbackFor = Exception.class)
   public Token renewToken(@Valid @RequestBody RenewTokenInput input) {
-    return userService.renewUserToken(input.getTokenId());
+    User user =
+        userRepository
+            .findById(currentUser().getId())
+            .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
+    if (user.isExternal()) {
+      throw new IllegalStateException(
+          "The admin token cannot be renewed using the API. Please change it in the configuration.");
+    }
+    return userService.renewUserToken(user, input.getTokenId());
   }
 
   @GetMapping(ME_URI + "/tenants")

--- a/openaev-api/src/main/java/io/openaev/service/UserService.java
+++ b/openaev-api/src/main/java/io/openaev/service/UserService.java
@@ -1,5 +1,6 @@
 package io.openaev.service;
 
+import static io.openaev.config.SessionHelper.currentUser;
 import static io.openaev.database.model.User.ROLE_ADMIN;
 import static io.openaev.database.model.User.ROLE_USER;
 import static io.openaev.utils.pagination.CriteriaBuilderPagination.paginate;
@@ -510,6 +511,10 @@ public class UserService {
         userRepository
             .findById(currentUser().getId())
             .orElseThrow(() -> new ElementNotFoundException("Current user not found"));
+    return renewUserToken(user, tokenId);
+  }
+
+  public Token renewUserToken(User user, String tokenId) {
     Token token = tokenRepository.findById(tokenId).orElseThrow(ElementNotFoundException::new);
     if (!user.equals(token.getUser())) {
       throw new AccessDeniedException("You are not allowed to renew this token");

--- a/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/AppSecurityConfigTest.java
@@ -1,17 +1,24 @@
 package io.openaev.config;
 
 import static io.openaev.rest.scenario.ScenarioApi.SCENARIO_URI;
+import static io.openaev.rest.user.MeApi.ME_URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
 import io.openaev.IntegrationTest;
 import io.openaev.database.model.Token;
+import io.openaev.database.model.User;
 import io.openaev.database.repository.TokenRepository;
+import io.openaev.service.UserService;
+import io.openaev.utils.fixtures.UserFixture;
+import io.openaev.utils.fixtures.composers.UserComposer;
 import jakarta.servlet.http.Cookie;
 import java.util.Objects;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -32,6 +39,8 @@ public class AppSecurityConfigTest extends IntegrationTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private TokenRepository tokenRepository;
+  @Autowired private UserService userService;
+  @Autowired private UserComposer userComposer;
 
   @Value("${openbas.admin.token:${openaev.admin.token:#{null}}}")
   private String adminToken;
@@ -198,21 +207,30 @@ public class AppSecurityConfigTest extends IntegrationTest {
   @DisplayName("given renewed token, should reject old bearer and accept new bearer")
   void given_renewedToken_should_reject_old_bearer_and_accept_new_bearer() throws Exception {
     // -- ARRANGE --
-    Token currentAdminToken = tokenRepository.findByValue(adminToken).orElseThrow();
+    // MeApi refuses to renew the admin token (User#isExternal(), covered in MeApiTest), so the
+    // rotation is exercised on a regular user. ME_URI is the probed endpoint because it only
+    // requires authentication, no capability.
+    User user =
+        userComposer
+            .forUser(UserFixture.getUser("Renew", "Bearer", UUID.randomUUID() + "@test.invalid"))
+            .persist()
+            .get();
+    Token previousToken = userService.createUserToken(user, UUID.randomUUID().toString());
+    String previousTokenValue = previousToken.getValue();
     String refreshBody =
         """
         {
           "token_id": "%s"
         }
         """
-            .formatted(currentAdminToken.getId());
+            .formatted(previousToken.getId());
 
     // -- ACT --
     MvcResult refreshResult =
         mockMvc
             .perform(
-                post("/api/me/token/refresh")
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                post(ME_URI + "/token/refresh")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + previousTokenValue)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(refreshBody))
             .andExpect(status().isOk())
@@ -220,23 +238,15 @@ public class AppSecurityConfigTest extends IntegrationTest {
 
     String refreshedToken =
         JsonPath.read(refreshResult.getResponse().getContentAsString(), "$.token_value");
-    assertThat(refreshedToken).isNotBlank().isNotEqualTo(adminToken);
+    assertThat(refreshedToken).isNotBlank().isNotEqualTo(previousTokenValue);
 
     // -- ASSERT --
     mockMvc
-        .perform(
-            post(SCENARIO_SEARCH_URI)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(SEARCH_BODY))
+        .perform(get(ME_URI).header(HttpHeaders.AUTHORIZATION, "Bearer " + previousTokenValue))
         .andExpect(status().isUnauthorized());
 
     mockMvc
-        .perform(
-            post(SCENARIO_SEARCH_URI)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + refreshedToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(SEARCH_BODY))
+        .perform(get(ME_URI).header(HttpHeaders.AUTHORIZATION, "Bearer " + refreshedToken))
         .andExpect(status().isOk());
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/user/MeApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/user/MeApiTest.java
@@ -1,10 +1,15 @@
 package io.openaev.rest.user;
 
+import static io.openaev.utils.JsonTestUtils.asJsonString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,16 +19,26 @@ import io.openaev.context.TenantContext;
 import io.openaev.database.model.Capability;
 import io.openaev.database.model.Group;
 import io.openaev.database.model.Tenant;
+import io.openaev.database.model.Token;
 import io.openaev.database.model.User;
 import io.openaev.database.repository.GroupRepository;
+import io.openaev.database.repository.TokenRepository;
+import io.openaev.database.repository.UserRepository;
+import io.openaev.rest.user.form.me.UpdateMePasswordInput;
+import io.openaev.rest.user.form.me.UpdateProfileInput;
+import io.openaev.service.UserService;
 import io.openaev.utils.TenantIsolationTestHelper;
+import io.openaev.utils.fixtures.UserFixture;
 import io.openaev.utils.fixtures.platform.PlatformGroupComposer;
 import io.openaev.utils.fixtures.platform.PlatformGroupFixture;
 import io.openaev.utils.mockUser.WithMockUser;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +52,12 @@ public class MeApiTest extends IntegrationTest {
   @Autowired private TenantIsolationTestHelper tenantIsolationHelper;
   @Autowired private PlatformGroupComposer platformGroupComposer;
   @Autowired private GroupRepository groupRepository;
+  @Autowired private UserRepository userRepository;
+  @Autowired private TokenRepository tokenRepository;
+  @Autowired private UserService userService;
+
+  @Value("${openbas.admin.token:${openaev.admin.token:#{null}}}")
+  private String adminToken;
 
   @Nested
   @DisplayName("GET /api/me")
@@ -225,5 +246,196 @@ public class MeApiTest extends IntegrationTest {
                   userGroups.contains(id),
                   "Tenant X group [" + id + "] must appear in tenant X context user_groups"));
     }
+  }
+
+  @Nested
+  @DisplayName("Self-service restrictions on the platform admin account")
+  class PlatformAdminSelfService {
+
+    // No @WithMockUser here on purpose: User#isExternal() is derived from the id
+    // (id == ADMIN_UUID), so only the bootstrap admin trips these guards. Authenticating through
+    // the configured admin bearer is the only way to reach them.
+    // The class is @Transactional, so the admin row is restored on rollback.
+
+    @Test
+    @DisplayName("Given the admin, changing the email should be refused")
+    void given_platformAdmin_should_refuseEmailChange() {
+      // -------- Arrange --------
+      User admin = userRepository.findById(User.ADMIN_UUID).orElseThrow();
+      String previousEmail = admin.getEmail();
+      UpdateProfileInput input = profileInput("changed-" + UUID.randomUUID() + "@test.invalid");
+
+      // -------- Act & Assert --------
+      assertThatThrownBy(
+              () ->
+                  mvc.perform(
+                      put(MeApi.ME_URI + "/profile")
+                          .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .content(asJsonString(input))))
+          .rootCause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("The admin email cannot be changed using the API");
+
+      entityManager.clear();
+      assertThat(userRepository.findById(User.ADMIN_UUID).orElseThrow().getEmail())
+          .isEqualTo(previousEmail);
+    }
+
+    @Test
+    @DisplayName("Given the admin, updating the profile without touching the email is allowed")
+    void given_platformAdmin_should_allowProfileUpdateWithoutEmailChange() throws Exception {
+      // -------- Arrange --------
+      // The guard must only trip on an actual email change, otherwise the admin could never edit
+      // its language or theme either.
+      User admin = userRepository.findById(User.ADMIN_UUID).orElseThrow();
+      UpdateProfileInput input = profileInput(admin.getEmail());
+      input.setFirstname("Renamed");
+
+      // -------- Act & Assert --------
+      mvc.perform(
+              put(MeApi.ME_URI + "/profile")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.user_firstname").value("Renamed"));
+    }
+
+    @Test
+    @DisplayName("Given the admin, changing the password should be refused")
+    void given_platformAdmin_should_refusePasswordChange() {
+      // -------- Arrange --------
+      UpdateMePasswordInput input = passwordInput();
+
+      // -------- Act & Assert --------
+      assertThatThrownBy(
+              () ->
+                  mvc.perform(
+                      put(MeApi.ME_URI + "/password")
+                          .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .content(asJsonString(input))))
+          .rootCause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("The admin password cannot be changed using the API");
+    }
+
+    @Test
+    @DisplayName("Given the admin, renewing the token should be refused")
+    void given_platformAdmin_should_refuseTokenRenewal() {
+      // -------- Arrange --------
+      Token currentAdminToken = tokenRepository.findByValue(adminToken).orElseThrow();
+
+      // -------- Act & Assert --------
+      assertThatThrownBy(
+              () ->
+                  mvc.perform(
+                      post(MeApi.ME_URI + "/token/refresh")
+                          .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                          .contentType(MediaType.APPLICATION_JSON)
+                          .content(renewTokenBody(currentAdminToken.getId()))))
+          .rootCause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("The admin token cannot be renewed using the API");
+
+      // The bearer must stay usable: a refused renewal never destroys the token.
+      entityManager.clear();
+      assertThat(tokenRepository.findByValue(adminToken)).isPresent();
+    }
+  }
+
+  @Nested
+  @DisplayName("Self-service updates for a regular user")
+  @WithMockUser
+  class RegularUserSelfService {
+
+    @Test
+    @DisplayName("Given a regular user, changing the email is allowed")
+    void given_regularUser_should_allowEmailChange() throws Exception {
+      // -------- Arrange --------
+      String newEmail = "changed-" + UUID.randomUUID() + "@test.invalid";
+      UpdateProfileInput input = profileInput(newEmail);
+
+      // -------- Act & Assert --------
+      mvc.perform(
+              put(MeApi.ME_URI + "/profile")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input))
+                  .with(csrf()))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.user_email").value(newEmail));
+    }
+
+    @Test
+    @DisplayName("Given a regular user, changing the password is allowed")
+    void given_regularUser_should_allowPasswordChange() throws Exception {
+      // -------- Arrange --------
+      User user = testUserHolder.get();
+      user.setPassword(UserFixture.ENCODED_PASSWORD);
+      entityManager.flush();
+      UpdateMePasswordInput input = passwordInput();
+
+      // -------- Act & Assert --------
+      mvc.perform(
+              put(MeApi.ME_URI + "/password")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input))
+                  .with(csrf()))
+          .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Given a regular user, renewing the token is allowed")
+    void given_regularUser_should_allowTokenRenewal() throws Exception {
+      // -------- Arrange --------
+      Token previousToken =
+          userService.createUserToken(testUserHolder.get(), UUID.randomUUID().toString());
+      entityManager.flush();
+
+      // -------- Act --------
+      String response =
+          mvc.perform(
+                  post(MeApi.ME_URI + "/token/refresh")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(renewTokenBody(previousToken.getId()))
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
+
+      // -------- Assert --------
+      // A new token is issued: the regular user is allowed to renew. The hard-delete semantics of
+      // the previous row are covered by UserServiceTest.
+      String renewedTokenId = JsonPath.read(response, "$.token_id");
+      assertThat(renewedTokenId).isNotBlank().isNotEqualTo(previousToken.getId());
+    }
+  }
+
+  private UpdateProfileInput profileInput(String email) {
+    UpdateProfileInput input = new UpdateProfileInput();
+    input.setEmail(email);
+    input.setFirstname("Self");
+    input.setLastname("Service");
+    input.setLang("auto");
+    input.setTheme("auto");
+    return input;
+  }
+
+  private UpdateMePasswordInput passwordInput() {
+    UpdateMePasswordInput input = new UpdateMePasswordInput();
+    input.setCurrentPassword(UserFixture.RAW_PASSWORD);
+    input.setPassword("anotherPwd24!@");
+    return input;
+  }
+
+  private String renewTokenBody(String tokenId) {
+    return """
+        {
+          "token_id": "%s"
+        }
+        """
+        .formatted(tokenId);
   }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/user/MeApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/user/MeApiTest.java
@@ -2,7 +2,6 @@ package io.openaev.rest.user;
 
 import static io.openaev.utils.JsonTestUtils.asJsonString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -259,23 +258,19 @@ public class MeApiTest extends IntegrationTest {
 
     @Test
     @DisplayName("Given the admin, changing the email should be refused")
-    void given_platformAdmin_should_refuseEmailChange() {
+    void given_platformAdmin_should_refuseEmailChange() throws Exception {
       // -------- Arrange --------
       User admin = userRepository.findById(User.ADMIN_UUID).orElseThrow();
       String previousEmail = admin.getEmail();
       UpdateProfileInput input = profileInput("changed-" + UUID.randomUUID() + "@test.invalid");
 
       // -------- Act & Assert --------
-      assertThatThrownBy(
-              () ->
-                  mvc.perform(
-                      put(MeApi.ME_URI + "/profile")
-                          .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
-                          .contentType(MediaType.APPLICATION_JSON)
-                          .content(asJsonString(input))))
-          .rootCause()
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("The admin email cannot be changed using the API");
+      mvc.perform(
+              put(MeApi.ME_URI + "/profile")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isForbidden());
 
       entityManager.clear();
       assertThat(userRepository.findById(User.ADMIN_UUID).orElseThrow().getEmail())
@@ -304,40 +299,32 @@ public class MeApiTest extends IntegrationTest {
 
     @Test
     @DisplayName("Given the admin, changing the password should be refused")
-    void given_platformAdmin_should_refusePasswordChange() {
+    void given_platformAdmin_should_refusePasswordChange() throws Exception {
       // -------- Arrange --------
       UpdateMePasswordInput input = passwordInput();
 
       // -------- Act & Assert --------
-      assertThatThrownBy(
-              () ->
-                  mvc.perform(
-                      put(MeApi.ME_URI + "/password")
-                          .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
-                          .contentType(MediaType.APPLICATION_JSON)
-                          .content(asJsonString(input))))
-          .rootCause()
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("The admin password cannot be changed using the API");
+      mvc.perform(
+              put(MeApi.ME_URI + "/password")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(asJsonString(input)))
+          .andExpect(status().isForbidden());
     }
 
     @Test
     @DisplayName("Given the admin, renewing the token should be refused")
-    void given_platformAdmin_should_refuseTokenRenewal() {
+    void given_platformAdmin_should_refuseTokenRenewal() throws Exception {
       // -------- Arrange --------
       Token currentAdminToken = tokenRepository.findByValue(adminToken).orElseThrow();
 
       // -------- Act & Assert --------
-      assertThatThrownBy(
-              () ->
-                  mvc.perform(
-                      post(MeApi.ME_URI + "/token/refresh")
-                          .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
-                          .contentType(MediaType.APPLICATION_JSON)
-                          .content(renewTokenBody(currentAdminToken.getId()))))
-          .rootCause()
-          .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("The admin token cannot be renewed using the API");
+      mvc.perform(
+              post(MeApi.ME_URI + "/token/refresh")
+                  .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(renewTokenBody(currentAdminToken.getId())))
+          .andExpect(status().isForbidden());
 
       // The bearer must stay usable: a refused renewal never destroys the token.
       entityManager.clear();

--- a/openaev-front/src/admin/components/profile/Index.jsx
+++ b/openaev-front/src/admin/components/profile/Index.jsx
@@ -1,4 +1,4 @@
-import { Button, Typography } from '@mui/material';
+import { Button, Tooltip, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import * as R from 'ramda';
 import { useDispatch } from 'react-redux';
@@ -115,14 +115,19 @@ const Index = () => {
           {t('Token key')}
         </Typography>
         <pre>{userToken?.token_value}</pre>
-        <Button
-          variant="contained"
-          color="primary"
-          component="a"
-          onClick={() => onRenew(userToken?.token_id)}
-        >
-          {t('RENEW')}
-        </Button>
+        <Tooltip title={initialValues.user_is_external ? t('Admin users cannot renew their token. Please change the token directly in the configuration.') : ''}>
+          <span>
+            <Button
+              variant="contained"
+              color="primary"
+              component="a"
+              disabled={initialValues.user_is_external}
+              onClick={() => onRenew(userToken?.token_id)}
+            >
+              {t('RENEW')}
+            </Button>
+          </span>
+        </Tooltip>
         <Typography
           gutterBottom={true}
           sx={{

--- a/openaev-front/src/utils/lang/de.json
+++ b/openaev-front/src/utils/lang/de.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "Fügt einen Tab für gelernte Lektionen hinzu, um Feedback mit Zielen und Fragebögen zu sammeln.",
   "Adjust or clear the filters to widen the scope.": "Passen Sie die Filter an oder löschen Sie sie, um den Bereich zu erweitern.",
   "Admin": "Admin",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "Admin-Benutzer können ihr Token nicht verlängern. Bitte ändern Sie das Token direkt in der Konfiguration.",
   "Admin_username": "Admin-Benutzername",
   "Administrator": "Administrator",
   "Adminusername": "Admin-Benutzername",

--- a/openaev-front/src/utils/lang/en.json
+++ b/openaev-front/src/utils/lang/en.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "Adds a lessons learned tab to collect feedback with objectives and questionnaires.",
   "Adjust or clear the filters to widen the scope.": "Adjust or clear the filters to widen the scope.",
   "Admin": "Admin",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "Admin users cannot renew their token. Please change the token directly in the configuration.",
   "Admin_username": "Admin username",
   "Administrator": "Administrator",
   "Adminusername": "Admin username",

--- a/openaev-front/src/utils/lang/es.json
+++ b/openaev-front/src/utils/lang/es.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "Añade una pestaña de lecciones aprendidas para recopilar comentarios con objetivos y cuestionarios.",
   "Adjust or clear the filters to widen the scope.": "Ajuste o borre los filtros para ampliar el alcance.",
   "Admin": "Admin",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "Los usuarios con permisos de administrador no pueden renovar su token. Por favor, cambia el token directamente en la configuración.",
   "Admin_username": "Nombre de usuario administrador",
   "Administrator": "Administrador",
   "Adminusername": "Nombre de usuario Admin",

--- a/openaev-front/src/utils/lang/fr.json
+++ b/openaev-front/src/utils/lang/fr.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "Ajoute un onglet retours d’expérience pour recueillir des retours via des objectifs et des questionnaires.",
   "Adjust or clear the filters to widen the scope.": "Ajustez ou effacez les filtres pour élargir le périmètre.",
   "Admin": "Administrateur",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "Les utilisateurs « Admin » ne peuvent pas renouveler leur jeton. Veuillez modifier le jeton directement dans la configuration.",
   "Admin_username": "Nom d'utilisateur administrateur",
   "Administrator": "Administrateur",
   "Adminusername": "Nom d'utilisateur de l'administrateur",

--- a/openaev-front/src/utils/lang/it.json
+++ b/openaev-front/src/utils/lang/it.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "Aggiunge una scheda delle lezioni apprese per raccogliere feedback con obiettivi e questionari.",
   "Adjust or clear the filters to widen the scope.": "Modifica o cancella i filtri per ampliare l’ambito.",
   "Admin": "Admin",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "Gli utenti amministratori non possono rinnovare il proprio token. Si prega di modificare il token direttamente nella configurazione.",
   "Admin_username": "Nome utente amministratore",
   "Administrator": "Amministratore",
   "Adminusername": "Nome utente amministratore",

--- a/openaev-front/src/utils/lang/ja.json
+++ b/openaev-front/src/utils/lang/ja.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "目標とアンケートでフィードバックを収集するためのタブを追加します。",
   "Adjust or clear the filters to widen the scope.": "フィルターを調整またはクリアして範囲を広げてください。",
   "Admin": "管理者",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "管理者ユーザーはトークンを更新できません。設定画面で直接トークンを変更してください。",
   "Admin_username": "管理者ユーザー名",
   "Administrator": "管理者",
   "Adminusername": "管理者ユーザー名",

--- a/openaev-front/src/utils/lang/ko.json
+++ b/openaev-front/src/utils/lang/ko.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "목표와 설문지로 피드백을 수집하는 배운 교훈 탭을 추가합니다.",
   "Adjust or clear the filters to widen the scope.": "필터를 조정하거나 지워 범위를 넓히세요.",
   "Admin": "관리자",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "관리자 사용자는 토큰을 갱신할 수 없습니다. 설정에서 직접 토큰을 변경해 주십시오.",
   "Admin_username": "관리자 사용자 이름",
   "Administrator": "관리자",
   "Adminusername": "관리자 사용자 아이디",

--- a/openaev-front/src/utils/lang/ru.json
+++ b/openaev-front/src/utils/lang/ru.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "Добавляет вкладку извлеченных уроков для сбора отзывов с помощью целей и анкет.",
   "Adjust or clear the filters to widen the scope.": "Настройте или очистите фильтры, чтобы расширить охват.",
   "Admin": "Admin",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "Пользователи с правами администратора не могут продлить срок действия своего токена. Пожалуйста, измените токен непосредственно в настройках.",
   "Admin_username": "Имя пользователя администратора",
   "Administrator": "Администратор",
   "Adminusername": "Имя пользователя администратора",

--- a/openaev-front/src/utils/lang/zh.json
+++ b/openaev-front/src/utils/lang/zh.json
@@ -227,6 +227,7 @@
   "Adds a lessons learned tab to collect feedback with objectives and questionnaires.": "添加经验教训选项卡，通过目标和问卷收集反馈。",
   "Adjust or clear the filters to widen the scope.": "调整或清除筛选条件以扩大范围。",
   "Admin": "管理",
+  "Admin users cannot renew their token. Please change the token directly in the configuration.": "管理员用户无法续期其令牌。请直接在配置中更改令牌。",
   "Admin_username": "管理员用户名",
   "Administrator": "管理员",
   "Adminusername": "管理员用户名",

--- a/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
@@ -20,6 +20,8 @@ public interface TokenRepository
 
   Optional<Token> findByValue(String value);
 
+  Optional<Token> findByUserId(String value);
+
   /**
    * Oldest (most stable) API token of a user. Used by the reporting renderer to authenticate the
    * headless browser as the acting user; the token value never leaves the server process.

--- a/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
+++ b/openaev-model/src/main/java/io/openaev/database/repository/TokenRepository.java
@@ -20,8 +20,6 @@ public interface TokenRepository
 
   Optional<Token> findByValue(String value);
 
-  Optional<Token> findByUserId(String value);
-
   /**
    * Oldest (most stable) API token of a user. Used by the reporting renderer to authenticate the
    * headless browser as the acting user; the token value never leaves the server process.


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Prevent the user from renewing his token if he is admin
* Adding some checks on the backend to prevent the change of password, email and token for the admin user just like in the UI

### Testing Instructions

1. Try to renew the token as the admin user
2. Check it's not possible
3. Try to renew the token as a normal user
4. Check it's working
5. Try to change the token, the password or the email of the admin user
6. Check it's not possible
7. Try to change the token, the password or the email of a normal user
8. Check it's working

### Related issues

* Related #7491 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
