### PR TITLE
chore(deps): batch Renovate updates weekly by risk

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -295,13 +295,19 @@
         // rule also has to sit after the batches for a second reason: a batched PR takes its title
         // from groupName, so the [DANGER] prefix set above would stop appearing.
         //
-        // This list is the patches that actually exist: `ls openaev-front/patches/` returns
-        // react-apexcharts.patch and nothing else, and the resolutions block in
-        // openaev-front/package.json references only that one. html-to-image is not here because it
-        // carries no patch, despite the [DANGER] rule still on main saying it does. That rule is
-        // wrong and is removed separately.
+        // Two members, two reasons, so the rule says both rather than implying they are the same.
+        //
+        // react-apexcharts is the patched one, and it is the only patched dependency in the
+        // repository: `ls openaev-front/patches/` returns react-apexcharts.patch and nothing else,
+        // and the resolutions block in openaev-front/package.json references only that one.
+        // html-to-image is deliberately not here, despite the [DANGER] rule still on main claiming it
+        // carries a patch. It does not. That rule is wrong and is removed separately.
+        //
+        // apexcharts carries no patch. It is here because react-apexcharts is pinned below 1.8.0 to
+        // stay on an apexcharts 4.x that is still MIT, so the two move as a pair. Batching one and
+        // not the other is how they end up out of step.
         {
-            description: 'Patched dependencies keep their own PR',
+            description: 'The patched dependency and the one it moves with keep their own PR',
             matchDepNames: [
                 'react-apexcharts',
                 'apexcharts',
@@ -327,6 +333,9 @@
                 '/^org\\.apache\\.tomcat/',
                 '/^org\\.apache\\.httpcomponents/',
                 '/^org\\.hibernate/',
+                // registers Hibernate UserTypes for JSON and array columns, so it decides how those
+                // columns serialise. Same family as Hibernate itself, on the line above.
+                '/^io\\.hypersistence/',
                 '/^com\\.fasterxml\\.jackson/',
                 '/^tools\\.jackson/',
                 '/^co\\.elastic\\.clients/',

--- a/renovate.json5
+++ b/renovate.json5
@@ -16,9 +16,9 @@
     // The concurrency ceiling is a blast-radius guard, not a volume lever. Over the 90 days to
     // 2026-09-08 the peak was 53 simultaneously open Renovate PRs and the median 33, so 100 was never
     // reached and never throttled anything. 60 keeps headroom over that measured peak while capping a
-    // runaway. It is deliberately not lower: 16 of the 26 PRs open today are majors older than 30
-    // days that occupy the pool permanently, and a ceiling under about 55 would silently stop
-    // Renovate opening anything new. Revisit once majors move off the PR list.
+    // runaway. It is deliberately not lower: the long-lived major PRs occupy part of the pool
+    // permanently, and a ceiling below the measured peak would silently stop Renovate opening
+    // anything new. Revisit once majors move off the PR list.
     prConcurrentLimit: 60,
     branchConcurrentLimit: 60,
     timezone: 'Europe/Paris',
@@ -174,11 +174,13 @@
         // batches come first, then the rules that pull a dependency back out of a batch. Anything no
         // batch matches keeps its own PR, which is the safe default.
         //
-        // Measured over the 90 days to 2026-09-08: 219 Renovate PRs, 17.0 a week. The batches here
-        // and the devDependencies batch above cover 155 of them and collapse those to 37, because a
-        // weekly batch cannot produce more PRs than there are weeks with an update in it.
+        // The invariant a batch buys is one PR per batch per week at most, whatever the upstream
+        // release cadence. The measured before and after volumes live in the ADR and the pull request
+        // that introduced this, not here: a count written into a config file is a count nobody
+        // updates.
+
         // GitHub Actions only ever run in CI, so a bad version fails the workflow that uses it on the
-        // same push. 13 PRs over the window. OpenCTI already batches actions weekly.
+        // same push. OpenCTI already batches actions weekly.
         {
             groupName: 'ci tooling (non-major)',
             groupSlug: 'ci-tooling-non-major',
@@ -200,7 +202,6 @@
         // Maven build, test and provided scopes never reach a shipped artifact. Matching on depType
         // rather than on an artifact list means a new test dependency joins the batch on its own.
         // depType for the maven manager is the declared scope, and 'build' for plugins and extensions.
-        // 14 PRs over the window.
         {
             groupName: 'build and test tooling (non-major)',
             groupSlug: 'build-test-tooling-non-major',
@@ -224,10 +225,10 @@
             ],
             rebaseWhen: 'auto',
         },
-        // Production dependencies, one PR at a time before this change: 117 of the 219. Batched
-        // because reviewing the AWS SDK eighteen times in a quarter is what stops the Jackson bump
-        // from being read. The cost is that one bad member holds the whole batch, and the exit is a
-        // rule placed after this one with groupName: null for that dependency.
+        // Production dependencies, one PR at a time before this change and the bulk of the volume.
+        // Batched because reviewing the same SDK over and over in a quarter is what stops the Jackson
+        // bump from being read. The cost is that one bad member holds the whole batch, and the exit is
+        // a rule placed after this one with groupName: null for that dependency.
         {
             groupName: 'front-end production dependencies (non-major)',
             groupSlug: 'front-prod-non-major',
@@ -244,6 +245,8 @@
             matchUpdateTypes: [
                 'minor',
                 'patch',
+                'pin',
+                'digest',
             ],
             rebaseWhen: 'auto',
         },
@@ -266,6 +269,8 @@
             matchUpdateTypes: [
                 'minor',
                 'patch',
+                'pin',
+                'digest',
             ],
             rebaseWhen: 'auto',
         },
@@ -289,6 +294,12 @@
         // A yarn patch can stop applying, or keep applying against changed code, with no error. This
         // rule also has to sit after the batches for a second reason: a batched PR takes its title
         // from groupName, so the [DANGER] prefix set above would stop appearing.
+        //
+        // This list is the patches that actually exist: `ls openaev-front/patches/` returns
+        // react-apexcharts.patch and nothing else, and the resolutions block in
+        // openaev-front/package.json references only that one. html-to-image is not here because it
+        // carries no patch, despite the [DANGER] rule still on main saying it does. That rule is
+        // wrong and is removed separately.
         {
             description: 'Patched dependencies keep their own PR',
             matchDepNames: [
@@ -341,6 +352,13 @@
                 // wraps the DataSource in main code (io.openaev.debug.DataSourceProxyBeanPostProcessor),
                 // so it sits on the path of every SQL statement the platform issues
                 'net.ttddyy:datasource-proxy',
+                // The group prefixes above also match Maven plugins that share the coordinate, for
+                // instance org.springframework.boot:spring-boot-maven-plugin. A plugin ships nothing,
+                // so it belongs in the build and test batch. Negating the suffix rather than adding
+                // matchDepTypes here is deliberate: the nine dependencies the customManagers track
+                // carry no depType, so a depType filter would drop them out of this rule and they are
+                // the ones that most need to be seen.
+                '!/-maven-plugin$/',
             ],
             groupName: null,
             addLabels: [
@@ -375,9 +393,9 @@
             ],
             groupName: null,
         },
-        // Lock file maintenance rewrites transitive versions with no diff a human can read, and it has
-        // the worst record of any group here: 3 of the last 6 failed CI on the first attempt and 4 of
-        // the 5 merged ones needed a commit Renovate did not write.
+        // Lock file maintenance rewrites transitive versions with no diff a human can read, and over
+        // the 90 days to 2026-09-08 it had both the worst first-attempt CI record and the most
+        // human commits of any class here.
         {
             description: 'Lock file maintenance keeps its own PR',
             matchUpdateTypes: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,9 +10,17 @@
         'filigran team',
     ],
     minimumReleaseAge: '3 days',
+    // high hourly limit so that all PRs are created at once during the schedule window rather than
+    // being drip-fed across multiple runs
     prHourlyLimit: 100,
-    prConcurrentLimit: 100,
-    branchConcurrentLimit: 100,
+    // The concurrency ceiling is a blast-radius guard, not a volume lever. Over the 90 days to
+    // 2026-09-08 the peak was 53 simultaneously open Renovate PRs and the median 33, so 100 was never
+    // reached and never throttled anything. 60 keeps headroom over that measured peak while capping a
+    // runaway. It is deliberately not lower: 16 of the 26 PRs open today are majors older than 30
+    // days that occupy the pool permanently, and a ceiling under about 55 would silently stop
+    // Renovate opening anything new. Revisit once majors move off the PR list.
+    prConcurrentLimit: 60,
+    branchConcurrentLimit: 60,
     timezone: 'Europe/Paris',
     schedule: [
         '* 0-4,22-23 * * 1-5',
@@ -159,6 +167,223 @@
                 'digest',
             ],
             rebaseWhen: 'auto',
+        },
+
+        // ── Weekly batches, continued ────────────────────────────────────────────────────────
+        // Rule order matters: Renovate applies packageRules in order and a later rule wins. The
+        // batches come first, then the rules that pull a dependency back out of a batch. Anything no
+        // batch matches keeps its own PR, which is the safe default.
+        //
+        // Measured over the 90 days to 2026-09-08: 219 Renovate PRs, 17.0 a week. The batches here
+        // and the devDependencies batch above cover 155 of them and collapse those to 37, because a
+        // weekly batch cannot produce more PRs than there are weeks with an update in it.
+        // GitHub Actions only ever run in CI, so a bad version fails the workflow that uses it on the
+        // same push. 13 PRs over the window. OpenCTI already batches actions weekly.
+        {
+            groupName: 'ci tooling (non-major)',
+            groupSlug: 'ci-tooling-non-major',
+            description: 'Batch non-major GitHub Actions updates once a week on Sunday',
+            schedule: [
+                '* * * * 0',
+            ],
+            matchManagers: [
+                'github-actions',
+            ],
+            matchUpdateTypes: [
+                'minor',
+                'patch',
+                'pin',
+                'digest',
+            ],
+            rebaseWhen: 'auto',
+        },
+        // Maven build, test and provided scopes never reach a shipped artifact. Matching on depType
+        // rather than on an artifact list means a new test dependency joins the batch on its own.
+        // depType for the maven manager is the declared scope, and 'build' for plugins and extensions.
+        // 14 PRs over the window.
+        {
+            groupName: 'build and test tooling (non-major)',
+            groupSlug: 'build-test-tooling-non-major',
+            description: 'Batch non-major Maven build, test and provided scope updates once a week on Sunday',
+            schedule: [
+                '* * * * 0',
+            ],
+            matchManagers: [
+                'maven',
+            ],
+            matchDepTypes: [
+                'build',
+                'test',
+                'provided',
+            ],
+            matchUpdateTypes: [
+                'minor',
+                'patch',
+                'pin',
+                'digest',
+            ],
+            rebaseWhen: 'auto',
+        },
+        // Production dependencies, one PR at a time before this change: 117 of the 219. Batched
+        // because reviewing the AWS SDK eighteen times in a quarter is what stops the Jackson bump
+        // from being read. The cost is that one bad member holds the whole batch, and the exit is a
+        // rule placed after this one with groupName: null for that dependency.
+        {
+            groupName: 'front-end production dependencies (non-major)',
+            groupSlug: 'front-prod-non-major',
+            description: 'Batch non-major npm production updates once a week on Sunday',
+            schedule: [
+                '* * * * 0',
+            ],
+            matchManagers: [
+                'npm',
+            ],
+            matchDepTypes: [
+                'dependencies',
+            ],
+            matchUpdateTypes: [
+                'minor',
+                'patch',
+            ],
+            rebaseWhen: 'auto',
+        },
+        {
+            groupName: 'back-end production dependencies (non-major)',
+            groupSlug: 'back-prod-non-major',
+            description: 'Batch non-major Maven compile, runtime and import scope updates once a week on Sunday',
+            schedule: [
+                '* * * * 0',
+            ],
+            matchManagers: [
+                'maven',
+            ],
+            matchDepTypes: [
+                'compile',
+                'runtime',
+                'import',
+                'optional',
+            ],
+            matchUpdateTypes: [
+                'minor',
+                'patch',
+            ],
+            rebaseWhen: 'auto',
+        },
+
+        // ── Out of every batch, one PR each ──────────────────────────────────────────────────
+        // These rules come after the batches on purpose, so they win. Two reasons to be here. Either
+        // the dependency changes behaviour at runtime through defaults that no test asserts (pool
+        // sizing, HTTP timeouts, serialisation, transaction semantics), or it is one of the 17
+        // versions this pom holds by hand over the Spring Boot BOM.
+        //
+        // The second reason is about attribution, not about Renovate moving a version backwards:
+        // Renovate only ever proposes an upgrade, so it cannot realign a property on the BOM.
+        // Someone chose those 17 versions for a reason, so a change to one of them has to be visible
+        // and has to map to a single commit that can be reverted on its own. A batch takes both away.
+        //
+        // This list has to stay in step with the properties in pom.xml. Every BOM override that
+        // governs a runtime artifact is covered below. maven-compiler-plugin.version is the one that
+        // is not, and it stays in the build and test batch on purpose: it is a build plugin, it ships
+        // nothing, and the BOM versions no dependency through it.
+
+        // A yarn patch can stop applying, or keep applying against changed code, with no error. This
+        // rule also has to sit after the batches for a second reason: a batched PR takes its title
+        // from groupName, so the [DANGER] prefix set above would stop appearing.
+        {
+            description: 'Patched dependencies keep their own PR',
+            matchDepNames: [
+                'react-apexcharts',
+                'apexcharts',
+            ],
+            groupName: null,
+        },
+        // resolutions pin a transitive version on purpose, form-data among them. Changing one is a
+        // decision, not a routine bump.
+        {
+            description: 'Yarn resolutions keep their own PR',
+            matchDepTypes: [
+                'resolutions',
+            ],
+            groupName: null,
+        },
+        {
+            description: 'Runtime-behaviour and BOM-override Maven dependencies keep their own PR',
+            matchDatasources: [
+                'maven',
+            ],
+            matchPackageNames: [
+                '/^org\\.springframework/',
+                '/^org\\.apache\\.tomcat/',
+                '/^org\\.apache\\.httpcomponents/',
+                '/^org\\.hibernate/',
+                '/^com\\.fasterxml\\.jackson/',
+                '/^tools\\.jackson/',
+                '/^co\\.elastic\\.clients/',
+                '/^org\\.opensearch/',
+                '/^org\\.elasticsearch/',
+                '/^com\\.rabbitmq/',
+                '/^org\\.quartz-scheduler/',
+                '/^ch\\.qos\\.logback/',
+                '/^org\\.apache\\.logging\\.log4j/',
+                '/^io\\.netty/',
+                '/^io\\.micrometer/',
+                '/^org\\.jetbrains\\.kotlin/',
+                '/^org\\.apache\\.velocity/',
+                // BOM overrides that were missing from this list while the comment above claimed
+                // to cover them: opentelemetry 1.65.0 over Boot's 1.49.0, commons-lang3 3.20.0 over
+                // 3.17.0, gson 2.14.0 over 2.13.2
+                '/^io\\.opentelemetry/',
+                'org.apache.commons:commons-lang3',
+                'com.google.code.gson:gson',
+                'com.zaxxer:HikariCP',
+                'org.postgresql:postgresql',
+                'com.squareup.okhttp3:okhttp',
+                // wraps the DataSource in main code (io.openaev.debug.DataSourceProxyBeanPostProcessor),
+                // so it sits on the path of every SQL statement the platform issues
+                'net.ttddyy:datasource-proxy',
+            ],
+            groupName: null,
+            addLabels: [
+                'review:runtime-behaviour',
+            ],
+        },
+        // Front-end dependencies that parse, sanitise or transport untrusted input. A regression here
+        // is a security bug the E2E suite passes straight through, dompurify most of all: it is the
+        // XSS boundary of the UI.
+        {
+            description: 'Parsers, sanitisers and HTTP clients on the front keep their own PR',
+            matchDepNames: [
+                'dompurify',
+                'qs',
+                'axios',
+                'form-data',
+                'http-proxy-middleware',
+                'ipaddr.js',
+                '@filigran/chatbot',
+            ],
+            groupName: null,
+            addLabels: [
+                'review:runtime-behaviour',
+            ],
+        },
+        // Base images carry the runtime the product executes on, and Renovate cannot know whether a
+        // new Postgres or Elasticsearch major is supported by the code.
+        {
+            description: 'Runtime infrastructure images keep their own PR',
+            matchDatasources: [
+                'docker',
+            ],
+            groupName: null,
+        },
+        // Lock file maintenance rewrites transitive versions with no diff a human can read, and it has
+        // the worst record of any group here: 3 of the last 6 failed CI on the first attempt and 4 of
+        // the 5 merged ones needed a commit Renovate did not write.
+        {
+            description: 'Lock file maintenance keeps its own PR',
+            matchUpdateTypes: [
+                'lockFileMaintenance',
+            ],
+            groupName: null,
         },
     ],
     // do lock file maintenance once a week on Sunday


