### PR TITLE
ci: use pull_request_target for docs gap check on fork PRs (#7857)

### DIFF
--- a/.github/workflows/copilot-docs-review.yml
+++ b/.github/workflows/copilot-docs-review.yml
@@ -1,7 +1,7 @@
 name: "[OpenAEV] Documentation Gap Check"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, labeled, unlabeled]
 
 permissions:


### PR DESCRIPTION
### Proposed changes

* `.github/workflows/copilot-docs-review.yml` — switched trigger from `pull_request` to `pull_request_target` so the `GITHUB_TOKEN` gets write permissions when the PR originates from a fork; GitHub always downgrades `pull_request`-triggered tokens to read-only for fork PRs regardless of the declared `permissions:` block, causing the comment-posting step to fail with `Resource not accessible by integration`. The script only reads PR metadata via the GitHub API and never checks out or executes fork code, so this trigger change is safe.

### Testing Instructions

1. Open a PR from a fork with functional source changes and no doc updates.
2. Confirm the "📖 Documentation gap check" job now succeeds and posts/updates its summary comment instead of failing with a 403 permission error.

### Related issues

* Related #7857

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

An alternative would be to drop the PR-comment step for fork PRs and only run the check (no comment), but keeping the comment for fork PRs preserves parity with same-repo PRs, which is why `pull_request_target` was chosen instead.
