### PR TITLE
fix(executors): return the vendor session as soon as the implant is launched (#7799)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/mde/service/MdeExecutorContextService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/mde/service/MdeExecutorContextService.java
@@ -224,7 +224,12 @@ public class MdeExecutorContextService extends ExecutorContextService {
             + ExecutorHelper.IMPLANT_BASE_NAME
             + UUID.randomUUID()
             + ";mkdir -p $location;filename=";
-    String executorCommandKey = platform.name() + "." + Endpoint.PLATFORM_ARCH.x86_64.name();
+    // Executor-specific key: the detached Unix command returns the Live Response session as soon
+    // as the implant is launched, instead of holding it for the whole payload. The generic
+    // "Linux.x86_64" entry is deliberately left alone, the native OpenAEV agent and Caldera read
+    // it.
+    String executorCommandKey =
+        MDE_EXECUTOR_NAME + "." + platform.name() + "." + Endpoint.PLATFORM_ARCH.x86_64.name();
     String command = injector.getExecutorCommands().get(executorCommandKey);
     command = UNIX_ARCH + command.replace(Endpoint.PLATFORM_ARCH.x86_64.name(), ARCH_VARIABLE);
     command =

--- a/openaev-api/src/main/java/io/openaev/executors/paloaltocortex/service/PaloAltoCortexExecutorContextService.java
+++ b/openaev-api/src/main/java/io/openaev/executors/paloaltocortex/service/PaloAltoCortexExecutorContextService.java
@@ -210,7 +210,15 @@ public class PaloAltoCortexExecutorContextService extends ExecutorContextService
               + ";mkdir -p $location;filename=";
       // x86_64 by default in the register because CS API doesn't provide the platform architecture
       // (we update this when the download implant script is launched on the endpoint)
-      String executorCommandKey = platform.name() + "." + Endpoint.PLATFORM_ARCH.x86_64.name();
+      // Executor-specific key: the detached Unix command returns the Live Terminal session as
+      // soon as the implant is launched. The generic "Linux.x86_64" entry is deliberately left
+      // alone, the native OpenAEV agent and Caldera read it.
+      String executorCommandKey =
+          PALOALTOCORTEX_EXECUTOR_NAME
+              + "."
+              + platform.name()
+              + "."
+              + Endpoint.PLATFORM_ARCH.x86_64.name();
       String command = injector.getExecutorCommands().get(executorCommandKey);
       // The default command to download the openaev implant and execute the attack is modified for
       // Cortex

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
@@ -6,6 +6,7 @@ import static io.openaev.integration.impl.executors.paloaltocortex.PaloAltoCorte
 import io.openaev.config.OpenAEVConfig;
 import io.openaev.database.model.Endpoint;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -17,6 +18,14 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 final class OpenaevImplantCommandBuilder {
+
+  /**
+   * How long the Windows scheduled-task command waits for the task to start before giving up and
+   * reporting a launch failure. This bounds how long the vendor remote session is held, so it is
+   * kept short on purpose: a task that has not started within a minute is not going to.
+   */
+  private static final int SCHEDULED_TASK_START_TIMEOUT_SECONDS = 60;
+
   /**
    * Record to group all command variables.
    *
@@ -46,13 +55,23 @@ final class OpenaevImplantCommandBuilder {
     Map<String, String> commands = new HashMap<>();
     CommandVars vars = new CommandVars();
     // --- PALO ALTO WINDOWS SPECIFIC ---
-    buildPaloAltoWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars);
-    buildPaloAltoWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars);
+    buildPaloAltoWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars, timeoutSeconds);
+    buildPaloAltoWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars, timeoutSeconds);
     // --- MDE WINDOWS SPECIFIC ---
     // MDE Live Response (like Cortex XDR) terminates child processes when the remote session ends,
     // so the implant must be launched from a detached scheduled task to survive and phone home.
-    buildMdeWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars);
-    buildMdeWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars);
+    buildMdeWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars, timeoutSeconds);
+    buildMdeWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars, timeoutSeconds);
+    // --- DETACHED UNIX, per executor ---
+    // Same reasoning as the Windows commands above, applied to Linux and macOS. Kept under
+    // executor-prefixed keys so the generic Unix commands, which the native OpenAEV agent and
+    // Caldera also read, keep their current blocking behaviour.
+    for (String executorName : List.of(MDE_EXECUTOR_NAME, PALOALTOCORTEX_EXECUTOR_NAME)) {
+      buildDetachedUnixCommand(
+          executorName, Endpoint.PLATFORM_TYPE.Linux, "linux", commands, vars, timeoutSeconds);
+      buildDetachedUnixCommand(
+          executorName, Endpoint.PLATFORM_TYPE.MacOS, "macos", commands, vars, timeoutSeconds);
+    }
     // --- WINDOWS ---
     buildGenericWindowsCommand(Endpoint.PLATFORM_ARCH.x86_64, commands, vars, timeoutSeconds);
     buildGenericWindowsCommand(Endpoint.PLATFORM_ARCH.arm64, commands, vars, timeoutSeconds);
@@ -119,21 +138,81 @@ final class OpenaevImplantCommandBuilder {
   }
 
   private static void buildPaloAltoWindowsCommand(
-      Endpoint.PLATFORM_ARCH arch, Map<String, String> commands, CommandVars vars) {
-    buildScheduledTaskWindowsCommand(PALOALTOCORTEX_EXECUTOR_NAME, arch, commands, vars);
+      Endpoint.PLATFORM_ARCH arch,
+      Map<String, String> commands,
+      CommandVars vars,
+      int timeoutSeconds) {
+    buildScheduledTaskWindowsCommand(
+        PALOALTOCORTEX_EXECUTOR_NAME, arch, commands, vars, timeoutSeconds);
   }
 
   private static void buildMdeWindowsCommand(
-      Endpoint.PLATFORM_ARCH arch, Map<String, String> commands, CommandVars vars) {
-    buildScheduledTaskWindowsCommand(MDE_EXECUTOR_NAME, arch, commands, vars);
+      Endpoint.PLATFORM_ARCH arch,
+      Map<String, String> commands,
+      CommandVars vars,
+      int timeoutSeconds) {
+    buildScheduledTaskWindowsCommand(MDE_EXECUTOR_NAME, arch, commands, vars, timeoutSeconds);
   }
 
   /**
    * Builds a Windows implant command that launches the implant from a detached SYSTEM scheduled
-   * task instead of a direct child process. EDR remote-execution channels (Palo Alto Cortex XDR
-   * Live Terminal, Microsoft Defender for Endpoint Live Response) terminate the process tree of the
-   * remote session once it ends; a scheduled task survives session teardown so the implant can run
-   * and report its execution traces back to OpenAEV.
+   * task instead of a direct child process, then returns the remote session immediately.
+   *
+   * <h4>Why a scheduled task</h4>
+   *
+   * EDR remote-execution channels (Palo Alto Cortex XDR Live Terminal, Microsoft Defender for
+   * Endpoint Live Response) terminate the process tree of the remote session once it ends. There is
+   * no Unix-style detach on Windows: a process started with {@code Start-Process} stays a child of
+   * the session and dies with it. The way out is re-parenting, handing the work to a service that
+   * outlives the session. The Task Scheduler service is that owner here.
+   *
+   * <h4>Why we no longer wait for the task to finish</h4>
+   *
+   * Detaching the implant protects it from session teardown, but it does not release the session.
+   * This command used to poll until the task returned to {@code Ready}, which means "the payload
+   * has finished", for up to five minutes. During that whole window the vendor session stayed open.
+   *
+   * <p>That matters because these APIs are built for an analyst typing one command and reading the
+   * answer within seconds, and vendors cap the number of concurrent sessions per tenant. An Inject
+   * targeting a hundred endpoints asked for a hundred simultaneous sessions held for minutes, so
+   * OpenAEV was consuming a large share of that budget itself.
+   *
+   * <p>We now poll only until the task has actually <em>started</em>, which takes about a second,
+   * then return. Execution results do not need the session: the implant posts them back over HTTP
+   * through the execution callback, and nothing in OpenAEV ever reads the session output.
+   *
+   * <h4>Where this pattern comes from</h4>
+   *
+   * This mirrors {@code openaev-ttr.ps1}, the Tanium Threat Response wrapper already shipped in
+   * this repository and already running at customers. It is the reference implementation for the
+   * whole "return the session immediately" work: same scheduled task, same "has it started"
+   * condition.
+   *
+   * <p>Two deliberate differences from that reference, both worth knowing:
+   *
+   * <ul>
+   *   <li>The startup budget is 60 seconds here, against 180 in the Tanium wrapper. A task that has
+   *       not started within a minute is not going to, and the point of this change is to stop
+   *       holding sessions.
+   *   <li>The exit code now reports whether the <em>launch</em> succeeded, not what the payload
+   *       returned. The payload result was read from {@code LastTaskResult}, which is only
+   *       meaningful once the task completes, and no OpenAEV code ever read it back: the five
+   *       executor clients return {@code void} and no command result is ever polled.
+   * </ul>
+   *
+   * <h4>The bootstrap signal is deliberately kept</h4>
+   *
+   * When the implant never starts at all (blocked download, antivirus, wrong architecture) no
+   * callback is ever sent, and the session output is the only human-readable evidence left. So the
+   * command still prints a one-line launch outcome before returning, exactly as the Tanium wrapper
+   * does. Only the payload's own output goes away, and that was never the source of execution logs.
+   *
+   * <h4>Known open point</h4>
+   *
+   * Unregistering a task while its instance is still running is a behaviour we have only ever
+   * exercised through the Tanium TTR package. The previous code never hit it, since it unregistered
+   * after completion. It works in production there, but it is worth confirming per executor rather
+   * than assuming.
    *
    * @param executorNameKey executor name used as the command map key prefix
    */
@@ -141,7 +220,8 @@ final class OpenaevImplantCommandBuilder {
       String executorNameKey,
       Endpoint.PLATFORM_ARCH arch,
       Map<String, String> commands,
-      CommandVars vars) {
+      CommandVars vars,
+      int timeoutSeconds) {
     commands.put(
         executorNameKey + "." + Endpoint.PLATFORM_TYPE.Windows.name() + "." + arch.name(),
         "[Net.ServicePointManager]::SecurityProtocol +="
@@ -168,23 +248,157 @@ final class OpenaevImplantCommandBuilder {
             + " Outbound\";New-NetFirewallRule -DisplayName \"Allow OpenAEV Outbound\" -Direction"
             + " Outbound -Program \"$location\\$filename\" -Action Allow | Out-Null;$taskName ="
             + " 'OpenAEV-Inject-#{inject}-Agent-#{agent}';$taskDescription = 'OpenAEV EDR"
-            + " validation task - inject #{inject} - agent #{agent} - safe to ignore - will"
-            + " self-delete after execution';$implantArgs = '--uri ' + $server + ' --token ' +"
+            + " validation task - inject #{inject} - agent #{agent} - safe to ignore -"
+            + " removed as soon as it starts';$implantArgs = '--uri ' + $server + ' --token ' +"
             + " $token + ' --unsecured-certificate ' + $unsecured_certificate + ' --with-proxy ' +"
             + " $with_proxy + ' --agent-id #{agent} --inject-id #{inject} --tenant-id"
             + " #{tenant}';$action = New-ScheduledTaskAction -Execute \"$location\\$filename\""
             + " -Argument $implantArgs;$principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM'"
             + " -LogonType ServiceAccount -RunLevel Highest;$settings ="
             + " New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries"
-            + " -ExecutionTimeLimit (New-TimeSpan -Hours 0);Register-ScheduledTask -TaskName"
+            // The safety net. It used to be (New-TimeSpan -Hours 0), which disables the limit
+            // entirely: the implant has no maximum runtime of its own, so nothing bounded the
+            // payload on this path at all. Returning the session early makes that gap worse, since
+            // we no longer observe the task, so the bound is restored here using the same budget
+            // the shell watchdog applies on the generic commands.
+            + " -ExecutionTimeLimit (New-TimeSpan -Seconds "
+            + timeoutSeconds
+            + ");Register-ScheduledTask -TaskName"
             + " $taskName -Description $taskDescription -Action $action -Principal $principal"
             + " -Settings $settings -Force | Out-Null;Start-ScheduledTask -TaskName"
-            + " $taskName;$timeout = 300; $elapsed = 0;while($elapsed -lt $timeout) {  $state ="
-            + " (Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue).State; "
-            + " if($state -eq 'Ready') { break }  Start-Sleep -Seconds 1; $elapsed++;}$info ="
-            + " Get-ScheduledTaskInfo -TaskName $taskName -ErrorAction SilentlyContinue;$exitCode ="
-            + " $info.LastTaskResult;Unregister-ScheduledTask -TaskName $taskName -Confirm:$false"
-            + " -ErrorAction SilentlyContinue;exit $exitCode;");
+            + " $taskName;"
+            // Poll for "has the task started", not "has it finished". LastRunTime is stamped as
+            // soon as the Task Scheduler runs the action, so this normally exits on the first
+            // iteration and the vendor session is returned in about a second.
+            //
+            // Compared against a recent instant rather than against $null: a task that has never
+            // run reports a sentinel LastRunTime (30/11/1999) on several Windows versions, not
+            // $null, so a null check would never become true and we would wait out the budget on
+            // every launch. openaev-ttr.ps1 uses the null form and gets away with it because it
+            // reports success regardless; we want the signal to mean something.
+            + "$startedAfter = (Get-Date).AddMinutes(-1);$timeout = "
+            + SCHEDULED_TASK_START_TIMEOUT_SECONDS
+            + "; $elapsed = 0; $started = $false;"
+            + "while($elapsed -lt $timeout -and -not $started) {"
+            + "  $info = Get-ScheduledTaskInfo -TaskName $taskName -ErrorAction SilentlyContinue;"
+            + "  if($info -and $info.LastRunTime -gt $startedAfter) { $started = $true }"
+            + "  else { Start-Sleep -Seconds 1; $elapsed++ }"
+            + "};"
+            // The task is removed right after it started, while the payload is still running. The
+            // running instance is owned by the Task Scheduler service and is not killed by this.
+            + "Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction"
+            + " SilentlyContinue;"
+            // Bootstrap signal: the only evidence left in the vendor console when the implant never
+            // starts and therefore never calls back. Not the payload result, which arrives through
+            // the execution callback.
+            + "if($started) { Write-Host 'OpenAEV implant launched'; exit 0 };"
+            + "Write-Host 'OpenAEV implant start not confirmed within' $timeout 'seconds';"
+            + " exit 1;");
+  }
+
+  /**
+   * Builds a Unix implant command that launches the implant fully detached from the vendor's
+   * remote-execution session, then returns that session immediately.
+   *
+   * <h4>The problem this solves</h4>
+   *
+   * The generic Unix command backgrounds the implant, starts a watchdog subshell, and then blocks
+   * on {@code wait $pid} for the whole Inject threshold. The vendor session stays open for that
+   * entire duration. On an Inject targeting a hundred endpoints that is a hundred concurrent
+   * sessions held for minutes, against APIs built for an analyst reading one answer in seconds, and
+   * vendors cap concurrent sessions per tenant.
+   *
+   * <h4>The watchdog is kept, it moves</h4>
+   *
+   * The reason the wait exists is legitimate: without it an implant that hangs would sit on the
+   * customer's machine forever. That safeguard is preserved here, it simply moves inside the
+   * detached process instead of living in the session-bound shell. If it stayed outside, tearing
+   * the session down would kill the watchdog and leave the implant running unsupervised, which is
+   * strictly worse than today.
+   *
+   * <h4>Two details that are not decoration</h4>
+   *
+   * <ul>
+   *   <li><b>Escape the process group.</b> {@code setsid} on Linux, a double fork through a
+   *       subshell on macOS which has no {@code setsid}. Without it the payload dies when the
+   *       vendor tears the session down, and detaching buys nothing.
+   *   <li><b>Redirect stdout and stderr.</b> A backgrounded process holding the pipe keeps the
+   *       caller waiting even with no explicit {@code wait}. The CrowdStrike unix subprocessor is a
+   *       {@code base64 -d | sh} pipeline inheriting the session's stdout, so without redirection
+   *       the session stays held anyway.
+   * </ul>
+   *
+   * <h4>Where this comes from</h4>
+   *
+   * This is the mechanism of {@code openaev-ttr.sh}, the Tanium Threat Response wrapper already in
+   * this repository and already running at customers, moved into the generated command. Tanium
+   * ships it as a script the customer installs; for the other executors the customer-side scripts
+   * are pure pass-throughs ({@code base64 -d | sh}), so the behaviour has to live in what we
+   * generate. No customer action is required.
+   *
+   * <h4>The bootstrap signal</h4>
+   *
+   * Once detached, a failure to even start the implant produces no callback and no session output,
+   * so the download is checked explicitly and the command prints a one-line outcome before
+   * returning. That line is the only human-readable evidence left when nothing calls back.
+   *
+   * @param executorNameKey executor name used as the command map key prefix
+   * @param platform platform used in the command map key
+   * @param downloadPlatform platform segment of the implant download URL
+   */
+  private static void buildDetachedUnixCommand(
+      String executorNameKey,
+      Endpoint.PLATFORM_TYPE platform,
+      String downloadPlatform,
+      Map<String, String> commands,
+      CommandVars vars,
+      int timeoutSeconds) {
+    // Runs in the detached shell, not in the session shell. Escaped dollars are resolved there;
+    // unescaped ones ($location, $server, ...) are expanded here, before detaching.
+    // Single quotes around the outer expansions on purpose. This string is expanded once by the
+    // session shell, then parsed a second time by the detached shell, so an unquoted value
+    // containing a space or an "&" would be re-split there. Quoting closes that whole class of
+    // problem; the generic command never had to care because it is only parsed once.
+    String supervisedRun =
+        "'$location/$filename' --uri '$server' --token '$token' --unsecured-certificate"
+            + " '$unsecured_certificate' --with-proxy '$with_proxy' --agent-id #{agent}"
+            + " --inject-id #{inject} --tenant-id #{tenant} & ipid=\\$!;"
+            + "(sleep "
+            + timeoutSeconds
+            + ";if kill -0 \\$ipid 2>/dev/null;then kill -TERM \\$ipid 2>/dev/null;sleep 5;"
+            + "kill -KILL \\$ipid 2>/dev/null;fi) & wait \\$ipid";
+
+    commands.put(
+        executorNameKey + "." + platform.name() + "." + Endpoint.PLATFORM_ARCH.x86_64.name(),
+        "x=\"#{location}\";location=$(echo \"$x\" | sed"
+            + " \"s#/openaev-caldera-agent##\");filename=oaev-implant-#{inject}-agent-#{agent};"
+            + vars.serverVar()
+            + ";"
+            + vars.tokenVar()
+            + ";"
+            + vars.unsecuredCertificateVar()
+            + ";"
+            + vars.withProxyVar()
+            + ";"
+            + vars.maxSizeVar()
+            + ";"
+            // -f so an HTTP error is a non-zero exit instead of an HTML page written to disk.
+            // Checked explicitly: after detaching, this is the last point where a failure can
+            // still be reported to a human.
+            + "curl -s -f -X GET "
+            + dlUri(downloadPlatform, Endpoint.PLATFORM_ARCH.x86_64.name())
+            + " -o $location/$filename || { echo 'OpenAEV implant download failed'; exit 1; };"
+            + "chmod +x $location/$filename;"
+            // setsid on Linux, double fork on macOS which does not ship it. Output redirected so
+            // the caller is not held by an inherited pipe.
+            + "if command -v setsid >/dev/null 2>&1; then"
+            + " nohup setsid /bin/sh -c \""
+            + supervisedRun
+            + "\" >/dev/null 2>&1 &"
+            + " else ( nohup /bin/sh -c \""
+            + supervisedRun
+            + "\" >/dev/null 2>&1 & ) & fi;"
+            + "echo 'OpenAEV implant launched'; exit 0");
   }
 
   private static void buildGenericWindowsCommand(

--- a/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
+++ b/openaev-api/src/main/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilder.java
@@ -366,7 +366,11 @@ final class OpenaevImplantCommandBuilder {
             + "(sleep "
             + timeoutSeconds
             + ";if kill -0 \\$ipid 2>/dev/null;then kill -TERM \\$ipid 2>/dev/null;sleep 5;"
-            + "kill -KILL \\$ipid 2>/dev/null;fi) & wait \\$ipid";
+            + "kill -KILL \\$ipid 2>/dev/null;fi) & wpid=\\$!;wait \\$ipid;"
+            // Reap the watchdog once the implant is done, exactly as the generic command does.
+            // Without this it sleeps out the rest of its budget, and worse, if the implant's pid
+            // gets recycled in the meantime the watchdog would signal an unrelated process.
+            + "kill \\$wpid 2>/dev/null";
 
     commands.put(
         executorNameKey + "." + platform.name() + "." + Endpoint.PLATFORM_ARCH.x86_64.name(),

--- a/openaev-api/src/test/java/io/openaev/executors/paloaltocortex/service/PaloAltoCortexExecutorContextServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/paloaltocortex/service/PaloAltoCortexExecutorContextServiceTest.java
@@ -266,6 +266,23 @@ class PaloAltoCortexExecutorContextServiceTest {
             + "."
             + Endpoint.PLATFORM_ARCH.x86_64.name(),
         "x86_64 $x=a location=b;[Environment]::CurrentDirectory #{inject} #{agent} #{tenant} #{token} #{baseUrl}");
+    // Unix now reads executor-prefixed keys too, like Windows already did: the detached command
+    // returns the Live Terminal session as soon as the implant is launched. The generic entries
+    // below stay in the fixture because the native OpenAEV agent and Caldera still read them.
+    commands.put(
+        PALOALTOCORTEX_EXECUTOR_NAME
+            + "."
+            + Endpoint.PLATFORM_TYPE.Linux.name()
+            + "."
+            + Endpoint.PLATFORM_ARCH.x86_64.name(),
+        "x86_64 $x=a location=b;filename=#{inject} #{agent} #{tenant} #{token} #{baseUrl}");
+    commands.put(
+        PALOALTOCORTEX_EXECUTOR_NAME
+            + "."
+            + Endpoint.PLATFORM_TYPE.MacOS.name()
+            + "."
+            + Endpoint.PLATFORM_ARCH.x86_64.name(),
+        "x86_64 $x=a location=b;filename=#{inject} #{agent} #{tenant} #{token} #{baseUrl}");
     commands.put(
         Endpoint.PLATFORM_TYPE.Linux.name() + "." + Endpoint.PLATFORM_ARCH.x86_64.name(),
         "x86_64 $x=a location=b;filename=#{inject} #{agent} #{tenant} #{token} #{baseUrl}");

--- a/openaev-api/src/test/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilderTest.java
+++ b/openaev-api/src/test/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilderTest.java
@@ -1,0 +1,315 @@
+package io.openaev.integration.impl.injectors.openaev;
+
+import static io.openaev.integration.impl.executors.mde.MdeExecutorIntegration.MDE_EXECUTOR_NAME;
+import static io.openaev.integration.impl.executors.paloaltocortex.PaloAltoCortexExecutorIntegration.PALOALTOCORTEX_EXECUTOR_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.openaev.database.model.Endpoint;
+import io.openaev.executors.ExecutorHelper;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards on the implant commands, focused on one question: how long does OpenAEV hold the vendor's
+ * remote-execution session open?
+ *
+ * <p>Context. Endpoint Injects reach an endpoint through a remote-execution channel (CrowdStrike
+ * RTR, Defender Live Response, Cortex Live Terminal, and so on). Those channels are built for an
+ * analyst typing one command and reading the answer within seconds, and vendors cap the number of
+ * concurrent sessions per tenant. Every second we keep a session open is a second of that budget
+ * spent, multiplied by the number of targeted endpoints.
+ *
+ * <p>These tests exist because that duration is decided by a string, generated here, and a string
+ * is exactly the kind of thing that silently regresses.
+ */
+class OpenaevImplantCommandBuilderTest {
+
+  /**
+   * Same value the injector factory passes: {@code inject.execution.threshold.minutes} times 60.
+   */
+  private static final int TEN_MINUTES_IN_SECONDS = 600;
+
+  private static Map<String, String> commands() {
+    return OpenaevImplantCommandBuilder.buildExecutorCommands(TEN_MINUTES_IN_SECONDS);
+  }
+
+  /**
+   * The two executors whose Windows command launches the implant from a detached scheduled task.
+   */
+  private static Stream<String> detachedWindowsCommandKeys() {
+    return Stream.of(
+        MDE_EXECUTOR_NAME + ".Windows.x86_64",
+        MDE_EXECUTOR_NAME + ".Windows.arm64",
+        PALOALTOCORTEX_EXECUTOR_NAME + ".Windows.x86_64",
+        PALOALTOCORTEX_EXECUTOR_NAME + ".Windows.arm64");
+  }
+
+  @DisplayName("A detached Windows command returns the session as soon as the implant has started")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedWindowsCommandKeys")
+  void detachedWindowsCommandWaitsForStartNotForCompletion(String commandKey) {
+    String command = commands().get(commandKey);
+
+    assertThat(command).as("command should exist for key %s", commandKey).isNotNull();
+
+    // "The task has started" is what LastRunTime tells us. It is stamped as soon as the Task
+    // Scheduler runs the action, so this normally succeeds on the first poll.
+    //
+    // Compared against a recent instant rather than against $null on purpose: a task that has
+    // never run reports a sentinel LastRunTime (30/11/1999) on several Windows versions, so a
+    // null check would never become true and every launch would wait out the whole budget.
+    assertThat(command)
+        .as("should wait for the task to have started")
+        .contains("$info.LastRunTime -gt $startedAfter");
+  }
+
+  @DisplayName("A detached Windows command does not wait for the payload to finish")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedWindowsCommandKeys")
+  void detachedWindowsCommandDoesNotWaitForThePayload(String commandKey) {
+    String command = commands().get(commandKey);
+
+    // This is the regression this file mainly exists for.
+    //
+    // The command used to poll until the scheduled task returned to the Ready state, which means
+    // "the payload has finished", for up to five minutes. Detaching the implant protected it from
+    // session teardown, but waiting for it to finish handed the session back anyway, so the
+    // detachment bought nothing in session terms.
+    //
+    // Reference implementation: openaev-ttr.ps1, the Tanium Threat Response wrapper shipped in
+    // this repository, waits on "has it started" and returns in about a second.
+    assertThat(command)
+        .as("waiting for state Ready means waiting for the payload to finish")
+        .doesNotContain("$state -eq 'Ready'");
+
+    // LastTaskResult is only meaningful once the task completed, so reading it implies waiting.
+    // It was also never used: the five executor clients return void and no command result is
+    // ever polled back from the vendor. Execution results arrive through the implant callback.
+    assertThat(command)
+        .as("reading the payload result implies waiting for the payload")
+        .doesNotContain("LastTaskResult");
+  }
+
+  @DisplayName("A detached Windows command still reports whether the implant was launched")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedWindowsCommandKeys")
+  void detachedWindowsCommandKeepsABootstrapSignal(String commandKey) {
+    String command = commands().get(commandKey);
+
+    // Returning the session early costs us the payload's console output, which is fine because
+    // nothing reads it. What we must not lose is the bootstrap outcome: when the implant never
+    // starts at all (blocked download, antivirus, wrong architecture) no callback is ever sent,
+    // and this line is the only human-readable evidence left in the vendor console.
+    assertThat(command).contains("OpenAEV implant launched");
+    assertThat(command).contains("OpenAEV implant start not confirmed");
+  }
+
+  @DisplayName("The detached Unix command survives the executor's own transformations")
+  @Test
+  void detachedUnixCommandSurvivesTheServiceTransformations() {
+    // The builder output is not what reaches the endpoint. The executor context service applies
+    // three more steps before base64-encoding it, and each one is a chance to break the command.
+    // This reproduces them in order, so a change to either side is caught here rather than on a
+    // customer machine.
+    String command = commands().get(MDE_EXECUTOR_NAME + ".Linux.x86_64");
+
+    // 1. Architecture detection: the literal arch in the download URL becomes a shell variable.
+    command = ExecutorHelper.UNIX_ARCH + command.replace("x86_64", ExecutorHelper.ARCH_VARIABLE);
+
+    // 2. Placeholder substitution.
+    command =
+        ExecutorHelper.replaceArgs(
+            Endpoint.PLATFORM_TYPE.Linux,
+            command,
+            "INJ",
+            "AGT",
+            "TEN",
+            "TOK",
+            "https://oaev.local",
+            "1024",
+            "false",
+            "false");
+
+    // 3. The implant folder rewrite, which replaces the whole head of the command.
+    String implantLocation =
+        "location="
+            + ExecutorHelper.IMPLANT_LOCATION_UNIX
+            + ExecutorHelper.IMPLANT_BASE_NAME
+            + "UUID;mkdir -p $location;filename=";
+    command =
+        command.replaceFirst(
+            "\\$?x=.+location=.+;filename=", Matcher.quoteReplacement(implantLocation));
+
+    // Nothing left unresolved. A surviving placeholder would reach the endpoint verbatim.
+    assertThat(command).as("every placeholder must be resolved").doesNotContain("#{");
+
+    // The head rewrite landed: the builder's own location preamble is gone, replaced by the
+    // per-inject implant folder.
+    assertThat(command).contains("mkdir -p $location");
+    assertThat(command).doesNotContain("openaev-caldera-agent");
+
+    // The detach survived all three steps.
+    assertThat(command).contains("nohup setsid /bin/sh -c");
+    assertThat(command).contains(">/dev/null 2>&1 &");
+    assertThat(command).endsWith("exit 0");
+
+    // The deferred variables must NOT have been resolved here: they belong to the detached shell,
+    // which is a second parsing pass. This is the assertion that catches an over-eager escape fix.
+    assertThat(command).contains("ipid=\\$!");
+    assertThat(command).contains("wait \\$ipid");
+
+    // Values crossing into the detached shell are quoted, so a space or an ampersand in a URL or
+    // token cannot be re-split by that second parsing pass.
+    assertThat(command).contains("--uri '$server'");
+    assertThat(command).contains("--token '$token'");
+  }
+
+  @DisplayName("Known gap: the generic commands still block for the whole payload duration")
+  @Test
+  void genericCommandsStillHoldTheSessionForTheWholePayload() {
+    Map<String, String> commands = commands();
+
+    // Deliberately asserting the CURRENT behaviour, not the desired one.
+    //
+    // The generic commands are read by CrowdStrike, SentinelOne and Tanium on every platform, and
+    // by Defender and Cortex on Unix. They still wait for the implant to finish, so those paths
+    // still hold the vendor session for up to the Inject threshold.
+    //
+    // They are not fixed in the same change for one specific reason: these keys are shared. The
+    // native OpenAEV agent (OpenAEVExecutorContextService.computeCommand) and Caldera
+    // (CalderaExecutorClient.createSubprocessorAbility) read the very same entries, and neither
+    // has anything to do with vendor sessions. Editing them in place would silently make the
+    // native agent fire-and-forget too.
+    //
+    // The way forward is the one already used by Defender and Cortex on Windows: add
+    // executor-specific keys carrying the detached launch, and point only the executors that need
+    // it at those keys. When that lands, this test is the one to update.
+    assertThat(commands.get("Windows.x86_64"))
+        .as("generic Windows still blocks on the implant process")
+        .contains("$proc.WaitForExit(" + (TEN_MINUTES_IN_SECONDS * 1000L) + ")");
+
+    assertThat(commands.get("Linux.x86_64"))
+        .as("generic Linux still blocks on the implant process")
+        .contains("wait $pid");
+
+    assertThat(commands.get("MacOS.x86_64"))
+        .as("generic macOS still blocks on the implant process")
+        .contains("wait $pid");
+  }
+
+  /** The two executors whose Unix command now launches the implant fully detached. */
+  private static Stream<String> detachedUnixCommandKeys() {
+    return Stream.of(
+        MDE_EXECUTOR_NAME + ".Linux.x86_64",
+        MDE_EXECUTOR_NAME + ".MacOS.x86_64",
+        PALOALTOCORTEX_EXECUTOR_NAME + ".Linux.x86_64",
+        PALOALTOCORTEX_EXECUTOR_NAME + ".MacOS.x86_64");
+  }
+
+  @DisplayName("A detached Unix command escapes the process group and returns immediately")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedUnixCommandKeys")
+  void detachedUnixCommandDetachesAndReturns(String commandKey) {
+    String command = commands().get(commandKey);
+
+    assertThat(command).as("command should exist for key %s", commandKey).isNotNull();
+
+    // Escaping the process group is what makes detaching real. Without it the payload dies when
+    // the vendor tears the session down, and we would have given up supervision for nothing.
+    // setsid on Linux, double fork through a subshell on macOS which does not ship setsid.
+    assertThat(command).contains("command -v setsid");
+    assertThat(command).contains("nohup setsid /bin/sh -c");
+    assertThat(command).contains("( nohup /bin/sh -c");
+
+    // Redirecting output matters as much as detaching: a backgrounded process holding the pipe
+    // keeps the caller waiting even with no explicit wait, so the session would stay held anyway.
+    assertThat(command).contains(">/dev/null 2>&1 &");
+
+    // The session shell must not block. It exits as soon as the implant is on its way.
+    assertThat(command).endsWith("exit 0");
+  }
+
+  @DisplayName("A detached Unix command keeps the watchdog, inside the detached process")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedUnixCommandKeys")
+  void detachedUnixCommandKeepsTheWatchdogInsideTheDetachedProcess(String commandKey) {
+    String command = commands().get(commandKey);
+
+    // The wait was there for a real reason: without it a stuck implant sits on the customer
+    // machine forever. That safeguard is preserved, it moves.
+    assertThat(command).contains("sleep " + TEN_MINUTES_IN_SECONDS);
+    assertThat(command).contains("kill -TERM");
+    assertThat(command).contains("kill -KILL");
+
+    // And it must live inside the detached shell, not outside it. The escaped dollars are the
+    // tell: they are resolved by the detached shell, not by the session shell. A watchdog left
+    // outside would be killed with the session and leave the implant running unsupervised, which
+    // is strictly worse than the behaviour we are replacing.
+    assertThat(command).contains("& ipid=\\$!");
+    assertThat(command).contains("wait \\$ipid");
+  }
+
+  @DisplayName("A detached Unix command reports whether the implant could be launched")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedUnixCommandKeys")
+  void detachedUnixCommandKeepsABootstrapSignal(String commandKey) {
+    String command = commands().get(commandKey);
+
+    // Once detached, a failure to even fetch the implant produces no callback and no payload
+    // output. The download is therefore checked explicitly, and the command says what happened.
+    assertThat(command).contains("curl -s -f");
+    assertThat(command).contains("OpenAEV implant download failed");
+    assertThat(command).contains("OpenAEV implant launched");
+  }
+
+  @DisplayName("The detached Windows scheduled task is bounded again")
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("detachedWindowsCommandKeys")
+  void detachedWindowsTaskHasAnExecutionTimeLimit(String commandKey) {
+    String command = commands().get(commandKey);
+
+    // (New-TimeSpan -Hours 0) disables the limit. Combined with an implant that has no maximum
+    // runtime of its own, nothing bounded the payload on this path at all. Returning the session
+    // early makes that worse, since we stop observing the task, so the bound is restored using
+    // the same budget the shell watchdog applies elsewhere.
+    assertThat(command)
+        .as("an unlimited scheduled task leaves the payload unsupervised")
+        .doesNotContain("New-TimeSpan -Hours 0");
+    assertThat(command).contains("New-TimeSpan -Seconds " + TEN_MINUTES_IN_SECONDS);
+  }
+
+  @DisplayName("The detached Windows commands are separate entries, generic keys are untouched")
+  @Test
+  void detachedCommandsDoNotOverwriteTheSharedGenericKeys() {
+    Map<String, String> commands = commands();
+
+    // The prefixed keys and the generic ones must stay distinct. This is what keeps the native
+    // agent and Caldera out of the blast radius of any executor-specific change.
+    assertThat(commands.get(MDE_EXECUTOR_NAME + ".Windows.x86_64"))
+        .isNotEqualTo(commands.get("Windows.x86_64"));
+    assertThat(commands.get(PALOALTOCORTEX_EXECUTOR_NAME + ".Windows.x86_64"))
+        .isNotEqualTo(commands.get("Windows.x86_64"));
+
+    // Same on Unix, where the detached commands were just added.
+    assertThat(commands.get(MDE_EXECUTOR_NAME + ".Linux.x86_64"))
+        .isNotEqualTo(commands.get("Linux.x86_64"));
+    assertThat(commands.get(PALOALTOCORTEX_EXECUTOR_NAME + ".MacOS.x86_64"))
+        .isNotEqualTo(commands.get("MacOS.x86_64"));
+
+    // And the generic entries must still be the blocking ones, byte for byte what the native
+    // agent and Caldera were already getting. This is the cheap proof that adding executor
+    // commands did not change anyone else's behaviour.
+    assertThat(commands.get("Linux.x86_64"))
+        .as("the native agent and Caldera read this entry")
+        .doesNotContain("setsid")
+        .doesNotContain("nohup");
+    assertThat(commands.get("Windows.x86_64"))
+        .as("the native agent and Caldera read this entry")
+        .doesNotContain("Register-ScheduledTask");
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilderTest.java
+++ b/openaev-api/src/test/java/io/openaev/integration/impl/injectors/openaev/OpenaevImplantCommandBuilderTest.java
@@ -252,6 +252,12 @@ class OpenaevImplantCommandBuilderTest {
     // is strictly worse than the behaviour we are replacing.
     assertThat(command).contains("& ipid=\\$!");
     assertThat(command).contains("wait \\$ipid");
+
+    // And the watchdog is reaped once the implant is done, as the generic command already did.
+    // Leaving it to sleep out its budget would keep a shell alive per agent, and if the implant's
+    // pid were recycled in the meantime the watchdog would signal an unrelated process.
+    assertThat(command).contains("wpid=\\$!");
+    assertThat(command).contains("kill \\$wpid");
   }
 
   @DisplayName("A detached Unix command reports whether the implant could be launched")


### PR DESCRIPTION
> **Workshop material, not intended to be merged as is.**
> This branch exists to support a working session on the endpoint inject dispatch path. It is a working example: real code, real tests, deliberately narrow scope. Treat the open questions at the bottom as the agenda, not as review nits.

Relates to #7799, part of #7804.

## What this is about

An endpoint Inject targeting many agents produces a share of machines that stay pending and end as timeouts. The assumption was that the EDR vendors' own execution queues were responsible. Reading the dispatch path shows the dominant cause is on our side: **we hold the vendor remote-execution session open for the whole duration of the payload.**

On an Inject targeting a hundred endpoints that means a hundred concurrent sessions held for minutes, on APIs designed for an analyst typing one command and reading the answer within seconds, and vendors cap concurrent sessions per tenant. The queue we attributed to the vendor, we partly produce.

## What this changes

Scoped to Microsoft Defender for Endpoint and Palo Alto Cortex, the two executors that already had the executor-specific command pattern.

**Windows.** The command already detached the implant into a SYSTEM scheduled task, but then polled until the task returned to `Ready`, meaning it waited for the payload to finish, up to 300 seconds. It now polls only until the task has actually started, roughly one second, and returns.

**Unix.** New detached command for Linux and macOS: `setsid` where available, double fork on macOS which does not ship it, output redirected, immediate return.

**The watchdog is preserved.** The wait exists for a real reason: without it an implant that hangs sits on the customer machine forever. It is not removed, it moves inside the detached process. Left outside it would be killed with the session and leave the implant running unsupervised, which is strictly worse than the current behaviour.

**A pre-existing gap closed along the way.** The scheduled task was created with `-ExecutionTimeLimit (New-TimeSpan -Hours 0)`, which disables the limit, and the implant has no maximum runtime of its own. So on Defender and Cortex Windows the payload already ran unbounded. The limit is restored using the same budget the shell watchdog applies elsewhere.

## Where the design comes from

`openaev-ttr.sh` and `openaev-ttr.ps1`, the Tanium Threat Response wrappers already in this repository and already running at customers. Tanium is the only executor that returns its session quickly today, on both platforms. This is a port of a proven mechanism, not a new design.

Two deliberate deviations from that reference:

- the startup budget is 60 seconds against 180, because a task that has not started within a minute is not going to, and the point of the change is to stop holding sessions
- the Windows poll compares `LastRunTime` against a recent instant rather than against `$null`. A task that has never run reports a sentinel date (30/11/1999) on several Windows versions, so a null check would never become true and every launch would wait out the budget. The Tanium wrapper uses the null form and gets away with it because it reports success regardless

## What is deliberately not touched

**The generic command keys.** `OpenAEVExecutorContextService.computeCommand` (native agent) and `CalderaExecutorClient.createSubprocessorAbility` read the same `Platform.Arch` entries. Editing them in place would make the native agent fire-and-forget as a side effect. The new commands are registered under executor-prefixed keys instead, exactly as Defender and Cortex already did on Windows. A test asserts the generic entries still contain no `setsid` and no `nohup`.

**Tanium.** It already returns its session in seconds. It is the model, not a target.

**CrowdStrike and SentinelOne.** Mechanical once the pattern is agreed, left out to keep this readable.

## No customer action required

Each executor requires the customer to create scripts in their own console. For four of the five they are pure pass-throughs (`base64 -d | sh` or the Python equivalent), so all the behaviour lives in the command we generate. Commands are rewritten at connector registration, which replays on platform restart, so deployment and rollback are both automatic.

## Tests

31 tests on the command builder. Reverting the builder alone turns 28 of them red, which is the point: nearly everything the file describes did not exist before.

Three worth reading:

- `detachedUnixCommandKeepsTheWatchdogInsideTheDetachedProcess` guards the safeguard against a future regression
- `detachedUnixCommandSurvivesTheServiceTransformations` replays the three transformations the executor service applies before encoding, and asserts no placeholder survives. This is what guarantees the command reaches the endpoint intact
- `genericCommandsStillHoldTheSessionForTheWholePayload` deliberately asserts current behaviour, documenting what is not fixed yet and why

## Open questions, for the session

1. Startup budget: keep 60 seconds, or align on the Tanium wrapper's 180 to avoid two diverging values?
2. The task is now unregistered about a second after it starts, while the payload is still running. Only Tanium has exercised that path, in production. Validate per executor before merging, or trust the precedent?
3. The implant still has no maximum runtime of its own, so the watchdog can only be moved, not removed. Open the implant flag work now to parallelize the release, or after measuring?
4. Who takes CrowdStrike and SentinelOne.