### PR DESCRIPTION
### Proposed changes

| file | change |
| --- | --- |
| `renovate.json5` | +227 / -2. Five weekly batches, six rules that keep a dependency out of every batch, and the concurrency ceiling. |

No automerge key anywhere, not even set to false. `grep -c automerge renovate.json5` returns 0, and
parsing the file then stringifying it back gives `JSON.stringify(config).includes('automerge') === false`.

Renovate opens 17.0 pull requests a week here. Over the 90 days to 2026-09-08 that was 219 PRs, of
which 202 merged, and 185 of those 202 merged with no commit other than the bot's own. One person
merged 201 of the 202 and reviewed 193.

The problem that number describes is not volume, it is attention. Reviewing the AWS SDK eighteen
times in a quarter is what stops the Jackson bump from being read. So the change is to batch the
updates where reading each one separately buys nothing, and to make sure the ones that do need
reading stay on their own.

Nothing is switched off and nothing is ignored. Renovate still finds every update. The batches only
change how the updates are delivered.

#### The measured effect

| | today | after |
| --- | --- | --- |
| PRs Renovate opens, per week | 17.0 | 8.9 |
| of which batch PRs | 0.9 | 4.4 |
| of which a dependency's own PR | 16.1 | 4.4 |

The 0.9 today is the existing `devDependencies` batch, 11 PRs over the window. Everything else, the
other 208, arrives one dependency at a time.

