### PR TITLE
fix(executor): sync only onboarded MDE devices as assets (#7842)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/executors/mde/client/MdeExecutorClient.java
+++ b/openaev-api/src/main/java/io/openaev/executors/mde/client/MdeExecutorClient.java
@@ -4,6 +4,7 @@ import static io.openaev.integration.impl.executors.mde.MdeExecutorIntegration.M
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import io.openaev.authorisation.HttpClientFactory;
 import io.openaev.executors.exception.ExecutorException;
 import io.openaev.executors.mde.config.MdeExecutorConfig;
@@ -51,6 +52,15 @@ public class MdeExecutorClient {
   private static final String MACHINE_ACTIONS_URI = "/machineactions";
   private static final String ADVANCED_QUERIES_URI = "/advancedqueries/run";
 
+  /**
+   * MDE {@code onboardingStatus} of a device that actually runs the Defender sensor and can execute
+   * Live Response. Discovered-only devices ({@code CanBeOnboarded}, {@code Unsupported}, {@code
+   * InsufficientInfo}) reject {@code runliveresponse} with HTTP 400 {@code
+   * ClientVersionNotSupported}, so they must never be synced as OpenAEV assets, otherwise every
+   * inject on them fails with a silent timeout.
+   */
+  private static final String ONBOARDED_STATUS = "Onboarded";
+
   private final MdeExecutorConfig config;
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final HttpClientFactory httpClientFactory;
@@ -65,12 +75,9 @@ public class MdeExecutorClient {
    */
   public List<MdeDevice> devicesAll() {
     try {
-      String formattedDateTime =
-          DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
-              .withZone(ZoneOffset.UTC)
-              .format(Instant.now().minusMillis(io.openaev.service.EndpointService.DELETE_TTL));
       String filterValue =
-          URLEncoder.encode("lastSeen gt " + formattedDateTime, StandardCharsets.UTF_8);
+          URLEncoder.encode(
+              buildDevicesFilter(null, activeSinceThresholdIso()), StandardCharsets.UTF_8);
       String json = get(MACHINES_URI + "?$filter=" + filterValue + "&$top=10000");
       MdeDeviceListResponse response = objectMapper.readValue(json, new TypeReference<>() {});
       return response.getValue() != null ? response.getValue() : List.of();
@@ -84,18 +91,14 @@ public class MdeExecutorClient {
    * Returns all devices belonging to the given MDE device group (rbacGroupId).
    *
    * <p>The MDE API filters machines by {@code rbacGroupId}. For active machines only, we also
-   * filter by {@code lastSeen} within the active threshold.
+   * filter by {@code lastSeen} within the active threshold, and restrict to genuinely onboarded
+   * devices (see {@link #ONBOARDED_STATUS}).
    */
   public List<MdeDevice> devices(String deviceGroupId) {
     try {
-      String formattedDateTime =
-          DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
-              .withZone(ZoneOffset.UTC)
-              .format(Instant.now().minusMillis(io.openaev.service.EndpointService.DELETE_TTL));
       String filterValue =
           URLEncoder.encode(
-              "rbacGroupId eq " + deviceGroupId + " and lastSeen gt " + formattedDateTime,
-              StandardCharsets.UTF_8);
+              buildDevicesFilter(deviceGroupId, activeSinceThresholdIso()), StandardCharsets.UTF_8);
       String json = get(MACHINES_URI + "?$filter=" + filterValue + "&$top=10000");
       MdeDeviceListResponse response = objectMapper.readValue(json, new TypeReference<>() {});
       return response.getValue() != null ? response.getValue() : List.of();
@@ -201,6 +204,34 @@ public class MdeExecutorClient {
   }
 
   // -- PRIVATE --
+
+  /**
+   * Builds the OData {@code $filter} for the {@code /machines} listing. Restricts to devices seen
+   * within the active window, optionally scoped to an RBAC device group, and, crucially, to
+   * genuinely {@link #ONBOARDED_STATUS onboarded} devices only. MDE's inventory also exposes merely
+   * discovered ("CanBeOnboarded") machines that have no Live-Response-capable sensor; syncing them
+   * would create OpenAEV assets whose every inject fails with a silent HTTP 400.
+   */
+  @VisibleForTesting
+  static String buildDevicesFilter(String deviceGroupId, String lastSeenThresholdIso) {
+    StringBuilder filter = new StringBuilder();
+    if (deviceGroupId != null && !deviceGroupId.isBlank()) {
+      filter.append("rbacGroupId eq ").append(deviceGroupId.trim()).append(" and ");
+    }
+    filter.append("lastSeen gt ").append(lastSeenThresholdIso);
+    filter.append(" and onboardingStatus eq '").append(ONBOARDED_STATUS).append("'");
+    return filter.toString();
+  }
+
+  /**
+   * ISO-8601 UTC threshold below which a device is considered stale (older than the endpoint delete
+   * TTL), formatted for the MDE {@code lastSeen gt} OData clause.
+   */
+  private static String activeSinceThresholdIso() {
+    return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        .withZone(ZoneOffset.UTC)
+        .format(Instant.now().minusMillis(io.openaev.service.EndpointService.DELETE_TTL));
+  }
 
   /**
    * Cancels stale Pending Live Response actions on a machine before a new dispatch. MDE permits a

--- a/openaev-api/src/test/java/io/openaev/executors/mde/client/MdeExecutorClientTest.java
+++ b/openaev-api/src/test/java/io/openaev/executors/mde/client/MdeExecutorClientTest.java
@@ -1,5 +1,6 @@
 package io.openaev.executors.mde.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -74,5 +75,51 @@ class MdeExecutorClientTest {
 
     // Act & Assert
     assertFalse(isStalePendingAction(action, staleBefore));
+  }
+
+  @Test
+  @DisplayName("without a device group, filter restricts to onboarded devices seen recently")
+  void given_noDeviceGroup_should_filterOnLastSeenAndOnboarded() {
+    // Act
+    String filter = MdeExecutorClient.buildDevicesFilter(null, "2026-09-08T00:00:00Z");
+
+    // Assert
+    assertThat(filter)
+        .isEqualTo("lastSeen gt 2026-09-08T00:00:00Z and onboardingStatus eq 'Onboarded'")
+        .doesNotContain("rbacGroupId");
+  }
+
+  @Test
+  @DisplayName("with a device group, filter scopes by rbacGroupId and stays onboarded-only")
+  void given_deviceGroup_should_scopeByRbacGroupAndOnboarded() {
+    // Act
+    String filter = MdeExecutorClient.buildDevicesFilter("367", "2026-09-08T00:00:00Z");
+
+    // Assert
+    assertThat(filter)
+        .isEqualTo(
+            "rbacGroupId eq 367 and lastSeen gt 2026-09-08T00:00:00Z"
+                + " and onboardingStatus eq 'Onboarded'");
+  }
+
+  @Test
+  @DisplayName("a blank device group is treated as no group scoping")
+  void given_blankDeviceGroup_should_notScopeByRbacGroup() {
+    // Act
+    String filter = MdeExecutorClient.buildDevicesFilter("   ", "2026-09-08T00:00:00Z");
+
+    // Assert
+    assertThat(filter)
+        .isEqualTo("lastSeen gt 2026-09-08T00:00:00Z and onboardingStatus eq 'Onboarded'");
+  }
+
+  @Test
+  @DisplayName("a device group id is trimmed before being placed in the filter")
+  void given_paddedDeviceGroup_should_trimBeforeFiltering() {
+    // Act
+    String filter = MdeExecutorClient.buildDevicesFilter(" 367 ", "2026-09-08T00:00:00Z");
+
+    // Assert
+    assertThat(filter).startsWith("rbacGroupId eq 367 and ");
   }
 }


### PR DESCRIPTION
## Problem

MDE's `/machines` inventory also exposes merely **discovered** devices (`onboardingStatus = "CanBeOnboarded"`) that have no Live-Response-capable sensor. The executor synced these as OpenAEV assets, but every inject targeting them fails: MDE rejects `runliveresponse` with `HTTP 400 ClientVersionNotSupported`, and `MdeExecutorClient.executeAction` swallows that error, so the inject stays `PENDING` then `TIMEOUT` with no actionable trace.

Diagnosed on the internal demo tenant: 11 of 12 MDE-registered assets were `CanBeOnboarded` (GOAD lab VMs discovered by the one onboarded sensor via Device Discovery). Only the single `Onboarded` device could actually run injects. Verified directly against the Defender API:

- `POST /runliveresponse` on the onboarded device → `HTTP 201`, action `Succeeded`.
- `POST /runliveresponse` on a `CanBeOnboarded` device → `HTTP 400 ClientVersionNotSupported`.
- `GET /machines?$filter=onboardingStatus eq 'Onboarded'` is supported and returns only the onboarded device.

## Change

Restrict the `/machines` listing to `onboardingStatus eq 'Onboarded'` in both `devices()` and `devicesAll()`, so only Live-Response-capable machines become assets. Extract `buildDevicesFilter(...)` / `activeSinceThresholdIso()` helpers and unit-test the filter construction (with/without device group, blank and padded group ids).

## Notes

- Backward compatible: `MdeExecutorService` already passes non-blank, trimmed group ids; the helper also guards null/blank.
- Not built locally (no Maven on the dev machine) — relying on CI for compile + tests.
- A complementary follow-up (surfacing the swallowed Live Response 4xx as an inject `ERROR` trace instead of a silent timeout) is worth doing for residual cases (stale sensor version, offline device, 429, status change between sync and dispatch) but is optional once this filter is in place.