### PR TITLE
fix(ci): pull MinIO image from quay.io

### DIFF
--- a/openaev-dev/docker-compose.yml
+++ b/openaev-dev/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # Credentials: minioadmin/minioadmin
   openaev-dev-minio:
     container_name: openaev-dev-minio
-    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
     ports:
       - "10000:9000"
       - "10001:9001"
@@ -113,7 +113,7 @@ services:
   # Test MinIO object storage (S3-compatible)
   openaev-test-minio:
     container_name: openaev-test-minio
-    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
     ports:
       - "11000:9000"
       - "11001:9001"


### PR DESCRIPTION
The minio/minio repository was removed from Docker Hub, so every CI job failed at the shared start-services step with exit code 125. All test jobs derive the MinIO image from openaev-dev/docker-compose.yml, so switching it to quay.io unblocks the whole pipeline. The tag exists on quay for both linux/amd64 and linux/arm64.