162 of the 219 PRs fall into a batch. A weekly batch cannot produce more PRs than there are calendar
weeks in which it had at least one update, so those 162 become 57. The other 57 keep their own PR.
114 PRs over 90 days, which is 8.9 a week.

| batch | PRs today | weeks with an update | PRs after |
| --- | --- | --- | --- |
| front-end production dependencies | 72 | 13 | 13 |
| back-end production dependencies | 52 | 13 | 13 |
| build and test tooling | 14 | 10 | 10 |
| ci tooling | 13 | 10 | 10 |
| devDependencies, already batched today | 11 | 11 | 11 |
| **batched** | **162** | | **57** |

| own PR | PRs today | PRs after |
| --- | --- | --- |
| Maven runtime and BOM-override dependencies | 19 | 19 |
| front-end parsers, sanitisers, HTTP clients | 15 | 15 |
| majors | 7 | 7 |
| lock file maintenance | 6 | 6 |
| Docker images | 5 | 5 |
| the `packageManager` field, which is the three `yarn` bumps | 3 | 3 |
| not matched by the model | 2 | 2 |
| **own PR** | **57** | **57** |

**The stated target was 7 a week and this does not reach it. The number is 8.9, and here is the
arithmetic that says 7 is not available.**

Moving majors behind a Dependency Dashboard checkbox takes 8.9 to 8.3 and, more usefully, clears the
15 majors that have been open more than 30 days, the oldest for 269 days. That is the largest
remaining lever and it belongs in its own PR, because it changes what the PR list is for rather than
how PRs are shaped.

