### PR TITLE
chore(dev): replace the MinIO image by pgsty/silo in the development and CI stacks (#7927)

### DIFF
--- a/.github/actions/api-tests/action.yml
+++ b/.github/actions/api-tests/action.yml
@@ -1,6 +1,6 @@
 name: API Tests
 description: >
-  Start service containers (PostgreSQL, Elasticsearch, RabbitMQ, MinIO),
+  Start service containers (PostgreSQL, Elasticsearch, RabbitMQ, Silo),
   download pre-compiled artifacts, and run API tests for a single shard.
   Requires job-level env vars:
   SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME,
@@ -172,12 +172,12 @@ runs:
         done
         docker exec rabbitmq rabbitmq-diagnostics -q check_running || { echo "❌ RabbitMQ failed to start"; exit 1; }
 
-        echo "⏳ Waiting for MinIO..."
+        echo "⏳ Waiting for Silo..."
         for i in $(seq 1 30); do
           curl -sf http://localhost:11000/minio/health/live && break
           sleep 1
         done
-        curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+        curl -sf http://localhost:11000/minio/health/live || { echo "❌ Silo failed to start"; exit 1; }
 
         echo "✅ All services ready"
 

--- a/.github/actions/api-types-check/action.yml
+++ b/.github/actions/api-types-check/action.yml
@@ -1,6 +1,6 @@
 name: API Types Check
 description: >
-  Start service containers (PostgreSQL, Elasticsearch, RabbitMQ, MinIO),
+  Start service containers (PostgreSQL, Elasticsearch, RabbitMQ, Silo),
   download and run the backend JAR, and verify that generated API types
   are up to date.
   Requires job-level env vars: SPRING_DATASOURCE_URL,
@@ -103,12 +103,12 @@ runs:
         done
         docker exec rabbitmq rabbitmq-diagnostics -q check_running || { echo "❌ RabbitMQ failed to start"; exit 1; }
 
-        echo "⏳ Waiting for MinIO..."
+        echo "⏳ Waiting for Silo..."
         for i in $(seq 1 30); do
           curl -sf http://localhost:11000/minio/health/live && break
           sleep 1
         done
-        curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+        curl -sf http://localhost:11000/minio/health/live || { echo "❌ Silo failed to start"; exit 1; }
 
         echo "✅ All services ready"
 

--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -1,6 +1,6 @@
 name: E2E Tests
 description: >
-  Start service containers (PostgreSQL, Elasticsearch, RabbitMQ, MinIO),
+  Start service containers (PostgreSQL, Elasticsearch, RabbitMQ, Silo),
   download and run the backend Docker image, and run Playwright E2E tests.
   The Docker image is built in parallel by the docker-build job; this action
   waits for a registry marker or image artifact and loads the first usable source.
@@ -177,12 +177,12 @@ runs:
         done
         docker exec rabbitmq rabbitmq-diagnostics -q check_running || { echo "❌ RabbitMQ failed to start"; exit 1; }
 
-        echo "⏳ Waiting for MinIO..."
+        echo "⏳ Waiting for Silo..."
         for i in $(seq 1 30); do
           curl -sf http://localhost:11000/minio/health/live && break
           sleep 1
         done
-        curl -sf http://localhost:11000/minio/health/live || { echo "❌ MinIO failed to start"; exit 1; }
+        curl -sf http://localhost:11000/minio/health/live || { echo "❌ Silo failed to start"; exit 1; }
 
         echo "✅ All services ready"
 

--- a/.github/actions/start-dev-services/action.yml
+++ b/.github/actions/start-dev-services/action.yml
@@ -1,7 +1,7 @@
 name: Start Dev Services
 description: >
   Start the backing service containers shared by the test jobs (PostgreSQL,
-  Elasticsearch or OpenSearch, RabbitMQ, MinIO) in the background and assert
+  Elasticsearch or OpenSearch, RabbitMQ, Silo) in the background and assert
   they came up. Image tags come from openaev-dev/docker-compose.yml. Containers
   are named pgsql, search-engine, rabbitmq and minio. Readiness polling is left
   to the caller so the containers can boot while other setup runs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ strategic levels.
 
 ### Architecture
 
-- **Backend**: Spring Boot (Java), PostgreSQL, Elasticsearch/OpenSearch, MinIO, RabbitMQ
+- **Backend**: Spring Boot (Java), PostgreSQL, Elasticsearch/OpenSearch, Silo (S3 object storage), RabbitMQ
 - **Frontend**: React, TypeScript, Vite, Material-UI
 - **Multi-module Maven project** with 3 modules: `openaev-model`, `openaev-framework`, `openaev-api`
 - ⚠️ **`openaev-framework` is deprecated** — it will be removed. **Never add new code to `openaev-framework`**. Place
