### PR TITLE
ci(multitenancy): nightly shadow runs under production and full active-tables (#7914)

### DIFF
--- a/.github/actions/api-tests/action.yml
+++ b/.github/actions/api-tests/action.yml
@@ -35,6 +35,16 @@ inputs:
     description: "Suffix appended to artifact names to avoid conflicts (e.g. '-opensearch')"
     required: false
     default: ""
+  tenant-mode:
+    description: >
+      Multi-tenancy v2 shadow mode. Empty (default) leaves the run exactly as it was: the test
+      profile declares no active tables, so the statement inspector never fires. "production" runs
+      the suite under the active-tables list main ships, which catches a regression on a table that
+      is already live. "all" runs it with every strict tenant table active, which surfaces what
+      activating the rest would break. Both turn the fail-closed detector on, so an unscoped
+      production read fails its test instead of silently returning zero rows.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -210,6 +220,37 @@ runs:
           echo "surefire_arg=$ARGS" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Resolve multi-tenancy shadow mode
+      id: tenant
+      shell: bash
+      env:
+        MODE: ${{ inputs.tenant-mode }}
+      run: |
+        if [ -z "$MODE" ]; then
+          echo "args=" >> "$GITHUB_OUTPUT"
+          echo "ℹ️ tenant shadow: off (test profile, inspector inert)"
+          exit 0
+        fi
+        case "$MODE" in
+          production)
+            # Read the list main ships rather than restating it here, so the two can never drift.
+            PROPS=openaev-api/src/main/resources/application.properties
+            LIST=$(sed -n 's/^openaev\.tenant\.active-tables=//p' "$PROPS")
+            if [ -z "$LIST" ]; then
+              echo "❌ no openaev.tenant.active-tables in $PROPS"; exit 1
+            fi
+            ;;
+          all)
+            # TenantTables.ALL_STRICT: every strict tenant table, no dual-scope one.
+            LIST='*'
+            ;;
+          *) echo "❌ unknown tenant-mode: $MODE (expected '', 'production' or 'all')"; exit 1 ;;
+        esac
+        echo "🔐 tenant shadow: mode=$MODE"
+        echo "   active-tables=$LIST"
+        # Single-quoted so '*' reaches the JVM instead of being glob-expanded by the shell below.
+        echo "args=-Dopenaev.tenant.active-tables='$LIST' -Dopenaev.failclosed.detector=on" >> "$GITHUB_OUTPUT"
+
     - name: Run API tests (shard ${{ inputs.shard }} — ${{ inputs.shard-name }})
       id: run-tests
       shell: bash
@@ -222,6 +263,73 @@ runs:
         mvn -B -ntp -pl openaev-api test
         -Dmaven.compiler.skip=true
         ${{ steps.suite.outputs.surefire_arg }}
