### PR TITLE
fix(multi-tenancy): narrow the primary FROM filter and pin every native query (#7843)

### DIFF
--- a/openaev-api/src/main/java/io/openaev/config/TenantStatementInspector.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantStatementInspector.java
@@ -39,8 +39,8 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
  * SELECT table (and any sub-query or CTE) is wrapped in a filtered sub-query; the primary FROM
  * table of a select, when it is a plain tenant table not NULL-extended by a RIGHT/FULL join, is
  * filtered through the select's WHERE instead of being wrapped, so it stays a base table and keeps
- * the primary key's functional dependency (wrapping it breaks {@code GROUP BY id}). The target of an
- * UPDATE or DELETE also gets the filter added to its WHERE (a written table cannot be wrapped).
+ * the primary key's functional dependency (wrapping it breaks {@code GROUP BY id}). The target of
+ * an UPDATE or DELETE also gets the filter added to its WHERE (a written table cannot be wrapped).
  * Completeness comes from visiting every select; a statement, FROM or join shape that is not
  * understood is rejected (fail-closed) rather than passed through unfiltered, which would leak rows
  * across tenants.
@@ -251,12 +251,12 @@ public class TenantStatementInspector implements StatementInspector {
   }
 
   /**
-   * Filters the FROM and join tenant tables of a single select level. Joined tables are wrapped in a
-   * filtered sub-query. The primary FROM item, when it is a plain tenant table, is instead filtered
-   * through the select's WHERE: wrapping it in a derived table would strip the primary key's
-   * functional dependency, so a {@code GROUP BY id} projecting other columns becomes invalid SQL in
-   * PostgreSQL. Moving the predicate to the WHERE is equivalent only while the primary table is
-   * never NULL-extended, so a RIGHT or FULL join anywhere in the join list forces a fallback to
+   * Filters the FROM and join tenant tables of a single select level. Joined tables are wrapped in
+   * a filtered sub-query. The primary FROM item, when it is a plain tenant table, is instead
+   * filtered through the select's WHERE: wrapping it in a derived table would strip the primary
+   * key's functional dependency, so a {@code GROUP BY id} projecting other columns becomes invalid
+   * SQL in PostgreSQL. Moving the predicate to the WHERE is equivalent only while the primary table
+   * is never NULL-extended, so a RIGHT or FULL join anywhere in the join list forces a fallback to
    * wrapping (a WHERE predicate on the NULL-extended side would drop those rows and silently turn
    * the outer join into an inner one). Every other primary shape is wrapped exactly as before.
    */
@@ -278,8 +278,9 @@ public class TenantStatementInspector implements StatementInspector {
 
   /**
    * Whether the join list NULL-extends the accumulated left side, which is what makes moving the
-   * primary table's predicate into the WHERE unsafe. A RIGHT join NULL-extends the left side, a FULL
-   * join both sides; either anywhere in the list rules out the narrowing for this select level.
+   * primary table's predicate into the WHERE unsafe. A RIGHT join NULL-extends the left side, a
+   * FULL join both sides; either anywhere in the list rules out the narrowing for this select
+   * level.
    */
   private static boolean hasRightOrFullJoin(List<Join> joins) {
     if (joins == null) {

--- a/openaev-api/src/main/java/io/openaev/config/TenantStatementInspector.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantStatementInspector.java
@@ -35,9 +35,12 @@ import org.hibernate.resource.jdbc.spi.StatementInspector;
  * can_access_tenant}, keeping a transaction limited to the tenants in its {@code
  * app.current_tenants} scope.
  *
- * <p>Security principle: <b>every</b> reference to a tenant-aware table must be filtered. SELECT
- * tables (FROM, joins, sub-queries, CTEs) are wrapped in a filtered sub-query; the target of an
- * UPDATE or DELETE gets the filter added to its WHERE (a written table cannot be wrapped).
+ * <p>Security principle: <b>every</b> reference to a tenant-aware table must be filtered. A joined
+ * SELECT table (and any sub-query or CTE) is wrapped in a filtered sub-query; the primary FROM
+ * table of a select, when it is a plain tenant table not NULL-extended by a RIGHT/FULL join, is
+ * filtered through the select's WHERE instead of being wrapped, so it stays a base table and keeps
+ * the primary key's functional dependency (wrapping it breaks {@code GROUP BY id}). The target of an
+ * UPDATE or DELETE also gets the filter added to its WHERE (a written table cannot be wrapped).
  * Completeness comes from visiting every select; a statement, FROM or join shape that is not
  * understood is rejected (fail-closed) rather than passed through unfiltered, which would leak rows
  * across tenants.
@@ -233,25 +236,61 @@ public class TenantStatementInspector implements StatementInspector {
     }
   }
 
-  /** Wraps the FROM and join tables of every select contained in the statement. */
+  /** Filters the FROM and join tables of every select contained in the statement. */
   private void filterContainedSelects(Statement statement) {
     PlainSelectCollector collector = new PlainSelectCollector();
     collector.getTables(statement);
-    for (PlainSelect plainSelect : collector.collected) {
-      filterTables(plainSelect);
+    // Descendants before ancestors: narrowing a primary table re-parses its select's WHERE
+    // (combineCall), rebuilding any sub-query in that WHERE from its string form. Filtering the
+    // inner select first bakes its own predicate into that string, so the rebuilt copy keeps it.
+    // The collector lists ancestors first (pre-order), so we walk it in reverse.
+    List<PlainSelect> collected = collector.collected;
+    for (int i = collected.size() - 1; i >= 0; i--) {
+      filterTables(collected.get(i));
     }
   }
 
-  /** Wraps the FROM and join tenant tables of a single select level. */
+  /**
+   * Filters the FROM and join tenant tables of a single select level. Joined tables are wrapped in a
+   * filtered sub-query. The primary FROM item, when it is a plain tenant table, is instead filtered
+   * through the select's WHERE: wrapping it in a derived table would strip the primary key's
+   * functional dependency, so a {@code GROUP BY id} projecting other columns becomes invalid SQL in
+   * PostgreSQL. Moving the predicate to the WHERE is equivalent only while the primary table is
+   * never NULL-extended, so a RIGHT or FULL join anywhere in the join list forces a fallback to
+   * wrapping (a WHERE predicate on the NULL-extended side would drop those rows and silently turn
+   * the outer join into an inner one). Every other primary shape is wrapped exactly as before.
+   */
   private void filterTables(PlainSelect select) {
-    if (select.getFromItem() != null) {
-      select.setFromItem(filterFromItem(select.getFromItem()));
+    FromItem from = select.getFromItem();
+    if (from instanceof Table table
+        && tables.family(table.getName()) != TenantTables.Family.NONE
+        && !hasRightOrFullJoin(select.getJoins())) {
+      select.setWhere(combineTenantFilter(table, select.getWhere(), true));
+    } else if (from != null) {
+      select.setFromItem(filterFromItem(from));
     }
     if (select.getJoins() != null) {
       for (Join join : select.getJoins()) {
         join.setRightItem(filterFromItem(join.getRightItem()));
       }
     }
+  }
+
+  /**
+   * Whether the join list NULL-extends the accumulated left side, which is what makes moving the
+   * primary table's predicate into the WHERE unsafe. A RIGHT join NULL-extends the left side, a FULL
+   * join both sides; either anywhere in the list rules out the narrowing for this select level.
+   */
+  private static boolean hasRightOrFullJoin(List<Join> joins) {
+    if (joins == null) {
+      return false;
+    }
+    for (Join join : joins) {
+      if (join.isRight() || join.isFull()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/openaev-api/src/test/java/io/openaev/architecture/NativeQueryTenantInspectorProbeTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/NativeQueryTenantInspectorProbeTest.java
@@ -69,9 +69,11 @@ class NativeQueryTenantInspectorProbeTest {
       try {
         CCJSqlParserUtil.parse(sql);
       } catch (Exception parseFailure) {
-        // Unparseable before the inspector runs: a parameter or dialect shape JSqlParser cannot
-        // read. Not a refusal; reported, not failed.
-        unparseable.add(query.method());
+        // A parse failure is NOT a free pass. TenantStatementInspector.inspect uses the same parser
+        // and refuses what it cannot parse, fail-closed, so a query that does not parse here is a
+        // query that breaks once its table is active. It is tracked separately only to give a clearer
+        // message (make it parseable, or carry a reason), and the assertion below fails on it.
+        unparseable.add(query.method() + " :: " + parseFailure.getMessage());
         continue;
       }
       try {
@@ -89,6 +91,12 @@ class NativeQueryTenantInspectorProbeTest {
             + " unparseable-before-rewrite="
             + unparseable.size());
     System.out.println("[native-query-probe] unparseable: " + unparseable);
+
+    assertTrue(
+        unparseable.isEmpty(),
+        "native queries JSqlParser cannot read, which the inspector refuses fail-closed in production"
+            + " exactly as it does here, so activating their table breaks them:\n  "
+            + String.join("\n  ", unparseable));
 
     assertTrue(
         refused.isEmpty(),

--- a/openaev-api/src/test/java/io/openaev/architecture/NativeQueryTenantInspectorProbeTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/NativeQueryTenantInspectorProbeTest.java
@@ -1,0 +1,136 @@
+package io.openaev.architecture;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import io.openaev.config.TenantFilteringException;
+import io.openaev.config.TenantStatementInspector;
+import io.openaev.config.TenantTables;
+import jakarta.persistence.Entity;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+/**
+ * Runs every {@code @Query(nativeQuery = true)} in the repository layer through {@link
+ * TenantStatementInspector} with every tenant table active, and fails naming the repository method
+ * of any query the inspector refuses. Activating a table then stops being the moment a refused query
+ * shape is discovered in production (the {@code #7007} / {@code #6438} class of regression): the
+ * shape is pinned here, before go-live, on the real SQL read reflectively off the annotation.
+ *
+ * <p>The active set is derived from the entity model with {@link TenantTables#fromEntities}, which
+ * is a plain unit-test path needing no database. It misses tables that carry a {@code tenant_id} but
+ * have no entity class (join and link tables); those are only visible to the schema-derived
+ * production path ({@code TenantFilteringConfig#deriveFromSchema}), which needs a live schema. The
+ * inspector's gate keys on table names, so a query that touches only such a name is not exercised
+ * here; the tables it names are still covered whenever they are entity-backed.
+ *
+ * <p>A query whose SpEL or parameter syntax cannot be parsed even before the inspector touches it is
+ * not a failure of the inspector: it is reported separately (parse gate below) and skipped, because
+ * the probe checks the rewrite shape, not parameter binding.
+ */
+@DisplayName("Native queries survive the tenant inspector with every table active")
+class NativeQueryTenantInspectorProbeTest {
+
+  /**
+   * Spring resolves a SpEL selector ({@code :#{...}} or {@code ?#{...}}) into a bind parameter long
+   * before Hibernate sees the SQL, so JSqlParser only ever parses the resolved form. Collapse each
+   * to a positional placeholder so the shape can be parsed.
+   */
+  private static final Pattern SPEL = Pattern.compile("[:?]#\\{[^}]*}");
+
+  private record NativeQuery(String method, String sql) {}
+
+  @Test
+  @DisplayName("no native query is refused by the inspector when every tenant table is active")
+  void noNativeQueryIsRefusedWithEveryTableActive() {
+    JavaClasses classes =
+        new ClassFileImporter()
+            .withImportOption(new ImportOption.DoNotIncludeTests())
+            .importPackages("io.openaev");
+
+    TenantStatementInspector inspector = new TenantStatementInspector(everyTenantTable(classes));
+
+    List<NativeQuery> queries = nativeQueries(classes);
+    List<String> refused = new ArrayList<>();
+    List<String> unparseable = new ArrayList<>();
+
+    for (NativeQuery query : queries) {
+      String sql = SPEL.matcher(query.sql()).replaceAll("?");
+      try {
+        CCJSqlParserUtil.parse(sql);
+      } catch (Exception parseFailure) {
+        // Unparseable before the inspector runs: a parameter or dialect shape JSqlParser cannot
+        // read. Not a refusal; reported, not failed.
+        unparseable.add(query.method());
+        continue;
+      }
+      try {
+        inspector.inspect(sql);
+      } catch (TenantFilteringException refusal) {
+        refused.add(query.method() + " :: " + refusal.getMessage());
+      }
+    }
+
+    System.out.println(
+        "[native-query-probe] total="
+            + queries.size()
+            + " refused="
+            + refused.size()
+            + " unparseable-before-rewrite="
+            + unparseable.size());
+    System.out.println("[native-query-probe] unparseable: " + unparseable);
+
+    assertTrue(
+        refused.isEmpty(),
+        "the tenant inspector refused native queries that activating their table would break in"
+            + " production; add the reviewed-safe marker (e.g. LATERAL) or cover the shape:\n"
+            + String.join("\n", refused));
+  }
+
+  /**
+   * Every {@code @Query(nativeQuery = true)} declared on a Spring Data repository interface, read
+   * reflectively so a query added or edited tomorrow is covered without a hand-maintained list.
+   */
+  private static List<NativeQuery> nativeQueries(JavaClasses classes) {
+    List<NativeQuery> found = new ArrayList<>();
+    for (JavaClass javaClass : classes) {
+      if (!javaClass.isInterface()) {
+        continue;
+      }
+      Class<?> repository = javaClass.reflect();
+      if (!Repository.class.isAssignableFrom(repository)) {
+        continue;
+      }
+      for (Method method : repository.getDeclaredMethods()) {
+        Query query = method.getAnnotation(Query.class);
+        if (query != null && query.nativeQuery() && !query.value().isBlank()) {
+          found.add(new NativeQuery(repository.getSimpleName() + "#" + method.getName(), query.value()));
+        }
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Every tenant table derived from the entity model, strict and dual-scope alike, so the probe
+   * exercises the widest activation the inspector will ever face.
+   */
+  private static TenantTables everyTenantTable(JavaClasses classes) {
+    List<Class<?>> entities =
+        classes.stream()
+            .filter(javaClass -> javaClass.isAnnotatedWith(Entity.class))
+            .<Class<?>>map(JavaClass::reflect)
+            .toList();
+    return TenantTables.fromEntities(entities);
+  }
+}

--- a/openaev-api/src/test/java/io/openaev/architecture/NativeQueryTenantInspectorProbeTest.java
+++ b/openaev-api/src/test/java/io/openaev/architecture/NativeQueryTenantInspectorProbeTest.java
@@ -23,20 +23,20 @@ import org.springframework.data.repository.Repository;
 /**
  * Runs every {@code @Query(nativeQuery = true)} in the repository layer through {@link
  * TenantStatementInspector} with every tenant table active, and fails naming the repository method
- * of any query the inspector refuses. Activating a table then stops being the moment a refused query
- * shape is discovered in production (the {@code #7007} / {@code #6438} class of regression): the
- * shape is pinned here, before go-live, on the real SQL read reflectively off the annotation.
+ * of any query the inspector refuses. Activating a table then stops being the moment a refused
+ * query shape is discovered in production (the {@code #7007} / {@code #6438} class of regression):
+ * the shape is pinned here, before go-live, on the real SQL read reflectively off the annotation.
  *
  * <p>The active set is derived from the entity model with {@link TenantTables#fromEntities}, which
- * is a plain unit-test path needing no database. It misses tables that carry a {@code tenant_id} but
- * have no entity class (join and link tables); those are only visible to the schema-derived
+ * is a plain unit-test path needing no database. It misses tables that carry a {@code tenant_id}
+ * but have no entity class (join and link tables); those are only visible to the schema-derived
  * production path ({@code TenantFilteringConfig#deriveFromSchema}), which needs a live schema. The
  * inspector's gate keys on table names, so a query that touches only such a name is not exercised
  * here; the tables it names are still covered whenever they are entity-backed.
  *
- * <p>A query whose SpEL or parameter syntax cannot be parsed even before the inspector touches it is
- * not a failure of the inspector: it is reported separately (parse gate below) and skipped, because
- * the probe checks the rewrite shape, not parameter binding.
+ * <p>A query whose SpEL or parameter syntax cannot be parsed even before the inspector touches it
+ * is not a failure of the inspector: it is reported separately (parse gate below) and skipped,
+ * because the probe checks the rewrite shape, not parameter binding.
  */
 @DisplayName("Native queries survive the tenant inspector with every table active")
 class NativeQueryTenantInspectorProbeTest {
@@ -71,7 +71,8 @@ class NativeQueryTenantInspectorProbeTest {
       } catch (Exception parseFailure) {
         // A parse failure is NOT a free pass. TenantStatementInspector.inspect uses the same parser
         // and refuses what it cannot parse, fail-closed, so a query that does not parse here is a
-        // query that breaks once its table is active. It is tracked separately only to give a clearer
+        // query that breaks once its table is active. It is tracked separately only to give a
+        // clearer
         // message (make it parseable, or carry a reason), and the assertion below fails on it.
         unparseable.add(query.method() + " :: " + parseFailure.getMessage());
         continue;
@@ -122,7 +123,8 @@ class NativeQueryTenantInspectorProbeTest {
       for (Method method : repository.getDeclaredMethods()) {
         Query query = method.getAnnotation(Query.class);
         if (query != null && query.nativeQuery() && !query.value().isBlank()) {
-          found.add(new NativeQuery(repository.getSimpleName() + "#" + method.getName(), query.value()));
+          found.add(
+              new NativeQuery(repository.getSimpleName() + "#" + method.getName(), query.value()));
         }
       }
     }

--- a/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracle.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracle.java
@@ -14,19 +14,19 @@ import java.util.regex.Pattern;
 /**
  * Parser-independent detector of unguarded tenant-table reads in (rewritten) SQL. It works purely
  * on text so it cannot share a blind spot with the JSQLParser-based rewriter it checks: a tenant
- * table whose {@code FROM}/{@code JOIN} reference the rewriter failed to guard is caught here rather
- * than leaking silently.
+ * table whose {@code FROM}/{@code JOIN} reference the rewriter failed to guard is caught here
+ * rather than leaking silently.
  *
  * <p>Invariant checked per table: every {@code FROM}/{@code JOIN} reference to a tenant table must
- * be guarded by a {@code can_access_tenant} predicate on that reference's own {@code tenant_id}. The
- * rewriter produces two guarded shapes, both covered here by binding the guard to the reference's
- * alias: a joined (or sub-selected) table is wrapped in a filtered sub-query ({@code FROM <table>
- * <alias> WHERE can_access_tenant(<alias>.tenant_id)}), and the primary FROM item is narrowed by
- * moving that same predicate into the select's own WHERE ({@code FROM <table> <alias> ... WHERE ...
- * can_access_tenant(<alias>.tenant_id)}). A single reference whose alias carries no such predicate is
- * caught even when sibling references in the same statement are guarded. A DELETE target ({@code
- * DELETE FROM <table>}) is guarded by a WHERE predicate, not a reference the rewriter wraps, so it is
- * excluded from the reference scan below.
+ * be guarded by a {@code can_access_tenant} predicate on that reference's own {@code tenant_id}.
+ * The rewriter produces two guarded shapes, both covered here by binding the guard to the
+ * reference's alias: a joined (or sub-selected) table is wrapped in a filtered sub-query ({@code
+ * FROM <table> <alias> WHERE can_access_tenant(<alias>.tenant_id)}), and the primary FROM item is
+ * narrowed by moving that same predicate into the select's own WHERE ({@code FROM <table> <alias>
+ * ... WHERE ... can_access_tenant(<alias>.tenant_id)}). A single reference whose alias carries no
+ * such predicate is caught even when sibling references in the same statement are guarded. A DELETE
+ * target ({@code DELETE FROM <table>}) is guarded by a WHERE predicate, not a reference the
+ * rewriter wraps, so it is excluded from the reference scan below.
  */
 final class TenantSqlLeakOracle {
 
@@ -38,9 +38,29 @@ final class TenantSqlLeakOracle {
    */
   private static final Set<String> NOT_AN_ALIAS =
       Set.of(
-          "where", "group", "order", "on", "and", "or", "left", "right", "inner", "outer", "full",
-          "cross", "join", "union", "limit", "having", "offset", "natural", "using", "for",
-          "window", "fetch", "returning");
+          "where",
+          "group",
+          "order",
+          "on",
+          "and",
+          "or",
+          "left",
+          "right",
+          "inner",
+          "outer",
+          "full",
+          "cross",
+          "join",
+          "union",
+          "limit",
+          "having",
+          "offset",
+          "natural",
+          "using",
+          "for",
+          "window",
+          "fetch",
+          "returning");
 
   private final Map<String, TablePatterns> byTable;
 
@@ -88,12 +108,12 @@ final class TenantSqlLeakOracle {
 
   /**
    * Textual matchers for one tenant table, all independent of the SQL parser: {@code mention}
-   * detects the table name as a word; {@code reference} matches a readable {@code FROM}/{@code JOIN}
-   * to it and captures the alias that follows (if any). The trailing look-ahead keeps a shorter name
-   * from matching a longer one (e.g. {@code assets} must not match {@code assets_archive}); the
-   * {@code (?<!delete )} look-behind excludes a DELETE target, which is guarded by a WHERE predicate,
-   * not by a reference the rewriter wraps. Whitespace is normalized to single spaces before
-   * matching, so the fixed-length look-behind is reliable.
+   * detects the table name as a word; {@code reference} matches a readable {@code FROM}/{@code
+   * JOIN} to it and captures the alias that follows (if any). The trailing look-ahead keeps a
+   * shorter name from matching a longer one (e.g. {@code assets} must not match {@code
+   * assets_archive}); the {@code (?<!delete )} look-behind excludes a DELETE target, which is
+   * guarded by a WHERE predicate, not by a reference the rewriter wraps. Whitespace is normalized
+   * to single spaces before matching, so the fixed-length look-behind is reliable.
    */
   record TablePatterns(String table, Pattern mention, Pattern reference) {
     static TablePatterns forTable(String table) {
@@ -108,20 +128,22 @@ final class TenantSqlLeakOracle {
     }
 
     /**
-     * Whether any {@code FROM}/{@code JOIN} reference to this table lacks a {@code can_access_tenant}
-     * predicate on its own reference (alias, or the table name when aliasless). The wrapper form and
-     * the narrowed-primary form both satisfy this, since both emit that predicate on the reference.
+     * Whether any {@code FROM}/{@code JOIN} reference to this table lacks a {@code
+     * can_access_tenant} predicate on its own reference (alias, or the table name when aliasless).
+     * The wrapper form and the narrowed-primary form both satisfy this, since both emit that
+     * predicate on the reference.
      */
     boolean hasUnguardedReference(String text) {
       Matcher matcher = reference.matcher(text);
       while (matcher.find()) {
         String ref = referenceName(matcher.group(1));
         Pattern guard =
-            Pattern.compile(
-                "(?i)can_access_tenant\\(\\s*" + Pattern.quote(ref) + "\\.tenant_id");
-        // Search the reference's own scope, not the whole statement. Aliases repeat constantly across
+            Pattern.compile("(?i)can_access_tenant\\(\\s*" + Pattern.quote(ref) + "\\.tenant_id");
+        // Search the reference's own scope, not the whole statement. Aliases repeat constantly
+        // across
         // nested selects, so a guarded "documents d" in one sub-query would otherwise launder an
-        // unguarded "documents d" in another. Both guard shapes live in the same scope as their FROM:
+        // unguarded "documents d" in another. Both guard shapes live in the same scope as their
+        // FROM:
         // the wrapper emits the predicate inside its parentheses, the narrowed primary in that
         // select's own WHERE.
         if (!guard.matcher(scopeFrom(text, matcher.end())).find()) {
@@ -132,9 +154,10 @@ final class TenantSqlLeakOracle {
     }
 
     /**
-     * The text from a reference to the end of the parenthesis group enclosing it, or to the end of the
-     * statement when the reference sits at the top level. Quoted string literals are already blanked
-     * before the oracle runs, so a parenthesis inside a literal cannot skew the depth count.
+     * The text from a reference to the end of the parenthesis group enclosing it, or to the end of
+     * the statement when the reference sits at the top level. Quoted string literals are already
+     * blanked before the oracle runs, so a parenthesis inside a literal cannot skew the depth
+     * count.
      */
     private static String scopeFrom(String text, int start) {
       int depth = 0;

--- a/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracle.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracle.java
@@ -119,11 +119,37 @@ final class TenantSqlLeakOracle {
         Pattern guard =
             Pattern.compile(
                 "(?i)can_access_tenant\\(\\s*" + Pattern.quote(ref) + "\\.tenant_id");
-        if (!guard.matcher(text).find()) {
+        // Search the reference's own scope, not the whole statement. Aliases repeat constantly across
+        // nested selects, so a guarded "documents d" in one sub-query would otherwise launder an
+        // unguarded "documents d" in another. Both guard shapes live in the same scope as their FROM:
+        // the wrapper emits the predicate inside its parentheses, the narrowed primary in that
+        // select's own WHERE.
+        if (!guard.matcher(scopeFrom(text, matcher.end())).find()) {
           return true;
         }
       }
       return false;
+    }
+
+    /**
+     * The text from a reference to the end of the parenthesis group enclosing it, or to the end of the
+     * statement when the reference sits at the top level. Quoted string literals are already blanked
+     * before the oracle runs, so a parenthesis inside a literal cannot skew the depth count.
+     */
+    private static String scopeFrom(String text, int start) {
+      int depth = 0;
+      for (int i = start; i < text.length(); i++) {
+        char c = text.charAt(i);
+        if (c == '(') {
+          depth++;
+        } else if (c == ')') {
+          if (depth == 0) {
+            return text.substring(start, i);
+          }
+          depth--;
+        }
+      }
+      return text.substring(start);
     }
 
     /** The reference the guard predicate must name: the alias, or the table name when aliasless. */

--- a/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracle.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracle.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -13,16 +14,33 @@ import java.util.regex.Pattern;
 /**
  * Parser-independent detector of unguarded tenant-table reads in (rewritten) SQL. It works purely
  * on text so it cannot share a blind spot with the JSQLParser-based rewriter it checks: a tenant
- * table whose {@code FROM}/{@code JOIN} reference the rewriter failed to wrap is caught here rather
+ * table whose {@code FROM}/{@code JOIN} reference the rewriter failed to guard is caught here rather
  * than leaking silently.
  *
- * <p>Invariant checked per table: in the SQL, every {@code FROM}/{@code JOIN} to a tenant table
- * must be a {@code can_access_tenant} wrapper of the exact shape the rewriter produces ({@code FROM
- * <table> <alias> WHERE can_access_tenant(...)}). The number of references must equal the number of
- * wrappers, so a single unwrapped reference is caught even when sibling tables in the same
- * statement are wrapped.
+ * <p>Invariant checked per table: every {@code FROM}/{@code JOIN} reference to a tenant table must
+ * be guarded by a {@code can_access_tenant} predicate on that reference's own {@code tenant_id}. The
+ * rewriter produces two guarded shapes, both covered here by binding the guard to the reference's
+ * alias: a joined (or sub-selected) table is wrapped in a filtered sub-query ({@code FROM <table>
+ * <alias> WHERE can_access_tenant(<alias>.tenant_id)}), and the primary FROM item is narrowed by
+ * moving that same predicate into the select's own WHERE ({@code FROM <table> <alias> ... WHERE ...
+ * can_access_tenant(<alias>.tenant_id)}). A single reference whose alias carries no such predicate is
+ * caught even when sibling references in the same statement are guarded. A DELETE target ({@code
+ * DELETE FROM <table>}) is guarded by a WHERE predicate, not a reference the rewriter wraps, so it is
+ * excluded from the reference scan below.
  */
 final class TenantSqlLeakOracle {
+
+  /**
+   * Tokens that can follow {@code FROM <table>} but are not an alias: keywords and clause starts.
+   * When one of them (or nothing) follows the table name, the reference is aliasless and the
+   * rewriter guards it on the table name itself, which is what {@link TablePatterns#referenceName}
+   * falls back to.
+   */
+  private static final Set<String> NOT_AN_ALIAS =
+      Set.of(
+          "where", "group", "order", "on", "and", "or", "left", "right", "inner", "outer", "full",
+          "cross", "join", "union", "limit", "having", "offset", "natural", "using", "for",
+          "window", "fetch", "returning");
 
   private final Map<String, TablePatterns> byTable;
 
@@ -45,13 +63,13 @@ final class TenantSqlLeakOracle {
     return found;
   }
 
-  /** Tenant tables with at least one {@code FROM}/{@code JOIN} reference that is not a wrapper. */
+  /** Tenant tables with at least one {@code FROM}/{@code JOIN} reference that is not guarded. */
   List<String> unwrappedTenantTables(String sql) {
     String text = normalize(sql);
     List<String> unwrapped = new ArrayList<>();
     byTable.forEach(
         (table, patterns) -> {
-          if (count(text, patterns.fromJoin()) != count(text, patterns.wrapper())) {
+          if (patterns.hasUnguardedReference(text)) {
             unwrapped.add(table);
           }
         });
@@ -68,32 +86,53 @@ final class TenantSqlLeakOracle {
     return sql.replaceAll("'(?:[^']|'')*'", "''");
   }
 
-  static int count(String haystack, Pattern pattern) {
-    Matcher matcher = pattern.matcher(haystack);
-    int count = 0;
-    while (matcher.find()) {
-      count++;
-    }
-    return count;
-  }
-
   /**
    * Textual matchers for one tenant table, all independent of the SQL parser: {@code mention}
-   * detects the table name as a word; {@code fromJoin} matches a readable {@code FROM}/{@code JOIN}
-   * to it; {@code wrapper} matches the {@code can_access_tenant} wrapper the rewriter must produce.
-   * The trailing look-ahead keeps a shorter name from matching a longer one (e.g. {@code assets}
-   * must not match {@code assets_archive}); the {@code (?<!delete )} look-behind excludes a DELETE
-   * target, which is guarded by a WHERE predicate, not by a wrapper. Whitespace is normalized to
-   * single spaces before matching, so the fixed-length look-behind is reliable.
+   * detects the table name as a word; {@code reference} matches a readable {@code FROM}/{@code JOIN}
+   * to it and captures the alias that follows (if any). The trailing look-ahead keeps a shorter name
+   * from matching a longer one (e.g. {@code assets} must not match {@code assets_archive}); the
+   * {@code (?<!delete )} look-behind excludes a DELETE target, which is guarded by a WHERE predicate,
+   * not by a reference the rewriter wraps. Whitespace is normalized to single spaces before
+   * matching, so the fixed-length look-behind is reliable.
    */
-  record TablePatterns(Pattern mention, Pattern fromJoin, Pattern wrapper) {
+  record TablePatterns(String table, Pattern mention, Pattern reference) {
     static TablePatterns forTable(String table) {
       String name = Pattern.quote(table);
       return new TablePatterns(
+          table,
           Pattern.compile("(?i)(?<![a-z0-9_])" + name + "(?![a-z0-9_])"),
-          Pattern.compile("(?i)(?<!delete )\\b(?:from|join)\\s+\"?" + name + "\"?(?![a-z0-9_])"),
           Pattern.compile(
-              "(?i)\\bfrom\\s+\"?" + name + "\"?\\s+\\S+\\s+where\\s+can_access_tenant\\("));
+              "(?i)(?<!delete )\\b(?:from|join)\\s+\"?"
+                  + name
+                  + "\"?(?![a-z0-9_])(?:\\s+(?:as\\s+)?(\"?[a-z0-9_]+\"?))?"));
+    }
+
+    /**
+     * Whether any {@code FROM}/{@code JOIN} reference to this table lacks a {@code can_access_tenant}
+     * predicate on its own reference (alias, or the table name when aliasless). The wrapper form and
+     * the narrowed-primary form both satisfy this, since both emit that predicate on the reference.
+     */
+    boolean hasUnguardedReference(String text) {
+      Matcher matcher = reference.matcher(text);
+      while (matcher.find()) {
+        String ref = referenceName(matcher.group(1));
+        Pattern guard =
+            Pattern.compile(
+                "(?i)can_access_tenant\\(\\s*" + Pattern.quote(ref) + "\\.tenant_id");
+        if (!guard.matcher(text).find()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** The reference the guard predicate must name: the alias, or the table name when aliasless. */
+    private String referenceName(String aliasToken) {
+      if (aliasToken == null) {
+        return table;
+      }
+      String alias = aliasToken.replace("\"", "");
+      return NOT_AN_ALIAS.contains(alias.toLowerCase(Locale.ROOT)) ? table : alias;
     }
   }
 }

--- a/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracleTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracleTest.java
@@ -124,6 +124,33 @@ class TenantSqlLeakOracleTest {
   }
 
   @Test
+  @DisplayName("a narrowed primary guarded by a WHERE predicate on its alias is clean")
+  void narrowedPrimaryGuardedByPredicateIsClean() {
+    // The inspector narrows the primary FROM item by moving can_access_tenant into the select's own
+    // WHERE instead of wrapping it (keeps the primary key's functional dependency for GROUP BY id).
+    // That is a guarded reference just as much as the wrapper, so it must not be flagged.
+    String sql =
+        "SELECT d.id, d.name FROM documents d WHERE (d.id = ?) AND (can_access_tenant(d.tenant_id))";
+    assertTrue(oracle.unwrappedTenantTables(sql).isEmpty());
+  }
+
+  @Test
+  @DisplayName("a narrowed dual-scope primary (allow_platform) is clean")
+  void narrowedDualScopePrimaryIsClean() {
+    String sql = "SELECT * FROM groups g WHERE can_access_tenant(g.tenant_id, true)";
+    assertTrue(oracle.unwrappedTenantTables(sql).isEmpty());
+  }
+
+  @Test
+  @DisplayName("a predicate on a different alias does not guard the reference (still a leak)")
+  void guardOnDifferentAliasIsStillLeak() {
+    // The guard must bind to the reference's own alias. can_access_tenant on some other alias in the
+    // statement must not launder an otherwise-unguarded FROM.
+    String sql = "SELECT * FROM documents d WHERE can_access_tenant(x.tenant_id)";
+    assertEquals(List.of("documents"), oracle.unwrappedTenantTables(sql));
+  }
+
+  @Test
   @DisplayName("a DELETE target guarded by a WHERE predicate is not a read leak")
   void deleteTargetGuardedByPredicateIsClean() {
     String sql = "DELETE FROM documents WHERE id = ? AND (can_access_tenant(documents.tenant_id))";

--- a/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracleTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracleTest.java
@@ -151,6 +151,28 @@ class TenantSqlLeakOracleTest {
   }
 
   @Test
+  @DisplayName("a guard in another scope does not cover a same-alias reference (still a leak)")
+  void guardInAnotherScopeIsStillLeak() {
+    // Aliases repeat constantly across nested selects: everyone writes d, f, i. Searching the whole
+    // statement for can_access_tenant(d.tenant_id) lets a guarded reference in one sub-query launder
+    // an unguarded one in another that happens to reuse the alias. The guard must be found in the
+    // reference's own scope.
+    String sql =
+        "SELECT * FROM (SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id)) x,"
+            + " (SELECT * FROM documents d) y";
+    assertEquals(List.of("documents"), oracle.unwrappedTenantTables(sql));
+  }
+
+  @Test
+  @DisplayName("each nested reference guarded in its own scope is clean")
+  void guardsInEachOwnScopeAreClean() {
+    String sql =
+        "SELECT * FROM (SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id)) x,"
+            + " (SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id)) y";
+    assertTrue(oracle.unwrappedTenantTables(sql).isEmpty());
+  }
+
+  @Test
   @DisplayName("a DELETE target guarded by a WHERE predicate is not a read leak")
   void deleteTargetGuardedByPredicateIsClean() {
     String sql = "DELETE FROM documents WHERE id = ? AND (can_access_tenant(documents.tenant_id))";

--- a/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracleTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantSqlLeakOracleTest.java
@@ -144,7 +144,8 @@ class TenantSqlLeakOracleTest {
   @Test
   @DisplayName("a predicate on a different alias does not guard the reference (still a leak)")
   void guardOnDifferentAliasIsStillLeak() {
-    // The guard must bind to the reference's own alias. can_access_tenant on some other alias in the
+    // The guard must bind to the reference's own alias. can_access_tenant on some other alias in
+    // the
     // statement must not launder an otherwise-unguarded FROM.
     String sql = "SELECT * FROM documents d WHERE can_access_tenant(x.tenant_id)";
     assertEquals(List.of("documents"), oracle.unwrappedTenantTables(sql));
@@ -154,7 +155,8 @@ class TenantSqlLeakOracleTest {
   @DisplayName("a guard in another scope does not cover a same-alias reference (still a leak)")
   void guardInAnotherScopeIsStillLeak() {
     // Aliases repeat constantly across nested selects: everyone writes d, f, i. Searching the whole
-    // statement for can_access_tenant(d.tenant_id) lets a guarded reference in one sub-query launder
+    // statement for can_access_tenant(d.tenant_id) lets a guarded reference in one sub-query
+    // launder
     // an unguarded one in another that happens to reuse the alias. The guard must be found in the
     // reference's own scope.
     String sql =

--- a/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
@@ -253,7 +253,8 @@ class TenantStatementInspectorTest {
     String out = inspect("SELECT d.id, d.name FROM documents d GROUP BY d.id");
     // The primary table stays a base table, so PostgreSQL keeps the primary key's functional
     // dependency and GROUP BY d.id over other projected columns is legal.
-    assertFalse(out.contains("(SELECT * FROM documents"), "primary table must not be wrapped: " + out);
+    assertFalse(
+        out.contains("(SELECT * FROM documents"), "primary table must not be wrapped: " + out);
     assertTrue(out.contains("can_access_tenant(d.tenant_id)"), out);
     assertTrue(out.contains("WHERE can_access_tenant(d.tenant_id)"), out);
     assertTrue(out.contains("GROUP BY d.id"), out);
@@ -266,7 +267,8 @@ class TenantStatementInspectorTest {
     // drop the NULL-extended rows and silently turn the RIGHT join into an INNER one. It must stay
     // wrapped. This fallback is not optional: a refactor that drops it is a silent semantic change.
     String out = inspect("SELECT * FROM documents d RIGHT JOIN findings f ON f.doc_id = d.id");
-    assertTrue(out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
+    assertTrue(
+        out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
   }
 
   @Test
@@ -274,7 +276,8 @@ class TenantStatementInspectorTest {
   void fullJoinFallsBackToWrappingPrimary() {
     // Both sides of a FULL join are NULL-extended, so the same reasoning as the RIGHT join applies.
     String out = inspect("SELECT * FROM documents d FULL JOIN findings f ON f.doc_id = d.id");
-    assertTrue(out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
+    assertTrue(
+        out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
   }
 
   @Test
@@ -286,7 +289,8 @@ class TenantStatementInspectorTest {
         inspect(
             "SELECT * FROM documents d JOIN groups g ON g.id = d.gid"
                 + " RIGHT JOIN findings f ON f.doc_id = d.id");
-    assertTrue(out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
+    assertTrue(
+        out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
   }
 
   @Test
@@ -295,11 +299,13 @@ class TenantStatementInspectorTest {
     String out = inspect("SELECT * FROM documents d JOIN findings f ON f.doc_id = d.id");
     assertFalse(out.contains("(SELECT * FROM documents"), "primary must be narrowed: " + out);
     assertTrue(out.contains("can_access_tenant(d.tenant_id)"), out);
-    assertTrue(out.contains("(SELECT * FROM findings f WHERE can_access_tenant(f.tenant_id))"), out);
+    assertTrue(
+        out.contains("(SELECT * FROM findings f WHERE can_access_tenant(f.tenant_id))"), out);
   }
 
   @Test
-  @DisplayName("the narrowed predicate is added once, not twice, when the select already has a WHERE")
+  @DisplayName(
+      "the narrowed predicate is added once, not twice, when the select already has a WHERE")
   void narrowedPredicateAddedOnceWithExistingWhere() {
     String out = inspect("SELECT * FROM documents d WHERE d.id = ?");
     assertEquals(
@@ -320,8 +326,7 @@ class TenantStatementInspectorTest {
   @Test
   @DisplayName("the narrowed output is valid, re-parsable SQL")
   void narrowedOutputIsValidSql() {
-    String out =
-        inspector.inspect("SELECT d.id, d.name FROM documents d GROUP BY d.id");
+    String out = inspector.inspect("SELECT d.id, d.name FROM documents d GROUP BY d.id");
     assertDoesNotThrow(() -> CCJSqlParserUtil.parse(out));
   }
 

--- a/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantStatementInspectorTest.java
@@ -238,6 +238,93 @@ class TenantStatementInspectorTest {
     assertTrue(out.contains("can_access_tenant(chl_dark.tenant_id)"), out);
   }
 
+  // --- Primary-table narrowing (#7843) -------------------------------------
+  //
+  // The primary FROM item, when it is a plain tenant table, is filtered through the select's WHERE
+  // instead of being wrapped in a derived sub-query. Wrapping strips the primary key's functional
+  // dependency, so "GROUP BY id" while projecting other columns becomes invalid SQL in PostgreSQL
+  // (passes in CI, where active-tables is empty, and fails in production). The move is equivalent
+  // only while the primary table is never NULL-extended, so a RIGHT or FULL join anywhere in the
+  // join list forces a fallback to wrapping. Joined tables stay wrapped exactly as before.
+
+  @Test
+  @DisplayName("the primary tenant table is narrowed to the WHERE, not wrapped in a sub-query")
+  void primaryTableIsNarrowedNotWrapped() {
+    String out = inspect("SELECT d.id, d.name FROM documents d GROUP BY d.id");
+    // The primary table stays a base table, so PostgreSQL keeps the primary key's functional
+    // dependency and GROUP BY d.id over other projected columns is legal.
+    assertFalse(out.contains("(SELECT * FROM documents"), "primary table must not be wrapped: " + out);
+    assertTrue(out.contains("can_access_tenant(d.tenant_id)"), out);
+    assertTrue(out.contains("WHERE can_access_tenant(d.tenant_id)"), out);
+    assertTrue(out.contains("GROUP BY d.id"), out);
+  }
+
+  @Test
+  @DisplayName("a RIGHT join falls back to wrapping the primary table")
+  void rightJoinFallsBackToWrappingPrimary() {
+    // documents is NULL-extended by the RIGHT join, so moving its predicate into the WHERE would
+    // drop the NULL-extended rows and silently turn the RIGHT join into an INNER one. It must stay
+    // wrapped. This fallback is not optional: a refactor that drops it is a silent semantic change.
+    String out = inspect("SELECT * FROM documents d RIGHT JOIN findings f ON f.doc_id = d.id");
+    assertTrue(out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
+  }
+
+  @Test
+  @DisplayName("a FULL join falls back to wrapping the primary table")
+  void fullJoinFallsBackToWrappingPrimary() {
+    // Both sides of a FULL join are NULL-extended, so the same reasoning as the RIGHT join applies.
+    String out = inspect("SELECT * FROM documents d FULL JOIN findings f ON f.doc_id = d.id");
+    assertTrue(out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
+  }
+
+  @Test
+  @DisplayName("a RIGHT join later in the list still forces the fallback for the whole select")
+  void rightJoinAfterInnerJoinStillFallsBack() {
+    // The RIGHT join NULL-extends the accumulated left side, so it is the whole join list that must
+    // be checked, not only the first join.
+    String out =
+        inspect(
+            "SELECT * FROM documents d JOIN groups g ON g.id = d.gid"
+                + " RIGHT JOIN findings f ON f.doc_id = d.id");
+    assertTrue(out.contains("(SELECT * FROM documents d WHERE can_access_tenant(d.tenant_id))"), out);
+  }
+
+  @Test
+  @DisplayName("in the narrowed case the joined tenant table is still wrapped")
+  void narrowedPrimaryStillWrapsJoinedTable() {
+    String out = inspect("SELECT * FROM documents d JOIN findings f ON f.doc_id = d.id");
+    assertFalse(out.contains("(SELECT * FROM documents"), "primary must be narrowed: " + out);
+    assertTrue(out.contains("can_access_tenant(d.tenant_id)"), out);
+    assertTrue(out.contains("(SELECT * FROM findings f WHERE can_access_tenant(f.tenant_id))"), out);
+  }
+
+  @Test
+  @DisplayName("the narrowed predicate is added once, not twice, when the select already has a WHERE")
+  void narrowedPredicateAddedOnceWithExistingWhere() {
+    String out = inspect("SELECT * FROM documents d WHERE d.id = ?");
+    assertEquals(
+        1,
+        out.split("can_access_tenant\\(d\\.tenant_id\\)", -1).length - 1,
+        "the tenant predicate must appear exactly once: " + out);
+    assertTrue(out.contains("d.id = ?"), out);
+  }
+
+  @Test
+  @DisplayName("a narrowed dual-scope primary table keeps allow_platform on reads")
+  void narrowedDualScopePrimaryKeepsAllowPlatform() {
+    String out = inspect("SELECT * FROM groups g WHERE g.id = ?");
+    assertFalse(out.contains("(SELECT * FROM groups"), "primary must be narrowed: " + out);
+    assertTrue(out.contains("can_access_tenant(g.tenant_id, true)"), out);
+  }
+
+  @Test
+  @DisplayName("the narrowed output is valid, re-parsable SQL")
+  void narrowedOutputIsValidSql() {
+    String out =
+        inspector.inspect("SELECT d.id, d.name FROM documents d GROUP BY d.id");
+    assertDoesNotThrow(() -> CCJSqlParserUtil.parse(out));
+  }
+
   // --- Single table --------------------------------------------------------
 
   @Test


### PR DESCRIPTION
Closes #7843.
Closes #7916.

Two sweeps of the multi-tenancy v2 programme, shipped together because the second is what makes the
first safe to land.

## Sweep B: the primary FROM item is filtered through the WHERE, not wrapped (#7843)

The inspector wrapped every tenant table in `(SELECT * FROM t a WHERE can_access_tenant(a.tenant_id)) a`.
For the **primary** FROM item that turns a base table into a derived one, and PostgreSQL then loses the
primary key's functional dependency: `GROUP BY id` while projecting other columns stops being valid
SQL. It fails in production and passes in CI, because the test profile ships an empty active-tables
list. That is #7843.

The primary FROM item is now filtered through the select's own WHERE, so it stays a base table. Joined
tables are wrapped exactly as before. This is not a new mechanism: `rewriteDelete` already filters its
`USING` sources through the WHERE with the same helper.

**The safety condition.** Moving the predicate is equivalent only while the primary table is never
NULL-extended. A `RIGHT` join NULL-extends the left side and a `FULL` join both, so a WHERE predicate
there would drop the NULL-extended rows and silently turn an outer join into an inner one. Either,
anywhere in the join list, forces the fallback to wrapping. Pinned by three tests (`RIGHT`, `FULL`,
and `RIGHT` not first in the list); their absence would let a future refactor change join semantics
in silence.

## Sweep D: every native query goes through the inspector at build time (#7916)

`NativeQueryTenantInspectorProbeTest` reflects **208** native queries across the repositories and runs
each through the inspector with every tenant table active. A refused shape now fails the build naming
the method, instead of being discovered when someone activates that table.

The `assets` activation found `EndpointRepository#findByHostnameAndAtleastOneMacAddress` refused for a
missing `LATERAL`, which would have broken agent registration. That is the probe's red case: removing
the prefix turns it red naming the method, restoring it turns it green.

## The defect finishing this branch surfaced

`TenantSqlLeakOracle`, the empirical gate's parser-independent leak detector, recognised only the
wrapper guard shape. The narrowing introduces a second, equally strong one, so the oracle counted 17
narrowed primaries as unguarded and the gate went red.

**This was never a live leak**: the inspector guards a tenant primary either way, and nothing had
shipped. It was a gate false positive that would have blocked the merge.

**It is a gate change in the same PR as the change the gate would have blocked, which is exactly the
shape that hides a weakening, so it deserves a real look.** The fix is alias-bound: a FROM or JOIN
reference is guarded only if `can_access_tenant(<its own alias>.tenant_id)` is present. That is
stricter than counting wrapper shapes, because a guard on a *different* alias no longer launders an
unguarded reference, and there is a new negative test for precisely that.

## Correction to #7843's text

The issue lists five affected sites. Two were never affected: `UserQueryHelper` and `PlayerQueryHelper`
query `users`, which implements `Base` and not `TenantBase`, so the inspector never wraps it and their
`GROUP BY user.id, org.id` was always valid. Only `scenarios` (#6432), `exercises` (#6434) and `teams`
(#6439) are genuinely fixed. `asset_groups` already carries its own group-every-column workaround from
#7836 and is untouched.

## Verification

- Full `openaev-api` regression green: **6497 tests, 0 failures, 0 errors**, one reactor summary.
- `TenantStatementInspectorTest`: 100 tests green, 27 of them new.
- Probe: 208 queries, 0 refused, red case proven and restored.
- Second break, on a different line from the fix: making the fallback ignore `FULL` joins turns
  `fullJoinFallsBackToWrappingPrimary` red.
- **Ordering, checked in review.** Narrowing re-parses the select's WHERE, which rebuilds any
  sub-query there from its string form, so contained selects must be filtered before their ancestors.
  Restoring the old ancestors-first order turns six tests red, including two real asset-group query
  shapes whose sub-query joins `findings`. The protection is not hollow.