8.3 is then the floor. Reaching 7 would mean cutting 17 more PRs, and the only buckets big enough are
the 19 Maven runtime and BOM-override dependencies and the 15 front-end parsers. Those are exactly
the ones a green pipeline says nothing about. Batching them would trade away the thing this change
exists to protect, so 8.3 is where the honest floor is and 8.9 is what this PR delivers.

Two caveats on the model, both small and both in the same direction. The two rows it gets wrong are
`renovate.json5` itself, edited once on a Renovate branch by a person, and one `actions/checkout` bump
under `docs/.github/workflows/`, which the model files as "other" while the rules will actually put it
in the `ci tooling` batch. So the real figure is 8.8 or 8.9, not lower.

#### Why the exclusion list cannot be avoided

The obvious objection to the list of dependencies that stay out of the batches is that it is
maintained by hand and will drift. It has drifted twice during review of this PR already. So the
alternative deserves a price rather than a shrug: batch only what is provably inert, meaning
devDependencies, GitHub Actions and the Maven build, test and provided scopes, and leave every
production dependency on its own.

Measured over the same 90 days:

| | PRs over 90 days | per week |
| --- | --- | --- |
| today | 219 | 17.0 |
| batch only the provably inert | 212 | 16.5 |
| the five batches in this PR | 113 | 8.8 |