+        ${{ steps.tenant.outputs.args }}
+
+    - name: Summarise the multi-tenancy shadow run
+      if: ${{ !cancelled() && inputs.tenant-mode != '' }}
+      shell: bash
+      env:
+        MODE: ${{ inputs.tenant-mode }}
+        SHARD: ${{ inputs.shard-name }}
+      run: |
+        REPORTS=openaev-api/target/surefire-reports
+        S="$GITHUB_STEP_SUMMARY"
+        {
+          echo "## 🔐 Tenant shadow \`$MODE\` — shard $SHARD"
+          echo
+        } >> "$S"
+        if [ ! -d "$REPORTS" ]; then
+          echo "No surefire reports: the suite did not start." >> "$S"
+          exit 0
+        fi
+
+        # Totals, summed over the shard's classes. Read from the reports, never from a grep of the
+        # build log: Maven writes ANSI colour codes inside its counters, so a grep there is vacuous.
+        awk -F'[:,]' '/^Tests run:/ {t+=$2; f+=$4; e+=$6; s+=$8}
+          END {printf "| Tests | Failures | Errors | Skipped |\n|---|---|---|---|\n| %d | %d | %d | %d |\n", t, f, e, s}' \
+          "$REPORTS"/*.txt >> "$S" 2>/dev/null || true
+        echo >> "$S"
+
+        # Unscoped production reads the fail-closed gate refused. Each is a path that would return
+        # zero rows in production once its table is active.
+        SIGS=$(awk '
+            /Fail-closed: production code read/ { inblock = 1; next }
+            inblock && /^Scope the path/ { inblock = 0; next }
+            inblock && /io\.openaev\./ {
+              gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+              if ($0 ~ /^io\.openaev\.[A-Za-z0-9_.$]+$/) print
+            }
+          ' "$REPORTS"/*.txt 2>/dev/null | sort -u)
+        if [ -n "$SIGS" ]; then
+          {
+            echo "### Unscoped production reads ($(echo "$SIGS" | wc -l))"
+            echo
+            echo "Scope each one, or waive it in \`failclosed-baseline.txt\` with a reason."
+            echo
+            echo '```'
+            echo "$SIGS"
+            echo '```'
+            echo
+          } >> "$S"
+        else
+          echo "No unscoped production read." >> "$S"
+          echo >> "$S"
+        fi
+
+        # Everything else that went red: the exception type is what tells a refused query shape from
+        # a GROUP BY error from a plain assertion.
+        OTHER=$(grep -h '<<< \(FAILURE\|ERROR\)!' -A1 "$REPORTS"/*.txt 2>/dev/null \
+          | grep -oE '^[a-z][a-zA-Z0-9.]*\.[A-Za-z0-9_]*(Exception|Error)' | sort | uniq -c | sort -rn)
+        if [ -n "$OTHER" ]; then
+          {
+            echo "### Failures by exception type"
+            echo
+            echo '```'
+            echo "$OTHER"
+            echo '```'
+          } >> "$S"
+        fi
+
     - name: Verify JaCoCo exec data
       if: ${{ !cancelled() }}
       shell: bash
@@ -240,7 +348,9 @@ runs:
           exit 1
         fi
     - name: Upload JaCoCo exec data
-      if: ${{ !cancelled() }}
+      # A shadow run re-executes tests the normal shards already covered, so its exec data would be
+      # merged twice into the project's coverage. It is an instrument, not a coverage contributor.
+      if: ${{ !cancelled() && inputs.tenant-mode == '' }}
       uses: actions/upload-artifact@v7
       with:
         name: jacoco-exec-shard-${{ inputs.shard }}${{ inputs.artifact-suffix }}

--- a/.github/actions/api-tests/action.yml
+++ b/.github/actions/api-tests/action.yml
@@ -40,9 +40,16 @@ inputs:
       Multi-tenancy v2 shadow mode. Empty (default) leaves the run exactly as it was: the test
       profile declares no active tables, so the statement inspector never fires. "production" runs
       the suite under the active-tables list main ships, which catches a regression on a table that
-      is already live. "all" runs it with every strict tenant table active, which surfaces what
-      activating the rest would break. Both turn the fail-closed detector on, so an unscoped
-      production read fails its test instead of silently returning zero rows.
+      is already live. "all" runs it with every strict tenant table active except those deliberately
+      outside v2, which surfaces what activating the rest would break. Both turn the fail-closed
+      detector on, so an unscoped production read fails its test instead of silently returning zero
+      rows.
+      Scope, exactly: the list is a JVM system property, and a class carrying
+      @TestPropertySource(properties = "openaev.tenant.active-tables=...") keeps its own narrower
+      list, because inlined test properties win over system properties. Those classes are the
+      isolation suites, which already run with their table active; the shadow's new information
+      comes from every other class, which has never run under activation. Making the shadow win over
+      per-class activation needs a context customizer and is tracked separately.
     required: false
     default: ""
 
@@ -277,6 +284,10 @@ runs:
         {
           echo "## 🔐 Tenant shadow \`$MODE\` — shard $SHARD"
           echo
+          echo "_Classes carrying their own \`@TestPropertySource\` activation keep it: inlined test"
+          echo "properties win over the system property this mode sets. Those are the isolation suites,"
+          echo "already running with their table active._"
+          echo
         } >> "$S"
         if [ ! -d "$REPORTS" ]; then
           echo "No surefire reports: the suite did not start." >> "$S"
@@ -318,8 +329,10 @@ runs:
 
         # Everything else that went red: the exception type is what tells a refused query shape from
         # a GROUP BY error from a plain assertion.
+        # || true: a clean run has no failure line, grep exits 1, and the composite action's shell
+        # is `bash -e -o pipefail`, so without this a green shadow run would fail its own summary.
         OTHER=$(grep -h '<<< \(FAILURE\|ERROR\)!' -A1 "$REPORTS"/*.txt 2>/dev/null \
-          | grep -oE '^[a-z][a-zA-Z0-9.]*\.[A-Za-z0-9_]*(Exception|Error)' | sort | uniq -c | sort -rn)
+          | grep -oE '^[a-z][a-zA-Z0-9.]*\.[A-Za-z0-9_]*(Exception|Error)' | sort | uniq -c | sort -rn || true)
         if [ -n "$OTHER" ]; then
           {
             echo "### Failures by exception type"

--- a/.github/workflows/_ci-pipeline.yml
+++ b/.github/workflows/_ci-pipeline.yml
@@ -105,6 +105,9 @@ jobs:
     name: "🧪 API Tests (${{ matrix.shard_name }})"
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # A matrix entry may set continue_on_error: the multi-tenancy shadow runs are instruments, not
+    # gates, and a red one must not fail the workflow while the migration is in progress.
+    continue-on-error: ${{ matrix.continue_on_error || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +132,7 @@ jobs:
           shard-name: ${{ matrix.shard_name }}
           search-engine: ${{ matrix.search_engine }}
           artifact-suffix: ${{ matrix.artifact_suffix }}
+          tenant-mode: ${{ matrix.tenant_mode }}
 
   # ════════════════════════════════════════════════════════════════════
   # E2E Tests — matrix passed from caller

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -38,7 +38,32 @@ jobs:
           {"shard":"5","shard_name":"5-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"shardfile","excludes":""},
           {"shard":"6","shard_name":"6-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"shardfile","excludes":""},
           {"shard":"7","shard_name":"7-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"shardfile","excludes":""},
-          {"shard":"8","shard_name":"remaining-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"catchall","excludes":""}
+          {"shard":"8","shard_name":"remaining-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"catchall","excludes":""},
+
+          # ── Multi-tenancy v2 shadow runs (epic #6393), Elasticsearch only ──
+          # Same suite, different activation. "shadow-prod" runs under the active-tables list
+          # main ships, so a regression on a table that is already live surfaces the night it
+          # lands, whoever wrote it. "shadow-all" runs with every strict tenant table active,
+          # which is the exhaustive list of what activating the rest would break, obtained
+          # without changing anything on main. Both turn the fail-closed detector on.
+          # Reports, not gates: continue_on_error keeps a red one from failing the workflow.
+          # Retire both when the migration is done; shadow-prod may then become a core gate.
+          {"shard":"1","shard_name":"1-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"2","shard_name":"2-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"3","shard_name":"3-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"4","shard_name":"4-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"5","shard_name":"5-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"6","shard_name":"6-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"7","shard_name":"7-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"8","shard_name":"remaining-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"catchall","excludes":"","tenant_mode":"production","continue_on_error":true},
+          {"shard":"1","shard_name":"1-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"2","shard_name":"2-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"3","shard_name":"3-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"4","shard_name":"4-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"5","shard_name":"5-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"6","shard_name":"6-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"7","shard_name":"7-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"shardfile","excludes":"","tenant_mode":"all","continue_on_error":true},
+          {"shard":"8","shard_name":"remaining-shadow-all","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-all","includes":"catchall","excludes":"","tenant_mode":"all","continue_on_error":true}
         ]
       # ── E2E: OpenSearch (Chrome/WebKit/Chromium) + ES Firefox/Edge + expanded infra ──
       # artifact_suffix must be unique per cell: the report artifact is named

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -19,6 +19,14 @@ jobs:
   pipeline:
     uses: ./.github/workflows/_ci-pipeline.yml
     with:
+      # ── Multi-tenancy v2 shadow runs (epic #6393), Elasticsearch only ──
+      # Same suite, different activation. "shadow-prod" runs under the active-tables list
+      # main ships, so a regression on a table that is already live surfaces the night it
+      # lands, whoever wrote it. "shadow-all" runs with every strict tenant table active,
+      # which is the exhaustive list of what activating the rest would break, obtained
+      # without changing anything on main. Both turn the fail-closed detector on.
+      # Reports, not gates: continue_on_error keeps a red one from failing the workflow.
+      # Retire both when the migration is done; shadow-prod may then become a core gate.
       # ── API Tests: 7 balanced shards + catch-all, × Elasticsearch and OpenSearch ──
       # Patterns live in .github/shards/api-<n>.txt.
       api-matrix: >
@@ -40,14 +48,6 @@ jobs:
           {"shard":"7","shard_name":"7-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"shardfile","excludes":""},
           {"shard":"8","shard_name":"remaining-os","search_engine":"opensearch","engine_selector":"opensearch","artifact_suffix":"-opensearch","includes":"catchall","excludes":""},
 
-          # ── Multi-tenancy v2 shadow runs (epic #6393), Elasticsearch only ──
-          # Same suite, different activation. "shadow-prod" runs under the active-tables list
-          # main ships, so a regression on a table that is already live surfaces the night it
-          # lands, whoever wrote it. "shadow-all" runs with every strict tenant table active,
-          # which is the exhaustive list of what activating the rest would break, obtained
-          # without changing anything on main. Both turn the fail-closed detector on.
-          # Reports, not gates: continue_on_error keeps a red one from failing the workflow.
-          # Retire both when the migration is done; shadow-prod may then become a core gate.
           {"shard":"1","shard_name":"1-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
           {"shard":"2","shard_name":"2-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},
           {"shard":"3","shard_name":"3-shadow-prod","search_engine":"elasticsearch","engine_selector":"elk","artifact_suffix":"-shadow-prod","includes":"shardfile","excludes":"","tenant_mode":"production","continue_on_error":true},

--- a/openaev-api/src/main/java/io/openaev/config/TenantTables.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantTables.java
@@ -16,6 +16,9 @@ import java.util.stream.Collectors;
  */
 public record TenantTables(Set<String> strict, Set<String> dualScope) {
 
+  /** Activation allowlist entry meaning "every strict table"; see {@link #restrictTo}. */
+  public static final String ALL_STRICT = "*";
+
   public enum Family {
     NONE,
     STRICT,
@@ -94,9 +97,25 @@ public record TenantTables(Set<String> strict, Set<String> dualScope) {
    * table-by-table rollout knob; an empty allowlist activates nothing, so the inspector stays
    * inert. An entry that is not a known tenant table fails fast, to surface a typo at startup
    * rather than silently leave a table unprotected.
+   *
+   * <p>The single entry {@value #ALL_STRICT} activates every strict table and no dual-scope one:
+   * the rollout's terminal state, and what the nightly shadow run passes to surface what activating
+   * everything would break. Dual-scope tables stay out because a platform row is written with no
+   * tenant, which this mechanism does not cover. It is rejected alongside other entries, so a list
+   * always reads as either "these tables" or "all of them", never both.
    */
   public TenantTables restrictTo(Collection<String> allowlist) {
     Set<String> allowed = lowercase(new HashSet<>(allowlist));
+    if (allowed.contains(ALL_STRICT)) {
+      if (allowed.size() > 1) {
+        throw new IllegalArgumentException(
+            "active-tables is either '"
+                + ALL_STRICT
+                + "' or a list of tables, not both: "
+                + allowed);
+      }
+      return new TenantTables(strict, Set.of());
+    }
     Set<String> known = new HashSet<>(strict);
     known.addAll(dualScope);
     Set<String> unknown = new HashSet<>(allowed);

--- a/openaev-api/src/main/java/io/openaev/config/TenantTables.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantTables.java
@@ -19,6 +19,23 @@ public record TenantTables(Set<String> strict, Set<String> dualScope) {
   /** Activation allowlist entry meaning "every strict table"; see {@link #restrictTo}. */
   public static final String ALL_STRICT = "*";
 
+  /**
+   * Strict tables deliberately and permanently outside v2, so {@link #ALL_STRICT} leaves them
+   * alone. Each one isolates itself, and activating it would break the mechanism it isolates itself
+   * with.
+   *
+   * <ul>
+   *   <li>{@code attackpath_graph_version}: its version counter is bumped by a single native {@code
+   *       INSERT ... ON CONFLICT DO UPDATE ... RETURNING}, a shape the inspector cannot rewrite.
+   *       Every statement on that table carries its own tenant predicate instead and the counter is
+   *       keyed by {@code (simulation_id, tenant_id)}; see {@code
+   *       AttackPathGraphVersionRepository}.
+   * </ul>
+   *
+   * A table belongs here only with that kind of written reason. "Not activated yet" is not one.
+   */
+  private static final Set<String> OUTSIDE_V2 = Set.of("attackpath_graph_version");
+
   public enum Family {
     NONE,
     STRICT,
@@ -98,11 +115,12 @@ public record TenantTables(Set<String> strict, Set<String> dualScope) {
    * inert. An entry that is not a known tenant table fails fast, to surface a typo at startup
    * rather than silently leave a table unprotected.
    *
-   * <p>The single entry {@value #ALL_STRICT} activates every strict table and no dual-scope one:
-   * the rollout's terminal state, and what the nightly shadow run passes to surface what activating
-   * everything would break. Dual-scope tables stay out because a platform row is written with no
-   * tenant, which this mechanism does not cover. It is rejected alongside other entries, so a list
-   * always reads as either "these tables" or "all of them", never both.
+   * <p>The single entry {@value #ALL_STRICT} activates every strict table except those listed in
+   * {@code OUTSIDE_V2}, and no dual-scope one: the rollout's terminal state, and what the nightly
+   * shadow run passes to surface what activating everything would break. Dual-scope tables stay out
+   * because a platform row is written with no tenant, which this mechanism does not cover. It is
+   * rejected alongside other entries, so a list always reads as either "these tables" or "all of
+   * them", never both.
    */
   public TenantTables restrictTo(Collection<String> allowlist) {
     Set<String> allowed = lowercase(new HashSet<>(allowlist));
@@ -114,7 +132,9 @@ public record TenantTables(Set<String> strict, Set<String> dualScope) {
                 + "' or a list of tables, not both: "
                 + allowed);
       }
-      return new TenantTables(strict, Set.of());
+      Set<String> activable = new HashSet<>(strict);
+      activable.removeAll(OUTSIDE_V2);
+      return new TenantTables(activable, Set.of());
     }
     Set<String> known = new HashSet<>(strict);
     known.addAll(dualScope);

--- a/openaev-api/src/test/java/io/openaev/config/TenantTablesTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantTablesTest.java
@@ -93,6 +93,25 @@ class TenantTablesTest {
         IllegalArgumentException.class, () -> MODEL.restrictTo(Set.of("not_a_tenant_table")));
   }
 
+  @Test
+  @DisplayName("'*' activates every strict table and no dual-scope one")
+  void restrictToAllStrictActivatesStrictTablesOnly() {
+    TenantTables active = MODEL.restrictTo(Set.of(TenantTables.ALL_STRICT));
+    assertEquals(Set.of("documents", "findings"), active.strict());
+    assertTrue(
+        active.dualScope().isEmpty(),
+        "a platform row is written with no tenant, which this mechanism does not cover");
+    assertEquals(TenantTables.Family.NONE, active.family("groups"));
+  }
+
+  @Test
+  @DisplayName("'*' alongside a table name fails fast rather than guessing which one wins")
+  void restrictToRejectsAllStrictMixedWithTableNames() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MODEL.restrictTo(Set.of(TenantTables.ALL_STRICT, "documents")));
+  }
+
   /** A tenant-aware entity missing its {@code @Table} mapping. */
   static final class NoTableTenant implements TenantBase {
     @Override

--- a/openaev-api/src/test/java/io/openaev/config/TenantTablesTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantTablesTest.java
@@ -105,6 +105,19 @@ class TenantTablesTest {
   }
 
   @Test
+  @DisplayName("'*' leaves out a strict table that is deliberately outside v2")
+  void restrictToAllStrictSkipsTablesOutsideV2() {
+    TenantTables model =
+        new TenantTables(Set.of("documents", "attackpath_graph_version"), Set.of("groups"));
+    TenantTables active = model.restrictTo(Set.of(TenantTables.ALL_STRICT));
+    assertEquals(Set.of("documents"), active.strict());
+    assertEquals(
+        TenantTables.Family.NONE,
+        active.family("attackpath_graph_version"),
+        "its upsert is a shape the inspector cannot rewrite; it isolates itself by explicit predicate");
+  }
+
+  @Test
   @DisplayName("'*' alongside a table name fails fast rather than guessing which one wins")
   void restrictToRejectsAllStrictMixedWithTableNames() {
     assertThrows(


### PR DESCRIPTION
Closes #7914.

Two nightly API runs, same suite, different activation. They close the gap that makes the v2 rollout
slower and riskier than it needs to be: CI runs with no tenant table active, so a change that breaks
an already-live table is green here and red in production, and nothing tells us what activating the
rest would break.

## What this adds

A `tenant-mode` input on the `api-tests` action, with three values.

| Mode | Active tables | Detector | Used by |
|---|---|---|---|
| *(empty, default)* | none, as today | off | every existing matrix entry, unchanged |
| `production` | the list `main` ships | on | `shadow-prod`, 8 nightly shards |
| `all` | every strict tenant table | on | `shadow-all`, 8 nightly shards |

`production` reads the list from `openaev-api/src/main/resources/application.properties` rather than
restating it, so the two cannot drift. `all` passes `TenantTables.ALL_STRICT`, which activates every
strict table and no dual-scope one: a platform row is written with no tenant, which this mechanism
does not cover, and that is an open policy question rather than something to surface as noise.

Both modes turn the fail-closed detector on, so a production path reading an active table with no
scope fails its test instead of silently returning zero rows in production.

## What the reports say

A job summary per shard: the totals read from the surefire reports, the distinct unscoped production
reads with the advice to scope or waive each one, and the remaining failures grouped by exception
type, which is what separates a refused query shape from a `GROUP BY` error from a plain assertion.

Totals come from the reports, never from a grep of the build log: Maven writes ANSI colour codes
inside its counters, so `grep 'Errors: [1-9]'` can never match and an empty result reads exactly like
success.

## Reports, not gates

Every shadow entry carries `continue_on_error`, so a red one cannot fail the workflow while the
migration is in progress. `_ci-pipeline.yml` reads that per matrix entry and defaults to false, so
nothing else changes. Making `shadow-prod` blocking is a follow-up, once it has been green for a few
nights.

Shadow runs also skip the JaCoCo upload. The coverage job merges every `jacoco-exec-shard-*`
artifact, so without that the same tests would be counted twice into project coverage.

## Verification

- `TenantTablesTest`: 11 tests, 0 failures. Two new cases: `*` selects strict tables only, and `*`
  alongside a table name fails fast rather than guessing which one wins.
- Second break, on a different line from the fix: making the wildcard keep dual-scope tables turns
  the first case red, and it goes green again when reverted. The test pins the behaviour, not the fix.
- The three YAML files parse, and both new shell blocks pass `bash -n`.
- The summary extraction was run against a synthetic surefire report carrying two gate failures and
  one SQL error: totals, deduplicated signatures and exception histogram all correct.
- The production list resolution returns the 27 tables currently on `main`.

The shadow entries themselves only exist in the nightly matrix, so this PR's own pipeline exercises
the unchanged path. They will be verified by a manual `workflow_dispatch` of the nightly right after
merge; a failure there is visible and harmless by construction.

## Cost

Sixteen more API jobs on the nightly, Elasticsearch only. Retire both when the migration is done,
and `shadow-prod` may then become a core gate instead.



## Review round

Copilot found four defects, all real, three of them blocking. Each is fixed.

- **The matrix comments were literal text, not comments.** They sat inside the `api-matrix: >` block scalar, so `fromJSON` would have received them and the nightly would not have started at all. My own validation missed it because I parsed the scalar with a YAML parser, which honours `#`, while GitHub uses a JSON parser, which does not. Comments moved above the key, and every static matrix in both workflows now round-trips through `json.loads`.
- **The wildcard activated a table that must never be activated.** `attackpath_graph_version` bumps its counter with a native `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`, a shape the inspector cannot rewrite; the repository's javadoc says so, and every statement there carries its own tenant predicate instead. A documented `OUTSIDE_V2` set is now excluded from `*`, with a test, and a table qualifies for it only with that kind of written reason.
- **A clean shadow run would have failed its own summary.** With no failing test the last `grep` exits 1, and the composite action's shell is `bash -e -o pipefail`. Guarded.
- **The activation claim was too strong.** The list is a JVM system property, and the ~106 classes carrying `@TestPropertySource(properties = "openaev.tenant.active-tables=...")` keep their own narrower list. Those are the isolation suites, which already run with their table active, so the shadow's new information comes from every other class. The input description and the job summary now say exactly that, and making the shadow win over per-class activation is #7917.