@@ -60,7 +60,7 @@ CI runs on GitHub Actions (see `.github/workflows/`):
 3. **E2E Tests**: Full app test with Playwright
 4. **Type Check**: `yarn generate-types-from-api` verification
 
-**Services**: PostgreSQL, MinIO, Elasticsearch, RabbitMQ (see workflow files for exact versions)
+**Services**: PostgreSQL, Silo, Elasticsearch, RabbitMQ (see workflow files for exact versions)
 
 ### Key Workflows
 
@@ -167,7 +167,7 @@ Examples:
 2. **Trust these instructions**: Only search for information if instructions are incomplete or incorrect.
 3. **Pre-existing issues**: Don't fix unrelated linting/build issues unless they block your task.
 4. **Frontend must build first**: The backend copies frontend build artifacts.
-5. **Services required**: PostgreSQL, MinIO, Elasticsearch/OpenSearch, and RabbitMQ must be running for tests.
+5. **Services required**: PostgreSQL, Silo, Elasticsearch/OpenSearch, and RabbitMQ must be running for tests.
 6. **Java 21 is mandatory**: The project will not compile with earlier versions.
 7. **Node.js version**: Check `openaev-front/package.json` engines field for the minimum required version.
 8. **API types**: After API changes, run `yarn generate-types-from-api` in frontend to update TypeScript types.

--- a/.github/skills/activate-tenant-table/SKILL.md
+++ b/.github/skills/activate-tenant-table/SKILL.md
@@ -1480,7 +1480,7 @@ mvn -B -ntp spotless:check || mvn -ntp spotless:apply
 mvn -ntp clean install -DskipTests
 
 # 8.3 your tests, then the FULL API suite (needs the Docker services from
-# openaev-dev/docker-compose.yml: PostgreSQL, MinIO, OpenSearch, RabbitMQ)
+# openaev-dev/docker-compose.yml: PostgreSQL, Silo, OpenSearch, RabbitMQ)
 mvn -ntp -pl openaev-api test -Dtest='{Entity}*IsolationTest'
 ```
 

--- a/docs/docs/deployment/installation.md
+++ b/docs/docs/deployment/installation.md
@@ -104,7 +104,7 @@ If the OpenAEV container exits immediately after starting:
 
 1. Check the logs: `docker compose logs openaev`
 2. Verify all required environment variables are set in your `.env` file
-3. Ensure all dependency containers (PostgreSQL, ElasticSearch, RabbitMQ, MinIO) are healthy:
+3. Ensure all dependency containers (PostgreSQL, ElasticSearch, RabbitMQ, Silo) are healthy:
    ```bash
    docker compose ps
    ```
@@ -128,7 +128,7 @@ You may refer to [the official Docker documentation](https://docs.docker.com/ref
 
 Otherwise, you are responsible for providing the dependencies yourself by installing and running them.
 You need at least a Java Runtime, PostgreSQL (database), ElasticSearch (database), RabbitMQ (queue management), and 
-MinIO (for object storage).
+Silo or any other S3-compatible service (for object storage).
 
 !!! note "Supported dependency versions"
 
@@ -140,7 +140,7 @@ If you choose to install the dependencies manually, please refer to their respec
 * PostgreSQL: the [PostgreSQL documentation portal](https://www.postgresql.org/docs/)
 * ElasticSearch: the [ElasticSearch documentation portal](https://www.elastic.co/docs)
 * RabbitMQ: the [RabbitMQ documentation portal](https://www.rabbitmq.com/docs)
-* MinIO: the [MinIO website](https://min.io/docs).
+* Silo (the community-maintained fork of MinIO): the [Silo documentation](https://silo.pgsty.com/docs/).
 
 #### Download the application files
 
@@ -174,7 +174,7 @@ See the relevant Configuration sections for more details:
 - [PostgreSQL](configuration.md#postgresql)
 - [ElasticSearch](configuration.md#engine)
 - [RabbitMQ](configuration.md#rabbitmq)
-- [MinIO](configuration.md#s3-bucket)
+- [S3 bucket / Silo](configuration.md#s3-bucket)
 
 #### Start the application
 

--- a/docs/docs/deployment/platform/overview.md
+++ b/docs/docs/deployment/platform/overview.md
@@ -56,7 +56,7 @@ if an inject (execution, emails, etc.) has been detected or prevented and fill t
 | PostgreSQL    | ≥ 17.0                          | 2 cores | ≥ 8GB   | SSD       | ≥ 16GB     |
 | ElasticSearch | ≥ 8.19                          | 2 cores | ≥ 8GB   | SSD       | ≥ 16GB     |
 | RabbitMQ      | >= 4.1                          | 1 core  | ≥ 512MB | Standard  | ≥ 2GB      |
-| S3 / MinIO    | ≥ RELEASE.2025-06-13T11-33-47Z  | 1 core  | ≥ 128MB | SSD       | ≥ 16GB     |
+| S3 / Silo     | latest (Silo is a MinIO fork)   | 1 core  | ≥ 128MB | SSD       | ≥ 16GB     |
 
 Please note that while the versions of these dependencies are the recommended ones, OpenAEV may still function with
 earlier versions. However, we will not provide support for versions prior to the recommended ones.

--- a/docs/docs/development/build-from-source.md
+++ b/docs/docs/development/build-from-source.md
@@ -40,7 +40,7 @@ cp ./openaev-api/src/main/resources/application.properties ./openaev-api/src/mai
 
 **Start the development dependencies docker stack**
 
-Preconfigured containers for all the needed support containers (PostgreSQL, MinIO, RabbitMQ, Elasticsearch...)
+Preconfigured containers for all the needed support containers (PostgreSQL, Silo, RabbitMQ, Elasticsearch...)
 can be found as a docker compose file in `./openaev/openaev-dev`.
 
 Create a file a this location: `./openaev/openaev-dev/.env` and populate it with a minimal set of keys:
@@ -69,7 +69,7 @@ and any additional configuration. Make sure the file contains settings for at th
 the following dependencies:
 
 - PostgreSQL
-- MinIO
+- S3 object storage (Silo in the development stack)
 - RabbitMQ
 - Engine (Elasticsearch or OpenSearch)
 

--- a/docs/docs/development/environment-windows.md
+++ b/docs/docs/development/environment-windows.md
@@ -34,7 +34,7 @@ mvn -version
 
 ### Docker Desktop
 
-Docker Desktop is required to run the development services (PostgreSQL, Elasticsearch, RabbitMQ, MinIO).
+Docker Desktop is required to run the development services (PostgreSQL, Elasticsearch, RabbitMQ, Silo).
 
 1. Download and install [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/).
 2. Enable the WSL 2 backend for better performance (recommended).
@@ -91,7 +91,7 @@ This starts:
 | Service | Port | Description |
 |---|---|---|
 | PostgreSQL 17 | 5432 | Database |
-| MinIO | 10000, 10001 | S3-compatible object storage |
+| Silo | 10000, 10001 | S3-compatible object storage (MinIO fork) |
 | Elasticsearch 8 | 9200 | Analytics engine |
 | RabbitMQ 4 | 5672, 15672 | Message broker |
 

--- a/openaev-dev/README.md
+++ b/openaev-dev/README.md
@@ -57,7 +57,7 @@ docker compose up -d openaev-dev-pgsql openaev-dev-minio openaev-dev-elasticsear
 | Service | Port | Why it's required |
 |---------|------|-------------------|
 | **PostgreSQL (dev)** | 5432 | Primary data store — all entities, users, scenarios |
-| **MinIO** | 10000 (API), 10001 (Console) | File/document storage (S3-compatible) |
+| **Silo** | 10000 (API), 10001 (Console) | File/document storage (S3-compatible, MinIO fork) |
 | **Elasticsearch (dev)** | 9200, 9300 | Full-text search & indexing engine |
 | **RabbitMQ** | 5672 (AMQP), 15672 (Management) | Async messaging between backend components |
 
@@ -79,7 +79,7 @@ This starts everything, including optional services:
 |---------|------|-------------|
 | PostgreSQL (dev) | 5432 | Main development database (persistent) |
 | PostgreSQL (test) | 5433 | Test database (ephemeral, no volume) |
-| MinIO | 10000 (API), 10001 (Console) | Object storage |
+| Silo | 10000 (API), 10001 (Console) | Object storage (S3-compatible) |
 | RabbitMQ | 5672 (AMQP), 15672 (Management) | Message queue |
 | Elasticsearch (dev) | 9200, 9300 | Search engine |
 | Elasticsearch (test) | 9201, 9301 | Test search engine |
@@ -90,7 +90,7 @@ This starts everything, including optional services:
 
 ### 4. Access services
 
-- **MinIO Console**: http://localhost:10001 (minioadmin/minioadmin)
+- **Silo Console**: http://localhost:10001 (minioadmin/minioadmin)
 - **RabbitMQ Management**: http://localhost:15672 (guest/guest)
 - **pgAdmin**: http://localhost:5050 (admin@openaev.io/admin by default, see `.env`)
 - **Kibana**: http://localhost:5601

--- a/openaev-dev/docker-compose.yml
+++ b/openaev-dev/docker-compose.yml
@@ -24,12 +24,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  # MinIO object storage (S3-compatible)
+  # Silo object storage (S3-compatible, community-maintained MinIO fork)
   # API: http://localhost:10000, Console: http://localhost:10001
   # Credentials: minioadmin/minioadmin
   openaev-dev-minio:
     container_name: openaev-dev-minio
-    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: pgsty/silo:latest
     ports:
       - "10000:9000"
       - "10001:9001"
@@ -110,10 +110,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  # Test MinIO object storage (S3-compatible)
+  # Test Silo object storage (S3-compatible)
   openaev-test-minio:
     container_name: openaev-test-minio
-    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: pgsty/silo:latest
     ports:
       - "11000:9000"
       - "11001:9001"


### PR DESCRIPTION
### Proposed changes

The `minio/minio` image can no longer be pulled: the upstream MinIO repository was archived on 24 April 2026 (the community edition is now source-only), and Docker Hub has since removed the `minio/minio` and `minio/mc` repositories altogether - every tag answers 404 and `docker pull` fails with `pull access denied for minio/minio`. Every fresh deployment or CI run of a stack that still references these images is broken today.

Following OpenCTI-Platform/opencti#18239, the stack moves to [Silo](https://github.com/pgsty/silo), the community-maintained fork of the MinIO server published by Pigsty (`pgsty/silo` on Docker Hub, amd64 and arm64). Silo keeps the S3 API, the `MINIO_*` variables, the `server /data --console-address` command, the `/minio/health/live` route, the bundled `mc` client (so `mc ready local` healthchecks keep working) and the on-disk format unchanged, so an existing data volume is reused as is.

The `latest` tag is used on purpose: the MinIO-style dated release tags are not tracked anymore, and the whole Filigran ecosystem is aligned on `pgsty/silo:latest` (and `pgsty/mc:latest` for the client).

* `openaev-dev/docker-compose.yml`: `openaev-dev-minio` (10000/10001) and `openaev-test-minio` (11000/11001) run `pgsty/silo:latest` instead of the frozen `quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z`. Container names, ports, `minioadmin` credentials, `server /data --console-address ":9001"` command and `curl /minio/health/live` healthcheck are untouched, so the `minio.*` configuration keys keep working and `.github/actions/start-dev-services` (which reads the image from the compose file) starts the new image with no change.
* `openaev-dev/README.md`, `docs/docs/deployment/installation.md`, `docs/docs/deployment/platform/overview.md`, `docs/docs/development/build-from-source.md`, `docs/docs/development/environment-windows.md`: MinIO is named Silo where it is the object storage of the stack; the dependency table points at the Silo documentation and the `latest` tag.
* `.github/copilot-instructions.md`, the CI action descriptions / wait messages (`api-tests`, `api-types-check`, `e2e-tests`, `start-dev-services`) and the `activate-tenant-table` skill comment: same rename.
* The `minio.*` / `MINIO_*` configuration keys, the `minio` service names and the MinIO Java SDK dependency keep their names (the S3 protocol and the client are unchanged).

### Testing Instructions

1. `cd openaev-dev && docker compose up -d openaev-dev-minio openaev-test-minio`
2. `docker compose ps` shows both containers `healthy`; `curl -f http://localhost:10000/minio/health/live` and `http://localhost:11000/minio/health/live` answer 200; the console is on http://localhost:10001 (minioadmin/minioadmin).
3. Run the API tests (`mvn test`) or start the backend against the dev stack and upload a document: it lands in the `openaev` bucket exactly as before. The CI actions on this PR run against the new image.

Verified locally with Docker 29.6 on `pgsty/silo:RELEASE.2026-09-03T13-18-01Z` (the current `latest`) with the exact compose settings of the stack: the container reaches `healthy` through `mc ready local`, `/minio/health/live` and the console on 9001 answer 200, and a bucket create / upload / read round trip works with `pgsty/mc`. The image ships `/usr/bin/mc`, `/usr/bin/mcli` and `/usr/bin/curl`, so both healthcheck styles used across the Filigran stacks are supported.

### Related issues

* Closes #7927
* Same change across the ecosystem: OpenCTI-Platform/opencti#18239, OpenAEV-Platform/docker#163, OpenCTI-Platform/docker#607, FiligranHQ/xtm-docker#44, XTM-One-Platform/xtm-one#3531

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

### Further comments

The `latest` tag is used on purpose: the dated MinIO-style release tags are not tracked anymore, and the whole Filigran ecosystem is aligned on `pgsty/silo:latest` (and `pgsty/mc:latest` for the client). An existing local `openaev-dev-minio` data volume is reused as is (same on-disk format).