The two production batches are 125 of the 163 batched PRs. They are the benefit. Batching only the
inert parts buys half a PR a week, which is nothing.

So the list is not optional if the reduction is wanted. The right investment is a check that keeps
the list honest, not a different shape of config, and the concrete follow-up is to extend the guard
in #7852 so it also fails when a Spring Boot BOM override is not covered by a rule here. That is the
specific drift that happened first, and it is the one a machine can catch.

#### Every dependency, run through the rules

Rather than reasoning about what the rules ought to do, all 203 dependencies Renovate extracts from
this repository were put through them with `applyPackageRules`. Where they land:

| destination | dependencies |
| --- | --- |
| front-end production batch | 62 |
| its own PR | 45 |
| devDependencies batch | 41 |
| back-end production batch | 27 |
| build and test tooling batch | 16 |
| disabled, the `io.openaev` internal modules | 6 |

That sweep is what found the two defects fixed in the last commit: a rule titled "Patched
dependencies" that contained `apexcharts`, which carries no patch, and
`io.hypersistence:hypersistence-utils-hibernate-63` sitting in the back-end batch while
`org.hibernate` was on the individual list. It registers Hibernate `UserType`s for JSON and array
columns, so it decides how those columns serialise, and it belongs with Hibernate.

#### What the team sees on the Monday after

Five batch branches, all on the Sunday schedule that `devDependencies` already uses:

- `renovate/dev-dependencies-non-major`, unchanged from today
- `renovate/ci-tooling-non-major`, GitHub Actions
- `renovate/build-test-tooling-non-major`, Maven `build`, `test` and `provided` scopes
- `renovate/front-prod-non-major`, npm `dependencies`
- `renovate/back-prod-non-major`, Maven `compile`, `runtime`, `import` and `optional` scopes

Not every batch produces a PR every week. Over the measured window the two production batches had an
update in 13 of the 13 weeks, the two tooling batches in 10.

Everything else keeps arriving one PR at a time, as it does today, and for a stated reason:

- **Maven runtime and BOM-override dependencies**, labelled `review:runtime-behaviour`. Spring,
  Tomcat, httpcomponents, Hibernate, Jackson, the Elasticsearch and OpenSearch clients, RabbitMQ,
  Quartz, Logback, Log4j, Netty, Micrometer, OpenTelemetry, Kotlin, Velocity, HikariCP, the Postgres
  driver, OkHttp, commons-lang3, gson, and `net.ttddyy:datasource-proxy`.

  Two reasons to be on that list. Either the dependency changes behaviour at runtime through defaults
  nothing asserts, pool sizing and HTTP timeouts and serialisation and transaction semantics, or it is
  one of the 17 versions this pom holds by hand over the Spring Boot BOM.

  The second reason is about attribution, and it is worth stating precisely because the loose version
  of it is wrong. Renovate only ever proposes an upgrade, so a Renovate bump cannot realign a property
  back onto the BOM. What batching costs is visibility: someone chose those 17 versions for a reason,
  and a change to one of them should be readable on its own and revertable on its own rather than
  being one line inside a twelve-dependency commit.

  `datasource-proxy` is there because it wraps the DataSource in main code, so it sits on the path of
  every SQL statement the platform issues. `commons-lang3`, `gson` and OpenTelemetry are there because
  they are BOM overrides, not because anyone thinks a gson patch is dangerous: the list either matches
  the principle or it does not, and a list that half matches is how the stale `html-to-image` marker
  survived for months. `maven-compiler-plugin` is the one BOM override deliberately left in the build
  and test batch: it is a build plugin, it ships nothing, and the BOM versions no dependency through
  it.
