### PR TITLE
fix(chaining): ports are now considered as text values to avoid removing leading zeros from them (#313)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/output_processor/PortOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/PortOutputProcessor.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class PortOutputProcessor extends FindingCapableOutputProcessor {
 
   public PortOutputProcessor(FindingService findingService) {
-    super(ContractOutputType.Port, ContractOutputTechnicalType.Number, List.of(), findingService);
+    super(ContractOutputType.Port, ContractOutputTechnicalType.Text, List.of(), findingService);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/output_processor/PortOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/PortOutputProcessor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.openaev.database.model.ContractOutputTechnicalType;
 import io.openaev.database.model.ContractOutputType;
 import io.openaev.rest.finding.FindingService;
+import io.openaev.service.chaining.PrimitiveValueValidator;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,11 @@ public class PortOutputProcessor extends FindingCapableOutputProcessor {
 
   public PortOutputProcessor(FindingService findingService) {
     super(ContractOutputType.Port, ContractOutputTechnicalType.Text, List.of(), findingService);
+  }
+
+  @Override
+  public boolean validate(JsonNode jsonNode) {
+    return jsonNode != null && PrimitiveValueValidator.isValidPort(jsonNode.asText());
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/output_processor/PortScanOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/PortScanOutputProcessor.java
@@ -26,7 +26,7 @@ public class PortScanOutputProcessor extends FindingCapableOutputProcessor {
         List.of(
             new ContractOutputField(ASSET_ID, ContractOutputTechnicalType.Text, false),
             new ContractOutputField(HOST, ContractOutputTechnicalType.Text, true),
-            new ContractOutputField(PORT, ContractOutputTechnicalType.Number, true),
+            new ContractOutputField(PORT, ContractOutputTechnicalType.Text, true),
             new ContractOutputField(SERVICE, ContractOutputTechnicalType.Text, true)),
         findingService);
   }

--- a/openaev-api/src/main/java/io/openaev/output_processor/PortScanOutputProcessor.java
+++ b/openaev-api/src/main/java/io/openaev/output_processor/PortScanOutputProcessor.java
@@ -7,6 +7,7 @@ import io.openaev.database.model.ContractOutputField;
 import io.openaev.database.model.ContractOutputTechnicalType;
 import io.openaev.database.model.ContractOutputType;
 import io.openaev.rest.finding.FindingService;
+import io.openaev.service.chaining.PrimitiveValueValidator;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -33,7 +34,11 @@ public class PortScanOutputProcessor extends FindingCapableOutputProcessor {
 
   @Override
   public boolean validate(JsonNode jsonNode) {
-    return jsonNode.hasNonNull(HOST) && jsonNode.hasNonNull(PORT) && jsonNode.hasNonNull(SERVICE);
+    return jsonNode != null
+        && jsonNode.hasNonNull(HOST)
+        && jsonNode.hasNonNull(PORT)
+        && PrimitiveValueValidator.isValidPort(jsonNode.get(PORT).asText())
+        && jsonNode.hasNonNull(SERVICE);
   }
 
   @Override

--- a/openaev-api/src/main/java/io/openaev/service/chaining/PrimitiveValueValidator.java
+++ b/openaev-api/src/main/java/io/openaev/service/chaining/PrimitiveValueValidator.java
@@ -10,9 +10,10 @@ import org.apache.commons.validator.routines.DomainValidator;
  *
  * <p>Validation is intentionally scope-driven: types that can be restricted by workflow scope rules
  * (IPs, subnets, domains, asset and asset-group IDs) get a format check plus an allowlist/denylist
- * check. Port and Number get a cheap format sanity check. Every other primitive type has no defined
- * rule yet and is accepted as-is - hence the "accepted" naming, to make explicit that this is not a
- * full semantic validation of every primitive type.
+ * check. Port and Number get a cheap format sanity check. Port validation is also reused by output
+ * processors before generating findings. Every other primitive type has no defined rule yet and is
+ * accepted as-is - hence the "accepted" naming, to make explicit that this is not a full semantic
+ * validation of every primitive type.
  */
 public final class PrimitiveValueValidator {
 
@@ -53,7 +54,7 @@ public final class PrimitiveValueValidator {
     };
   }
 
-  private static boolean isValidPort(String value) {
+  public static boolean isValidPort(String value) {
     try {
       int port = Integer.parseInt(value.trim());
       return port >= 0 && port <= MAX_PORT;

--- a/openaev-api/src/test/java/io/openaev/output_processor/PortOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/PortOutputProcessorTest.java
@@ -1,6 +1,8 @@
 package io.openaev.output_processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -45,5 +47,28 @@ class PortOutputProcessorTest {
     JsonNode node = objectMapper.readTree("\"05\"");
     String result = processor.toFindingValue(node);
     assertEquals("05", result);
+  }
+
+  @Test
+  @DisplayName("Should reject non numeric port value")
+  void shouldRejectNonNumericPortValue() throws Exception {
+    JsonNode node = objectMapper.readTree("\"abc\"");
+    assertFalse(processor.validate(node));
+  }
+
+  @Test
+  @DisplayName("Should reject out of range port value")
+  void shouldRejectOutOfRangePortValue() throws Exception {
+    JsonNode tooLargeNode = objectMapper.readTree("\"99999\"");
+    JsonNode negativeNode = objectMapper.readTree("\"-1\"");
+    assertFalse(processor.validate(tooLargeNode));
+    assertFalse(processor.validate(negativeNode));
+  }
+
+  @Test
+  @DisplayName("Should accept port value with leading zero")
+  void shouldAcceptPortValueWithLeadingZero() throws Exception {
+    JsonNode node = objectMapper.readTree("\"05\"");
+    assertTrue(processor.validate(node));
   }
 }

--- a/openaev-api/src/test/java/io/openaev/output_processor/PortOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/PortOutputProcessorTest.java
@@ -38,4 +38,12 @@ class PortOutputProcessorTest {
     String result = processor.toFindingValue(node);
     assertEquals("", result);
   }
+
+  @Test
+  @DisplayName("Should preserve leading zero for port value")
+  void shouldPreserveLeadingZeroForPortValue() throws Exception {
+    JsonNode node = objectMapper.readTree("\"05\"");
+    String result = processor.toFindingValue(node);
+    assertEquals("05", result);
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/output_processor/PortScanOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/PortScanOutputProcessorTest.java
@@ -37,6 +37,16 @@ class PortScanOutputProcessorTest {
   }
 
   @Test
+  @DisplayName("Should preserve leading zero in port field of PortsScan")
+  void shouldPreserveLeadingZeroInPortField() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{\"host\": \"192.168.1.1\", \"port\": \"05\", \"service\": \"ssh\"}");
+    String result = processor.toFindingValue(node);
+    assertEquals("192.168.1.1:05 (ssh)", result);
+  }
+
+  @Test
   @DisplayName("Should return single asset id when asset_id is present")
   void shouldReturnSingleAssetIdWhenAssetIdPresent() throws Exception {
     JsonNode node =

--- a/openaev-api/src/test/java/io/openaev/output_processor/PortScanOutputProcessorTest.java
+++ b/openaev-api/src/test/java/io/openaev/output_processor/PortScanOutputProcessorTest.java
@@ -123,4 +123,31 @@ class PortScanOutputProcessorTest {
             "{\"host\": \"192.168.1.1\", \"port\": \"22\", \"service\": \"ssh\"}");
     assertTrue(processor.validate(node));
   }
+
+  @Test
+  @DisplayName("Should reject PortsScan finding with non numeric port")
+  void shouldRejectPortsScanWithNonNumericPort() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{\"host\": \"192.168.1.1\", \"port\": \"abc\", \"service\": \"ssh\"}");
+    assertFalse(processor.validate(node));
+  }
+
+  @Test
+  @DisplayName("Should reject PortsScan finding with out of range port")
+  void shouldRejectPortsScanWithOutOfRangePort() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{\"host\": \"192.168.1.1\", \"port\": \"70000\", \"service\": \"ssh\"}");
+    assertFalse(processor.validate(node));
+  }
+
+  @Test
+  @DisplayName("Should accept PortsScan finding with leading zero port")
+  void shouldAcceptPortsScanWithLeadingZeroPort() throws Exception {
+    JsonNode node =
+        objectMapper.readTree(
+            "{\"host\": \"192.168.1.1\", \"port\": \"05\", \"service\": \"ssh\"}");
+    assertTrue(processor.validate(node));
+  }
 }

--- a/openaev-api/src/test/java/io/openaev/rest/inject/InjectApiTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/InjectApiTest.java
@@ -2096,6 +2096,38 @@ class InjectApiTest extends IntegrationTest {
         assertTrue(injectTestHelper.findFindingsByInjectId(portScanInject.getId()).isEmpty());
       }
 
+      @Test
+      @DisplayName("Should not create PortScan findings when extracted port is invalid")
+      void shouldNotCreatePortScanFindingsWhenExtractedPortIsInvalid() throws Exception {
+        // -- PREPARE --
+        RegexGroup hostGroup = OutputParserFixture.getRegexGroup("host", "$1");
+        RegexGroup portGroup = OutputParserFixture.getRegexGroup("port", "$2");
+        RegexGroup serviceGroup = OutputParserFixture.getRegexGroup("service", "$3");
+        ContractOutputElement portScanElement =
+            OutputParserFixture.getContractOutputElement(
+                ContractOutputType.PortsScan,
+                "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}):([A-Za-z0-9-]+)\\s+\\S+\\s+(LISTENING)",
+                Set.of(hostGroup, portGroup, serviceGroup),
+                true);
+        OutputParser outputParser = OutputParserFixture.getOutputParser(Set.of(portScanElement));
+        Object[] setup = buildInjectWithOutputParser(outputParser);
+        Inject portScanInject = (Inject) setup[0];
+        String agentId = (String) setup[1];
+
+        InjectExecutionInput input = new InjectExecutionInput();
+        input.setMessage(
+            "{\"stdout\":\"192.168.1.10:70000 0.0.0.0:0 LISTENING\\n"
+                + "10.0.0.5:abc 0.0.0.0:0 LISTENING\\n\"}");
+        input.setAction(InjectExecutionAction.command_execution);
+        input.setStatus("SUCCESS");
+
+        // -- EXECUTE --
+        performCallbackRequest(agentId, portScanInject.getId(), input);
+
+        // -- ASSERT --
+        assertTrue(injectTestHelper.findFindingsByInjectId(portScanInject.getId()).isEmpty());
+      }
+
       // Port
 
       @Test
@@ -2157,6 +2189,34 @@ class InjectApiTest extends IntegrationTest {
         String agentId = (String) setup[1];
 
         InjectExecutionInput input = buildStdoutInput("no ports here");
+
+        // -- EXECUTE --
+        performCallbackRequest(agentId, portInject.getId(), input);
+
+        // -- ASSERT --
+        assertTrue(injectTestHelper.findFindingsByInjectId(portInject.getId()).isEmpty());
+      }
+
+      @Test
+      @DisplayName("Should not create Port findings when extracted port is invalid")
+      void shouldNotCreatePortFindingsWhenExtractedPortIsInvalid() throws Exception {
+        // -- PREPARE --
+        RegexGroup portGroup = OutputParserFixture.getRegexGroup("port", "$1");
+        ContractOutputElement portElement =
+            OutputParserFixture.getContractOutputElement(
+                ContractOutputType.Port,
+                "(?:TCP|UDP)\\s+[\\d\\.]+:([A-Za-z0-9-]+)",
+                Set.of(portGroup),
+                true);
+        OutputParser outputParser = OutputParserFixture.getOutputParser(Set.of(portElement));
+        Object[] setup = buildInjectWithOutputParser(outputParser);
+        Inject portInject = (Inject) setup[0];
+        String agentId = (String) setup[1];
+
+        String rawOutput =
+            "  TCP    192.168.1.10:abc            0.0.0.0:0              LISTENING\\n"
+                + "  TCP    192.168.1.10:99999            0.0.0.0:0              LISTENING\\n";
+        InjectExecutionInput input = buildStdoutInput(rawOutput);
 
         // -- EXECUTE --
         performCallbackRequest(agentId, portInject.getId(), input);

--- a/openaev-api/src/test/java/io/openaev/rest/inject/StructuredOutputUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/StructuredOutputUtilsTest.java
@@ -250,6 +250,46 @@ class StructuredOutputUtilsTest extends IntegrationTest {
   }
 
   @Test
+  @DisplayName("Should filter invalid Port values from structured output")
+  void given_raw_output_with_invalid_port_should_filter_port_result() {
+    RegexGroup regexGroup = new RegexGroup();
+    regexGroup.setField("port");
+    regexGroup.setIndexValues("$1");
+
+    testRegexExtraction(
+        "TCP 192.168.1.10:abc 0.0.0.0:0 LISTENING\n",
+        Set.of(regexGroup),
+        ContractOutputType.Port,
+        "Port",
+        "(?:TCP|UDP)\\s+[\\d\\.]+:([A-Za-z0-9-]+)",
+        "[]");
+  }
+
+  @Test
+  @DisplayName("Should filter invalid PortsScan values from structured output")
+  void given_raw_output_with_invalid_portscan_port_should_filter_portscan_result() {
+    RegexGroup regexGroup1 = new RegexGroup();
+    regexGroup1.setField("host");
+    regexGroup1.setIndexValues("$2");
+
+    RegexGroup regexGroup2 = new RegexGroup();
+    regexGroup2.setField("port");
+    regexGroup2.setIndexValues("$3");
+
+    RegexGroup regexGroup3 = new RegexGroup();
+    regexGroup3.setField("service");
+    regexGroup3.setIndexValues("$4");
+
+    testRegexExtraction(
+        "TCP 192.168.1.10:70000 0.0.0.0:0 LISTENING\n",
+        Set.of(regexGroup1, regexGroup2, regexGroup3),
+        ContractOutputType.PortsScan,
+        "PortScan",
+        "^\\s*(TCP|UDP)\\s+([\\d\\.]+|\\*)?:?([A-Za-z0-9-]+)\\s+\\S+\\s+(\\S+)",
+        "[]");
+  }
+
+  @Test
   @DisplayName("Should return IPv4s from raw output of netstat -an command")
   void given_raw_output_netstat_should_return_ipv4() {
     RegexGroup regexGroup = new RegexGroup();

--- a/openaev-api/src/test/java/io/openaev/rest/inject/StructuredOutputUtilsTest.java
+++ b/openaev-api/src/test/java/io/openaev/rest/inject/StructuredOutputUtilsTest.java
@@ -1,7 +1,9 @@
 package io.openaev.rest.inject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -189,7 +191,7 @@ class StructuredOutputUtilsTest extends IntegrationTest {
         ContractOutputType.PortsScan,
         "PortScan",
         "^\\s*(TCP|UDP)\\s+([\\d\\.]+|\\*)?:?(\\d+)\\s+\\S+\\s+(\\S+)",
-        "[{\"asset_id\":null,\"host\":\"192.168.1.10\",\"port\":135,\"service\":\"LISTENING\"},{\"asset_id\":null,\"host\":\"176.125.125.10\",\"port\":445,\"service\":\"LISTENING\"},{\"asset_id\":null,\"host\":\"192.168.12.12\",\"port\":902,\"service\":\"LISTENING\"}]");
+        "[{\"asset_id\":null,\"host\":\"192.168.1.10\",\"port\":\"135\",\"service\":\"LISTENING\"},{\"asset_id\":null,\"host\":\"176.125.125.10\",\"port\":\"445\",\"service\":\"LISTENING\"},{\"asset_id\":null,\"host\":\"192.168.12.12\",\"port\":\"902\",\"service\":\"LISTENING\"}]");
   }
 
   @Test
@@ -205,7 +207,46 @@ class StructuredOutputUtilsTest extends IntegrationTest {
         ContractOutputType.Port,
         "Port",
         "(?:TCP|UDP)\\s+[\\d\\.]+:(\\d+)",
-        "[135,445,902]");
+        "[\"135\",\"445\",\"902\"]");
+  }
+
+  @Test
+  @DisplayName("Should preserve leading zero for port in structured output")
+  void given_raw_output_netstat_should_preserve_leading_zero_for_port() {
+    String rawOutput =
+        "\n"
+            + "Active Connections\n"
+            + "\n"
+            + "  Proto  Local Address          Foreign Address        State\n"
+            + "  TCP    192.168.1.10:05            0.0.0.0:0              LISTENING\n";
+
+    RegexGroup regexGroup = new RegexGroup();
+    regexGroup.setField("port");
+    regexGroup.setIndexValues("$1");
+
+    ContractOutputElement contractOutputElement = new ContractOutputElement();
+    contractOutputElement.setType(ContractOutputType.Port);
+    contractOutputElement.setRule("(?:TCP|UDP)\\s+[\\d\\.]+:(\\d+)");
+    contractOutputElement.setKey("Port");
+    contractOutputElement.setRegexGroups(Set.of(regexGroup));
+
+    OutputParser outputParser = new OutputParser();
+    outputParser.setType(ParserType.REGEX);
+    outputParser.setMode(ParserMode.STDOUT);
+    outputParser.setContractOutputElements(Set.of(contractOutputElement));
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode stdoutNode = mapper.createObjectNode();
+    stdoutNode.put("stdout", rawOutput);
+
+    Optional<ObjectNode> result =
+        structuredOutputUtils.computeStructuredOutputFromOutputParsers(
+            Set.of(outputParser), stdoutNode.toString());
+
+    assertTrue(result.isPresent());
+    String structuredPort = result.get().get("Port").toString();
+    assertTrue(structuredPort.contains("\"05\""));
+    assertFalse(structuredPort.contains("[5]"));
   }
 
   @Test

--- a/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/chaining/ConditionServiceTest.java
@@ -908,6 +908,38 @@ public class ConditionServiceTest {
     }
 
     @Test
+    void given_portMapperWithLeadingZeroScopeValue_should_preserveDistinctCandidatesAndDefault() {
+      // -------- Arrange --------
+      Step stepTemplate = mock(Step.class);
+      Workflow workflowRun = mock(Workflow.class);
+      when(workflowRun.getId()).thenReturn("wf-port-leading-zero-defined-value");
+
+      Condition portMapper = mapper(MappingType.LOCAL, PrimitiveType.Port, "22");
+      portMapper.setKey("portValue");
+      List<Condition> mappers = List.of(portMapper);
+
+      WorkflowStateEntries localEntries = entries(List.of(input("Port", "05", "445")), List.of());
+      WorkflowStateEntries globalEntries = entries(List.of(), List.of());
+
+      when(workflowStateService.getGlobalStateByWorkflowId("wf-port-leading-zero-defined-value"))
+          .thenReturn(stateFromEntries(globalEntries));
+      when(workflowStateService.loadOrBuildLocalState(stepTemplate, workflowRun))
+          .thenReturn(stateFromEntries(localEntries));
+
+      // -------- Act --------
+      List<ConditionService.ExecutionBatch> batches =
+          conditionService.prepareInputsForStepExecution(stepTemplate, workflowRun, mappers);
+
+      // -------- Assert --------
+      assertEquals(3, batches.size());
+      Set<String> values =
+          batches.stream()
+              .map(b -> b.usedMappers().getFirst().getValue())
+              .collect(java.util.stream.Collectors.toSet());
+      assertEquals(Set.of("05", "445", "22"), values);
+    }
+
+    @Test
     void given_defaultMapperAndMissingLinkedMapper_should_generateSingleBatchWithDefaultOnly() {
       // -------- Arrange --------
       Step stepTemplate = mock(Step.class);


### PR DESCRIPTION
### Proposed changes

In the backend, Ports were described as numerical value which meant an automatic conversion to a number, thus removing the leading 0s. This PR changes that so that they are considered as text

There are no impact on form validation, they still require an integer value between 0 and 65535.

### Testing Instructions
Reproducing the bug: 
- Create two scope variables of type port: 05 and 445.
- Create an action of type port (default value 22) executing echo <portValue>.
- Run the workflow/simulation.
- Observe 4 executions instead of 3, with a superfluous extra echo 5 execution.

With the fix, the 4th execution doesn't happen

### Related issues

* Related https://github.com/OpenAEV-Platform/filigran-private/issues/313

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug
