### PR TITLE
fix(multi-tenancy): keep the tenant registry out of v2 activation (#7914)

### DIFF
--- a/.github/actions/api-tests/action.yml
+++ b/.github/actions/api-tests/action.yml
@@ -242,9 +242,15 @@ runs:
           production)
             # Read the list main ships rather than restating it here, so the two can never drift.
             PROPS=openaev-api/src/main/resources/application.properties
+            # Exactly one definition, or fail: sed prints every match, so a second definition would
+            # make LIST multi-line and silently corrupt the -D below.
+            COUNT=$(grep -c '^openaev\.tenant\.active-tables=' "$PROPS" || true)
+            if [ "$COUNT" != "1" ]; then
+              echo "❌ expected exactly one openaev.tenant.active-tables in $PROPS, found $COUNT"; exit 1
+            fi
             LIST=$(sed -n 's/^openaev\.tenant\.active-tables=//p' "$PROPS")
             if [ -z "$LIST" ]; then
-              echo "❌ no openaev.tenant.active-tables in $PROPS"; exit 1
+              echo "❌ openaev.tenant.active-tables is empty in $PROPS"; exit 1
             fi
             ;;
           all)

--- a/openaev-api/src/main/java/io/openaev/config/TenantTables.java
+++ b/openaev-api/src/main/java/io/openaev/config/TenantTables.java
@@ -30,11 +30,19 @@ public record TenantTables(Set<String> strict, Set<String> dualScope) {
    *       Every statement on that table carries its own tenant predicate instead and the counter is
    *       keyed by {@code (simulation_id, tenant_id)}; see {@code
    *       AttackPathGraphVersionRepository}.
+   *   <li>{@code tenants}: the registry of tenants, not tenant-scoped data. It is derived as a
+   *       tenant table only because its primary key column happens to be named {@code tenant_id},
+   *       which the schema derivation reads as "this row belongs to a tenant". Gating it stops the
+   *       platform from starting: the bootstrap must read the default tenant in order to create it,
+   *       and under an empty scope that read returns nothing, so the admin user's save fails
+   *       resolving the tenant. Which tenants a caller may see is a permission question, answered
+   *       by group membership (see #7248), not a row-filtering one; two mechanisms answering it
+   *       would eventually disagree.
    * </ul>
    *
    * A table belongs here only with that kind of written reason. "Not activated yet" is not one.
    */
-  private static final Set<String> OUTSIDE_V2 = Set.of("attackpath_graph_version");
+  private static final Set<String> OUTSIDE_V2 = Set.of("attackpath_graph_version", "tenants");
 
   public enum Family {
     NONE,

--- a/openaev-api/src/test/java/io/openaev/config/TenantTablesTest.java
+++ b/openaev-api/src/test/java/io/openaev/config/TenantTablesTest.java
@@ -10,6 +10,7 @@ import io.openaev.database.model.Setting;
 import io.openaev.database.model.Tenant;
 import io.openaev.database.model.TenantBase;
 import io.openaev.database.model.Token;
+import io.openaev.database.model.attackpath.AttackPathGraphVersion;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -104,17 +105,34 @@ class TenantTablesTest {
     assertEquals(TenantTables.Family.NONE, active.family("groups"));
   }
 
+  /**
+   * The table each entity is mapped to, read from the entity itself. Writing the name as a literal
+   * here would make the test pass after a rename while the exclusion silently stopped matching,
+   * which is the whole protection gone with nothing red.
+   */
+  private static String tableOf(Class<?> entity) {
+    return entity.getAnnotation(jakarta.persistence.Table.class).name();
+  }
+
   @Test
-  @DisplayName("'*' leaves out a strict table that is deliberately outside v2")
+  @DisplayName("'*' leaves out every strict table that is deliberately outside v2")
   void restrictToAllStrictSkipsTablesOutsideV2() {
+    String graphVersion = tableOf(AttackPathGraphVersion.class);
+    String tenants = tableOf(Tenant.class);
     TenantTables model =
-        new TenantTables(Set.of("documents", "attackpath_graph_version"), Set.of("groups"));
+        new TenantTables(Set.of("documents", graphVersion, tenants), Set.of("groups"));
+
     TenantTables active = model.restrictTo(Set.of(TenantTables.ALL_STRICT));
+
     assertEquals(Set.of("documents"), active.strict());
     assertEquals(
         TenantTables.Family.NONE,
-        active.family("attackpath_graph_version"),
+        active.family(graphVersion),
         "its upsert is a shape the inspector cannot rewrite; it isolates itself by explicit predicate");
+    assertEquals(
+        TenantTables.Family.NONE,
+        active.family(tenants),
+        "the tenant registry is not tenant-scoped data; gating it stops the platform from bootstrapping");
   }
 
   @Test


### PR DESCRIPTION
Three fixes to the nightly shadow instrument #7914 shipped, two of them found by reviewing it after the
fact rather than before.

## The tenant registry is not tenant-scoped data

`shadow-all` produced almost nothing on its first run: three signatures instead of the exhaustive list
it exists for, because the Spring context did not start at all. 310 `Failed to load ApplicationContext`
errors against one test failure.

The cause is a category error in the schema derivation. `TenantFilteringConfig` decides a table is
tenant-scoped by asking `information_schema` for a column named `tenant_id`. The `tenants` table's
**primary key** is called `tenant_id`, because that is what it holds, so the registry of tenants is
read as data belonging to a tenant.

Nobody had noticed because the active list has always been written by hand, table by table, and nobody
would put `tenants` in it. `ALL_STRICT` did, which is how this surfaced: the defect is in the wildcard
shipped yesterday, not a hidden prerequisite of the migration.

What breaks: the bootstrap must read the default tenant in order to create it. Gated, that read returns
nothing under an empty scope, and the admin user's save then fails resolving a `Tenant` proxy by id.
The platform closes on its own foundation.

`tenants` joins `OUTSIDE_V2`. Which tenants a caller may see is a permission question, answered by group
membership (#7248), not a row-filtering one; two mechanisms answering the same question would eventually
disagree.

**Verified empirically**, not just by unit test: `AppTest` (a real `@SpringBootTest`) now boots and passes
with `-Dopenaev.tenant.active-tables='*'`. Before this change that context did not start.

## The exclusion test was hollow

It built its own `TenantTables` with the table name written as a string literal. A rename would have left
the test green while the exclusion silently stopped matching, so the protection would have disappeared
with nothing red anywhere. It now reads the name from the entity's own `@Table`, for both excluded
tables. Simulating a rename turns it red.

## The production list extraction was not bounded to one line

`sed -n 's/^openaev\.tenant\.active-tables=//p'` prints **every** matching line. One definition exists
today, so it works; a second one, even in a profile block, would make the value multi-line and corrupt
the `-D`. The step now fails unless there is exactly one definition.

## What is not fixed here

The 129 signatures `shadow-prod` reported are triaged, not fixed: 26 are bootstrap work, 90 are test
artefacts where production does set the scope, and the real yield is 4 candidate defects plus 5
unclassified. Those get their own triage issue. The detector cannot yet tell a read during per-tenant
provisioning from one on a request path; teaching it that is a separate reviewed change, because it means
touching production choke points.