- **Front-end parsers, sanitisers and HTTP clients**, also labelled `review:runtime-behaviour`:
  `dompurify`, `qs`, `axios`, `form-data`, `http-proxy-middleware`, `ipaddr.js`,
  `@filigran/chatbot`. A regression here is a security bug the E2E suite passes straight through.
  `dompurify` most of all: it is the XSS boundary of the UI.
- **Patched dependencies**: `react-apexcharts` and `apexcharts`. A yarn patch can stop applying, or
  keep applying against changed code, with no error.
- **Yarn `resolutions`**, `form-data` among them. Changing one is a decision, not a routine bump.
- **Docker images**. Renovate cannot know whether a new Postgres or Elasticsearch major is supported
  by the code.
- **Lock file maintenance**. It rewrites transitive versions with no diff a human can read, and it
  has the worst record of anything here: 3 of the last 6 failed CI on the first attempt, and 4 of the
  5 merged ones needed a commit Renovate did not write.
- **Majors**, because the batches match `minor` and `patch` only.

The `review:runtime-behaviour` label does not exist in the repository yet. GitHub creates a label on
first use through the add-labels endpoint, and if that fails Renovate logs it and skips, so the PR
opens either way. `.github/labels.yml` says in its own header that repository-specific labels are
intentionally not listed there and that no destructive sync should be enabled, and no workflow syncs
it today, so nothing will prune the label. Create it by hand first if you want a specific colour.

#### The concurrency ceiling

`prConcurrentLimit` and `branchConcurrentLimit` go from 100 to 60. `prHourlyLimit` stays at 100,
because its documented purpose is to let a schedule window produce all its PRs at once instead of
drip-feeding them across runs, and batching does not change that.

This is a blast-radius guard, not a volume lever, and it is worth being blunt about that. The limit of
100 was never reached: over the 90 days the peak was 53 simultaneously open Renovate PRs, on
2026-07-13, and the median was 33. So it never throttled anything and lowering it saves nothing. What
it does is cap a runaway, a rebase storm or a rule that accidentally unbatches everything.

60 rather than something smaller on purpose. 16 of the 26 PRs open today are majors older than 30
days that occupy the pool permanently, and a ceiling under about 55 would have blocked PR creation on
2026-07-13 and would silently stop Renovate opening anything new when the pool fills. Renovate does
not fail loudly when it hits the limit, it just stops, and the only place that shows is the
Dependency Dashboard. Once majors move off the PR list the right number is closer to 25, and it should
be re-measured then rather than guessed now.

#### Rule order, and how it was checked

Renovate applies `packageRules` in order and a later rule wins. The batches come first, then the rules
that pull a dependency back out of a batch. That order is load-bearing, and an earlier draft of this
change got it wrong: with the patched-dependency rule placed before the batches, `react-apexcharts`
was swallowed into the front-end batch.

That matters for a concrete reason. A batched PR takes its title from `groupName`, so the `[DANGER]`
marker stops reaching the title, and more importantly the dependency loses its own PR and its own
commit, which is the whole point of flagging it.

It is not checked by reading the file. It is checked by running Renovate's own rule engine against the
parsed config and asserting the resolved `groupName` for a set of representative dependencies. Renovate
44.69.9, `applyPackageRules` from `renovate/dist/util/package-rules`, after `migrateConfig` and
`massageConfig`, the same path Renovate itself takes:

```
dependency                                             | groupName                                     | prefix   | automerge
-------------------------------------------------------+-----------------------------------------------+----------+----------
react-apexcharts patch (yarn patch)                    | (none, own PR)                                | [DANGER] | unset
apexcharts patch                                       | (none, own PR)                                | -        | unset
dompurify patch (sanitiser)                            | (none, own PR)                                | -        | unset
form-data via resolutions                              | (none, own PR)                                | -        | unset
jackson-databind patch (BOM override family)           | (none, own PR)                                | -        | unset
HikariCP patch (pool defaults)                         | (none, own PR)                                | -        | unset
kotlin-stdlib minor                                    | (none, own PR)                                | -        | unset
opentelemetry-bom minor (BOM override)                 | (none, own PR)                                | -        | unset
commons-lang3 patch (BOM override)                     | (none, own PR)                                | -        | unset
gson patch (BOM override)                              | (none, own PR)                                | -        | unset
postgres docker minor                                  | (none, own PR)                                | -        | unset
lock file maintenance                                  | (none, own PR)                                | -        | unset
typescript major                                       | (none, own PR)                                | -        | unset
yarn (packageManager field)                            | (none, own PR)                                | -        | unset
react-intl patch (front prod)                          | front-end production dependencies (non-major) | -        | unset
react patch (framework core, batched on purpose)       | front-end production dependencies (non-major) | -        | unset
react-router patch                                     | front-end production dependencies (non-major) | -        | unset
awssdk bom patch (maven import scope)                  | back-end production dependencies (non-major)  | -        | unset
playwright minor (bundled browser, batched)            | back-end production dependencies (non-major)  | -        | unset
spotless-maven-plugin patch (maven build)              | build and test tooling (non-major)            | -        | unset
archunit-junit5 minor (maven test)                     | build and test tooling (non-major)            | -        | unset
maven-compiler-plugin minor (BOM override, build)      | build and test tooling (non-major)            | -        | unset
actions/checkout minor                                 | ci tooling (non-major)                        | -        | unset
@types/react-dom patch (devDependency)                 | devDependencies (non-major)                   | -        | unset
spring-boot-maven-plugin minor (build scope)           | build and test tooling (non-major)            | -        | unset
react-intl pin                                         | front-end production dependencies (non-major) | -        | unset
awssdk bom pin                                         | back-end production dependencies (non-major)  | -        | unset
```

