### PR TITLE
fix(injectors): only offer contracts with a registered injector in the inject picker (#7805)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/Executor.java
+++ b/openaev-api/src/main/java/io/openaev/executors/Executor.java
@@ -113,7 +113,12 @@ public class Executor {
               .orElseThrow(
                   () ->
                       new IllegalStateException(
-                          "Injector not found for type: " + inject.getType()));
+                          "No injector registered for contract "
+                              + injectorContract.getId()
+                              + " in tenant "
+                              + inject.getTenant().getId()
+                              + ". Register/deploy the injector for this tenant before running"
+                              + " the inject."));
     }
 
     // Telemetry - We shouldn't have multiple injector type per executable inject but if it happens,

--- a/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractApi.java
+++ b/openaev-api/src/main/java/io/openaev/rest/injector_contract/InjectorContractApi.java
@@ -12,6 +12,7 @@ import io.openaev.database.model.Action;
 import io.openaev.database.model.InjectorContract;
 import io.openaev.database.model.ResourceType;
 import io.openaev.database.raw.RawInjectorsContracts;
+import io.openaev.database.specification.InjectorContractSpecification;
 import io.openaev.rest.helper.RestBehavior;
 import io.openaev.rest.injector_contract.form.InjectorContractAddInput;
 import io.openaev.rest.injector_contract.form.InjectorContractUpdateInput;
@@ -31,6 +32,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -81,11 +83,17 @@ public class InjectorContractApi extends RestBehavior {
   // InjectorContractService#mapFull), which resolves against the activated injectors table.
   public Page<? extends InjectorContractBaseOutput> injectorContracts(
       TxCtx ctx, @RequestBody @Valid final InjectorContractSearchPaginationInput input) {
+    // The inject-creation picker must only offer contracts that can actually run: a contract with no
+    // injector registered in the current tenant would let the user build an inject that dies at
+    // execution with "Injector not found". This does not affect the Threat Arsenal catalog, which is
+    // served by ThreatArsenalService rather than this endpoint.
+    Specification<InjectorContract> hasInjector =
+        InjectorContractSpecification.hasRegisteredInjector();
     return buildPaginationCriteriaBuilder(
         (spec, specCount, pageable) ->
             this.injectorContractService.getSinglePage(
-                spec,
-                specCount,
+                spec.and(hasInjector),
+                specCount.and(hasInjector),
                 pageable,
                 input.isIncludeFullDetails()
                     ? InjectorContractService.OutputMode.FULL

--- a/openaev-api/src/test/java/io/openaev/executors/ExecutorTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/ExecutorTest.java
@@ -146,7 +146,7 @@ class ExecutorTest {
       // -------- Act / Assert --------
       assertThatThrownBy(() -> executor.execute(executableInject))
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("Injector not found for type");
+          .hasMessageContaining("No injector registered for contract");
     }
 
     @Test

--- a/openaev-model/src/main/java/io/openaev/database/specification/InjectorContractSpecification.java
+++ b/openaev-model/src/main/java/io/openaev/database/specification/InjectorContractSpecification.java
@@ -3,11 +3,42 @@ package io.openaev.database.specification;
 import io.openaev.database.model.*;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import org.springframework.data.jpa.domain.Specification;
 
 public class InjectorContractSpecification {
 
   private InjectorContractSpecification() {}
+
+  /**
+   * Keeps only contracts that have an injector registered in the same tenant as the contract.
+   *
+   * <p>The inject-creation picker must never offer a contract whose injector is not registered in
+   * the current tenant: the inject can be created but dies at execution with a cryptic {@code
+   * Injector not found}, because {@link io.openaev.executors.Executor} resolves the injector strictly
+   * per tenant. The join row of {@link InjectorInjectorContract} always shares the {@code tenant_id}
+   * of both endpoints (foreign-tenant links are rejected at link time), so matching the link on both
+   * the contract id and the contract tenant id is enough and does not depend on the Hibernate {@code
+   * tenantFilter}. This deliberately does not touch the Threat Arsenal catalog, which shares the
+   * underlying query but is browsed, not executed.
+   */
+  public static Specification<InjectorContract> hasRegisteredInjector() {
+    return (root, query, cb) -> {
+      Subquery<Integer> sub = query.subquery(Integer.class);
+      Root<InjectorInjectorContract> link = sub.from(InjectorInjectorContract.class);
+      sub.select(cb.literal(1));
+      sub.where(
+          cb.equal(
+              link.get("injectorContractId"),
+              root.get(InjectorContract.COMPOSITE_ID_FIELD_NAME)
+                  .get(InjectorContract.ID_FIELD_NAME)),
+          cb.equal(
+              link.get("tenantId"),
+              root.get(InjectorContract.COMPOSITE_ID_FIELD_NAME).get("tenantId")));
+      return cb.exists(sub);
+    };
+  }
 
   public static Specification<InjectorContract> fromAttackPattern(String attackPatternId) {
     return (root, query, cb) -> cb.equal(root.get("attackPatterns").get("id"), attackPatternId);


### PR DESCRIPTION
Closes #7805

## What

The inject-creation picker (atomic testing, scenario, simulation) offered injector contracts **even when no injector was registered for the current tenant**. A contract like `Nmap - TCP Connect Scan` could be selected and launched, only to die at execution with a cryptic `Injector not found for type: null`.

## Why

Injector resolution is strictly per-tenant (`Executor#execute`, `InjectorContract#getInjectors()` tenant-filtered), while the picker's contract query (`InjectorContractService#buildCommonInjectorContractContext`, endpoint `/injector_contracts/search`) `LEFT`-joins the injector, so contracts without an injector in the tenant were still offered. Injectors register per tenant and cross-tenant links are rejected, so such a contract is genuinely non-executable.

## How

- New `InjectorContractSpecification.hasRegisteredInjector()`: `EXISTS` an `InjectorInjectorContract` matching both the contract id **and** tenant id (the join row always shares the contract's tenant, so this is robust and independent of the Hibernate `tenantFilter`).
- Applied on the picker endpoint (`InjectorContractApi#injectorContracts`, on both `spec` and `specCount`). Covers atomic testing, scenario and simulation (same endpoint). **Threat Arsenal is untouched** — it is served by `ThreatArsenalService`, not this endpoint, and is browsed rather than executed.
- Replaced the cryptic `Injector not found for type: null` with an actionable message naming the contract and tenant.

## Note (ops, not code)

To actually run Nmap/Nuclei on a tenant, the external injector must be registered/deployed **for that tenant** (its `OPENAEV_URL`/token targeting the tenant). Without it, no scan runs regardless of this fix.

## Tests

- `ExecutorTest` updated for the new message.
- Existing `/injector_contracts/search` tests cover regression: built-in injectors are registered per tenant, so their contracts still appear. An integration test asserting an injector-less contract is excluded is a good follow-up (needs multi-tenant fixture).

_Found via internal dogfooding._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
