### PR TITLE
fix(notifications): email notification is not sent when scenario score is degraded (#7542)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/notification/handler/ScenarioNotificationEventHandler.java
+++ b/openaev-api/src/main/java/io/openaev/notification/handler/ScenarioNotificationEventHandler.java
@@ -1,5 +1,7 @@
 package io.openaev.notification.handler;
 
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
 import io.openaev.database.model.*;
 import io.openaev.expectation.ExpectationType;
 import io.openaev.notification.engine.NotificationEngineService;
@@ -19,7 +21,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Session;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Detects scenario score degradations between the two most recent finished simulations and, when
@@ -32,51 +33,78 @@ public class ScenarioNotificationEventHandler implements NotificationEventHandle
   private final EntityManager entityManager;
   private final ExerciseService exerciseService;
   private final NotificationEngineService notificationEngineService;
+  private final TenantScopedTransaction tenantTx;
+
+  /** Outcome of the detection phase; {@code null} stands for "no degradation to report". */
+  private record Degradation(String scenarioId, String tenantId, String message) {}
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
   public void handle(NotificationEvent event) {
+    if (!NotificationEventType.SIMULATION_COMPLETED.equals(event.getEventType())) {
+      return;
+    }
+    // Two phases, deliberately not one transaction. Detection needs a transaction and a tenant
+    // scope to read the simulations; the engine then opens its OWN scoped transaction per trigger
+    // and TenantScopedTransaction.execute() refuses to run inside an active one. So the detection
+    // transaction must be closed before the engine is called - the same contract the CRUD path
+    // gets for free from @TransactionalEventListener (it runs after commit).
+    Degradation degradation = tenantTx.execute(TxCtx.allTenants(), () -> detect(event));
+    if (degradation == null) {
+      return;
+    }
+    notificationEngineService.handleEventWithMessage(
+        NotificationResourceCatalog.SCENARIO,
+        degradation.scenarioId(),
+        degradation.tenantId(),
+        NotificationTriggerEventType.SCORE_DEGRADATION,
+        degradation.message());
+  }
+
+  /** Compares the two most recent finished simulations of the scenario. */
+  private Degradation detect(NotificationEvent event) {
     // Disable tenant filter — this handler runs cross-tenant
     entityManager.unwrap(Session.class).disableFilter("tenantFilter");
-    if (NotificationEventType.SIMULATION_COMPLETED.equals(event.getEventType())) {
-      // get the last 2 simulations
-      Exercise lastSimulation =
-          exerciseService.previousFinishedSimulation(event.getResourceId(), event.getTimestamp());
-      if (lastSimulation == null || lastSimulation.getEnd().isEmpty()) {
-        return;
-      }
-      Exercise secondLastSimulation =
-          exerciseService.previousFinishedSimulation(
-              event.getResourceId(), lastSimulation.getEnd().get());
-      if (secondLastSimulation == null) {
-        return;
-      }
-
-      // create map with the results to facilitate the computing of the score difference
-      // TODO update exerciseService to return a map with result
-      Map<ExpectationType, ExpectationResultsByType> lastSimulationResultsMap =
-          exerciseService.getGlobalResults(lastSimulation.getId()).stream()
-              .collect(Collectors.toMap(ExpectationResultsByType::type, Function.identity()));
-      Map<ExpectationType, ExpectationResultsByType> secondLastSimulationResultsMap =
-          exerciseService.getGlobalResults(secondLastSimulation.getId()).stream()
-              .collect(Collectors.toMap(ExpectationResultsByType::type, Function.identity()));
-
-      if (exerciseService.isThereAScoreDegradation(
-          lastSimulationResultsMap, secondLastSimulationResultsMap)) {
-        Scenario scenario = lastSimulation.getScenario();
-        notificationEngineService.handleEventWithMessage(
-            NotificationResourceCatalog.SCENARIO,
-            scenario.getId(),
-            scenario.getTenant() != null ? scenario.getTenant().getId() : null,
-            NotificationTriggerEventType.SCORE_DEGRADATION,
-            buildDegradationMessage(
-                scenario,
-                lastSimulation,
-                secondLastSimulation,
-                lastSimulationResultsMap,
-                secondLastSimulationResultsMap));
-      }
+    // get the last 2 simulations
+    Exercise lastSimulation =
+        exerciseService.previousFinishedSimulation(event.getResourceId(), event.getTimestamp());
+    if (lastSimulation == null || lastSimulation.getEnd().isEmpty()) {
+      return null;
     }
+    Exercise secondLastSimulation =
+        exerciseService.previousFinishedSimulation(
+            event.getResourceId(), lastSimulation.getEnd().get());
+    if (secondLastSimulation == null) {
+      return null;
+    }
+
+    // create map with the results to facilitate the computing of the score difference
+    // TODO update exerciseService to return a map with result
+    Map<ExpectationType, ExpectationResultsByType> lastSimulationResultsMap =
+        exerciseService.getGlobalResults(lastSimulation.getId()).stream()
+            .collect(Collectors.toMap(ExpectationResultsByType::type, Function.identity()));
+    Map<ExpectationType, ExpectationResultsByType> secondLastSimulationResultsMap =
+        exerciseService.getGlobalResults(secondLastSimulation.getId()).stream()
+            .collect(Collectors.toMap(ExpectationResultsByType::type, Function.identity()));
+
+    if (!exerciseService.isThereAScoreDegradation(
+        lastSimulationResultsMap, secondLastSimulationResultsMap)) {
+      return null;
+    }
+    Scenario scenario = lastSimulation.getScenario();
+    String tenantId = scenario.getTenant() != null ? scenario.getTenant().getId() : null;
+    if (tenantId == null) {
+      // The engine drops tenant-less events fail-closed anyway; bail out now.
+      return null;
+    }
+    return new Degradation(
+        scenario.getId(),
+        tenantId,
+        buildDegradationMessage(
+            scenario,
+            lastSimulation,
+            secondLastSimulation,
+            lastSimulationResultsMap,
+            secondLastSimulationResultsMap));
   }
 
   private String buildDegradationMessage(

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -1355,9 +1355,9 @@ public class ExerciseService {
       ExpectationType type = entry.getKey();
 
       // we ignore manual expectation
-      //      if (ExpectationType.HUMAN_RESPONSE.equals(type)) {
-      //        continue;
-      //      }
+      if (ExpectationType.HUMAN_RESPONSE.equals(type)) {
+        continue;
+      }
 
       ExpectationResultsByType secondLastSimulationResultsByType =
           secondLastSimulationResultsMap.get(type);

--- a/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
+++ b/openaev-api/src/main/java/io/openaev/rest/exercise/service/ExerciseService.java
@@ -1355,9 +1355,9 @@ public class ExerciseService {
       ExpectationType type = entry.getKey();
 
       // we ignore manual expectation
-      if (ExpectationType.HUMAN_RESPONSE.equals(type)) {
-        continue;
-      }
+      //      if (ExpectationType.HUMAN_RESPONSE.equals(type)) {
+      //        continue;
+      //      }
 
       ExpectationResultsByType secondLastSimulationResultsByType =
           secondLastSimulationResultsMap.get(type);

--- a/openaev-api/src/main/java/io/openaev/service/MailingService.java
+++ b/openaev-api/src/main/java/io/openaev/service/MailingService.java
@@ -5,6 +5,9 @@ import static io.openaev.config.SessionHelper.currentUser;
 import static io.openaev.database.model.Tenant.DEFAULT_TENANT_UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.database.model.Execution;
+import io.openaev.database.model.ExecutionStatus;
+import io.openaev.database.model.ExecutionTrace;
 import io.openaev.database.model.Exercise;
 import io.openaev.database.model.Inject;
 import io.openaev.database.model.Injector;
@@ -24,6 +27,7 @@ import io.openaev.telemetry.metric_collectors.ResultsMetricCollector;
 import jakarta.annotation.Resource;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -45,6 +49,27 @@ public class MailingService {
           "Email injector contract has no linked injector: " + injectorContract.getId());
     }
     return injectorContract.getInjectors().getFirst();
+  }
+
+  /**
+   * Turns a failed or partially failed delivery into an exception. The email injector swallows
+   * every error into {@link Execution} traces, so this is the only place where a caller can learn
+   * that nothing was actually sent.
+   */
+  private void raiseOnFailedDelivery(Execution execution, String contractId, int recipientCount) {
+    ExecutionStatus status = execution.getStatus();
+    if (!ExecutionStatus.ERROR.equals(status) && !ExecutionStatus.PARTIAL.equals(status)) {
+      return;
+    }
+    String errors =
+        execution.getTraces().stream()
+            .filter(trace -> trace.getStatus().isError())
+            .map(ExecutionTrace::getMessage)
+            .collect(Collectors.joining("; "));
+    throw new IllegalStateException(
+        String.format(
+            "Email delivery %s for contract %s (%d recipient(s)): %s",
+            status, contractId, recipientCount, errors));
   }
 
   private String resolveInjectorType(InjectorContract injectorContract, Injector firstInjector) {
@@ -103,7 +128,12 @@ public class MailingService {
                   new ExecutableInject(false, true, inject, userInjectContexts);
               io.openaev.executors.Injector executor =
                   managerFactory.getManager(tenantId).requestInjectorExecutorByType(injectorType);
-              executor.executeInjection(injection);
+              // Injector.execute() never propagates: it catches every failure into execution
+              // traces. Discarding the returned Execution would make a failed delivery (SMTP
+              // down, misconfigured mailer, encryption error) indistinguishable from a success,
+              // which is how notification emails went missing with no trace in the logs.
+              Execution execution = executor.executeInjection(injection);
+              raiseOnFailedDelivery(execution, injectorContract.getId(), userInjectContexts.size());
             });
   }
 

--- a/openaev-api/src/test/java/io/openaev/notification/handler/ScenarioNotificationEventHandlerTest.java
+++ b/openaev-api/src/test/java/io/openaev/notification/handler/ScenarioNotificationEventHandlerTest.java
@@ -1,0 +1,216 @@
+package io.openaev.notification.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.openaev.context.TenantScopedTransaction;
+import io.openaev.context.TxCtx;
+import io.openaev.database.model.Exercise;
+import io.openaev.database.model.NotificationTriggerEventType;
+import io.openaev.database.model.Scenario;
+import io.openaev.database.model.Tenant;
+import io.openaev.notification.engine.NotificationEngineService;
+import io.openaev.notification.engine.NotificationResourceCatalog;
+import io.openaev.notification.model.NotificationEvent;
+import io.openaev.notification.model.NotificationEventType;
+import io.openaev.rest.exercise.service.ExerciseService;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * The handler detects the degradation inside a tenant-scoped transaction, then calls the engine
+ * OUTSIDE of it: {@code NotificationEngineService} opens its own scoped transaction per trigger and
+ * {@code TenantScopedTransaction.execute()} refuses to run inside an active one.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("Scenario score degradation notification handler")
+class ScenarioNotificationEventHandlerTest {
+
+  private static final String SCENARIO_ID = "scenario-1";
+  private static final String TENANT_ID = "tenant-1";
+  private static final Instant EVENT_AT = Instant.parse("2026-01-02T00:00:00Z");
+  private static final Instant LAST_END = Instant.parse("2026-01-01T12:00:00Z");
+  private static final Instant PREVIOUS_END = Instant.parse("2025-12-31T12:00:00Z");
+
+  @Mock private EntityManager entityManager;
+  @Mock private Session session;
+  @Mock private ExerciseService exerciseService;
+  @Mock private NotificationEngineService notificationEngineService;
+  @Mock private TenantScopedTransaction tenantTx;
+
+  @Captor private ArgumentCaptor<TxCtx> txCtxCaptor;
+
+  private ScenarioNotificationEventHandler handler;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    when(entityManager.unwrap(Session.class)).thenReturn(session);
+    handler =
+        new ScenarioNotificationEventHandler(
+            entityManager, exerciseService, notificationEngineService, tenantTx);
+    // Run the detection phase inline so its outcome can be asserted.
+    when(tenantTx.execute(any(TxCtx.class), any(Supplier.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1, Supplier.class).get());
+  }
+
+  private NotificationEvent simulationCompleted() {
+    return NotificationEvent.builder()
+        .eventType(NotificationEventType.SIMULATION_COMPLETED)
+        .resourceId(SCENARIO_ID)
+        .timestamp(EVENT_AT)
+        .build();
+  }
+
+  private Exercise simulation(String id, Instant end, Scenario scenario) {
+    Exercise exercise = mock(Exercise.class);
+    when(exercise.getId()).thenReturn(id);
+    when(exercise.getEnd()).thenReturn(Optional.ofNullable(end));
+    when(exercise.getScenario()).thenReturn(scenario);
+    return exercise;
+  }
+
+  private Scenario scenarioWithTenant(String tenantId) {
+    Scenario scenario = mock(Scenario.class);
+    when(scenario.getId()).thenReturn(SCENARIO_ID);
+    when(scenario.getName()).thenReturn("Scenario under test");
+    when(scenario.getTenant()).thenReturn(tenantId == null ? null : new Tenant(tenantId));
+    return scenario;
+  }
+
+  private void givenTwoFinishedSimulations(Scenario scenario) {
+    // Mocks must be fully built BEFORE being handed to thenReturn(): creating a mock inside a
+    // stubbing expression is what Mockito reports as "unfinished stubbing".
+    Exercise last = simulation("sim-last", LAST_END, scenario);
+    Exercise previous = simulation("sim-previous", PREVIOUS_END, scenario);
+    when(exerciseService.previousFinishedSimulation(eq(SCENARIO_ID), eq(EVENT_AT)))
+        .thenReturn(last);
+    when(exerciseService.previousFinishedSimulation(eq(SCENARIO_ID), eq(LAST_END)))
+        .thenReturn(previous);
+    when(exerciseService.getGlobalResults(anyString())).thenReturn(List.of());
+  }
+
+  @Nested
+  @DisplayName("When a score degradation is detected")
+  class WhenDegradationDetected {
+
+    @Test
+    @DisplayName("given a degradation, should detect in a scope then dispatch outside it")
+    void given_degradation_should_detectInScopeThenDispatchOutside() {
+      // -- ARRANGE --
+      givenTwoFinishedSimulations(scenarioWithTenant(TENANT_ID));
+      when(exerciseService.isThereAScoreDegradation(anyMap(), anyMap())).thenReturn(true);
+
+      // -- ACT --
+      handler.handle(simulationCompleted());
+
+      // -- ASSERT --
+      // Detection is cross-tenant: the scenario's tenant is only known once it has been read.
+      verify(tenantTx).execute(txCtxCaptor.capture(), any(Supplier.class));
+      assertEquals(TxCtx.allTenants(), txCtxCaptor.getValue());
+      verify(notificationEngineService)
+          .handleEventWithMessage(
+              eq(NotificationResourceCatalog.SCENARIO),
+              eq(SCENARIO_ID),
+              eq(TENANT_ID),
+              eq(NotificationTriggerEventType.SCORE_DEGRADATION),
+              anyString());
+    }
+
+    @Test
+    @DisplayName("given a degradation, should never nest the engine call in a transaction")
+    void given_degradation_should_neverNestEngineCallInTransaction() {
+      // -- ARRANGE --
+      // Regression guard: wrapping the engine call in executeNew() made it fail with
+      // "TenantScopedTransaction.execute() refuses to open inside an active transaction".
+      givenTwoFinishedSimulations(scenarioWithTenant(TENANT_ID));
+      when(exerciseService.isThereAScoreDegradation(anyMap(), anyMap())).thenReturn(true);
+
+      // -- ACT --
+      handler.handle(simulationCompleted());
+
+      // -- ASSERT --
+      verify(tenantTx, never()).executeNew(any(TxCtx.class), any(Runnable.class));
+      verify(tenantTx, never()).executeNew(any(TxCtx.class), any(Supplier.class));
+    }
+
+    @Test
+    @DisplayName("given a scenario without tenant, should not dispatch at all")
+    void given_scenarioWithoutTenant_should_notDispatch() {
+      // -- ARRANGE --
+      // The engine drops tenant-less events fail-closed anyway.
+      givenTwoFinishedSimulations(scenarioWithTenant(null));
+      when(exerciseService.isThereAScoreDegradation(anyMap(), anyMap())).thenReturn(true);
+
+      // -- ACT --
+      handler.handle(simulationCompleted());
+
+      // -- ASSERT --
+      verify(notificationEngineService, never())
+          .handleEventWithMessage(any(), anyString(), anyString(), any(), anyString());
+    }
+  }
+
+  @Nested
+  @DisplayName("When no score degradation occurred")
+  class WhenNoDegradation {
+
+    @Test
+    @DisplayName("given no degradation, should not reach the engine")
+    void given_noDegradation_should_notReachEngine() {
+      // -- ARRANGE --
+      givenTwoFinishedSimulations(scenarioWithTenant(TENANT_ID));
+      when(exerciseService.isThereAScoreDegradation(anyMap(), anyMap())).thenReturn(false);
+
+      // -- ACT --
+      handler.handle(simulationCompleted());
+
+      // -- ASSERT --
+      verify(notificationEngineService, never())
+          .handleEventWithMessage(any(), anyString(), anyString(), any(), anyString());
+    }
+
+    @Test
+    @DisplayName("given a single finished simulation, should return before comparing")
+    void given_singleFinishedSimulation_should_returnEarly() {
+      // -- ARRANGE --
+      Scenario scenario = scenarioWithTenant(TENANT_ID);
+      Exercise last = simulation("sim-last", LAST_END, scenario);
+      when(exerciseService.previousFinishedSimulation(eq(SCENARIO_ID), eq(EVENT_AT)))
+          .thenReturn(last);
+      when(exerciseService.previousFinishedSimulation(eq(SCENARIO_ID), eq(LAST_END)))
+          .thenReturn(null);
+
+      // -- ACT --
+      handler.handle(simulationCompleted());
+
+      // -- ASSERT --
+      verify(exerciseService, never()).isThereAScoreDegradation(anyMap(), anyMap());
+      verify(notificationEngineService, never())
+          .handleEventWithMessage(any(), anyString(), anyString(), any(), anyString());
+    }
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/rest/scenario/configuration/WithMockEmailSender.java
+++ b/openaev-api/src/test/java/io/openaev/rest/scenario/configuration/WithMockEmailSender.java
@@ -1,5 +1,7 @@
 package io.openaev.rest.scenario.configuration;
 
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,12 +9,26 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 
+/**
+ * Test double for the SMTP sender: builds real {@link MimeMessage} instances and discards the
+ * actual send.
+ *
+ * <p>{@code createMimeMessage()} must be stubbed explicitly. It is abstract on the {@link
+ * JavaMailSender} interface, so {@code CALLS_REAL_METHODS} alone returned {@code null} and every
+ * email path NPEd - silently, because the email injector funnels failures into execution traces
+ * instead of propagating them. Tests were passing over a delivery that never happened.
+ */
 @Profile("test")
 @Configuration
 public class WithMockEmailSender {
   @Bean
   @Primary
   public JavaMailSender mailSender() {
-    return Mockito.mock(JavaMailSender.class, Mockito.CALLS_REAL_METHODS);
+    JavaMailSender mailSender = Mockito.mock(JavaMailSender.class, Mockito.CALLS_REAL_METHODS);
+    // A fresh message per call: callers mutate it (recipients, body, attachments).
+    Mockito.doAnswer(invocation -> new MimeMessage((Session) null))
+        .when(mailSender)
+        .createMimeMessage();
+    return mailSender;
   }
 }

--- a/openaev-api/src/test/java/io/openaev/service/MailingServiceTest.java
+++ b/openaev-api/src/test/java/io/openaev/service/MailingServiceTest.java
@@ -1,0 +1,173 @@
+package io.openaev.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openaev.database.model.Execution;
+import io.openaev.database.model.ExecutionTrace;
+import io.openaev.database.model.ExecutionTraceAction;
+import io.openaev.database.model.Inject;
+import io.openaev.database.model.Injector;
+import io.openaev.database.model.InjectorContract;
+import io.openaev.database.model.InjectorContractId;
+import io.openaev.database.model.User;
+import io.openaev.database.repository.InjectorContractRepository;
+import io.openaev.database.repository.UserRepository;
+import io.openaev.execution.ExecutionContext;
+import io.openaev.execution.ExecutionContextService;
+import io.openaev.injectors.email.EmailContract;
+import io.openaev.integration.Manager;
+import io.openaev.integration.ManagerFactory;
+import io.openaev.telemetry.metric_collectors.ResultsMetricCollector;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The email injector never propagates: {@code Injector.execute()} funnels every failure into
+ * execution traces. These tests pin the contract that {@link MailingService} inspects that result
+ * instead of discarding it, so a failed delivery cannot masquerade as a success.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MailingServiceTest {
+
+  private static final String TENANT_ID = "tenant-1";
+  private static final String INJECTOR_TYPE = "openaev_email";
+
+  @Mock private UserRepository userRepository;
+  @Mock private ResultsMetricCollector resultsMetricCollector;
+  @Mock private InjectorContractRepository injectorContractRepository;
+  @Mock private ExecutionContextService executionContextService;
+  @Mock private ManagerFactory managerFactory;
+
+  @InjectMocks private MailingService mailingService;
+
+  private io.openaev.executors.Injector executor;
+
+  @BeforeEach
+  void setUp() {
+    // MailingService uses constructor injection for its dependencies, so Mockito skips field
+    // injection: the @Resource-annotated mapper has to be set explicitly.
+    ReflectionTestUtils.setField(mailingService, "mapper", new ObjectMapper());
+
+    Injector injector = new Injector();
+    injector.setId("injector-1");
+    injector.setType(INJECTOR_TYPE);
+    InjectorContract contract = new InjectorContract();
+    contract.setId(EmailContract.EMAIL_DEFAULT);
+    contract.addInjector(injector);
+
+    when(injectorContractRepository.findById(any(InjectorContractId.class)))
+        .thenReturn(Optional.of(contract));
+    when(executionContextService.executionContext(
+            any(User.class), any(Inject.class), any(String.class)))
+        .thenReturn(mock(ExecutionContext.class));
+
+    executor = mock(io.openaev.executors.Injector.class);
+    Manager manager = mock(Manager.class);
+    when(manager.requestInjectorExecutorByType(INJECTOR_TYPE)).thenReturn(executor);
+    when(managerFactory.getManager(TENANT_ID)).thenReturn(manager);
+  }
+
+  private static Execution executionWith(ExecutionTrace... traces) {
+    Execution execution = new Execution(true);
+    for (ExecutionTrace trace : traces) {
+      execution.addTrace(trace);
+    }
+    execution.stop();
+    return execution;
+  }
+
+  private void sendEmail() {
+    User recipient = new User();
+    recipient.setId("user-1");
+    recipient.setEmail("player@example.com");
+    mailingService.sendEmail("subject", "body", List.of(recipient), TENANT_ID);
+  }
+
+  @Nested
+  @DisplayName("When the injector reports a failed delivery")
+  class FailedDelivery {
+
+    @Test
+    @DisplayName("given only error traces, should raise with the underlying cause")
+    void given_onlyErrorTraces_should_raiseWithUnderlyingCause() {
+      // -- PREPARE --
+      when(executor.executeInjection(any()))
+          .thenReturn(
+              executionWith(
+                  ExecutionTrace.getNewErrorTrace(
+                      "SMTP connection refused", ExecutionTraceAction.COMPLETE)));
+
+      // -- EXECUTE & ASSERT --
+      assertThatThrownBy(MailingServiceTest.this::sendEmail)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("SMTP connection refused")
+          .hasMessageContaining(EmailContract.EMAIL_DEFAULT);
+    }
+
+    @Test
+    @DisplayName("given a partial delivery, should still raise so the failure is not lost")
+    void given_partialDelivery_should_stillRaise() {
+      // -- PREPARE --
+      when(executor.executeInjection(any()))
+          .thenReturn(
+              executionWith(
+                  ExecutionTrace.getNewSuccessTrace("sent to a", ExecutionTraceAction.COMPLETE),
+                  ExecutionTrace.getNewErrorTrace(
+                      "mailbox unavailable for b", ExecutionTraceAction.COMPLETE)));
+
+      // -- EXECUTE & ASSERT --
+      assertThatThrownBy(MailingServiceTest.this::sendEmail)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("mailbox unavailable for b");
+    }
+  }
+
+  @Nested
+  @DisplayName("When the injector reports a successful delivery")
+  class SuccessfulDelivery {
+
+    @Test
+    @DisplayName("given success traces, should not raise")
+    void given_successTraces_should_notRaise() {
+      // -- PREPARE --
+      when(executor.executeInjection(any()))
+          .thenReturn(
+              executionWith(
+                  ExecutionTrace.getNewSuccessTrace("sent", ExecutionTraceAction.COMPLETE)));
+
+      // -- EXECUTE & ASSERT --
+      assertThatCode(MailingServiceTest.this::sendEmail).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("given no trace at all, should not raise")
+    void given_noTrace_should_notRaise() {
+      // -- PREPARE --
+      when(executor.executeInjection(any())).thenReturn(executionWith());
+
+      // -- EXECUTE --
+      assertThatCode(MailingServiceTest.this::sendEmail).doesNotThrowAnyException();
+
+      // -- ASSERT --
+      assertThat(executionWith().getTraces()).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* ScenarioNotificationEventHandler : split handle() into a scoped detection phase and an unscoped dispatch phase, and drop its @Transactional. The handler runs on a scheduler thread with no tenant scope, so the v2-active injectors table was fail-closed and MailingService.resolveFirstInjector threw Email injector contract has no linked injector. Detection now runs in tenantTx.execute(TxCtx.allTenants(), …); the engine is called after that transaction closes, since it opens its own scoped transaction per trigger and refuses to nest.
* MailingService : inspect the Execution returned by executeInjection and raise on ERROR / PARTIAL. Injector.execute() never propagates, so a dead SMTP server was indistinguishable from a successful send. Failures now surface in NotificationDispatchService's catch, with trigger and recipient context.

### Testing Instructions

1. Log in to OpenAEV using an email address you have access to (so you can verify email receipt).
2. Create a scenario
3. Enable notifications on the scenario (add both "User interface" and "Email" as notifiers, with "Score degradation" checked).
4. Launch a simulation from the scenario
5. Wait for this simulation to finish.
6. Launch the simulation a second time, ensuring it produces a degraded score compared to the first run. (If you want to test with a human-response score (based on manual inject validation rather than automated detection), you need to comment out lines 1358–1359 in ExerciseService beforehand, otherwise human responses are skipped.)
7. Expected result: You should receive both:
- a notification in the platform
- an email

### Related issues

* Related #7542 


### Further comments
<img width="2356" height="45" alt="Capture d’écran 2026-09-09 à 17 31 46" src="https://github.com/user-attachments/assets/0a3569ce-0d88-43a9-ae94-a658a9680850" />