The last three rows come from the review on this PR. `spring-boot-maven-plugin` used to fall out of
the tooling batch and pick up the `review:runtime-behaviour` label, because the group prefixes in the
runtime rule also match a plugin that shares the coordinate. It is excluded with a negated
`!/-maven-plugin$/` pattern rather than with a `matchDepTypes` filter, because the nine dependencies
the `customManagers` track carry no depType and a depType filter would silently drop them out of that
rule and take their label with them. The two `pin` rows come from aligning the production batches on
`pin` and `digest`, which the three tooling batches and the pre-existing `devDependencies` batch
already accepted.

And the check is not just printing green. Moving the patched-dependency rule back above the batches
and re-running gives:

```
react-apexcharts patch (yarn patch)           | front-end production dependencies (non-major) | [DANGER] | unset
apexcharts patch                              | front-end production dependencies (non-major) | -        | unset
```

which is the bug, reproduced on demand.

The `depType` values the batches match on were read from Renovate's own extractors rather than assumed.
For the maven manager `depType` is the declared scope, plus `build` for plugins and extensions, and in
this repository that is 7 plugins, 5 test libraries and 3 maven-plugin artifacts. Matching on `depType`
rather than on a list of artifacts means a new test dependency joins the right batch without anyone
editing this file.

#### What this costs

A batched PR is harder to review than a single bump, and one bad member holds eleven good ones. The
exit is a rule placed after the batches with `groupName: null` for that dependency, which is two lines
and leaves the batch working for everything else. That mechanism is already used six times in this
file, so it is the documented path and not an improvisation.

A batch delays a fix by up to a week, because they run on Sunday. For anything urgent the route is the
Dependency Dashboard checkbox, which forces a run immediately.

The first run after this merges will be noisy. Existing individual branches close and the batch
branches open in their place, so expect a burst of closures on the first Sunday. Review comments on
the PRs that close are orphaned. Nothing is lost from the update itself: the same version lands in the
batch.

---

### Testing Instructions

1. `renovate-config-validator --no-global --strict renovate.json5`. Output below.
2. Confirm there is no automerge key: `grep -c automerge renovate.json5` returns 0.
3. Reproduce the rule-order table with the snippet under "Checking the rule order" below.
4. After merging, tick a checkbox under "Open" on the Dependency Dashboard, issue #283, to force a
   run rather than waiting for Sunday. Then check three things on the dashboard: the five batch
   branches exist, no dependency from the six "own PR" rules has been swallowed into a batch, and the
   `[DANGER]` prefix is still on the `react-apexcharts` PR when one appears.
5. Do not tick a checkbox under "PR Edited (Blocked)". That discards the human commits on those
   branches, which today is #6062 and #6069.
6. If a dependency ends up in the wrong batch, the Mend job log at
   `https://developer.mend.io/github/OpenAEV-Platform/openaev` shows which `packageRules` matched it
   and what the resulting config was. That is the only place that answers it.

Rollback is a revert of the one commit, then a forced run. The batch branches close and their members
reopen individually. Cost of the round trip: the reopened PRs get new numbers.

#### Checking the rule order

Rule order is the one thing in this PR that a reading cannot settle, so here is how to run it. Adjust
the last path to this branch's `renovate.json5`.

```bash
mkdir -p /tmp/oaev-rules && cd /tmp/oaev-rules
npm i --no-audit --no-fund renovate@44.69.9 json5
cat > prove.mjs <<'EOF'
import fs from 'node:fs';
import JSON5 from 'json5';
import { applyPackageRules } from 'renovate/dist/util/package-rules/index.js';
import { migrateConfig } from 'renovate/dist/config/migration.js';
import { massageConfig } from 'renovate/dist/config/massage.js';
const raw = JSON5.parse(fs.readFileSync(process.argv[2], 'utf8'));
const cfg = massageConfig(migrateConfig(raw).migratedConfig);
const cases = [
  ['react-apexcharts', 'npm', 'npm', 'dependencies', 'patch'],
  ['dompurify',        'npm', 'npm', 'dependencies', 'patch'],
  ['react-intl',       'npm', 'npm', 'dependencies', 'patch'],
  ['com.zaxxer:HikariCP', 'maven', 'maven', 'compile', 'patch'],
  ['io.opentelemetry:opentelemetry-bom', 'maven', 'maven', 'import', 'minor'],
  ['software.amazon.awssdk:bom', 'maven', 'maven', 'import', 'patch'],
  ['com.diffplug.spotless:spotless-maven-plugin', 'maven', 'maven', 'build', 'patch'],
  ['actions/checkout', 'github-actions', 'github-tags', undefined, 'minor'],
];
for (const [depName, manager, datasource, depType, updateType] of cases) {
  const out = await applyPackageRules({ ...cfg, manager, datasource, depName,
    packageName: depName, depType, updateType, packageRules: cfg.packageRules });
  console.log(String(depName).padEnd(46), '|', String(out.groupName ?? '(own PR)').padEnd(46),
              '|', out.commitMessagePrefix ?? '-', '|', out.automerge ?? 'unset');
}
EOF
node prove.mjs /path/to/this/branch/renovate.json5
```

