### PR TITLE
chore(docs): document the PR description format in agent instructions (#7742)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ Before creating a pull request, validate locally:
 2. **PR title**: Must match `type(scope?): description (#issue)` — no `[context]` prefix. The `openaev-pr-checks` GitHub App validates this pattern; titles with extra prefixes (e.g. `[backend]`) will be rejected.
 3. **Compile**: `mvn compile -DskipTests` (or via Docker)
 4. **Frontend** (if changed): `cd openaev-front && yarn check-ts && yarn lint`
-5. **PR description**: Must follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) — see [PR description format](#pr-description-format).
+5. **PR description**: Must follow [`.github/PULL_REQUEST_TEMPLATE.md`](/.github/PULL_REQUEST_TEMPLATE.md) — see [PR description format](#pr-description-format).
 
 ## Code Conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,6 +90,7 @@ Before creating a pull request, validate locally:
 2. **PR title**: Must match `type(scope?): description (#issue)` — no `[context]` prefix. The `openaev-pr-checks` GitHub App validates this pattern; titles with extra prefixes (e.g. `[backend]`) will be rejected.
 3. **Compile**: `mvn compile -DskipTests` (or via Docker)
 4. **Frontend** (if changed): `cd openaev-front && yarn check-ts && yarn lint`
+5. **PR description**: Must follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) — see [PR description format](#pr-description-format).
 
 ## Code Conventions
 
@@ -122,6 +123,30 @@ Conventions are defined in dedicated instruction files that activate automatical
 | `test-specialist`        | Creates and maintains tests following project patterns                   |
 
 ## PR & Review Conventions
+
+### PR description format
+
+**Every pull request description MUST follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).**
+When you open a PR (via `gh pr create`, the `create_pull_request` tool, or the UI), read that
+template first and reproduce its structure — do not invent your own headings.
+
+Required sections, in this order:
+
+| Section | Content |
+|---|---|
+| `### Proposed changes` | Bullet list of what changed, one bullet per file or logical group, with the *why* — not a diff paraphrase |
+| `### Testing Instructions` | Numbered, reproducible steps + environment/config notes (services to start, commands run) |
+| `### Related issues` | `* Related #ISSUE-NUMBER` — mandatory, every PR must be linked to an issue |
+| `### Checklist` | Keep every line; tick with `[x]` only what is genuinely done, leave `[ ]` otherwise (never delete a line) |
+| `### Further comments` | Design rationale, alternatives considered, explicit out-of-scope items. Omit only for trivial PRs |
+
+Rules:
+
+- Keep the section headings verbatim (`###` level, exact wording) — tooling and reviewers rely on them.
+- Drop the HTML comments from the template in the final description; keep the checklist items themselves.
+- Never mark a checklist item as done when it is not (e.g. don't tick "I wrote test cases" on a PR without tests).
+- State explicitly what is intentionally out of scope, so reviewers don't flag it as missing.
+- The PR title still follows Conventional Commits and ends with the issue reference: `type(scope?): description (#issue)`.
 
 ### Conventional Comments (for code reviews)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,14 +137,14 @@ Required sections, in this order:
 | `### Proposed changes` | Bullet list of what changed, one bullet per file or logical group, with the *why* — not a diff paraphrase |
 | `### Testing Instructions` | Numbered, reproducible steps + environment/config notes (services to start, commands run) |
 | `### Related issues` | `* Related #ISSUE-NUMBER` — mandatory, every PR must be linked to an issue |
-| `### Checklist` | Keep every line; tick with `[x]` only what is genuinely done, leave `[ ]` otherwise (never delete a line) |
+| `### Checklist` | Reproduce every line unchecked (`[ ]`); never delete a line and never tick a box — the human author does that |
 | `### Further comments` | Design rationale, alternatives considered, explicit out-of-scope items. Omit only for trivial PRs |
 
 Rules:
 
 - Keep the section headings verbatim (`###` level, exact wording) — tooling and reviewers rely on them.
 - Drop the HTML comments from the template in the final description; keep the checklist items themselves.
-- Never mark a checklist item as done when it is not (e.g. don't tick "I wrote test cases" on a PR without tests).
+- **Never tick a checklist item.** Leave every box as `[ ]` — ticking them is the human author's responsibility, after their own review.
 - State explicitly what is intentionally out of scope, so reviewers don't flag it as missing.
 - The PR title still follows Conventional Commits and ends with the issue reference: `type(scope?): description (#issue)`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -145,7 +145,6 @@ Rules:
 - Keep the section headings verbatim (`###` level, exact wording) — tooling and reviewers rely on them.
 - Drop the HTML comments from the template in the final description; keep the checklist items themselves.
 - **Never tick a checklist item.** Leave every box as `[ ]` — ticking them is the human author's responsibility, after their own review.
-- State explicitly what is intentionally out of scope, so reviewers don't flag it as missing.
 - The PR title still follows Conventional Commits and ends with the issue reference: `type(scope?): description (#issue)`.
 
 ### Conventional Comments (for code reviews)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Sections, verbatim and in this order: `### Proposed changes`, `### Testing Instr
 `### Related issues`, `### Checklist`, `### Further comments`.
 
 - `Related issues` is mandatory (`* Related #1234`) — every PR is linked to an issue.
-- Keep all checklist lines; tick `[x]` only what is genuinely done.
+- Keep all checklist lines **unchecked** — never tick a box, the human author does that.
 - Drop the template's HTML comments from the final body.
 - Title follows Conventional Commits and ends with the issue reference.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,21 @@ These apply to **all agents**. Do not flag these — they are intentional patter
 - Test files using hardcoded credentials for mock setup → test-only context
 - Legacy `io.openaev.rest` controllers passing tenant to services → acceptable (legacy package)
 
+## Opening a Pull Request
+
+> **The PR description MUST follow [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).**
+> Read the template before writing the body — never invent your own headings.
+
+Sections, verbatim and in this order: `### Proposed changes`, `### Testing Instructions`,
+`### Related issues`, `### Checklist`, `### Further comments`.
+
+- `Related issues` is mandatory (`* Related #1234`) — every PR is linked to an issue.
+- Keep all checklist lines; tick `[x]` only what is genuinely done.
+- Drop the template's HTML comments from the final body.
+- Title follows Conventional Commits and ends with the issue reference.
+
+Full rules: [copilot-instructions.md → PR description format](.github/copilot-instructions.md#pr-description-format).
+
 ## Agent Maintenance Rule
 
 > **When you modify a `.github/instructions/*.md` file, you must update the corresponding


### PR DESCRIPTION
### Proposed changes

* `.github/copilot-instructions.md` — add a `### PR description format` section under `## PR & Review Conventions`, describing the five mandatory sections of `.github/PULL_REQUEST_TEMPLATE.md` and the rules around them (verbatim headings, mandatory issue link, checklist left untouched, drop HTML comments). Until now the instructions only covered PR *titles*, so agents and contributors had no written rule for PR *bodies* and each PR description looked different.
* `.github/copilot-instructions.md` — add entry 5 to the Pre-PR Checklist so the description requirement sits next to the other pre-merge validations instead of being buried further down the file.
* `AGENTS.md` — add a short `## Opening a Pull Request` section pointing at the template, with the section list and the key rules, and a link to the full rules in `copilot-instructions.md`. `AGENTS.md` is the quick-reference index, so it gets the summary and delegates the detail, consistent with how the other domains are indexed there.

Two follow-up commits refine the rules: the checklist rule becomes absolute (an agent-authored description never ticks a box, every line is reproduced as `[ ]`, ticking is left to the human author after their own review), and the "state what is out of scope" bullet is dropped as unnecessary prescription.

Documentation only — no code, no test, no behaviour change.

### Testing Instructions

1. Open `.github/copilot-instructions.md` and check that the `### PR description format` heading renders under `## PR & Review Conventions`, and that the Pre-PR Checklist now has 5 entries.
2. Click the `.github/PULL_REQUEST_TEMPLATE.md` links in both files — they resolve from the repo root.
3. Click the `copilot-instructions.md → PR description format` link at the end of the new `AGENTS.md` section — the `#pr-description-format` anchor resolves to the new heading.
4. Compare the section names listed in the docs with the actual headings in `.github/PULL_REQUEST_TEMPLATE.md` — they match verbatim (`### Proposed changes`, `### Testing Instructions`, `### Related issues`, `### Checklist`, `### Further comments`).
5. Run `grep -n -i -E '\[x\]|tick|genuinely done|uncheck' AGENTS.md .github/copilot-instructions.md` — only the three strict-rule lines match; no wording anywhere suggests an agent may tick a box.

No services, build or test run is required.

### Related issues

* Related #7742

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [NA] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ NA Where necessary I refactored code to improve the overall quality
- [NA] For bug fix -> I implemented a test that covers the bug

### Further comments

The convention is documented in two places on purpose: `AGENTS.md` is the entry point agents read first and only carries the summary, while `.github/copilot-instructions.md` holds the detailed rules. This mirrors the existing split for every other domain in the repo, so there is no new pattern to learn.

The checklist rule is deliberately absolute rather than conditional ("tick only what is genuinely done"). A conditional rule requires the agent to judge its own work, which is exactly the judgement the checklist exists to capture from a human. An always-unticked checklist is also trivially verifiable at review time.

The auto-generated `<!-- filigran-conventions -->` block was deliberately left untouched — it covers commit/PR *titles* and issue references, which is a different concern from the PR *body*, and it is regenerated by tooling.

This PR does not change `.github/PULL_REQUEST_TEMPLATE.md` itself: the template is already correct, only the written convention around it was missing. It also adds no CI check enforcing the description format — this is a documentation-first step, and automated enforcement can follow if the convention proves to drift.