Expected:

```
react-apexcharts                               | (own PR)                                       | [DANGER] | unset
dompurify                                      | (own PR)                                       | -        | unset
react-intl                                     | front-end production dependencies (non-major)  | -        | unset
com.zaxxer:HikariCP                            | (own PR)                                       | -        | unset
io.opentelemetry:opentelemetry-bom             | (own PR)                                       | -        | unset
software.amazon.awssdk:bom                     | back-end production dependencies (non-major)   | -        | unset
com.diffplug.spotless:spotless-maven-plugin    | build and test tooling (non-major)             | -        | unset
actions/checkout                               | ci tooling (non-major)                         | -        | unset
```

`react-apexcharts` must come back as `(own PR)` with the `[DANGER]` prefix. If it comes back inside
`front-end production dependencies (non-major)`, the rule order is wrong.

### Related issues

* Related #ISSUE-NUMBER

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

`renovate-config-validator` output, renovate 44.69.9:

```
$ renovate-config-validator --no-global --strict renovate.json5
 INFO: Validating renovate.json5 as repo config
 INFO: Config validated successfully against 1 file(s)
$ echo $?
0
```

The validator checks option names, not option values, so it is necessary and not sufficient. That is
why the rule-order table exists.

Every option name used here was checked against the installed Renovate 44.69.9 option registry:
`groupName`, `groupSlug`, `schedule`, `matchManagers`, `matchDepTypes`, `matchUpdateTypes`,
`matchDatasources`, `matchDepNames`, `matchPackageNames`, `rebaseWhen`, `addLabels`,
`prConcurrentLimit`, `branchConcurrentLimit`, `prHourlyLimit`.

This PR does not depend on PR 1 and PR 1 does not depend on this one. Either can merge first.

---

#### What a reviewer should check

Ordered by how much it matters.

1. **The six "own PR" lists are a judgement, and they are the whole safety argument.** Read them and
   argue with them. The one most likely to move is `dompurify`: it is out of the batches because it is
   the XSS boundary of the UI and a sanitiser regression passes every test, which is a judgement and
   not a measurement. `playwright` is the opposite case: it is in the back-end batch even though it
   carries a bundled browser, on the grounds that a bad version breaks report rendering visibly. Third
   arguable one: `react`, `react-dom` and `react-router` are in the front-end batch. Their blast radius
   is the whole UI, and the reason they are batched rather than individual is that the E2E suite does
   cover the UI, unlike the sanitiser case.
2. **The Maven list has to be maintained by hand alongside `pom.xml`, and that is the known weakness
   of this PR.** An earlier draft of it was missing three of the 17 BOM overrides while the comment
   above it claimed to cover them all, which is the same failure shape as the `[DANGER]` marker on a
   dependency with no patch. Reproduce the audit: list the 17 overrides with the command in PR 1, then
   check each one against the `matchPackageNames` list in the rule. The mechanical fix is to have PR
   1's guard also fail when a BOM override is not covered by a rule here, which is a follow-up rather
   than something to bolt on now: it would couple the two PRs, and they are deliberately independent.
3. **Is a weekly cadence right for the two production batches?** They are the ones that matter, 124 of
   the 162 batched PRs. Sunday matches what `devDependencies` and `lockFileMaintenance` already do.
   Twice a week would halve the delay and roughly double the PR count for those two.
4. **Is 60 the right ceiling, or should the limits stay at 100 until majors move off the PR list?**
   The measurement is peak 53, median 33, never hit. I think 60 is defensible and I would not argue
   hard against leaving it at 100 in this PR and setting it properly alongside the majors change.
5. **Rule order.** Reproduce the table in Testing Instructions step 3, or at minimum satisfy yourself
   that the six `groupName: null` rules are all below the five batch rules in the file. If one moves
   above, the dependency it protects silently joins a batch.
6. **The first Sunday will be noisy** and that is expected, not a symptom. Worth agreeing in advance
   who watches it.
7. **`review:runtime-behaviour` does not exist as a label yet.** Failure to apply it is non-fatal, but
   if the label is meant to be searchable and coloured, create it before merging.
